### PR TITLE
package-gale: ANTLR4 prefix-alt prediction & bt-scan fixes

### DIFF
--- a/package-gale/src/gen_context.wado
+++ b/package-gale/src/gen_context.wado
@@ -40,17 +40,17 @@ pub struct GenContext {
     /// self-ref runs with the precedence ANTLR4 assigns to that alt.
     /// 0 means no override (the default emission applies).
     pub prefix_self_ref_min_prec: i32,
-    /// When true, `gen_scan_element`'s RuleRef branch emits
-    /// `scan_<rule>_atom(...)` instead of `scan_<rule>(...)` for LR rules.
-    /// Set by `gen_bt_scan_if_possible` so that prediction-time bt-scans
-    /// don't follow an LR rule's suffix loop into tokens that the OUTER
-    /// LR loop would parse — mirroring ANTLR4's k-lookahead semantics
-    /// where the prediction stops at the differentiating prefix instead
-    /// of running the full LR cascade. False (the default) keeps
-    /// `scan_<rule>` for LR-helper sites that legitimately scan the
-    /// whole sub-expression (e.g. the right operand inside
-    /// `scan_<rule>_lr_N`).
-    pub scan_for_prediction: bool,
+    /// `min_prec` argument that `gen_scan_element` passes when emitting a
+    /// `scan_<rule>(tokens, pos, …)` call for a `RuleRef`. Default is 0
+    /// (full LR scan, matching the parser side). `gen_bt_scan_elements`
+    /// raises this to `i32::MAX` for the LAST element when it is a
+    /// self-reference to the current rule, so that prefix-alt scans
+    /// (`op expr`, etc.) short-circuit the LR suffix loop the OUTER
+    /// LR loop is going to consume — mirroring ANTLR4's k-lookahead.
+    /// Non-LR `scan_<rule>` accept an unused `min_prec` parameter so the
+    /// emitted call site is uniform regardless of whether the target rule
+    /// is left-recursive.
+    pub scan_ruleref_min_prec: i32,
     /// Maps single-alt group type name → the rule name that first defines it.
     /// Used to resolve general group type names inside shared single-alt groups.
     single_alt_owner: TreeMap<String, String>,
@@ -79,7 +79,7 @@ impl GenContext {
             group_counter: 0,
             alt_gc_starts: [],
             prefix_self_ref_min_prec: 0,
-            scan_for_prediction: false,
+            scan_ruleref_min_prec: 0,
             single_alt_owner,
             kind_set_registry: TreeMap::<String, KindSetEntry>::new(),
         };

--- a/package-gale/src/gen_context.wado
+++ b/package-gale/src/gen_context.wado
@@ -32,6 +32,14 @@ pub struct GenContext {
     pub current_rule_name: String,
     pub group_counter: i32,
     pub alt_gc_starts: Array<i32>,
+    /// Override for self-recursive RuleRef calls inside a prefix alt body.
+    /// When non-zero, `gen_element`'s RuleRef branch emits
+    /// `parse_<rule>(p, prefix_self_ref_min_prec)` instead of the default
+    /// `parse_<rule>(p)`. Set by call sites that wrap `gen_alt_body` for
+    /// prefix alts (non-LR alts containing a self-ref) so the inner
+    /// self-ref runs with the precedence ANTLR4 assigns to that alt.
+    /// 0 means no override (the default emission applies).
+    pub prefix_self_ref_min_prec: i32,
     /// Maps single-alt group type name → the rule name that first defines it.
     /// Used to resolve general group type names inside shared single-alt groups.
     single_alt_owner: TreeMap<String, String>,
@@ -59,6 +67,7 @@ impl GenContext {
             current_rule_name: "",
             group_counter: 0,
             alt_gc_starts: [],
+            prefix_self_ref_min_prec: 0,
             single_alt_owner,
             kind_set_registry: TreeMap::<String, KindSetEntry>::new(),
         };

--- a/package-gale/src/gen_context.wado
+++ b/package-gale/src/gen_context.wado
@@ -40,6 +40,17 @@ pub struct GenContext {
     /// self-ref runs with the precedence ANTLR4 assigns to that alt.
     /// 0 means no override (the default emission applies).
     pub prefix_self_ref_min_prec: i32,
+    /// When true, `gen_scan_element`'s RuleRef branch emits
+    /// `scan_<rule>_atom(...)` instead of `scan_<rule>(...)` for LR rules.
+    /// Set by `gen_bt_scan_if_possible` so that prediction-time bt-scans
+    /// don't follow an LR rule's suffix loop into tokens that the OUTER
+    /// LR loop would parse — mirroring ANTLR4's k-lookahead semantics
+    /// where the prediction stops at the differentiating prefix instead
+    /// of running the full LR cascade. False (the default) keeps
+    /// `scan_<rule>` for LR-helper sites that legitimately scan the
+    /// whole sub-expression (e.g. the right operand inside
+    /// `scan_<rule>_lr_N`).
+    pub scan_for_prediction: bool,
     /// Maps single-alt group type name → the rule name that first defines it.
     /// Used to resolve general group type names inside shared single-alt groups.
     single_alt_owner: TreeMap<String, String>,
@@ -68,6 +79,7 @@ impl GenContext {
             group_counter: 0,
             alt_gc_starts: [],
             prefix_self_ref_min_prec: 0,
+            scan_for_prediction: false,
             single_alt_owner,
             kind_set_registry: TreeMap::<String, KindSetEntry>::new(),
         };
@@ -345,9 +357,16 @@ impl GenContext {
             for let alt of &rule.alternatives {
                 let mut non_nullable_count = 0;
                 let mut single_ok = false;
+                let mut has_nullable = false;
                 for let elem of &alt.elements {
                     if is_nullable(elem) {
-                        continue;
+                        // A nullable element (Star/Optional Repeat) can consume
+                        // additional tokens when its inner matches. e.g.
+                        // `'-'? Integer` is 1 token without `-` but 2 with `-`.
+                        // Treat any nullable element as disqualifying so the
+                        // rule isn't misclassified as strictly single-token.
+                        has_nullable = true;
+                        break;
                     }
                     non_nullable_count += 1;
                     if non_nullable_count > 1 {
@@ -359,7 +378,7 @@ impl GenContext {
                         single_ok = self.rule_is_single_token(&r.name, visiting);
                     }
                 }
-                if non_nullable_count != 1 || !single_ok {
+                if has_nullable || non_nullable_count != 1 || !single_ok {
                     all_alts_ok = false;
                     break;
                 }

--- a/package-gale/src/parser_gen.wado
+++ b/package-gale/src/parser_gen.wado
@@ -1215,10 +1215,13 @@ fn gen_bt_scan_if_possible(w: &mut CodeWriter, alt: &Alternative, fn_name: &Stri
     f.emit_begin(w);
     w.line("let mut pos = pos;");
 
-    let saved_scan_for_prediction = ctx.scan_for_prediction;
-    ctx.scan_for_prediction = true;
-    gen_scan_elements(w, &alt.elements, 0, prefix_len, ctx);
-    ctx.scan_for_prediction = saved_scan_for_prediction;
+    // bt-scan should treat the LAST element as atom-only when it is a
+    // self-reference to the current rule — that is the prefix-alt case
+    // (`op expr` etc.) where the OUTER LR loop will consume what follows
+    // and including it here would over-match. Inner self-refs, by
+    // contrast, are bounded by surrounding tokens (e.g. `K_WHEN expr
+    // K_THEN expr` inside `case_expr`) and need a full scan.
+    gen_bt_scan_elements(w, &alt.elements, 0, prefix_len, ctx);
 
     w.line("return pos;");
     w.end();
@@ -1913,6 +1916,34 @@ fn gen_scan_elements(w: &mut CodeWriter, elements: &Array<Element>, start: i32, 
             }
         }
         gen_scan_element(w, elem, ctx, &"return -1;");
+    }
+}
+
+/// Specialisation of `gen_scan_elements` for bt-scan helpers. Toggles
+/// `ctx.scan_for_prediction` on for the LAST element only when it is a
+/// self-reference to the current rule, so that the inner scan emits
+/// `scan_<rule>_atom` (no LR suffix loop) — the prefix-alt scenario
+/// where the outer LR loop will consume the trailing tokens.
+fn gen_bt_scan_elements(w: &mut CodeWriter, elements: &Array<Element>, start: i32, end: i32, ctx: &mut GenContext) {
+    for let mut i = start; i < end; i += 1 {
+        let elem = &elements[i];
+        let is_last_self_ref = i == end - 1 && is_self_ref_element(elem, &ctx.current_rule_name);
+        let saved = ctx.scan_for_prediction;
+        if is_last_self_ref {
+            ctx.scan_for_prediction = true;
+        }
+        if let Repeat(rep) = elem {
+            if let Optional = rep.kind {
+                if is_ruleref_optional(&rep.element) {
+                    let follow = ctx.first_of_elements_from(elements, i + 1);
+                    gen_scan_repeat_optional_with_follow(w, rep, ctx, &follow);
+                    ctx.scan_for_prediction = saved;
+                    continue;
+                }
+            }
+        }
+        gen_scan_element(w, elem, ctx, &"return -1;");
+        ctx.scan_for_prediction = saved;
     }
 }
 

--- a/package-gale/src/parser_gen.wado
+++ b/package-gale/src/parser_gen.wado
@@ -2412,6 +2412,8 @@ fn gen_parse_fn(w: &mut CodeWriter, rule: &ParserRule, ctx: &mut GenContext) {
                     f.emit_begin(w);
                     w.line("let start = p.peek().span.start;");
                     ctx.group_counter = ctx.alt_gc_starts[alt_idx];
+                    let saved_prefix_prec = ctx.prefix_self_ref_min_prec;
+                    ctx.prefix_self_ref_min_prec = compute_prefix_self_ref_min_prec(rule, alt_idx);
                     gen_alt_body(
                         w,
                         &type_name,
@@ -2420,6 +2422,7 @@ fn gen_parse_fn(w: &mut CodeWriter, rule: &ParserRule, ctx: &mut GenContext) {
                         alt,
                         ctx,
                     );
+                    ctx.prefix_self_ref_min_prec = saved_prefix_prec;
                     w.end();
                     w.blank();
 
@@ -2592,6 +2595,8 @@ fn gen_multi_alt_body(w: &mut CodeWriter, rule: &ParserRule, type_name: &String,
         }
 
         ctx.group_counter = ctx.alt_gc_starts[alt_idx];
+        let saved_prefix_prec = ctx.prefix_self_ref_min_prec;
+        ctx.prefix_self_ref_min_prec = compute_prefix_self_ref_min_prec(rule, alt_idx);
         gen_alt_body(
             w,
             type_name,
@@ -2600,6 +2605,7 @@ fn gen_multi_alt_body(w: &mut CodeWriter, rule: &ParserRule, type_name: &String,
             alt,
             ctx,
         );
+        ctx.prefix_self_ref_min_prec = saved_prefix_prec;
         w.end();
     }
 
@@ -2685,7 +2691,11 @@ fn gen_element(w: &mut CodeWriter, elem: &Element, ctx: &mut GenContext, name_co
     if let RuleRef(r) = elem {
         let fn_name = `parse_{r.snake_name}`;
         let field_name = dedup_name(&r.field_name, name_counts);
-        w.line(`let {field_name} = {fn_name}(p)?;`);
+        if ctx.prefix_self_ref_min_prec > 0 && r.name == ctx.current_rule_name {
+            w.line(`let {field_name} = {fn_name}(p, {ctx.prefix_self_ref_min_prec})?;`);
+        } else {
+            w.line(`let {field_name} = {fn_name}(p)?;`);
+        }
         return;
     }
     if let Wildcard(_) = elem {
@@ -5629,6 +5639,8 @@ fn gen_prediction_code_inner(w: &mut CodeWriter, node: &PredictionNode, fn_name:
             let alt = &alts[*idx];
             let sname = `{strip_suffix(type_name, "Node")}{alt_case_names[*idx]}`;
             ctx.group_counter = ctx.alt_gc_starts[*idx];
+            let saved_prefix_prec = ctx.prefix_self_ref_min_prec;
+            ctx.prefix_self_ref_min_prec = compute_prefix_self_ref_min_prec_alts(alts, &ctx.current_rule_name, *idx);
             gen_alt_body_skip(
                 w,
                 type_name,
@@ -5638,6 +5650,7 @@ fn gen_prediction_code_inner(w: &mut CodeWriter, node: &PredictionNode, fn_name:
                 ctx,
                 skip,
             );
+            ctx.prefix_self_ref_min_prec = saved_prefix_prec;
         }
         return;
     }
@@ -5856,6 +5869,8 @@ fn gen_multi_alt_body_bt(w: &mut CodeWriter, rule: &ParserRule, type_name: &Stri
             let alt = &rule.alternatives[alt_idx];
             let sname = `{strip_suffix(type_name, "Node")}{case_names[alt_idx]}`;
             ctx.group_counter = ctx.alt_gc_starts[alt_idx];
+            let saved_prefix_prec = ctx.prefix_self_ref_min_prec;
+            ctx.prefix_self_ref_min_prec = compute_prefix_self_ref_min_prec(rule, alt_idx);
             gen_alt_body(
                 w,
                 type_name,
@@ -5864,6 +5879,7 @@ fn gen_multi_alt_body_bt(w: &mut CodeWriter, rule: &ParserRule, type_name: &Stri
                 alt,
                 ctx,
             );
+            ctx.prefix_self_ref_min_prec = saved_prefix_prec;
         } else {
             // Sort group by specificity before building prediction tree.
             let mut sorted_group = group.sorted();
@@ -6049,6 +6065,84 @@ fn is_left_recursive(alt: &Alternative, rule_name: &String) -> bool {
         return r.name == *rule_name;
     }
     return false;
+}
+
+/// True iff the alternative matches ANTLR4's `prefix` shape from
+/// `LeftRecursiveRuleWalker.g`:
+///   prefix : ALT element+ recurse epsilonElement* ;
+/// i.e. the alt does NOT start with a self-reference but its LAST
+/// element IS a self-reference. Examples: `'-' e`, `('~'|'!') e`,
+/// `'(' typespec ')' e`. Counter-examples that look superficially
+/// similar but are NOT prefix alts in ANTLR4's classification:
+///   - `'(' e ')'` — last elem is `')'`, not self-ref → "other" alt
+///   - `'new' T ( ... e ... )` — last elem is a Group → "other" alt
+/// "Other" alts (`otherAlt`) are NOT given a precedence rewrite in
+/// ANTLR4: their inner self-refs run with `_p = 0`, accepting all
+/// LR operators inside.
+///
+/// Gale's IR has already stripped action bodies and semantic predicates,
+/// so the upstream `epsilonElement*` tail collapses to the empty case.
+fn is_prefix_alt(alt: &Alternative, rule_name: &String) -> bool {
+    if is_left_recursive(alt, rule_name) {
+        return false;
+    }
+    if alt.elements.len() == 0 {
+        return false;
+    }
+    let last_idx = alt.elements.len() - 1;
+    return is_self_ref_element(&alt.elements[last_idx], rule_name);
+}
+
+/// True iff the element is a direct RuleRef to `rule_name` (possibly
+/// wrapped in a single `Label`). Mirrors `is_left_recursive`'s use of
+/// `unwrap_label` so labeled self-refs at the alt tail (e.g. `b=e`)
+/// are still recognised.
+fn is_self_ref_element(elem: &Element, rule_name: &String) -> bool {
+    if let RuleRef(r) = unwrap_label(elem) {
+        return r.name == *rule_name;
+    }
+    return false;
+}
+
+/// Compute the `min_prec` value to pass into self-recursive RuleRef calls
+/// inside a prefix alt. ANTLR4's left-recursion transform calls the inner
+/// `e` of a prefix alt with the alt's own precedence (`e[precedence(alt)]`),
+/// so any LR suffix below the prefix alt in source order is excluded.
+///
+/// Returns 0 if the alt is not a prefix alt, or if the rule has no LR alts
+/// (in which case `parse_<rule>` has no `min_prec` parameter and the
+/// override would not be valid).
+///
+/// Formula: count the LR alts at positions strictly greater than `alt_idx`
+/// in `rule.alternatives`. Their `own_prec` values are 1..N (N = the count),
+/// so setting `min_prec = N + 1` rejects all of them while still admitting
+/// LR alts that come before this prefix.
+fn compute_prefix_self_ref_min_prec(rule: &ParserRule, alt_idx: i32) -> i32 {
+    return compute_prefix_self_ref_min_prec_alts(&rule.alternatives, &rule.name, alt_idx);
+}
+
+fn compute_prefix_self_ref_min_prec_alts(alts: &Array<Alternative>, rule_name: &String, alt_idx: i32) -> i32 {
+    if alt_idx < 0 || alt_idx >= alts.len() {
+        return 0;
+    }
+    let alt = &alts[alt_idx];
+    if !is_prefix_alt(alt, rule_name) {
+        return 0;
+    }
+    let mut lr_after = 0;
+    let mut has_any_lr = false;
+    for let mut i = 0; i < alts.len(); i += 1 {
+        if is_left_recursive(&alts[i], rule_name) {
+            has_any_lr = true;
+            if i > alt_idx {
+                lr_after += 1;
+            }
+        }
+    }
+    if !has_any_lr {
+        return 0;
+    }
+    return lr_after + 1;
 }
 
 fn compute_overlap_groups(first_sets: &Array<Array<String>>) -> Array<Array<i32>> {

--- a/package-gale/src/parser_gen.wado
+++ b/package-gale/src/parser_gen.wado
@@ -1927,10 +1927,12 @@ fn gen_scan_elements(w: &mut CodeWriter, elements: &Array<Element>, start: i32, 
     }
 }
 
-/// Specialisation of `gen_scan_elements` for bt-scan helpers. Toggles
-/// `ctx.scan_for_prediction` on for the LAST element only when it is a
-/// self-reference to the current rule, so that the inner scan emits
-/// `scan_<rule>_atom` (no LR suffix loop) — the prefix-alt scenario
+/// Specialisation of `gen_scan_elements` for bt-scan helpers. Raises
+/// `ctx.scan_ruleref_min_prec` to `i32::MAX` for the LAST element only
+/// when it is a self-reference to the current rule, so that
+/// `gen_scan_element` emits `scan_<rule>(tokens, pos, i32::MAX)` for
+/// that one position. The MAX guards short-circuit the LR suffix loop
+/// inside the target rule's `scan_<rule>` — the prefix-alt scenario
 /// where the outer LR loop will consume the trailing tokens.
 fn gen_bt_scan_elements(w: &mut CodeWriter, elements: &Array<Element>, start: i32, end: i32, ctx: &mut GenContext) {
     for let mut i = start; i < end; i += 1 {

--- a/package-gale/src/parser_gen.wado
+++ b/package-gale/src/parser_gen.wado
@@ -1272,6 +1272,14 @@ fn gen_scan_function(w: &mut CodeWriter, rule: &ParserRule, ctx: &mut GenContext
     let mut f = FnSpec::new(&fn_name);
     f.add_param("tokens", "&Array<Token>");
     f.add_param("pos", "i32");
+    // Accept (and ignore) min_prec so call sites pass it uniformly
+    // regardless of whether the target rule is left-recursive. See
+    // `GenContext.scan_ruleref_min_prec` for the bt-scan use case.
+    f.add_param_spec(ParamSpec {
+        name: "min_prec",
+        type_str: "i32",
+        default_value: Option::<String>::Some("0"),
+    });
     f.set_return_type("i32");
     f.emit_begin(w);
 
@@ -1928,22 +1936,22 @@ fn gen_bt_scan_elements(w: &mut CodeWriter, elements: &Array<Element>, start: i3
     for let mut i = start; i < end; i += 1 {
         let elem = &elements[i];
         let is_last_self_ref = i == end - 1 && is_self_ref_element(elem, &ctx.current_rule_name);
-        let saved = ctx.scan_for_prediction;
+        let saved = ctx.scan_ruleref_min_prec;
         if is_last_self_ref {
-            ctx.scan_for_prediction = true;
+            ctx.scan_ruleref_min_prec = i32::MAX;
         }
         if let Repeat(rep) = elem {
             if let Optional = rep.kind {
                 if is_ruleref_optional(&rep.element) {
                     let follow = ctx.first_of_elements_from(elements, i + 1);
                     gen_scan_repeat_optional_with_follow(w, rep, ctx, &follow);
-                    ctx.scan_for_prediction = saved;
+                    ctx.scan_ruleref_min_prec = saved;
                     continue;
                 }
             }
         }
         gen_scan_element(w, elem, ctx, &"return -1;");
-        ctx.scan_for_prediction = saved;
+        ctx.scan_ruleref_min_prec = saved;
     }
 }
 
@@ -2117,8 +2125,10 @@ fn gen_scan_element(w: &mut CodeWriter, elem: &Element, ctx: &mut GenContext, fa
         return;
     }
     if let RuleRef(r) = elem {
-        let fn_name = scan_call_name_for_ruleref(&r.name, &r.snake_name, ctx);
-        w.line(`pos = {fn_name}(tokens, pos);`);
+        // Always pass min_prec — non-LR `scan_<rule>` accept and ignore it.
+        // bt-scan sets `ctx.scan_ruleref_min_prec` to `i32::MAX` so any LR
+        // suffix loop in the target rule short-circuits.
+        w.line(`pos = scan_{r.snake_name}(tokens, pos, {ctx.scan_ruleref_min_prec});`);
         w.line(`if pos < 0 \{ {*fail_stmt} \}`);
         return;
     }
@@ -2143,37 +2153,6 @@ fn gen_scan_element(w: &mut CodeWriter, elem: &Element, ctx: &mut GenContext, fa
     }
 }
 
-/// Pick the right `scan_<rule>` function name based on whether we're emitting
-/// a scan for a prediction-time bt-scan or for the LR helper itself.
-///
-/// In prediction-time bt-scans (`ctx.scan_for_prediction == true`), an LR rule
-/// reference must use `scan_<rule>_atom` so the scan stops after one atom and
-/// does not wander into LR-suffix tokens that the OUTER LR loop is going to
-/// parse — otherwise `op expr` (alt 1 of `expr : literal | op expr | expr op
-/// expr`) would scan the whole binary-expression cascade and outpace the
-/// `literal` alt's scan, even though ANTLR4's prediction would treat them as
-/// equivalent and pick the earlier alt. For non-LR rules, `scan_<rule>` is
-/// already atom-only, and for LR-helper sites the full `scan_<rule>` is what
-/// we want for the right operand.
-fn scan_call_name_for_ruleref(rule_name: &String, snake_name: &String, ctx: &mut GenContext) -> String {
-    if ctx.scan_for_prediction && rule_has_lr_alt(rule_name, ctx) {
-        return `scan_{*snake_name}_atom`;
-    }
-    return `scan_{*snake_name}`;
-}
-
-fn rule_has_lr_alt(rule_name: &String, ctx: &GenContext) -> bool {
-    let r = ctx.find_rule(rule_name);
-    if let Some(rule) = r {
-        for let alt of &rule.alternatives {
-            if is_left_recursive(alt, rule_name) {
-                return true;
-            }
-        }
-    }
-    return false;
-}
-
 /// Emit scan code for an element that assigns to `pos` (may set -1 on failure).
 /// Used inside optional/repetition blocks where failure means backtrack, not abort.
 fn gen_scan_element_assign(w: &mut CodeWriter, elem: &Element, ctx: &mut GenContext) {
@@ -2192,8 +2171,7 @@ fn gen_scan_element_assign(w: &mut CodeWriter, elem: &Element, ctx: &mut GenCont
         return;
     }
     if let RuleRef(r) = elem {
-        let fn_name = `scan_{r.snake_name}`;
-        w.line(`pos = {fn_name}(tokens, pos);`);
+        w.line(`pos = scan_{r.snake_name}(tokens, pos, {ctx.scan_ruleref_min_prec});`);
         return;
     }
     if let Wildcard(_) = elem {
@@ -5705,7 +5683,9 @@ fn gen_prediction_code_inner(w: &mut CodeWriter, node: &PredictionNode, fn_name:
             let sname = `{strip_suffix(type_name, "Node")}{alt_case_names[*idx]}`;
             ctx.group_counter = ctx.alt_gc_starts[*idx];
             let saved_prefix_prec = ctx.prefix_self_ref_min_prec;
-            ctx.prefix_self_ref_min_prec = compute_prefix_self_ref_min_prec_alts(alts, &ctx.current_rule_name, *idx);
+            if let Some(rule) = ctx.find_rule(&ctx.current_rule_name) {
+                ctx.prefix_self_ref_min_prec = compute_prefix_self_ref_min_prec(rule, *idx);
+            }
             gen_alt_body_skip(
                 w,
                 type_name,
@@ -6121,15 +6101,13 @@ fn increment_count(counts: &mut Array<[String, i32]>, name: &String) {
 /// True iff the alternative is left-recursive: its first element references
 /// the enclosing rule by name. ANTLR4 treats labeled self-references like
 /// `a=e` at the start of an alt as left-recursive too (per
-/// `vendor/antlr4/doc/left-recursion.md`), so we unwrap one `Label`.
+/// `vendor/antlr4/doc/left-recursion.md`), so `is_self_ref_element`
+/// unwraps one `Label`.
 fn is_left_recursive(alt: &Alternative, rule_name: &String) -> bool {
     if alt.elements.len() == 0 {
         return false;
     }
-    if let RuleRef(r) = unwrap_label(&alt.elements[0]) {
-        return r.name == *rule_name;
-    }
-    return false;
+    return is_self_ref_element(&alt.elements[0], rule_name);
 }
 
 /// True iff the alternative matches ANTLR4's `prefix` shape from
@@ -6183,10 +6161,8 @@ fn is_self_ref_element(elem: &Element, rule_name: &String) -> bool {
 /// so setting `min_prec = N + 1` rejects all of them while still admitting
 /// LR alts that come before this prefix.
 fn compute_prefix_self_ref_min_prec(rule: &ParserRule, alt_idx: i32) -> i32 {
-    return compute_prefix_self_ref_min_prec_alts(&rule.alternatives, &rule.name, alt_idx);
-}
-
-fn compute_prefix_self_ref_min_prec_alts(alts: &Array<Alternative>, rule_name: &String, alt_idx: i32) -> i32 {
+    let alts = &rule.alternatives;
+    let rule_name = &rule.name;
     if alt_idx < 0 || alt_idx >= alts.len() {
         return 0;
     }

--- a/package-gale/src/parser_gen.wado
+++ b/package-gale/src/parser_gen.wado
@@ -1215,7 +1215,10 @@ fn gen_bt_scan_if_possible(w: &mut CodeWriter, alt: &Alternative, fn_name: &Stri
     f.emit_begin(w);
     w.line("let mut pos = pos;");
 
+    let saved_scan_for_prediction = ctx.scan_for_prediction;
+    ctx.scan_for_prediction = true;
     gen_scan_elements(w, &alt.elements, 0, prefix_len, ctx);
+    ctx.scan_for_prediction = saved_scan_for_prediction;
 
     w.line("return pos;");
     w.end();
@@ -2083,7 +2086,7 @@ fn gen_scan_element(w: &mut CodeWriter, elem: &Element, ctx: &mut GenContext, fa
         return;
     }
     if let RuleRef(r) = elem {
-        let fn_name = `scan_{r.snake_name}`;
+        let fn_name = scan_call_name_for_ruleref(&r.name, &r.snake_name, ctx);
         w.line(`pos = {fn_name}(tokens, pos);`);
         w.line(`if pos < 0 \{ {*fail_stmt} \}`);
         return;
@@ -2107,6 +2110,37 @@ fn gen_scan_element(w: &mut CodeWriter, elem: &Element, ctx: &mut GenContext, fa
         gen_scan_group(w, &g.alternatives, ctx, fail_stmt, is_lenient_group(&g.alternatives));
         return;
     }
+}
+
+/// Pick the right `scan_<rule>` function name based on whether we're emitting
+/// a scan for a prediction-time bt-scan or for the LR helper itself.
+///
+/// In prediction-time bt-scans (`ctx.scan_for_prediction == true`), an LR rule
+/// reference must use `scan_<rule>_atom` so the scan stops after one atom and
+/// does not wander into LR-suffix tokens that the OUTER LR loop is going to
+/// parse — otherwise `op expr` (alt 1 of `expr : literal | op expr | expr op
+/// expr`) would scan the whole binary-expression cascade and outpace the
+/// `literal` alt's scan, even though ANTLR4's prediction would treat them as
+/// equivalent and pick the earlier alt. For non-LR rules, `scan_<rule>` is
+/// already atom-only, and for LR-helper sites the full `scan_<rule>` is what
+/// we want for the right operand.
+fn scan_call_name_for_ruleref(rule_name: &String, snake_name: &String, ctx: &mut GenContext) -> String {
+    if ctx.scan_for_prediction && rule_has_lr_alt(rule_name, ctx) {
+        return `scan_{*snake_name}_atom`;
+    }
+    return `scan_{*snake_name}`;
+}
+
+fn rule_has_lr_alt(rule_name: &String, ctx: &GenContext) -> bool {
+    let r = ctx.find_rule(rule_name);
+    if let Some(rule) = r {
+        for let alt of &rule.alternatives {
+            if is_left_recursive(alt, rule_name) {
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 /// Emit scan code for an element that assigns to `pos` (may set -1 on failure).

--- a/package-gale/tests/antlr4-compat/stage_b/LeftRecursion/Expressions_7_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b/LeftRecursion/Expressions_7_test.wado
@@ -14,8 +14,6 @@ use t from "../../grammars/LeftRecursion/Expressions_7.g4"
     };
 use { normalize_tree } from "../../grammars/LeftRecursion/Expressions_7.g4";
 
-#[TODO]
-// triage: Stage B parse-tree shape divergence in LR rewriting (prefix vs binary op grouping) — investigation pending
 test "stage_b: LeftRecursion/Expressions_7" {
     let input = "-a+b";
     let expected = "(s (e (e - (e a)) + (e b)))";

--- a/package-gale/tests/antlr4-compat/stage_b/LeftRecursion/PrefixAndOtherAlt_1_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b/LeftRecursion/PrefixAndOtherAlt_1_test.wado
@@ -14,8 +14,6 @@ use t from "../../grammars/LeftRecursion/PrefixAndOtherAlt_1.g4"
     };
 use { normalize_tree } from "../../grammars/LeftRecursion/PrefixAndOtherAlt_1.g4";
 
-#[TODO]
-// triage: Stage B parse-tree shape divergence in LR with prefix operator alternation — investigation pending
 test "stage_b: LeftRecursion/PrefixAndOtherAlt_1" {
     let input = "-1";
     let expected = "(s (expr (literal - 1)))";

--- a/package-gale/tests/antlr4-compat/stage_b/LeftRecursion/PrefixAndOtherAlt_2_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b/LeftRecursion/PrefixAndOtherAlt_2_test.wado
@@ -14,8 +14,6 @@ use t from "../../grammars/LeftRecursion/PrefixAndOtherAlt_2.g4"
     };
 use { normalize_tree } from "../../grammars/LeftRecursion/PrefixAndOtherAlt_2.g4";
 
-#[TODO]
-// triage: Stage B parse-tree shape divergence in LR with prefix operator alternation — investigation pending
 test "stage_b: LeftRecursion/PrefixAndOtherAlt_2" {
     let input = "-1 + -1";
     let expected = "(s (expr (expr (literal - 1)) (op +) (expr (literal - 1))))";

--- a/package-gale/tests/antlr4-compat/status.toml
+++ b/package-gale/tests/antlr4-compat/status.toml
@@ -43,7 +43,6 @@
 "ParserErrors/SingleTokenDeletionConsumption" = "trailing <! ... !> StringTemplate comment outside any rule — testsuite descriptor artifact, not a self-contained .g4"
 
 [stage_b_todo]
-"LeftRecursion/Expressions_7" = "Stage B parse-tree shape divergence in LR rewriting (prefix vs binary op grouping) — investigation pending"
 "LeftRecursion/JavaExpressions_7" = "Stage B test parse fails with Result::Err — investigation pending"
 "LeftRecursion/JavaExpressions_8" = "Stage B test parse fails with Result::Err — investigation pending"
 "LeftRecursion/JavaExpressions_9" = "Stage B test parse fails with Result::Err — investigation pending"

--- a/package-gale/tests/antlr4-compat/status.toml
+++ b/package-gale/tests/antlr4-compat/status.toml
@@ -48,8 +48,6 @@
 "LeftRecursion/JavaExpressions_9" = "Stage B test parse fails with Result::Err — investigation pending"
 "LeftRecursion/JavaExpressions_12" = "Stage B test parse fails with Result::Err — investigation pending"
 "LeftRecursion/PrecedenceFilterConsidersContext" = "Stage B test parse fails with Result::Err — precedence filter behaviour gap"
-"LeftRecursion/PrefixAndOtherAlt_1" = "Stage B parse-tree shape divergence in LR with prefix operator alternation — investigation pending"
-"LeftRecursion/PrefixAndOtherAlt_2" = "Stage B parse-tree shape divergence in LR with prefix operator alternation — investigation pending"
 "LeftRecursion/SemPredFailOption" = "Stage B parse-tree shape diverges because action bodies are skipped (the predicate guard is dropped) — Stage C territory"
 "ParserExec/BuildParseTree_TRUE" = "Stage B test parse fails or tree shape diverges — investigation pending"
 "ParserExec/PredictionMode_LL" = "Stage B test parse fails with Result::Err — full-context LL prediction not yet enabled in generated parsers"

--- a/package-gale/tests/driver_rust_test.wado
+++ b/package-gale/tests/driver_rust_test.wado
@@ -150,23 +150,28 @@ test "tree: deeply nested grouping" {
 }
 
 test "tree: negation scoping with boolean and comparison" {
+    // Per ANTLR4 left-recursion precedence: a prefix alt's inner self-ref
+    // is called with the alt's own precedence, so `!`/`-` (NegationExpression
+    // at alt position 13) only admits suffix operators with strictly higher
+    // precedence — the boolean and comparison operators below it do not
+    // attach. `!true && 1 != 2 || false` therefore parses as
+    // `((!true) && (1 != 2)) || false`.
     assert_tree(&"const X: i32 = !true && 1 != 2 || false;", &"
         (crate (item (visItem (constantItem
             const (identifier X) :
             (type_ (typeNoBounds (traitObjectTypeOneBound (traitBound
                 (typePath (typePathSegment (pathIdentSegment (identifier i32))))))))
             =
-            (expression !
+            (expression
                 (expression
+                    (expression ! (expression (literalExpression true)))
+                    &&
                     (expression
-                        (expression (literalExpression true))
-                        &&
-                        (expression
-                            (expression (literalExpression 1))
-                            (comparisonOperator !=)
-                            (expression (literalExpression 2))))
-                    ||
-                    (expression (literalExpression false))))
+                        (expression (literalExpression 1))
+                        (comparisonOperator !=)
+                        (expression (literalExpression 2))))
+                ||
+                (expression (literalExpression false)))
             ;))))
     ");
 }

--- a/package-gale/tests/generated/antlr4/ANTLRv4Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4/ANTLRv4Lexer.g4.kiln.json
@@ -17,7 +17,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4/antlrv4.wado",
-      "hash": "9db5215520896ec5d90eda7dc2166deeaced5f1dbd6b792b72362245042cccd9",
+      "hash": "72493c07d081794663f40d4bdd31121991e1d9d59a663c360c52430e2a41d2f4",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4/ANTLRv4Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4/ANTLRv4Lexer.g4.kiln.json
@@ -17,7 +17,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4/antlrv4.wado",
-      "hash": "72493c07d081794663f40d4bdd31121991e1d9d59a663c360c52430e2a41d2f4",
+      "hash": "2286c951bdc22845f111ae4378bcd120634f6ff765d263309ff9c4212792bc2f",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4/antlrv4.wado
+++ b/package-gale/tests/generated/antlr4/antlrv4.wado
@@ -7120,18 +7120,28 @@ fn parse_element(p: &mut Parser) -> Result<ElementNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if _gale_kind_set_20(kind) {
-        if p.peek_kind() == TK_RULE_REF {
-            if _gale_kind_set_21(p.peek_at(1)) {
+        if _gale_kind_set_1(p.peek_kind()) {
+            let _sd_tokens = &p.tokens;
+            let _sd_pos = p.pos;
+            let _sd_p_0 = parse_element_scan_0(_sd_tokens, _sd_pos);
+            let _sd_p_1 = parse_element_scan_1(_sd_tokens, _sd_pos);
+            let mut _sd_best_i: i32 = -1;
+            let mut _sd_best_p: i32 = -1;
+            if _sd_p_0 > _sd_best_p {
+                _sd_best_p = _sd_p_0;
+                _sd_best_i = 0;
+            }
+            if _sd_p_1 > _sd_best_p {
+                _sd_best_p = _sd_p_1;
+                _sd_best_i = 1;
+            }
+            if _sd_best_i == 0 {
                 return parse_element_bt_0(p);
-            } else if _gale_kind_set_10(p.peek_at(1)) {
+            }
+            if _sd_best_i == 1 {
                 return parse_element_bt_1(p);
             }
-        } else if p.peek_kind() == TK_TOKEN_REF {
-            if _gale_kind_set_21(p.peek_at(1)) {
-                return parse_element_bt_0(p);
-            } else if _gale_kind_set_10(p.peek_at(1)) {
-                return parse_element_bt_1(p);
-            }
+            return parse_element_bt_1(p);
         } else if _gale_kind_set_14(p.peek_kind()) {
             return parse_element_bt_1(p);
         }
@@ -7459,27 +7469,11 @@ fn parse_lexer_atom(p: &mut Parser) -> Result<LexerAtomNode, ParseError> {
     let kind = p.peek_kind();
     if _gale_kind_set_17(kind) {
         if p.peek_kind() == TK_STRING_LITERAL {
-            let _sd_tokens = &p.tokens;
-            let _sd_pos = p.pos;
-            let _sd_p_0 = parse_lexer_atom_scan_0(_sd_tokens, _sd_pos);
-            let _sd_p_1 = parse_lexer_atom_scan_1(_sd_tokens, _sd_pos);
-            let mut _sd_best_i: i32 = -1;
-            let mut _sd_best_p: i32 = -1;
-            if _sd_p_0 > _sd_best_p {
-                _sd_best_p = _sd_p_0;
-                _sd_best_i = 0;
-            }
-            if _sd_p_1 > _sd_best_p {
-                _sd_best_p = _sd_p_1;
-                _sd_best_i = 1;
-            }
-            if _sd_best_i == 0 {
+            if p.peek_at(1) == TK_RANGE {
                 return parse_lexer_atom_bt_0(p);
-            }
-            if _sd_best_i == 1 {
+            } else if p.peek_at(1) == TK_LT {
                 return parse_lexer_atom_bt_1(p);
             }
-            return parse_lexer_atom_bt_1(p);
         } else if p.peek_kind() == TK_TOKEN_REF {
             return parse_lexer_atom_bt_1(p);
         }
@@ -7611,7 +7605,7 @@ fn parse_not_set(p: &mut Parser) -> Result<NotSetNode, ParseError> {
     let kind = p.peek_kind();
     if kind == TK_NOT {
         let not = p.expect(TK_NOT)?;
-        if _gale_kind_set_22(p.peek_kind()) {
+        if _gale_kind_set_21(p.peek_kind()) {
             let set_element = parse_set_element(p)?;
             return Result::<NotSetNode, ParseError>::Ok(NotSetNode::Alt0(NotSetAlt0 {
                 span: Span::new(start, p.last_end()),
@@ -8060,14 +8054,28 @@ fn parse_element_option(p: &mut Parser) -> Result<ElementOptionNode, ParseError>
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if _gale_kind_set_1(kind) {
-        if p.peek_kind() == TK_RULE_REF {
-            if p.peek_at(1) == TK_ASSIGN {
+        if _gale_kind_set_1(p.peek_kind()) {
+            let _sd_tokens = &p.tokens;
+            let _sd_pos = p.pos;
+            let _sd_p_0 = parse_element_option_scan_0(_sd_tokens, _sd_pos);
+            let _sd_p_1 = parse_element_option_scan_1(_sd_tokens, _sd_pos);
+            let mut _sd_best_i: i32 = -1;
+            let mut _sd_best_p: i32 = -1;
+            if _sd_p_0 > _sd_best_p {
+                _sd_best_p = _sd_p_0;
+                _sd_best_i = 0;
+            }
+            if _sd_p_1 > _sd_best_p {
+                _sd_best_p = _sd_p_1;
+                _sd_best_i = 1;
+            }
+            if _sd_best_i == 0 {
+                return parse_element_option_bt_0(p);
+            }
+            if _sd_best_i == 1 {
                 return parse_element_option_bt_1(p);
             }
-        } else if p.peek_kind() == TK_TOKEN_REF {
-            if p.peek_at(1) == TK_ASSIGN {
-                return parse_element_option_bt_1(p);
-            }
+            return parse_element_option_bt_1(p);
         }
     }
     return Result::<ElementOptionNode, ParseError>::Err(ParseError::new(
@@ -9245,10 +9253,6 @@ fn _gale_kind_set_20(k: i32) -> bool {
 }
 
 fn _gale_kind_set_21(k: i32) -> bool {
-    return k matches { TK_ASSIGN | TK_PLUS_ASSIGN };
-}
-
-fn _gale_kind_set_22(k: i32) -> bool {
     return k matches { TK_LEXER_CHAR_SET | TK_STRING_LITERAL | TK_TOKEN_REF };
 }
 

--- a/package-gale/tests/generated/antlr4/antlrv4.wado
+++ b/package-gale/tests/generated/antlr4/antlrv4.wado
@@ -3822,21 +3822,21 @@ impl Parser {
     }
 }
 
-fn scan_grammar_spec(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_grammar_spec(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_grammar_decl(tokens, pos);
+    pos = scan_grammar_decl(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && _gale_kind_set_0(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_prequel_construct(tokens, pos);
+        pos = scan_prequel_construct(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
-    pos = scan_rules(tokens, pos);
+    pos = scan_rules(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_MODE {
         let sp = pos;
-        pos = scan_mode_spec(tokens, pos);
+        pos = scan_mode_spec(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -3845,18 +3845,18 @@ fn scan_grammar_spec(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_grammar_decl(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_grammar_decl(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_grammar_type(tokens, pos);
+    pos = scan_grammar_type(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_grammar_type(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_grammar_type(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -3896,7 +3896,7 @@ fn scan_grammar_type(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_prequel_construct(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_prequel_construct(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -3904,7 +3904,7 @@ fn scan_prequel_construct(tokens: &Array<Token>, pos: i32) -> i32 {
         if alt_kind == TK_OPTIONS {
             pos = start;
             try_0: {
-                pos = scan_options_spec(tokens, pos);
+                pos = scan_options_spec(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -3912,7 +3912,7 @@ fn scan_prequel_construct(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_IMPORT {
             pos = start;
             try_1: {
-                pos = scan_delegate_grammars(tokens, pos);
+                pos = scan_delegate_grammars(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -3920,7 +3920,7 @@ fn scan_prequel_construct(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_TOKENS {
             pos = start;
             try_2: {
-                pos = scan_tokens_spec(tokens, pos);
+                pos = scan_tokens_spec(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -3928,7 +3928,7 @@ fn scan_prequel_construct(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_CHANNELS {
             pos = start;
             try_3: {
-                pos = scan_channels_spec(tokens, pos);
+                pos = scan_channels_spec(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -3936,7 +3936,7 @@ fn scan_prequel_construct(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_AT {
             pos = start;
             try_4: {
-                pos = scan_action_(tokens, pos);
+                pos = scan_action_(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 break scan_alts;
             }
@@ -3948,7 +3948,7 @@ fn scan_prequel_construct(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_options_spec(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_options_spec(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_OPTIONS { return -1; }
     pos += 1;
@@ -3956,7 +3956,7 @@ fn scan_options_spec(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_0_done: {
             sg_0: {
-                pos = scan_option(tokens, pos);
+                pos = scan_option(tokens, pos, 0);
                 if pos < 0 { break sg_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { break sg_0; }
                 pos += 1;
@@ -3972,18 +3972,18 @@ fn scan_options_spec(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_option(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_option(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_ASSIGN { return -1; }
     pos += 1;
-    pos = scan_option_value(tokens, pos);
+    pos = scan_option_value(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_option_value(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_option_value(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -3991,7 +3991,7 @@ fn scan_option_value(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_1(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 while pos < tokens.len() && tokens[pos].kind == TK_DOT {
                     let sp = pos;
@@ -3999,7 +3999,7 @@ fn scan_option_value(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_1: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_DOT { break sg_1; }
                             pos += 1;
-                            pos = scan_identifier(tokens, pos);
+                            pos = scan_identifier(tokens, pos, 0);
                             if pos < 0 { break sg_1; }
                             break sg_1_done;
                         }
@@ -4022,7 +4022,7 @@ fn scan_option_value(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_ACTION {
             pos = start;
             try_2: {
-                pos = scan_action_block(tokens, pos);
+                pos = scan_action_block(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -4042,11 +4042,11 @@ fn scan_option_value(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_delegate_grammars(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_delegate_grammars(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_IMPORT { return -1; }
     pos += 1;
-    pos = scan_delegate_grammar(tokens, pos);
+    pos = scan_delegate_grammar(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
         let sp = pos;
@@ -4054,7 +4054,7 @@ fn scan_delegate_grammars(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_2: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_2; }
                 pos += 1;
-                pos = scan_delegate_grammar(tokens, pos);
+                pos = scan_delegate_grammar(tokens, pos, 0);
                 if pos < 0 { break sg_2; }
                 break sg_2_done;
             }
@@ -4068,7 +4068,7 @@ fn scan_delegate_grammars(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_delegate_grammar(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_delegate_grammar(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -4076,17 +4076,17 @@ fn scan_delegate_grammar(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_1(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_0: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_ASSIGN { break try_0; }
                 pos += 1;
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -4098,13 +4098,13 @@ fn scan_delegate_grammar(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_tokens_spec(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_tokens_spec(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_TOKENS { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_id_list(tokens, pos);
+        pos = scan_id_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_RBRACE { return -1; }
@@ -4112,13 +4112,13 @@ fn scan_tokens_spec(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_channels_spec(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_channels_spec(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_CHANNELS { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_id_list(tokens, pos);
+        pos = scan_id_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_RBRACE { return -1; }
@@ -4126,9 +4126,9 @@ fn scan_channels_spec(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_id_list(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_id_list(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
         let sp = pos;
@@ -4136,7 +4136,7 @@ fn scan_id_list(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_3: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_3; }
                 pos += 1;
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break sg_3; }
                 break sg_3_done;
             }
@@ -4153,7 +4153,7 @@ fn scan_id_list(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_action_(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_action_(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_AT { return -1; }
     pos += 1;
@@ -4161,7 +4161,7 @@ fn scan_action_(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_4_done: {
             sg_4: {
-                pos = scan_action_scope_name(tokens, pos);
+                pos = scan_action_scope_name(tokens, pos, 0);
                 if pos < 0 { break sg_4; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_COLONCOLON { break sg_4; }
                 pos += 1;
@@ -4171,14 +4171,14 @@ fn scan_action_(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_action_block(tokens, pos);
+    pos = scan_action_block(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_action_scope_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_action_scope_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -4186,7 +4186,7 @@ fn scan_action_scope_name(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_1(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -4214,14 +4214,14 @@ fn scan_action_scope_name(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_action_block(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_action_block(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_ACTION { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_arg_action_block(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_arg_action_block(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_BEGIN_ARGUMENT { return -1; }
     pos += 1;
@@ -4236,35 +4236,35 @@ fn scan_arg_action_block(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_mode_spec(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_mode_spec(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_MODE { return -1; }
     pos += 1;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { return -1; }
     pos += 1;
     while pos < tokens.len() && _gale_kind_set_3(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_lexer_rule_spec(tokens, pos);
+        pos = scan_lexer_rule_spec(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
     return pos;
 }
 
-fn scan_rules(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_rules(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && _gale_kind_set_4(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_rule_spec(tokens, pos);
+        pos = scan_rule_spec(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
     return pos;
 }
 
-fn scan_rule_spec(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_rule_spec(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -4272,7 +4272,7 @@ fn scan_rule_spec(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_5(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_parser_rule_spec(tokens, pos);
+                pos = scan_parser_rule_spec(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -4280,13 +4280,13 @@ fn scan_rule_spec(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_FRAGMENT {
             pos = start;
             try_0: {
-                pos = scan_parser_rule_spec(tokens, pos);
+                pos = scan_parser_rule_spec(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_1: {
-                pos = scan_lexer_rule_spec(tokens, pos);
+                pos = scan_lexer_rule_spec(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -4294,7 +4294,7 @@ fn scan_rule_spec(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_TOKEN_REF {
             pos = start;
             try_1: {
-                pos = scan_lexer_rule_spec(tokens, pos);
+                pos = scan_lexer_rule_spec(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -4306,89 +4306,89 @@ fn scan_rule_spec(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_parser_rule_spec(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_parser_rule_spec(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && _gale_kind_set_6(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_rule_modifiers(tokens, pos);
+        pos = scan_rule_modifiers(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_RULE_REF { return -1; }
     pos += 1;
     if pos < tokens.len() && tokens[pos].kind == TK_BEGIN_ARGUMENT {
         let sp = pos;
-        pos = scan_arg_action_block(tokens, pos);
+        pos = scan_arg_action_block(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos < tokens.len() && tokens[pos].kind == TK_RETURNS {
         let sp = pos;
-        pos = scan_rule_returns(tokens, pos);
+        pos = scan_rule_returns(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos < tokens.len() && tokens[pos].kind == TK_THROWS {
         let sp = pos;
-        pos = scan_throws_spec(tokens, pos);
+        pos = scan_throws_spec(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos < tokens.len() && tokens[pos].kind == TK_LOCALS {
         let sp = pos;
-        pos = scan_locals_spec(tokens, pos);
+        pos = scan_locals_spec(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     while pos < tokens.len() && _gale_kind_set_7(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_rule_prequel(tokens, pos);
+        pos = scan_rule_prequel(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_COLON { return -1; }
     pos += 1;
-    pos = scan_rule_block(tokens, pos);
+    pos = scan_rule_block(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { return -1; }
     pos += 1;
-    pos = scan_exception_group(tokens, pos);
+    pos = scan_exception_group(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_exception_group(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_exception_group(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && tokens[pos].kind == TK_CATCH {
         let sp = pos;
-        pos = scan_exception_handler(tokens, pos);
+        pos = scan_exception_handler(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
     if pos < tokens.len() && tokens[pos].kind == TK_FINALLY {
         let sp = pos;
-        pos = scan_finally_clause(tokens, pos);
+        pos = scan_finally_clause(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     return pos;
 }
 
-fn scan_exception_handler(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_exception_handler(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_CATCH { return -1; }
     pos += 1;
-    pos = scan_arg_action_block(tokens, pos);
+    pos = scan_arg_action_block(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_action_block(tokens, pos);
+    pos = scan_action_block(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_finally_clause(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_finally_clause(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_FINALLY { return -1; }
     pos += 1;
-    pos = scan_action_block(tokens, pos);
+    pos = scan_action_block(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_rule_prequel(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_rule_prequel(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -4396,7 +4396,7 @@ fn scan_rule_prequel(tokens: &Array<Token>, pos: i32) -> i32 {
         if alt_kind == TK_OPTIONS {
             pos = start;
             try_0: {
-                pos = scan_options_spec(tokens, pos);
+                pos = scan_options_spec(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -4404,7 +4404,7 @@ fn scan_rule_prequel(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_AT {
             pos = start;
             try_1: {
-                pos = scan_rule_action(tokens, pos);
+                pos = scan_rule_action(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -4416,20 +4416,20 @@ fn scan_rule_prequel(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_rule_returns(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_rule_returns(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_RETURNS { return -1; }
     pos += 1;
-    pos = scan_arg_action_block(tokens, pos);
+    pos = scan_arg_action_block(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_throws_spec(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_throws_spec(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_THROWS { return -1; }
     pos += 1;
-    pos = scan_qualified_identifier(tokens, pos);
+    pos = scan_qualified_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
         let sp = pos;
@@ -4437,7 +4437,7 @@ fn scan_throws_spec(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_5: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_5; }
                 pos += 1;
-                pos = scan_qualified_identifier(tokens, pos);
+                pos = scan_qualified_identifier(tokens, pos, 0);
                 if pos < 0 { break sg_5; }
                 break sg_5_done;
             }
@@ -4449,56 +4449,56 @@ fn scan_throws_spec(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_locals_spec(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_locals_spec(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LOCALS { return -1; }
     pos += 1;
-    pos = scan_arg_action_block(tokens, pos);
+    pos = scan_arg_action_block(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_rule_action(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_rule_action(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_AT { return -1; }
     pos += 1;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_action_block(tokens, pos);
+    pos = scan_action_block(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_rule_modifiers(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_rule_modifiers(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_rule_modifier(tokens, pos);
+    pos = scan_rule_modifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && _gale_kind_set_6(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_rule_modifier(tokens, pos);
+        pos = scan_rule_modifier(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
     return pos;
 }
 
-fn scan_rule_modifier(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_rule_modifier(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_6(tokens[pos].kind) {
         return pos + 1;
     }
     return -1;
 }
 
-fn scan_rule_block(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_rule_block(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_rule_alt_list(tokens, pos);
+    pos = scan_rule_alt_list(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_rule_alt_list(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_rule_alt_list(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_labeled_alt(tokens, pos);
+    pos = scan_labeled_alt(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_OR {
         let sp = pos;
@@ -4506,7 +4506,7 @@ fn scan_rule_alt_list(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_6: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_OR { break sg_6; }
                 pos += 1;
-                pos = scan_labeled_alt(tokens, pos);
+                pos = scan_labeled_alt(tokens, pos, 0);
                 if pos < 0 { break sg_6; }
                 break sg_6_done;
             }
@@ -4518,9 +4518,9 @@ fn scan_rule_alt_list(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_labeled_alt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_labeled_alt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_alternative(tokens, pos);
+    pos = scan_alternative(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_POUND {
         let sp = pos;
@@ -4528,7 +4528,7 @@ fn scan_labeled_alt(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_7: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_POUND { break sg_7; }
                 pos += 1;
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break sg_7; }
                 break sg_7_done;
             }
@@ -4539,7 +4539,7 @@ fn scan_labeled_alt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_lexer_rule_spec(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_lexer_rule_spec(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_FRAGMENT {
         let sp = pos;
@@ -4550,28 +4550,28 @@ fn scan_lexer_rule_spec(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && tokens[pos].kind == TK_OPTIONS {
         let sp = pos;
-        pos = scan_options_spec(tokens, pos);
+        pos = scan_options_spec(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_COLON { return -1; }
     pos += 1;
-    pos = scan_lexer_rule_block(tokens, pos);
+    pos = scan_lexer_rule_block(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_lexer_rule_block(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_lexer_rule_block(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_lexer_alt_list(tokens, pos);
+    pos = scan_lexer_alt_list(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_lexer_alt_list(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_lexer_alt_list(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_lexer_alt(tokens, pos);
+    pos = scan_lexer_alt(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_OR {
         let sp = pos;
@@ -4579,7 +4579,7 @@ fn scan_lexer_alt_list(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_8: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_OR { break sg_8; }
                 pos += 1;
-                pos = scan_lexer_alt(tokens, pos);
+                pos = scan_lexer_alt(tokens, pos, 0);
                 if pos < 0 { break sg_8; }
                 break sg_8_done;
             }
@@ -4591,18 +4591,18 @@ fn scan_lexer_alt_list(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_lexer_alt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_lexer_alt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
     scan_alts: {
         pos = start;
         try_0: {
-            pos = scan_lexer_elements(tokens, pos);
+            pos = scan_lexer_elements(tokens, pos, 0);
             if pos < 0 { break try_0; }
             if pos < tokens.len() && tokens[pos].kind == TK_RARROW {
                 let sp = pos;
-                pos = scan_lexer_commands(tokens, pos);
+                pos = scan_lexer_commands(tokens, pos, 0);
                 if pos < 0 { pos = sp; }
             }
             break scan_alts;
@@ -4616,7 +4616,7 @@ fn scan_lexer_alt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_lexer_elements(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_lexer_elements(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -4624,11 +4624,11 @@ fn scan_lexer_elements(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_8(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_lexer_element(tokens, pos);
+                pos = scan_lexer_element(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 while pos < tokens.len() && _gale_kind_set_8(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_lexer_element(tokens, pos);
+                    pos = scan_lexer_element(tokens, pos, 0);
                     if pos < 0 { pos = sp; break; }
                     if pos == sp { break; }
                 }
@@ -4650,7 +4650,7 @@ fn scan_lexer_elements(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_lexer_element(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_lexer_element(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -4658,11 +4658,11 @@ fn scan_lexer_element(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_9(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_lexer_atom(tokens, pos);
+                pos = scan_lexer_atom(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos < tokens.len() && _gale_kind_set_10(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_ebnf_suffix(tokens, pos);
+                    pos = scan_ebnf_suffix(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break scan_alts;
@@ -4671,11 +4671,11 @@ fn scan_lexer_element(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LPAREN {
             pos = start;
             try_1: {
-                pos = scan_lexer_block(tokens, pos);
+                pos = scan_lexer_block(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos < tokens.len() && _gale_kind_set_10(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_ebnf_suffix(tokens, pos);
+                    pos = scan_ebnf_suffix(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break scan_alts;
@@ -4684,7 +4684,7 @@ fn scan_lexer_element(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_ACTION {
             pos = start;
             try_2: {
-                pos = scan_action_block(tokens, pos);
+                pos = scan_action_block(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 if pos < tokens.len() && tokens[pos].kind == TK_QUESTION {
                     let sp = pos;
@@ -4701,22 +4701,22 @@ fn scan_lexer_element(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_lexer_block(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_lexer_block(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
     pos += 1;
-    pos = scan_lexer_alt_list(tokens, pos);
+    pos = scan_lexer_alt_list(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_lexer_commands(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_lexer_commands(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_RARROW { return -1; }
     pos += 1;
-    pos = scan_lexer_command(tokens, pos);
+    pos = scan_lexer_command(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
         let sp = pos;
@@ -4724,7 +4724,7 @@ fn scan_lexer_commands(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_9: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_9; }
                 pos += 1;
-                pos = scan_lexer_command(tokens, pos);
+                pos = scan_lexer_command(tokens, pos, 0);
                 if pos < 0 { break sg_9; }
                 break sg_9_done;
             }
@@ -4736,7 +4736,7 @@ fn scan_lexer_commands(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_lexer_command(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_lexer_command(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -4744,17 +4744,17 @@ fn scan_lexer_command(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_11(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_lexer_command_name(tokens, pos);
+                pos = scan_lexer_command_name(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_0: {
-                pos = scan_lexer_command_name(tokens, pos);
+                pos = scan_lexer_command_name(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { break try_0; }
                 pos += 1;
-                pos = scan_lexer_command_expr(tokens, pos);
+                pos = scan_lexer_command_expr(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { break try_0; }
                 pos += 1;
@@ -4768,7 +4768,7 @@ fn scan_lexer_command(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_lexer_command_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_lexer_command_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -4776,7 +4776,7 @@ fn scan_lexer_command_name(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_1(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -4796,7 +4796,7 @@ fn scan_lexer_command_name(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_lexer_command_expr(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_lexer_command_expr(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -4804,7 +4804,7 @@ fn scan_lexer_command_expr(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_1(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -4824,9 +4824,9 @@ fn scan_lexer_command_expr(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_alt_list(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_alt_list(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_alternative(tokens, pos);
+    pos = scan_alternative(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_OR {
         let sp = pos;
@@ -4834,7 +4834,7 @@ fn scan_alt_list(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_10: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_OR { break sg_10; }
                 pos += 1;
-                pos = scan_alternative(tokens, pos);
+                pos = scan_alternative(tokens, pos, 0);
                 if pos < 0 { break sg_10; }
                 break sg_10_done;
             }
@@ -4846,7 +4846,7 @@ fn scan_alt_list(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_alternative(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_alternative(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -4856,14 +4856,14 @@ fn scan_alternative(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos < tokens.len() && tokens[pos].kind == TK_LT {
                     let sp = pos;
-                    pos = scan_element_options(tokens, pos);
+                    pos = scan_element_options(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_element(tokens, pos);
+                pos = scan_element(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 while pos < tokens.len() && _gale_kind_set_13(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_element(tokens, pos);
+                    pos = scan_element(tokens, pos, 0);
                     if pos < 0 { pos = sp; break; }
                     if pos == sp { break; }
                 }
@@ -4885,7 +4885,7 @@ fn scan_alternative(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_element(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_element(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -4893,7 +4893,7 @@ fn scan_element(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_1(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_labeled_element(tokens, pos);
+                pos = scan_labeled_element(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 let gp_11 = pos;
                 let sgk_11 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -4901,7 +4901,7 @@ fn scan_element(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_11: {
                         pos = gp_11;
                         sg_11_0: {
-                            pos = scan_ebnf_suffix(tokens, pos);
+                            pos = scan_ebnf_suffix(tokens, pos, 0);
                             if pos < 0 { break sg_11_0; }
                             break sg_11;
                         }
@@ -4916,7 +4916,7 @@ fn scan_element(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_1: {
-                pos = scan_atom(tokens, pos);
+                pos = scan_atom(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 let gp_12 = pos;
                 let sgk_12 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -4924,7 +4924,7 @@ fn scan_element(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_12: {
                         pos = gp_12;
                         sg_12_0: {
-                            pos = scan_ebnf_suffix(tokens, pos);
+                            pos = scan_ebnf_suffix(tokens, pos, 0);
                             if pos < 0 { break sg_12_0; }
                             break sg_12;
                         }
@@ -4941,7 +4941,7 @@ fn scan_element(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_14(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_atom(tokens, pos);
+                pos = scan_atom(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 let gp_13 = pos;
                 let sgk_13 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -4949,7 +4949,7 @@ fn scan_element(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_13: {
                         pos = gp_13;
                         sg_13_0: {
-                            pos = scan_ebnf_suffix(tokens, pos);
+                            pos = scan_ebnf_suffix(tokens, pos, 0);
                             if pos < 0 { break sg_13_0; }
                             break sg_13;
                         }
@@ -4966,7 +4966,7 @@ fn scan_element(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LPAREN {
             pos = start;
             try_2: {
-                pos = scan_ebnf(tokens, pos);
+                pos = scan_ebnf(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -4974,7 +4974,7 @@ fn scan_element(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_ACTION {
             pos = start;
             try_3: {
-                pos = scan_action_block(tokens, pos);
+                pos = scan_action_block(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 if pos < tokens.len() && tokens[pos].kind == TK_QUESTION {
                     let sp = pos;
@@ -4983,7 +4983,7 @@ fn scan_element(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos < tokens.len() && tokens[pos].kind == TK_LT {
                     let sp = pos;
-                    pos = scan_predicate_options(tokens, pos);
+                    pos = scan_predicate_options(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break scan_alts;
@@ -4996,11 +4996,11 @@ fn scan_element(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_predicate_options(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_predicate_options(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LT { return -1; }
     pos += 1;
-    pos = scan_predicate_option(tokens, pos);
+    pos = scan_predicate_option(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
         let sp = pos;
@@ -5008,7 +5008,7 @@ fn scan_predicate_options(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_14: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_14; }
                 pos += 1;
-                pos = scan_predicate_option(tokens, pos);
+                pos = scan_predicate_option(tokens, pos, 0);
                 if pos < 0 { break sg_14; }
                 break sg_14_done;
             }
@@ -5022,7 +5022,7 @@ fn scan_predicate_options(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_predicate_option(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_predicate_option(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -5030,13 +5030,13 @@ fn scan_predicate_option(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_1(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_element_option(tokens, pos);
+                pos = scan_element_option(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_1: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_ASSIGN { break try_1; }
                 pos += 1;
@@ -5046,7 +5046,7 @@ fn scan_predicate_option(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_15: {
                         pos = gp_15;
                         sg_15_0: {
-                            pos = scan_action_block(tokens, pos);
+                            pos = scan_action_block(tokens, pos, 0);
                             if pos < 0 { break sg_15_0; }
                             break sg_15;
                         }
@@ -5075,9 +5075,9 @@ fn scan_predicate_option(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_labeled_element(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_labeled_element(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     let gp_16 = pos;
     sg_16: {
@@ -5101,13 +5101,13 @@ fn scan_labeled_element(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_17: {
             pos = gp_17;
             sg_17_0: {
-                pos = scan_atom(tokens, pos);
+                pos = scan_atom(tokens, pos, 0);
                 if pos < 0 { break sg_17_0; }
                 break sg_17;
             }
             pos = gp_17;
             sg_17_1: {
-                pos = scan_block(tokens, pos);
+                pos = scan_block(tokens, pos, 0);
                 if pos < 0 { break sg_17_1; }
                 break sg_17;
             }
@@ -5117,26 +5117,26 @@ fn scan_labeled_element(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_ebnf(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_ebnf(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_block(tokens, pos);
+    pos = scan_block(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && _gale_kind_set_10(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_block_suffix(tokens, pos);
+        pos = scan_block_suffix(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     return pos;
 }
 
-fn scan_block_suffix(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_block_suffix(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_ebnf_suffix(tokens, pos);
+    pos = scan_ebnf_suffix(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_ebnf_suffix(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_ebnf_suffix(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -5187,7 +5187,7 @@ fn scan_ebnf_suffix(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_lexer_atom(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_lexer_atom(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -5195,13 +5195,13 @@ fn scan_lexer_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         if alt_kind == TK_STRING_LITERAL {
             pos = start;
             try_0: {
-                pos = scan_character_range(tokens, pos);
+                pos = scan_character_range(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_1: {
-                pos = scan_terminal_def(tokens, pos);
+                pos = scan_terminal_def(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -5209,7 +5209,7 @@ fn scan_lexer_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_TOKEN_REF {
             pos = start;
             try_1: {
-                pos = scan_terminal_def(tokens, pos);
+                pos = scan_terminal_def(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -5217,7 +5217,7 @@ fn scan_lexer_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_NOT {
             pos = start;
             try_2: {
-                pos = scan_not_set(tokens, pos);
+                pos = scan_not_set(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -5233,7 +5233,7 @@ fn scan_lexer_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_DOT {
             pos = start;
             try_4: {
-                pos = scan_wildcard(tokens, pos);
+                pos = scan_wildcard(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 break scan_alts;
             }
@@ -5245,7 +5245,7 @@ fn scan_lexer_atom(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_atom(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_atom(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -5253,7 +5253,7 @@ fn scan_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_17(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_terminal_def(tokens, pos);
+                pos = scan_terminal_def(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -5261,7 +5261,7 @@ fn scan_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_RULE_REF {
             pos = start;
             try_1: {
-                pos = scan_ruleref(tokens, pos);
+                pos = scan_ruleref(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -5269,7 +5269,7 @@ fn scan_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_NOT {
             pos = start;
             try_2: {
-                pos = scan_not_set(tokens, pos);
+                pos = scan_not_set(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -5277,7 +5277,7 @@ fn scan_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_DOT {
             pos = start;
             try_3: {
-                pos = scan_wildcard(tokens, pos);
+                pos = scan_wildcard(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -5289,19 +5289,19 @@ fn scan_atom(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_wildcard(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_wildcard(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_DOT { return -1; }
     pos += 1;
     if pos < tokens.len() && tokens[pos].kind == TK_LT {
         let sp = pos;
-        pos = scan_element_options(tokens, pos);
+        pos = scan_element_options(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     return pos;
 }
 
-fn scan_not_set(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_not_set(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -5311,7 +5311,7 @@ fn scan_not_set(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_NOT { break try_0; }
                 pos += 1;
-                pos = scan_set_element(tokens, pos);
+                pos = scan_set_element(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -5319,7 +5319,7 @@ fn scan_not_set(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_NOT { break try_1; }
                 pos += 1;
-                pos = scan_block_set(tokens, pos);
+                pos = scan_block_set(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -5331,11 +5331,11 @@ fn scan_not_set(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_block_set(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_block_set(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
     pos += 1;
-    pos = scan_set_element(tokens, pos);
+    pos = scan_set_element(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_OR {
         let sp = pos;
@@ -5343,7 +5343,7 @@ fn scan_block_set(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_18: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_OR { break sg_18; }
                 pos += 1;
-                pos = scan_set_element(tokens, pos);
+                pos = scan_set_element(tokens, pos, 0);
                 if pos < 0 { break sg_18; }
                 break sg_18_done;
             }
@@ -5357,7 +5357,7 @@ fn scan_block_set(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_set_element(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_set_element(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -5369,7 +5369,7 @@ fn scan_set_element(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos < tokens.len() && tokens[pos].kind == TK_LT {
                     let sp = pos;
-                    pos = scan_element_options(tokens, pos);
+                    pos = scan_element_options(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break scan_alts;
@@ -5382,14 +5382,14 @@ fn scan_set_element(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos < tokens.len() && tokens[pos].kind == TK_LT {
                     let sp = pos;
-                    pos = scan_element_options(tokens, pos);
+                    pos = scan_element_options(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break scan_alts;
             }
             pos = start;
             try_2: {
-                pos = scan_character_range(tokens, pos);
+                pos = scan_character_range(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -5409,17 +5409,17 @@ fn scan_set_element(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_block(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_block(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
     pos += 1;
     if pos < tokens.len() && tokens[pos].kind == TK_OPTIONS && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_AT && pos + 2 < tokens.len() && tokens[pos + 2].kind == TK_COLON {
         sol_19: {
-            pos = scan_options_spec(tokens, pos);
+            pos = scan_options_spec(tokens, pos, 0);
             if pos < 0 { break sol_19; }
             while pos < tokens.len() && tokens[pos].kind == TK_AT {
                 let sp = pos;
-                pos = scan_rule_action(tokens, pos);
+                pos = scan_rule_action(tokens, pos, 0);
                 if pos < 0 { pos = sp; break; }
                 if pos == sp { break; }
             }
@@ -5430,7 +5430,7 @@ fn scan_block(tokens: &Array<Token>, pos: i32) -> i32 {
         sol_20: {
             while pos < tokens.len() && tokens[pos].kind == TK_AT {
                 let sp = pos;
-                pos = scan_rule_action(tokens, pos);
+                pos = scan_rule_action(tokens, pos, 0);
                 if pos < 0 { pos = sp; break; }
                 if pos == sp { break; }
             }
@@ -5439,7 +5439,7 @@ fn scan_block(tokens: &Array<Token>, pos: i32) -> i32 {
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_OPTIONS && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_COLON {
         sol_21: {
-            pos = scan_options_spec(tokens, pos);
+            pos = scan_options_spec(tokens, pos, 0);
             if pos < 0 { break sol_21; }
             if pos >= tokens.len() || tokens[pos].kind != TK_COLON { break sol_21; }
             pos += 1;
@@ -5450,31 +5450,31 @@ fn scan_block(tokens: &Array<Token>, pos: i32) -> i32 {
             pos += 1;
         }
     }
-    pos = scan_alt_list(tokens, pos);
+    pos = scan_alt_list(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_ruleref(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_ruleref(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_RULE_REF { return -1; }
     pos += 1;
     if pos < tokens.len() && tokens[pos].kind == TK_BEGIN_ARGUMENT {
         let sp = pos;
-        pos = scan_arg_action_block(tokens, pos);
+        pos = scan_arg_action_block(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos < tokens.len() && tokens[pos].kind == TK_LT {
         let sp = pos;
-        pos = scan_element_options(tokens, pos);
+        pos = scan_element_options(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     return pos;
 }
 
-fn scan_character_range(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_character_range(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_STRING_LITERAL { return -1; }
     pos += 1;
@@ -5485,7 +5485,7 @@ fn scan_character_range(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_terminal_def(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_terminal_def(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -5497,7 +5497,7 @@ fn scan_terminal_def(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos < tokens.len() && tokens[pos].kind == TK_LT {
                     let sp = pos;
-                    pos = scan_element_options(tokens, pos);
+                    pos = scan_element_options(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break scan_alts;
@@ -5510,7 +5510,7 @@ fn scan_terminal_def(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos < tokens.len() && tokens[pos].kind == TK_LT {
                     let sp = pos;
-                    pos = scan_element_options(tokens, pos);
+                    pos = scan_element_options(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break scan_alts;
@@ -5523,11 +5523,11 @@ fn scan_terminal_def(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_element_options(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_element_options(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LT { return -1; }
     pos += 1;
-    pos = scan_element_option(tokens, pos);
+    pos = scan_element_option(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
         let sp = pos;
@@ -5535,7 +5535,7 @@ fn scan_element_options(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_23: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_23; }
                 pos += 1;
-                pos = scan_element_option(tokens, pos);
+                pos = scan_element_option(tokens, pos, 0);
                 if pos < 0 { break sg_23; }
                 break sg_23_done;
             }
@@ -5549,7 +5549,7 @@ fn scan_element_options(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_element_option(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_element_option(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -5557,13 +5557,13 @@ fn scan_element_option(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_1(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_qualified_identifier(tokens, pos);
+                pos = scan_qualified_identifier(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_1: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_ASSIGN { break try_1; }
                 pos += 1;
@@ -5573,7 +5573,7 @@ fn scan_element_option(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_24: {
                         pos = gp_24;
                         sg_24_0: {
-                            pos = scan_qualified_identifier(tokens, pos);
+                            pos = scan_qualified_identifier(tokens, pos, 0);
                             if pos < 0 { break sg_24_0; }
                             break sg_24;
                         }
@@ -5602,16 +5602,16 @@ fn scan_element_option(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_identifier(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_identifier(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         return pos + 1;
     }
     return -1;
 }
 
-fn scan_qualified_identifier(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_qualified_identifier(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_DOT {
         let sp = pos;
@@ -5619,7 +5619,7 @@ fn scan_qualified_identifier(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_25: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_DOT { break sg_25; }
                 pos += 1;
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break sg_25; }
                 break sg_25_done;
             }
@@ -5640,7 +5640,7 @@ fn parse_grammar_spec(p: &mut Parser) -> Result<GrammarSpecNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_prequel_construct(tokens, pos);
+            pos = scan_prequel_construct(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -5656,7 +5656,7 @@ fn parse_grammar_spec(p: &mut Parser) -> Result<GrammarSpecNode, ParseError> {
         rep_scan_2: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_mode_spec(tokens, pos);
+            pos = scan_mode_spec(tokens, pos, 0);
             if pos < 0 { break rep_scan_2; }
             if pos <= p.pos { break rep_scan_2; }
             rep_scan_pos_2 = pos;
@@ -5778,7 +5778,7 @@ fn parse_options_spec(p: &mut Parser) -> Result<OptionsSpecNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_option(tokens, pos);
+            pos = scan_option(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { break rep_scan; }
             pos += 1;
@@ -5829,7 +5829,7 @@ fn parse_option_value(p: &mut Parser) -> Result<OptionValueNode, ParseError> {
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_DOT { break rep_scan; }
                 pos += 1;
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -5889,7 +5889,7 @@ fn parse_delegate_grammars(p: &mut Parser) -> Result<DelegateGrammarsNode, Parse
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_delegate_grammar(tokens, pos);
+            pos = scan_delegate_grammar(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -5924,7 +5924,7 @@ fn parse_delegate_grammar_bt_1(p: &mut Parser) -> Result<DelegateGrammarNode, Pa
 
 fn parse_delegate_grammar_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -5944,11 +5944,11 @@ fn parse_delegate_grammar_bt_0(p: &mut Parser) -> Result<DelegateGrammarNode, Pa
 
 fn parse_delegate_grammar_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_ASSIGN { return -1; }
     pos += 1;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -6021,7 +6021,7 @@ fn parse_id_list(p: &mut Parser) -> Result<IdListNode, ParseError> {
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_identifier(tokens, pos);
+            pos = scan_identifier(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -6056,7 +6056,7 @@ fn parse_action_(p: &mut Parser) -> Result<ActionNode, ParseError> {
     opt_scan: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_action_scope_name(tokens, pos);
+        pos = scan_action_scope_name(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         if pos >= tokens.len() || tokens[pos].kind != TK_COLONCOLON { break opt_scan; }
         pos += 1;
@@ -6152,7 +6152,7 @@ fn parse_mode_spec(p: &mut Parser) -> Result<ModeSpecNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_lexer_rule_spec(tokens, pos);
+            pos = scan_lexer_rule_spec(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -6178,7 +6178,7 @@ fn parse_rules(p: &mut Parser) -> Result<RulesNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_rule_spec(tokens, pos);
+            pos = scan_rule_spec(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -6204,7 +6204,7 @@ fn parse_rule_spec_bt_1(p: &mut Parser) -> Result<RuleSpecNode, ParseError> {
 
 fn parse_rule_spec_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_lexer_rule_spec(tokens, pos);
+    pos = scan_lexer_rule_spec(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -6220,7 +6220,7 @@ fn parse_rule_spec_bt_0(p: &mut Parser) -> Result<RuleSpecNode, ParseError> {
 
 fn parse_rule_spec_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_parser_rule_spec(tokens, pos);
+    pos = scan_parser_rule_spec(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -6287,7 +6287,7 @@ fn parse_parser_rule_spec(p: &mut Parser) -> Result<ParserRuleSpecNode, ParseErr
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_rule_prequel(tokens, pos);
+            pos = scan_rule_prequel(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -6324,7 +6324,7 @@ fn parse_exception_group(p: &mut Parser) -> Result<ExceptionGroupNode, ParseErro
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_exception_handler(tokens, pos);
+            pos = scan_exception_handler(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -6417,7 +6417,7 @@ fn parse_throws_spec(p: &mut Parser) -> Result<ThrowsSpecNode, ParseError> {
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_qualified_identifier(tokens, pos);
+            pos = scan_qualified_identifier(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -6473,7 +6473,7 @@ fn parse_rule_modifiers(p: &mut Parser) -> Result<RuleModifiersNode, ParseError>
             rep_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_rule_modifier(tokens, pos);
+                pos = scan_rule_modifier(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -6548,7 +6548,7 @@ fn parse_rule_alt_list(p: &mut Parser) -> Result<RuleAltListNode, ParseError> {
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_OR { break rep_scan; }
             pos += 1;
-            pos = scan_labeled_alt(tokens, pos);
+            pos = scan_labeled_alt(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -6639,7 +6639,7 @@ fn parse_lexer_alt_list(p: &mut Parser) -> Result<LexerAltListNode, ParseError> 
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_OR { break rep_scan; }
             pos += 1;
-            pos = scan_lexer_alt(tokens, pos);
+            pos = scan_lexer_alt(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -6701,7 +6701,7 @@ fn parse_lexer_elements(p: &mut Parser) -> Result<LexerElementsNode, ParseError>
                 rep_scan: {
                     let tokens = &p.tokens;
                     let mut pos: i32 = p.pos;
-                    pos = scan_lexer_element(tokens, pos);
+                    pos = scan_lexer_element(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -6806,7 +6806,7 @@ fn parse_lexer_commands(p: &mut Parser) -> Result<LexerCommandsNode, ParseError>
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_lexer_command(tokens, pos);
+            pos = scan_lexer_command(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -6839,7 +6839,7 @@ fn parse_lexer_command_bt_1(p: &mut Parser) -> Result<LexerCommandNode, ParseErr
 
 fn parse_lexer_command_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_lexer_command_name(tokens, pos);
+    pos = scan_lexer_command_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -6861,11 +6861,11 @@ fn parse_lexer_command_bt_0(p: &mut Parser) -> Result<LexerCommandNode, ParseErr
 
 fn parse_lexer_command_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_lexer_command_name(tokens, pos);
+    pos = scan_lexer_command_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
     pos += 1;
-    pos = scan_lexer_command_expr(tokens, pos);
+    pos = scan_lexer_command_expr(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { return -1; }
     pos += 1;
@@ -6956,7 +6956,7 @@ fn parse_alt_list(p: &mut Parser) -> Result<AltListNode, ParseError> {
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_OR { break rep_scan; }
             pos += 1;
-            pos = scan_alternative(tokens, pos);
+            pos = scan_alternative(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -6995,7 +6995,7 @@ fn parse_alternative(p: &mut Parser) -> Result<AlternativeNode, ParseError> {
                 rep_scan: {
                     let tokens = &p.tokens;
                     let mut pos: i32 = p.pos;
-                    pos = scan_element(tokens, pos);
+                    pos = scan_element(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -7048,7 +7048,7 @@ fn parse_element_bt_0(p: &mut Parser) -> Result<ElementNode, ParseError> {
 
 fn parse_element_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_labeled_element(tokens, pos);
+    pos = scan_labeled_element(tokens, pos, 0);
     if pos < 0 { return -1; }
     let gp_26 = pos;
     let sgk_26 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -7056,7 +7056,7 @@ fn parse_element_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_26: {
             pos = gp_26;
             sg_26_0: {
-                pos = scan_ebnf_suffix(tokens, pos);
+                pos = scan_ebnf_suffix(tokens, pos, 0);
                 if pos < 0 { break sg_26_0; }
                 break sg_26;
             }
@@ -7094,7 +7094,7 @@ fn parse_element_bt_1(p: &mut Parser) -> Result<ElementNode, ParseError> {
 
 fn parse_element_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_atom(tokens, pos);
+    pos = scan_atom(tokens, pos, 0);
     if pos < 0 { return -1; }
     let gp_27 = pos;
     let sgk_27 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -7102,7 +7102,7 @@ fn parse_element_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_27: {
             pos = gp_27;
             sg_27_0: {
-                pos = scan_ebnf_suffix(tokens, pos);
+                pos = scan_ebnf_suffix(tokens, pos, 0);
                 if pos < 0 { break sg_27_0; }
                 break sg_27;
             }
@@ -7193,7 +7193,7 @@ fn parse_predicate_options(p: &mut Parser) -> Result<PredicateOptionsNode, Parse
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_predicate_option(tokens, pos);
+            pos = scan_predicate_option(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -7228,7 +7228,7 @@ fn parse_predicate_option_bt_0(p: &mut Parser) -> Result<PredicateOptionNode, Pa
 
 fn parse_predicate_option_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_element_option(tokens, pos);
+    pos = scan_element_option(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -7266,7 +7266,7 @@ fn parse_predicate_option_bt_1(p: &mut Parser) -> Result<PredicateOptionNode, Pa
 
 fn parse_predicate_option_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_ASSIGN { return -1; }
     pos += 1;
@@ -7276,7 +7276,7 @@ fn parse_predicate_option_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_28: {
             pos = gp_28;
             sg_28_0: {
-                pos = scan_action_block(tokens, pos);
+                pos = scan_action_block(tokens, pos, 0);
                 if pos < 0 { break sg_28_0; }
                 break sg_28;
             }
@@ -7443,7 +7443,7 @@ fn parse_lexer_atom_bt_0(p: &mut Parser) -> Result<LexerAtomNode, ParseError> {
 
 fn parse_lexer_atom_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_character_range(tokens, pos);
+    pos = scan_character_range(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -7459,7 +7459,7 @@ fn parse_lexer_atom_bt_1(p: &mut Parser) -> Result<LexerAtomNode, ParseError> {
 
 fn parse_lexer_atom_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_terminal_def(tokens, pos);
+    pos = scan_terminal_def(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -7575,7 +7575,7 @@ fn parse_not_set_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_NOT { return -1; }
     pos += 1;
-    pos = scan_set_element(tokens, pos);
+    pos = scan_set_element(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -7595,7 +7595,7 @@ fn parse_not_set_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_NOT { return -1; }
     pos += 1;
-    pos = scan_block_set(tokens, pos);
+    pos = scan_block_set(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -7640,7 +7640,7 @@ fn parse_block_set(p: &mut Parser) -> Result<BlockSetNode, ParseError> {
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_OR { break rep_scan; }
             pos += 1;
-            pos = scan_set_element(tokens, pos);
+            pos = scan_set_element(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -7686,7 +7686,7 @@ fn parse_set_element_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && tokens[pos].kind == TK_LT {
         let sp = pos;
-        pos = scan_element_options(tokens, pos);
+        pos = scan_element_options(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     return pos;
@@ -7703,7 +7703,7 @@ fn parse_set_element_bt_2(p: &mut Parser) -> Result<SetElementNode, ParseError> 
 
 fn parse_set_element_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_character_range(tokens, pos);
+    pos = scan_character_range(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -7780,7 +7780,7 @@ fn parse_block(p: &mut Parser) -> Result<BlockNode, ParseError> {
             rep_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_rule_action(tokens, pos);
+                pos = scan_rule_action(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -7804,7 +7804,7 @@ fn parse_block(p: &mut Parser) -> Result<BlockNode, ParseError> {
             rep_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_rule_action(tokens, pos);
+                pos = scan_rule_action(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -7945,7 +7945,7 @@ fn parse_element_options(p: &mut Parser) -> Result<ElementOptionsNode, ParseErro
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_element_option(tokens, pos);
+            pos = scan_element_option(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -7980,7 +7980,7 @@ fn parse_element_option_bt_0(p: &mut Parser) -> Result<ElementOptionNode, ParseE
 
 fn parse_element_option_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_qualified_identifier(tokens, pos);
+    pos = scan_qualified_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -8018,7 +8018,7 @@ fn parse_element_option_bt_1(p: &mut Parser) -> Result<ElementOptionNode, ParseE
 
 fn parse_element_option_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_ASSIGN { return -1; }
     pos += 1;
@@ -8028,7 +8028,7 @@ fn parse_element_option_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_29: {
             pos = gp_29;
             sg_29_0: {
-                pos = scan_qualified_identifier(tokens, pos);
+                pos = scan_qualified_identifier(tokens, pos, 0);
                 if pos < 0 { break sg_29_0; }
                 break sg_29;
             }
@@ -8120,7 +8120,7 @@ fn parse_qualified_identifier(p: &mut Parser) -> Result<QualifiedIdentifierNode,
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_DOT { break rep_scan; }
             pos += 1;
-            pos = scan_identifier(tokens, pos);
+            pos = scan_identifier(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_1/t.wado",
-      "hash": "49c7c86f5711d93e9a44557b45dfb5bcf29c82a36d1105fa773c05533334b054",
+      "hash": "6689b5ed70f461b75cca864ccb9f7fef092f0238a4d8ef1d38d84ecbb309482a",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_1/t.wado",
-      "hash": "421b6f9abc7555c3adcdf9cf5c00228b7428a363994c1c414bf1fb8af9a0bb20",
+      "hash": "49c7c86f5711d93e9a44557b45dfb5bcf29c82a36d1105fa773c05533334b054",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_1/t.wado
@@ -959,7 +959,7 @@ fn parse_declarator_atom(p: &mut Parser) -> Result<DeclaratorNode, ParseError> {
     let kind = p.peek_kind();
     if kind == TK_LIT_STAR {
         let star = p.expect(TK_LIT_STAR)?;
-        let declarator = parse_declarator(p)?;
+        let declarator = parse_declarator(p, 1)?;
         return Result::<DeclaratorNode, ParseError>::Ok(DeclaratorNode::Alt3(DeclaratorAlt3 {
             span: Span::new(start, p.last_end()),
             star,

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_1/t.wado
@@ -818,9 +818,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_declarator(tokens, pos);
+    pos = scan_declarator(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
@@ -837,7 +837,7 @@ fn scan_declarator_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_STAR { break try_0; }
                 pos += 1;
-                pos = scan_declarator(tokens, pos);
+                pos = scan_declarator(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -847,7 +847,7 @@ fn scan_declarator_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_1; }
                 pos += 1;
-                pos = scan_declarator(tokens, pos);
+                pos = scan_declarator(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_1; }
                 pos += 1;
@@ -873,7 +873,7 @@ fn scan_declarator_lr_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { return -1; }
     pos += 1;
@@ -936,7 +936,7 @@ fn scan_declarator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     return pos;
 }
 
-fn scan_e(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_INT { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_10/t.wado",
-      "hash": "bf390d9ea441a9cad963c49a319aca2b83180236f310c9b645698b9cc444d192",
+      "hash": "52881f674b915fb4f8df5aed9cbac1f1f736510e6598d43c644a64468d3352d2",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_10/t.wado",
-      "hash": "52881f674b915fb4f8df5aed9cbac1f1f736510e6598d43c644a64468d3352d2",
+      "hash": "5b66de4b1ff872cf2aa51148ada665b6db8c6082927825c2ce0dd7e0301d41b8",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_10/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_10/t.wado
@@ -959,7 +959,7 @@ fn parse_declarator_atom(p: &mut Parser) -> Result<DeclaratorNode, ParseError> {
     let kind = p.peek_kind();
     if kind == TK_LIT_STAR {
         let star = p.expect(TK_LIT_STAR)?;
-        let declarator = parse_declarator(p)?;
+        let declarator = parse_declarator(p, 1)?;
         return Result::<DeclaratorNode, ParseError>::Ok(DeclaratorNode::Alt3(DeclaratorAlt3 {
             span: Span::new(start, p.last_end()),
             star,

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_10/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_10/t.wado
@@ -818,9 +818,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_declarator(tokens, pos);
+    pos = scan_declarator(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
@@ -837,7 +837,7 @@ fn scan_declarator_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_STAR { break try_0; }
                 pos += 1;
-                pos = scan_declarator(tokens, pos);
+                pos = scan_declarator(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -847,7 +847,7 @@ fn scan_declarator_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_1; }
                 pos += 1;
-                pos = scan_declarator(tokens, pos);
+                pos = scan_declarator(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_1; }
                 pos += 1;
@@ -873,7 +873,7 @@ fn scan_declarator_lr_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { return -1; }
     pos += 1;
@@ -936,7 +936,7 @@ fn scan_declarator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     return pos;
 }
 
-fn scan_e(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_INT { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_2/t.wado",
-      "hash": "8c31022ac945cb12912ed16d42179b5812fb861d9cec91e0b94c06a463a43575",
+      "hash": "acf0c95cd8e2183d5095ee991011b54265d950a0a624754d1ec0749d92163551",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_2/t.wado",
-      "hash": "acf0c95cd8e2183d5095ee991011b54265d950a0a624754d1ec0749d92163551",
+      "hash": "5d8067a7c1b5ea3c41c11df3c3e096224325099b228641196e588f0f914fbe18",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_2/t.wado
@@ -959,7 +959,7 @@ fn parse_declarator_atom(p: &mut Parser) -> Result<DeclaratorNode, ParseError> {
     let kind = p.peek_kind();
     if kind == TK_LIT_STAR {
         let star = p.expect(TK_LIT_STAR)?;
-        let declarator = parse_declarator(p)?;
+        let declarator = parse_declarator(p, 1)?;
         return Result::<DeclaratorNode, ParseError>::Ok(DeclaratorNode::Alt3(DeclaratorAlt3 {
             span: Span::new(start, p.last_end()),
             star,

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_2/t.wado
@@ -818,9 +818,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_declarator(tokens, pos);
+    pos = scan_declarator(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
@@ -837,7 +837,7 @@ fn scan_declarator_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_STAR { break try_0; }
                 pos += 1;
-                pos = scan_declarator(tokens, pos);
+                pos = scan_declarator(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -847,7 +847,7 @@ fn scan_declarator_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_1; }
                 pos += 1;
-                pos = scan_declarator(tokens, pos);
+                pos = scan_declarator(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_1; }
                 pos += 1;
@@ -873,7 +873,7 @@ fn scan_declarator_lr_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { return -1; }
     pos += 1;
@@ -936,7 +936,7 @@ fn scan_declarator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     return pos;
 }
 
-fn scan_e(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_INT { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_3/t.wado",
-      "hash": "0f03a9794b5dd1f70121c91d335c0d71528b0b3df85e70f04d9e90df4a7d65a7",
+      "hash": "e6ec27c955c4f17d28d45b130dc10c4614dd16fb5cf45bab648849e2df47760c",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_3/t.wado",
-      "hash": "e6ec27c955c4f17d28d45b130dc10c4614dd16fb5cf45bab648849e2df47760c",
+      "hash": "f8aec618cdd5558e0eb036d559e17623c1a4422cf769efc815f6d42410281027",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_3/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_3/t.wado
@@ -959,7 +959,7 @@ fn parse_declarator_atom(p: &mut Parser) -> Result<DeclaratorNode, ParseError> {
     let kind = p.peek_kind();
     if kind == TK_LIT_STAR {
         let star = p.expect(TK_LIT_STAR)?;
-        let declarator = parse_declarator(p)?;
+        let declarator = parse_declarator(p, 1)?;
         return Result::<DeclaratorNode, ParseError>::Ok(DeclaratorNode::Alt3(DeclaratorAlt3 {
             span: Span::new(start, p.last_end()),
             star,

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_3/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_3/t.wado
@@ -818,9 +818,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_declarator(tokens, pos);
+    pos = scan_declarator(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
@@ -837,7 +837,7 @@ fn scan_declarator_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_STAR { break try_0; }
                 pos += 1;
-                pos = scan_declarator(tokens, pos);
+                pos = scan_declarator(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -847,7 +847,7 @@ fn scan_declarator_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_1; }
                 pos += 1;
-                pos = scan_declarator(tokens, pos);
+                pos = scan_declarator(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_1; }
                 pos += 1;
@@ -873,7 +873,7 @@ fn scan_declarator_lr_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { return -1; }
     pos += 1;
@@ -936,7 +936,7 @@ fn scan_declarator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     return pos;
 }
 
-fn scan_e(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_INT { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_4/t.wado",
-      "hash": "86f37aa59131ec6d8c06e1e927ed2c89c737584de832c850eac5e5924fd55e08",
+      "hash": "eebc020ba09c424695b3891ca613e40b370579ed99b86fe83a0a630cdda6e667",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_4/t.wado",
-      "hash": "eebc020ba09c424695b3891ca613e40b370579ed99b86fe83a0a630cdda6e667",
+      "hash": "ef016e81737c1c42423f10f3c203b4a56a940d202e4fd4fd5dbd9eb77cade10d",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_4/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_4/t.wado
@@ -959,7 +959,7 @@ fn parse_declarator_atom(p: &mut Parser) -> Result<DeclaratorNode, ParseError> {
     let kind = p.peek_kind();
     if kind == TK_LIT_STAR {
         let star = p.expect(TK_LIT_STAR)?;
-        let declarator = parse_declarator(p)?;
+        let declarator = parse_declarator(p, 1)?;
         return Result::<DeclaratorNode, ParseError>::Ok(DeclaratorNode::Alt3(DeclaratorAlt3 {
             span: Span::new(start, p.last_end()),
             star,

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_4/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_4/t.wado
@@ -818,9 +818,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_declarator(tokens, pos);
+    pos = scan_declarator(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
@@ -837,7 +837,7 @@ fn scan_declarator_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_STAR { break try_0; }
                 pos += 1;
-                pos = scan_declarator(tokens, pos);
+                pos = scan_declarator(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -847,7 +847,7 @@ fn scan_declarator_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_1; }
                 pos += 1;
-                pos = scan_declarator(tokens, pos);
+                pos = scan_declarator(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_1; }
                 pos += 1;
@@ -873,7 +873,7 @@ fn scan_declarator_lr_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { return -1; }
     pos += 1;
@@ -936,7 +936,7 @@ fn scan_declarator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     return pos;
 }
 
-fn scan_e(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_INT { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_5/t.wado",
-      "hash": "d041d023399841c27ba981e7aa0bb5efb109a5dadcb25a60995ff261c268453b",
+      "hash": "fe86614bf3f1236a411c4e63ced28f8d324b3d62143b2014f1dc2a3ae54153c6",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_5/t.wado",
-      "hash": "fe86614bf3f1236a411c4e63ced28f8d324b3d62143b2014f1dc2a3ae54153c6",
+      "hash": "ad707af2a5df1d2bacf3c9470a3bd7f6f8d70fa5c04c5c553bafaec344e4b174",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_5/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_5/t.wado
@@ -959,7 +959,7 @@ fn parse_declarator_atom(p: &mut Parser) -> Result<DeclaratorNode, ParseError> {
     let kind = p.peek_kind();
     if kind == TK_LIT_STAR {
         let star = p.expect(TK_LIT_STAR)?;
-        let declarator = parse_declarator(p)?;
+        let declarator = parse_declarator(p, 1)?;
         return Result::<DeclaratorNode, ParseError>::Ok(DeclaratorNode::Alt3(DeclaratorAlt3 {
             span: Span::new(start, p.last_end()),
             star,

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_5/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_5/t.wado
@@ -818,9 +818,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_declarator(tokens, pos);
+    pos = scan_declarator(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
@@ -837,7 +837,7 @@ fn scan_declarator_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_STAR { break try_0; }
                 pos += 1;
-                pos = scan_declarator(tokens, pos);
+                pos = scan_declarator(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -847,7 +847,7 @@ fn scan_declarator_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_1; }
                 pos += 1;
-                pos = scan_declarator(tokens, pos);
+                pos = scan_declarator(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_1; }
                 pos += 1;
@@ -873,7 +873,7 @@ fn scan_declarator_lr_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { return -1; }
     pos += 1;
@@ -936,7 +936,7 @@ fn scan_declarator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     return pos;
 }
 
-fn scan_e(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_INT { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_6/t.wado",
-      "hash": "a78ceb80b11ce98ab55fc8a9c6dc5ad1a7fbc24edde88ff8890e28dbf7191694",
+      "hash": "bec6f392c08890060b186367641bf623570db033a20e14ac8258ebbb5f8e9937",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_6/t.wado",
-      "hash": "bec6f392c08890060b186367641bf623570db033a20e14ac8258ebbb5f8e9937",
+      "hash": "df9131b975f356e64b69ed54c958e2a9de8e909eeb49e03aa7469b48cc61101c",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_6/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_6/t.wado
@@ -959,7 +959,7 @@ fn parse_declarator_atom(p: &mut Parser) -> Result<DeclaratorNode, ParseError> {
     let kind = p.peek_kind();
     if kind == TK_LIT_STAR {
         let star = p.expect(TK_LIT_STAR)?;
-        let declarator = parse_declarator(p)?;
+        let declarator = parse_declarator(p, 1)?;
         return Result::<DeclaratorNode, ParseError>::Ok(DeclaratorNode::Alt3(DeclaratorAlt3 {
             span: Span::new(start, p.last_end()),
             star,

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_6/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_6/t.wado
@@ -818,9 +818,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_declarator(tokens, pos);
+    pos = scan_declarator(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
@@ -837,7 +837,7 @@ fn scan_declarator_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_STAR { break try_0; }
                 pos += 1;
-                pos = scan_declarator(tokens, pos);
+                pos = scan_declarator(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -847,7 +847,7 @@ fn scan_declarator_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_1; }
                 pos += 1;
-                pos = scan_declarator(tokens, pos);
+                pos = scan_declarator(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_1; }
                 pos += 1;
@@ -873,7 +873,7 @@ fn scan_declarator_lr_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { return -1; }
     pos += 1;
@@ -936,7 +936,7 @@ fn scan_declarator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     return pos;
 }
 
-fn scan_e(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_INT { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_7/t.wado",
-      "hash": "6f3df9704a5f0ba59eee895da81740f421624b4820c05db462374db87262c5f3",
+      "hash": "0791548decb331def050be92f7d04da03aa570258b9cd8efea0249b0a5f4708a",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_7/t.wado",
-      "hash": "f3575a1c7dac955b66e26be249e50e93533ad7d1b42d0d2019145a836561b643",
+      "hash": "6f3df9704a5f0ba59eee895da81740f421624b4820c05db462374db87262c5f3",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_7/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_7/t.wado
@@ -959,7 +959,7 @@ fn parse_declarator_atom(p: &mut Parser) -> Result<DeclaratorNode, ParseError> {
     let kind = p.peek_kind();
     if kind == TK_LIT_STAR {
         let star = p.expect(TK_LIT_STAR)?;
-        let declarator = parse_declarator(p)?;
+        let declarator = parse_declarator(p, 1)?;
         return Result::<DeclaratorNode, ParseError>::Ok(DeclaratorNode::Alt3(DeclaratorAlt3 {
             span: Span::new(start, p.last_end()),
             star,

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_7/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_7/t.wado
@@ -818,9 +818,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_declarator(tokens, pos);
+    pos = scan_declarator(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
@@ -837,7 +837,7 @@ fn scan_declarator_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_STAR { break try_0; }
                 pos += 1;
-                pos = scan_declarator(tokens, pos);
+                pos = scan_declarator(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -847,7 +847,7 @@ fn scan_declarator_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_1; }
                 pos += 1;
-                pos = scan_declarator(tokens, pos);
+                pos = scan_declarator(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_1; }
                 pos += 1;
@@ -873,7 +873,7 @@ fn scan_declarator_lr_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { return -1; }
     pos += 1;
@@ -936,7 +936,7 @@ fn scan_declarator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     return pos;
 }
 
-fn scan_e(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_INT { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_8/t.wado",
-      "hash": "13d3c9d90b1d0713e50bd63136d38db557ddcb12fe38673f9197cbc69c84f50d",
+      "hash": "85e45ef12e451e5014a76fbf9b8dc716423601f9b60a71cbc89413a2d6093564",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_8/t.wado",
-      "hash": "85e45ef12e451e5014a76fbf9b8dc716423601f9b60a71cbc89413a2d6093564",
+      "hash": "9276d1799e21d8b320b7a3cd6de56532449519797b6cb79597dc0e8b1e34bf46",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_8/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_8/t.wado
@@ -959,7 +959,7 @@ fn parse_declarator_atom(p: &mut Parser) -> Result<DeclaratorNode, ParseError> {
     let kind = p.peek_kind();
     if kind == TK_LIT_STAR {
         let star = p.expect(TK_LIT_STAR)?;
-        let declarator = parse_declarator(p)?;
+        let declarator = parse_declarator(p, 1)?;
         return Result::<DeclaratorNode, ParseError>::Ok(DeclaratorNode::Alt3(DeclaratorAlt3 {
             span: Span::new(start, p.last_end()),
             star,

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_8/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_8/t.wado
@@ -818,9 +818,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_declarator(tokens, pos);
+    pos = scan_declarator(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
@@ -837,7 +837,7 @@ fn scan_declarator_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_STAR { break try_0; }
                 pos += 1;
-                pos = scan_declarator(tokens, pos);
+                pos = scan_declarator(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -847,7 +847,7 @@ fn scan_declarator_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_1; }
                 pos += 1;
-                pos = scan_declarator(tokens, pos);
+                pos = scan_declarator(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_1; }
                 pos += 1;
@@ -873,7 +873,7 @@ fn scan_declarator_lr_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { return -1; }
     pos += 1;
@@ -936,7 +936,7 @@ fn scan_declarator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     return pos;
 }
 
-fn scan_e(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_INT { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_9/t.wado",
-      "hash": "602ffa4ae69cb5c8bdc7e97bc38abd24f5875c3f08d3dfd962913dbeacc8708f",
+      "hash": "d48a232e849ef8b48cf60b2acdc5ae161524cd24477a010fbecdd23c140d11d4",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_9/t.wado",
-      "hash": "4d07ab212e33b7dc6b75ef40afdc513240be4b788e95a2ae60a2d7133250d1d9",
+      "hash": "602ffa4ae69cb5c8bdc7e97bc38abd24f5875c3f08d3dfd962913dbeacc8708f",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_9/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_9/t.wado
@@ -959,7 +959,7 @@ fn parse_declarator_atom(p: &mut Parser) -> Result<DeclaratorNode, ParseError> {
     let kind = p.peek_kind();
     if kind == TK_LIT_STAR {
         let star = p.expect(TK_LIT_STAR)?;
-        let declarator = parse_declarator(p)?;
+        let declarator = parse_declarator(p, 1)?;
         return Result::<DeclaratorNode, ParseError>::Ok(DeclaratorNode::Alt3(DeclaratorAlt3 {
             span: Span::new(start, p.last_end()),
             star,

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_9/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_9/t.wado
@@ -818,9 +818,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_declarator(tokens, pos);
+    pos = scan_declarator(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
@@ -837,7 +837,7 @@ fn scan_declarator_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_STAR { break try_0; }
                 pos += 1;
-                pos = scan_declarator(tokens, pos);
+                pos = scan_declarator(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -847,7 +847,7 @@ fn scan_declarator_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_1; }
                 pos += 1;
-                pos = scan_declarator(tokens, pos);
+                pos = scan_declarator(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_1; }
                 pos += 1;
@@ -873,7 +873,7 @@ fn scan_declarator_lr_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { return -1; }
     pos += 1;
@@ -936,7 +936,7 @@ fn scan_declarator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     return pos;
 }
 
-fn scan_e(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_INT { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Expressions_1/t.wado",
-      "hash": "7f06779693b83180bdec50cb2921b397ee4cdf711b367d3d4c7465821acb7f69",
+      "hash": "cf7f2043feeaf69b8b15d0de7915b48eb41c7928f1f303ace55d660c86306486",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Expressions_1/t.wado",
-      "hash": "4628f50bafcbe4503fccd804618f5b186e2f2e909aafc19baaca1c55fdc73fde",
+      "hash": "7f06779693b83180bdec50cb2921b397ee4cdf711b367d3d4c7465821acb7f69",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_1/t.wado
@@ -982,7 +982,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
     let kind = p.peek_kind();
     if kind == TK_LIT_MINUS {
         let minus = p.expect(TK_LIT_MINUS)?;
-        let e = parse_e(p)?;
+        let e = parse_e(p, 3)?;
         return Result::<ENode, ParseError>::Ok(ENode::Alt2(EAlt2 {
             span: Span::new(start, p.last_end()),
             minus,

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_1/t.wado
@@ -824,9 +824,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
@@ -843,7 +843,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_MINUS { break try_0; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Expressions_2/t.wado",
-      "hash": "9b207609c01ad67a5aabaee8e325112efb019670ab27a2212d27066fb8cc503c",
+      "hash": "eca481d4e3ea764ace1b6c27ba27fcfe64100f18021c7449e7b4fa40f5fb48e3",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Expressions_2/t.wado",
-      "hash": "19215edfab0e6cc21d253c036ddcf317befaa3c7ce862095dae3d99ef4f88cce",
+      "hash": "9b207609c01ad67a5aabaee8e325112efb019670ab27a2212d27066fb8cc503c",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_2/t.wado
@@ -982,7 +982,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
     let kind = p.peek_kind();
     if kind == TK_LIT_MINUS {
         let minus = p.expect(TK_LIT_MINUS)?;
-        let e = parse_e(p)?;
+        let e = parse_e(p, 3)?;
         return Result::<ENode, ParseError>::Ok(ENode::Alt2(EAlt2 {
             span: Span::new(start, p.last_end()),
             minus,

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_2/t.wado
@@ -824,9 +824,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
@@ -843,7 +843,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_MINUS { break try_0; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Expressions_3/t.wado",
-      "hash": "fb145f29e58abd8d7c8f4c42b13ab1191fd96c1316707d04944b753c9de692ff",
+      "hash": "cc7a3ad48626273e0a3c7ec9abca25f3185d20d1b2b4aac5a0835f379bb15e1e",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Expressions_3/t.wado",
-      "hash": "d1c190b86a02ff58b1c086d402af0e0ea18a3f5269ed64556c4c868a8d54ff4f",
+      "hash": "fb145f29e58abd8d7c8f4c42b13ab1191fd96c1316707d04944b753c9de692ff",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_3/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_3/t.wado
@@ -982,7 +982,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
     let kind = p.peek_kind();
     if kind == TK_LIT_MINUS {
         let minus = p.expect(TK_LIT_MINUS)?;
-        let e = parse_e(p)?;
+        let e = parse_e(p, 3)?;
         return Result::<ENode, ParseError>::Ok(ENode::Alt2(EAlt2 {
             span: Span::new(start, p.last_end()),
             minus,

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_3/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_3/t.wado
@@ -824,9 +824,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
@@ -843,7 +843,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_MINUS { break try_0; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Expressions_4/t.wado",
-      "hash": "9f73239e7b54934c5dd005f981bc24be4c29f2e59e60c6f6fddae83cc2756053",
+      "hash": "bd10e14aa390c59186ad4a1d223fa98d3a072b9d25d417470ea0f2ab4cb383b3",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Expressions_4/t.wado",
-      "hash": "e37a9aa0ad70bd9c6a53caa99509b889b94e7e3ec5426a868d4c0696880a0efa",
+      "hash": "9f73239e7b54934c5dd005f981bc24be4c29f2e59e60c6f6fddae83cc2756053",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_4/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_4/t.wado
@@ -982,7 +982,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
     let kind = p.peek_kind();
     if kind == TK_LIT_MINUS {
         let minus = p.expect(TK_LIT_MINUS)?;
-        let e = parse_e(p)?;
+        let e = parse_e(p, 3)?;
         return Result::<ENode, ParseError>::Ok(ENode::Alt2(EAlt2 {
             span: Span::new(start, p.last_end()),
             minus,

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_4/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_4/t.wado
@@ -824,9 +824,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
@@ -843,7 +843,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_MINUS { break try_0; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Expressions_5/t.wado",
-      "hash": "8bd21f8519e814ba90e85edfac055cfabad93741cca55de11a5e4282f36b914e",
+      "hash": "743c084232c27a716086a47ecb7ce1b32f29d35da8b1a27832b63f1087472c86",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Expressions_5/t.wado",
-      "hash": "46247952959e737209989bcc5c53caf0f71364189f780ad8aff324c105233924",
+      "hash": "8bd21f8519e814ba90e85edfac055cfabad93741cca55de11a5e4282f36b914e",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_5/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_5/t.wado
@@ -982,7 +982,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
     let kind = p.peek_kind();
     if kind == TK_LIT_MINUS {
         let minus = p.expect(TK_LIT_MINUS)?;
-        let e = parse_e(p)?;
+        let e = parse_e(p, 3)?;
         return Result::<ENode, ParseError>::Ok(ENode::Alt2(EAlt2 {
             span: Span::new(start, p.last_end()),
             minus,

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_5/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_5/t.wado
@@ -824,9 +824,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
@@ -843,7 +843,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_MINUS { break try_0; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Expressions_6/t.wado",
-      "hash": "f548efdbbac9ad50cdab3a767ebc1bf08482bb016b78e2c8498fd60add2561ac",
+      "hash": "e9f7dbfb83082f7b7214c49edb85ce1a02fc6cf41732520bde93079c0fabf49a",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Expressions_6/t.wado",
-      "hash": "e9f7dbfb83082f7b7214c49edb85ce1a02fc6cf41732520bde93079c0fabf49a",
+      "hash": "13c3ab50024c69f89e830bdcb9fea636a2cc3ba09f116f07bad47d366d0119bf",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_6/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_6/t.wado
@@ -982,7 +982,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
     let kind = p.peek_kind();
     if kind == TK_LIT_MINUS {
         let minus = p.expect(TK_LIT_MINUS)?;
-        let e = parse_e(p)?;
+        let e = parse_e(p, 3)?;
         return Result::<ENode, ParseError>::Ok(ENode::Alt2(EAlt2 {
             span: Span::new(start, p.last_end()),
             minus,

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_6/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_6/t.wado
@@ -824,9 +824,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
@@ -843,7 +843,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_MINUS { break try_0; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Expressions_7/t.wado",
-      "hash": "614f9d094801df6c56feaa40c5321e9672801a98183741c9dc2e294cda3ecffd",
+      "hash": "53f7442b7c35dcc5d5eca41647b831ee280b0dca0ebab2a08e09dd87a93e1e18",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Expressions_7/t.wado",
-      "hash": "52a8811d1b0622fc9cc8e98e4d9eb2f3defd25f260bbaf716c50027adec14906",
+      "hash": "614f9d094801df6c56feaa40c5321e9672801a98183741c9dc2e294cda3ecffd",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_7/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_7/t.wado
@@ -982,7 +982,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
     let kind = p.peek_kind();
     if kind == TK_LIT_MINUS {
         let minus = p.expect(TK_LIT_MINUS)?;
-        let e = parse_e(p)?;
+        let e = parse_e(p, 3)?;
         return Result::<ENode, ParseError>::Ok(ENode::Alt2(EAlt2 {
             span: Span::new(start, p.last_end()),
             minus,

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_7/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_7/t.wado
@@ -824,9 +824,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
@@ -843,7 +843,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_MINUS { break try_0; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/t.wado",
-      "hash": "3134b31a5848d95a69920508d4b98fdeb34fbc86e7c5075f31d84f568b919235",
+      "hash": "198d5a4abfbc6e9f627023e8b4a2a1f04d36f9d70edfc0eb101856af2e1ad322",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/t.wado",
-      "hash": "1569e42ae226b96d2e424a51a73e64ca94f690f89d2b728f6c651cdcd50ee57d",
+      "hash": "3134b31a5848d95a69920508d4b98fdeb34fbc86e7c5075f31d84f568b919235",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/t.wado",
-      "hash": "198d5a4abfbc6e9f627023e8b4a2a1f04d36f9d70edfc0eb101856af2e1ad322",
+      "hash": "3627adfaf9cd2893ffb5325ae456204ce77015c8eee0d57f82b1842fa147b18b",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/t.wado",
-      "hash": "98305412b01919bca4f5eb899916aa44c6868dba09058ccfaf9e696c979e528c",
+      "hash": "1569e42ae226b96d2e424a51a73e64ca94f690f89d2b728f6c651cdcd50ee57d",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/t.wado
@@ -1645,18 +1645,18 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_expression_list(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_expression_list(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -1664,7 +1664,7 @@ fn scan_expression_list(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_0; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break sg_0; }
                 break sg_0_done;
             }
@@ -1686,11 +1686,11 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_7: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_7; }
                 pos += 1;
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_7; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 break scan_alts;
             }
@@ -1698,7 +1698,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_0; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_0; }
                 pos += 1;
@@ -1732,7 +1732,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_ID {
             pos = start;
             try_5: {
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break try_5; }
                 pos += 1;
@@ -1750,7 +1750,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_INT {
             pos = start;
             try_5: {
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break try_5; }
                 pos += 1;
@@ -1764,7 +1764,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_6: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_NEW { break try_6; }
                 pos += 1;
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 let gp_1 = pos;
                 let sgk_1 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -1776,7 +1776,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                             pos += 1;
                             if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
                                 let sp = pos;
-                                pos = scan_expression_list(tokens, pos);
+                                pos = scan_expression_list(tokens, pos, 0);
                                 if pos < 0 { pos = sp; }
                             }
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_1_0; }
@@ -1789,7 +1789,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                 sg_2: {
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break sg_2; }
                                     pos += 1;
-                                    pos = scan_e(tokens, pos);
+                                    pos = scan_e(tokens, pos, 0);
                                     if pos < 0 { break sg_2; }
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break sg_2; }
                                     pos += 1;
@@ -1803,7 +1803,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_3: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break sg_3; }
                                         pos += 1;
-                                        pos = scan_e(tokens, pos);
+                                        pos = scan_e(tokens, pos, 0);
                                         if pos < 0 { break sg_3; }
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break sg_3; }
                                         pos += 1;
@@ -1853,7 +1853,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     break try_8;
                 }
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
@@ -1877,7 +1877,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     break try_9;
                 }
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_9; }
                 break scan_alts;
             }
@@ -1917,7 +1917,7 @@ fn scan_e_lr_8(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_list(tokens, pos);
+        pos = scan_expression_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
@@ -1937,7 +1937,7 @@ fn scan_e_lr_9(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_list(tokens, pos);
+        pos = scan_expression_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
@@ -1983,7 +1983,7 @@ fn scan_e_lr_14(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_list(tokens, pos);
+        pos = scan_expression_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
@@ -2437,7 +2437,7 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     return pos;
 }
 
-fn scan_typespec(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_typespec(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -2507,7 +2507,7 @@ fn parse_expression_list(p: &mut Parser) -> Result<ExpressionListNode, ParseErro
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_e(tokens, pos);
+            pos = scan_e(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -2547,11 +2547,11 @@ fn parse_e_scan_12(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_typespec(tokens, pos);
+    pos = scan_typespec(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_e_atom(tokens, pos);
+    pos = scan_e(tokens, pos, 2147483647);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -2573,7 +2573,7 @@ fn parse_e_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
@@ -2595,7 +2595,7 @@ fn parse_e_bt_5(p: &mut Parser) -> Result<ENode, ParseError> {
 
 fn parse_e_scan_5(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_typespec(tokens, pos);
+    pos = scan_typespec(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
     pos += 1;
@@ -2724,7 +2724,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
                         let mut pos: i32 = p.pos;
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break rep_scan; }
                         pos += 1;
-                        pos = scan_e(tokens, pos);
+                        pos = scan_e(tokens, pos, 0);
                         if pos < 0 { break rep_scan; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break rep_scan; }
                         pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/t.wado
@@ -2551,7 +2551,7 @@ fn parse_e_scan_12(tokens: &Array<Token>, pos: i32) -> i32 {
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e_atom(tokens, pos);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -2573,7 +2573,7 @@ fn parse_e_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e_atom(tokens, pos);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/t.wado
@@ -2533,7 +2533,7 @@ fn parse_e_bt_12(p: &mut Parser) -> Result<ENode, ParseError> {
     let lparen = p.expect(TK_LIT_LPAREN)?;
     let typespec = parse_typespec(p)?;
     let rparen = p.expect(TK_LIT_RPAREN)?;
-    let e = parse_e(p)?;
+    let e = parse_e(p, 16)?;
     return Result::<ENode, ParseError>::Ok(ENode::Alt12(EAlt12 {
         span: Span::new(start, p.last_end()),
         lparen,
@@ -2758,7 +2758,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
     }
     if _gale_kind_set_2(kind) {
         let plus_or_minus_or_lit_plusplus_or_lit_minusminus = p.advance();
-        let e = parse_e(p)?;
+        let e = parse_e(p, 14)?;
         return Result::<ENode, ParseError>::Ok(ENode::Alt15(EAlt15 {
             span: Span::new(start, p.last_end()),
             plus_or_minus_or_lit_plusplus_or_lit_minusminus,
@@ -2767,7 +2767,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
     }
     if _gale_kind_set_3(kind) {
         let tilde_or_bang = p.advance();
-        let e = parse_e(p)?;
+        let e = parse_e(p, 14)?;
         return Result::<ENode, ParseError>::Ok(ENode::Alt16(EAlt16 {
             span: Span::new(start, p.last_end()),
             tilde_or_bang,

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/t.wado
@@ -2573,7 +2573,7 @@ fn parse_e_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_e_atom(tokens, pos);
+    pos = scan_e(tokens, pos);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/t.wado",
-      "hash": "91b42777900f04a1a30b64249d4b20eced402642c09ebc18d5893b5131194223",
+      "hash": "017f6b55acb3004e58427eb38d936fa71c1e7235103384134935a6d52fd5acb7",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/t.wado",
-      "hash": "68d9b6c27d847e4771135248acd974db31ce50bff285cfe889cc26a648f450c7",
+      "hash": "32baac7881a55aba65fd9132a0c9cf999215dba9d91dd81d15b51c5a2ad5cc16",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/t.wado",
-      "hash": "32baac7881a55aba65fd9132a0c9cf999215dba9d91dd81d15b51c5a2ad5cc16",
+      "hash": "df42eb3f131a6194ac05bfb34eff5a9ea90d26c130abd7edf8fb2893e08fa5c6",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/t.wado",
-      "hash": "df42eb3f131a6194ac05bfb34eff5a9ea90d26c130abd7edf8fb2893e08fa5c6",
+      "hash": "91b42777900f04a1a30b64249d4b20eced402642c09ebc18d5893b5131194223",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/t.wado
@@ -1645,18 +1645,18 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_expression_list(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_expression_list(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -1664,7 +1664,7 @@ fn scan_expression_list(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_0; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break sg_0; }
                 break sg_0_done;
             }
@@ -1686,11 +1686,11 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_7: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_7; }
                 pos += 1;
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_7; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 break scan_alts;
             }
@@ -1698,7 +1698,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_0; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_0; }
                 pos += 1;
@@ -1732,7 +1732,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_ID {
             pos = start;
             try_5: {
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break try_5; }
                 pos += 1;
@@ -1750,7 +1750,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_INT {
             pos = start;
             try_5: {
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break try_5; }
                 pos += 1;
@@ -1764,7 +1764,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_6: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_NEW { break try_6; }
                 pos += 1;
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 let gp_1 = pos;
                 let sgk_1 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -1776,7 +1776,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                             pos += 1;
                             if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
                                 let sp = pos;
-                                pos = scan_expression_list(tokens, pos);
+                                pos = scan_expression_list(tokens, pos, 0);
                                 if pos < 0 { pos = sp; }
                             }
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_1_0; }
@@ -1789,7 +1789,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                 sg_2: {
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break sg_2; }
                                     pos += 1;
-                                    pos = scan_e(tokens, pos);
+                                    pos = scan_e(tokens, pos, 0);
                                     if pos < 0 { break sg_2; }
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break sg_2; }
                                     pos += 1;
@@ -1803,7 +1803,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_3: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break sg_3; }
                                         pos += 1;
-                                        pos = scan_e(tokens, pos);
+                                        pos = scan_e(tokens, pos, 0);
                                         if pos < 0 { break sg_3; }
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break sg_3; }
                                         pos += 1;
@@ -1853,7 +1853,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     break try_8;
                 }
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
@@ -1877,7 +1877,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     break try_9;
                 }
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_9; }
                 break scan_alts;
             }
@@ -1917,7 +1917,7 @@ fn scan_e_lr_8(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_list(tokens, pos);
+        pos = scan_expression_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
@@ -1937,7 +1937,7 @@ fn scan_e_lr_9(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_list(tokens, pos);
+        pos = scan_expression_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
@@ -1983,7 +1983,7 @@ fn scan_e_lr_14(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_list(tokens, pos);
+        pos = scan_expression_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
@@ -2437,7 +2437,7 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     return pos;
 }
 
-fn scan_typespec(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_typespec(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -2507,7 +2507,7 @@ fn parse_expression_list(p: &mut Parser) -> Result<ExpressionListNode, ParseErro
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_e(tokens, pos);
+            pos = scan_e(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -2547,11 +2547,11 @@ fn parse_e_scan_12(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_typespec(tokens, pos);
+    pos = scan_typespec(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_e_atom(tokens, pos);
+    pos = scan_e(tokens, pos, 2147483647);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -2573,7 +2573,7 @@ fn parse_e_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
@@ -2595,7 +2595,7 @@ fn parse_e_bt_5(p: &mut Parser) -> Result<ENode, ParseError> {
 
 fn parse_e_scan_5(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_typespec(tokens, pos);
+    pos = scan_typespec(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
     pos += 1;
@@ -2724,7 +2724,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
                         let mut pos: i32 = p.pos;
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break rep_scan; }
                         pos += 1;
-                        pos = scan_e(tokens, pos);
+                        pos = scan_e(tokens, pos, 0);
                         if pos < 0 { break rep_scan; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break rep_scan; }
                         pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/t.wado
@@ -2551,7 +2551,7 @@ fn parse_e_scan_12(tokens: &Array<Token>, pos: i32) -> i32 {
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e_atom(tokens, pos);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -2573,7 +2573,7 @@ fn parse_e_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e_atom(tokens, pos);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/t.wado
@@ -2533,7 +2533,7 @@ fn parse_e_bt_12(p: &mut Parser) -> Result<ENode, ParseError> {
     let lparen = p.expect(TK_LIT_LPAREN)?;
     let typespec = parse_typespec(p)?;
     let rparen = p.expect(TK_LIT_RPAREN)?;
-    let e = parse_e(p)?;
+    let e = parse_e(p, 16)?;
     return Result::<ENode, ParseError>::Ok(ENode::Alt12(EAlt12 {
         span: Span::new(start, p.last_end()),
         lparen,
@@ -2758,7 +2758,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
     }
     if _gale_kind_set_2(kind) {
         let plus_or_minus_or_lit_plusplus_or_lit_minusminus = p.advance();
-        let e = parse_e(p)?;
+        let e = parse_e(p, 14)?;
         return Result::<ENode, ParseError>::Ok(ENode::Alt15(EAlt15 {
             span: Span::new(start, p.last_end()),
             plus_or_minus_or_lit_plusplus_or_lit_minusminus,
@@ -2767,7 +2767,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
     }
     if _gale_kind_set_3(kind) {
         let tilde_or_bang = p.advance();
-        let e = parse_e(p)?;
+        let e = parse_e(p, 14)?;
         return Result::<ENode, ParseError>::Ok(ENode::Alt16(EAlt16 {
             span: Span::new(start, p.last_end()),
             tilde_or_bang,

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/t.wado
@@ -2573,7 +2573,7 @@ fn parse_e_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_e_atom(tokens, pos);
+    pos = scan_e(tokens, pos);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/t.wado",
-      "hash": "1e8b00dc444b89ce62fb87be904766b943df87c31e0d5bf9b4ab3ca2805d9d80",
+      "hash": "6b0540398d8f69c39ae90d3664e77cbd055b6065fc5a36e7981bd35576141ea6",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/t.wado",
-      "hash": "87095bab64500a92294e682a41d29cece50e5e7ba722ead559e0c8594fc86100",
+      "hash": "f7434236b134e05751e6fc7cc4f07a7bb87d0c47dcef701fa268e54d671f400b",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/t.wado",
-      "hash": "6b0540398d8f69c39ae90d3664e77cbd055b6065fc5a36e7981bd35576141ea6",
+      "hash": "87095bab64500a92294e682a41d29cece50e5e7ba722ead559e0c8594fc86100",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/t.wado",
-      "hash": "f7434236b134e05751e6fc7cc4f07a7bb87d0c47dcef701fa268e54d671f400b",
+      "hash": "49f1275bf02bd13b615251804b803e1a7d8b9b702283e9da98a798af40f84c10",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/t.wado
@@ -1645,18 +1645,18 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_expression_list(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_expression_list(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -1664,7 +1664,7 @@ fn scan_expression_list(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_0; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break sg_0; }
                 break sg_0_done;
             }
@@ -1686,11 +1686,11 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_7: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_7; }
                 pos += 1;
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_7; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 break scan_alts;
             }
@@ -1698,7 +1698,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_0; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_0; }
                 pos += 1;
@@ -1732,7 +1732,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_ID {
             pos = start;
             try_5: {
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break try_5; }
                 pos += 1;
@@ -1750,7 +1750,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_INT {
             pos = start;
             try_5: {
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break try_5; }
                 pos += 1;
@@ -1764,7 +1764,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_6: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_NEW { break try_6; }
                 pos += 1;
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 let gp_1 = pos;
                 let sgk_1 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -1776,7 +1776,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                             pos += 1;
                             if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
                                 let sp = pos;
-                                pos = scan_expression_list(tokens, pos);
+                                pos = scan_expression_list(tokens, pos, 0);
                                 if pos < 0 { pos = sp; }
                             }
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_1_0; }
@@ -1789,7 +1789,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                 sg_2: {
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break sg_2; }
                                     pos += 1;
-                                    pos = scan_e(tokens, pos);
+                                    pos = scan_e(tokens, pos, 0);
                                     if pos < 0 { break sg_2; }
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break sg_2; }
                                     pos += 1;
@@ -1803,7 +1803,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_3: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break sg_3; }
                                         pos += 1;
-                                        pos = scan_e(tokens, pos);
+                                        pos = scan_e(tokens, pos, 0);
                                         if pos < 0 { break sg_3; }
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break sg_3; }
                                         pos += 1;
@@ -1853,7 +1853,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     break try_8;
                 }
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
@@ -1877,7 +1877,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     break try_9;
                 }
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_9; }
                 break scan_alts;
             }
@@ -1917,7 +1917,7 @@ fn scan_e_lr_8(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_list(tokens, pos);
+        pos = scan_expression_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
@@ -1937,7 +1937,7 @@ fn scan_e_lr_9(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_list(tokens, pos);
+        pos = scan_expression_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
@@ -1983,7 +1983,7 @@ fn scan_e_lr_14(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_list(tokens, pos);
+        pos = scan_expression_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
@@ -2437,7 +2437,7 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     return pos;
 }
 
-fn scan_typespec(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_typespec(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -2507,7 +2507,7 @@ fn parse_expression_list(p: &mut Parser) -> Result<ExpressionListNode, ParseErro
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_e(tokens, pos);
+            pos = scan_e(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -2547,11 +2547,11 @@ fn parse_e_scan_12(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_typespec(tokens, pos);
+    pos = scan_typespec(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_e_atom(tokens, pos);
+    pos = scan_e(tokens, pos, 2147483647);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -2573,7 +2573,7 @@ fn parse_e_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
@@ -2595,7 +2595,7 @@ fn parse_e_bt_5(p: &mut Parser) -> Result<ENode, ParseError> {
 
 fn parse_e_scan_5(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_typespec(tokens, pos);
+    pos = scan_typespec(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
     pos += 1;
@@ -2724,7 +2724,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
                         let mut pos: i32 = p.pos;
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break rep_scan; }
                         pos += 1;
-                        pos = scan_e(tokens, pos);
+                        pos = scan_e(tokens, pos, 0);
                         if pos < 0 { break rep_scan; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break rep_scan; }
                         pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/t.wado
@@ -2551,7 +2551,7 @@ fn parse_e_scan_12(tokens: &Array<Token>, pos: i32) -> i32 {
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e_atom(tokens, pos);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -2573,7 +2573,7 @@ fn parse_e_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e_atom(tokens, pos);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/t.wado
@@ -2533,7 +2533,7 @@ fn parse_e_bt_12(p: &mut Parser) -> Result<ENode, ParseError> {
     let lparen = p.expect(TK_LIT_LPAREN)?;
     let typespec = parse_typespec(p)?;
     let rparen = p.expect(TK_LIT_RPAREN)?;
-    let e = parse_e(p)?;
+    let e = parse_e(p, 16)?;
     return Result::<ENode, ParseError>::Ok(ENode::Alt12(EAlt12 {
         span: Span::new(start, p.last_end()),
         lparen,
@@ -2758,7 +2758,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
     }
     if _gale_kind_set_2(kind) {
         let plus_or_minus_or_lit_plusplus_or_lit_minusminus = p.advance();
-        let e = parse_e(p)?;
+        let e = parse_e(p, 14)?;
         return Result::<ENode, ParseError>::Ok(ENode::Alt15(EAlt15 {
             span: Span::new(start, p.last_end()),
             plus_or_minus_or_lit_plusplus_or_lit_minusminus,
@@ -2767,7 +2767,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
     }
     if _gale_kind_set_3(kind) {
         let tilde_or_bang = p.advance();
-        let e = parse_e(p)?;
+        let e = parse_e(p, 14)?;
         return Result::<ENode, ParseError>::Ok(ENode::Alt16(EAlt16 {
             span: Span::new(start, p.last_end()),
             tilde_or_bang,

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/t.wado
@@ -2573,7 +2573,7 @@ fn parse_e_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_e_atom(tokens, pos);
+    pos = scan_e(tokens, pos);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/t.wado",
-      "hash": "ff0b92a2adf6d4962da21b60c7a3a96082e05edd3beacc64445dface882f6405",
+      "hash": "cb14b0e56400362643d0b009fdfff5ae33efd145951dee77d3e48adc010d5dda",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/t.wado",
-      "hash": "eedad2e46f262b83b8072199051b907c61f55dc260a8d0ce81d284564ca5af8b",
+      "hash": "ef006e78d35a120655b7baa8abb2a069ffc36fb43611951ea777ee39fba7b979",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/t.wado",
-      "hash": "192d982f4ac83bcf9df2bac50ac515d01848f928f6649f3b312b4df7ebf262ee",
+      "hash": "eedad2e46f262b83b8072199051b907c61f55dc260a8d0ce81d284564ca5af8b",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/t.wado",
-      "hash": "cb14b0e56400362643d0b009fdfff5ae33efd145951dee77d3e48adc010d5dda",
+      "hash": "192d982f4ac83bcf9df2bac50ac515d01848f928f6649f3b312b4df7ebf262ee",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/t.wado
@@ -1645,18 +1645,18 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_expression_list(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_expression_list(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -1664,7 +1664,7 @@ fn scan_expression_list(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_0; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break sg_0; }
                 break sg_0_done;
             }
@@ -1686,11 +1686,11 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_7: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_7; }
                 pos += 1;
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_7; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 break scan_alts;
             }
@@ -1698,7 +1698,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_0; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_0; }
                 pos += 1;
@@ -1732,7 +1732,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_ID {
             pos = start;
             try_5: {
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break try_5; }
                 pos += 1;
@@ -1750,7 +1750,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_INT {
             pos = start;
             try_5: {
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break try_5; }
                 pos += 1;
@@ -1764,7 +1764,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_6: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_NEW { break try_6; }
                 pos += 1;
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 let gp_1 = pos;
                 let sgk_1 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -1776,7 +1776,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                             pos += 1;
                             if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
                                 let sp = pos;
-                                pos = scan_expression_list(tokens, pos);
+                                pos = scan_expression_list(tokens, pos, 0);
                                 if pos < 0 { pos = sp; }
                             }
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_1_0; }
@@ -1789,7 +1789,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                 sg_2: {
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break sg_2; }
                                     pos += 1;
-                                    pos = scan_e(tokens, pos);
+                                    pos = scan_e(tokens, pos, 0);
                                     if pos < 0 { break sg_2; }
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break sg_2; }
                                     pos += 1;
@@ -1803,7 +1803,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_3: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break sg_3; }
                                         pos += 1;
-                                        pos = scan_e(tokens, pos);
+                                        pos = scan_e(tokens, pos, 0);
                                         if pos < 0 { break sg_3; }
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break sg_3; }
                                         pos += 1;
@@ -1853,7 +1853,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     break try_8;
                 }
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
@@ -1877,7 +1877,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     break try_9;
                 }
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_9; }
                 break scan_alts;
             }
@@ -1917,7 +1917,7 @@ fn scan_e_lr_8(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_list(tokens, pos);
+        pos = scan_expression_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
@@ -1937,7 +1937,7 @@ fn scan_e_lr_9(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_list(tokens, pos);
+        pos = scan_expression_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
@@ -1983,7 +1983,7 @@ fn scan_e_lr_14(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_list(tokens, pos);
+        pos = scan_expression_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
@@ -2437,7 +2437,7 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     return pos;
 }
 
-fn scan_typespec(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_typespec(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -2507,7 +2507,7 @@ fn parse_expression_list(p: &mut Parser) -> Result<ExpressionListNode, ParseErro
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_e(tokens, pos);
+            pos = scan_e(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -2547,11 +2547,11 @@ fn parse_e_scan_12(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_typespec(tokens, pos);
+    pos = scan_typespec(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_e_atom(tokens, pos);
+    pos = scan_e(tokens, pos, 2147483647);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -2573,7 +2573,7 @@ fn parse_e_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
@@ -2595,7 +2595,7 @@ fn parse_e_bt_5(p: &mut Parser) -> Result<ENode, ParseError> {
 
 fn parse_e_scan_5(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_typespec(tokens, pos);
+    pos = scan_typespec(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
     pos += 1;
@@ -2724,7 +2724,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
                         let mut pos: i32 = p.pos;
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break rep_scan; }
                         pos += 1;
-                        pos = scan_e(tokens, pos);
+                        pos = scan_e(tokens, pos, 0);
                         if pos < 0 { break rep_scan; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break rep_scan; }
                         pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/t.wado
@@ -2551,7 +2551,7 @@ fn parse_e_scan_12(tokens: &Array<Token>, pos: i32) -> i32 {
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e_atom(tokens, pos);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -2573,7 +2573,7 @@ fn parse_e_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e_atom(tokens, pos);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/t.wado
@@ -2533,7 +2533,7 @@ fn parse_e_bt_12(p: &mut Parser) -> Result<ENode, ParseError> {
     let lparen = p.expect(TK_LIT_LPAREN)?;
     let typespec = parse_typespec(p)?;
     let rparen = p.expect(TK_LIT_RPAREN)?;
-    let e = parse_e(p)?;
+    let e = parse_e(p, 16)?;
     return Result::<ENode, ParseError>::Ok(ENode::Alt12(EAlt12 {
         span: Span::new(start, p.last_end()),
         lparen,
@@ -2758,7 +2758,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
     }
     if _gale_kind_set_2(kind) {
         let plus_or_minus_or_lit_plusplus_or_lit_minusminus = p.advance();
-        let e = parse_e(p)?;
+        let e = parse_e(p, 14)?;
         return Result::<ENode, ParseError>::Ok(ENode::Alt15(EAlt15 {
             span: Span::new(start, p.last_end()),
             plus_or_minus_or_lit_plusplus_or_lit_minusminus,
@@ -2767,7 +2767,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
     }
     if _gale_kind_set_3(kind) {
         let tilde_or_bang = p.advance();
-        let e = parse_e(p)?;
+        let e = parse_e(p, 14)?;
         return Result::<ENode, ParseError>::Ok(ENode::Alt16(EAlt16 {
             span: Span::new(start, p.last_end()),
             tilde_or_bang,

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/t.wado
@@ -2573,7 +2573,7 @@ fn parse_e_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_e_atom(tokens, pos);
+    pos = scan_e(tokens, pos);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/t.wado",
-      "hash": "44c5ca07830ba4289a599f3987425df07375d170a3729a9eb831e4abed8d50b9",
+      "hash": "852a522f5d830ca0d2b69c68c49c9f9423812c6243233c191958245c526e8009",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/t.wado",
-      "hash": "852a522f5d830ca0d2b69c68c49c9f9423812c6243233c191958245c526e8009",
+      "hash": "071fd362f32d9c167350d8064c929e8bbcfdb78631d7533098d05714de54817e",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/t.wado",
-      "hash": "071fd362f32d9c167350d8064c929e8bbcfdb78631d7533098d05714de54817e",
+      "hash": "7c295b0adeb28edbfbf32d5bfe24f7197284d99127587cd7777ee248bef904cc",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/t.wado",
-      "hash": "7c295b0adeb28edbfbf32d5bfe24f7197284d99127587cd7777ee248bef904cc",
+      "hash": "9e65229603bda8a6e0eba0ee7c51a79f9865f44b8e3da15ae6be57af93cb86db",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/t.wado
@@ -1645,18 +1645,18 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_expression_list(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_expression_list(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -1664,7 +1664,7 @@ fn scan_expression_list(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_0; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break sg_0; }
                 break sg_0_done;
             }
@@ -1686,11 +1686,11 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_7: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_7; }
                 pos += 1;
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_7; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 break scan_alts;
             }
@@ -1698,7 +1698,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_0; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_0; }
                 pos += 1;
@@ -1732,7 +1732,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_ID {
             pos = start;
             try_5: {
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break try_5; }
                 pos += 1;
@@ -1750,7 +1750,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_INT {
             pos = start;
             try_5: {
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break try_5; }
                 pos += 1;
@@ -1764,7 +1764,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_6: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_NEW { break try_6; }
                 pos += 1;
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 let gp_1 = pos;
                 let sgk_1 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -1776,7 +1776,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                             pos += 1;
                             if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
                                 let sp = pos;
-                                pos = scan_expression_list(tokens, pos);
+                                pos = scan_expression_list(tokens, pos, 0);
                                 if pos < 0 { pos = sp; }
                             }
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_1_0; }
@@ -1789,7 +1789,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                 sg_2: {
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break sg_2; }
                                     pos += 1;
-                                    pos = scan_e(tokens, pos);
+                                    pos = scan_e(tokens, pos, 0);
                                     if pos < 0 { break sg_2; }
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break sg_2; }
                                     pos += 1;
@@ -1803,7 +1803,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_3: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break sg_3; }
                                         pos += 1;
-                                        pos = scan_e(tokens, pos);
+                                        pos = scan_e(tokens, pos, 0);
                                         if pos < 0 { break sg_3; }
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break sg_3; }
                                         pos += 1;
@@ -1853,7 +1853,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     break try_8;
                 }
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
@@ -1877,7 +1877,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     break try_9;
                 }
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_9; }
                 break scan_alts;
             }
@@ -1917,7 +1917,7 @@ fn scan_e_lr_8(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_list(tokens, pos);
+        pos = scan_expression_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
@@ -1937,7 +1937,7 @@ fn scan_e_lr_9(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_list(tokens, pos);
+        pos = scan_expression_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
@@ -1983,7 +1983,7 @@ fn scan_e_lr_14(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_list(tokens, pos);
+        pos = scan_expression_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
@@ -2437,7 +2437,7 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     return pos;
 }
 
-fn scan_typespec(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_typespec(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -2507,7 +2507,7 @@ fn parse_expression_list(p: &mut Parser) -> Result<ExpressionListNode, ParseErro
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_e(tokens, pos);
+            pos = scan_e(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -2547,11 +2547,11 @@ fn parse_e_scan_12(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_typespec(tokens, pos);
+    pos = scan_typespec(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_e_atom(tokens, pos);
+    pos = scan_e(tokens, pos, 2147483647);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -2573,7 +2573,7 @@ fn parse_e_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
@@ -2595,7 +2595,7 @@ fn parse_e_bt_5(p: &mut Parser) -> Result<ENode, ParseError> {
 
 fn parse_e_scan_5(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_typespec(tokens, pos);
+    pos = scan_typespec(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
     pos += 1;
@@ -2724,7 +2724,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
                         let mut pos: i32 = p.pos;
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break rep_scan; }
                         pos += 1;
-                        pos = scan_e(tokens, pos);
+                        pos = scan_e(tokens, pos, 0);
                         if pos < 0 { break rep_scan; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break rep_scan; }
                         pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/t.wado
@@ -2551,7 +2551,7 @@ fn parse_e_scan_12(tokens: &Array<Token>, pos: i32) -> i32 {
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e_atom(tokens, pos);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -2573,7 +2573,7 @@ fn parse_e_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e_atom(tokens, pos);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/t.wado
@@ -2533,7 +2533,7 @@ fn parse_e_bt_12(p: &mut Parser) -> Result<ENode, ParseError> {
     let lparen = p.expect(TK_LIT_LPAREN)?;
     let typespec = parse_typespec(p)?;
     let rparen = p.expect(TK_LIT_RPAREN)?;
-    let e = parse_e(p)?;
+    let e = parse_e(p, 16)?;
     return Result::<ENode, ParseError>::Ok(ENode::Alt12(EAlt12 {
         span: Span::new(start, p.last_end()),
         lparen,
@@ -2758,7 +2758,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
     }
     if _gale_kind_set_2(kind) {
         let plus_or_minus_or_lit_plusplus_or_lit_minusminus = p.advance();
-        let e = parse_e(p)?;
+        let e = parse_e(p, 14)?;
         return Result::<ENode, ParseError>::Ok(ENode::Alt15(EAlt15 {
             span: Span::new(start, p.last_end()),
             plus_or_minus_or_lit_plusplus_or_lit_minusminus,
@@ -2767,7 +2767,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
     }
     if _gale_kind_set_3(kind) {
         let tilde_or_bang = p.advance();
-        let e = parse_e(p)?;
+        let e = parse_e(p, 14)?;
         return Result::<ENode, ParseError>::Ok(ENode::Alt16(EAlt16 {
             span: Span::new(start, p.last_end()),
             tilde_or_bang,

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/t.wado
@@ -2573,7 +2573,7 @@ fn parse_e_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_e_atom(tokens, pos);
+    pos = scan_e(tokens, pos);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/t.wado",
-      "hash": "b362012f7387e25cb72a924896ce9400e4467b5e08263f07b1ce1f5860435aaf",
+      "hash": "d451941088c2c4757a1b43b0423a3ce220fb02999ea38be0d16d0fc3ce662b75",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/t.wado",
-      "hash": "9a4a8cf5d4b369d6905a37ba8da165f15d10b5abec21063c0ed5e43955261dcc",
+      "hash": "53d8f87a3d2c994ebf550977dd204e95e8a423fb6efefc79810636a2dd47b26c",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/t.wado",
-      "hash": "91d85b70c17f2c49cbbadd96494691dbe9b08e9321969fe5831bebb0281c0c5f",
+      "hash": "b362012f7387e25cb72a924896ce9400e4467b5e08263f07b1ce1f5860435aaf",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/t.wado",
-      "hash": "53d8f87a3d2c994ebf550977dd204e95e8a423fb6efefc79810636a2dd47b26c",
+      "hash": "91d85b70c17f2c49cbbadd96494691dbe9b08e9321969fe5831bebb0281c0c5f",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/t.wado
@@ -1645,18 +1645,18 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_expression_list(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_expression_list(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -1664,7 +1664,7 @@ fn scan_expression_list(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_0; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break sg_0; }
                 break sg_0_done;
             }
@@ -1686,11 +1686,11 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_7: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_7; }
                 pos += 1;
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_7; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 break scan_alts;
             }
@@ -1698,7 +1698,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_0; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_0; }
                 pos += 1;
@@ -1732,7 +1732,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_ID {
             pos = start;
             try_5: {
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break try_5; }
                 pos += 1;
@@ -1750,7 +1750,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_INT {
             pos = start;
             try_5: {
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break try_5; }
                 pos += 1;
@@ -1764,7 +1764,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_6: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_NEW { break try_6; }
                 pos += 1;
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 let gp_1 = pos;
                 let sgk_1 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -1776,7 +1776,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                             pos += 1;
                             if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
                                 let sp = pos;
-                                pos = scan_expression_list(tokens, pos);
+                                pos = scan_expression_list(tokens, pos, 0);
                                 if pos < 0 { pos = sp; }
                             }
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_1_0; }
@@ -1789,7 +1789,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                 sg_2: {
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break sg_2; }
                                     pos += 1;
-                                    pos = scan_e(tokens, pos);
+                                    pos = scan_e(tokens, pos, 0);
                                     if pos < 0 { break sg_2; }
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break sg_2; }
                                     pos += 1;
@@ -1803,7 +1803,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_3: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break sg_3; }
                                         pos += 1;
-                                        pos = scan_e(tokens, pos);
+                                        pos = scan_e(tokens, pos, 0);
                                         if pos < 0 { break sg_3; }
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break sg_3; }
                                         pos += 1;
@@ -1853,7 +1853,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     break try_8;
                 }
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
@@ -1877,7 +1877,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     break try_9;
                 }
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_9; }
                 break scan_alts;
             }
@@ -1917,7 +1917,7 @@ fn scan_e_lr_8(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_list(tokens, pos);
+        pos = scan_expression_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
@@ -1937,7 +1937,7 @@ fn scan_e_lr_9(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_list(tokens, pos);
+        pos = scan_expression_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
@@ -1983,7 +1983,7 @@ fn scan_e_lr_14(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_list(tokens, pos);
+        pos = scan_expression_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
@@ -2437,7 +2437,7 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     return pos;
 }
 
-fn scan_typespec(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_typespec(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -2507,7 +2507,7 @@ fn parse_expression_list(p: &mut Parser) -> Result<ExpressionListNode, ParseErro
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_e(tokens, pos);
+            pos = scan_e(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -2547,11 +2547,11 @@ fn parse_e_scan_12(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_typespec(tokens, pos);
+    pos = scan_typespec(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_e_atom(tokens, pos);
+    pos = scan_e(tokens, pos, 2147483647);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -2573,7 +2573,7 @@ fn parse_e_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
@@ -2595,7 +2595,7 @@ fn parse_e_bt_5(p: &mut Parser) -> Result<ENode, ParseError> {
 
 fn parse_e_scan_5(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_typespec(tokens, pos);
+    pos = scan_typespec(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
     pos += 1;
@@ -2724,7 +2724,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
                         let mut pos: i32 = p.pos;
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break rep_scan; }
                         pos += 1;
-                        pos = scan_e(tokens, pos);
+                        pos = scan_e(tokens, pos, 0);
                         if pos < 0 { break rep_scan; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break rep_scan; }
                         pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/t.wado
@@ -2551,7 +2551,7 @@ fn parse_e_scan_12(tokens: &Array<Token>, pos: i32) -> i32 {
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e_atom(tokens, pos);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -2573,7 +2573,7 @@ fn parse_e_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e_atom(tokens, pos);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/t.wado
@@ -2533,7 +2533,7 @@ fn parse_e_bt_12(p: &mut Parser) -> Result<ENode, ParseError> {
     let lparen = p.expect(TK_LIT_LPAREN)?;
     let typespec = parse_typespec(p)?;
     let rparen = p.expect(TK_LIT_RPAREN)?;
-    let e = parse_e(p)?;
+    let e = parse_e(p, 16)?;
     return Result::<ENode, ParseError>::Ok(ENode::Alt12(EAlt12 {
         span: Span::new(start, p.last_end()),
         lparen,
@@ -2758,7 +2758,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
     }
     if _gale_kind_set_2(kind) {
         let plus_or_minus_or_lit_plusplus_or_lit_minusminus = p.advance();
-        let e = parse_e(p)?;
+        let e = parse_e(p, 14)?;
         return Result::<ENode, ParseError>::Ok(ENode::Alt15(EAlt15 {
             span: Span::new(start, p.last_end()),
             plus_or_minus_or_lit_plusplus_or_lit_minusminus,
@@ -2767,7 +2767,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
     }
     if _gale_kind_set_3(kind) {
         let tilde_or_bang = p.advance();
-        let e = parse_e(p)?;
+        let e = parse_e(p, 14)?;
         return Result::<ENode, ParseError>::Ok(ENode::Alt16(EAlt16 {
             span: Span::new(start, p.last_end()),
             tilde_or_bang,

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/t.wado
@@ -2573,7 +2573,7 @@ fn parse_e_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_e_atom(tokens, pos);
+    pos = scan_e(tokens, pos);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/t.wado",
-      "hash": "25707eca033ded9d754972303f9313f4437608575548f660b6ddd7b1381b6cce",
+      "hash": "1fe609d542b28a90e4986d9868c89bc5b00c98cf2b0b22be51b723906c81a9af",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/t.wado",
-      "hash": "d599c7e82dd38b6db262d80fac6d56ba8951bf5413cd4205e6ae8071a8c3fd62",
+      "hash": "df0f11cef75ce860c50ee97178680f0d6026d2c0780e98c5fe57df90fc7f8345",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/t.wado",
-      "hash": "54a7b1b0ce2a4ba144875a9e60dd4023c75bcc05026416739f40c5e7c6cefe80",
+      "hash": "25707eca033ded9d754972303f9313f4437608575548f660b6ddd7b1381b6cce",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/t.wado",
-      "hash": "1fe609d542b28a90e4986d9868c89bc5b00c98cf2b0b22be51b723906c81a9af",
+      "hash": "d599c7e82dd38b6db262d80fac6d56ba8951bf5413cd4205e6ae8071a8c3fd62",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/t.wado
@@ -1645,18 +1645,18 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_expression_list(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_expression_list(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -1664,7 +1664,7 @@ fn scan_expression_list(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_0; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break sg_0; }
                 break sg_0_done;
             }
@@ -1686,11 +1686,11 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_7: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_7; }
                 pos += 1;
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_7; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 break scan_alts;
             }
@@ -1698,7 +1698,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_0; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_0; }
                 pos += 1;
@@ -1732,7 +1732,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_ID {
             pos = start;
             try_5: {
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break try_5; }
                 pos += 1;
@@ -1750,7 +1750,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_INT {
             pos = start;
             try_5: {
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break try_5; }
                 pos += 1;
@@ -1764,7 +1764,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_6: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_NEW { break try_6; }
                 pos += 1;
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 let gp_1 = pos;
                 let sgk_1 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -1776,7 +1776,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                             pos += 1;
                             if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
                                 let sp = pos;
-                                pos = scan_expression_list(tokens, pos);
+                                pos = scan_expression_list(tokens, pos, 0);
                                 if pos < 0 { pos = sp; }
                             }
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_1_0; }
@@ -1789,7 +1789,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                 sg_2: {
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break sg_2; }
                                     pos += 1;
-                                    pos = scan_e(tokens, pos);
+                                    pos = scan_e(tokens, pos, 0);
                                     if pos < 0 { break sg_2; }
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break sg_2; }
                                     pos += 1;
@@ -1803,7 +1803,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_3: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break sg_3; }
                                         pos += 1;
-                                        pos = scan_e(tokens, pos);
+                                        pos = scan_e(tokens, pos, 0);
                                         if pos < 0 { break sg_3; }
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break sg_3; }
                                         pos += 1;
@@ -1853,7 +1853,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     break try_8;
                 }
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
@@ -1877,7 +1877,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     break try_9;
                 }
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_9; }
                 break scan_alts;
             }
@@ -1917,7 +1917,7 @@ fn scan_e_lr_8(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_list(tokens, pos);
+        pos = scan_expression_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
@@ -1937,7 +1937,7 @@ fn scan_e_lr_9(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_list(tokens, pos);
+        pos = scan_expression_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
@@ -1983,7 +1983,7 @@ fn scan_e_lr_14(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_list(tokens, pos);
+        pos = scan_expression_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
@@ -2437,7 +2437,7 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     return pos;
 }
 
-fn scan_typespec(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_typespec(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -2507,7 +2507,7 @@ fn parse_expression_list(p: &mut Parser) -> Result<ExpressionListNode, ParseErro
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_e(tokens, pos);
+            pos = scan_e(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -2547,11 +2547,11 @@ fn parse_e_scan_12(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_typespec(tokens, pos);
+    pos = scan_typespec(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_e_atom(tokens, pos);
+    pos = scan_e(tokens, pos, 2147483647);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -2573,7 +2573,7 @@ fn parse_e_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
@@ -2595,7 +2595,7 @@ fn parse_e_bt_5(p: &mut Parser) -> Result<ENode, ParseError> {
 
 fn parse_e_scan_5(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_typespec(tokens, pos);
+    pos = scan_typespec(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
     pos += 1;
@@ -2724,7 +2724,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
                         let mut pos: i32 = p.pos;
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break rep_scan; }
                         pos += 1;
-                        pos = scan_e(tokens, pos);
+                        pos = scan_e(tokens, pos, 0);
                         if pos < 0 { break rep_scan; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break rep_scan; }
                         pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/t.wado
@@ -2551,7 +2551,7 @@ fn parse_e_scan_12(tokens: &Array<Token>, pos: i32) -> i32 {
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e_atom(tokens, pos);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -2573,7 +2573,7 @@ fn parse_e_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e_atom(tokens, pos);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/t.wado
@@ -2533,7 +2533,7 @@ fn parse_e_bt_12(p: &mut Parser) -> Result<ENode, ParseError> {
     let lparen = p.expect(TK_LIT_LPAREN)?;
     let typespec = parse_typespec(p)?;
     let rparen = p.expect(TK_LIT_RPAREN)?;
-    let e = parse_e(p)?;
+    let e = parse_e(p, 16)?;
     return Result::<ENode, ParseError>::Ok(ENode::Alt12(EAlt12 {
         span: Span::new(start, p.last_end()),
         lparen,
@@ -2758,7 +2758,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
     }
     if _gale_kind_set_2(kind) {
         let plus_or_minus_or_lit_plusplus_or_lit_minusminus = p.advance();
-        let e = parse_e(p)?;
+        let e = parse_e(p, 14)?;
         return Result::<ENode, ParseError>::Ok(ENode::Alt15(EAlt15 {
             span: Span::new(start, p.last_end()),
             plus_or_minus_or_lit_plusplus_or_lit_minusminus,
@@ -2767,7 +2767,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
     }
     if _gale_kind_set_3(kind) {
         let tilde_or_bang = p.advance();
-        let e = parse_e(p)?;
+        let e = parse_e(p, 14)?;
         return Result::<ENode, ParseError>::Ok(ENode::Alt16(EAlt16 {
             span: Span::new(start, p.last_end()),
             tilde_or_bang,

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/t.wado
@@ -2573,7 +2573,7 @@ fn parse_e_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_e_atom(tokens, pos);
+    pos = scan_e(tokens, pos);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/t.wado",
-      "hash": "9bed70e401c1ac68b892f1e83aa27a68e48ddaa9af29424a5f2195d69c27ea60",
+      "hash": "77e657f97b388b6bb61be96301e14ae4c25af3546e64b468035edbfb2cacfe39",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/t.wado",
-      "hash": "77e657f97b388b6bb61be96301e14ae4c25af3546e64b468035edbfb2cacfe39",
+      "hash": "4121ae276353e8d192e1b52b4e2a09facbbd4ef4b35b0a2d76a7f278bd8f0bc3",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/t.wado",
-      "hash": "4d31fff2c3838095a70c866eb909959a23eb8b56ebcefbdc6bcf510b7e285b9f",
+      "hash": "9bed70e401c1ac68b892f1e83aa27a68e48ddaa9af29424a5f2195d69c27ea60",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/t.wado",
-      "hash": "4121ae276353e8d192e1b52b4e2a09facbbd4ef4b35b0a2d76a7f278bd8f0bc3",
+      "hash": "55594194a4c89ae556a1a29f566a4d3e3271910c884adbc8104bd31d33e10d55",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/t.wado
@@ -1645,18 +1645,18 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_expression_list(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_expression_list(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -1664,7 +1664,7 @@ fn scan_expression_list(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_0; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break sg_0; }
                 break sg_0_done;
             }
@@ -1686,11 +1686,11 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_7: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_7; }
                 pos += 1;
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_7; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 break scan_alts;
             }
@@ -1698,7 +1698,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_0; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_0; }
                 pos += 1;
@@ -1732,7 +1732,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_ID {
             pos = start;
             try_5: {
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break try_5; }
                 pos += 1;
@@ -1750,7 +1750,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_INT {
             pos = start;
             try_5: {
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break try_5; }
                 pos += 1;
@@ -1764,7 +1764,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_6: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_NEW { break try_6; }
                 pos += 1;
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 let gp_1 = pos;
                 let sgk_1 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -1776,7 +1776,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                             pos += 1;
                             if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
                                 let sp = pos;
-                                pos = scan_expression_list(tokens, pos);
+                                pos = scan_expression_list(tokens, pos, 0);
                                 if pos < 0 { pos = sp; }
                             }
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_1_0; }
@@ -1789,7 +1789,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                 sg_2: {
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break sg_2; }
                                     pos += 1;
-                                    pos = scan_e(tokens, pos);
+                                    pos = scan_e(tokens, pos, 0);
                                     if pos < 0 { break sg_2; }
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break sg_2; }
                                     pos += 1;
@@ -1803,7 +1803,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_3: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break sg_3; }
                                         pos += 1;
-                                        pos = scan_e(tokens, pos);
+                                        pos = scan_e(tokens, pos, 0);
                                         if pos < 0 { break sg_3; }
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break sg_3; }
                                         pos += 1;
@@ -1853,7 +1853,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     break try_8;
                 }
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
@@ -1877,7 +1877,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     break try_9;
                 }
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_9; }
                 break scan_alts;
             }
@@ -1917,7 +1917,7 @@ fn scan_e_lr_8(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_list(tokens, pos);
+        pos = scan_expression_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
@@ -1937,7 +1937,7 @@ fn scan_e_lr_9(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_list(tokens, pos);
+        pos = scan_expression_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
@@ -1983,7 +1983,7 @@ fn scan_e_lr_14(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_list(tokens, pos);
+        pos = scan_expression_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
@@ -2437,7 +2437,7 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     return pos;
 }
 
-fn scan_typespec(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_typespec(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -2507,7 +2507,7 @@ fn parse_expression_list(p: &mut Parser) -> Result<ExpressionListNode, ParseErro
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_e(tokens, pos);
+            pos = scan_e(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -2547,11 +2547,11 @@ fn parse_e_scan_12(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_typespec(tokens, pos);
+    pos = scan_typespec(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_e_atom(tokens, pos);
+    pos = scan_e(tokens, pos, 2147483647);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -2573,7 +2573,7 @@ fn parse_e_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
@@ -2595,7 +2595,7 @@ fn parse_e_bt_5(p: &mut Parser) -> Result<ENode, ParseError> {
 
 fn parse_e_scan_5(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_typespec(tokens, pos);
+    pos = scan_typespec(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
     pos += 1;
@@ -2724,7 +2724,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
                         let mut pos: i32 = p.pos;
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break rep_scan; }
                         pos += 1;
-                        pos = scan_e(tokens, pos);
+                        pos = scan_e(tokens, pos, 0);
                         if pos < 0 { break rep_scan; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break rep_scan; }
                         pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/t.wado
@@ -2551,7 +2551,7 @@ fn parse_e_scan_12(tokens: &Array<Token>, pos: i32) -> i32 {
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e_atom(tokens, pos);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -2573,7 +2573,7 @@ fn parse_e_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e_atom(tokens, pos);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/t.wado
@@ -2533,7 +2533,7 @@ fn parse_e_bt_12(p: &mut Parser) -> Result<ENode, ParseError> {
     let lparen = p.expect(TK_LIT_LPAREN)?;
     let typespec = parse_typespec(p)?;
     let rparen = p.expect(TK_LIT_RPAREN)?;
-    let e = parse_e(p)?;
+    let e = parse_e(p, 16)?;
     return Result::<ENode, ParseError>::Ok(ENode::Alt12(EAlt12 {
         span: Span::new(start, p.last_end()),
         lparen,
@@ -2758,7 +2758,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
     }
     if _gale_kind_set_2(kind) {
         let plus_or_minus_or_lit_plusplus_or_lit_minusminus = p.advance();
-        let e = parse_e(p)?;
+        let e = parse_e(p, 14)?;
         return Result::<ENode, ParseError>::Ok(ENode::Alt15(EAlt15 {
             span: Span::new(start, p.last_end()),
             plus_or_minus_or_lit_plusplus_or_lit_minusminus,
@@ -2767,7 +2767,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
     }
     if _gale_kind_set_3(kind) {
         let tilde_or_bang = p.advance();
-        let e = parse_e(p)?;
+        let e = parse_e(p, 14)?;
         return Result::<ENode, ParseError>::Ok(ENode::Alt16(EAlt16 {
             span: Span::new(start, p.last_end()),
             tilde_or_bang,

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/t.wado
@@ -2573,7 +2573,7 @@ fn parse_e_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_e_atom(tokens, pos);
+    pos = scan_e(tokens, pos);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/t.wado",
-      "hash": "00383f0f2003053e6a7d69afb48452a35d41c07b31ddd1a02d48a7cd00b1337a",
+      "hash": "d1ed3646c63aa2e62d4563bdd05e7cc5c0bc351ad87c49dbdf69fe5c5f1669b3",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/t.wado",
-      "hash": "d1ed3646c63aa2e62d4563bdd05e7cc5c0bc351ad87c49dbdf69fe5c5f1669b3",
+      "hash": "d3ed017f495add8d3be1871c337eeb1871fa2d0afd44dde741460313ada281b1",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/t.wado",
-      "hash": "2333b430ca0aded43b030c294da446c43331d2044bcdec5fc7ccb10769bfba99",
+      "hash": "00383f0f2003053e6a7d69afb48452a35d41c07b31ddd1a02d48a7cd00b1337a",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/t.wado",
-      "hash": "d3ed017f495add8d3be1871c337eeb1871fa2d0afd44dde741460313ada281b1",
+      "hash": "56ff892f3695278b28ee6a2ef989684ad328e0c3ccc74d812373cc1ae680b852",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/t.wado
@@ -1645,18 +1645,18 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_expression_list(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_expression_list(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -1664,7 +1664,7 @@ fn scan_expression_list(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_0; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break sg_0; }
                 break sg_0_done;
             }
@@ -1686,11 +1686,11 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_7: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_7; }
                 pos += 1;
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_7; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 break scan_alts;
             }
@@ -1698,7 +1698,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_0; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_0; }
                 pos += 1;
@@ -1732,7 +1732,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_ID {
             pos = start;
             try_5: {
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break try_5; }
                 pos += 1;
@@ -1750,7 +1750,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_INT {
             pos = start;
             try_5: {
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break try_5; }
                 pos += 1;
@@ -1764,7 +1764,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_6: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_NEW { break try_6; }
                 pos += 1;
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 let gp_1 = pos;
                 let sgk_1 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -1776,7 +1776,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                             pos += 1;
                             if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
                                 let sp = pos;
-                                pos = scan_expression_list(tokens, pos);
+                                pos = scan_expression_list(tokens, pos, 0);
                                 if pos < 0 { pos = sp; }
                             }
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_1_0; }
@@ -1789,7 +1789,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                 sg_2: {
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break sg_2; }
                                     pos += 1;
-                                    pos = scan_e(tokens, pos);
+                                    pos = scan_e(tokens, pos, 0);
                                     if pos < 0 { break sg_2; }
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break sg_2; }
                                     pos += 1;
@@ -1803,7 +1803,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_3: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break sg_3; }
                                         pos += 1;
-                                        pos = scan_e(tokens, pos);
+                                        pos = scan_e(tokens, pos, 0);
                                         if pos < 0 { break sg_3; }
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break sg_3; }
                                         pos += 1;
@@ -1853,7 +1853,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     break try_8;
                 }
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
@@ -1877,7 +1877,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     break try_9;
                 }
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_9; }
                 break scan_alts;
             }
@@ -1917,7 +1917,7 @@ fn scan_e_lr_8(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_list(tokens, pos);
+        pos = scan_expression_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
@@ -1937,7 +1937,7 @@ fn scan_e_lr_9(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_list(tokens, pos);
+        pos = scan_expression_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
@@ -1983,7 +1983,7 @@ fn scan_e_lr_14(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_list(tokens, pos);
+        pos = scan_expression_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
@@ -2437,7 +2437,7 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     return pos;
 }
 
-fn scan_typespec(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_typespec(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -2507,7 +2507,7 @@ fn parse_expression_list(p: &mut Parser) -> Result<ExpressionListNode, ParseErro
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_e(tokens, pos);
+            pos = scan_e(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -2547,11 +2547,11 @@ fn parse_e_scan_12(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_typespec(tokens, pos);
+    pos = scan_typespec(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_e_atom(tokens, pos);
+    pos = scan_e(tokens, pos, 2147483647);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -2573,7 +2573,7 @@ fn parse_e_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
@@ -2595,7 +2595,7 @@ fn parse_e_bt_5(p: &mut Parser) -> Result<ENode, ParseError> {
 
 fn parse_e_scan_5(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_typespec(tokens, pos);
+    pos = scan_typespec(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
     pos += 1;
@@ -2724,7 +2724,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
                         let mut pos: i32 = p.pos;
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break rep_scan; }
                         pos += 1;
-                        pos = scan_e(tokens, pos);
+                        pos = scan_e(tokens, pos, 0);
                         if pos < 0 { break rep_scan; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break rep_scan; }
                         pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/t.wado
@@ -2551,7 +2551,7 @@ fn parse_e_scan_12(tokens: &Array<Token>, pos: i32) -> i32 {
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e_atom(tokens, pos);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -2573,7 +2573,7 @@ fn parse_e_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e_atom(tokens, pos);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/t.wado
@@ -2533,7 +2533,7 @@ fn parse_e_bt_12(p: &mut Parser) -> Result<ENode, ParseError> {
     let lparen = p.expect(TK_LIT_LPAREN)?;
     let typespec = parse_typespec(p)?;
     let rparen = p.expect(TK_LIT_RPAREN)?;
-    let e = parse_e(p)?;
+    let e = parse_e(p, 16)?;
     return Result::<ENode, ParseError>::Ok(ENode::Alt12(EAlt12 {
         span: Span::new(start, p.last_end()),
         lparen,
@@ -2758,7 +2758,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
     }
     if _gale_kind_set_2(kind) {
         let plus_or_minus_or_lit_plusplus_or_lit_minusminus = p.advance();
-        let e = parse_e(p)?;
+        let e = parse_e(p, 14)?;
         return Result::<ENode, ParseError>::Ok(ENode::Alt15(EAlt15 {
             span: Span::new(start, p.last_end()),
             plus_or_minus_or_lit_plusplus_or_lit_minusminus,
@@ -2767,7 +2767,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
     }
     if _gale_kind_set_3(kind) {
         let tilde_or_bang = p.advance();
-        let e = parse_e(p)?;
+        let e = parse_e(p, 14)?;
         return Result::<ENode, ParseError>::Ok(ENode::Alt16(EAlt16 {
             span: Span::new(start, p.last_end()),
             tilde_or_bang,

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/t.wado
@@ -2573,7 +2573,7 @@ fn parse_e_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_e_atom(tokens, pos);
+    pos = scan_e(tokens, pos);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/t.wado",
-      "hash": "728f77e46333588011eed67ec571cb922039db1642e1ea3c0ab0db5e8219f6c2",
+      "hash": "3705b15b65883004579723d5c03871783c8b84a6511be0f3ab98d39a8b11f9e3",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/t.wado",
-      "hash": "f3826ece80cbbb152e15bc00178dd51a69bc9c3128ee29e6709db0d5a19d3742",
+      "hash": "44d1cc1bdf40a1498d836f81e8cde7a7a1da635123487c72159945d568d75ba8",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/t.wado",
-      "hash": "ab1e75b54e925cc0cf2d1659c6c7021c8851a7ca8466f8b6ec853259c15df142",
+      "hash": "728f77e46333588011eed67ec571cb922039db1642e1ea3c0ab0db5e8219f6c2",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/t.wado",
-      "hash": "44d1cc1bdf40a1498d836f81e8cde7a7a1da635123487c72159945d568d75ba8",
+      "hash": "ab1e75b54e925cc0cf2d1659c6c7021c8851a7ca8466f8b6ec853259c15df142",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/t.wado
@@ -1645,18 +1645,18 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_expression_list(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_expression_list(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -1664,7 +1664,7 @@ fn scan_expression_list(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_0; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break sg_0; }
                 break sg_0_done;
             }
@@ -1686,11 +1686,11 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_7: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_7; }
                 pos += 1;
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_7; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 break scan_alts;
             }
@@ -1698,7 +1698,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_0; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_0; }
                 pos += 1;
@@ -1732,7 +1732,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_ID {
             pos = start;
             try_5: {
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break try_5; }
                 pos += 1;
@@ -1750,7 +1750,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_INT {
             pos = start;
             try_5: {
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break try_5; }
                 pos += 1;
@@ -1764,7 +1764,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_6: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_NEW { break try_6; }
                 pos += 1;
-                pos = scan_typespec(tokens, pos);
+                pos = scan_typespec(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 let gp_1 = pos;
                 let sgk_1 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -1776,7 +1776,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                             pos += 1;
                             if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
                                 let sp = pos;
-                                pos = scan_expression_list(tokens, pos);
+                                pos = scan_expression_list(tokens, pos, 0);
                                 if pos < 0 { pos = sp; }
                             }
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_1_0; }
@@ -1789,7 +1789,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                 sg_2: {
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break sg_2; }
                                     pos += 1;
-                                    pos = scan_e(tokens, pos);
+                                    pos = scan_e(tokens, pos, 0);
                                     if pos < 0 { break sg_2; }
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break sg_2; }
                                     pos += 1;
@@ -1803,7 +1803,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_3: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break sg_3; }
                                         pos += 1;
-                                        pos = scan_e(tokens, pos);
+                                        pos = scan_e(tokens, pos, 0);
                                         if pos < 0 { break sg_3; }
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break sg_3; }
                                         pos += 1;
@@ -1853,7 +1853,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     break try_8;
                 }
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
@@ -1877,7 +1877,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     break try_9;
                 }
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_9; }
                 break scan_alts;
             }
@@ -1917,7 +1917,7 @@ fn scan_e_lr_8(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_list(tokens, pos);
+        pos = scan_expression_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
@@ -1937,7 +1937,7 @@ fn scan_e_lr_9(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_list(tokens, pos);
+        pos = scan_expression_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
@@ -1983,7 +1983,7 @@ fn scan_e_lr_14(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_list(tokens, pos);
+        pos = scan_expression_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
@@ -2437,7 +2437,7 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     return pos;
 }
 
-fn scan_typespec(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_typespec(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -2507,7 +2507,7 @@ fn parse_expression_list(p: &mut Parser) -> Result<ExpressionListNode, ParseErro
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_e(tokens, pos);
+            pos = scan_e(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -2547,11 +2547,11 @@ fn parse_e_scan_12(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_typespec(tokens, pos);
+    pos = scan_typespec(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_e_atom(tokens, pos);
+    pos = scan_e(tokens, pos, 2147483647);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -2573,7 +2573,7 @@ fn parse_e_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
@@ -2595,7 +2595,7 @@ fn parse_e_bt_5(p: &mut Parser) -> Result<ENode, ParseError> {
 
 fn parse_e_scan_5(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_typespec(tokens, pos);
+    pos = scan_typespec(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
     pos += 1;
@@ -2724,7 +2724,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
                         let mut pos: i32 = p.pos;
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break rep_scan; }
                         pos += 1;
-                        pos = scan_e(tokens, pos);
+                        pos = scan_e(tokens, pos, 0);
                         if pos < 0 { break rep_scan; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break rep_scan; }
                         pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/t.wado
@@ -2551,7 +2551,7 @@ fn parse_e_scan_12(tokens: &Array<Token>, pos: i32) -> i32 {
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e_atom(tokens, pos);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -2573,7 +2573,7 @@ fn parse_e_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_e(tokens, pos);
+    pos = scan_e_atom(tokens, pos);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/t.wado
@@ -2533,7 +2533,7 @@ fn parse_e_bt_12(p: &mut Parser) -> Result<ENode, ParseError> {
     let lparen = p.expect(TK_LIT_LPAREN)?;
     let typespec = parse_typespec(p)?;
     let rparen = p.expect(TK_LIT_RPAREN)?;
-    let e = parse_e(p)?;
+    let e = parse_e(p, 16)?;
     return Result::<ENode, ParseError>::Ok(ENode::Alt12(EAlt12 {
         span: Span::new(start, p.last_end()),
         lparen,
@@ -2758,7 +2758,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
     }
     if _gale_kind_set_2(kind) {
         let plus_or_minus_or_lit_plusplus_or_lit_minusminus = p.advance();
-        let e = parse_e(p)?;
+        let e = parse_e(p, 14)?;
         return Result::<ENode, ParseError>::Ok(ENode::Alt15(EAlt15 {
             span: Span::new(start, p.last_end()),
             plus_or_minus_or_lit_plusplus_or_lit_minusminus,
@@ -2767,7 +2767,7 @@ fn parse_e_atom(p: &mut Parser) -> Result<ENode, ParseError> {
     }
     if _gale_kind_set_3(kind) {
         let tilde_or_bang = p.advance();
-        let e = parse_e(p)?;
+        let e = parse_e(p, 14)?;
         return Result::<ENode, ParseError>::Ok(ENode::Alt16(EAlt16 {
             span: Span::new(start, p.last_end()),
             tilde_or_bang,

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/t.wado
@@ -2573,7 +2573,7 @@ fn parse_e_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_e_atom(tokens, pos);
+    pos = scan_e(tokens, pos);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_1/t.wado",
-      "hash": "c2c66a3fb6adb58dc15a9d55f120ad14fe6d48dd1622264dea848f688191572e",
+      "hash": "014b27ad7b1d5c992f5bed9ba11d58e6ba2d4aa35892de11621c565d6b65b6f5",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_1/t.wado
@@ -753,9 +753,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -778,7 +778,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_1; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_1; }
                 pos += 1;
@@ -810,7 +810,7 @@ fn scan_e_lr_0(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         return -1;
     }
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_2/t.wado",
-      "hash": "f882701656ccac1409bcf318abda9ab361d12d22eb85cd55d6f13c979f77710c",
+      "hash": "ad323a32d83b2826972b2028c2be9d64e315c8a5d52b34eb552683970f804c74",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_2/t.wado
@@ -753,9 +753,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -778,7 +778,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_1; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_1; }
                 pos += 1;
@@ -810,7 +810,7 @@ fn scan_e_lr_0(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         return -1;
     }
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_3/t.wado",
-      "hash": "7d77992bad68e87747a6317d448348d0bbd76e9c370406b73103380052676454",
+      "hash": "c9e49d14271d64dd723e48b5e88b828011dc216d251d6035ee33b2cffd855ce2",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_3/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_3/t.wado
@@ -753,9 +753,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -778,7 +778,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_1; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_1; }
                 pos += 1;
@@ -810,7 +810,7 @@ fn scan_e_lr_0(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         return -1;
     }
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_1/t.wado",
-      "hash": "24b052ed07c37e8f8f282f500ba2d5997b47eb7afb13820989d20458761b051d",
+      "hash": "3f67432f213b88b8700fcfd96ae7ab7a5df27c7e97847cf3c15f957593bb430e",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_1/t.wado
@@ -781,9 +781,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -806,7 +806,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_1; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_1; }
                 pos += 1;
@@ -838,7 +838,7 @@ fn scan_e_lr_0(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         return -1;
     }
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -861,7 +861,7 @@ fn scan_e_lr_1(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         return -1;
     }
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_2/t.wado",
-      "hash": "2bbf30b26eebf3f89c2fd7334355ce46b5231a170777a2de28a2ac96f0209c2c",
+      "hash": "8a53b5551be9693a5d20c07e35660c5ac1cb15ecff2f40924aa77c4811d558a7",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_2/t.wado
@@ -781,9 +781,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -806,7 +806,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_1; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_1; }
                 pos += 1;
@@ -838,7 +838,7 @@ fn scan_e_lr_0(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         return -1;
     }
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -861,7 +861,7 @@ fn scan_e_lr_1(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         return -1;
     }
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_3/t.wado",
-      "hash": "0ad079d5bfb84881656a7cbadb4696ffa627a0b35e8f321abc3259e7400f118a",
+      "hash": "4ac555e66b81599fbc34fb87882c216ec872252155ccb1c50cef2ebfde8bdc82",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_3/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_3/t.wado
@@ -781,9 +781,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -806,7 +806,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_1; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_1; }
                 pos += 1;
@@ -838,7 +838,7 @@ fn scan_e_lr_0(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         return -1;
     }
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -861,7 +861,7 @@ fn scan_e_lr_1(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         return -1;
     }
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/MultipleActions_1/t.wado",
-      "hash": "ee250433de1efa305c6d88dc31d8ce4be7bc24cefb71bbee56e545f769a2b0a8",
+      "hash": "daaf017c9fcca3166038013af1cee137ad019d50bdafb649bbdc9d9fdb08cac0",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_1/t.wado
@@ -753,9 +753,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -778,7 +778,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_1; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_1; }
                 pos += 1;
@@ -810,7 +810,7 @@ fn scan_e_lr_0(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         return -1;
     }
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/MultipleActions_2/t.wado",
-      "hash": "1bb8c8744d8e48aaa7c75c9ff2f11cd4ae19283382d49fb93ade6164ab8926d3",
+      "hash": "5a6e7a26668e683cd9019911e4e75661fbd38c14edd7254bb0bb47c4facacb36",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_2/t.wado
@@ -753,9 +753,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -778,7 +778,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_1; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_1; }
                 pos += 1;
@@ -810,7 +810,7 @@ fn scan_e_lr_0(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         return -1;
     }
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/MultipleActions_3/t.wado",
-      "hash": "17cb886d9191c631923b1f5170d8f3903f1a5a69239cf2ac1cdd3d4068835d73",
+      "hash": "354aa097d55d2b560f9a15b663d548558c620d4c270437bc2d18129b4b5d1d73",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_3/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_3/t.wado
@@ -753,9 +753,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -778,7 +778,7 @@ fn scan_e_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_1; }
                 pos += 1;
-                pos = scan_e(tokens, pos);
+                pos = scan_e(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_1; }
                 pos += 1;
@@ -810,7 +810,7 @@ fn scan_e_lr_0(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         return -1;
     }
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/PrecedenceFilterConsidersContext/t.wado",
-      "hash": "49e1e2ea2ed040c4b0d0988da64ab52601ccc1638ee07de4057b3e26656bc2c0",
+      "hash": "2aea3659836291a7f46a51c686c027862bc7fa39efc0b8697319d514af0edbaf",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrecedenceFilterConsidersContext/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrecedenceFilterConsidersContext/t.wado
@@ -677,11 +677,11 @@ impl Parser {
     }
 }
 
-fn scan_prog(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_prog(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_A {
         let sp = pos;
-        pos = scan_statement(tokens, pos);
+        pos = scan_statement(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -692,14 +692,14 @@ fn scan_prog(tokens: &Array<Token>, pos: i32) -> i32 {
 
 fn scan_statement_atom(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_letter_a(tokens, pos);
+    pos = scan_letter_a(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
 fn scan_statement_lr_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_letter_a(tokens, pos);
+    pos = scan_letter_a(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_B { return -1; }
     pos += 1;
@@ -725,7 +725,7 @@ fn scan_statement(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     return pos;
 }
 
-fn scan_letter_a(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_letter_a(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_A { return -1; }
     pos += 1;
@@ -740,7 +740,7 @@ fn parse_prog(p: &mut Parser) -> Result<ProgNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_statement(tokens, pos);
+            pos = scan_statement(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/t.wado",
-      "hash": "2a3471bb5270d3d6899ef76a3f906e6b3aadc69fac2b14c0c5ec1cc4ecfecd23",
+      "hash": "cb9a4925f60635cce0e221b0cd8ce8696194d7daddb162b0d5770099f7353556",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/t.wado",
-      "hash": "cb9a4925f60635cce0e221b0cd8ce8696194d7daddb162b0d5770099f7353556",
+      "hash": "4300b7fc3edd0ac7506180d97d705f021e5437965cb926a24e9dfa13b5c39600",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/t.wado",
-      "hash": "4300b7fc3edd0ac7506180d97d705f021e5437965cb926a24e9dfa13b5c39600",
+      "hash": "08186153a3b4448f1300fdd5534fbc6a2c820a39004954bab7df393e77594d55",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/t.wado
@@ -756,9 +756,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_expr(tokens, pos);
+    pos = scan_expr(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
@@ -773,15 +773,15 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         if alt_kind == TK_LIT_MINUS {
             pos = start;
             try_0: {
-                pos = scan_literal(tokens, pos);
+                pos = scan_literal(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_1: {
-                pos = scan_op(tokens, pos);
+                pos = scan_op(tokens, pos, 0);
                 if pos < 0 { break try_1; }
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -789,7 +789,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Integer {
             pos = start;
             try_0: {
-                pos = scan_literal(tokens, pos);
+                pos = scan_literal(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -797,9 +797,9 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_PLUS {
             pos = start;
             try_1: {
-                pos = scan_op(tokens, pos);
+                pos = scan_op(tokens, pos, 0);
                 if pos < 0 { break try_1; }
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -813,7 +813,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
 
 fn scan_expr_lr_2(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_op(tokens, pos);
+    pos = scan_op(tokens, pos, 0);
     if pos < 0 { return -1; }
     pos = scan_expr(tokens, pos, 2);
     if pos < 0 { return -1; }
@@ -839,7 +839,7 @@ fn scan_expr(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     return pos;
 }
 
-fn scan_literal(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_literal(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_MINUS {
         let sp = pos;
@@ -851,7 +851,7 @@ fn scan_literal(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_op(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_op(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_0(tokens[pos].kind) {
         return pos + 1;
     }
@@ -880,7 +880,7 @@ fn parse_expr_bt_0(p: &mut Parser) -> Result<ExprNode, ParseError> {
 
 fn parse_expr_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_literal(tokens, pos);
+    pos = scan_literal(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -898,9 +898,9 @@ fn parse_expr_bt_1(p: &mut Parser) -> Result<ExprNode, ParseError> {
 
 fn parse_expr_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_op(tokens, pos);
+    pos = scan_op(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_expr_atom(tokens, pos);
+    pos = scan_expr(tokens, pos, 2147483647);
     if pos < 0 { return -1; }
     return pos;
 }

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/t.wado
@@ -900,7 +900,7 @@ fn parse_expr_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     pos = scan_op(tokens, pos);
     if pos < 0 { return -1; }
-    pos = scan_expr(tokens, pos);
+    pos = scan_expr_atom(tokens, pos);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -910,9 +910,27 @@ fn parse_expr_atom(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let kind = p.peek_kind();
     if _gale_kind_set_1(kind) {
         if p.peek_kind() == TK_LIT_MINUS {
-            if _gale_kind_set_1(p.peek_at(1)) {
+            let _sd_tokens = &p.tokens;
+            let _sd_pos = p.pos;
+            let _sd_p_0 = parse_expr_scan_0(_sd_tokens, _sd_pos);
+            let _sd_p_1 = parse_expr_scan_1(_sd_tokens, _sd_pos);
+            let mut _sd_best_i: i32 = -1;
+            let mut _sd_best_p: i32 = -1;
+            if _sd_p_0 > _sd_best_p {
+                _sd_best_p = _sd_p_0;
+                _sd_best_i = 0;
+            }
+            if _sd_p_1 > _sd_best_p {
+                _sd_best_p = _sd_p_1;
+                _sd_best_i = 1;
+            }
+            if _sd_best_i == 0 {
+                return parse_expr_bt_0(p);
+            }
+            if _sd_best_i == 1 {
                 return parse_expr_bt_1(p);
             }
+            return parse_expr_bt_1(p);
         } else if p.peek_kind() == TK_Integer {
             return parse_expr_bt_0(p);
         } else if p.peek_kind() == TK_LIT_PLUS {

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/t.wado
@@ -888,7 +888,7 @@ fn parse_expr_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
 fn parse_expr_bt_1(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let start = p.peek().span.start;
     let op = parse_op(p)?;
-    let expr = parse_expr(p)?;
+    let expr = parse_expr(p, 2)?;
     return Result::<ExprNode, ParseError>::Ok(ExprNode::Alt1(ExprAlt1 {
         span: Span::new(start, p.last_end()),
         op,

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/t.wado",
-      "hash": "2b7ab2754b126c5585239ce19f8fe7cdef87f7b57c6e0ae6eb1adaecda0e80e5",
+      "hash": "e2d0cc5ec137c63dfad3f34e7908f2655585634a94ae0236a2c56dd42b3514ff",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/t.wado",
-      "hash": "e2d0cc5ec137c63dfad3f34e7908f2655585634a94ae0236a2c56dd42b3514ff",
+      "hash": "f7f2a41604c502f243c828bef0f5a485ee2ab03c355d1cb16cee0c42af7a034e",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/t.wado",
-      "hash": "d8b01ba9c586990067f08290b285fa99603d59060cbdd5b29b8a8bc868f6f772",
+      "hash": "2b7ab2754b126c5585239ce19f8fe7cdef87f7b57c6e0ae6eb1adaecda0e80e5",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/t.wado
@@ -756,9 +756,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_expr(tokens, pos);
+    pos = scan_expr(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
@@ -773,15 +773,15 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         if alt_kind == TK_LIT_MINUS {
             pos = start;
             try_0: {
-                pos = scan_literal(tokens, pos);
+                pos = scan_literal(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_1: {
-                pos = scan_op(tokens, pos);
+                pos = scan_op(tokens, pos, 0);
                 if pos < 0 { break try_1; }
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -789,7 +789,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Integer {
             pos = start;
             try_0: {
-                pos = scan_literal(tokens, pos);
+                pos = scan_literal(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -797,9 +797,9 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_PLUS {
             pos = start;
             try_1: {
-                pos = scan_op(tokens, pos);
+                pos = scan_op(tokens, pos, 0);
                 if pos < 0 { break try_1; }
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -813,7 +813,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
 
 fn scan_expr_lr_2(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_op(tokens, pos);
+    pos = scan_op(tokens, pos, 0);
     if pos < 0 { return -1; }
     pos = scan_expr(tokens, pos, 2);
     if pos < 0 { return -1; }
@@ -839,7 +839,7 @@ fn scan_expr(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     return pos;
 }
 
-fn scan_literal(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_literal(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_MINUS {
         let sp = pos;
@@ -851,7 +851,7 @@ fn scan_literal(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_op(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_op(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_0(tokens[pos].kind) {
         return pos + 1;
     }
@@ -880,7 +880,7 @@ fn parse_expr_bt_0(p: &mut Parser) -> Result<ExprNode, ParseError> {
 
 fn parse_expr_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_literal(tokens, pos);
+    pos = scan_literal(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -898,9 +898,9 @@ fn parse_expr_bt_1(p: &mut Parser) -> Result<ExprNode, ParseError> {
 
 fn parse_expr_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_op(tokens, pos);
+    pos = scan_op(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_expr_atom(tokens, pos);
+    pos = scan_expr(tokens, pos, 2147483647);
     if pos < 0 { return -1; }
     return pos;
 }

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/t.wado
@@ -900,7 +900,7 @@ fn parse_expr_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     pos = scan_op(tokens, pos);
     if pos < 0 { return -1; }
-    pos = scan_expr(tokens, pos);
+    pos = scan_expr_atom(tokens, pos);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -910,9 +910,27 @@ fn parse_expr_atom(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let kind = p.peek_kind();
     if _gale_kind_set_1(kind) {
         if p.peek_kind() == TK_LIT_MINUS {
-            if _gale_kind_set_1(p.peek_at(1)) {
+            let _sd_tokens = &p.tokens;
+            let _sd_pos = p.pos;
+            let _sd_p_0 = parse_expr_scan_0(_sd_tokens, _sd_pos);
+            let _sd_p_1 = parse_expr_scan_1(_sd_tokens, _sd_pos);
+            let mut _sd_best_i: i32 = -1;
+            let mut _sd_best_p: i32 = -1;
+            if _sd_p_0 > _sd_best_p {
+                _sd_best_p = _sd_p_0;
+                _sd_best_i = 0;
+            }
+            if _sd_p_1 > _sd_best_p {
+                _sd_best_p = _sd_p_1;
+                _sd_best_i = 1;
+            }
+            if _sd_best_i == 0 {
+                return parse_expr_bt_0(p);
+            }
+            if _sd_best_i == 1 {
                 return parse_expr_bt_1(p);
             }
+            return parse_expr_bt_1(p);
         } else if p.peek_kind() == TK_Integer {
             return parse_expr_bt_0(p);
         } else if p.peek_kind() == TK_LIT_PLUS {

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/t.wado
@@ -888,7 +888,7 @@ fn parse_expr_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
 fn parse_expr_bt_1(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let start = p.peek().span.start;
     let op = parse_op(p)?;
-    let expr = parse_expr(p)?;
+    let expr = parse_expr(p, 2)?;
     return Result::<ExprNode, ParseError>::Ok(ExprNode::Alt1(ExprAlt1 {
         span: Span::new(start, p.last_end()),
         op,

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPred/SemPred.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPred/SemPred.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/SemPred/t.wado",
-      "hash": "6f13b0e7a14c51a5cb6c574e7b8acaa91970e5b03052b5fb6fb534a0e1500a45",
+      "hash": "3178d7ce72c81e3c18423e4a318d30059a393b62dff2212fd5e8a952a751cdb1",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPred/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPred/t.wado
@@ -704,9 +704,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_a(tokens, pos);
+    pos = scan_a(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPredFailOption/SemPredFailOption.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPredFailOption/SemPredFailOption.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/SemPredFailOption/t.wado",
-      "hash": "f58e4935615d44185fa57cdabe8e110ee76ab4fba86cc4d83cea086982cc3617",
+      "hash": "e5da379b8ac01eed17e2dbb676605ad5b2aff20515d7b19d8c7a3e60362bac13",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPredFailOption/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPredFailOption/t.wado
@@ -704,9 +704,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_a(tokens, pos);
+    pos = scan_a(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Simple_1/t.wado",
-      "hash": "a9a77b56695d2cfb24d0d4f6e773a6ff28fee80ed1e80173bddee908dab40900",
+      "hash": "6cd920a30d072ec76ac15fb5074b8672c55d26653ab5460e92df6d1694e41b5b",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_1/t.wado
@@ -704,9 +704,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_a(tokens, pos);
+    pos = scan_a(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Simple_2/t.wado",
-      "hash": "5ede54c4be454f238a68204604c41e296fb78a29d7ff7e36e663e21703187260",
+      "hash": "15e43a6f6fec31173026866d7d9a67a0dad0da29d1f1f26a71da6509e77fcfa1",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_2/t.wado
@@ -704,9 +704,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_a(tokens, pos);
+    pos = scan_a(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Simple_3/t.wado",
-      "hash": "0ee1493dc2f469b7c4bf00353696a1fb3d7ba15034d8f0cdd0a806c1487c3c9c",
+      "hash": "2e1f9b64c7569d5857fe3137184a7ad2eaf9eb050fe2be9f48ca780f3c4a23d6",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_3/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_3/t.wado
@@ -704,9 +704,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_a(tokens, pos);
+    pos = scan_a(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_1/t.wado",
-      "hash": "b907524ae0222d44ed745d4c2a45f958ae9e983cf48ec40af0ba904340c13a0b",
+      "hash": "8f9ec1b08b8b4621ca351426ac38ad441d7c7b9472519f2fdb66af8612b7bf31",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_1/t.wado
@@ -782,9 +782,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_2/t.wado",
-      "hash": "38627a0e9e10463262911817628b2a9718eecdad5b17a6e1bebf37b62e35103d",
+      "hash": "e3463fbe825dee70da9c87f35837099e83d479429890f83af360ba2a700d17e4",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_2/t.wado
@@ -782,9 +782,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_3/t.wado",
-      "hash": "1bef3b04340915607153b1f11e3c28f591830b9d6d02b01a5d97d4bc147971d0",
+      "hash": "0a7bb6c9761eee622b731a266ac3e67ac5cbed1680e9990272ab7786f25a852d",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_3/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_3/t.wado
@@ -782,9 +782,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_4/t.wado",
-      "hash": "ebaf59c1e6ebd046980ee940d1e708e004235a10b31f99012d125fb5eb1ed994",
+      "hash": "dd550d01630fc0d944c589bf993021a279419ca304c9e75948fc6b5bf86597e0",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_4/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_4/t.wado
@@ -782,9 +782,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_5/t.wado",
-      "hash": "7d4fb34a51f419ca5d38fe8fab1314a078d640d7ba685c5c3787b3739379b259",
+      "hash": "43038506f6bce7be8f79d30a61048a75d204fb1b8de6517a606053d1c9d21583",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_5/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_5/t.wado
@@ -782,9 +782,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_6/t.wado",
-      "hash": "8d4f5e33bc76d4d3c6337a74a9c3e5fb2ce866b08d096c6026e72c483d09f0f9",
+      "hash": "7d85dfedbf579b59c62b3aad5a6bc72d85fa70e8372b4f5e678559047481625b",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_6/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_6/t.wado
@@ -782,9 +782,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_7/t.wado",
-      "hash": "425c0e43e5c2b56203d4c568942832b82a069736c44cc5da4ce4ef3a49a17ea5",
+      "hash": "c25dbdde491808187d2ecba03f0807b13c04f02cfb54f5922a677ac10c806559",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_7/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_7/t.wado
@@ -782,9 +782,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_8/t.wado",
-      "hash": "6a4cac988872d8a3706de32995182370733a8e0fc08b61bd938879a2f3b8e9ae",
+      "hash": "852ddcac6423d347b1b6198138808b0cf303bb3712d22621ef18a275a45a7d5d",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_8/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_8/t.wado
@@ -782,9 +782,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_9/t.wado",
-      "hash": "c225233c430296f2bd57096a9fb5952be42ec436027121be950ecdf17a68dc94",
+      "hash": "e4cdc1e70df863b17aed4e9147e180e2801e85482c3c593230f924805db5d5df",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_9/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_9/t.wado
@@ -782,9 +782,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_1/t.wado",
-      "hash": "5732f291bf4756411c82f6e442ebf68bf660e1c492fe157e83da482bbee97926",
+      "hash": "63cfddde936c5fc020eb096cabf95b3de2e7000a3ce9f94fc4223a71c0e87f7a",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_1/t.wado
@@ -782,9 +782,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_2/t.wado",
-      "hash": "fe6b915954e0049484056c06c6ea94a0511164a428734e8ce55fff0d4c10bf52",
+      "hash": "7e32519ca78eb72f23e5024afc0c9686da78aed13750b9c7b12aacb9134b32ce",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_2/t.wado
@@ -782,9 +782,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_3/t.wado",
-      "hash": "cd1c9f4c23622327ac19ab5b363014888bf2aa2ccc30321c4d7b17d4e5c956ce",
+      "hash": "3f0b8c65b4388f40caac3ffd97878f07ff2d6b30a16969e91b57f51a9f151c72",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_3/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_3/t.wado
@@ -782,9 +782,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_4/t.wado",
-      "hash": "deb2723d49350b523868fc2656badfd91fdd702db364be6e44af918879ee75ff",
+      "hash": "740688ed275e59b6e8a85aa3eb73c6860f81780c92a7c0f1c16b63164f70fcb1",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_4/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_4/t.wado
@@ -782,9 +782,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_5/t.wado",
-      "hash": "72c54ec90d23623236cda91771085cf70599aa6bf449836876f8e920c5ba079a",
+      "hash": "57ad67440ec648f42a68104776f8798f4c31ec2764a5dc00f1bbb21030a088a1",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_5/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_5/t.wado
@@ -782,9 +782,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_6/t.wado",
-      "hash": "baf1e65123597fbaaa2ec0ab8040fc55db307c2b758fbc81d875fb3132c1cdfe",
+      "hash": "52344531e09b549b438ae222718da63d83000d28b2ba5eaf366e278735fdff75",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_6/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_6/t.wado
@@ -782,9 +782,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_7/t.wado",
-      "hash": "baf561815c0117e5de1709095b0445752fa2331fe96d045fa0afd1990cb34bea",
+      "hash": "3e0dd40a14baf855386c203be7fb0fcbcb229d6ff119e3a16f9373b83d263797",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_7/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_7/t.wado
@@ -782,9 +782,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_8/t.wado",
-      "hash": "4524620b7d0c056e37258787477627ee4fad07e55f55b83b88bc270e291b0993",
+      "hash": "cece6b2866f6ddaf748cbf4bd45744f6a542ade234818f26b9941ad5d1c219e9",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_8/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_8/t.wado
@@ -782,9 +782,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_9/t.wado",
-      "hash": "2bf8f212f4a871ceec0bbe8ee075b3d1398f25fe056d80394c9e87b4d63524b4",
+      "hash": "e2393ae7b2aee08ec1c37b44e237f292829d103d534f751e0e74f701d9ab8f31",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_9/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_9/t.wado
@@ -782,9 +782,9 @@ impl Parser {
     }
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_e(tokens, pos);
+    pos = scan_e(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/ParserExec/BuildParseTree_TRUE/t.wado",
-      "hash": "a9599cfb5bb30a7cf26866b309be103c9b6dc677639c6f235ef19c055f10662d",
+      "hash": "34a7ff94b11efd92640d6884ffb70029450b867f27f8d14222d03a4fa82535d1",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/BuildParseTree_TRUE/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/BuildParseTree_TRUE/t.wado
@@ -692,23 +692,23 @@ impl Parser {
     }
 }
 
-fn scan_r(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_r(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_a(tokens, pos);
+    pos = scan_a(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_b(tokens, pos);
+    pos = scan_b(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_a(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_a(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_A { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_b(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_b(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_B { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/ParserExec/PredictionIssue334/t.wado",
-      "hash": "2a20c892682d87802c7dcab28d638cc72957f7c64d52f903e82326fb993842b2",
+      "hash": "bbf0dedd95277a07f73cb2c8f0e1c388ba2faa0e442fb24fb10cb84f67d42d20",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionIssue334/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionIssue334/t.wado
@@ -742,9 +742,9 @@ impl Parser {
     }
 }
 
-fn scan_file_(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_file_(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_item(tokens, pos);
+    pos = scan_item(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_SEMICOLON {
         let sp = pos;
@@ -752,7 +752,7 @@ fn scan_file_(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_SEMICOLON { break sg_0; }
                 pos += 1;
-                pos = scan_item(tokens, pos);
+                pos = scan_item(tokens, pos, 0);
                 if pos < 0 { break sg_0; }
                 break sg_0_done;
             }
@@ -771,7 +771,7 @@ fn scan_file_(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_item(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_item(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_A { return -1; }
     pos += 1;
@@ -794,7 +794,7 @@ fn parse_file_(p: &mut Parser) -> Result<FileNode, ParseError> {
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_SEMICOLON { break rep_scan; }
             pos += 1;
-            pos = scan_item(tokens, pos);
+            pos = scan_item(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/ParserExec/PredictionMode_LL/t.wado",
-      "hash": "7b436897158f552cb5b42188d7bd966dc036391c22fbb9beaf5aa22927d36dba",
+      "hash": "d9bb3aa77685901c2c56cd8c66c527cad00d5c506bde2847d8cde4b674ecd7d0",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionMode_LL/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionMode_LL/t.wado
@@ -707,7 +707,7 @@ impl Parser {
     }
 }
 
-fn scan_r(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_r(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     let gp_0 = pos;
     let sgk_0 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -716,15 +716,15 @@ fn scan_r(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_0: {
             pos = gp_0;
             sg_0_0: {
-                pos = scan_a(tokens, pos);
+                pos = scan_a(tokens, pos, 0);
                 if pos < 0 { break sg_0_0; }
-                pos = scan_b(tokens, pos);
+                pos = scan_b(tokens, pos, 0);
                 if pos < 0 { break sg_0_0; }
                 if pos > sg_0_best { sg_0_best = pos; }
             }
             pos = gp_0;
             sg_0_1: {
-                pos = scan_a(tokens, pos);
+                pos = scan_a(tokens, pos, 0);
                 if pos < 0 { break sg_0_1; }
                 if pos > sg_0_best { sg_0_best = pos; }
             }
@@ -737,7 +737,7 @@ fn scan_r(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_a(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_a(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_X { return -1; }
     pos += 1;
@@ -749,7 +749,7 @@ fn scan_a(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_b(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_b(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Y { return -1; }
     pos += 1;
@@ -766,7 +766,7 @@ fn parse_r(p: &mut Parser) -> Result<RNode, ParseError> {
             gd_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_a(tokens, pos);
+                pos = scan_a(tokens, pos, 0);
                 if pos < 0 { break gd_scan; }
                 gd_winner = 0;
                 break gd_dispatch;

--- a/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_1/PredFromAltTestedInLoopBack_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_1/PredFromAltTestedInLoopBack_1.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_1/t.wado",
-      "hash": "02a2a851e69e58456302e71d60a5ff3897020ad50bc4cdf28bf45f731961eb3d",
+      "hash": "b711e9443e4106f88f4cc548a3e784fcf5ac8bfd585a74899a758be927fd901c",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_1/t.wado
@@ -701,20 +701,20 @@ impl Parser {
     }
 }
 
-fn scan_file_(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_file_(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_para(tokens, pos);
+    pos = scan_para(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_para(tokens, pos);
+    pos = scan_para(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_para(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_para(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_para_content(tokens, pos);
+    pos = scan_para_content(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_NL { return -1; }
     pos += 1;
@@ -723,7 +723,7 @@ fn scan_para(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_para_content(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_para_content(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     let gp_0 = pos;
     sg_0: {
@@ -777,7 +777,7 @@ fn scan_para_content(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_S { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_2/t.wado",
-      "hash": "6f09c3c7a58e0038082b63b6fb32b73f48a6ed23f6938686946dbb3b6acddc73",
+      "hash": "c50a30245fba68525b763c537d4c7774264c9e3e4e5a659aa5f834a72d76ee43",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_2/t.wado
@@ -701,20 +701,20 @@ impl Parser {
     }
 }
 
-fn scan_file_(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_file_(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_para(tokens, pos);
+    pos = scan_para(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_para(tokens, pos);
+    pos = scan_para(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_para(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_para(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_para_content(tokens, pos);
+    pos = scan_para_content(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_NL { return -1; }
     pos += 1;
@@ -723,7 +723,7 @@ fn scan_para(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_para_content(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_para_content(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     let gp_0 = pos;
     sg_0: {
@@ -777,7 +777,7 @@ fn scan_para_content(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_s(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_S { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/calculator/calculator.g4.kiln.json
+++ b/package-gale/tests/generated/calculator/calculator.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/calculator/calculator.wado",
-      "hash": "327fb4e092e1448338d319bd7ea054355c611aa37e4591fe4b59d31885c9fbff",
+      "hash": "8e75878d6a5d045c91748750486cf3090bf5505d3008a1437475ed76e431b111",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/calculator/calculator.wado
+++ b/package-gale/tests/generated/calculator/calculator.wado
@@ -1452,22 +1452,22 @@ impl Parser {
     }
 }
 
-fn scan_equation(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_equation(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_expression(tokens, pos);
+    pos = scan_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_relop(tokens, pos);
+    pos = scan_relop(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_expression(tokens, pos);
+    pos = scan_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_multiplying_expression(tokens, pos);
+    pos = scan_multiplying_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && _gale_kind_set_0(tokens[pos].kind) {
         let sp = pos;
@@ -1489,7 +1489,7 @@ fn scan_expression(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     break sg_0;
                 }
-                pos = scan_multiplying_expression(tokens, pos);
+                pos = scan_multiplying_expression(tokens, pos, 0);
                 if pos < 0 { break sg_0; }
                 break sg_0_done;
             }
@@ -1501,9 +1501,9 @@ fn scan_expression(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_multiplying_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_multiplying_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_pow_expression(tokens, pos);
+    pos = scan_pow_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
@@ -1525,7 +1525,7 @@ fn scan_multiplying_expression(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     break sg_2;
                 }
-                pos = scan_pow_expression(tokens, pos);
+                pos = scan_pow_expression(tokens, pos, 0);
                 if pos < 0 { break sg_2; }
                 break sg_2_done;
             }
@@ -1537,9 +1537,9 @@ fn scan_multiplying_expression(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_pow_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_pow_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_signed_atom(tokens, pos);
+    pos = scan_signed_atom(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_POW {
         let sp = pos;
@@ -1547,7 +1547,7 @@ fn scan_pow_expression(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_4: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_POW { break sg_4; }
                 pos += 1;
-                pos = scan_signed_atom(tokens, pos);
+                pos = scan_signed_atom(tokens, pos, 0);
                 if pos < 0 { break sg_4; }
                 break sg_4_done;
             }
@@ -1559,7 +1559,7 @@ fn scan_pow_expression(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_signed_atom(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_signed_atom(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -1569,7 +1569,7 @@ fn scan_signed_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_PLUS { break try_0; }
                 pos += 1;
-                pos = scan_signed_atom(tokens, pos);
+                pos = scan_signed_atom(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -1579,7 +1579,7 @@ fn scan_signed_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_MINUS { break try_1; }
                 pos += 1;
-                pos = scan_signed_atom(tokens, pos);
+                pos = scan_signed_atom(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -1587,7 +1587,7 @@ fn scan_signed_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_2(alt_kind) {
             pos = start;
             try_2: {
-                pos = scan_func_(tokens, pos);
+                pos = scan_func_(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -1595,7 +1595,7 @@ fn scan_signed_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_3(alt_kind) {
             pos = start;
             try_3: {
-                pos = scan_atom(tokens, pos);
+                pos = scan_atom(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -1607,7 +1607,7 @@ fn scan_signed_atom(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_atom(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_atom(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -1615,7 +1615,7 @@ fn scan_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         if alt_kind == TK_SCIENTIFIC_NUMBER {
             pos = start;
             try_0: {
-                pos = scan_scientific(tokens, pos);
+                pos = scan_scientific(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -1623,7 +1623,7 @@ fn scan_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_VARIABLE {
             pos = start;
             try_1: {
-                pos = scan_variable(tokens, pos);
+                pos = scan_variable(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -1631,7 +1631,7 @@ fn scan_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_4(alt_kind) {
             pos = start;
             try_2: {
-                pos = scan_constant(tokens, pos);
+                pos = scan_constant(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -1641,7 +1641,7 @@ fn scan_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_3: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { break try_3; }
                 pos += 1;
-                pos = scan_expression(tokens, pos);
+                pos = scan_expression(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { break try_3; }
                 pos += 1;
@@ -1655,34 +1655,34 @@ fn scan_atom(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_scientific(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_scientific(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_SCIENTIFIC_NUMBER { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_constant(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_constant(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_4(tokens[pos].kind) {
         return pos + 1;
     }
     return -1;
 }
 
-fn scan_variable(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_variable(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_VARIABLE { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_func_(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_func_(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_funcname(tokens, pos);
+    pos = scan_funcname(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
     pos += 1;
-    pos = scan_expression(tokens, pos);
+    pos = scan_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
         let sp = pos;
@@ -1690,7 +1690,7 @@ fn scan_func_(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_5: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_5; }
                 pos += 1;
-                pos = scan_expression(tokens, pos);
+                pos = scan_expression(tokens, pos, 0);
                 if pos < 0 { break sg_5; }
                 break sg_5_done;
             }
@@ -1704,14 +1704,14 @@ fn scan_func_(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_funcname(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_funcname(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) {
         return pos + 1;
     }
     return -1;
 }
 
-fn scan_relop(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_relop(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_5(tokens[pos].kind) {
         return pos + 1;
     }
@@ -1758,7 +1758,7 @@ fn parse_expression(p: &mut Parser) -> Result<ExpressionNode, ParseError> {
                 }
                 break rep_scan;
             }
-            pos = scan_multiplying_expression(tokens, pos);
+            pos = scan_multiplying_expression(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -1804,7 +1804,7 @@ fn parse_multiplying_expression(p: &mut Parser) -> Result<MultiplyingExpressionN
                 }
                 break rep_scan;
             }
-            pos = scan_pow_expression(tokens, pos);
+            pos = scan_pow_expression(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -1836,7 +1836,7 @@ fn parse_pow_expression(p: &mut Parser) -> Result<PowExpressionNode, ParseError>
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_POW { break rep_scan; }
             pos += 1;
-            pos = scan_signed_atom(tokens, pos);
+            pos = scan_signed_atom(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -2003,7 +2003,7 @@ fn parse_func_(p: &mut Parser) -> Result<FuncNode, ParseError> {
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_expression(tokens, pos);
+            pos = scan_expression(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;

--- a/package-gale/tests/generated/ci_rule_override/ci_rule_override.g4.kiln.json
+++ b/package-gale/tests/generated/ci_rule_override/ci_rule_override.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/ci_rule_override/ci_rule_override.wado",
-      "hash": "eeebcce8913eaa66b0850046d1a270b163c68737ab9eb10503a3320a3fca9b29",
+      "hash": "ac9f16291bbaa0b43174fb02dc960594fb4c07311f046392dabe7d99563a48e3",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/ci_rule_override/ci_rule_override.wado
+++ b/package-gale/tests/generated/ci_rule_override/ci_rule_override.wado
@@ -734,7 +734,7 @@ impl Parser {
     }
 }
 
-fn scan_line(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_line(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     let gp_0 = pos;
     sg_0: {

--- a/package-gale/tests/generated/ci_sql/ci_sql.g4.kiln.json
+++ b/package-gale/tests/generated/ci_sql/ci_sql.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/ci_sql/ci_sql.wado",
-      "hash": "7930dec3596536ba2f54f63cc720510233b3abb7ab43e9be2e3a8221b91e463e",
+      "hash": "14bd99f2b4a42ceafa2039945e1ab5d05eafc933e4f97370224a4febe8ad919e",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/ci_sql/ci_sql.wado
+++ b/package-gale/tests/generated/ci_sql/ci_sql.wado
@@ -715,7 +715,7 @@ impl Parser {
     }
 }
 
-fn scan_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_IF { return -1; }
     pos += 1;

--- a/package-gale/tests/generated/css3/css3.wado
+++ b/package-gale/tests/generated/css3/css3.wado
@@ -29346,15 +29346,15 @@ impl Parser {
     }
 }
 
-fn scan_stylesheet(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_stylesheet(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_Charset {
         let sp = pos;
         sg_0_done: {
             sg_0: {
-                pos = scan_charset(tokens, pos);
+                pos = scan_charset(tokens, pos, 0);
                 if pos < 0 { break sg_0; }
                 while pos < tokens.len() && _gale_kind_set_0(tokens[pos].kind) {
                     let sp = pos;
@@ -29400,7 +29400,7 @@ fn scan_stylesheet(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_2_done: {
             sg_2: {
-                pos = scan_imports(tokens, pos);
+                pos = scan_imports(tokens, pos, 0);
                 if pos < 0 { break sg_2; }
                 while pos < tokens.len() && _gale_kind_set_0(tokens[pos].kind) {
                     let sp = pos;
@@ -29446,7 +29446,7 @@ fn scan_stylesheet(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_4_done: {
             sg_4: {
-                pos = scan_namespace_(tokens, pos);
+                pos = scan_namespace_(tokens, pos, 0);
                 if pos < 0 { break sg_4; }
                 while pos < tokens.len() && _gale_kind_set_0(tokens[pos].kind) {
                     let sp = pos;
@@ -29492,7 +29492,7 @@ fn scan_stylesheet(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_6_done: {
             sg_6: {
-                pos = scan_nested_statement(tokens, pos);
+                pos = scan_nested_statement(tokens, pos, 0);
                 if pos < 0 { break sg_6; }
                 while pos < tokens.len() && _gale_kind_set_0(tokens[pos].kind) {
                     let sp = pos;
@@ -29539,7 +29539,7 @@ fn scan_stylesheet(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_charset(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_charset(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -29549,15 +29549,15 @@ fn scan_charset(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_Charset { break try_0; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_String_ { break try_0; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { break try_0; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -29565,11 +29565,11 @@ fn scan_charset(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_Charset { break try_1; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_String_ { break try_1; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -29581,7 +29581,7 @@ fn scan_charset(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_imports(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_imports(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -29591,7 +29591,7 @@ fn scan_imports(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_Import { break try_0; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 let gp_8 = pos;
                 let sgk_8 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -29605,20 +29605,20 @@ fn scan_imports(tokens: &Array<Token>, pos: i32) -> i32 {
                         }
                         pos = gp_8;
                         sg_8_1: {
-                            pos = scan_url(tokens, pos);
+                            pos = scan_url(tokens, pos, 0);
                             if pos < 0 { break sg_8_1; }
                             break sg_8;
                         }
                         pos = gp_8;
                     }
                 }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_0; }
-                pos = scan_media_query_list(tokens, pos);
+                pos = scan_media_query_list(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { break try_0; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -29626,7 +29626,7 @@ fn scan_imports(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_Import { break try_1; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 let gp_9 = pos;
                 let sgk_9 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -29640,18 +29640,18 @@ fn scan_imports(tokens: &Array<Token>, pos: i32) -> i32 {
                         }
                         pos = gp_9;
                         sg_9_1: {
-                            pos = scan_url(tokens, pos);
+                            pos = scan_url(tokens, pos, 0);
                             if pos < 0 { break sg_9_1; }
                             break sg_9;
                         }
                         pos = gp_9;
                     }
                 }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { break try_1; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -29659,7 +29659,7 @@ fn scan_imports(tokens: &Array<Token>, pos: i32) -> i32 {
             try_2: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_Import { break try_2; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 let gp_10 = pos;
                 let sgk_10 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -29673,16 +29673,16 @@ fn scan_imports(tokens: &Array<Token>, pos: i32) -> i32 {
                         }
                         pos = gp_10;
                         sg_10_1: {
-                            pos = scan_url(tokens, pos);
+                            pos = scan_url(tokens, pos, 0);
                             if pos < 0 { break sg_10_1; }
                             break sg_10;
                         }
                         pos = gp_10;
                     }
                 }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_2; }
-                pos = scan_media_query_list(tokens, pos);
+                pos = scan_media_query_list(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -29690,7 +29690,7 @@ fn scan_imports(tokens: &Array<Token>, pos: i32) -> i32 {
             try_3: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_Import { break try_3; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 let gp_11 = pos;
                 let sgk_11 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -29704,14 +29704,14 @@ fn scan_imports(tokens: &Array<Token>, pos: i32) -> i32 {
                         }
                         pos = gp_11;
                         sg_11_1: {
-                            pos = scan_url(tokens, pos);
+                            pos = scan_url(tokens, pos, 0);
                             if pos < 0 { break sg_11_1; }
                             break sg_11;
                         }
                         pos = gp_11;
                     }
                 }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -29723,7 +29723,7 @@ fn scan_imports(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_namespace_(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_namespace_(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -29733,15 +29733,15 @@ fn scan_namespace_(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_Namespace { break try_0; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos < tokens.len() && _gale_kind_set_3(tokens[pos].kind) {
                     let sp = pos;
                     sg_12_done: {
                         sg_12: {
-                            pos = scan_namespace_prefix(tokens, pos);
+                            pos = scan_namespace_prefix(tokens, pos, 0);
                             if pos < 0 { break sg_12; }
-                            pos = scan_ws(tokens, pos);
+                            pos = scan_ws(tokens, pos, 0);
                             if pos < 0 { break sg_12; }
                             break sg_12_done;
                         }
@@ -29761,18 +29761,18 @@ fn scan_namespace_(tokens: &Array<Token>, pos: i32) -> i32 {
                         }
                         pos = gp_13;
                         sg_13_1: {
-                            pos = scan_url(tokens, pos);
+                            pos = scan_url(tokens, pos, 0);
                             if pos < 0 { break sg_13_1; }
                             break sg_13;
                         }
                         pos = gp_13;
                     }
                 }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { break try_0; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -29780,15 +29780,15 @@ fn scan_namespace_(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_Namespace { break try_1; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos < tokens.len() && _gale_kind_set_3(tokens[pos].kind) {
                     let sp = pos;
                     sg_14_done: {
                         sg_14: {
-                            pos = scan_namespace_prefix(tokens, pos);
+                            pos = scan_namespace_prefix(tokens, pos, 0);
                             if pos < 0 { break sg_14; }
-                            pos = scan_ws(tokens, pos);
+                            pos = scan_ws(tokens, pos, 0);
                             if pos < 0 { break sg_14; }
                             break sg_14_done;
                         }
@@ -29808,14 +29808,14 @@ fn scan_namespace_(tokens: &Array<Token>, pos: i32) -> i32 {
                         }
                         pos = gp_15;
                         sg_15_1: {
-                            pos = scan_url(tokens, pos);
+                            pos = scan_url(tokens, pos, 0);
                             if pos < 0 { break sg_15_1; }
                             break sg_15;
                         }
                         pos = gp_15;
                     }
                 }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -29827,35 +29827,35 @@ fn scan_namespace_(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_namespace_prefix(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_namespace_prefix(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_ident(tokens, pos);
+    pos = scan_ident(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_media(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_media(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Media { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_media_query_list(tokens, pos);
+    pos = scan_media_query_list(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_group_rule_body(tokens, pos);
+    pos = scan_group_rule_body(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_media_query_list(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_media_query_list(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && _gale_kind_set_4(tokens[pos].kind) {
         let sp = pos;
         sg_16_done: {
             sg_16: {
-                pos = scan_media_query(tokens, pos);
+                pos = scan_media_query(tokens, pos, 0);
                 if pos < 0 { break sg_16; }
                 while pos < tokens.len() && tokens[pos].kind == TK_Comma {
                     let sp = pos;
@@ -29863,9 +29863,9 @@ fn scan_media_query_list(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_17: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_Comma { break sg_17; }
                             pos += 1;
-                            pos = scan_ws(tokens, pos);
+                            pos = scan_ws(tokens, pos, 0);
                             if pos < 0 { break sg_17; }
-                            pos = scan_media_query(tokens, pos);
+                            pos = scan_media_query(tokens, pos, 0);
                             if pos < 0 { break sg_17; }
                             break sg_17_done;
                         }
@@ -29880,12 +29880,12 @@ fn scan_media_query_list(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_media_query(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_media_query(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -29913,11 +29913,11 @@ fn scan_media_query(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_0; }
-                pos = scan_media_type(tokens, pos);
+                pos = scan_media_type(tokens, pos, 0);
                 if pos < 0 { break try_0; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 while pos < tokens.len() && tokens[pos].kind == TK_And {
                     let sp = pos;
@@ -29925,9 +29925,9 @@ fn scan_media_query(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_19: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_And { break sg_19; }
                             pos += 1;
-                            pos = scan_ws(tokens, pos);
+                            pos = scan_ws(tokens, pos, 0);
                             if pos < 0 { break sg_19; }
-                            pos = scan_media_expression(tokens, pos);
+                            pos = scan_media_expression(tokens, pos, 0);
                             if pos < 0 { break sg_19; }
                             break sg_19_done;
                         }
@@ -29942,7 +29942,7 @@ fn scan_media_query(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_LPAREN {
             pos = start;
             try_1: {
-                pos = scan_media_expression(tokens, pos);
+                pos = scan_media_expression(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 while pos < tokens.len() && tokens[pos].kind == TK_And {
                     let sp = pos;
@@ -29950,9 +29950,9 @@ fn scan_media_query(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_20: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_And { break sg_20; }
                             pos += 1;
-                            pos = scan_ws(tokens, pos);
+                            pos = scan_ws(tokens, pos, 0);
                             if pos < 0 { break sg_20; }
-                            pos = scan_media_expression(tokens, pos);
+                            pos = scan_media_expression(tokens, pos, 0);
                             if pos < 0 { break sg_20; }
                             break sg_20_done;
                         }
@@ -29971,20 +29971,20 @@ fn scan_media_query(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_media_type(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_media_type(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_ident(tokens, pos);
+    pos = scan_ident(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_media_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_media_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_media_feature(tokens, pos);
+    pos = scan_media_feature(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_COLON {
         let sp = pos;
@@ -29992,9 +29992,9 @@ fn scan_media_expression(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_21: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { break sg_21; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_21; }
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_21; }
                 break sg_21_done;
             }
@@ -30004,38 +30004,38 @@ fn scan_media_expression(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_media_feature(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_media_feature(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_ident(tokens, pos);
+    pos = scan_ident(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_page(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_page(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Page { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_COLON {
         let sp = pos;
-        pos = scan_pseudo_page(tokens, pos);
+        pos = scan_pseudo_page(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && _gale_kind_set_7(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_declaration(tokens, pos);
+        pos = scan_declaration(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_SEMI {
@@ -30044,11 +30044,11 @@ fn scan_page(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_22: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { break sg_22; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_22; }
                 if pos < tokens.len() && _gale_kind_set_7(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_declaration(tokens, pos);
+                    pos = scan_declaration(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break sg_22_done;
@@ -30060,25 +30060,25 @@ fn scan_page(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_pseudo_page(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_pseudo_page(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { return -1; }
     pos += 1;
-    pos = scan_ident(tokens, pos);
+    pos = scan_ident(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_selector_group(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_selector_group(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_selector(tokens, pos);
+    pos = scan_selector(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_Comma {
         let sp = pos;
@@ -30086,9 +30086,9 @@ fn scan_selector_group(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_23: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_Comma { break sg_23; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_23; }
-                pos = scan_selector(tokens, pos);
+                pos = scan_selector(tokens, pos, 0);
                 if pos < 0 { break sg_23; }
                 break sg_23_done;
             }
@@ -30100,21 +30100,21 @@ fn scan_selector_group(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_selector(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_selector(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_simple_selector_sequence(tokens, pos);
+    pos = scan_simple_selector_sequence(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && _gale_kind_set_8(tokens[pos].kind) {
         let sp = pos;
         sg_24_done: {
             sg_24: {
-                pos = scan_combinator(tokens, pos);
+                pos = scan_combinator(tokens, pos, 0);
                 if pos < 0 { break sg_24; }
-                pos = scan_simple_selector_sequence(tokens, pos);
+                pos = scan_simple_selector_sequence(tokens, pos, 0);
                 if pos < 0 { break sg_24; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_24; }
                 break sg_24_done;
             }
@@ -30126,7 +30126,7 @@ fn scan_selector(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_combinator(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_combinator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -30136,7 +30136,7 @@ fn scan_combinator(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_Plus { break try_0; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -30146,7 +30146,7 @@ fn scan_combinator(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_Greater { break try_1; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -30156,7 +30156,7 @@ fn scan_combinator(tokens: &Array<Token>, pos: i32) -> i32 {
             try_2: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_Tilde { break try_2; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -30166,7 +30166,7 @@ fn scan_combinator(tokens: &Array<Token>, pos: i32) -> i32 {
             try_3: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_Space { break try_3; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -30178,7 +30178,7 @@ fn scan_combinator(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_simple_selector_sequence(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_simple_selector_sequence(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -30193,13 +30193,13 @@ fn scan_simple_selector_sequence(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_25: {
                         pos = gp_25;
                         sg_25_0: {
-                            pos = scan_type_selector(tokens, pos);
+                            pos = scan_type_selector(tokens, pos, 0);
                             if pos < 0 { break sg_25_0; }
                             if pos > sg_25_best { sg_25_best = pos; }
                         }
                         pos = gp_25;
                         sg_25_1: {
-                            pos = scan_universal(tokens, pos);
+                            pos = scan_universal(tokens, pos, 0);
                             if pos < 0 { break sg_25_1; }
                             if pos > sg_25_best { sg_25_best = pos; }
                         }
@@ -30219,25 +30219,25 @@ fn scan_simple_selector_sequence(tokens: &Array<Token>, pos: i32) -> i32 {
                         }
                         pos = gp_26;
                         sg_26_1: {
-                            pos = scan_class_name(tokens, pos);
+                            pos = scan_class_name(tokens, pos, 0);
                             if pos < 0 { break sg_26_1; }
                             break sg_26;
                         }
                         pos = gp_26;
                         sg_26_2: {
-                            pos = scan_attrib(tokens, pos);
+                            pos = scan_attrib(tokens, pos, 0);
                             if pos < 0 { break sg_26_2; }
                             break sg_26;
                         }
                         pos = gp_26;
                         sg_26_3: {
-                            pos = scan_pseudo(tokens, pos);
+                            pos = scan_pseudo(tokens, pos, 0);
                             if pos < 0 { break sg_26_3; }
                             break sg_26;
                         }
                         pos = gp_26;
                         sg_26_4: {
-                            pos = scan_negation(tokens, pos);
+                            pos = scan_negation(tokens, pos, 0);
                             if pos < 0 { break sg_26_4; }
                             break sg_26;
                         }
@@ -30264,25 +30264,25 @@ fn scan_simple_selector_sequence(tokens: &Array<Token>, pos: i32) -> i32 {
                         }
                         pos = gp_27;
                         sg_27_1: {
-                            pos = scan_class_name(tokens, pos);
+                            pos = scan_class_name(tokens, pos, 0);
                             if pos < 0 { break sg_27_1; }
                             break sg_27;
                         }
                         pos = gp_27;
                         sg_27_2: {
-                            pos = scan_attrib(tokens, pos);
+                            pos = scan_attrib(tokens, pos, 0);
                             if pos < 0 { break sg_27_2; }
                             break sg_27;
                         }
                         pos = gp_27;
                         sg_27_3: {
-                            pos = scan_pseudo(tokens, pos);
+                            pos = scan_pseudo(tokens, pos, 0);
                             if pos < 0 { break sg_27_3; }
                             break sg_27;
                         }
                         pos = gp_27;
                         sg_27_4: {
-                            pos = scan_negation(tokens, pos);
+                            pos = scan_negation(tokens, pos, 0);
                             if pos < 0 { break sg_27_4; }
                             break sg_27;
                         }
@@ -30301,25 +30301,25 @@ fn scan_simple_selector_sequence(tokens: &Array<Token>, pos: i32) -> i32 {
                         }
                         pos = gp_28;
                         sg_28_1: {
-                            pos = scan_class_name(tokens, pos);
+                            pos = scan_class_name(tokens, pos, 0);
                             if pos < 0 { break sg_28_1; }
                             break sg_28;
                         }
                         pos = gp_28;
                         sg_28_2: {
-                            pos = scan_attrib(tokens, pos);
+                            pos = scan_attrib(tokens, pos, 0);
                             if pos < 0 { break sg_28_2; }
                             break sg_28;
                         }
                         pos = gp_28;
                         sg_28_3: {
-                            pos = scan_pseudo(tokens, pos);
+                            pos = scan_pseudo(tokens, pos, 0);
                             if pos < 0 { break sg_28_3; }
                             break sg_28;
                         }
                         pos = gp_28;
                         sg_28_4: {
-                            pos = scan_negation(tokens, pos);
+                            pos = scan_negation(tokens, pos, 0);
                             if pos < 0 { break sg_28_4; }
                             break sg_28;
                         }
@@ -30338,19 +30338,19 @@ fn scan_simple_selector_sequence(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_type_selector(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_type_selector(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && _gale_kind_set_11(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_type_namespace_prefix(tokens, pos);
+        pos = scan_type_namespace_prefix(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
-    pos = scan_element_name(tokens, pos);
+    pos = scan_element_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_type_namespace_prefix(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_type_namespace_prefix(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && _gale_kind_set_12(tokens[pos].kind) {
         let sp = pos;
@@ -30358,7 +30358,7 @@ fn scan_type_namespace_prefix(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_29: {
             pos = gp_29;
             sg_29_0: {
-                pos = scan_ident(tokens, pos);
+                pos = scan_ident(tokens, pos, 0);
                 if pos < 0 { break sg_29_0; }
                 break sg_29;
             }
@@ -30377,18 +30377,18 @@ fn scan_type_namespace_prefix(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_element_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_element_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_ident(tokens, pos);
+    pos = scan_ident(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_universal(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_universal(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && _gale_kind_set_13(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_type_namespace_prefix(tokens, pos);
+        pos = scan_type_namespace_prefix(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_STAR { return -1; }
@@ -30396,29 +30396,29 @@ fn scan_universal(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_class_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_class_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
     pos += 1;
-    pos = scan_ident(tokens, pos);
+    pos = scan_ident(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_attrib(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_attrib(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && _gale_kind_set_11(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_type_namespace_prefix(tokens, pos);
+        pos = scan_type_namespace_prefix(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
-    pos = scan_ident(tokens, pos);
+    pos = scan_ident(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && _gale_kind_set_14(tokens[pos].kind) {
         let sp = pos;
@@ -30464,7 +30464,7 @@ fn scan_attrib(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     break sg_30;
                 }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_30; }
                 let gp_32 = pos;
                 let sgk_32 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -30472,7 +30472,7 @@ fn scan_attrib(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_32: {
                         pos = gp_32;
                         sg_32_0: {
-                            pos = scan_ident(tokens, pos);
+                            pos = scan_ident(tokens, pos, 0);
                             if pos < 0 { break sg_32_0; }
                             break sg_32;
                         }
@@ -30485,7 +30485,7 @@ fn scan_attrib(tokens: &Array<Token>, pos: i32) -> i32 {
                         pos = gp_32;
                     }
                 }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_30; }
                 break sg_30_done;
             }
@@ -30498,7 +30498,7 @@ fn scan_attrib(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_pseudo(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_pseudo(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { return -1; }
     pos += 1;
@@ -30513,13 +30513,13 @@ fn scan_pseudo(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_33: {
             pos = gp_33;
             sg_33_0: {
-                pos = scan_ident(tokens, pos);
+                pos = scan_ident(tokens, pos, 0);
                 if pos < 0 { break sg_33_0; }
                 break sg_33;
             }
             pos = gp_33;
             sg_33_1: {
-                pos = scan_functional_pseudo(tokens, pos);
+                pos = scan_functional_pseudo(tokens, pos, 0);
                 if pos < 0 { break sg_33_1; }
                 break sg_33;
             }
@@ -30529,20 +30529,20 @@ fn scan_pseudo(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_functional_pseudo(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_functional_pseudo(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Function_ { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_expression(tokens, pos);
+    pos = scan_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     sg_34_done: {
         sg_34: {
@@ -30588,14 +30588,14 @@ fn scan_expression(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     pos = gp_35;
                     sg_35_6: {
-                        pos = scan_ident(tokens, pos);
+                        pos = scan_ident(tokens, pos, 0);
                         if pos < 0 { break sg_35_6; }
                         break sg_35;
                     }
                     pos = gp_35;
                 }
             }
-            pos = scan_ws(tokens, pos);
+            pos = scan_ws(tokens, pos, 0);
             if pos < 0 { break sg_34; }
             break sg_34_done;
         }
@@ -30647,14 +30647,14 @@ fn scan_expression(tokens: &Array<Token>, pos: i32) -> i32 {
                         }
                         pos = gp_37;
                         sg_37_6: {
-                            pos = scan_ident(tokens, pos);
+                            pos = scan_ident(tokens, pos, 0);
                             if pos < 0 { break sg_37_6; }
                             break sg_37;
                         }
                         pos = gp_37;
                     }
                 }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_36; }
                 break sg_36_done;
             }
@@ -30666,22 +30666,22 @@ fn scan_expression(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_negation(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_negation(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_PseudoNot { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_negation_arg(tokens, pos);
+    pos = scan_negation_arg(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_negation_arg(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_negation_arg(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -30689,13 +30689,13 @@ fn scan_negation_arg(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_9(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_type_selector(tokens, pos);
+                pos = scan_type_selector(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_1: {
-                pos = scan_universal(tokens, pos);
+                pos = scan_universal(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -30711,7 +30711,7 @@ fn scan_negation_arg(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_DOT {
             pos = start;
             try_3: {
-                pos = scan_class_name(tokens, pos);
+                pos = scan_class_name(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -30719,7 +30719,7 @@ fn scan_negation_arg(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_LBRACKET {
             pos = start;
             try_4: {
-                pos = scan_attrib(tokens, pos);
+                pos = scan_attrib(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 break scan_alts;
             }
@@ -30727,7 +30727,7 @@ fn scan_negation_arg(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_COLON {
             pos = start;
             try_5: {
-                pos = scan_pseudo(tokens, pos);
+                pos = scan_pseudo(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 break scan_alts;
             }
@@ -30739,7 +30739,7 @@ fn scan_negation_arg(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_operator_(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_operator_(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -30749,7 +30749,7 @@ fn scan_operator_(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SLASH { break try_0; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -30759,7 +30759,7 @@ fn scan_operator_(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_Comma { break try_1; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -30769,7 +30769,7 @@ fn scan_operator_(tokens: &Array<Token>, pos: i32) -> i32 {
             try_2: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_Space { break try_2; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -30779,7 +30779,7 @@ fn scan_operator_(tokens: &Array<Token>, pos: i32) -> i32 {
             try_3: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQ { break try_3; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -30791,7 +30791,7 @@ fn scan_operator_(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_property_(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_property_(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -30799,9 +30799,9 @@ fn scan_property_(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_3(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_ident(tokens, pos);
+                pos = scan_ident(tokens, pos, 0);
                 if pos < 0 { break try_0; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -30811,7 +30811,7 @@ fn scan_property_(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_Variable { break try_1; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -30821,7 +30821,7 @@ fn scan_property_(tokens: &Array<Token>, pos: i32) -> i32 {
             try_2: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_STAR { break try_2; }
                 pos += 1;
-                pos = scan_ident(tokens, pos);
+                pos = scan_ident(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -30831,7 +30831,7 @@ fn scan_property_(tokens: &Array<Token>, pos: i32) -> i32 {
             try_3: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_U5f { break try_3; }
                 pos += 1;
-                pos = scan_ident(tokens, pos);
+                pos = scan_ident(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -30843,7 +30843,7 @@ fn scan_property_(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_ruleset(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_ruleset(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -30853,41 +30853,41 @@ fn scan_ruleset(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 while pos < tokens.len() && _gale_kind_set_19(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_any_(tokens, pos);
+                    pos = scan_any_(tokens, pos, 0);
                     if pos < 0 { pos = sp; break; }
                     if pos == sp { break; }
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { break try_1; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos < tokens.len() && _gale_kind_set_20(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_declaration_list(tokens, pos);
+                    pos = scan_declaration_list(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { break try_1; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_0: {
-                pos = scan_selector_group(tokens, pos);
+                pos = scan_selector_group(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { break try_0; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos < tokens.len() && _gale_kind_set_20(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_declaration_list(tokens, pos);
+                    pos = scan_declaration_list(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { break try_0; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -30895,20 +30895,20 @@ fn scan_ruleset(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_21(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_selector_group(tokens, pos);
+                pos = scan_selector_group(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { break try_0; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos < tokens.len() && _gale_kind_set_20(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_declaration_list(tokens, pos);
+                    pos = scan_declaration_list(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { break try_0; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -30918,22 +30918,22 @@ fn scan_ruleset(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 while pos < tokens.len() && _gale_kind_set_19(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_any_(tokens, pos);
+                    pos = scan_any_(tokens, pos, 0);
                     if pos < 0 { pos = sp; break; }
                     if pos == sp { break; }
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { break try_1; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos < tokens.len() && _gale_kind_set_20(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_declaration_list(tokens, pos);
+                    pos = scan_declaration_list(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { break try_1; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -30945,7 +30945,7 @@ fn scan_ruleset(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_declaration_list(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_declaration_list(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_SEMI {
         let sp = pos;
@@ -30953,7 +30953,7 @@ fn scan_declaration_list(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_38: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { break sg_38; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_38; }
                 break sg_38_done;
             }
@@ -30962,9 +30962,9 @@ fn scan_declaration_list(tokens: &Array<Token>, pos: i32) -> i32 {
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
-    pos = scan_declaration(tokens, pos);
+    pos = scan_declaration(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_SEMI {
         let sp = pos;
@@ -30972,11 +30972,11 @@ fn scan_declaration_list(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_39: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { break sg_39; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_39; }
                 if pos < tokens.len() && _gale_kind_set_7(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_declaration(tokens, pos);
+                    pos = scan_declaration(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break sg_39_done;
@@ -30989,7 +30989,7 @@ fn scan_declaration_list(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_declaration(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -30997,30 +30997,30 @@ fn scan_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_7(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_property_(tokens, pos);
+                pos = scan_property_(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { break try_0; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_0; }
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos < tokens.len() && tokens[pos].kind == TK_Important {
                     let sp = pos;
-                    pos = scan_prio(tokens, pos);
+                    pos = scan_prio(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break scan_alts;
             }
             pos = start;
             try_1: {
-                pos = scan_property_(tokens, pos);
+                pos = scan_property_(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { break try_1; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_1; }
-                pos = scan_value(tokens, pos);
+                pos = scan_value(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -31032,16 +31032,16 @@ fn scan_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_prio(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_prio(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Important { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_value(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_value(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     let gp_40 = pos;
     let sgk_40 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -31049,13 +31049,13 @@ fn scan_value(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_40: {
             pos = gp_40;
             sg_40_0: {
-                pos = scan_any_(tokens, pos);
+                pos = scan_any_(tokens, pos, 0);
                 if pos < 0 { break sg_40_0; }
                 break sg_40;
             }
             pos = gp_40;
             sg_40_1: {
-                pos = scan_block(tokens, pos);
+                pos = scan_block(tokens, pos, 0);
                 if pos < 0 { break sg_40_1; }
                 break sg_40;
             }
@@ -31063,7 +31063,7 @@ fn scan_value(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_40_2: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_AtKeyword { break sg_40_2; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_40_2; }
                 break sg_40;
             }
@@ -31076,13 +31076,13 @@ fn scan_value(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_41: {
             pos = gp_41;
             sg_41_0: {
-                pos = scan_any_(tokens, pos);
+                pos = scan_any_(tokens, pos, 0);
                 if pos < 0 { break sg_41_0; }
                 break sg_41;
             }
             pos = gp_41;
             sg_41_1: {
-                pos = scan_block(tokens, pos);
+                pos = scan_block(tokens, pos, 0);
                 if pos < 0 { break sg_41_1; }
                 break sg_41;
             }
@@ -31090,7 +31090,7 @@ fn scan_value(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_41_2: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_AtKeyword { break sg_41_2; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_41_2; }
                 break sg_41;
             }
@@ -31102,9 +31102,9 @@ fn scan_value(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_expr(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_expr(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_term(tokens, pos);
+    pos = scan_term(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && _gale_kind_set_24(tokens[pos].kind) {
         let sp = pos;
@@ -31112,10 +31112,10 @@ fn scan_expr(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_42: {
                 if pos < tokens.len() && _gale_kind_set_25(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_operator_(tokens, pos);
+                    pos = scan_operator_(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_term(tokens, pos);
+                pos = scan_term(tokens, pos, 0);
                 if pos < 0 { break sg_42; }
                 break sg_42_done;
             }
@@ -31127,7 +31127,7 @@ fn scan_expr(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_term(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_term(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -31135,33 +31135,33 @@ fn scan_term(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_26(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_number(tokens, pos);
+                pos = scan_number(tokens, pos, 0);
                 if pos < 0 { break try_0; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_1: {
-                pos = scan_percentage(tokens, pos);
+                pos = scan_percentage(tokens, pos, 0);
                 if pos < 0 { break try_1; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_2: {
-                pos = scan_dimension(tokens, pos);
+                pos = scan_dimension(tokens, pos, 0);
                 if pos < 0 { break try_2; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
             pos = start;
             try_11: {
-                pos = scan_unknown_dimension(tokens, pos);
+                pos = scan_unknown_dimension(tokens, pos, 0);
                 if pos < 0 { break try_11; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_11; }
                 break scan_alts;
             }
@@ -31169,9 +31169,9 @@ fn scan_term(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Number {
             pos = start;
             try_0: {
-                pos = scan_number(tokens, pos);
+                pos = scan_number(tokens, pos, 0);
                 if pos < 0 { break try_0; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -31179,9 +31179,9 @@ fn scan_term(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Percentage {
             pos = start;
             try_1: {
-                pos = scan_percentage(tokens, pos);
+                pos = scan_percentage(tokens, pos, 0);
                 if pos < 0 { break try_1; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -31189,9 +31189,9 @@ fn scan_term(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Dimension {
             pos = start;
             try_2: {
-                pos = scan_dimension(tokens, pos);
+                pos = scan_dimension(tokens, pos, 0);
                 if pos < 0 { break try_2; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -31201,7 +31201,7 @@ fn scan_term(tokens: &Array<Token>, pos: i32) -> i32 {
             try_3: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_String_ { break try_3; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -31211,7 +31211,7 @@ fn scan_term(tokens: &Array<Token>, pos: i32) -> i32 {
             try_4: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_UnicodeRange { break try_4; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 break scan_alts;
             }
@@ -31219,9 +31219,9 @@ fn scan_term(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_3(alt_kind) {
             pos = start;
             try_5: {
-                pos = scan_ident(tokens, pos);
+                pos = scan_ident(tokens, pos, 0);
                 if pos < 0 { break try_5; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 break scan_alts;
             }
@@ -31229,7 +31229,7 @@ fn scan_term(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Var {
             pos = start;
             try_6: {
-                pos = scan_var_(tokens, pos);
+                pos = scan_var_(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 break scan_alts;
             }
@@ -31237,9 +31237,9 @@ fn scan_term(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_27(alt_kind) {
             pos = start;
             try_7: {
-                pos = scan_url(tokens, pos);
+                pos = scan_url(tokens, pos, 0);
                 if pos < 0 { break try_7; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 break scan_alts;
             }
@@ -31247,7 +31247,7 @@ fn scan_term(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Hash {
             pos = start;
             try_8: {
-                pos = scan_hexcolor(tokens, pos);
+                pos = scan_hexcolor(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
@@ -31255,7 +31255,7 @@ fn scan_term(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Calc {
             pos = start;
             try_9: {
-                pos = scan_calc(tokens, pos);
+                pos = scan_calc(tokens, pos, 0);
                 if pos < 0 { break try_9; }
                 break scan_alts;
             }
@@ -31263,7 +31263,7 @@ fn scan_term(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Function_ {
             pos = start;
             try_10: {
-                pos = scan_function_(tokens, pos);
+                pos = scan_function_(tokens, pos, 0);
                 if pos < 0 { break try_10; }
                 break scan_alts;
             }
@@ -31271,9 +31271,9 @@ fn scan_term(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_UnknownDimension {
             pos = start;
             try_11: {
-                pos = scan_unknown_dimension(tokens, pos);
+                pos = scan_unknown_dimension(tokens, pos, 0);
                 if pos < 0 { break try_11; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_11; }
                 break scan_alts;
             }
@@ -31281,7 +31281,7 @@ fn scan_term(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_DxImageTransform {
             pos = start;
             try_12: {
-                pos = scan_dx_image_transform(tokens, pos);
+                pos = scan_dx_image_transform(tokens, pos, 0);
                 if pos < 0 { break try_12; }
                 break scan_alts;
             }
@@ -31293,46 +31293,46 @@ fn scan_term(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_function_(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_function_(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Function_ { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_expr(tokens, pos);
+    pos = scan_expr(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_dx_image_transform(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_dx_image_transform(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_DxImageTransform { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_expr(tokens, pos);
+    pos = scan_expr(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_hexcolor(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_hexcolor(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Hash { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_number(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_number(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && _gale_kind_set_26(tokens[pos].kind) {
         let sp = pos;
@@ -31359,7 +31359,7 @@ fn scan_number(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_percentage(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_percentage(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && _gale_kind_set_26(tokens[pos].kind) {
         let sp = pos;
@@ -31386,7 +31386,7 @@ fn scan_percentage(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_dimension(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_dimension(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && _gale_kind_set_26(tokens[pos].kind) {
         let sp = pos;
@@ -31413,7 +31413,7 @@ fn scan_dimension(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_unknown_dimension(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_unknown_dimension(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && _gale_kind_set_26(tokens[pos].kind) {
         let sp = pos;
@@ -31440,7 +31440,7 @@ fn scan_unknown_dimension(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_any_(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_any_(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -31448,9 +31448,9 @@ fn scan_any_(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_3(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_ident(tokens, pos);
+                pos = scan_ident(tokens, pos, 0);
                 if pos < 0 { break try_0; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -31458,33 +31458,33 @@ fn scan_any_(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_26(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_number(tokens, pos);
+                pos = scan_number(tokens, pos, 0);
                 if pos < 0 { break try_1; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_2: {
-                pos = scan_percentage(tokens, pos);
+                pos = scan_percentage(tokens, pos, 0);
                 if pos < 0 { break try_2; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
             pos = start;
             try_3: {
-                pos = scan_dimension(tokens, pos);
+                pos = scan_dimension(tokens, pos, 0);
                 if pos < 0 { break try_3; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
             pos = start;
             try_4: {
-                pos = scan_unknown_dimension(tokens, pos);
+                pos = scan_unknown_dimension(tokens, pos, 0);
                 if pos < 0 { break try_4; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 break scan_alts;
             }
@@ -31492,9 +31492,9 @@ fn scan_any_(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Number {
             pos = start;
             try_1: {
-                pos = scan_number(tokens, pos);
+                pos = scan_number(tokens, pos, 0);
                 if pos < 0 { break try_1; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -31502,9 +31502,9 @@ fn scan_any_(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Percentage {
             pos = start;
             try_2: {
-                pos = scan_percentage(tokens, pos);
+                pos = scan_percentage(tokens, pos, 0);
                 if pos < 0 { break try_2; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -31512,9 +31512,9 @@ fn scan_any_(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Dimension {
             pos = start;
             try_3: {
-                pos = scan_dimension(tokens, pos);
+                pos = scan_dimension(tokens, pos, 0);
                 if pos < 0 { break try_3; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -31522,9 +31522,9 @@ fn scan_any_(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_UnknownDimension {
             pos = start;
             try_4: {
-                pos = scan_unknown_dimension(tokens, pos);
+                pos = scan_unknown_dimension(tokens, pos, 0);
                 if pos < 0 { break try_4; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 break scan_alts;
             }
@@ -31534,7 +31534,7 @@ fn scan_any_(tokens: &Array<Token>, pos: i32) -> i32 {
             try_5: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_String_ { break try_5; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 break scan_alts;
             }
@@ -31542,9 +31542,9 @@ fn scan_any_(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_27(alt_kind) {
             pos = start;
             try_6: {
-                pos = scan_url(tokens, pos);
+                pos = scan_url(tokens, pos, 0);
                 if pos < 0 { break try_6; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 break scan_alts;
             }
@@ -31554,7 +31554,7 @@ fn scan_any_(tokens: &Array<Token>, pos: i32) -> i32 {
             try_7: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_Hash { break try_7; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 break scan_alts;
             }
@@ -31564,7 +31564,7 @@ fn scan_any_(tokens: &Array<Token>, pos: i32) -> i32 {
             try_8: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_UnicodeRange { break try_8; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
@@ -31574,7 +31574,7 @@ fn scan_any_(tokens: &Array<Token>, pos: i32) -> i32 {
             try_9: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_Includes { break try_9; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_9; }
                 break scan_alts;
             }
@@ -31584,7 +31584,7 @@ fn scan_any_(tokens: &Array<Token>, pos: i32) -> i32 {
             try_10: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_DashMatch { break try_10; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_10; }
                 break scan_alts;
             }
@@ -31594,7 +31594,7 @@ fn scan_any_(tokens: &Array<Token>, pos: i32) -> i32 {
             try_11: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { break try_11; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_11; }
                 break scan_alts;
             }
@@ -31604,7 +31604,7 @@ fn scan_any_(tokens: &Array<Token>, pos: i32) -> i32 {
             try_12: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_Function_ { break try_12; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_12; }
                 while pos < tokens.len() && _gale_kind_set_28(tokens[pos].kind) {
                     let sp = pos;
@@ -31612,13 +31612,13 @@ fn scan_any_(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_47: {
                         pos = gp_47;
                         sg_47_0: {
-                            pos = scan_any_(tokens, pos);
+                            pos = scan_any_(tokens, pos, 0);
                             if pos < 0 { break sg_47_0; }
                             break sg_47;
                         }
                         pos = gp_47;
                         sg_47_1: {
-                            pos = scan_unused(tokens, pos);
+                            pos = scan_unused(tokens, pos, 0);
                             if pos < 0 { break sg_47_1; }
                             break sg_47;
                         }
@@ -31629,7 +31629,7 @@ fn scan_any_(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_12; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_12; }
                 break scan_alts;
             }
@@ -31639,7 +31639,7 @@ fn scan_any_(tokens: &Array<Token>, pos: i32) -> i32 {
             try_13: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_13; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_13; }
                 while pos < tokens.len() && _gale_kind_set_28(tokens[pos].kind) {
                     let sp = pos;
@@ -31647,13 +31647,13 @@ fn scan_any_(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_48: {
                         pos = gp_48;
                         sg_48_0: {
-                            pos = scan_any_(tokens, pos);
+                            pos = scan_any_(tokens, pos, 0);
                             if pos < 0 { break sg_48_0; }
                             break sg_48;
                         }
                         pos = gp_48;
                         sg_48_1: {
-                            pos = scan_unused(tokens, pos);
+                            pos = scan_unused(tokens, pos, 0);
                             if pos < 0 { break sg_48_1; }
                             break sg_48;
                         }
@@ -31664,7 +31664,7 @@ fn scan_any_(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_13; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_13; }
                 break scan_alts;
             }
@@ -31674,7 +31674,7 @@ fn scan_any_(tokens: &Array<Token>, pos: i32) -> i32 {
             try_14: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break try_14; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_14; }
                 while pos < tokens.len() && _gale_kind_set_28(tokens[pos].kind) {
                     let sp = pos;
@@ -31682,13 +31682,13 @@ fn scan_any_(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_49: {
                         pos = gp_49;
                         sg_49_0: {
-                            pos = scan_any_(tokens, pos);
+                            pos = scan_any_(tokens, pos, 0);
                             if pos < 0 { break sg_49_0; }
                             break sg_49;
                         }
                         pos = gp_49;
                         sg_49_1: {
-                            pos = scan_unused(tokens, pos);
+                            pos = scan_unused(tokens, pos, 0);
                             if pos < 0 { break sg_49_1; }
                             break sg_49;
                         }
@@ -31699,7 +31699,7 @@ fn scan_any_(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break try_14; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_14; }
                 break scan_alts;
             }
@@ -31711,15 +31711,15 @@ fn scan_any_(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_at_rule(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_at_rule(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_AtKeyword { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && _gale_kind_set_19(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_any_(tokens, pos);
+        pos = scan_any_(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -31729,7 +31729,7 @@ fn scan_at_rule(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_50: {
             pos = gp_50;
             sg_50_0: {
-                pos = scan_block(tokens, pos);
+                pos = scan_block(tokens, pos, 0);
                 if pos < 0 { break sg_50_0; }
                 break sg_50;
             }
@@ -31737,7 +31737,7 @@ fn scan_at_rule(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_50_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { break sg_50_1; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_50_1; }
                 break sg_50;
             }
@@ -31747,7 +31747,7 @@ fn scan_at_rule(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_unused(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_unused(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -31755,7 +31755,7 @@ fn scan_unused(tokens: &Array<Token>, pos: i32) -> i32 {
         if alt_kind == TK_LIT_LBRACE {
             pos = start;
             try_0: {
-                pos = scan_block(tokens, pos);
+                pos = scan_block(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -31765,7 +31765,7 @@ fn scan_unused(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_AtKeyword { break try_1; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -31775,7 +31775,7 @@ fn scan_unused(tokens: &Array<Token>, pos: i32) -> i32 {
             try_2: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { break try_2; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -31785,7 +31785,7 @@ fn scan_unused(tokens: &Array<Token>, pos: i32) -> i32 {
             try_3: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_Cdo { break try_3; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -31795,7 +31795,7 @@ fn scan_unused(tokens: &Array<Token>, pos: i32) -> i32 {
             try_4: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_Cdc { break try_4; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 break scan_alts;
             }
@@ -31807,11 +31807,11 @@ fn scan_unused(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_block(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_block(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && _gale_kind_set_30(tokens[pos].kind) {
         let sp = pos;
@@ -31820,25 +31820,25 @@ fn scan_block(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_51: {
             pos = gp_51;
             sg_51_0: {
-                pos = scan_declaration_list(tokens, pos);
+                pos = scan_declaration_list(tokens, pos, 0);
                 if pos < 0 { break sg_51_0; }
                 if pos > sg_51_best { sg_51_best = pos; }
             }
             pos = gp_51;
             sg_51_1: {
-                pos = scan_nested_statement(tokens, pos);
+                pos = scan_nested_statement(tokens, pos, 0);
                 if pos < 0 { break sg_51_1; }
                 if pos > sg_51_best { sg_51_best = pos; }
             }
             pos = gp_51;
             sg_51_2: {
-                pos = scan_any_(tokens, pos);
+                pos = scan_any_(tokens, pos, 0);
                 if pos < 0 { break sg_51_2; }
                 if pos > sg_51_best { sg_51_best = pos; }
             }
             pos = gp_51;
             sg_51_3: {
-                pos = scan_block(tokens, pos);
+                pos = scan_block(tokens, pos, 0);
                 if pos < 0 { break sg_51_3; }
                 if pos > sg_51_best { sg_51_best = pos; }
             }
@@ -31846,7 +31846,7 @@ fn scan_block(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_51_4: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_AtKeyword { break sg_51_4; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_51_4; }
                 if pos > sg_51_best { sg_51_best = pos; }
             }
@@ -31854,7 +31854,7 @@ fn scan_block(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_51_5: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { break sg_51_5; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_51_5; }
                 if pos > sg_51_best { sg_51_best = pos; }
             }
@@ -31866,12 +31866,12 @@ fn scan_block(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_nested_statement(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_nested_statement(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -31879,7 +31879,7 @@ fn scan_nested_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_31(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_ruleset(tokens, pos);
+                pos = scan_ruleset(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -31887,7 +31887,7 @@ fn scan_nested_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Media {
             pos = start;
             try_1: {
-                pos = scan_media(tokens, pos);
+                pos = scan_media(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -31895,7 +31895,7 @@ fn scan_nested_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Page {
             pos = start;
             try_2: {
-                pos = scan_page(tokens, pos);
+                pos = scan_page(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -31903,7 +31903,7 @@ fn scan_nested_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_FontFace {
             pos = start;
             try_3: {
-                pos = scan_font_face_rule(tokens, pos);
+                pos = scan_font_face_rule(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -31911,7 +31911,7 @@ fn scan_nested_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Keyframes {
             pos = start;
             try_4: {
-                pos = scan_keyframes_rule(tokens, pos);
+                pos = scan_keyframes_rule(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 break scan_alts;
             }
@@ -31919,7 +31919,7 @@ fn scan_nested_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Supports {
             pos = start;
             try_5: {
-                pos = scan_supports_rule(tokens, pos);
+                pos = scan_supports_rule(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 break scan_alts;
             }
@@ -31927,7 +31927,7 @@ fn scan_nested_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Viewport {
             pos = start;
             try_6: {
-                pos = scan_viewport(tokens, pos);
+                pos = scan_viewport(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 break scan_alts;
             }
@@ -31935,7 +31935,7 @@ fn scan_nested_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_CounterStyle {
             pos = start;
             try_7: {
-                pos = scan_counter_style(tokens, pos);
+                pos = scan_counter_style(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 break scan_alts;
             }
@@ -31943,7 +31943,7 @@ fn scan_nested_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_FontFeatureValues {
             pos = start;
             try_8: {
-                pos = scan_font_feature_values_rule(tokens, pos);
+                pos = scan_font_feature_values_rule(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
@@ -31951,7 +31951,7 @@ fn scan_nested_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_AtKeyword {
             pos = start;
             try_9: {
-                pos = scan_at_rule(tokens, pos);
+                pos = scan_at_rule(tokens, pos, 0);
                 if pos < 0 { break try_9; }
                 break scan_alts;
             }
@@ -31963,41 +31963,41 @@ fn scan_nested_statement(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_group_rule_body(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_group_rule_body(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_nested_statement(tokens, pos);
+        pos = scan_nested_statement(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_supports_rule(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_supports_rule(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Supports { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_supports_condition(tokens, pos);
+    pos = scan_supports_condition(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_group_rule_body(tokens, pos);
+    pos = scan_group_rule_body(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_supports_condition(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_supports_condition(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -32005,7 +32005,7 @@ fn scan_supports_condition(tokens: &Array<Token>, pos: i32) -> i32 {
         if alt_kind == TK_Not {
             pos = start;
             try_0: {
-                pos = scan_supports_negation(tokens, pos);
+                pos = scan_supports_negation(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -32013,19 +32013,19 @@ fn scan_supports_condition(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_32(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_supports_conjunction(tokens, pos);
+                pos = scan_supports_conjunction(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_2: {
-                pos = scan_supports_disjunction(tokens, pos);
+                pos = scan_supports_disjunction(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
             pos = start;
             try_3: {
-                pos = scan_supports_condition_in_parens(tokens, pos);
+                pos = scan_supports_condition_in_parens(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -32037,7 +32037,7 @@ fn scan_supports_condition(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_supports_condition_in_parens(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_supports_condition_in_parens(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -32047,11 +32047,11 @@ fn scan_supports_condition_in_parens(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_0; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_0; }
-                pos = scan_supports_condition(tokens, pos);
+                pos = scan_supports_condition(tokens, pos, 0);
                 if pos < 0 { break try_0; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_0; }
                 pos += 1;
@@ -32059,13 +32059,13 @@ fn scan_supports_condition_in_parens(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_1: {
-                pos = scan_supports_declaration_condition(tokens, pos);
+                pos = scan_supports_declaration_condition(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_2: {
-                pos = scan_general_enclosed(tokens, pos);
+                pos = scan_general_enclosed(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -32073,7 +32073,7 @@ fn scan_supports_condition_in_parens(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Function_ {
             pos = start;
             try_2: {
-                pos = scan_general_enclosed(tokens, pos);
+                pos = scan_general_enclosed(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -32085,42 +32085,42 @@ fn scan_supports_condition_in_parens(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_supports_negation(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_supports_negation(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Not { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_Space { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_supports_condition_in_parens(tokens, pos);
+    pos = scan_supports_condition_in_parens(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_supports_conjunction(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_supports_conjunction(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_supports_condition_in_parens(tokens, pos);
+    pos = scan_supports_condition_in_parens(tokens, pos, 0);
     if pos < 0 { return -1; }
     sg_52_done: {
         sg_52: {
-            pos = scan_ws(tokens, pos);
+            pos = scan_ws(tokens, pos, 0);
             if pos < 0 { break sg_52; }
             if pos >= tokens.len() || tokens[pos].kind != TK_Space { break sg_52; }
             pos += 1;
-            pos = scan_ws(tokens, pos);
+            pos = scan_ws(tokens, pos, 0);
             if pos < 0 { break sg_52; }
             if pos >= tokens.len() || tokens[pos].kind != TK_And { break sg_52; }
             pos += 1;
-            pos = scan_ws(tokens, pos);
+            pos = scan_ws(tokens, pos, 0);
             if pos < 0 { break sg_52; }
             if pos >= tokens.len() || tokens[pos].kind != TK_Space { break sg_52; }
             pos += 1;
-            pos = scan_ws(tokens, pos);
+            pos = scan_ws(tokens, pos, 0);
             if pos < 0 { break sg_52; }
-            pos = scan_supports_condition_in_parens(tokens, pos);
+            pos = scan_supports_condition_in_parens(tokens, pos, 0);
             if pos < 0 { break sg_52; }
             break sg_52_done;
         }
@@ -32130,21 +32130,21 @@ fn scan_supports_conjunction(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_53_done: {
             sg_53: {
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_53; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_Space { break sg_53; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_53; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_And { break sg_53; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_53; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_Space { break sg_53; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_53; }
-                pos = scan_supports_condition_in_parens(tokens, pos);
+                pos = scan_supports_condition_in_parens(tokens, pos, 0);
                 if pos < 0 { break sg_53; }
                 break sg_53_done;
             }
@@ -32156,27 +32156,27 @@ fn scan_supports_conjunction(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_supports_disjunction(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_supports_disjunction(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_supports_condition_in_parens(tokens, pos);
+    pos = scan_supports_condition_in_parens(tokens, pos, 0);
     if pos < 0 { return -1; }
     sg_54_done: {
         sg_54: {
-            pos = scan_ws(tokens, pos);
+            pos = scan_ws(tokens, pos, 0);
             if pos < 0 { break sg_54; }
             if pos >= tokens.len() || tokens[pos].kind != TK_Space { break sg_54; }
             pos += 1;
-            pos = scan_ws(tokens, pos);
+            pos = scan_ws(tokens, pos, 0);
             if pos < 0 { break sg_54; }
             if pos >= tokens.len() || tokens[pos].kind != TK_Or { break sg_54; }
             pos += 1;
-            pos = scan_ws(tokens, pos);
+            pos = scan_ws(tokens, pos, 0);
             if pos < 0 { break sg_54; }
             if pos >= tokens.len() || tokens[pos].kind != TK_Space { break sg_54; }
             pos += 1;
-            pos = scan_ws(tokens, pos);
+            pos = scan_ws(tokens, pos, 0);
             if pos < 0 { break sg_54; }
-            pos = scan_supports_condition_in_parens(tokens, pos);
+            pos = scan_supports_condition_in_parens(tokens, pos, 0);
             if pos < 0 { break sg_54; }
             break sg_54_done;
         }
@@ -32186,21 +32186,21 @@ fn scan_supports_disjunction(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_55_done: {
             sg_55: {
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_55; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_Space { break sg_55; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_55; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_Or { break sg_55; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_55; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_Space { break sg_55; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_55; }
-                pos = scan_supports_condition_in_parens(tokens, pos);
+                pos = scan_supports_condition_in_parens(tokens, pos, 0);
                 if pos < 0 { break sg_55; }
                 break sg_55_done;
             }
@@ -32212,20 +32212,20 @@ fn scan_supports_disjunction(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_supports_declaration_condition(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_supports_declaration_condition(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_declaration(tokens, pos);
+    pos = scan_declaration(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_general_enclosed(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_general_enclosed(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     let gp_56 = pos;
     sg_56: {
@@ -32249,13 +32249,13 @@ fn scan_general_enclosed(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_57: {
             pos = gp_57;
             sg_57_0: {
-                pos = scan_any_(tokens, pos);
+                pos = scan_any_(tokens, pos, 0);
                 if pos < 0 { break sg_57_0; }
                 break sg_57;
             }
             pos = gp_57;
             sg_57_1: {
-                pos = scan_unused(tokens, pos);
+                pos = scan_unused(tokens, pos, 0);
                 if pos < 0 { break sg_57_1; }
                 break sg_57;
             }
@@ -32269,7 +32269,7 @@ fn scan_general_enclosed(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_url(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_url(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -32279,11 +32279,11 @@ fn scan_url(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_Url_ { break try_0; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_String_ { break try_0; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_0; }
                 pos += 1;
@@ -32305,41 +32305,41 @@ fn scan_url(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_var_(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_var_(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Var { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_Variable { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_calc(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_calc(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Calc { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_calc_sum(tokens, pos);
+    pos = scan_calc_sum(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_calc_sum(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_calc_sum(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_calc_product(tokens, pos);
+    pos = scan_calc_product(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_Space {
         let sp = pos;
@@ -32347,7 +32347,7 @@ fn scan_calc_sum(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_58: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_Space { break sg_58; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_58; }
                 let gp_59 = pos;
                 sg_59: {
@@ -32365,13 +32365,13 @@ fn scan_calc_sum(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     break sg_58;
                 }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_58; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_Space { break sg_58; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_58; }
-                pos = scan_calc_product(tokens, pos);
+                pos = scan_calc_product(tokens, pos, 0);
                 if pos < 0 { break sg_58; }
                 break sg_58_done;
             }
@@ -32383,9 +32383,9 @@ fn scan_calc_sum(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_calc_product(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_calc_product(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_calc_value(tokens, pos);
+    pos = scan_calc_value(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && _gale_kind_set_34(tokens[pos].kind) {
         let sp = pos;
@@ -32395,9 +32395,9 @@ fn scan_calc_product(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_60_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_STAR { break sg_60_0; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_60_0; }
-                pos = scan_calc_value(tokens, pos);
+                pos = scan_calc_value(tokens, pos, 0);
                 if pos < 0 { break sg_60_0; }
                 break sg_60;
             }
@@ -32405,11 +32405,11 @@ fn scan_calc_product(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_60_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SLASH { break sg_60_1; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_60_1; }
-                pos = scan_number(tokens, pos);
+                pos = scan_number(tokens, pos, 0);
                 if pos < 0 { break sg_60_1; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_60_1; }
                 break sg_60;
             }
@@ -32421,7 +32421,7 @@ fn scan_calc_product(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_calc_value(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_calc_value(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -32429,33 +32429,33 @@ fn scan_calc_value(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_26(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_number(tokens, pos);
+                pos = scan_number(tokens, pos, 0);
                 if pos < 0 { break try_0; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_1: {
-                pos = scan_dimension(tokens, pos);
+                pos = scan_dimension(tokens, pos, 0);
                 if pos < 0 { break try_1; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_2: {
-                pos = scan_unknown_dimension(tokens, pos);
+                pos = scan_unknown_dimension(tokens, pos, 0);
                 if pos < 0 { break try_2; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
             pos = start;
             try_3: {
-                pos = scan_percentage(tokens, pos);
+                pos = scan_percentage(tokens, pos, 0);
                 if pos < 0 { break try_3; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -32463,9 +32463,9 @@ fn scan_calc_value(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Number {
             pos = start;
             try_0: {
-                pos = scan_number(tokens, pos);
+                pos = scan_number(tokens, pos, 0);
                 if pos < 0 { break try_0; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -32473,9 +32473,9 @@ fn scan_calc_value(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Dimension {
             pos = start;
             try_1: {
-                pos = scan_dimension(tokens, pos);
+                pos = scan_dimension(tokens, pos, 0);
                 if pos < 0 { break try_1; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -32483,9 +32483,9 @@ fn scan_calc_value(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_UnknownDimension {
             pos = start;
             try_2: {
-                pos = scan_unknown_dimension(tokens, pos);
+                pos = scan_unknown_dimension(tokens, pos, 0);
                 if pos < 0 { break try_2; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -32493,9 +32493,9 @@ fn scan_calc_value(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Percentage {
             pos = start;
             try_3: {
-                pos = scan_percentage(tokens, pos);
+                pos = scan_percentage(tokens, pos, 0);
                 if pos < 0 { break try_3; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -32505,13 +32505,13 @@ fn scan_calc_value(tokens: &Array<Token>, pos: i32) -> i32 {
             try_4: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_4; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_4; }
-                pos = scan_calc_sum(tokens, pos);
+                pos = scan_calc_sum(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_4; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 break scan_alts;
             }
@@ -32523,19 +32523,19 @@ fn scan_calc_value(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_font_face_rule(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_font_face_rule(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_FontFace { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && _gale_kind_set_7(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_font_face_declaration(tokens, pos);
+        pos = scan_font_face_declaration(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_SEMI {
@@ -32544,11 +32544,11 @@ fn scan_font_face_rule(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_61: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { break sg_61; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_61; }
                 if pos < tokens.len() && _gale_kind_set_7(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_font_face_declaration(tokens, pos);
+                    pos = scan_font_face_declaration(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break sg_61_done;
@@ -32560,12 +32560,12 @@ fn scan_font_face_rule(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_font_face_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_font_face_declaration(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -32573,25 +32573,25 @@ fn scan_font_face_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_7(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_property_(tokens, pos);
+                pos = scan_property_(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { break try_0; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_0; }
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_1: {
-                pos = scan_property_(tokens, pos);
+                pos = scan_property_(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { break try_1; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break try_1; }
-                pos = scan_value(tokens, pos);
+                pos = scan_value(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -32603,55 +32603,55 @@ fn scan_font_face_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_keyframes_rule(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_keyframes_rule(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Keyframes { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_Space { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_ident(tokens, pos);
+    pos = scan_ident(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && _gale_kind_set_35(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_keyframe_block(tokens, pos);
+        pos = scan_keyframe_block(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_keyframe_block(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_keyframe_block(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     sg_62_done: {
         sg_62: {
-            pos = scan_keyframe_selector(tokens, pos);
+            pos = scan_keyframe_selector(tokens, pos, 0);
             if pos < 0 { break sg_62; }
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { break sg_62; }
             pos += 1;
-            pos = scan_ws(tokens, pos);
+            pos = scan_ws(tokens, pos, 0);
             if pos < 0 { break sg_62; }
             if pos < tokens.len() && _gale_kind_set_20(tokens[pos].kind) {
                 let sp = pos;
-                pos = scan_declaration_list(tokens, pos);
+                pos = scan_declaration_list(tokens, pos, 0);
                 if pos < 0 { pos = sp; }
             }
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { break sg_62; }
             pos += 1;
-            pos = scan_ws(tokens, pos);
+            pos = scan_ws(tokens, pos, 0);
             if pos < 0 { break sg_62; }
             break sg_62_done;
         }
@@ -32660,7 +32660,7 @@ fn scan_keyframe_block(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_keyframe_selector(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_keyframe_selector(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     let gp_63 = pos;
     sg_63: {
@@ -32684,7 +32684,7 @@ fn scan_keyframe_selector(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         return -1;
     }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_Comma {
         let sp = pos;
@@ -32692,7 +32692,7 @@ fn scan_keyframe_selector(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_64: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_Comma { break sg_64; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_64; }
                 let gp_65 = pos;
                 sg_65: {
@@ -32716,7 +32716,7 @@ fn scan_keyframe_selector(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     break sg_64;
                 }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_64; }
                 break sg_64_done;
             }
@@ -32728,96 +32728,96 @@ fn scan_keyframe_selector(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_viewport(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_viewport(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Viewport { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && _gale_kind_set_20(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_declaration_list(tokens, pos);
+        pos = scan_declaration_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_counter_style(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_counter_style(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_CounterStyle { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_ident(tokens, pos);
+    pos = scan_ident(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && _gale_kind_set_20(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_declaration_list(tokens, pos);
+        pos = scan_declaration_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_font_feature_values_rule(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_font_feature_values_rule(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_FontFeatureValues { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_font_family_name_list(tokens, pos);
+    pos = scan_font_family_name_list(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_AtKeyword {
         let sp = pos;
-        pos = scan_feature_value_block(tokens, pos);
+        pos = scan_feature_value_block(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_font_family_name_list(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_font_family_name_list(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_font_family_name(tokens, pos);
+    pos = scan_font_family_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && _gale_kind_set_33(tokens[pos].kind) {
         let sp = pos;
         sg_66_done: {
             sg_66: {
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_66; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_Comma { break sg_66; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_66; }
-                pos = scan_font_family_name(tokens, pos);
+                pos = scan_font_family_name(tokens, pos, 0);
                 if pos < 0 { break sg_66; }
                 break sg_66_done;
             }
@@ -32829,7 +32829,7 @@ fn scan_font_family_name_list(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_font_family_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_font_family_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -32845,15 +32845,15 @@ fn scan_font_family_name(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_3(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_ident(tokens, pos);
+                pos = scan_ident(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 while pos < tokens.len() && _gale_kind_set_33(tokens[pos].kind) {
                     let sp = pos;
                     sg_67_done: {
                         sg_67: {
-                            pos = scan_ws(tokens, pos);
+                            pos = scan_ws(tokens, pos, 0);
                             if pos < 0 { break sg_67; }
-                            pos = scan_ident(tokens, pos);
+                            pos = scan_ident(tokens, pos, 0);
                             if pos < 0 { break sg_67; }
                             break sg_67_done;
                         }
@@ -32872,34 +32872,34 @@ fn scan_font_family_name(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_feature_value_block(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_feature_value_block(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_feature_type(tokens, pos);
+    pos = scan_feature_type(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && _gale_kind_set_3(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_feature_value_definition(tokens, pos);
+        pos = scan_feature_value_definition(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     while pos < tokens.len() && _gale_kind_set_33(tokens[pos].kind) {
         let sp = pos;
         sg_68_done: {
             sg_68: {
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_68; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { break sg_68; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_68; }
                 if pos < tokens.len() && _gale_kind_set_3(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_feature_value_definition(tokens, pos);
+                    pos = scan_feature_value_definition(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break sg_68_done;
@@ -32911,37 +32911,37 @@ fn scan_feature_value_block(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_feature_type(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_feature_type(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_AtKeyword { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_feature_value_definition(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_feature_value_definition(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_ident(tokens, pos);
+    pos = scan_ident(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_number(tokens, pos);
+    pos = scan_number(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && _gale_kind_set_33(tokens[pos].kind) {
         let sp = pos;
         sg_69_done: {
             sg_69: {
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_69; }
-                pos = scan_number(tokens, pos);
+                pos = scan_number(tokens, pos, 0);
                 if pos < 0 { break sg_69; }
                 break sg_69_done;
             }
@@ -32953,14 +32953,14 @@ fn scan_feature_value_definition(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_ident(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_ident(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_3(tokens[pos].kind) {
         return pos + 1;
     }
     return -1;
 }
 
-fn scan_ws(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_ws(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && _gale_kind_set_33(tokens[pos].kind) {
         let sp = pos;
@@ -32995,7 +32995,7 @@ fn parse_stylesheet(p: &mut Parser) -> Result<StylesheetNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_charset(tokens, pos);
+            pos = scan_charset(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             while pos < tokens.len() && _gale_kind_set_0(tokens[pos].kind) {
                 let sp = pos;
@@ -33088,7 +33088,7 @@ fn parse_stylesheet(p: &mut Parser) -> Result<StylesheetNode, ParseError> {
         rep_scan_2: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_imports(tokens, pos);
+            pos = scan_imports(tokens, pos, 0);
             if pos < 0 { break rep_scan_2; }
             while pos < tokens.len() && _gale_kind_set_0(tokens[pos].kind) {
                 let sp = pos;
@@ -33181,7 +33181,7 @@ fn parse_stylesheet(p: &mut Parser) -> Result<StylesheetNode, ParseError> {
         rep_scan_3: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_namespace_(tokens, pos);
+            pos = scan_namespace_(tokens, pos, 0);
             if pos < 0 { break rep_scan_3; }
             while pos < tokens.len() && _gale_kind_set_0(tokens[pos].kind) {
                 let sp = pos;
@@ -33274,7 +33274,7 @@ fn parse_stylesheet(p: &mut Parser) -> Result<StylesheetNode, ParseError> {
         rep_scan_4: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_nested_statement(tokens, pos);
+            pos = scan_nested_statement(tokens, pos, 0);
             if pos < 0 { break rep_scan_4; }
             while pos < tokens.len() && _gale_kind_set_0(tokens[pos].kind) {
                 let sp = pos;
@@ -33396,15 +33396,15 @@ fn parse_charset_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Charset { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_String_ { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -33428,11 +33428,11 @@ fn parse_charset_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Charset { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_String_ { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -33508,7 +33508,7 @@ fn parse_imports_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Import { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     let gp_79 = pos;
     let sgk_79 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -33522,20 +33522,20 @@ fn parse_imports_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = gp_79;
             sg_79_1: {
-                pos = scan_url(tokens, pos);
+                pos = scan_url(tokens, pos, 0);
                 if pos < 0 { break sg_79_1; }
                 break sg_79;
             }
             pos = gp_79;
         }
     }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_media_query_list(tokens, pos);
+    pos = scan_media_query_list(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -33576,7 +33576,7 @@ fn parse_imports_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Import { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     let gp_80 = pos;
     let sgk_80 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -33590,18 +33590,18 @@ fn parse_imports_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = gp_80;
             sg_80_1: {
-                pos = scan_url(tokens, pos);
+                pos = scan_url(tokens, pos, 0);
                 if pos < 0 { break sg_80_1; }
                 break sg_80;
             }
             pos = gp_80;
         }
     }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -33640,7 +33640,7 @@ fn parse_imports_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Import { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     let gp_81 = pos;
     let sgk_81 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -33654,16 +33654,16 @@ fn parse_imports_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = gp_81;
             sg_81_1: {
-                pos = scan_url(tokens, pos);
+                pos = scan_url(tokens, pos, 0);
                 if pos < 0 { break sg_81_1; }
                 break sg_81;
             }
             pos = gp_81;
         }
     }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_media_query_list(tokens, pos);
+    pos = scan_media_query_list(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -33700,7 +33700,7 @@ fn parse_imports_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Import { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     let gp_82 = pos;
     let sgk_82 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -33714,14 +33714,14 @@ fn parse_imports_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = gp_82;
             sg_82_1: {
-                pos = scan_url(tokens, pos);
+                pos = scan_url(tokens, pos, 0);
                 if pos < 0 { break sg_82_1; }
                 break sg_82;
             }
             pos = gp_82;
         }
     }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -33783,9 +33783,9 @@ fn parse_namespace__bt_0(p: &mut Parser) -> Result<NamespaceNode, ParseError> {
     opt_scan: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_namespace_prefix(tokens, pos);
+        pos = scan_namespace_prefix(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
-        pos = scan_ws(tokens, pos);
+        pos = scan_ws(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         opt_scan_pos = pos;
     }
@@ -33833,15 +33833,15 @@ fn parse_namespace__scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Namespace { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && _gale_kind_set_3(tokens[pos].kind) {
         let sp = pos;
         sg_83_done: {
             sg_83: {
-                pos = scan_namespace_prefix(tokens, pos);
+                pos = scan_namespace_prefix(tokens, pos, 0);
                 if pos < 0 { break sg_83; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_83; }
                 break sg_83_done;
             }
@@ -33861,18 +33861,18 @@ fn parse_namespace__scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = gp_84;
             sg_84_1: {
-                pos = scan_url(tokens, pos);
+                pos = scan_url(tokens, pos, 0);
                 if pos < 0 { break sg_84_1; }
                 break sg_84;
             }
             pos = gp_84;
         }
     }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -33885,9 +33885,9 @@ fn parse_namespace__bt_1(p: &mut Parser) -> Result<NamespaceNode, ParseError> {
     opt_scan: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_namespace_prefix(tokens, pos);
+        pos = scan_namespace_prefix(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
-        pos = scan_ws(tokens, pos);
+        pos = scan_ws(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         opt_scan_pos = pos;
     }
@@ -33931,15 +33931,15 @@ fn parse_namespace__scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Namespace { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && _gale_kind_set_3(tokens[pos].kind) {
         let sp = pos;
         sg_85_done: {
             sg_85: {
-                pos = scan_namespace_prefix(tokens, pos);
+                pos = scan_namespace_prefix(tokens, pos, 0);
                 if pos < 0 { break sg_85; }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break sg_85; }
                 break sg_85_done;
             }
@@ -33959,14 +33959,14 @@ fn parse_namespace__scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = gp_86;
             sg_86_1: {
-                pos = scan_url(tokens, pos);
+                pos = scan_url(tokens, pos, 0);
                 if pos < 0 { break sg_86_1; }
                 break sg_86;
             }
             pos = gp_86;
         }
     }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -34036,7 +34036,7 @@ fn parse_media_query_list(p: &mut Parser) -> Result<MediaQueryListNode, ParseErr
     opt_scan: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_media_query(tokens, pos);
+        pos = scan_media_query(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         while pos < tokens.len() && tokens[pos].kind == TK_Comma {
             let sp = pos;
@@ -34044,9 +34044,9 @@ fn parse_media_query_list(p: &mut Parser) -> Result<MediaQueryListNode, ParseErr
                 sg_87: {
                     if pos >= tokens.len() || tokens[pos].kind != TK_Comma { break sg_87; }
                     pos += 1;
-                    pos = scan_ws(tokens, pos);
+                    pos = scan_ws(tokens, pos, 0);
                     if pos < 0 { break sg_87; }
-                    pos = scan_media_query(tokens, pos);
+                    pos = scan_media_query(tokens, pos, 0);
                     if pos < 0 { break sg_87; }
                     break sg_87_done;
                 }
@@ -34067,9 +34067,9 @@ fn parse_media_query_list(p: &mut Parser) -> Result<MediaQueryListNode, ParseErr
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_Comma { break rep_scan; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
-                pos = scan_media_query(tokens, pos);
+                pos = scan_media_query(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -34144,9 +34144,9 @@ fn parse_media_query(p: &mut Parser) -> Result<MediaQueryNode, ParseError> {
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_And { break rep_scan; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
-                pos = scan_media_expression(tokens, pos);
+                pos = scan_media_expression(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -34181,9 +34181,9 @@ fn parse_media_query(p: &mut Parser) -> Result<MediaQueryNode, ParseError> {
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_And { break rep_scan; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
-                pos = scan_media_expression(tokens, pos);
+                pos = scan_media_expression(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -34289,11 +34289,11 @@ fn parse_page(p: &mut Parser) -> Result<PageNode, ParseError> {
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { break rep_scan; }
             pos += 1;
-            pos = scan_ws(tokens, pos);
+            pos = scan_ws(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos < tokens.len() && _gale_kind_set_7(tokens[pos].kind) {
                 let sp = pos;
-                pos = scan_declaration(tokens, pos);
+                pos = scan_declaration(tokens, pos, 0);
                 if pos < 0 { pos = sp; }
             }
             if pos <= p.pos { break rep_scan; }
@@ -34355,9 +34355,9 @@ fn parse_selector_group(p: &mut Parser) -> Result<SelectorGroupNode, ParseError>
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_Comma { break rep_scan; }
             pos += 1;
-            pos = scan_ws(tokens, pos);
+            pos = scan_ws(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
-            pos = scan_selector(tokens, pos);
+            pos = scan_selector(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -34390,11 +34390,11 @@ fn parse_selector(p: &mut Parser) -> Result<SelectorNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_combinator(tokens, pos);
+            pos = scan_combinator(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
-            pos = scan_simple_selector_sequence(tokens, pos);
+            pos = scan_simple_selector_sequence(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
-            pos = scan_ws(tokens, pos);
+            pos = scan_ws(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -34476,7 +34476,7 @@ fn parse_simple_selector_sequence(p: &mut Parser) -> Result<SimpleSelectorSequen
                 gd_scan: {
                     let tokens = &p.tokens;
                     let mut pos: i32 = p.pos;
-                    pos = scan_type_selector(tokens, pos);
+                    pos = scan_type_selector(tokens, pos, 0);
                     if pos < 0 { break gd_scan; }
                     gd_winner = 0;
                     break gd_dispatch;
@@ -34507,25 +34507,25 @@ fn parse_simple_selector_sequence(p: &mut Parser) -> Result<SimpleSelectorSequen
                     }
                     pos = gp_89;
                     sg_89_1: {
-                        pos = scan_class_name(tokens, pos);
+                        pos = scan_class_name(tokens, pos, 0);
                         if pos < 0 { break sg_89_1; }
                         break sg_89;
                     }
                     pos = gp_89;
                     sg_89_2: {
-                        pos = scan_attrib(tokens, pos);
+                        pos = scan_attrib(tokens, pos, 0);
                         if pos < 0 { break sg_89_2; }
                         break sg_89;
                     }
                     pos = gp_89;
                     sg_89_3: {
-                        pos = scan_pseudo(tokens, pos);
+                        pos = scan_pseudo(tokens, pos, 0);
                         if pos < 0 { break sg_89_3; }
                         break sg_89;
                     }
                     pos = gp_89;
                     sg_89_4: {
-                        pos = scan_negation(tokens, pos);
+                        pos = scan_negation(tokens, pos, 0);
                         if pos < 0 { break sg_89_4; }
                         break sg_89;
                     }
@@ -34588,25 +34588,25 @@ fn parse_simple_selector_sequence(p: &mut Parser) -> Result<SimpleSelectorSequen
                         }
                         pos = gp_90;
                         sg_90_1: {
-                            pos = scan_class_name(tokens, pos);
+                            pos = scan_class_name(tokens, pos, 0);
                             if pos < 0 { break sg_90_1; }
                             break sg_90;
                         }
                         pos = gp_90;
                         sg_90_2: {
-                            pos = scan_attrib(tokens, pos);
+                            pos = scan_attrib(tokens, pos, 0);
                             if pos < 0 { break sg_90_2; }
                             break sg_90;
                         }
                         pos = gp_90;
                         sg_90_3: {
-                            pos = scan_pseudo(tokens, pos);
+                            pos = scan_pseudo(tokens, pos, 0);
                             if pos < 0 { break sg_90_3; }
                             break sg_90;
                         }
                         pos = gp_90;
                         sg_90_4: {
-                            pos = scan_negation(tokens, pos);
+                            pos = scan_negation(tokens, pos, 0);
                             if pos < 0 { break sg_90_4; }
                             break sg_90;
                         }
@@ -34684,7 +34684,7 @@ fn parse_type_namespace_prefix(p: &mut Parser) -> Result<TypeNamespacePrefixNode
         sg_91: {
             pos = gp_91;
             sg_91_0: {
-                pos = scan_ident(tokens, pos);
+                pos = scan_ident(tokens, pos, 0);
                 if pos < 0 { break sg_91_0; }
                 break sg_91;
             }
@@ -34814,7 +34814,7 @@ fn parse_attrib(p: &mut Parser) -> Result<AttribNode, ParseError> {
             }
             break opt_scan;
         }
-        pos = scan_ws(tokens, pos);
+        pos = scan_ws(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         let gp_93 = pos;
         let sgk_93 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -34822,7 +34822,7 @@ fn parse_attrib(p: &mut Parser) -> Result<AttribNode, ParseError> {
             sg_93: {
                 pos = gp_93;
                 sg_93_0: {
-                    pos = scan_ident(tokens, pos);
+                    pos = scan_ident(tokens, pos, 0);
                     if pos < 0 { break sg_93_0; }
                     break sg_93;
                 }
@@ -34835,7 +34835,7 @@ fn parse_attrib(p: &mut Parser) -> Result<AttribNode, ParseError> {
                 pos = gp_93;
             }
         }
-        pos = scan_ws(tokens, pos);
+        pos = scan_ws(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         opt_scan_pos = pos;
     }
@@ -34974,14 +34974,14 @@ fn parse_expression(p: &mut Parser) -> Result<ExpressionNode, ParseError> {
                         }
                         pos = gp_94;
                         sg_94_6: {
-                            pos = scan_ident(tokens, pos);
+                            pos = scan_ident(tokens, pos, 0);
                             if pos < 0 { break sg_94_6; }
                             break sg_94;
                         }
                         pos = gp_94;
                     }
                 }
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -35069,7 +35069,7 @@ fn parse_negation_arg_bt_0(p: &mut Parser) -> Result<NegationArgNode, ParseError
 
 fn parse_negation_arg_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_type_selector(tokens, pos);
+    pos = scan_type_selector(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -35085,7 +35085,7 @@ fn parse_negation_arg_bt_1(p: &mut Parser) -> Result<NegationArgNode, ParseError
 
 fn parse_negation_arg_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_universal(tokens, pos);
+    pos = scan_universal(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -35285,7 +35285,7 @@ fn parse_ruleset_bt_1(p: &mut Parser) -> Result<RulesetNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_any_(tokens, pos);
+            pos = scan_any_(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -35319,22 +35319,22 @@ fn parse_ruleset_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && _gale_kind_set_19(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_any_(tokens, pos);
+        pos = scan_any_(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && _gale_kind_set_20(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_declaration_list(tokens, pos);
+        pos = scan_declaration_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -35365,20 +35365,20 @@ fn parse_ruleset_bt_0(p: &mut Parser) -> Result<RulesetNode, ParseError> {
 
 fn parse_ruleset_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_selector_group(tokens, pos);
+    pos = scan_selector_group(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && _gale_kind_set_20(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_declaration_list(tokens, pos);
+        pos = scan_declaration_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -35432,7 +35432,7 @@ fn parse_declaration_list(p: &mut Parser) -> Result<DeclarationListNode, ParseEr
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { break rep_scan; }
             pos += 1;
-            pos = scan_ws(tokens, pos);
+            pos = scan_ws(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -35456,11 +35456,11 @@ fn parse_declaration_list(p: &mut Parser) -> Result<DeclarationListNode, ParseEr
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { break rep_scan_2; }
             pos += 1;
-            pos = scan_ws(tokens, pos);
+            pos = scan_ws(tokens, pos, 0);
             if pos < 0 { break rep_scan_2; }
             if pos < tokens.len() && _gale_kind_set_7(tokens[pos].kind) {
                 let sp = pos;
-                pos = scan_declaration(tokens, pos);
+                pos = scan_declaration(tokens, pos, 0);
                 if pos < 0 { pos = sp; }
             }
             if pos <= p.pos { break rep_scan_2; }
@@ -35515,17 +35515,17 @@ fn parse_declaration_bt_0(p: &mut Parser) -> Result<DeclarationNode, ParseError>
 
 fn parse_declaration_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_property_(tokens, pos);
+    pos = scan_property_(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_expr(tokens, pos);
+    pos = scan_expr(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_Important {
         let sp = pos;
-        pos = scan_prio(tokens, pos);
+        pos = scan_prio(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     return pos;
@@ -35548,13 +35548,13 @@ fn parse_declaration_bt_1(p: &mut Parser) -> Result<DeclarationNode, ParseError>
 
 fn parse_declaration_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_property_(tokens, pos);
+    pos = scan_property_(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_value(tokens, pos);
+    pos = scan_value(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -35619,13 +35619,13 @@ fn parse_value(p: &mut Parser) -> Result<ValueNode, ParseError> {
                 sg_95: {
                     pos = gp_95;
                     sg_95_0: {
-                        pos = scan_any_(tokens, pos);
+                        pos = scan_any_(tokens, pos, 0);
                         if pos < 0 { break sg_95_0; }
                         break sg_95;
                     }
                     pos = gp_95;
                     sg_95_1: {
-                        pos = scan_block(tokens, pos);
+                        pos = scan_block(tokens, pos, 0);
                         if pos < 0 { break sg_95_1; }
                         break sg_95;
                     }
@@ -35633,7 +35633,7 @@ fn parse_value(p: &mut Parser) -> Result<ValueNode, ParseError> {
                     sg_95_2: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_AtKeyword { break sg_95_2; }
                         pos += 1;
-                        pos = scan_ws(tokens, pos);
+                        pos = scan_ws(tokens, pos, 0);
                         if pos < 0 { break sg_95_2; }
                         break sg_95;
                     }
@@ -35682,10 +35682,10 @@ fn parse_expr(p: &mut Parser) -> Result<ExprNode, ParseError> {
             let mut pos: i32 = p.pos;
             if pos < tokens.len() && _gale_kind_set_25(tokens[pos].kind) {
                 let sp = pos;
-                pos = scan_operator_(tokens, pos);
+                pos = scan_operator_(tokens, pos, 0);
                 if pos < 0 { pos = sp; }
             }
-            pos = scan_term(tokens, pos);
+            pos = scan_term(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -35724,9 +35724,9 @@ fn parse_term_bt_0(p: &mut Parser) -> Result<TermNode, ParseError> {
 
 fn parse_term_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_number(tokens, pos);
+    pos = scan_number(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -35744,9 +35744,9 @@ fn parse_term_bt_1(p: &mut Parser) -> Result<TermNode, ParseError> {
 
 fn parse_term_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_percentage(tokens, pos);
+    pos = scan_percentage(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -35764,9 +35764,9 @@ fn parse_term_bt_2(p: &mut Parser) -> Result<TermNode, ParseError> {
 
 fn parse_term_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_dimension(tokens, pos);
+    pos = scan_dimension(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -35784,9 +35784,9 @@ fn parse_term_bt_11(p: &mut Parser) -> Result<TermNode, ParseError> {
 
 fn parse_term_scan_11(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_unknown_dimension(tokens, pos);
+    pos = scan_unknown_dimension(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -36113,9 +36113,9 @@ fn parse_any__bt_1(p: &mut Parser) -> Result<AnyNode, ParseError> {
 
 fn parse_any__scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_number(tokens, pos);
+    pos = scan_number(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -36133,9 +36133,9 @@ fn parse_any__bt_2(p: &mut Parser) -> Result<AnyNode, ParseError> {
 
 fn parse_any__scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_percentage(tokens, pos);
+    pos = scan_percentage(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -36153,9 +36153,9 @@ fn parse_any__bt_3(p: &mut Parser) -> Result<AnyNode, ParseError> {
 
 fn parse_any__scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_dimension(tokens, pos);
+    pos = scan_dimension(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -36173,9 +36173,9 @@ fn parse_any__bt_4(p: &mut Parser) -> Result<AnyNode, ParseError> {
 
 fn parse_any__scan_4(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_unknown_dimension(tokens, pos);
+    pos = scan_unknown_dimension(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -36299,13 +36299,13 @@ fn parse_any_(p: &mut Parser) -> Result<AnyNode, ParseError> {
                 sg_100: {
                     pos = gp_100;
                     sg_100_0: {
-                        pos = scan_any_(tokens, pos);
+                        pos = scan_any_(tokens, pos, 0);
                         if pos < 0 { break sg_100_0; }
                         break sg_100;
                     }
                     pos = gp_100;
                     sg_100_1: {
-                        pos = scan_unused(tokens, pos);
+                        pos = scan_unused(tokens, pos, 0);
                         if pos < 0 { break sg_100_1; }
                         break sg_100;
                     }
@@ -36348,13 +36348,13 @@ fn parse_any_(p: &mut Parser) -> Result<AnyNode, ParseError> {
                 sg_101: {
                     pos = gp_101;
                     sg_101_0: {
-                        pos = scan_any_(tokens, pos);
+                        pos = scan_any_(tokens, pos, 0);
                         if pos < 0 { break sg_101_0; }
                         break sg_101;
                     }
                     pos = gp_101;
                     sg_101_1: {
-                        pos = scan_unused(tokens, pos);
+                        pos = scan_unused(tokens, pos, 0);
                         if pos < 0 { break sg_101_1; }
                         break sg_101;
                     }
@@ -36397,13 +36397,13 @@ fn parse_any_(p: &mut Parser) -> Result<AnyNode, ParseError> {
                 sg_102: {
                     pos = gp_102;
                     sg_102_0: {
-                        pos = scan_any_(tokens, pos);
+                        pos = scan_any_(tokens, pos, 0);
                         if pos < 0 { break sg_102_0; }
                         break sg_102;
                     }
                     pos = gp_102;
                     sg_102_1: {
-                        pos = scan_unused(tokens, pos);
+                        pos = scan_unused(tokens, pos, 0);
                         if pos < 0 { break sg_102_1; }
                         break sg_102;
                     }
@@ -36450,7 +36450,7 @@ fn parse_at_rule(p: &mut Parser) -> Result<AtRuleNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_any_(tokens, pos);
+            pos = scan_any_(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -36552,25 +36552,25 @@ fn parse_block(p: &mut Parser) -> Result<BlockNode, ParseError> {
             sg_103: {
                 pos = gp_103;
                 sg_103_0: {
-                    pos = scan_declaration_list(tokens, pos);
+                    pos = scan_declaration_list(tokens, pos, 0);
                     if pos < 0 { break sg_103_0; }
                     if pos > sg_103_best { sg_103_best = pos; }
                 }
                 pos = gp_103;
                 sg_103_1: {
-                    pos = scan_nested_statement(tokens, pos);
+                    pos = scan_nested_statement(tokens, pos, 0);
                     if pos < 0 { break sg_103_1; }
                     if pos > sg_103_best { sg_103_best = pos; }
                 }
                 pos = gp_103;
                 sg_103_2: {
-                    pos = scan_any_(tokens, pos);
+                    pos = scan_any_(tokens, pos, 0);
                     if pos < 0 { break sg_103_2; }
                     if pos > sg_103_best { sg_103_best = pos; }
                 }
                 pos = gp_103;
                 sg_103_3: {
-                    pos = scan_block(tokens, pos);
+                    pos = scan_block(tokens, pos, 0);
                     if pos < 0 { break sg_103_3; }
                     if pos > sg_103_best { sg_103_best = pos; }
                 }
@@ -36578,7 +36578,7 @@ fn parse_block(p: &mut Parser) -> Result<BlockNode, ParseError> {
                 sg_103_4: {
                     if pos >= tokens.len() || tokens[pos].kind != TK_AtKeyword { break sg_103_4; }
                     pos += 1;
-                    pos = scan_ws(tokens, pos);
+                    pos = scan_ws(tokens, pos, 0);
                     if pos < 0 { break sg_103_4; }
                     if pos > sg_103_best { sg_103_best = pos; }
                 }
@@ -36586,7 +36586,7 @@ fn parse_block(p: &mut Parser) -> Result<BlockNode, ParseError> {
                 sg_103_5: {
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { break sg_103_5; }
                     pos += 1;
-                    pos = scan_ws(tokens, pos);
+                    pos = scan_ws(tokens, pos, 0);
                     if pos < 0 { break sg_103_5; }
                     if pos > sg_103_best { sg_103_best = pos; }
                 }
@@ -36607,7 +36607,7 @@ fn parse_block(p: &mut Parser) -> Result<BlockNode, ParseError> {
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_AtKeyword { break gd_scan; }
                     pos += 1;
-                    pos = scan_ws(tokens, pos);
+                    pos = scan_ws(tokens, pos, 0);
                     if pos < 0 { break gd_scan; }
                     gd_winner = 0;
                     break gd_dispatch;
@@ -36617,7 +36617,7 @@ fn parse_block(p: &mut Parser) -> Result<BlockNode, ParseError> {
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { break gd_scan_2; }
                     pos += 1;
-                    pos = scan_ws(tokens, pos);
+                    pos = scan_ws(tokens, pos, 0);
                     if pos < 0 { break gd_scan_2; }
                     gd_winner = 1;
                     break gd_dispatch;
@@ -36625,7 +36625,7 @@ fn parse_block(p: &mut Parser) -> Result<BlockNode, ParseError> {
                 gd_scan_3: {
                     let tokens = &p.tokens;
                     let mut pos: i32 = p.pos;
-                    pos = scan_any_(tokens, pos);
+                    pos = scan_any_(tokens, pos, 0);
                     if pos < 0 { break gd_scan_3; }
                     gd_winner = 2;
                     break gd_dispatch;
@@ -36633,7 +36633,7 @@ fn parse_block(p: &mut Parser) -> Result<BlockNode, ParseError> {
                 gd_scan_4: {
                     let tokens = &p.tokens;
                     let mut pos: i32 = p.pos;
-                    pos = scan_block(tokens, pos);
+                    pos = scan_block(tokens, pos, 0);
                     if pos < 0 { break gd_scan_4; }
                     gd_winner = 3;
                     break gd_dispatch;
@@ -36641,7 +36641,7 @@ fn parse_block(p: &mut Parser) -> Result<BlockNode, ParseError> {
                 gd_scan_5: {
                     let tokens = &p.tokens;
                     let mut pos: i32 = p.pos;
-                    pos = scan_declaration_list(tokens, pos);
+                    pos = scan_declaration_list(tokens, pos, 0);
                     if pos < 0 { break gd_scan_5; }
                     gd_winner = 4;
                     break gd_dispatch;
@@ -36791,7 +36791,7 @@ fn parse_group_rule_body(p: &mut Parser) -> Result<GroupRuleBodyNode, ParseError
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_nested_statement(tokens, pos);
+            pos = scan_nested_statement(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -36840,7 +36840,7 @@ fn parse_supports_condition_bt_1(p: &mut Parser) -> Result<SupportsConditionNode
 
 fn parse_supports_condition_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_supports_conjunction(tokens, pos);
+    pos = scan_supports_conjunction(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -36856,7 +36856,7 @@ fn parse_supports_condition_bt_2(p: &mut Parser) -> Result<SupportsConditionNode
 
 fn parse_supports_condition_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_supports_disjunction(tokens, pos);
+    pos = scan_supports_disjunction(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -36872,7 +36872,7 @@ fn parse_supports_condition_bt_3(p: &mut Parser) -> Result<SupportsConditionNode
 
 fn parse_supports_condition_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_supports_condition_in_parens(tokens, pos);
+    pos = scan_supports_condition_in_parens(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -36948,11 +36948,11 @@ fn parse_supports_condition_in_parens_scan_0(tokens: &Array<Token>, pos: i32) ->
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_supports_condition(tokens, pos);
+    pos = scan_supports_condition(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
@@ -36970,7 +36970,7 @@ fn parse_supports_condition_in_parens_bt_1(p: &mut Parser) -> Result<SupportsCon
 
 fn parse_supports_condition_in_parens_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_supports_declaration_condition(tokens, pos);
+    pos = scan_supports_declaration_condition(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -36986,7 +36986,7 @@ fn parse_supports_condition_in_parens_bt_2(p: &mut Parser) -> Result<SupportsCon
 
 fn parse_supports_condition_in_parens_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_general_enclosed(tokens, pos);
+    pos = scan_general_enclosed(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -37064,21 +37064,21 @@ fn parse_supports_conjunction(p: &mut Parser) -> Result<SupportsConjunctionNode,
             rep_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_Space { break rep_scan; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_And { break rep_scan; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_Space { break rep_scan; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
-                pos = scan_supports_condition_in_parens(tokens, pos);
+                pos = scan_supports_condition_in_parens(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -37124,21 +37124,21 @@ fn parse_supports_disjunction(p: &mut Parser) -> Result<SupportsDisjunctionNode,
             rep_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_Space { break rep_scan; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_Or { break rep_scan; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_Space { break rep_scan; }
                 pos += 1;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
-                pos = scan_supports_condition_in_parens(tokens, pos);
+                pos = scan_supports_condition_in_parens(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -37201,13 +37201,13 @@ fn parse_general_enclosed(p: &mut Parser) -> Result<GeneralEnclosedNode, ParseEr
             sg_104: {
                 pos = gp_104;
                 sg_104_0: {
-                    pos = scan_any_(tokens, pos);
+                    pos = scan_any_(tokens, pos, 0);
                     if pos < 0 { break sg_104_0; }
                     break sg_104;
                 }
                 pos = gp_104;
                 sg_104_1: {
-                    pos = scan_unused(tokens, pos);
+                    pos = scan_unused(tokens, pos, 0);
                     if pos < 0 { break sg_104_1; }
                     break sg_104;
                 }
@@ -37314,7 +37314,7 @@ fn parse_calc_sum(p: &mut Parser) -> Result<CalcSumNode, ParseError> {
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_Space { break rep_scan; }
             pos += 1;
-            pos = scan_ws(tokens, pos);
+            pos = scan_ws(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             let gp_105 = pos;
             sg_105: {
@@ -37332,13 +37332,13 @@ fn parse_calc_sum(p: &mut Parser) -> Result<CalcSumNode, ParseError> {
                 }
                 break rep_scan;
             }
-            pos = scan_ws(tokens, pos);
+            pos = scan_ws(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos >= tokens.len() || tokens[pos].kind != TK_Space { break rep_scan; }
             pos += 1;
-            pos = scan_ws(tokens, pos);
+            pos = scan_ws(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
-            pos = scan_calc_product(tokens, pos);
+            pos = scan_calc_product(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -37384,9 +37384,9 @@ fn parse_calc_product(p: &mut Parser) -> Result<CalcProductNode, ParseError> {
                 sg_106_0: {
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_STAR { break sg_106_0; }
                     pos += 1;
-                    pos = scan_ws(tokens, pos);
+                    pos = scan_ws(tokens, pos, 0);
                     if pos < 0 { break sg_106_0; }
-                    pos = scan_calc_value(tokens, pos);
+                    pos = scan_calc_value(tokens, pos, 0);
                     if pos < 0 { break sg_106_0; }
                     break sg_106;
                 }
@@ -37394,11 +37394,11 @@ fn parse_calc_product(p: &mut Parser) -> Result<CalcProductNode, ParseError> {
                 sg_106_1: {
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SLASH { break sg_106_1; }
                     pos += 1;
-                    pos = scan_ws(tokens, pos);
+                    pos = scan_ws(tokens, pos, 0);
                     if pos < 0 { break sg_106_1; }
-                    pos = scan_number(tokens, pos);
+                    pos = scan_number(tokens, pos, 0);
                     if pos < 0 { break sg_106_1; }
-                    pos = scan_ws(tokens, pos);
+                    pos = scan_ws(tokens, pos, 0);
                     if pos < 0 { break sg_106_1; }
                     break sg_106;
                 }
@@ -37451,9 +37451,9 @@ fn parse_calc_value_bt_0(p: &mut Parser) -> Result<CalcValueNode, ParseError> {
 
 fn parse_calc_value_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_number(tokens, pos);
+    pos = scan_number(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -37471,9 +37471,9 @@ fn parse_calc_value_bt_1(p: &mut Parser) -> Result<CalcValueNode, ParseError> {
 
 fn parse_calc_value_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_dimension(tokens, pos);
+    pos = scan_dimension(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -37491,9 +37491,9 @@ fn parse_calc_value_bt_2(p: &mut Parser) -> Result<CalcValueNode, ParseError> {
 
 fn parse_calc_value_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_unknown_dimension(tokens, pos);
+    pos = scan_unknown_dimension(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -37511,9 +37511,9 @@ fn parse_calc_value_bt_3(p: &mut Parser) -> Result<CalcValueNode, ParseError> {
 
 fn parse_calc_value_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_percentage(tokens, pos);
+    pos = scan_percentage(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -37594,11 +37594,11 @@ fn parse_font_face_rule(p: &mut Parser) -> Result<FontFaceRuleNode, ParseError> 
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { break rep_scan; }
             pos += 1;
-            pos = scan_ws(tokens, pos);
+            pos = scan_ws(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos < tokens.len() && _gale_kind_set_7(tokens[pos].kind) {
                 let sp = pos;
-                pos = scan_font_face_declaration(tokens, pos);
+                pos = scan_font_face_declaration(tokens, pos, 0);
                 if pos < 0 { pos = sp; }
             }
             if pos <= p.pos { break rep_scan; }
@@ -37652,13 +37652,13 @@ fn parse_font_face_declaration_bt_0(p: &mut Parser) -> Result<FontFaceDeclaratio
 
 fn parse_font_face_declaration_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_property_(tokens, pos);
+    pos = scan_property_(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_expr(tokens, pos);
+    pos = scan_expr(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -37680,13 +37680,13 @@ fn parse_font_face_declaration_bt_1(p: &mut Parser) -> Result<FontFaceDeclaratio
 
 fn parse_font_face_declaration_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_property_(tokens, pos);
+    pos = scan_property_(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { return -1; }
     pos += 1;
-    pos = scan_ws(tokens, pos);
+    pos = scan_ws(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_value(tokens, pos);
+    pos = scan_value(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -37742,7 +37742,7 @@ fn parse_keyframes_rule(p: &mut Parser) -> Result<KeyframesRuleNode, ParseError>
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_keyframe_block(tokens, pos);
+            pos = scan_keyframe_block(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -37808,7 +37808,7 @@ fn parse_keyframe_selector(p: &mut Parser) -> Result<KeyframeSelectorNode, Parse
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_Comma { break rep_scan; }
             pos += 1;
-            pos = scan_ws(tokens, pos);
+            pos = scan_ws(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             let gp_107 = pos;
             sg_107: {
@@ -37832,7 +37832,7 @@ fn parse_keyframe_selector(p: &mut Parser) -> Result<KeyframeSelectorNode, Parse
                 }
                 break rep_scan;
             }
-            pos = scan_ws(tokens, pos);
+            pos = scan_ws(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -37928,7 +37928,7 @@ fn parse_font_feature_values_rule(p: &mut Parser) -> Result<FontFeatureValuesRul
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_feature_value_block(tokens, pos);
+            pos = scan_feature_value_block(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -37962,13 +37962,13 @@ fn parse_font_family_name_list(p: &mut Parser) -> Result<FontFamilyNameListNode,
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_ws(tokens, pos);
+            pos = scan_ws(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos >= tokens.len() || tokens[pos].kind != TK_Comma { break rep_scan; }
             pos += 1;
-            pos = scan_ws(tokens, pos);
+            pos = scan_ws(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
-            pos = scan_font_family_name(tokens, pos);
+            pos = scan_font_family_name(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -38011,9 +38011,9 @@ fn parse_font_family_name(p: &mut Parser) -> Result<FontFamilyNameNode, ParseErr
             rep_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_ws(tokens, pos);
+                pos = scan_ws(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
-                pos = scan_ident(tokens, pos);
+                pos = scan_ident(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -38058,15 +38058,15 @@ fn parse_feature_value_block(p: &mut Parser) -> Result<FeatureValueBlockNode, Pa
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_ws(tokens, pos);
+            pos = scan_ws(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_SEMI { break rep_scan; }
             pos += 1;
-            pos = scan_ws(tokens, pos);
+            pos = scan_ws(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos < tokens.len() && _gale_kind_set_3(tokens[pos].kind) {
                 let sp = pos;
-                pos = scan_feature_value_definition(tokens, pos);
+                pos = scan_feature_value_definition(tokens, pos, 0);
                 if pos < 0 { pos = sp; }
             }
             if pos <= p.pos { break rep_scan; }
@@ -38127,9 +38127,9 @@ fn parse_feature_value_definition(p: &mut Parser) -> Result<FeatureValueDefiniti
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_ws(tokens, pos);
+            pos = scan_ws(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
-            pos = scan_number(tokens, pos);
+            pos = scan_number(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;

--- a/package-gale/tests/generated/css3/css3.wado
+++ b/package-gale/tests/generated/css3/css3.wado
@@ -35094,28 +35094,60 @@ fn parse_negation_arg(p: &mut Parser) -> Result<NegationArgNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if _gale_kind_set_9(kind) {
-        if _gale_kind_set_9(p.peek_kind()) {
-            let _sd_tokens = &p.tokens;
-            let _sd_pos = p.pos;
-            let _sd_p_0 = parse_negation_arg_scan_0(_sd_tokens, _sd_pos);
-            let _sd_p_1 = parse_negation_arg_scan_1(_sd_tokens, _sd_pos);
-            let mut _sd_best_i: i32 = -1;
-            let mut _sd_best_p: i32 = -1;
-            if _sd_p_0 > _sd_best_p {
-                _sd_best_p = _sd_p_0;
-                _sd_best_i = 0;
-            }
-            if _sd_p_1 > _sd_best_p {
-                _sd_best_p = _sd_p_1;
-                _sd_best_i = 1;
-            }
-            if _sd_best_i == 0 {
+        if p.peek_kind() == TK_Ident {
+            if _gale_kind_set_3(p.peek_at(1)) {
                 return parse_negation_arg_bt_0(p);
-            }
-            if _sd_best_i == 1 {
+            } else if p.peek_at(1) == TK_LIT_STAR {
                 return parse_negation_arg_bt_1(p);
             }
-            return parse_negation_arg_bt_1(p);
+        } else if p.peek_kind() == TK_MediaOnly {
+            if _gale_kind_set_3(p.peek_at(1)) {
+                return parse_negation_arg_bt_0(p);
+            } else if p.peek_at(1) == TK_LIT_STAR {
+                return parse_negation_arg_bt_1(p);
+            }
+        } else if p.peek_kind() == TK_Not {
+            if _gale_kind_set_3(p.peek_at(1)) {
+                return parse_negation_arg_bt_0(p);
+            } else if p.peek_at(1) == TK_LIT_STAR {
+                return parse_negation_arg_bt_1(p);
+            }
+        } else if p.peek_kind() == TK_And {
+            if _gale_kind_set_3(p.peek_at(1)) {
+                return parse_negation_arg_bt_0(p);
+            } else if p.peek_at(1) == TK_LIT_STAR {
+                return parse_negation_arg_bt_1(p);
+            }
+        } else if p.peek_kind() == TK_Or {
+            if _gale_kind_set_3(p.peek_at(1)) {
+                return parse_negation_arg_bt_0(p);
+            } else if p.peek_at(1) == TK_LIT_STAR {
+                return parse_negation_arg_bt_1(p);
+            }
+        } else if p.peek_kind() == TK_From {
+            if _gale_kind_set_3(p.peek_at(1)) {
+                return parse_negation_arg_bt_0(p);
+            } else if p.peek_at(1) == TK_LIT_STAR {
+                return parse_negation_arg_bt_1(p);
+            }
+        } else if p.peek_kind() == TK_To {
+            if _gale_kind_set_3(p.peek_at(1)) {
+                return parse_negation_arg_bt_0(p);
+            } else if p.peek_at(1) == TK_LIT_STAR {
+                return parse_negation_arg_bt_1(p);
+            }
+        } else if p.peek_kind() == TK_LIT_STAR {
+            if _gale_kind_set_3(p.peek_at(1)) {
+                return parse_negation_arg_bt_0(p);
+            } else if p.peek_at(1) == TK_LIT_STAR {
+                return parse_negation_arg_bt_1(p);
+            }
+        } else if p.peek_kind() == TK_LIT_PIPE {
+            if _gale_kind_set_3(p.peek_at(1)) {
+                return parse_negation_arg_bt_0(p);
+            } else if p.peek_at(1) == TK_LIT_STAR {
+                return parse_negation_arg_bt_1(p);
+            }
         }
     }
     if kind == TK_Hash {
@@ -35764,83 +35796,23 @@ fn parse_term(p: &mut Parser) -> Result<TermNode, ParseError> {
     let kind = p.peek_kind();
     if _gale_kind_set_36(kind) {
         if p.peek_kind() == TK_Plus {
-            if _gale_kind_set_33(p.peek_at(1)) {
-                let _sd_tokens = &p.tokens;
-                let _sd_pos = p.pos;
-                let _sd_p_0 = parse_term_scan_0(_sd_tokens, _sd_pos);
-                let _sd_p_1 = parse_term_scan_1(_sd_tokens, _sd_pos);
-                let _sd_p_2 = parse_term_scan_2(_sd_tokens, _sd_pos);
-                let _sd_p_11 = parse_term_scan_11(_sd_tokens, _sd_pos);
-                let mut _sd_best_i: i32 = -1;
-                let mut _sd_best_p: i32 = -1;
-                if _sd_p_0 > _sd_best_p {
-                    _sd_best_p = _sd_p_0;
-                    _sd_best_i = 0;
-                }
-                if _sd_p_1 > _sd_best_p {
-                    _sd_best_p = _sd_p_1;
-                    _sd_best_i = 1;
-                }
-                if _sd_p_2 > _sd_best_p {
-                    _sd_best_p = _sd_p_2;
-                    _sd_best_i = 2;
-                }
-                if _sd_p_11 > _sd_best_p {
-                    _sd_best_p = _sd_p_11;
-                    _sd_best_i = 11;
-                }
-                if _sd_best_i == 0 {
-                    return parse_term_bt_0(p);
-                }
-                if _sd_best_i == 1 {
-                    return parse_term_bt_1(p);
-                }
-                if _sd_best_i == 2 {
-                    return parse_term_bt_2(p);
-                }
-                if _sd_best_i == 11 {
-                    return parse_term_bt_11(p);
-                }
+            if p.peek_at(1) == TK_Number {
+                return parse_term_bt_0(p);
+            } else if p.peek_at(1) == TK_Percentage {
+                return parse_term_bt_1(p);
+            } else if p.peek_at(1) == TK_Dimension {
+                return parse_term_bt_2(p);
+            } else if p.peek_at(1) == TK_UnknownDimension {
                 return parse_term_bt_11(p);
             }
         } else if p.peek_kind() == TK_Minus {
-            if _gale_kind_set_33(p.peek_at(1)) {
-                let _sd_tokens = &p.tokens;
-                let _sd_pos = p.pos;
-                let _sd_p_0 = parse_term_scan_0(_sd_tokens, _sd_pos);
-                let _sd_p_1 = parse_term_scan_1(_sd_tokens, _sd_pos);
-                let _sd_p_2 = parse_term_scan_2(_sd_tokens, _sd_pos);
-                let _sd_p_11 = parse_term_scan_11(_sd_tokens, _sd_pos);
-                let mut _sd_best_i: i32 = -1;
-                let mut _sd_best_p: i32 = -1;
-                if _sd_p_0 > _sd_best_p {
-                    _sd_best_p = _sd_p_0;
-                    _sd_best_i = 0;
-                }
-                if _sd_p_1 > _sd_best_p {
-                    _sd_best_p = _sd_p_1;
-                    _sd_best_i = 1;
-                }
-                if _sd_p_2 > _sd_best_p {
-                    _sd_best_p = _sd_p_2;
-                    _sd_best_i = 2;
-                }
-                if _sd_p_11 > _sd_best_p {
-                    _sd_best_p = _sd_p_11;
-                    _sd_best_i = 11;
-                }
-                if _sd_best_i == 0 {
-                    return parse_term_bt_0(p);
-                }
-                if _sd_best_i == 1 {
-                    return parse_term_bt_1(p);
-                }
-                if _sd_best_i == 2 {
-                    return parse_term_bt_2(p);
-                }
-                if _sd_best_i == 11 {
-                    return parse_term_bt_11(p);
-                }
+            if p.peek_at(1) == TK_Number {
+                return parse_term_bt_0(p);
+            } else if p.peek_at(1) == TK_Percentage {
+                return parse_term_bt_1(p);
+            } else if p.peek_at(1) == TK_Dimension {
+                return parse_term_bt_2(p);
+            } else if p.peek_at(1) == TK_UnknownDimension {
                 return parse_term_bt_11(p);
             }
         } else if p.peek_kind() == TK_Number {
@@ -36222,83 +36194,23 @@ fn parse_any_(p: &mut Parser) -> Result<AnyNode, ParseError> {
     }
     if _gale_kind_set_36(kind) {
         if p.peek_kind() == TK_Plus {
-            if _gale_kind_set_33(p.peek_at(1)) {
-                let _sd_tokens = &p.tokens;
-                let _sd_pos = p.pos;
-                let _sd_p_1 = parse_any__scan_1(_sd_tokens, _sd_pos);
-                let _sd_p_2 = parse_any__scan_2(_sd_tokens, _sd_pos);
-                let _sd_p_3 = parse_any__scan_3(_sd_tokens, _sd_pos);
-                let _sd_p_4 = parse_any__scan_4(_sd_tokens, _sd_pos);
-                let mut _sd_best_i: i32 = -1;
-                let mut _sd_best_p: i32 = -1;
-                if _sd_p_1 > _sd_best_p {
-                    _sd_best_p = _sd_p_1;
-                    _sd_best_i = 1;
-                }
-                if _sd_p_2 > _sd_best_p {
-                    _sd_best_p = _sd_p_2;
-                    _sd_best_i = 2;
-                }
-                if _sd_p_3 > _sd_best_p {
-                    _sd_best_p = _sd_p_3;
-                    _sd_best_i = 3;
-                }
-                if _sd_p_4 > _sd_best_p {
-                    _sd_best_p = _sd_p_4;
-                    _sd_best_i = 4;
-                }
-                if _sd_best_i == 1 {
-                    return parse_any__bt_1(p);
-                }
-                if _sd_best_i == 2 {
-                    return parse_any__bt_2(p);
-                }
-                if _sd_best_i == 3 {
-                    return parse_any__bt_3(p);
-                }
-                if _sd_best_i == 4 {
-                    return parse_any__bt_4(p);
-                }
+            if p.peek_at(1) == TK_Number {
+                return parse_any__bt_1(p);
+            } else if p.peek_at(1) == TK_Percentage {
+                return parse_any__bt_2(p);
+            } else if p.peek_at(1) == TK_Dimension {
+                return parse_any__bt_3(p);
+            } else if p.peek_at(1) == TK_UnknownDimension {
                 return parse_any__bt_4(p);
             }
         } else if p.peek_kind() == TK_Minus {
-            if _gale_kind_set_33(p.peek_at(1)) {
-                let _sd_tokens = &p.tokens;
-                let _sd_pos = p.pos;
-                let _sd_p_1 = parse_any__scan_1(_sd_tokens, _sd_pos);
-                let _sd_p_2 = parse_any__scan_2(_sd_tokens, _sd_pos);
-                let _sd_p_3 = parse_any__scan_3(_sd_tokens, _sd_pos);
-                let _sd_p_4 = parse_any__scan_4(_sd_tokens, _sd_pos);
-                let mut _sd_best_i: i32 = -1;
-                let mut _sd_best_p: i32 = -1;
-                if _sd_p_1 > _sd_best_p {
-                    _sd_best_p = _sd_p_1;
-                    _sd_best_i = 1;
-                }
-                if _sd_p_2 > _sd_best_p {
-                    _sd_best_p = _sd_p_2;
-                    _sd_best_i = 2;
-                }
-                if _sd_p_3 > _sd_best_p {
-                    _sd_best_p = _sd_p_3;
-                    _sd_best_i = 3;
-                }
-                if _sd_p_4 > _sd_best_p {
-                    _sd_best_p = _sd_p_4;
-                    _sd_best_i = 4;
-                }
-                if _sd_best_i == 1 {
-                    return parse_any__bt_1(p);
-                }
-                if _sd_best_i == 2 {
-                    return parse_any__bt_2(p);
-                }
-                if _sd_best_i == 3 {
-                    return parse_any__bt_3(p);
-                }
-                if _sd_best_i == 4 {
-                    return parse_any__bt_4(p);
-                }
+            if p.peek_at(1) == TK_Number {
+                return parse_any__bt_1(p);
+            } else if p.peek_at(1) == TK_Percentage {
+                return parse_any__bt_2(p);
+            } else if p.peek_at(1) == TK_Dimension {
+                return parse_any__bt_3(p);
+            } else if p.peek_at(1) == TK_UnknownDimension {
                 return parse_any__bt_4(p);
             }
         } else if p.peek_kind() == TK_Number {
@@ -37611,83 +37523,23 @@ fn parse_calc_value(p: &mut Parser) -> Result<CalcValueNode, ParseError> {
     let kind = p.peek_kind();
     if _gale_kind_set_36(kind) {
         if p.peek_kind() == TK_Plus {
-            if _gale_kind_set_33(p.peek_at(1)) {
-                let _sd_tokens = &p.tokens;
-                let _sd_pos = p.pos;
-                let _sd_p_0 = parse_calc_value_scan_0(_sd_tokens, _sd_pos);
-                let _sd_p_1 = parse_calc_value_scan_1(_sd_tokens, _sd_pos);
-                let _sd_p_2 = parse_calc_value_scan_2(_sd_tokens, _sd_pos);
-                let _sd_p_3 = parse_calc_value_scan_3(_sd_tokens, _sd_pos);
-                let mut _sd_best_i: i32 = -1;
-                let mut _sd_best_p: i32 = -1;
-                if _sd_p_0 > _sd_best_p {
-                    _sd_best_p = _sd_p_0;
-                    _sd_best_i = 0;
-                }
-                if _sd_p_1 > _sd_best_p {
-                    _sd_best_p = _sd_p_1;
-                    _sd_best_i = 1;
-                }
-                if _sd_p_2 > _sd_best_p {
-                    _sd_best_p = _sd_p_2;
-                    _sd_best_i = 2;
-                }
-                if _sd_p_3 > _sd_best_p {
-                    _sd_best_p = _sd_p_3;
-                    _sd_best_i = 3;
-                }
-                if _sd_best_i == 0 {
-                    return parse_calc_value_bt_0(p);
-                }
-                if _sd_best_i == 1 {
-                    return parse_calc_value_bt_1(p);
-                }
-                if _sd_best_i == 2 {
-                    return parse_calc_value_bt_2(p);
-                }
-                if _sd_best_i == 3 {
-                    return parse_calc_value_bt_3(p);
-                }
+            if p.peek_at(1) == TK_Number {
+                return parse_calc_value_bt_0(p);
+            } else if p.peek_at(1) == TK_Dimension {
+                return parse_calc_value_bt_1(p);
+            } else if p.peek_at(1) == TK_UnknownDimension {
+                return parse_calc_value_bt_2(p);
+            } else if p.peek_at(1) == TK_Percentage {
                 return parse_calc_value_bt_3(p);
             }
         } else if p.peek_kind() == TK_Minus {
-            if _gale_kind_set_33(p.peek_at(1)) {
-                let _sd_tokens = &p.tokens;
-                let _sd_pos = p.pos;
-                let _sd_p_0 = parse_calc_value_scan_0(_sd_tokens, _sd_pos);
-                let _sd_p_1 = parse_calc_value_scan_1(_sd_tokens, _sd_pos);
-                let _sd_p_2 = parse_calc_value_scan_2(_sd_tokens, _sd_pos);
-                let _sd_p_3 = parse_calc_value_scan_3(_sd_tokens, _sd_pos);
-                let mut _sd_best_i: i32 = -1;
-                let mut _sd_best_p: i32 = -1;
-                if _sd_p_0 > _sd_best_p {
-                    _sd_best_p = _sd_p_0;
-                    _sd_best_i = 0;
-                }
-                if _sd_p_1 > _sd_best_p {
-                    _sd_best_p = _sd_p_1;
-                    _sd_best_i = 1;
-                }
-                if _sd_p_2 > _sd_best_p {
-                    _sd_best_p = _sd_p_2;
-                    _sd_best_i = 2;
-                }
-                if _sd_p_3 > _sd_best_p {
-                    _sd_best_p = _sd_p_3;
-                    _sd_best_i = 3;
-                }
-                if _sd_best_i == 0 {
-                    return parse_calc_value_bt_0(p);
-                }
-                if _sd_best_i == 1 {
-                    return parse_calc_value_bt_1(p);
-                }
-                if _sd_best_i == 2 {
-                    return parse_calc_value_bt_2(p);
-                }
-                if _sd_best_i == 3 {
-                    return parse_calc_value_bt_3(p);
-                }
+            if p.peek_at(1) == TK_Number {
+                return parse_calc_value_bt_0(p);
+            } else if p.peek_at(1) == TK_Dimension {
+                return parse_calc_value_bt_1(p);
+            } else if p.peek_at(1) == TK_UnknownDimension {
+                return parse_calc_value_bt_2(p);
+            } else if p.peek_at(1) == TK_Percentage {
                 return parse_calc_value_bt_3(p);
             }
         } else if p.peek_kind() == TK_Number {

--- a/package-gale/tests/generated/css3/css3Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/css3/css3Lexer.g4.kiln.json
@@ -17,7 +17,7 @@
   "outputs": [
     {
       "path": "tests/generated/css3/css3.wado",
-      "hash": "c0390176b6272bd6a62530a88bf6a04b200eeeb5e80eac31675d050e0ac04711",
+      "hash": "ab437ad0426e4d9e12d6548e1dcdea0f95007236aa2056eb76fce7c7fb393700",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/css3/css3Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/css3/css3Lexer.g4.kiln.json
@@ -17,7 +17,7 @@
   "outputs": [
     {
       "path": "tests/generated/css3/css3.wado",
-      "hash": "323449f7eb52fffb431c868fa58508d63bdddde1db10d584baafcb22293c3ff4",
+      "hash": "c0390176b6272bd6a62530a88bf6a04b200eeeb5e80eac31675d050e0ac04711",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/html/HTMLLexer.g4.kiln.json
+++ b/package-gale/tests/generated/html/HTMLLexer.g4.kiln.json
@@ -17,7 +17,7 @@
   "outputs": [
     {
       "path": "tests/generated/html/html.wado",
-      "hash": "5815a60d983fdce81fac0e1194e44fae7ad29aba6ffafa8311eee8cf6571c793",
+      "hash": "95096891c5ba3bdc1952ccf44a2aec4661a32964128f16a4c002d9b1a6af6437",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/html/html.wado
+++ b/package-gale/tests/generated/html/html.wado
@@ -2023,11 +2023,11 @@ impl Parser {
     }
 }
 
-fn scan_html_document(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_html_document(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && _gale_kind_set_0(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_scriptlet_or_sea_ws(tokens, pos);
+        pos = scan_scriptlet_or_sea_ws(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -2038,7 +2038,7 @@ fn scan_html_document(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     while pos < tokens.len() && _gale_kind_set_0(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_scriptlet_or_sea_ws(tokens, pos);
+        pos = scan_scriptlet_or_sea_ws(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -2049,46 +2049,46 @@ fn scan_html_document(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     while pos < tokens.len() && _gale_kind_set_0(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_scriptlet_or_sea_ws(tokens, pos);
+        pos = scan_scriptlet_or_sea_ws(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
     while pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_html_elements(tokens, pos);
+        pos = scan_html_elements(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
     return pos;
 }
 
-fn scan_scriptlet_or_sea_ws(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_scriptlet_or_sea_ws(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_0(tokens[pos].kind) {
         return pos + 1;
     }
     return -1;
 }
 
-fn scan_html_elements(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_html_elements(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_html_misc(tokens, pos);
+        pos = scan_html_misc(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
-    pos = scan_html_element(tokens, pos);
+    pos = scan_html_element(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_html_misc(tokens, pos);
+        pos = scan_html_misc(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
     return pos;
 }
 
-fn scan_html_element(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_html_element(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -2102,7 +2102,7 @@ fn scan_html_element(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 while pos < tokens.len() && tokens[pos].kind == TK_TAG_NAME {
                     let sp = pos;
-                    pos = scan_html_attribute(tokens, pos);
+                    pos = scan_html_attribute(tokens, pos, 0);
                     if pos < 0 { pos = sp; break; }
                     if pos == sp { break; }
                 }
@@ -2118,7 +2118,7 @@ fn scan_html_element(tokens: &Array<Token>, pos: i32) -> i32 {
                                 let sp = pos;
                                 sg_1_done: {
                                     sg_1: {
-                                        pos = scan_html_content(tokens, pos);
+                                        pos = scan_html_content(tokens, pos, 0);
                                         if pos < 0 { break sg_1; }
                                         if pos >= tokens.len() || tokens[pos].kind != TK_TAG_OPEN { break sg_1; }
                                         pos += 1;
@@ -2159,7 +2159,7 @@ fn scan_html_element(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_SCRIPT_OPEN {
             pos = start;
             try_2: {
-                pos = scan_script(tokens, pos);
+                pos = scan_script(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -2167,7 +2167,7 @@ fn scan_html_element(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_STYLE_OPEN {
             pos = start;
             try_3: {
-                pos = scan_style(tokens, pos);
+                pos = scan_style(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -2179,11 +2179,11 @@ fn scan_html_element(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_html_content(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_html_content(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && _gale_kind_set_5(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_html_chardata(tokens, pos);
+        pos = scan_html_chardata(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     while pos < tokens.len() && _gale_kind_set_6(tokens[pos].kind) {
@@ -2196,7 +2196,7 @@ fn scan_html_content(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_3: {
                         pos = gp_3;
                         sg_3_0: {
-                            pos = scan_html_element(tokens, pos);
+                            pos = scan_html_element(tokens, pos, 0);
                             if pos < 0 { break sg_3_0; }
                             break sg_3;
                         }
@@ -2208,7 +2208,7 @@ fn scan_html_content(tokens: &Array<Token>, pos: i32) -> i32 {
                         }
                         pos = gp_3;
                         sg_3_2: {
-                            pos = scan_html_comment(tokens, pos);
+                            pos = scan_html_comment(tokens, pos, 0);
                             if pos < 0 { break sg_3_2; }
                             break sg_3;
                         }
@@ -2217,7 +2217,7 @@ fn scan_html_content(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos < tokens.len() && _gale_kind_set_5(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_html_chardata(tokens, pos);
+                    pos = scan_html_chardata(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break sg_2_done;
@@ -2230,7 +2230,7 @@ fn scan_html_content(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_html_attribute(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_html_attribute(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_TAG_NAME { return -1; }
     pos += 1;
@@ -2251,14 +2251,14 @@ fn scan_html_attribute(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_html_chardata(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_html_chardata(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_5(tokens[pos].kind) {
         return pos + 1;
     }
     return -1;
 }
 
-fn scan_html_misc(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_html_misc(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -2266,7 +2266,7 @@ fn scan_html_misc(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_7(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_html_comment(tokens, pos);
+                pos = scan_html_comment(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -2286,14 +2286,14 @@ fn scan_html_misc(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_html_comment(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_html_comment(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_7(tokens[pos].kind) {
         return pos + 1;
     }
     return -1;
 }
 
-fn scan_script(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_script(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_SCRIPT_OPEN { return -1; }
     pos += 1;
@@ -2316,7 +2316,7 @@ fn scan_script(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_style(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_style(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_STYLE_OPEN { return -1; }
     pos += 1;
@@ -2347,7 +2347,7 @@ fn parse_html_document(p: &mut Parser) -> Result<HtmlDocumentNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_scriptlet_or_sea_ws(tokens, pos);
+            pos = scan_scriptlet_or_sea_ws(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -2368,7 +2368,7 @@ fn parse_html_document(p: &mut Parser) -> Result<HtmlDocumentNode, ParseError> {
         rep_scan_2: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_scriptlet_or_sea_ws(tokens, pos);
+            pos = scan_scriptlet_or_sea_ws(tokens, pos, 0);
             if pos < 0 { break rep_scan_2; }
             if pos <= p.pos { break rep_scan_2; }
             rep_scan_pos_2 = pos;
@@ -2389,7 +2389,7 @@ fn parse_html_document(p: &mut Parser) -> Result<HtmlDocumentNode, ParseError> {
         rep_scan_3: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_scriptlet_or_sea_ws(tokens, pos);
+            pos = scan_scriptlet_or_sea_ws(tokens, pos, 0);
             if pos < 0 { break rep_scan_3; }
             if pos <= p.pos { break rep_scan_3; }
             rep_scan_pos_3 = pos;
@@ -2404,7 +2404,7 @@ fn parse_html_document(p: &mut Parser) -> Result<HtmlDocumentNode, ParseError> {
         rep_scan_4: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_html_elements(tokens, pos);
+            pos = scan_html_elements(tokens, pos, 0);
             if pos < 0 { break rep_scan_4; }
             if pos <= p.pos { break rep_scan_4; }
             rep_scan_pos_4 = pos;
@@ -2456,7 +2456,7 @@ fn parse_html_elements(p: &mut Parser) -> Result<HtmlElementsNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_html_misc(tokens, pos);
+            pos = scan_html_misc(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -2472,7 +2472,7 @@ fn parse_html_elements(p: &mut Parser) -> Result<HtmlElementsNode, ParseError> {
         rep_scan_2: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_html_misc(tokens, pos);
+            pos = scan_html_misc(tokens, pos, 0);
             if pos < 0 { break rep_scan_2; }
             if pos <= p.pos { break rep_scan_2; }
             rep_scan_pos_2 = pos;
@@ -2501,7 +2501,7 @@ fn parse_html_element(p: &mut Parser) -> Result<HtmlElementNode, ParseError> {
             rep_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_html_attribute(tokens, pos);
+                pos = scan_html_attribute(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -2518,7 +2518,7 @@ fn parse_html_element(p: &mut Parser) -> Result<HtmlElementNode, ParseError> {
             opt_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_html_content(tokens, pos);
+                pos = scan_html_content(tokens, pos, 0);
                 if pos < 0 { break opt_scan; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_TAG_OPEN { break opt_scan; }
                 pos += 1;
@@ -2614,7 +2614,7 @@ fn parse_html_content(p: &mut Parser) -> Result<HtmlContentNode, ParseError> {
                 sg_7: {
                     pos = gp_7;
                     sg_7_0: {
-                        pos = scan_html_element(tokens, pos);
+                        pos = scan_html_element(tokens, pos, 0);
                         if pos < 0 { break sg_7_0; }
                         break sg_7;
                     }
@@ -2626,7 +2626,7 @@ fn parse_html_content(p: &mut Parser) -> Result<HtmlContentNode, ParseError> {
                     }
                     pos = gp_7;
                     sg_7_2: {
-                        pos = scan_html_comment(tokens, pos);
+                        pos = scan_html_comment(tokens, pos, 0);
                         if pos < 0 { break sg_7_2; }
                         break sg_7;
                     }
@@ -2635,7 +2635,7 @@ fn parse_html_content(p: &mut Parser) -> Result<HtmlContentNode, ParseError> {
             }
             if pos < tokens.len() && _gale_kind_set_5(tokens[pos].kind) {
                 let sp = pos;
-                pos = scan_html_chardata(tokens, pos);
+                pos = scan_html_chardata(tokens, pos, 0);
                 if pos < 0 { pos = sp; }
             }
             if pos <= p.pos { break rep_scan; }

--- a/package-gale/tests/generated/json/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/json/JSON.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/json/json.wado",
-      "hash": "4e03c9415ba90edadb182e853d0661a4c7e2b259c56518d941e13db10dfeda66",
+      "hash": "230df672b58d67d69c7b0f841d19f4a7520f81f115be61ca341d2f73bc01e68b",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/json/json.wado
+++ b/package-gale/tests/generated/json/json.wado
@@ -1058,16 +1058,16 @@ impl Parser {
     }
 }
 
-fn scan_json(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_json(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_value(tokens, pos);
+    pos = scan_value(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_obj(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_obj(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -1077,7 +1077,7 @@ fn scan_obj(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { break try_0; }
                 pos += 1;
-                pos = scan_pair(tokens, pos);
+                pos = scan_pair(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -1085,7 +1085,7 @@ fn scan_obj(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_0: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_0; }
                             pos += 1;
-                            pos = scan_pair(tokens, pos);
+                            pos = scan_pair(tokens, pos, 0);
                             if pos < 0 { break sg_0; }
                             break sg_0_done;
                         }
@@ -1114,18 +1114,18 @@ fn scan_obj(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_pair(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_pair(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_STRING { return -1; }
     pos += 1;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { return -1; }
     pos += 1;
-    pos = scan_value(tokens, pos);
+    pos = scan_value(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_arr(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_arr(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -1135,7 +1135,7 @@ fn scan_arr(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break try_0; }
                 pos += 1;
-                pos = scan_value(tokens, pos);
+                pos = scan_value(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -1143,7 +1143,7 @@ fn scan_arr(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_1: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_1; }
                             pos += 1;
-                            pos = scan_value(tokens, pos);
+                            pos = scan_value(tokens, pos, 0);
                             if pos < 0 { break sg_1; }
                             break sg_1_done;
                         }
@@ -1172,7 +1172,7 @@ fn scan_arr(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_value(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_value(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -1196,7 +1196,7 @@ fn scan_value(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_LBRACE {
             pos = start;
             try_2: {
-                pos = scan_obj(tokens, pos);
+                pos = scan_obj(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -1204,7 +1204,7 @@ fn scan_value(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_LBRACKET {
             pos = start;
             try_3: {
-                pos = scan_arr(tokens, pos);
+                pos = scan_arr(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -1263,7 +1263,7 @@ fn parse_obj_bt_0(p: &mut Parser) -> Result<ObjNode, ParseError> {
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_pair(tokens, pos);
+            pos = scan_pair(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -1291,7 +1291,7 @@ fn parse_obj_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
     pos += 1;
-    pos = scan_pair(tokens, pos);
+    pos = scan_pair(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -1299,7 +1299,7 @@ fn parse_obj_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_2: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_2; }
                 pos += 1;
-                pos = scan_pair(tokens, pos);
+                pos = scan_pair(tokens, pos, 0);
                 if pos < 0 { break sg_2; }
                 break sg_2_done;
             }
@@ -1348,7 +1348,7 @@ fn parse_obj(p: &mut Parser) -> Result<ObjNode, ParseError> {
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                     pos += 1;
-                    pos = scan_pair(tokens, pos);
+                    pos = scan_pair(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -1411,7 +1411,7 @@ fn parse_arr_bt_0(p: &mut Parser) -> Result<ArrNode, ParseError> {
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_value(tokens, pos);
+            pos = scan_value(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -1439,7 +1439,7 @@ fn parse_arr_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { return -1; }
     pos += 1;
-    pos = scan_value(tokens, pos);
+    pos = scan_value(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -1447,7 +1447,7 @@ fn parse_arr_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_3: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_3; }
                 pos += 1;
-                pos = scan_value(tokens, pos);
+                pos = scan_value(tokens, pos, 0);
                 if pos < 0 { break sg_3; }
                 break sg_3_done;
             }
@@ -1496,7 +1496,7 @@ fn parse_arr(p: &mut Parser) -> Result<ArrNode, ParseError> {
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                     pos += 1;
-                    pos = scan_value(tokens, pos);
+                    pos = scan_value(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;

--- a/package-gale/tests/generated/json_highlight/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/json_highlight/JSON.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/json_highlight/json.wado",
-      "hash": "60dee7a012c1f869410be1f224186fb1d8bcd7c360c3f0358c0fe91ffc1e1955",
+      "hash": "ebf3b985394dd53653a067dd50a72e35fee64f7b357741b650a5344881a99583",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/json_highlight/json.wado
+++ b/package-gale/tests/generated/json_highlight/json.wado
@@ -1058,16 +1058,16 @@ impl Parser {
     }
 }
 
-fn scan_json(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_json(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_value(tokens, pos);
+    pos = scan_value(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_obj(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_obj(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -1077,7 +1077,7 @@ fn scan_obj(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { break try_0; }
                 pos += 1;
-                pos = scan_pair(tokens, pos);
+                pos = scan_pair(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -1085,7 +1085,7 @@ fn scan_obj(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_0: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_0; }
                             pos += 1;
-                            pos = scan_pair(tokens, pos);
+                            pos = scan_pair(tokens, pos, 0);
                             if pos < 0 { break sg_0; }
                             break sg_0_done;
                         }
@@ -1114,18 +1114,18 @@ fn scan_obj(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_pair(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_pair(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_STRING { return -1; }
     pos += 1;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { return -1; }
     pos += 1;
-    pos = scan_value(tokens, pos);
+    pos = scan_value(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_arr(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_arr(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -1135,7 +1135,7 @@ fn scan_arr(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break try_0; }
                 pos += 1;
-                pos = scan_value(tokens, pos);
+                pos = scan_value(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -1143,7 +1143,7 @@ fn scan_arr(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_1: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_1; }
                             pos += 1;
-                            pos = scan_value(tokens, pos);
+                            pos = scan_value(tokens, pos, 0);
                             if pos < 0 { break sg_1; }
                             break sg_1_done;
                         }
@@ -1172,7 +1172,7 @@ fn scan_arr(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_value(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_value(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -1196,7 +1196,7 @@ fn scan_value(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_LBRACE {
             pos = start;
             try_2: {
-                pos = scan_obj(tokens, pos);
+                pos = scan_obj(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -1204,7 +1204,7 @@ fn scan_value(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_LBRACKET {
             pos = start;
             try_3: {
-                pos = scan_arr(tokens, pos);
+                pos = scan_arr(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -1263,7 +1263,7 @@ fn parse_obj_bt_0(p: &mut Parser) -> Result<ObjNode, ParseError> {
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_pair(tokens, pos);
+            pos = scan_pair(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -1291,7 +1291,7 @@ fn parse_obj_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
     pos += 1;
-    pos = scan_pair(tokens, pos);
+    pos = scan_pair(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -1299,7 +1299,7 @@ fn parse_obj_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_2: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_2; }
                 pos += 1;
-                pos = scan_pair(tokens, pos);
+                pos = scan_pair(tokens, pos, 0);
                 if pos < 0 { break sg_2; }
                 break sg_2_done;
             }
@@ -1348,7 +1348,7 @@ fn parse_obj(p: &mut Parser) -> Result<ObjNode, ParseError> {
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                     pos += 1;
-                    pos = scan_pair(tokens, pos);
+                    pos = scan_pair(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -1411,7 +1411,7 @@ fn parse_arr_bt_0(p: &mut Parser) -> Result<ArrNode, ParseError> {
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_value(tokens, pos);
+            pos = scan_value(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -1439,7 +1439,7 @@ fn parse_arr_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { return -1; }
     pos += 1;
-    pos = scan_value(tokens, pos);
+    pos = scan_value(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -1447,7 +1447,7 @@ fn parse_arr_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_3: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_3; }
                 pos += 1;
-                pos = scan_value(tokens, pos);
+                pos = scan_value(tokens, pos, 0);
                 if pos < 0 { break sg_3; }
                 break sg_3_done;
             }
@@ -1496,7 +1496,7 @@ fn parse_arr(p: &mut Parser) -> Result<ArrNode, ParseError> {
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                     pos += 1;
-                    pos = scan_value(tokens, pos);
+                    pos = scan_value(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;

--- a/package-gale/tests/generated/label_gaps/label_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/label_gaps/label_gaps.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/label_gaps/label_gaps.wado",
-      "hash": "32b27042da2dbd1be281d41775ec8cd35ebf94390d0fe0d31f7863287a337845",
+      "hash": "002989fb88384830147c25dc904362998523f0fef5f28038049b979550aab303",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/label_gaps/label_gaps.wado
+++ b/package-gale/tests/generated/label_gaps/label_gaps.wado
@@ -887,11 +887,11 @@ impl Parser {
     }
 }
 
-fn scan_program(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_program(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && _gale_kind_set_0(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_stmt(tokens, pos);
+        pos = scan_stmt(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -900,7 +900,7 @@ fn scan_program(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -908,7 +908,7 @@ fn scan_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         if alt_kind == TK_ID {
             pos = start;
             try_0: {
-                pos = scan_assign_stmt(tokens, pos);
+                pos = scan_assign_stmt(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -916,7 +916,7 @@ fn scan_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_PAIR {
             pos = start;
             try_1: {
-                pos = scan_pair_stmt(tokens, pos);
+                pos = scan_pair_stmt(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -924,7 +924,7 @@ fn scan_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIST {
             pos = start;
             try_2: {
-                pos = scan_mix_stmt(tokens, pos);
+                pos = scan_mix_stmt(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -936,7 +936,7 @@ fn scan_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_assign_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_assign_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_ID { return -1; }
     pos += 1;
@@ -949,11 +949,11 @@ fn scan_assign_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_pair_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_pair_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_PAIR { return -1; }
     pos += 1;
-    pos = scan_key_rule(tokens, pos);
+    pos = scan_key_rule(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_COLON { return -1; }
     pos += 1;
@@ -964,14 +964,14 @@ fn scan_pair_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_key_rule(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_key_rule(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_ID { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_mix_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_mix_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIST { return -1; }
     pos += 1;
@@ -1005,7 +1005,7 @@ fn parse_program(p: &mut Parser) -> Result<ProgramNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_stmt(tokens, pos);
+            pos = scan_stmt(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;

--- a/package-gale/tests/generated/lexer_command_gaps/lexer_command_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/lexer_command_gaps/lexer_command_gaps.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/lexer_command_gaps/lexer_command_gaps.wado",
-      "hash": "5584ac71813b60c6e2ab6b2b17fdcd0ea033b215a52391b8575faec1b411e822",
+      "hash": "376c123a7e30b8fd2aba5e201faa040e0b182c03d02ef60f7a1ccaffafc75f5f",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/lexer_command_gaps/lexer_command_gaps.wado
+++ b/package-gale/tests/generated/lexer_command_gaps/lexer_command_gaps.wado
@@ -862,7 +862,7 @@ impl Parser {
     }
 }
 
-fn scan_text(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_text(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && _gale_kind_set_0(tokens[pos].kind) {
         let sp = pos;

--- a/package-gale/tests/generated/mode_gaps/mode_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/mode_gaps/mode_gaps.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/mode_gaps/mode_gaps.wado",
-      "hash": "1318c4b4e4da897e4ff341c19f3b1edc39bb5f3cef2c317e0d3b8a35dd466f88",
+      "hash": "eceb46185f06b04991a676876ca3f5f20f8b76d86302422ccb940cf327d278f3",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/mode_gaps/mode_gaps.wado
+++ b/package-gale/tests/generated/mode_gaps/mode_gaps.wado
@@ -776,7 +776,7 @@ impl Parser {
     }
 }
 
-fn scan_text(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_text(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && _gale_kind_set_0(tokens[pos].kind) {
         let sp = pos;

--- a/package-gale/tests/generated/non_greedy_gaps/non_greedy_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/non_greedy_gaps/non_greedy_gaps.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/non_greedy_gaps/non_greedy_gaps.wado",
-      "hash": "ad949727a8cdb82600b7f6b6220c845d3fcd07c620d1db6c9776920dea9a8fed",
+      "hash": "5cfc98926f9138e76e71aa57bbd6b9aa4146c55b45a964bdb9ebc23b99d387cc",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/non_greedy_gaps/non_greedy_gaps.wado
+++ b/package-gale/tests/generated/non_greedy_gaps/non_greedy_gaps.wado
@@ -831,7 +831,7 @@ impl Parser {
     }
 }
 
-fn scan_file(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_file(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && true {
         let sp = pos;
@@ -841,7 +841,7 @@ fn scan_file(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     sg_0_done: {
         sg_0: {
-            pos = scan_constant(tokens, pos);
+            pos = scan_constant(tokens, pos, 0);
             if pos < 0 { break sg_0; }
             while pos < tokens.len() && true {
                 let sp = pos;
@@ -857,7 +857,7 @@ fn scan_file(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_1_done: {
             sg_1: {
-                pos = scan_constant(tokens, pos);
+                pos = scan_constant(tokens, pos, 0);
                 if pos < 0 { break sg_1; }
                 while pos < tokens.len() && true {
                     let sp = pos;
@@ -877,7 +877,7 @@ fn scan_file(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_constant(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_constant(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_PUBLIC { return -1; }
     pos += 1;
@@ -907,7 +907,7 @@ fn parse_file(p: &mut Parser) -> Result<FileNode, ParseError> {
             rep_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_constant(tokens, pos);
+                pos = scan_constant(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 while pos < tokens.len() && true {
                     let sp = pos;

--- a/package-gale/tests/generated/parser_gaps/parser_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/parser_gaps/parser_gaps.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/parser_gaps/parser_gaps.wado",
-      "hash": "fb26c43cceb5be38f6b6f959fac80ebb0e6e872b714c91cdb42553228b7dc72b",
+      "hash": "4fd0d9a3a16d688c8e75bf1e48f079bb1f75f716062d575dd198860425aaaee7",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/parser_gaps/parser_gaps.wado
+++ b/package-gale/tests/generated/parser_gaps/parser_gaps.wado
@@ -882,11 +882,11 @@ impl Parser {
     }
 }
 
-fn scan_program(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_program(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && _gale_kind_set_0(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_stmt(tokens, pos);
+        pos = scan_stmt(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -895,7 +895,7 @@ fn scan_program(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -903,7 +903,7 @@ fn scan_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         if alt_kind == TK_LIST {
             pos = start;
             try_0: {
-                pos = scan_list_stmt(tokens, pos);
+                pos = scan_list_stmt(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -911,7 +911,7 @@ fn scan_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_1(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_not_stmt(tokens, pos);
+                pos = scan_not_stmt(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -919,7 +919,7 @@ fn scan_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_ANY {
             pos = start;
             try_2: {
-                pos = scan_any_stmt(tokens, pos);
+                pos = scan_any_stmt(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -931,7 +931,7 @@ fn scan_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_list_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_list_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIST { return -1; }
     pos += 1;
@@ -957,7 +957,7 @@ fn scan_list_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_not_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_not_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -993,7 +993,7 @@ fn scan_not_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_any_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_any_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_ANY { return -1; }
     pos += 1;
@@ -1012,7 +1012,7 @@ fn parse_program(p: &mut Parser) -> Result<ProgramNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_stmt(tokens, pos);
+            pos = scan_stmt(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;

--- a/package-gale/tests/generated/recursive_lexer/recursive_lexer.g4.kiln.json
+++ b/package-gale/tests/generated/recursive_lexer/recursive_lexer.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/recursive_lexer/recursive_lexer.wado",
-      "hash": "8b56e8dcb105452b6196137e8a29ea4e82169045649ada8ca283e87b075e462c",
+      "hash": "d1091b7a64f8f65f2d8ee0723d1f72bf32440ac0cf8491a8eabb979673aee0ab",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/recursive_lexer/recursive_lexer.wado
+++ b/package-gale/tests/generated/recursive_lexer/recursive_lexer.wado
@@ -742,7 +742,7 @@ impl Parser {
     }
 }
 
-fn scan_file(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_file(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     let gp_0 = pos;
     sg_0: {

--- a/package-gale/tests/generated/rust/RustLexer.g4.kiln.json
+++ b/package-gale/tests/generated/rust/RustLexer.g4.kiln.json
@@ -17,7 +17,7 @@
   "outputs": [
     {
       "path": "tests/generated/rust/rust.wado",
-      "hash": "15a3bec1a14c9334acfa8828c495e82dc46416567e0a1d497f80be706c4d1202",
+      "hash": "0979eed585ff5d07ca9c17f82abf957cd5d7f5f781d14b274e61e4fc06aedc6a",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/rust/RustLexer.g4.kiln.json
+++ b/package-gale/tests/generated/rust/RustLexer.g4.kiln.json
@@ -17,7 +17,7 @@
   "outputs": [
     {
       "path": "tests/generated/rust/rust.wado",
-      "hash": "d168f96888257a9147f1df9d07fe58e7a98e64e2fbac9440a6dc935727521dc8",
+      "hash": "15a3bec1a14c9334acfa8828c495e82dc46416567e0a1d497f80be706c4d1202",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/rust/RustLexer.g4.kiln.json
+++ b/package-gale/tests/generated/rust/RustLexer.g4.kiln.json
@@ -17,7 +17,7 @@
   "outputs": [
     {
       "path": "tests/generated/rust/rust.wado",
-      "hash": "033fb1c18fd3dbeb7c7d56f6308732153384332a4361ce109745a7fb2bca602e",
+      "hash": "d168f96888257a9147f1df9d07fe58e7a98e64e2fbac9440a6dc935727521dc8",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/rust/rust.wado
+++ b/package-gale/tests/generated/rust/rust.wado
@@ -16919,70 +16919,36 @@ fn parse_macro_invocation_semi(p: &mut Parser) -> Result<MacroInvocationSemiNode
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if _gale_kind_set_9(kind) {
-        if p.peek_kind() == TK_PATHSEP {
-            if p.peek_at(1) == TK_LPAREN {
+        if _gale_kind_set_9(p.peek_kind()) {
+            let _sd_tokens = &p.tokens;
+            let _sd_pos = p.pos;
+            let _sd_p_0 = parse_macro_invocation_semi_scan_0(_sd_tokens, _sd_pos);
+            let _sd_p_1 = parse_macro_invocation_semi_scan_1(_sd_tokens, _sd_pos);
+            let _sd_p_2 = parse_macro_invocation_semi_scan_2(_sd_tokens, _sd_pos);
+            let mut _sd_best_i: i32 = -1;
+            let mut _sd_best_p: i32 = -1;
+            if _sd_p_0 > _sd_best_p {
+                _sd_best_p = _sd_p_0;
+                _sd_best_i = 0;
+            }
+            if _sd_p_1 > _sd_best_p {
+                _sd_best_p = _sd_p_1;
+                _sd_best_i = 1;
+            }
+            if _sd_p_2 > _sd_best_p {
+                _sd_best_p = _sd_p_2;
+                _sd_best_i = 2;
+            }
+            if _sd_best_i == 0 {
                 return parse_macro_invocation_semi_bt_0(p);
-            } else if p.peek_at(1) == TK_LSQUAREBRACKET {
+            }
+            if _sd_best_i == 1 {
                 return parse_macro_invocation_semi_bt_1(p);
-            } else if p.peek_at(1) == TK_LCURLYBRACE {
+            }
+            if _sd_best_i == 2 {
                 return parse_macro_invocation_semi_bt_2(p);
             }
-        } else if p.peek_kind() == TK_NON_KEYWORD_IDENTIFIER {
-            if p.peek_at(1) == TK_LPAREN {
-                return parse_macro_invocation_semi_bt_0(p);
-            } else if p.peek_at(1) == TK_LSQUAREBRACKET {
-                return parse_macro_invocation_semi_bt_1(p);
-            } else if p.peek_at(1) == TK_LCURLYBRACE {
-                return parse_macro_invocation_semi_bt_2(p);
-            }
-        } else if p.peek_kind() == TK_RAW_IDENTIFIER {
-            if p.peek_at(1) == TK_LPAREN {
-                return parse_macro_invocation_semi_bt_0(p);
-            } else if p.peek_at(1) == TK_LSQUAREBRACKET {
-                return parse_macro_invocation_semi_bt_1(p);
-            } else if p.peek_at(1) == TK_LCURLYBRACE {
-                return parse_macro_invocation_semi_bt_2(p);
-            }
-        } else if p.peek_kind() == TK_KW_MACRORULES {
-            if p.peek_at(1) == TK_LPAREN {
-                return parse_macro_invocation_semi_bt_0(p);
-            } else if p.peek_at(1) == TK_LSQUAREBRACKET {
-                return parse_macro_invocation_semi_bt_1(p);
-            } else if p.peek_at(1) == TK_LCURLYBRACE {
-                return parse_macro_invocation_semi_bt_2(p);
-            }
-        } else if p.peek_kind() == TK_KW_SUPER {
-            if p.peek_at(1) == TK_LPAREN {
-                return parse_macro_invocation_semi_bt_0(p);
-            } else if p.peek_at(1) == TK_LSQUAREBRACKET {
-                return parse_macro_invocation_semi_bt_1(p);
-            } else if p.peek_at(1) == TK_LCURLYBRACE {
-                return parse_macro_invocation_semi_bt_2(p);
-            }
-        } else if p.peek_kind() == TK_KW_SELFVALUE {
-            if p.peek_at(1) == TK_LPAREN {
-                return parse_macro_invocation_semi_bt_0(p);
-            } else if p.peek_at(1) == TK_LSQUAREBRACKET {
-                return parse_macro_invocation_semi_bt_1(p);
-            } else if p.peek_at(1) == TK_LCURLYBRACE {
-                return parse_macro_invocation_semi_bt_2(p);
-            }
-        } else if p.peek_kind() == TK_KW_CRATE {
-            if p.peek_at(1) == TK_LPAREN {
-                return parse_macro_invocation_semi_bt_0(p);
-            } else if p.peek_at(1) == TK_LSQUAREBRACKET {
-                return parse_macro_invocation_semi_bt_1(p);
-            } else if p.peek_at(1) == TK_LCURLYBRACE {
-                return parse_macro_invocation_semi_bt_2(p);
-            }
-        } else if p.peek_kind() == TK_KW_DOLLARCRATE {
-            if p.peek_at(1) == TK_LPAREN {
-                return parse_macro_invocation_semi_bt_0(p);
-            } else if p.peek_at(1) == TK_LSQUAREBRACKET {
-                return parse_macro_invocation_semi_bt_1(p);
-            } else if p.peek_at(1) == TK_LCURLYBRACE {
-                return parse_macro_invocation_semi_bt_2(p);
-            }
+            return parse_macro_invocation_semi_bt_2(p);
         }
     }
     return Result::<MacroInvocationSemiNode, ParseError>::Err(ParseError::new(
@@ -18264,54 +18230,28 @@ fn parse_use_tree(p: &mut Parser) -> Result<UseTreeNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if _gale_kind_set_20(kind) {
-        if p.peek_kind() == TK_PATHSEP {
-            if p.peek_at(1) == TK_KW_AS {
-                return parse_use_tree_bt_1(p);
-            } else if _gale_kind_set_19(p.peek_at(1)) {
+        if _gale_kind_set_9(p.peek_kind()) {
+            let _sd_tokens = &p.tokens;
+            let _sd_pos = p.pos;
+            let _sd_p_0 = parse_use_tree_scan_0(_sd_tokens, _sd_pos);
+            let _sd_p_1 = parse_use_tree_scan_1(_sd_tokens, _sd_pos);
+            let mut _sd_best_i: i32 = -1;
+            let mut _sd_best_p: i32 = -1;
+            if _sd_p_0 > _sd_best_p {
+                _sd_best_p = _sd_p_0;
+                _sd_best_i = 0;
+            }
+            if _sd_p_1 > _sd_best_p {
+                _sd_best_p = _sd_p_1;
+                _sd_best_i = 1;
+            }
+            if _sd_best_i == 0 {
                 return parse_use_tree_bt_0(p);
             }
-        } else if p.peek_kind() == TK_NON_KEYWORD_IDENTIFIER {
-            if p.peek_at(1) == TK_KW_AS {
+            if _sd_best_i == 1 {
                 return parse_use_tree_bt_1(p);
-            } else if _gale_kind_set_19(p.peek_at(1)) {
-                return parse_use_tree_bt_0(p);
             }
-        } else if p.peek_kind() == TK_RAW_IDENTIFIER {
-            if p.peek_at(1) == TK_KW_AS {
-                return parse_use_tree_bt_1(p);
-            } else if _gale_kind_set_19(p.peek_at(1)) {
-                return parse_use_tree_bt_0(p);
-            }
-        } else if p.peek_kind() == TK_KW_MACRORULES {
-            if p.peek_at(1) == TK_KW_AS {
-                return parse_use_tree_bt_1(p);
-            } else if _gale_kind_set_19(p.peek_at(1)) {
-                return parse_use_tree_bt_0(p);
-            }
-        } else if p.peek_kind() == TK_KW_SUPER {
-            if p.peek_at(1) == TK_KW_AS {
-                return parse_use_tree_bt_1(p);
-            } else if _gale_kind_set_19(p.peek_at(1)) {
-                return parse_use_tree_bt_0(p);
-            }
-        } else if p.peek_kind() == TK_KW_SELFVALUE {
-            if p.peek_at(1) == TK_KW_AS {
-                return parse_use_tree_bt_1(p);
-            } else if _gale_kind_set_19(p.peek_at(1)) {
-                return parse_use_tree_bt_0(p);
-            }
-        } else if p.peek_kind() == TK_KW_CRATE {
-            if p.peek_at(1) == TK_KW_AS {
-                return parse_use_tree_bt_1(p);
-            } else if _gale_kind_set_19(p.peek_at(1)) {
-                return parse_use_tree_bt_0(p);
-            }
-        } else if p.peek_kind() == TK_KW_DOLLARCRATE {
-            if p.peek_at(1) == TK_KW_AS {
-                return parse_use_tree_bt_1(p);
-            } else if _gale_kind_set_19(p.peek_at(1)) {
-                return parse_use_tree_bt_0(p);
-            }
+            return parse_use_tree_bt_1(p);
         } else if _gale_kind_set_19(p.peek_kind()) {
             return parse_use_tree_bt_0(p);
         }
@@ -20766,7 +20706,7 @@ fn parse_expression_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
-    pos = scan_expression(tokens, pos);
+    pos = scan_expression_atom(tokens, pos);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -22418,60 +22358,36 @@ fn parse_struct_expression(p: &mut Parser) -> Result<StructExpressionNode, Parse
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if _gale_kind_set_61(kind) {
-        if p.peek_kind() == TK_PATHSEP {
-            if p.peek_at(1) == TK_LCURLYBRACE {
+        if _gale_kind_set_61(p.peek_kind()) {
+            let _sd_tokens = &p.tokens;
+            let _sd_pos = p.pos;
+            let _sd_p_0 = parse_struct_expression_scan_0(_sd_tokens, _sd_pos);
+            let _sd_p_1 = parse_struct_expression_scan_1(_sd_tokens, _sd_pos);
+            let _sd_p_2 = parse_struct_expression_scan_2(_sd_tokens, _sd_pos);
+            let mut _sd_best_i: i32 = -1;
+            let mut _sd_best_p: i32 = -1;
+            if _sd_p_0 > _sd_best_p {
+                _sd_best_p = _sd_p_0;
+                _sd_best_i = 0;
+            }
+            if _sd_p_1 > _sd_best_p {
+                _sd_best_p = _sd_p_1;
+                _sd_best_i = 1;
+            }
+            if _sd_p_2 > _sd_best_p {
+                _sd_best_p = _sd_p_2;
+                _sd_best_i = 2;
+            }
+            if _sd_best_i == 0 {
                 return parse_struct_expression_bt_0(p);
-            } else if p.peek_at(1) == TK_LPAREN {
+            }
+            if _sd_best_i == 1 {
                 return parse_struct_expression_bt_1(p);
             }
-        } else if p.peek_kind() == TK_NON_KEYWORD_IDENTIFIER {
-            if p.peek_at(1) == TK_LCURLYBRACE {
-                return parse_struct_expression_bt_0(p);
-            } else if p.peek_at(1) == TK_LPAREN {
-                return parse_struct_expression_bt_1(p);
+            if _sd_best_i == 2 {
+                return parse_struct_expression_bt_2(p);
             }
-        } else if p.peek_kind() == TK_RAW_IDENTIFIER {
-            if p.peek_at(1) == TK_LCURLYBRACE {
-                return parse_struct_expression_bt_0(p);
-            } else if p.peek_at(1) == TK_LPAREN {
-                return parse_struct_expression_bt_1(p);
-            }
-        } else if p.peek_kind() == TK_KW_MACRORULES {
-            if p.peek_at(1) == TK_LCURLYBRACE {
-                return parse_struct_expression_bt_0(p);
-            } else if p.peek_at(1) == TK_LPAREN {
-                return parse_struct_expression_bt_1(p);
-            }
-        } else if p.peek_kind() == TK_KW_SUPER {
-            if p.peek_at(1) == TK_LCURLYBRACE {
-                return parse_struct_expression_bt_0(p);
-            } else if p.peek_at(1) == TK_LPAREN {
-                return parse_struct_expression_bt_1(p);
-            }
-        } else if p.peek_kind() == TK_KW_SELFVALUE {
-            if p.peek_at(1) == TK_LCURLYBRACE {
-                return parse_struct_expression_bt_0(p);
-            } else if p.peek_at(1) == TK_LPAREN {
-                return parse_struct_expression_bt_1(p);
-            }
-        } else if p.peek_kind() == TK_KW_SELFTYPE {
-            if p.peek_at(1) == TK_LCURLYBRACE {
-                return parse_struct_expression_bt_0(p);
-            } else if p.peek_at(1) == TK_LPAREN {
-                return parse_struct_expression_bt_1(p);
-            }
-        } else if p.peek_kind() == TK_KW_CRATE {
-            if p.peek_at(1) == TK_LCURLYBRACE {
-                return parse_struct_expression_bt_0(p);
-            } else if p.peek_at(1) == TK_LPAREN {
-                return parse_struct_expression_bt_1(p);
-            }
-        } else if p.peek_kind() == TK_KW_DOLLARCRATE {
-            if p.peek_at(1) == TK_LCURLYBRACE {
-                return parse_struct_expression_bt_0(p);
-            } else if p.peek_at(1) == TK_LPAREN {
-                return parse_struct_expression_bt_1(p);
-            }
+            return parse_struct_expression_bt_2(p);
         }
     }
     return Result::<StructExpressionNode, ParseError>::Err(ParseError::new(
@@ -22875,60 +22791,36 @@ fn parse_enumeration_variant_expression(p: &mut Parser) -> Result<EnumerationVar
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if _gale_kind_set_61(kind) {
-        if p.peek_kind() == TK_PATHSEP {
-            if p.peek_at(1) == TK_LCURLYBRACE {
+        if _gale_kind_set_61(p.peek_kind()) {
+            let _sd_tokens = &p.tokens;
+            let _sd_pos = p.pos;
+            let _sd_p_0 = parse_enumeration_variant_expression_scan_0(_sd_tokens, _sd_pos);
+            let _sd_p_1 = parse_enumeration_variant_expression_scan_1(_sd_tokens, _sd_pos);
+            let _sd_p_2 = parse_enumeration_variant_expression_scan_2(_sd_tokens, _sd_pos);
+            let mut _sd_best_i: i32 = -1;
+            let mut _sd_best_p: i32 = -1;
+            if _sd_p_0 > _sd_best_p {
+                _sd_best_p = _sd_p_0;
+                _sd_best_i = 0;
+            }
+            if _sd_p_1 > _sd_best_p {
+                _sd_best_p = _sd_p_1;
+                _sd_best_i = 1;
+            }
+            if _sd_p_2 > _sd_best_p {
+                _sd_best_p = _sd_p_2;
+                _sd_best_i = 2;
+            }
+            if _sd_best_i == 0 {
                 return parse_enumeration_variant_expression_bt_0(p);
-            } else if p.peek_at(1) == TK_LPAREN {
+            }
+            if _sd_best_i == 1 {
                 return parse_enumeration_variant_expression_bt_1(p);
             }
-        } else if p.peek_kind() == TK_NON_KEYWORD_IDENTIFIER {
-            if p.peek_at(1) == TK_LCURLYBRACE {
-                return parse_enumeration_variant_expression_bt_0(p);
-            } else if p.peek_at(1) == TK_LPAREN {
-                return parse_enumeration_variant_expression_bt_1(p);
+            if _sd_best_i == 2 {
+                return parse_enumeration_variant_expression_bt_2(p);
             }
-        } else if p.peek_kind() == TK_RAW_IDENTIFIER {
-            if p.peek_at(1) == TK_LCURLYBRACE {
-                return parse_enumeration_variant_expression_bt_0(p);
-            } else if p.peek_at(1) == TK_LPAREN {
-                return parse_enumeration_variant_expression_bt_1(p);
-            }
-        } else if p.peek_kind() == TK_KW_MACRORULES {
-            if p.peek_at(1) == TK_LCURLYBRACE {
-                return parse_enumeration_variant_expression_bt_0(p);
-            } else if p.peek_at(1) == TK_LPAREN {
-                return parse_enumeration_variant_expression_bt_1(p);
-            }
-        } else if p.peek_kind() == TK_KW_SUPER {
-            if p.peek_at(1) == TK_LCURLYBRACE {
-                return parse_enumeration_variant_expression_bt_0(p);
-            } else if p.peek_at(1) == TK_LPAREN {
-                return parse_enumeration_variant_expression_bt_1(p);
-            }
-        } else if p.peek_kind() == TK_KW_SELFVALUE {
-            if p.peek_at(1) == TK_LCURLYBRACE {
-                return parse_enumeration_variant_expression_bt_0(p);
-            } else if p.peek_at(1) == TK_LPAREN {
-                return parse_enumeration_variant_expression_bt_1(p);
-            }
-        } else if p.peek_kind() == TK_KW_SELFTYPE {
-            if p.peek_at(1) == TK_LCURLYBRACE {
-                return parse_enumeration_variant_expression_bt_0(p);
-            } else if p.peek_at(1) == TK_LPAREN {
-                return parse_enumeration_variant_expression_bt_1(p);
-            }
-        } else if p.peek_kind() == TK_KW_CRATE {
-            if p.peek_at(1) == TK_LCURLYBRACE {
-                return parse_enumeration_variant_expression_bt_0(p);
-            } else if p.peek_at(1) == TK_LPAREN {
-                return parse_enumeration_variant_expression_bt_1(p);
-            }
-        } else if p.peek_kind() == TK_KW_DOLLARCRATE {
-            if p.peek_at(1) == TK_LCURLYBRACE {
-                return parse_enumeration_variant_expression_bt_0(p);
-            } else if p.peek_at(1) == TK_LPAREN {
-                return parse_enumeration_variant_expression_bt_1(p);
-            }
+            return parse_enumeration_variant_expression_bt_2(p);
         }
     }
     return Result::<EnumerationVariantExpressionNode, ParseError>::Err(ParseError::new(

--- a/package-gale/tests/generated/rust/rust.wado
+++ b/package-gale/tests/generated/rust/rust.wado
@@ -8992,17 +8992,17 @@ impl Parser {
     }
 }
 
-fn scan_crate(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_crate(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && tokens[pos].kind == TK_POUND {
         let sp = pos;
-        pos = scan_inner_attribute(tokens, pos);
+        pos = scan_inner_attribute(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
     while pos < tokens.len() && _gale_kind_set_0(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_item(tokens, pos);
+        pos = scan_item(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -9011,18 +9011,18 @@ fn scan_crate(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_macro_invocation(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_macro_invocation(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_simple_path(tokens, pos);
+    pos = scan_simple_path(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_NOT { return -1; }
     pos += 1;
-    pos = scan_delim_token_tree(tokens, pos);
+    pos = scan_delim_token_tree(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_delim_token_tree(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_delim_token_tree(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -9034,7 +9034,7 @@ fn scan_delim_token_tree(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 while pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_token_tree(tokens, pos);
+                    pos = scan_token_tree(tokens, pos, 0);
                     if pos < 0 { pos = sp; break; }
                     if pos == sp { break; }
                 }
@@ -9050,7 +9050,7 @@ fn scan_delim_token_tree(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 while pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_token_tree(tokens, pos);
+                    pos = scan_token_tree(tokens, pos, 0);
                     if pos < 0 { pos = sp; break; }
                     if pos == sp { break; }
                 }
@@ -9066,7 +9066,7 @@ fn scan_delim_token_tree(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 while pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_token_tree(tokens, pos);
+                    pos = scan_token_tree(tokens, pos, 0);
                     if pos < 0 { pos = sp; break; }
                     if pos == sp { break; }
                 }
@@ -9082,7 +9082,7 @@ fn scan_delim_token_tree(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_token_tree(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_token_tree(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -9090,11 +9090,11 @@ fn scan_token_tree(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_2(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_token_tree_token(tokens, pos);
+                pos = scan_token_tree_token(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 while pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_token_tree_token(tokens, pos);
+                    pos = scan_token_tree_token(tokens, pos, 0);
                     if pos < 0 { pos = sp; break; }
                     if pos == sp { break; }
                 }
@@ -9104,7 +9104,7 @@ fn scan_token_tree(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_3(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_delim_token_tree(tokens, pos);
+                pos = scan_delim_token_tree(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -9116,7 +9116,7 @@ fn scan_token_tree(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_token_tree_token(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_token_tree_token(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -9124,7 +9124,7 @@ fn scan_token_tree_token(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_4(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_macro_identifier_like_token(tokens, pos);
+                pos = scan_macro_identifier_like_token(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -9132,13 +9132,13 @@ fn scan_token_tree_token(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_5(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_macro_identifier_like_token(tokens, pos);
+                pos = scan_macro_identifier_like_token(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_1: {
-                pos = scan_macro_literal_token(tokens, pos);
+                pos = scan_macro_literal_token(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -9146,7 +9146,7 @@ fn scan_token_tree_token(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_6(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_macro_literal_token(tokens, pos);
+                pos = scan_macro_literal_token(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -9154,7 +9154,7 @@ fn scan_token_tree_token(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_7(alt_kind) {
             pos = start;
             try_2: {
-                pos = scan_macro_punctuation_token(tokens, pos);
+                pos = scan_macro_punctuation_token(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -9162,7 +9162,7 @@ fn scan_token_tree_token(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_8(alt_kind) {
             pos = start;
             try_3: {
-                pos = scan_macro_rep_op(tokens, pos);
+                pos = scan_macro_rep_op(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -9182,7 +9182,7 @@ fn scan_token_tree_token(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_macro_invocation_semi(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_macro_invocation_semi(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -9190,7 +9190,7 @@ fn scan_macro_invocation_semi(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_9(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_simple_path(tokens, pos);
+                pos = scan_simple_path(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_NOT { break try_0; }
                 pos += 1;
@@ -9198,7 +9198,7 @@ fn scan_macro_invocation_semi(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 while pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_token_tree(tokens, pos);
+                    pos = scan_token_tree(tokens, pos, 0);
                     if pos < 0 { pos = sp; break; }
                     if pos == sp { break; }
                 }
@@ -9210,7 +9210,7 @@ fn scan_macro_invocation_semi(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_1: {
-                pos = scan_simple_path(tokens, pos);
+                pos = scan_simple_path(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_NOT { break try_1; }
                 pos += 1;
@@ -9218,7 +9218,7 @@ fn scan_macro_invocation_semi(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 while pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_token_tree(tokens, pos);
+                    pos = scan_token_tree(tokens, pos, 0);
                     if pos < 0 { pos = sp; break; }
                     if pos == sp { break; }
                 }
@@ -9230,7 +9230,7 @@ fn scan_macro_invocation_semi(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_2: {
-                pos = scan_simple_path(tokens, pos);
+                pos = scan_simple_path(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_NOT { break try_2; }
                 pos += 1;
@@ -9238,7 +9238,7 @@ fn scan_macro_invocation_semi(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 while pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_token_tree(tokens, pos);
+                    pos = scan_token_tree(tokens, pos, 0);
                     if pos < 0 { pos = sp; break; }
                     if pos == sp { break; }
                 }
@@ -9254,20 +9254,20 @@ fn scan_macro_invocation_semi(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_macro_rules_definition(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_macro_rules_definition(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_MACRORULES { return -1; }
     pos += 1;
     if pos >= tokens.len() || tokens[pos].kind != TK_NOT { return -1; }
     pos += 1;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_macro_rules_def(tokens, pos);
+    pos = scan_macro_rules_def(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_macro_rules_def(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_macro_rules_def(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -9277,7 +9277,7 @@ fn scan_macro_rules_def(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { break try_0; }
                 pos += 1;
-                pos = scan_macro_rules(tokens, pos);
+                pos = scan_macro_rules(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { break try_0; }
                 pos += 1;
@@ -9291,7 +9291,7 @@ fn scan_macro_rules_def(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LSQUAREBRACKET { break try_1; }
                 pos += 1;
-                pos = scan_macro_rules(tokens, pos);
+                pos = scan_macro_rules(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_RSQUAREBRACKET { break try_1; }
                 pos += 1;
@@ -9305,7 +9305,7 @@ fn scan_macro_rules_def(tokens: &Array<Token>, pos: i32) -> i32 {
             try_2: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LCURLYBRACE { break try_2; }
                 pos += 1;
-                pos = scan_macro_rules(tokens, pos);
+                pos = scan_macro_rules(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_RCURLYBRACE { break try_2; }
                 pos += 1;
@@ -9319,9 +9319,9 @@ fn scan_macro_rules_def(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_macro_rules(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_macro_rules(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_macro_rule(tokens, pos);
+    pos = scan_macro_rule(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_SEMI {
         let sp = pos;
@@ -9329,7 +9329,7 @@ fn scan_macro_rules(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { break sg_0; }
                 pos += 1;
-                pos = scan_macro_rule(tokens, pos);
+                pos = scan_macro_rule(tokens, pos, 0);
                 if pos < 0 { break sg_0; }
                 break sg_0_done;
             }
@@ -9346,18 +9346,18 @@ fn scan_macro_rules(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_macro_rule(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_macro_rule(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_macro_matcher(tokens, pos);
+    pos = scan_macro_matcher(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_FATARROW { return -1; }
     pos += 1;
-    pos = scan_macro_transcriber(tokens, pos);
+    pos = scan_macro_transcriber(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_macro_matcher(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_macro_matcher(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -9369,7 +9369,7 @@ fn scan_macro_matcher(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 while pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_macro_match(tokens, pos);
+                    pos = scan_macro_match(tokens, pos, 0);
                     if pos < 0 { pos = sp; break; }
                     if pos == sp { break; }
                 }
@@ -9385,7 +9385,7 @@ fn scan_macro_matcher(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 while pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_macro_match(tokens, pos);
+                    pos = scan_macro_match(tokens, pos, 0);
                     if pos < 0 { pos = sp; break; }
                     if pos == sp { break; }
                 }
@@ -9401,7 +9401,7 @@ fn scan_macro_matcher(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 while pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_macro_match(tokens, pos);
+                    pos = scan_macro_match(tokens, pos, 0);
                     if pos < 0 { pos = sp; break; }
                     if pos == sp { break; }
                 }
@@ -9417,7 +9417,7 @@ fn scan_macro_matcher(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_macro_match(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_macro_match(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -9425,11 +9425,11 @@ fn scan_macro_match(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_10(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_macro_match_token(tokens, pos);
+                pos = scan_macro_match_token(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 while pos < tokens.len() && _gale_kind_set_10(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_macro_match_token(tokens, pos);
+                    pos = scan_macro_match_token(tokens, pos, 0);
                     if pos < 0 { pos = sp; break; }
                     if pos == sp { break; }
                 }
@@ -9439,7 +9439,7 @@ fn scan_macro_match(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_3(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_macro_matcher(tokens, pos);
+                pos = scan_macro_matcher(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -9451,11 +9451,11 @@ fn scan_macro_match(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { break try_3; }
                 pos += 1;
-                pos = scan_macro_match(tokens, pos);
+                pos = scan_macro_match(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 while pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_macro_match(tokens, pos);
+                    pos = scan_macro_match(tokens, pos, 0);
                     if pos < 0 { pos = sp; break; }
                     if pos == sp { break; }
                 }
@@ -9463,10 +9463,10 @@ fn scan_macro_match(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos < tokens.len() && _gale_kind_set_11(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_macro_rep_sep(tokens, pos);
+                    pos = scan_macro_rep_sep(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_macro_rep_op(tokens, pos);
+                pos = scan_macro_rep_op(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -9480,7 +9480,7 @@ fn scan_macro_match(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_1: {
                         pos = gp_1;
                         sg_1_0: {
-                            pos = scan_identifier(tokens, pos);
+                            pos = scan_identifier(tokens, pos, 0);
                             if pos < 0 { break sg_1_0; }
                             break sg_1;
                         }
@@ -9495,7 +9495,7 @@ fn scan_macro_match(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_COLON { break try_2; }
                 pos += 1;
-                pos = scan_macro_frag_spec(tokens, pos);
+                pos = scan_macro_frag_spec(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -9507,7 +9507,7 @@ fn scan_macro_match(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_macro_match_token(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_macro_match_token(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -9515,7 +9515,7 @@ fn scan_macro_match_token(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_4(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_macro_identifier_like_token(tokens, pos);
+                pos = scan_macro_identifier_like_token(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -9523,13 +9523,13 @@ fn scan_macro_match_token(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_5(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_macro_identifier_like_token(tokens, pos);
+                pos = scan_macro_identifier_like_token(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_1: {
-                pos = scan_macro_literal_token(tokens, pos);
+                pos = scan_macro_literal_token(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -9537,7 +9537,7 @@ fn scan_macro_match_token(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_6(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_macro_literal_token(tokens, pos);
+                pos = scan_macro_literal_token(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -9545,7 +9545,7 @@ fn scan_macro_match_token(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_7(alt_kind) {
             pos = start;
             try_2: {
-                pos = scan_macro_punctuation_token(tokens, pos);
+                pos = scan_macro_punctuation_token(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -9553,7 +9553,7 @@ fn scan_macro_match_token(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_8(alt_kind) {
             pos = start;
             try_3: {
-                pos = scan_macro_rep_op(tokens, pos);
+                pos = scan_macro_rep_op(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -9565,14 +9565,14 @@ fn scan_macro_match_token(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_macro_frag_spec(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_macro_frag_spec(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_macro_rep_sep(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_macro_rep_sep(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -9580,7 +9580,7 @@ fn scan_macro_rep_sep(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_4(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_macro_identifier_like_token(tokens, pos);
+                pos = scan_macro_identifier_like_token(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -9588,13 +9588,13 @@ fn scan_macro_rep_sep(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_5(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_macro_identifier_like_token(tokens, pos);
+                pos = scan_macro_identifier_like_token(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_1: {
-                pos = scan_macro_literal_token(tokens, pos);
+                pos = scan_macro_literal_token(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -9602,7 +9602,7 @@ fn scan_macro_rep_sep(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_6(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_macro_literal_token(tokens, pos);
+                pos = scan_macro_literal_token(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -9610,7 +9610,7 @@ fn scan_macro_rep_sep(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_7(alt_kind) {
             pos = start;
             try_2: {
-                pos = scan_macro_punctuation_token(tokens, pos);
+                pos = scan_macro_punctuation_token(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -9630,25 +9630,25 @@ fn scan_macro_rep_sep(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_macro_rep_op(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_macro_rep_op(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_8(tokens[pos].kind) {
         return pos + 1;
     }
     return -1;
 }
 
-fn scan_macro_transcriber(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_macro_transcriber(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_delim_token_tree(tokens, pos);
+    pos = scan_delim_token_tree(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_item(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_item(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && tokens[pos].kind == TK_POUND {
         let sp = pos;
-        pos = scan_outer_attribute(tokens, pos);
+        pos = scan_outer_attribute(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -9658,13 +9658,13 @@ fn scan_item(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_2: {
             pos = gp_2;
             sg_2_0: {
-                pos = scan_vis_item(tokens, pos);
+                pos = scan_vis_item(tokens, pos, 0);
                 if pos < 0 { break sg_2_0; }
                 break sg_2;
             }
             pos = gp_2;
             sg_2_1: {
-                pos = scan_macro_item(tokens, pos);
+                pos = scan_macro_item(tokens, pos, 0);
                 if pos < 0 { break sg_2_1; }
                 break sg_2;
             }
@@ -9674,11 +9674,11 @@ fn scan_item(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_vis_item(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_vis_item(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_KW_PUB {
         let sp = pos;
-        pos = scan_visibility(tokens, pos);
+        pos = scan_visibility(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     let gp_3 = pos;
@@ -9688,79 +9688,79 @@ fn scan_vis_item(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_3: {
             pos = gp_3;
             sg_3_0: {
-                pos = scan_module(tokens, pos);
+                pos = scan_module(tokens, pos, 0);
                 if pos < 0 { break sg_3_0; }
                 if pos > sg_3_best { sg_3_best = pos; }
             }
             pos = gp_3;
             sg_3_1: {
-                pos = scan_extern_crate(tokens, pos);
+                pos = scan_extern_crate(tokens, pos, 0);
                 if pos < 0 { break sg_3_1; }
                 if pos > sg_3_best { sg_3_best = pos; }
             }
             pos = gp_3;
             sg_3_2: {
-                pos = scan_use_declaration(tokens, pos);
+                pos = scan_use_declaration(tokens, pos, 0);
                 if pos < 0 { break sg_3_2; }
                 break sg_3;
             }
             pos = gp_3;
             sg_3_3: {
-                pos = scan_function_(tokens, pos);
+                pos = scan_function_(tokens, pos, 0);
                 if pos < 0 { break sg_3_3; }
                 if pos > sg_3_best { sg_3_best = pos; }
             }
             pos = gp_3;
             sg_3_4: {
-                pos = scan_type_alias(tokens, pos);
+                pos = scan_type_alias(tokens, pos, 0);
                 if pos < 0 { break sg_3_4; }
                 break sg_3;
             }
             pos = gp_3;
             sg_3_5: {
-                pos = scan_struct_(tokens, pos);
+                pos = scan_struct_(tokens, pos, 0);
                 if pos < 0 { break sg_3_5; }
                 break sg_3;
             }
             pos = gp_3;
             sg_3_6: {
-                pos = scan_enumeration(tokens, pos);
+                pos = scan_enumeration(tokens, pos, 0);
                 if pos < 0 { break sg_3_6; }
                 break sg_3;
             }
             pos = gp_3;
             sg_3_7: {
-                pos = scan_union_(tokens, pos);
+                pos = scan_union_(tokens, pos, 0);
                 if pos < 0 { break sg_3_7; }
                 break sg_3;
             }
             pos = gp_3;
             sg_3_8: {
-                pos = scan_constant_item(tokens, pos);
+                pos = scan_constant_item(tokens, pos, 0);
                 if pos < 0 { break sg_3_8; }
                 if pos > sg_3_best { sg_3_best = pos; }
             }
             pos = gp_3;
             sg_3_9: {
-                pos = scan_static_item(tokens, pos);
+                pos = scan_static_item(tokens, pos, 0);
                 if pos < 0 { break sg_3_9; }
                 break sg_3;
             }
             pos = gp_3;
             sg_3_10: {
-                pos = scan_trait_(tokens, pos);
+                pos = scan_trait_(tokens, pos, 0);
                 if pos < 0 { break sg_3_10; }
                 if pos > sg_3_best { sg_3_best = pos; }
             }
             pos = gp_3;
             sg_3_11: {
-                pos = scan_implementation(tokens, pos);
+                pos = scan_implementation(tokens, pos, 0);
                 if pos < 0 { break sg_3_11; }
                 if pos > sg_3_best { sg_3_best = pos; }
             }
             pos = gp_3;
             sg_3_12: {
-                pos = scan_extern_block(tokens, pos);
+                pos = scan_extern_block(tokens, pos, 0);
                 if pos < 0 { break sg_3_12; }
                 if pos > sg_3_best { sg_3_best = pos; }
             }
@@ -9771,7 +9771,7 @@ fn scan_vis_item(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_macro_item(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_macro_item(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -9779,7 +9779,7 @@ fn scan_macro_item(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_15(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_macro_invocation_semi(tokens, pos);
+                pos = scan_macro_invocation_semi(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -9787,13 +9787,13 @@ fn scan_macro_item(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_KW_MACRORULES {
             pos = start;
             try_0: {
-                pos = scan_macro_invocation_semi(tokens, pos);
+                pos = scan_macro_invocation_semi(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_1: {
-                pos = scan_macro_rules_definition(tokens, pos);
+                pos = scan_macro_rules_definition(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -9805,7 +9805,7 @@ fn scan_macro_item(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_module(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_module(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_KW_UNSAFE {
         let sp = pos;
@@ -9814,7 +9814,7 @@ fn scan_module(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_MOD { return -1; }
     pos += 1;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     let gp_4 = pos;
     let sgk_4 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -9832,13 +9832,13 @@ fn scan_module(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 while pos < tokens.len() && tokens[pos].kind == TK_POUND {
                     let sp = pos;
-                    pos = scan_inner_attribute(tokens, pos);
+                    pos = scan_inner_attribute(tokens, pos, 0);
                     if pos < 0 { pos = sp; break; }
                     if pos == sp { break; }
                 }
                 while pos < tokens.len() && _gale_kind_set_0(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_item(tokens, pos);
+                    pos = scan_item(tokens, pos, 0);
                     if pos < 0 { pos = sp; break; }
                     if pos == sp { break; }
                 }
@@ -9852,17 +9852,17 @@ fn scan_module(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_extern_crate(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_extern_crate(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_EXTERN { return -1; }
     pos += 1;
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_CRATE { return -1; }
     pos += 1;
-    pos = scan_crate_ref(tokens, pos);
+    pos = scan_crate_ref(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_KW_AS {
         let sp = pos;
-        pos = scan_as_clause(tokens, pos);
+        pos = scan_as_clause(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { return -1; }
@@ -9870,7 +9870,7 @@ fn scan_extern_crate(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_crate_ref(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_crate_ref(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -9878,7 +9878,7 @@ fn scan_crate_ref(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_17(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -9898,7 +9898,7 @@ fn scan_crate_ref(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_as_clause(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_as_clause(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_AS { return -1; }
     pos += 1;
@@ -9908,7 +9908,7 @@ fn scan_as_clause(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_5: {
             pos = gp_5;
             sg_5_0: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break sg_5_0; }
                 break sg_5;
             }
@@ -9924,18 +9924,18 @@ fn scan_as_clause(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_use_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_use_declaration(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_USE { return -1; }
     pos += 1;
-    pos = scan_use_tree(tokens, pos);
+    pos = scan_use_tree(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_use_tree(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_use_tree(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -9945,7 +9945,7 @@ fn scan_use_tree(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos < tokens.len() && _gale_kind_set_9(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_PATHSEP {
                     sol_6: {
-                        pos = scan_simple_path(tokens, pos);
+                        pos = scan_simple_path(tokens, pos, 0);
                         if pos < 0 { break sol_6; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_PATHSEP { break sol_6; }
                         pos += 1;
@@ -9972,7 +9972,7 @@ fn scan_use_tree(tokens: &Array<Token>, pos: i32) -> i32 {
                             pos += 1;
                             if pos < tokens.len() && _gale_kind_set_20(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_COMMA && pos + 2 < tokens.len() && tokens[pos + 2].kind == TK_COMMA {
                                 sol_9: {
-                                    pos = scan_use_tree(tokens, pos);
+                                    pos = scan_use_tree(tokens, pos, 0);
                                     if pos < 0 { break sol_9; }
                                     while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
                                         let sp = pos;
@@ -9980,7 +9980,7 @@ fn scan_use_tree(tokens: &Array<Token>, pos: i32) -> i32 {
                                             sg_10: {
                                                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_10; }
                                                 pos += 1;
-                                                pos = scan_use_tree(tokens, pos);
+                                                pos = scan_use_tree(tokens, pos, 0);
                                                 if pos < 0 { break sg_10; }
                                                 break sg_10_done;
                                             }
@@ -9994,14 +9994,14 @@ fn scan_use_tree(tokens: &Array<Token>, pos: i32) -> i32 {
                                 }
                             } else if pos < tokens.len() && _gale_kind_set_20(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_COMMA {
                                 sol_11: {
-                                    pos = scan_use_tree(tokens, pos);
+                                    pos = scan_use_tree(tokens, pos, 0);
                                     if pos < 0 { break sol_11; }
                                     if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sol_11; }
                                     pos += 1;
                                 }
                             } else if pos < tokens.len() && _gale_kind_set_20(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_COMMA {
                                 sol_12: {
-                                    pos = scan_use_tree(tokens, pos);
+                                    pos = scan_use_tree(tokens, pos, 0);
                                     if pos < 0 { break sol_12; }
                                     while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
                                         let sp = pos;
@@ -10009,7 +10009,7 @@ fn scan_use_tree(tokens: &Array<Token>, pos: i32) -> i32 {
                                             sg_13: {
                                                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_13; }
                                                 pos += 1;
-                                                pos = scan_use_tree(tokens, pos);
+                                                pos = scan_use_tree(tokens, pos, 0);
                                                 if pos < 0 { break sg_13; }
                                                 break sg_13_done;
                                             }
@@ -10021,7 +10021,7 @@ fn scan_use_tree(tokens: &Array<Token>, pos: i32) -> i32 {
                                 }
                             } else if pos < tokens.len() && _gale_kind_set_20(tokens[pos].kind) {
                                 sol_14: {
-                                    pos = scan_use_tree(tokens, pos);
+                                    pos = scan_use_tree(tokens, pos, 0);
                                     if pos < 0 { break sol_14; }
                                 }
                             }
@@ -10036,7 +10036,7 @@ fn scan_use_tree(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_1: {
-                pos = scan_simple_path(tokens, pos);
+                pos = scan_simple_path(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos < tokens.len() && tokens[pos].kind == TK_KW_AS {
                     let sp = pos;
@@ -10050,7 +10050,7 @@ fn scan_use_tree(tokens: &Array<Token>, pos: i32) -> i32 {
                                 sg_16: {
                                     pos = gp_16;
                                     sg_16_0: {
-                                        pos = scan_identifier(tokens, pos);
+                                        pos = scan_identifier(tokens, pos, 0);
                                         if pos < 0 { break sg_16_0; }
                                         break sg_16;
                                     }
@@ -10077,7 +10077,7 @@ fn scan_use_tree(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos < tokens.len() && _gale_kind_set_9(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_PATHSEP {
                     sol_17: {
-                        pos = scan_simple_path(tokens, pos);
+                        pos = scan_simple_path(tokens, pos, 0);
                         if pos < 0 { break sol_17; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_PATHSEP { break sol_17; }
                         pos += 1;
@@ -10104,7 +10104,7 @@ fn scan_use_tree(tokens: &Array<Token>, pos: i32) -> i32 {
                             pos += 1;
                             if pos < tokens.len() && _gale_kind_set_20(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_COMMA && pos + 2 < tokens.len() && tokens[pos + 2].kind == TK_COMMA {
                                 sol_20: {
-                                    pos = scan_use_tree(tokens, pos);
+                                    pos = scan_use_tree(tokens, pos, 0);
                                     if pos < 0 { break sol_20; }
                                     while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
                                         let sp = pos;
@@ -10112,7 +10112,7 @@ fn scan_use_tree(tokens: &Array<Token>, pos: i32) -> i32 {
                                             sg_21: {
                                                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_21; }
                                                 pos += 1;
-                                                pos = scan_use_tree(tokens, pos);
+                                                pos = scan_use_tree(tokens, pos, 0);
                                                 if pos < 0 { break sg_21; }
                                                 break sg_21_done;
                                             }
@@ -10126,14 +10126,14 @@ fn scan_use_tree(tokens: &Array<Token>, pos: i32) -> i32 {
                                 }
                             } else if pos < tokens.len() && _gale_kind_set_20(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_COMMA {
                                 sol_22: {
-                                    pos = scan_use_tree(tokens, pos);
+                                    pos = scan_use_tree(tokens, pos, 0);
                                     if pos < 0 { break sol_22; }
                                     if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sol_22; }
                                     pos += 1;
                                 }
                             } else if pos < tokens.len() && _gale_kind_set_20(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_COMMA {
                                 sol_23: {
-                                    pos = scan_use_tree(tokens, pos);
+                                    pos = scan_use_tree(tokens, pos, 0);
                                     if pos < 0 { break sol_23; }
                                     while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
                                         let sp = pos;
@@ -10141,7 +10141,7 @@ fn scan_use_tree(tokens: &Array<Token>, pos: i32) -> i32 {
                                             sg_24: {
                                                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_24; }
                                                 pos += 1;
-                                                pos = scan_use_tree(tokens, pos);
+                                                pos = scan_use_tree(tokens, pos, 0);
                                                 if pos < 0 { break sg_24; }
                                                 break sg_24_done;
                                             }
@@ -10153,7 +10153,7 @@ fn scan_use_tree(tokens: &Array<Token>, pos: i32) -> i32 {
                                 }
                             } else if pos < tokens.len() && _gale_kind_set_20(tokens[pos].kind) {
                                 sol_25: {
-                                    pos = scan_use_tree(tokens, pos);
+                                    pos = scan_use_tree(tokens, pos, 0);
                                     if pos < 0 { break sol_25; }
                                 }
                             }
@@ -10174,36 +10174,36 @@ fn scan_use_tree(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_function_(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_function_(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_function_qualifiers(tokens, pos);
+    pos = scan_function_qualifiers(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_FN { return -1; }
     pos += 1;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LT {
         let sp = pos;
-        pos = scan_generic_params(tokens, pos);
+        pos = scan_generic_params(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_21(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_function_parameters(tokens, pos);
+        pos = scan_function_parameters(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { return -1; }
     pos += 1;
     if pos < tokens.len() && tokens[pos].kind == TK_RARROW {
         let sp = pos;
-        pos = scan_function_return_type(tokens, pos);
+        pos = scan_function_return_type(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos < tokens.len() && tokens[pos].kind == TK_KW_WHERE {
         let sp = pos;
-        pos = scan_where_clause(tokens, pos);
+        pos = scan_where_clause(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     let gp_26 = pos;
@@ -10212,7 +10212,7 @@ fn scan_function_(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_26: {
             pos = gp_26;
             sg_26_0: {
-                pos = scan_block_expression(tokens, pos);
+                pos = scan_block_expression(tokens, pos, 0);
                 if pos < 0 { break sg_26_0; }
                 break sg_26;
             }
@@ -10228,7 +10228,7 @@ fn scan_function_(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_function_qualifiers(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_function_qualifiers(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_KW_CONST {
         let sp = pos;
@@ -10249,7 +10249,7 @@ fn scan_function_qualifiers(tokens: &Array<Token>, pos: i32) -> i32 {
         sol_27: {
             if pos >= tokens.len() || tokens[pos].kind != TK_KW_EXTERN { break sol_27; }
             pos += 1;
-            pos = scan_abi(tokens, pos);
+            pos = scan_abi(tokens, pos, 0);
             if pos < 0 { break sol_27; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_KW_EXTERN {
@@ -10261,14 +10261,14 @@ fn scan_function_qualifiers(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_abi(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_abi(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_22(tokens[pos].kind) {
         return pos + 1;
     }
     return -1;
 }
 
-fn scan_function_parameters(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_function_parameters(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -10280,7 +10280,7 @@ fn scan_function_parameters(tokens: &Array<Token>, pos: i32) -> i32 {
                     let sp = pos;
                     sg_29_done: {
                         sg_29: {
-                            pos = scan_self_param(tokens, pos);
+                            pos = scan_self_param(tokens, pos, 0);
                             if pos < 0 { break sg_29; }
                             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_29; }
                             pos += 1;
@@ -10290,7 +10290,7 @@ fn scan_function_parameters(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_function_param(tokens, pos);
+                pos = scan_function_param(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
                     let sp = pos;
@@ -10298,7 +10298,7 @@ fn scan_function_parameters(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_30: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_30; }
                             pos += 1;
-                            pos = scan_function_param(tokens, pos);
+                            pos = scan_function_param(tokens, pos, 0);
                             if pos < 0 { break sg_30; }
                             break sg_30_done;
                         }
@@ -10316,7 +10316,7 @@ fn scan_function_parameters(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_0: {
-                pos = scan_self_param(tokens, pos);
+                pos = scan_self_param(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos < tokens.len() && tokens[pos].kind == TK_COMMA {
                     let sp = pos;
@@ -10333,7 +10333,7 @@ fn scan_function_parameters(tokens: &Array<Token>, pos: i32) -> i32 {
                     let sp = pos;
                     sg_31_done: {
                         sg_31: {
-                            pos = scan_self_param(tokens, pos);
+                            pos = scan_self_param(tokens, pos, 0);
                             if pos < 0 { break sg_31; }
                             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_31; }
                             pos += 1;
@@ -10343,7 +10343,7 @@ fn scan_function_parameters(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_function_param(tokens, pos);
+                pos = scan_function_param(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
                     let sp = pos;
@@ -10351,7 +10351,7 @@ fn scan_function_parameters(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_32: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_32; }
                             pos += 1;
-                            pos = scan_function_param(tokens, pos);
+                            pos = scan_function_param(tokens, pos, 0);
                             if pos < 0 { break sg_32; }
                             break sg_32_done;
                         }
@@ -10375,11 +10375,11 @@ fn scan_function_parameters(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_self_param(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_self_param(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && tokens[pos].kind == TK_POUND {
         let sp = pos;
-        pos = scan_outer_attribute(tokens, pos);
+        pos = scan_outer_attribute(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -10390,13 +10390,13 @@ fn scan_self_param(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_33: {
             pos = gp_33;
             sg_33_0: {
-                pos = scan_shorthand_self(tokens, pos);
+                pos = scan_shorthand_self(tokens, pos, 0);
                 if pos < 0 { break sg_33_0; }
                 if pos > sg_33_best { sg_33_best = pos; }
             }
             pos = gp_33;
             sg_33_1: {
-                pos = scan_typed_self(tokens, pos);
+                pos = scan_typed_self(tokens, pos, 0);
                 if pos < 0 { break sg_33_1; }
                 if pos > sg_33_best { sg_33_best = pos; }
             }
@@ -10407,13 +10407,13 @@ fn scan_self_param(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_shorthand_self(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_shorthand_self(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_AND && pos + 1 < tokens.len() && _gale_kind_set_26(tokens[pos + 1].kind) {
         sol_34: {
             if pos >= tokens.len() || tokens[pos].kind != TK_AND { break sol_34; }
             pos += 1;
-            pos = scan_lifetime(tokens, pos);
+            pos = scan_lifetime(tokens, pos, 0);
             if pos < 0 { break sol_34; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_AND {
@@ -10432,7 +10432,7 @@ fn scan_shorthand_self(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_typed_self(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_typed_self(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_KW_MUT {
         let sp = pos;
@@ -10443,16 +10443,16 @@ fn scan_typed_self(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos >= tokens.len() || tokens[pos].kind != TK_COLON { return -1; }
     pos += 1;
-    pos = scan_type_(tokens, pos);
+    pos = scan_type_(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_function_param(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_function_param(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && tokens[pos].kind == TK_POUND {
         let sp = pos;
-        pos = scan_outer_attribute(tokens, pos);
+        pos = scan_outer_attribute(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -10463,7 +10463,7 @@ fn scan_function_param(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_36: {
             pos = gp_36;
             sg_36_0: {
-                pos = scan_function_param_pattern(tokens, pos);
+                pos = scan_function_param_pattern(tokens, pos, 0);
                 if pos < 0 { break sg_36_0; }
                 if pos > sg_36_best { sg_36_best = pos; }
             }
@@ -10475,7 +10475,7 @@ fn scan_function_param(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = gp_36;
             sg_36_2: {
-                pos = scan_type_(tokens, pos);
+                pos = scan_type_(tokens, pos, 0);
                 if pos < 0 { break sg_36_2; }
                 if pos > sg_36_best { sg_36_best = pos; }
             }
@@ -10486,9 +10486,9 @@ fn scan_function_param(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_function_param_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_function_param_pattern(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_pattern(tokens, pos);
+    pos = scan_pattern(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_COLON { return -1; }
     pos += 1;
@@ -10498,7 +10498,7 @@ fn scan_function_param_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_37: {
             pos = gp_37;
             sg_37_0: {
-                pos = scan_type_(tokens, pos);
+                pos = scan_type_(tokens, pos, 0);
                 if pos < 0 { break sg_37_0; }
                 break sg_37;
             }
@@ -10514,29 +10514,29 @@ fn scan_function_param_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_function_return_type(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_function_return_type(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_RARROW { return -1; }
     pos += 1;
-    pos = scan_type_(tokens, pos);
+    pos = scan_type_(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_type_alias(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_type_alias(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_TYPE { return -1; }
     pos += 1;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LT {
         let sp = pos;
-        pos = scan_generic_params(tokens, pos);
+        pos = scan_generic_params(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos < tokens.len() && tokens[pos].kind == TK_KW_WHERE {
         let sp = pos;
-        pos = scan_where_clause(tokens, pos);
+        pos = scan_where_clause(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos < tokens.len() && tokens[pos].kind == TK_EQ {
@@ -10545,7 +10545,7 @@ fn scan_type_alias(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_38: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_EQ { break sg_38; }
                 pos += 1;
-                pos = scan_type_(tokens, pos);
+                pos = scan_type_(tokens, pos, 0);
                 if pos < 0 { break sg_38; }
                 break sg_38_done;
             }
@@ -10558,7 +10558,7 @@ fn scan_type_alias(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_struct_(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_struct_(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -10566,13 +10566,13 @@ fn scan_struct_(tokens: &Array<Token>, pos: i32) -> i32 {
         if alt_kind == TK_KW_STRUCT {
             pos = start;
             try_0: {
-                pos = scan_struct_struct(tokens, pos);
+                pos = scan_struct_struct(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_1: {
-                pos = scan_tuple_struct(tokens, pos);
+                pos = scan_tuple_struct(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -10584,20 +10584,20 @@ fn scan_struct_(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_struct_struct(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_struct_struct(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_STRUCT { return -1; }
     pos += 1;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LT {
         let sp = pos;
-        pos = scan_generic_params(tokens, pos);
+        pos = scan_generic_params(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos < tokens.len() && tokens[pos].kind == TK_KW_WHERE {
         let sp = pos;
-        pos = scan_where_clause(tokens, pos);
+        pos = scan_where_clause(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     let gp_39 = pos;
@@ -10610,7 +10610,7 @@ fn scan_struct_struct(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos < tokens.len() && _gale_kind_set_29(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_struct_fields(tokens, pos);
+                    pos = scan_struct_fields(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_RCURLYBRACE { break sg_39_0; }
@@ -10629,29 +10629,29 @@ fn scan_struct_struct(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_tuple_struct(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_tuple_struct(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_STRUCT { return -1; }
     pos += 1;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LT {
         let sp = pos;
-        pos = scan_generic_params(tokens, pos);
+        pos = scan_generic_params(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_30(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_tuple_fields(tokens, pos);
+        pos = scan_tuple_fields(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { return -1; }
     pos += 1;
     if pos < tokens.len() && tokens[pos].kind == TK_KW_WHERE {
         let sp = pos;
-        pos = scan_where_clause(tokens, pos);
+        pos = scan_where_clause(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { return -1; }
@@ -10659,9 +10659,9 @@ fn scan_tuple_struct(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_struct_fields(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_struct_fields(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_struct_field(tokens, pos);
+    pos = scan_struct_field(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
         let sp = pos;
@@ -10669,7 +10669,7 @@ fn scan_struct_fields(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_40: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_40; }
                 pos += 1;
-                pos = scan_struct_field(tokens, pos);
+                pos = scan_struct_field(tokens, pos, 0);
                 if pos < 0 { break sg_40; }
                 break sg_40_done;
             }
@@ -10686,31 +10686,31 @@ fn scan_struct_fields(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_struct_field(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_struct_field(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && tokens[pos].kind == TK_POUND {
         let sp = pos;
-        pos = scan_outer_attribute(tokens, pos);
+        pos = scan_outer_attribute(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
     if pos < tokens.len() && tokens[pos].kind == TK_KW_PUB {
         let sp = pos;
-        pos = scan_visibility(tokens, pos);
+        pos = scan_visibility(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_COLON { return -1; }
     pos += 1;
-    pos = scan_type_(tokens, pos);
+    pos = scan_type_(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_tuple_fields(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_tuple_fields(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_tuple_field(tokens, pos);
+    pos = scan_tuple_field(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
         let sp = pos;
@@ -10718,7 +10718,7 @@ fn scan_tuple_fields(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_41: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_41; }
                 pos += 1;
-                pos = scan_tuple_field(tokens, pos);
+                pos = scan_tuple_field(tokens, pos, 0);
                 if pos < 0 { break sg_41; }
                 break sg_41_done;
             }
@@ -10735,45 +10735,45 @@ fn scan_tuple_fields(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_tuple_field(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_tuple_field(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && tokens[pos].kind == TK_POUND {
         let sp = pos;
-        pos = scan_outer_attribute(tokens, pos);
+        pos = scan_outer_attribute(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
     if pos < tokens.len() && tokens[pos].kind == TK_KW_PUB {
         let sp = pos;
-        pos = scan_visibility(tokens, pos);
+        pos = scan_visibility(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
-    pos = scan_type_(tokens, pos);
+    pos = scan_type_(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_enumeration(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_enumeration(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_ENUM { return -1; }
     pos += 1;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LT {
         let sp = pos;
-        pos = scan_generic_params(tokens, pos);
+        pos = scan_generic_params(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos < tokens.len() && tokens[pos].kind == TK_KW_WHERE {
         let sp = pos;
-        pos = scan_where_clause(tokens, pos);
+        pos = scan_where_clause(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LCURLYBRACE { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_29(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_enum_items(tokens, pos);
+        pos = scan_enum_items(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_RCURLYBRACE { return -1; }
@@ -10781,9 +10781,9 @@ fn scan_enumeration(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_enum_items(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_enum_items(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_enum_item(tokens, pos);
+    pos = scan_enum_item(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
         let sp = pos;
@@ -10791,7 +10791,7 @@ fn scan_enum_items(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_42: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_42; }
                 pos += 1;
-                pos = scan_enum_item(tokens, pos);
+                pos = scan_enum_item(tokens, pos, 0);
                 if pos < 0 { break sg_42; }
                 break sg_42_done;
             }
@@ -10808,20 +10808,20 @@ fn scan_enum_items(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_enum_item(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_enum_item(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && tokens[pos].kind == TK_POUND {
         let sp = pos;
-        pos = scan_outer_attribute(tokens, pos);
+        pos = scan_outer_attribute(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
     if pos < tokens.len() && tokens[pos].kind == TK_KW_PUB {
         let sp = pos;
-        pos = scan_visibility(tokens, pos);
+        pos = scan_visibility(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && _gale_kind_set_31(tokens[pos].kind) {
         let sp = pos;
@@ -10829,19 +10829,19 @@ fn scan_enum_item(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_43: {
             pos = gp_43;
             sg_43_0: {
-                pos = scan_enum_item_tuple(tokens, pos);
+                pos = scan_enum_item_tuple(tokens, pos, 0);
                 if pos < 0 { break sg_43_0; }
                 break sg_43;
             }
             pos = gp_43;
             sg_43_1: {
-                pos = scan_enum_item_struct(tokens, pos);
+                pos = scan_enum_item_struct(tokens, pos, 0);
                 if pos < 0 { break sg_43_1; }
                 break sg_43;
             }
             pos = gp_43;
             sg_43_2: {
-                pos = scan_enum_item_discriminant(tokens, pos);
+                pos = scan_enum_item_discriminant(tokens, pos, 0);
                 if pos < 0 { break sg_43_2; }
                 break sg_43;
             }
@@ -10852,13 +10852,13 @@ fn scan_enum_item(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_enum_item_tuple(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_enum_item_tuple(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_30(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_tuple_fields(tokens, pos);
+        pos = scan_tuple_fields(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { return -1; }
@@ -10866,13 +10866,13 @@ fn scan_enum_item_tuple(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_enum_item_struct(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_enum_item_struct(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LCURLYBRACE { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_29(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_struct_fields(tokens, pos);
+        pos = scan_struct_fields(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_RCURLYBRACE { return -1; }
@@ -10880,41 +10880,41 @@ fn scan_enum_item_struct(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_enum_item_discriminant(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_enum_item_discriminant(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_EQ { return -1; }
     pos += 1;
-    pos = scan_expression(tokens, pos);
+    pos = scan_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_union_(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_union_(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_UNION { return -1; }
     pos += 1;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LT {
         let sp = pos;
-        pos = scan_generic_params(tokens, pos);
+        pos = scan_generic_params(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos < tokens.len() && tokens[pos].kind == TK_KW_WHERE {
         let sp = pos;
-        pos = scan_where_clause(tokens, pos);
+        pos = scan_where_clause(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LCURLYBRACE { return -1; }
     pos += 1;
-    pos = scan_struct_fields(tokens, pos);
+    pos = scan_struct_fields(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_RCURLYBRACE { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_constant_item(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_constant_item(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_CONST { return -1; }
     pos += 1;
@@ -10924,7 +10924,7 @@ fn scan_constant_item(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_44: {
             pos = gp_44;
             sg_44_0: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break sg_44_0; }
                 break sg_44;
             }
@@ -10939,7 +10939,7 @@ fn scan_constant_item(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_COLON { return -1; }
     pos += 1;
-    pos = scan_type_(tokens, pos);
+    pos = scan_type_(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_EQ {
         let sp = pos;
@@ -10947,7 +10947,7 @@ fn scan_constant_item(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_45: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_EQ { break sg_45; }
                 pos += 1;
-                pos = scan_expression(tokens, pos);
+                pos = scan_expression(tokens, pos, 0);
                 if pos < 0 { break sg_45; }
                 break sg_45_done;
             }
@@ -10960,7 +10960,7 @@ fn scan_constant_item(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_static_item(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_static_item(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_STATIC { return -1; }
     pos += 1;
@@ -10969,11 +10969,11 @@ fn scan_static_item(tokens: &Array<Token>, pos: i32) -> i32 {
         if pos >= tokens.len() || tokens[pos].kind != TK_KW_MUT { pos = -1; } else { pos += 1; }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_COLON { return -1; }
     pos += 1;
-    pos = scan_type_(tokens, pos);
+    pos = scan_type_(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_EQ {
         let sp = pos;
@@ -10981,7 +10981,7 @@ fn scan_static_item(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_46: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_EQ { break sg_46; }
                 pos += 1;
-                pos = scan_expression(tokens, pos);
+                pos = scan_expression(tokens, pos, 0);
                 if pos < 0 { break sg_46; }
                 break sg_46_done;
             }
@@ -10994,7 +10994,7 @@ fn scan_static_item(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_trait_(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_trait_(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_KW_UNSAFE {
         let sp = pos;
@@ -11003,18 +11003,18 @@ fn scan_trait_(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_TRAIT { return -1; }
     pos += 1;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LT {
         let sp = pos;
-        pos = scan_generic_params(tokens, pos);
+        pos = scan_generic_params(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos < tokens.len() && tokens[pos].kind == TK_COLON && pos + 1 < tokens.len() && _gale_kind_set_32(tokens[pos + 1].kind) {
         sol_47: {
             if pos >= tokens.len() || tokens[pos].kind != TK_COLON { break sol_47; }
             pos += 1;
-            pos = scan_type_param_bounds(tokens, pos);
+            pos = scan_type_param_bounds(tokens, pos, 0);
             if pos < 0 { break sol_47; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_COLON {
@@ -11025,20 +11025,20 @@ fn scan_trait_(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     if pos < tokens.len() && tokens[pos].kind == TK_KW_WHERE {
         let sp = pos;
-        pos = scan_where_clause(tokens, pos);
+        pos = scan_where_clause(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LCURLYBRACE { return -1; }
     pos += 1;
     while pos < tokens.len() && tokens[pos].kind == TK_POUND {
         let sp = pos;
-        pos = scan_inner_attribute(tokens, pos);
+        pos = scan_inner_attribute(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
     while pos < tokens.len() && _gale_kind_set_33(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_associated_item(tokens, pos);
+        pos = scan_associated_item(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -11047,7 +11047,7 @@ fn scan_trait_(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_implementation(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_implementation(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -11055,13 +11055,13 @@ fn scan_implementation(tokens: &Array<Token>, pos: i32) -> i32 {
         if alt_kind == TK_KW_IMPL {
             pos = start;
             try_0: {
-                pos = scan_inherent_impl(tokens, pos);
+                pos = scan_inherent_impl(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_1: {
-                pos = scan_trait_impl(tokens, pos);
+                pos = scan_trait_impl(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -11069,7 +11069,7 @@ fn scan_implementation(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_KW_UNSAFE {
             pos = start;
             try_1: {
-                pos = scan_trait_impl(tokens, pos);
+                pos = scan_trait_impl(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -11081,28 +11081,28 @@ fn scan_implementation(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_inherent_impl(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_inherent_impl(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_IMPL { return -1; }
     pos += 1;
-    pos = scan_type_(tokens, pos);
+    pos = scan_type_(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_KW_WHERE {
         let sp = pos;
-        pos = scan_where_clause(tokens, pos);
+        pos = scan_where_clause(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LCURLYBRACE { return -1; }
     pos += 1;
     while pos < tokens.len() && tokens[pos].kind == TK_POUND {
         let sp = pos;
-        pos = scan_inner_attribute(tokens, pos);
+        pos = scan_inner_attribute(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
     while pos < tokens.len() && _gale_kind_set_33(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_associated_item(tokens, pos);
+        pos = scan_associated_item(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -11111,7 +11111,7 @@ fn scan_inherent_impl(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_trait_impl(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_trait_impl(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_KW_UNSAFE {
         let sp = pos;
@@ -11122,7 +11122,7 @@ fn scan_trait_impl(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && tokens[pos].kind == TK_LT {
         let sp = pos;
-        pos = scan_generic_params(tokens, pos);
+        pos = scan_generic_params(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos < tokens.len() && tokens[pos].kind == TK_NOT {
@@ -11130,28 +11130,28 @@ fn scan_trait_impl(tokens: &Array<Token>, pos: i32) -> i32 {
         if pos >= tokens.len() || tokens[pos].kind != TK_NOT { pos = -1; } else { pos += 1; }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_type_path(tokens, pos);
+    pos = scan_type_path(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_FOR { return -1; }
     pos += 1;
-    pos = scan_type_(tokens, pos);
+    pos = scan_type_(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_KW_WHERE {
         let sp = pos;
-        pos = scan_where_clause(tokens, pos);
+        pos = scan_where_clause(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LCURLYBRACE { return -1; }
     pos += 1;
     while pos < tokens.len() && tokens[pos].kind == TK_POUND {
         let sp = pos;
-        pos = scan_inner_attribute(tokens, pos);
+        pos = scan_inner_attribute(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
     while pos < tokens.len() && _gale_kind_set_33(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_associated_item(tokens, pos);
+        pos = scan_associated_item(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -11160,7 +11160,7 @@ fn scan_trait_impl(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_extern_block(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_extern_block(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_KW_UNSAFE {
         let sp = pos;
@@ -11171,20 +11171,20 @@ fn scan_extern_block(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_22(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_abi(tokens, pos);
+        pos = scan_abi(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LCURLYBRACE { return -1; }
     pos += 1;
     while pos < tokens.len() && tokens[pos].kind == TK_POUND {
         let sp = pos;
-        pos = scan_inner_attribute(tokens, pos);
+        pos = scan_inner_attribute(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
     while pos < tokens.len() && _gale_kind_set_34(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_external_item(tokens, pos);
+        pos = scan_external_item(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -11193,11 +11193,11 @@ fn scan_extern_block(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_external_item(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_external_item(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && tokens[pos].kind == TK_POUND {
         let sp = pos;
-        pos = scan_outer_attribute(tokens, pos);
+        pos = scan_outer_attribute(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -11207,7 +11207,7 @@ fn scan_external_item(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_49: {
             pos = gp_49;
             sg_49_0: {
-                pos = scan_macro_invocation_semi(tokens, pos);
+                pos = scan_macro_invocation_semi(tokens, pos, 0);
                 if pos < 0 { break sg_49_0; }
                 break sg_49;
             }
@@ -11215,7 +11215,7 @@ fn scan_external_item(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_49_1: {
                 if pos < tokens.len() && tokens[pos].kind == TK_KW_PUB {
                     let sp = pos;
-                    pos = scan_visibility(tokens, pos);
+                    pos = scan_visibility(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 let gp_50 = pos;
@@ -11224,13 +11224,13 @@ fn scan_external_item(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_50: {
                         pos = gp_50;
                         sg_50_0: {
-                            pos = scan_static_item(tokens, pos);
+                            pos = scan_static_item(tokens, pos, 0);
                             if pos < 0 { break sg_50_0; }
                             break sg_50;
                         }
                         pos = gp_50;
                         sg_50_1: {
-                            pos = scan_function_(tokens, pos);
+                            pos = scan_function_(tokens, pos, 0);
                             if pos < 0 { break sg_50_1; }
                             break sg_50;
                         }
@@ -11245,7 +11245,7 @@ fn scan_external_item(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_generic_params(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_generic_params(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LT { return -1; }
     pos += 1;
@@ -11255,7 +11255,7 @@ fn scan_generic_params(tokens: &Array<Token>, pos: i32) -> i32 {
                 let sp = pos;
                 sg_52_done: {
                     sg_52: {
-                        pos = scan_generic_param(tokens, pos);
+                        pos = scan_generic_param(tokens, pos, 0);
                         if pos < 0 { break sg_52; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_52; }
                         pos += 1;
@@ -11266,14 +11266,14 @@ fn scan_generic_params(tokens: &Array<Token>, pos: i32) -> i32 {
                 if pos < 0 { pos = sp; break; }
                 if pos == sp { break; }
             }
-            pos = scan_generic_param(tokens, pos);
+            pos = scan_generic_param(tokens, pos, 0);
             if pos < 0 { break sol_51; }
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sol_51; }
             pos += 1;
         }
     } else if pos < tokens.len() && _gale_kind_set_37(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_COMMA {
         sol_53: {
-            pos = scan_generic_param(tokens, pos);
+            pos = scan_generic_param(tokens, pos, 0);
             if pos < 0 { break sol_53; }
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sol_53; }
             pos += 1;
@@ -11284,7 +11284,7 @@ fn scan_generic_params(tokens: &Array<Token>, pos: i32) -> i32 {
                 let sp = pos;
                 sg_55_done: {
                     sg_55: {
-                        pos = scan_generic_param(tokens, pos);
+                        pos = scan_generic_param(tokens, pos, 0);
                         if pos < 0 { break sg_55; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_55; }
                         pos += 1;
@@ -11295,12 +11295,12 @@ fn scan_generic_params(tokens: &Array<Token>, pos: i32) -> i32 {
                 if pos < 0 { pos = sp; break; }
                 if pos == sp { break; }
             }
-            pos = scan_generic_param(tokens, pos);
+            pos = scan_generic_param(tokens, pos, 0);
             if pos < 0 { break sol_54; }
         }
     } else if pos < tokens.len() && _gale_kind_set_37(tokens[pos].kind) {
         sol_56: {
-            pos = scan_generic_param(tokens, pos);
+            pos = scan_generic_param(tokens, pos, 0);
             if pos < 0 { break sol_56; }
         }
     }
@@ -11309,11 +11309,11 @@ fn scan_generic_params(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_generic_param(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_generic_param(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && tokens[pos].kind == TK_POUND {
         let sp = pos;
-        pos = scan_outer_attribute(tokens, pos);
+        pos = scan_outer_attribute(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -11324,19 +11324,19 @@ fn scan_generic_param(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_57: {
             pos = gp_57;
             sg_57_0: {
-                pos = scan_lifetime_param(tokens, pos);
+                pos = scan_lifetime_param(tokens, pos, 0);
                 if pos < 0 { break sg_57_0; }
                 if pos > sg_57_best { sg_57_best = pos; }
             }
             pos = gp_57;
             sg_57_1: {
-                pos = scan_type_param(tokens, pos);
+                pos = scan_type_param(tokens, pos, 0);
                 if pos < 0 { break sg_57_1; }
                 if pos > sg_57_best { sg_57_best = pos; }
             }
             pos = gp_57;
             sg_57_2: {
-                pos = scan_const_param(tokens, pos);
+                pos = scan_const_param(tokens, pos, 0);
                 if pos < 0 { break sg_57_2; }
                 break sg_57;
             }
@@ -11347,11 +11347,11 @@ fn scan_generic_param(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_lifetime_param(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_lifetime_param(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_POUND {
         let sp = pos;
-        pos = scan_outer_attribute(tokens, pos);
+        pos = scan_outer_attribute(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIFETIME_OR_LABEL { return -1; }
@@ -11362,7 +11362,7 @@ fn scan_lifetime_param(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_58: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_COLON { break sg_58; }
                 pos += 1;
-                pos = scan_lifetime_bounds(tokens, pos);
+                pos = scan_lifetime_bounds(tokens, pos, 0);
                 if pos < 0 { break sg_58; }
                 break sg_58_done;
             }
@@ -11373,20 +11373,20 @@ fn scan_lifetime_param(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_type_param(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_type_param(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_POUND {
         let sp = pos;
-        pos = scan_outer_attribute(tokens, pos);
+        pos = scan_outer_attribute(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_COLON && pos + 1 < tokens.len() && _gale_kind_set_32(tokens[pos + 1].kind) {
         sol_59: {
             if pos >= tokens.len() || tokens[pos].kind != TK_COLON { break sol_59; }
             pos += 1;
-            pos = scan_type_param_bounds(tokens, pos);
+            pos = scan_type_param_bounds(tokens, pos, 0);
             if pos < 0 { break sol_59; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_COLON {
@@ -11401,7 +11401,7 @@ fn scan_type_param(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_61: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_EQ { break sg_61; }
                 pos += 1;
-                pos = scan_type_(tokens, pos);
+                pos = scan_type_(tokens, pos, 0);
                 if pos < 0 { break sg_61; }
                 break sg_61_done;
             }
@@ -11412,20 +11412,20 @@ fn scan_type_param(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_const_param(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_const_param(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_CONST { return -1; }
     pos += 1;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_COLON { return -1; }
     pos += 1;
-    pos = scan_type_(tokens, pos);
+    pos = scan_type_(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_where_clause(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_where_clause(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_WHERE { return -1; }
     pos += 1;
@@ -11433,7 +11433,7 @@ fn scan_where_clause(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_62_done: {
             sg_62: {
-                pos = scan_where_clause_item(tokens, pos);
+                pos = scan_where_clause_item(tokens, pos, 0);
                 if pos < 0 { break sg_62; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_62; }
                 pos += 1;
@@ -11446,13 +11446,13 @@ fn scan_where_clause(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     if pos < tokens.len() && _gale_kind_set_38(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_where_clause_item(tokens, pos);
+        pos = scan_where_clause_item(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     return pos;
 }
 
-fn scan_where_clause_item(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_where_clause_item(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -11460,13 +11460,13 @@ fn scan_where_clause_item(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_26(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_lifetime_where_clause_item(tokens, pos);
+                pos = scan_lifetime_where_clause_item(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_1: {
-                pos = scan_type_bound_where_clause_item(tokens, pos);
+                pos = scan_type_bound_where_clause_item(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -11474,7 +11474,7 @@ fn scan_where_clause_item(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_39(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_type_bound_where_clause_item(tokens, pos);
+                pos = scan_type_bound_where_clause_item(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -11486,45 +11486,45 @@ fn scan_where_clause_item(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_lifetime_where_clause_item(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_lifetime_where_clause_item(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_lifetime(tokens, pos);
+    pos = scan_lifetime(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_COLON { return -1; }
     pos += 1;
-    pos = scan_lifetime_bounds(tokens, pos);
+    pos = scan_lifetime_bounds(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_type_bound_where_clause_item(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_type_bound_where_clause_item(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_type_(tokens, pos);
+    pos = scan_type_(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_COLON { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_32(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_type_param_bounds(tokens, pos);
+        pos = scan_type_param_bounds(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     return pos;
 }
 
-fn scan_for_lifetimes(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_for_lifetimes(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_FOR { return -1; }
     pos += 1;
-    pos = scan_generic_params(tokens, pos);
+    pos = scan_generic_params(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_associated_item(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_associated_item(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && tokens[pos].kind == TK_POUND {
         let sp = pos;
-        pos = scan_outer_attribute(tokens, pos);
+        pos = scan_outer_attribute(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -11534,7 +11534,7 @@ fn scan_associated_item(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_63: {
             pos = gp_63;
             sg_63_0: {
-                pos = scan_macro_invocation_semi(tokens, pos);
+                pos = scan_macro_invocation_semi(tokens, pos, 0);
                 if pos < 0 { break sg_63_0; }
                 break sg_63;
             }
@@ -11542,7 +11542,7 @@ fn scan_associated_item(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_63_1: {
                 if pos < tokens.len() && tokens[pos].kind == TK_KW_PUB {
                     let sp = pos;
-                    pos = scan_visibility(tokens, pos);
+                    pos = scan_visibility(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 let gp_64 = pos;
@@ -11552,19 +11552,19 @@ fn scan_associated_item(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_64: {
                         pos = gp_64;
                         sg_64_0: {
-                            pos = scan_type_alias(tokens, pos);
+                            pos = scan_type_alias(tokens, pos, 0);
                             if pos < 0 { break sg_64_0; }
                             break sg_64;
                         }
                         pos = gp_64;
                         sg_64_1: {
-                            pos = scan_constant_item(tokens, pos);
+                            pos = scan_constant_item(tokens, pos, 0);
                             if pos < 0 { break sg_64_1; }
                             if pos > sg_64_best { sg_64_best = pos; }
                         }
                         pos = gp_64;
                         sg_64_2: {
-                            pos = scan_function_(tokens, pos);
+                            pos = scan_function_(tokens, pos, 0);
                             if pos < 0 { break sg_64_2; }
                             if pos > sg_64_best { sg_64_best = pos; }
                         }
@@ -11580,7 +11580,7 @@ fn scan_associated_item(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_inner_attribute(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_inner_attribute(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_POUND { return -1; }
     pos += 1;
@@ -11588,39 +11588,39 @@ fn scan_inner_attribute(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos >= tokens.len() || tokens[pos].kind != TK_LSQUAREBRACKET { return -1; }
     pos += 1;
-    pos = scan_attr(tokens, pos);
+    pos = scan_attr(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_RSQUAREBRACKET { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_outer_attribute(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_outer_attribute(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_POUND { return -1; }
     pos += 1;
     if pos >= tokens.len() || tokens[pos].kind != TK_LSQUAREBRACKET { return -1; }
     pos += 1;
-    pos = scan_attr(tokens, pos);
+    pos = scan_attr(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_RSQUAREBRACKET { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_attr(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_attr(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_simple_path(tokens, pos);
+    pos = scan_simple_path(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && _gale_kind_set_42(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_attr_input(tokens, pos);
+        pos = scan_attr_input(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     return pos;
 }
 
-fn scan_attr_input(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_attr_input(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -11628,7 +11628,7 @@ fn scan_attr_input(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_3(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_delim_token_tree(tokens, pos);
+                pos = scan_delim_token_tree(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -11638,7 +11638,7 @@ fn scan_attr_input(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_EQ { break try_1; }
                 pos += 1;
-                pos = scan_literal_expression(tokens, pos);
+                pos = scan_literal_expression(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -11650,7 +11650,7 @@ fn scan_attr_input(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_statement(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -11666,19 +11666,19 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_POUND {
             pos = start;
             try_1: {
-                pos = scan_item(tokens, pos);
+                pos = scan_item(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_2: {
-                pos = scan_let_statement(tokens, pos);
+                pos = scan_let_statement(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
             pos = start;
             try_3: {
-                pos = scan_expression_statement(tokens, pos);
+                pos = scan_expression_statement(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -11686,7 +11686,7 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_43(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_item(tokens, pos);
+                pos = scan_item(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -11694,13 +11694,13 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_44(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_item(tokens, pos);
+                pos = scan_item(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_3: {
-                pos = scan_expression_statement(tokens, pos);
+                pos = scan_expression_statement(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -11708,19 +11708,19 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_9(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_item(tokens, pos);
+                pos = scan_item(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_3: {
-                pos = scan_expression_statement(tokens, pos);
+                pos = scan_expression_statement(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
             pos = start;
             try_4: {
-                pos = scan_macro_invocation_semi(tokens, pos);
+                pos = scan_macro_invocation_semi(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 break scan_alts;
             }
@@ -11728,7 +11728,7 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_KW_LET {
             pos = start;
             try_2: {
-                pos = scan_let_statement(tokens, pos);
+                pos = scan_let_statement(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -11736,7 +11736,7 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_45(alt_kind) {
             pos = start;
             try_3: {
-                pos = scan_expression_statement(tokens, pos);
+                pos = scan_expression_statement(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -11748,17 +11748,17 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_let_statement(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_let_statement(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && tokens[pos].kind == TK_POUND {
         let sp = pos;
-        pos = scan_outer_attribute(tokens, pos);
+        pos = scan_outer_attribute(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_LET { return -1; }
     pos += 1;
-    pos = scan_pattern_no_top_alt(tokens, pos);
+    pos = scan_pattern_no_top_alt(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_COLON {
         let sp = pos;
@@ -11766,7 +11766,7 @@ fn scan_let_statement(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_65: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_COLON { break sg_65; }
                 pos += 1;
-                pos = scan_type_(tokens, pos);
+                pos = scan_type_(tokens, pos, 0);
                 if pos < 0 { break sg_65; }
                 break sg_65_done;
             }
@@ -11780,7 +11780,7 @@ fn scan_let_statement(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_66: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_EQ { break sg_66; }
                 pos += 1;
-                pos = scan_expression(tokens, pos);
+                pos = scan_expression(tokens, pos, 0);
                 if pos < 0 { break sg_66; }
                 break sg_66_done;
             }
@@ -11793,7 +11793,7 @@ fn scan_let_statement(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_expression_statement(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_expression_statement(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -11801,7 +11801,7 @@ fn scan_expression_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_46(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_expression(tokens, pos);
+                pos = scan_expression(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { break try_0; }
                 pos += 1;
@@ -11809,7 +11809,7 @@ fn scan_expression_statement(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_1: {
-                pos = scan_expression_with_block(tokens, pos);
+                pos = scan_expression_with_block(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos < tokens.len() && tokens[pos].kind == TK_SEMI {
                     let sp = pos;
@@ -11822,7 +11822,7 @@ fn scan_expression_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_47(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_expression(tokens, pos);
+                pos = scan_expression(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { break try_0; }
                 pos += 1;
@@ -11844,21 +11844,21 @@ fn scan_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         if alt_kind == TK_POUND {
             pos = start;
             try_17: {
-                pos = scan_expression_with_block(tokens, pos);
+                pos = scan_expression_with_block(tokens, pos, 0);
                 if pos < 0 { break try_17; }
                 break scan_alts;
             }
             pos = start;
             try_0: {
-                pos = scan_outer_attribute(tokens, pos);
+                pos = scan_outer_attribute(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 while pos < tokens.len() && tokens[pos].kind == TK_POUND {
                     let sp = pos;
-                    pos = scan_outer_attribute(tokens, pos);
+                    pos = scan_outer_attribute(tokens, pos, 0);
                     if pos < 0 { pos = sp; break; }
                     if pos == sp { break; }
                 }
-                pos = scan_expression(tokens, pos);
+                pos = scan_expression(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -11866,7 +11866,7 @@ fn scan_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_48(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_literal_expression(tokens, pos);
+                pos = scan_literal_expression(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -11874,25 +11874,25 @@ fn scan_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_9(alt_kind) {
             pos = start;
             try_2: {
-                pos = scan_path_expression(tokens, pos);
+                pos = scan_path_expression(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
             pos = start;
             try_14: {
-                pos = scan_struct_expression(tokens, pos);
+                pos = scan_struct_expression(tokens, pos, 0);
                 if pos < 0 { break try_14; }
                 break scan_alts;
             }
             pos = start;
             try_15: {
-                pos = scan_enumeration_variant_expression(tokens, pos);
+                pos = scan_enumeration_variant_expression(tokens, pos, 0);
                 if pos < 0 { break try_15; }
                 break scan_alts;
             }
             pos = start;
             try_18: {
-                pos = scan_macro_invocation(tokens, pos);
+                pos = scan_macro_invocation(tokens, pos, 0);
                 if pos < 0 { break try_18; }
                 break scan_alts;
             }
@@ -11900,19 +11900,19 @@ fn scan_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_KW_SELFTYPE {
             pos = start;
             try_2: {
-                pos = scan_path_expression(tokens, pos);
+                pos = scan_path_expression(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
             pos = start;
             try_14: {
-                pos = scan_struct_expression(tokens, pos);
+                pos = scan_struct_expression(tokens, pos, 0);
                 if pos < 0 { break try_14; }
                 break scan_alts;
             }
             pos = start;
             try_15: {
-                pos = scan_enumeration_variant_expression(tokens, pos);
+                pos = scan_enumeration_variant_expression(tokens, pos, 0);
                 if pos < 0 { break try_15; }
                 break scan_alts;
             }
@@ -11920,7 +11920,7 @@ fn scan_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LT {
             pos = start;
             try_2: {
-                pos = scan_path_expression(tokens, pos);
+                pos = scan_path_expression(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -11949,7 +11949,7 @@ fn scan_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                     if pos >= tokens.len() || tokens[pos].kind != TK_KW_MUT { pos = -1; } else { pos += 1; }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_expression(tokens, pos);
+                pos = scan_expression(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -11959,7 +11959,7 @@ fn scan_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_4: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_STAR { break try_4; }
                 pos += 1;
-                pos = scan_expression(tokens, pos);
+                pos = scan_expression(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 break scan_alts;
             }
@@ -11983,7 +11983,7 @@ fn scan_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     break try_5;
                 }
-                pos = scan_expression(tokens, pos);
+                pos = scan_expression(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 break scan_alts;
             }
@@ -11995,7 +11995,7 @@ fn scan_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos < tokens.len() && _gale_kind_set_51(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_expression(tokens, pos);
+                    pos = scan_expression(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break scan_alts;
@@ -12006,7 +12006,7 @@ fn scan_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_7: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_DOTDOTEQ { break try_7; }
                 pos += 1;
-                pos = scan_expression(tokens, pos);
+                pos = scan_expression(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 break scan_alts;
             }
@@ -12023,7 +12023,7 @@ fn scan_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos < tokens.len() && _gale_kind_set_51(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_expression(tokens, pos);
+                    pos = scan_expression(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break scan_alts;
@@ -12041,7 +12041,7 @@ fn scan_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos < tokens.len() && _gale_kind_set_51(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_expression(tokens, pos);
+                    pos = scan_expression(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break scan_alts;
@@ -12054,7 +12054,7 @@ fn scan_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos < tokens.len() && _gale_kind_set_51(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_expression(tokens, pos);
+                    pos = scan_expression(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break scan_alts;
@@ -12067,11 +12067,11 @@ fn scan_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 while pos < tokens.len() && tokens[pos].kind == TK_POUND {
                     let sp = pos;
-                    pos = scan_inner_attribute(tokens, pos);
+                    pos = scan_inner_attribute(tokens, pos, 0);
                     if pos < 0 { pos = sp; break; }
                     if pos == sp { break; }
                 }
-                pos = scan_expression(tokens, pos);
+                pos = scan_expression(tokens, pos, 0);
                 if pos < 0 { break try_11; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { break try_11; }
                 pos += 1;
@@ -12083,13 +12083,13 @@ fn scan_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 while pos < tokens.len() && tokens[pos].kind == TK_POUND {
                     let sp = pos;
-                    pos = scan_inner_attribute(tokens, pos);
+                    pos = scan_inner_attribute(tokens, pos, 0);
                     if pos < 0 { pos = sp; break; }
                     if pos == sp { break; }
                 }
                 if pos < tokens.len() && _gale_kind_set_51(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_tuple_elements(tokens, pos);
+                    pos = scan_tuple_elements(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { break try_13; }
@@ -12104,13 +12104,13 @@ fn scan_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 while pos < tokens.len() && tokens[pos].kind == TK_POUND {
                     let sp = pos;
-                    pos = scan_inner_attribute(tokens, pos);
+                    pos = scan_inner_attribute(tokens, pos, 0);
                     if pos < 0 { pos = sp; break; }
                     if pos == sp { break; }
                 }
                 if pos < tokens.len() && _gale_kind_set_51(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_array_elements(tokens, pos);
+                    pos = scan_array_elements(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_RSQUAREBRACKET { break try_12; }
@@ -12121,7 +12121,7 @@ fn scan_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_52(alt_kind) {
             pos = start;
             try_16: {
-                pos = scan_closure_expression(tokens, pos);
+                pos = scan_closure_expression(tokens, pos, 0);
                 if pos < 0 { break try_16; }
                 break scan_alts;
             }
@@ -12129,7 +12129,7 @@ fn scan_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_53(alt_kind) {
             pos = start;
             try_17: {
-                pos = scan_expression_with_block(tokens, pos);
+                pos = scan_expression_with_block(tokens, pos, 0);
                 if pos < 0 { break try_17; }
                 break scan_alts;
             }
@@ -12145,13 +12145,13 @@ fn scan_expression_lr_3(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_DOT { return -1; }
     pos += 1;
-    pos = scan_path_expr_segment(tokens, pos);
+    pos = scan_path_expr_segment(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_51(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_call_params(tokens, pos);
+        pos = scan_call_params(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { return -1; }
@@ -12163,7 +12163,7 @@ fn scan_expression_lr_4(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_DOT { return -1; }
     pos += 1;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -12172,7 +12172,7 @@ fn scan_expression_lr_5(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_DOT { return -1; }
     pos += 1;
-    pos = scan_tuple_index(tokens, pos);
+    pos = scan_tuple_index(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -12192,7 +12192,7 @@ fn scan_expression_lr_7(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_51(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_call_params(tokens, pos);
+        pos = scan_call_params(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { return -1; }
@@ -12222,7 +12222,7 @@ fn scan_expression_lr_13(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_AS { return -1; }
     pos += 1;
-    pos = scan_type_no_bounds(tokens, pos);
+    pos = scan_type_no_bounds(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -12287,13 +12287,13 @@ fn scan_expression_lr_16(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_71: {
             pos = gp_71;
             sg_71_0: {
-                pos = scan_shl(tokens, pos);
+                pos = scan_shl(tokens, pos, 0);
                 if pos < 0 { break sg_71_0; }
                 break sg_71;
             }
             pos = gp_71;
             sg_71_1: {
-                pos = scan_shr(tokens, pos);
+                pos = scan_shr(tokens, pos, 0);
                 if pos < 0 { break sg_71_1; }
                 break sg_71;
             }
@@ -12334,7 +12334,7 @@ fn scan_expression_lr_19(tokens: &Array<Token>, pos: i32) -> i32 {
 
 fn scan_expression_lr_20(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_comparison_operator(tokens, pos);
+    pos = scan_comparison_operator(tokens, pos, 0);
     if pos < 0 { return -1; }
     pos = scan_expression(tokens, pos, 8);
     if pos < 0 { return -1; }
@@ -12365,7 +12365,7 @@ fn scan_expression_lr_23(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_51(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression(tokens, pos);
+        pos = scan_expression(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     return pos;
@@ -12391,7 +12391,7 @@ fn scan_expression_lr_27(tokens: &Array<Token>, pos: i32) -> i32 {
 
 fn scan_expression_lr_28(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_compound_assign_operator(tokens, pos);
+    pos = scan_compound_assign_operator(tokens, pos, 0);
     if pos < 0 { return -1; }
     pos = scan_expression(tokens, pos, 2);
     if pos < 0 { return -1; }
@@ -12612,21 +12612,21 @@ fn scan_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     return pos;
 }
 
-fn scan_comparison_operator(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_comparison_operator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_58(tokens[pos].kind) {
         return pos + 1;
     }
     return -1;
 }
 
-fn scan_compound_assign_operator(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_compound_assign_operator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_59(tokens[pos].kind) {
         return pos + 1;
     }
     return -1;
 }
 
-fn scan_expression_with_block(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_expression_with_block(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -12634,15 +12634,15 @@ fn scan_expression_with_block(tokens: &Array<Token>, pos: i32) -> i32 {
         if alt_kind == TK_POUND {
             pos = start;
             try_0: {
-                pos = scan_outer_attribute(tokens, pos);
+                pos = scan_outer_attribute(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 while pos < tokens.len() && tokens[pos].kind == TK_POUND {
                     let sp = pos;
-                    pos = scan_outer_attribute(tokens, pos);
+                    pos = scan_outer_attribute(tokens, pos, 0);
                     if pos < 0 { pos = sp; break; }
                     if pos == sp { break; }
                 }
-                pos = scan_expression_with_block(tokens, pos);
+                pos = scan_expression_with_block(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -12650,7 +12650,7 @@ fn scan_expression_with_block(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LCURLYBRACE {
             pos = start;
             try_1: {
-                pos = scan_block_expression(tokens, pos);
+                pos = scan_block_expression(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -12658,7 +12658,7 @@ fn scan_expression_with_block(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_KW_ASYNC {
             pos = start;
             try_2: {
-                pos = scan_async_block_expression(tokens, pos);
+                pos = scan_async_block_expression(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -12666,7 +12666,7 @@ fn scan_expression_with_block(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_KW_UNSAFE {
             pos = start;
             try_3: {
-                pos = scan_unsafe_block_expression(tokens, pos);
+                pos = scan_unsafe_block_expression(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -12674,7 +12674,7 @@ fn scan_expression_with_block(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_60(alt_kind) {
             pos = start;
             try_4: {
-                pos = scan_loop_expression(tokens, pos);
+                pos = scan_loop_expression(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 break scan_alts;
             }
@@ -12682,13 +12682,13 @@ fn scan_expression_with_block(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_KW_IF {
             pos = start;
             try_5: {
-                pos = scan_if_expression(tokens, pos);
+                pos = scan_if_expression(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 break scan_alts;
             }
             pos = start;
             try_6: {
-                pos = scan_if_let_expression(tokens, pos);
+                pos = scan_if_let_expression(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 break scan_alts;
             }
@@ -12696,7 +12696,7 @@ fn scan_expression_with_block(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_KW_MATCH {
             pos = start;
             try_7: {
-                pos = scan_match_expression(tokens, pos);
+                pos = scan_match_expression(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 break scan_alts;
             }
@@ -12708,14 +12708,14 @@ fn scan_expression_with_block(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_literal_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_literal_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_48(tokens[pos].kind) {
         return pos + 1;
     }
     return -1;
 }
 
-fn scan_path_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_path_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -12723,7 +12723,7 @@ fn scan_path_expression(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_61(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_path_in_expression(tokens, pos);
+                pos = scan_path_in_expression(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -12731,7 +12731,7 @@ fn scan_path_expression(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LT {
             pos = start;
             try_1: {
-                pos = scan_qualified_path_in_expression(tokens, pos);
+                pos = scan_qualified_path_in_expression(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -12743,19 +12743,19 @@ fn scan_path_expression(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_block_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_block_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LCURLYBRACE { return -1; }
     pos += 1;
     while pos < tokens.len() && tokens[pos].kind == TK_POUND {
         let sp = pos;
-        pos = scan_inner_attribute(tokens, pos);
+        pos = scan_inner_attribute(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
     if pos < tokens.len() && _gale_kind_set_62(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_statements(tokens, pos);
+        pos = scan_statements(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_RCURLYBRACE { return -1; }
@@ -12763,7 +12763,7 @@ fn scan_block_expression(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_statements(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_statements(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -12771,17 +12771,17 @@ fn scan_statements(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_63(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_statement(tokens, pos);
+                pos = scan_statement(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 while pos < tokens.len() && _gale_kind_set_62(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_statement(tokens, pos);
+                    pos = scan_statement(tokens, pos, 0);
                     if pos < 0 { pos = sp; break; }
                     if pos == sp { break; }
                 }
                 if pos < tokens.len() && _gale_kind_set_51(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_expression(tokens, pos);
+                    pos = scan_expression(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break scan_alts;
@@ -12790,23 +12790,23 @@ fn scan_statements(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_51(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_expression(tokens, pos);
+                pos = scan_expression(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_0: {
-                pos = scan_statement(tokens, pos);
+                pos = scan_statement(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 while pos < tokens.len() && _gale_kind_set_62(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_statement(tokens, pos);
+                    pos = scan_statement(tokens, pos, 0);
                     if pos < 0 { pos = sp; break; }
                     if pos == sp { break; }
                 }
                 if pos < tokens.len() && _gale_kind_set_51(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_expression(tokens, pos);
+                    pos = scan_expression(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break scan_alts;
@@ -12819,7 +12819,7 @@ fn scan_statements(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_async_block_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_async_block_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_ASYNC { return -1; }
     pos += 1;
@@ -12828,21 +12828,21 @@ fn scan_async_block_expression(tokens: &Array<Token>, pos: i32) -> i32 {
         if pos >= tokens.len() || tokens[pos].kind != TK_KW_MOVE { pos = -1; } else { pos += 1; }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_block_expression(tokens, pos);
+    pos = scan_block_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_unsafe_block_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_unsafe_block_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_UNSAFE { return -1; }
     pos += 1;
-    pos = scan_block_expression(tokens, pos);
+    pos = scan_block_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_array_elements(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_array_elements(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -12850,7 +12850,7 @@ fn scan_array_elements(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_51(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_expression(tokens, pos);
+                pos = scan_expression(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
                     let sp = pos;
@@ -12858,7 +12858,7 @@ fn scan_array_elements(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_72: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_72; }
                             pos += 1;
-                            pos = scan_expression(tokens, pos);
+                            pos = scan_expression(tokens, pos, 0);
                             if pos < 0 { break sg_72; }
                             break sg_72_done;
                         }
@@ -12876,11 +12876,11 @@ fn scan_array_elements(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_1: {
-                pos = scan_expression(tokens, pos);
+                pos = scan_expression(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { break try_1; }
                 pos += 1;
-                pos = scan_expression(tokens, pos);
+                pos = scan_expression(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -12892,11 +12892,11 @@ fn scan_array_elements(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_tuple_elements(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_tuple_elements(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     sg_73_done: {
         sg_73: {
-            pos = scan_expression(tokens, pos);
+            pos = scan_expression(tokens, pos, 0);
             if pos < 0 { break sg_73; }
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_73; }
             pos += 1;
@@ -12908,7 +12908,7 @@ fn scan_tuple_elements(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_74_done: {
             sg_74: {
-                pos = scan_expression(tokens, pos);
+                pos = scan_expression(tokens, pos, 0);
                 if pos < 0 { break sg_74; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_74; }
                 pos += 1;
@@ -12921,20 +12921,20 @@ fn scan_tuple_elements(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     if pos < tokens.len() && _gale_kind_set_51(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression(tokens, pos);
+        pos = scan_expression(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     return pos;
 }
 
-fn scan_tuple_index(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_tuple_index(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_INTEGER_LITERAL { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_struct_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_struct_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -12942,19 +12942,19 @@ fn scan_struct_expression(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_61(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_struct_expr_struct(tokens, pos);
+                pos = scan_struct_expr_struct(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_1: {
-                pos = scan_struct_expr_tuple(tokens, pos);
+                pos = scan_struct_expr_tuple(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_2: {
-                pos = scan_struct_expr_unit(tokens, pos);
+                pos = scan_struct_expr_unit(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -12966,15 +12966,15 @@ fn scan_struct_expression(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_struct_expr_struct(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_struct_expr_struct(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_path_in_expression(tokens, pos);
+    pos = scan_path_in_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LCURLYBRACE { return -1; }
     pos += 1;
     while pos < tokens.len() && tokens[pos].kind == TK_POUND {
         let sp = pos;
-        pos = scan_inner_attribute(tokens, pos);
+        pos = scan_inner_attribute(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -12984,13 +12984,13 @@ fn scan_struct_expr_struct(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_75: {
             pos = gp_75;
             sg_75_0: {
-                pos = scan_struct_expr_fields(tokens, pos);
+                pos = scan_struct_expr_fields(tokens, pos, 0);
                 if pos < 0 { break sg_75_0; }
                 break sg_75;
             }
             pos = gp_75;
             sg_75_1: {
-                pos = scan_struct_base(tokens, pos);
+                pos = scan_struct_base(tokens, pos, 0);
                 if pos < 0 { break sg_75_1; }
                 break sg_75;
             }
@@ -13003,9 +13003,9 @@ fn scan_struct_expr_struct(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_struct_expr_fields(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_struct_expr_fields(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_struct_expr_field(tokens, pos);
+    pos = scan_struct_expr_field(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
         let sp = pos;
@@ -13013,7 +13013,7 @@ fn scan_struct_expr_fields(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_76: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_76; }
                 pos += 1;
-                pos = scan_struct_expr_field(tokens, pos);
+                pos = scan_struct_expr_field(tokens, pos, 0);
                 if pos < 0 { break sg_76; }
                 break sg_76_done;
             }
@@ -13031,7 +13031,7 @@ fn scan_struct_expr_fields(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_77_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_77_0; }
                 pos += 1;
-                pos = scan_struct_base(tokens, pos);
+                pos = scan_struct_base(tokens, pos, 0);
                 if pos < 0 { break sg_77_0; }
                 if pos > sg_77_best { sg_77_best = pos; }
             }
@@ -13051,11 +13051,11 @@ fn scan_struct_expr_fields(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_struct_expr_field(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_struct_expr_field(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && tokens[pos].kind == TK_POUND {
         let sp = pos;
-        pos = scan_outer_attribute(tokens, pos);
+        pos = scan_outer_attribute(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -13066,7 +13066,7 @@ fn scan_struct_expr_field(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_78: {
             pos = gp_78;
             sg_78_0: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break sg_78_0; }
                 if pos > sg_78_best { sg_78_best = pos; }
             }
@@ -13078,13 +13078,13 @@ fn scan_struct_expr_field(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_79: {
                         pos = gp_79;
                         sg_79_0: {
-                            pos = scan_identifier(tokens, pos);
+                            pos = scan_identifier(tokens, pos, 0);
                             if pos < 0 { break sg_79_0; }
                             break sg_79;
                         }
                         pos = gp_79;
                         sg_79_1: {
-                            pos = scan_tuple_index(tokens, pos);
+                            pos = scan_tuple_index(tokens, pos, 0);
                             if pos < 0 { break sg_79_1; }
                             break sg_79;
                         }
@@ -13093,7 +13093,7 @@ fn scan_struct_expr_field(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_COLON { break sg_78_1; }
                 pos += 1;
-                pos = scan_expression(tokens, pos);
+                pos = scan_expression(tokens, pos, 0);
                 if pos < 0 { break sg_78_1; }
                 if pos > sg_78_best { sg_78_best = pos; }
             }
@@ -13104,30 +13104,30 @@ fn scan_struct_expr_field(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_struct_base(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_struct_base(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_DOTDOT { return -1; }
     pos += 1;
-    pos = scan_expression(tokens, pos);
+    pos = scan_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_struct_expr_tuple(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_struct_expr_tuple(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_path_in_expression(tokens, pos);
+    pos = scan_path_in_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
     pos += 1;
     while pos < tokens.len() && tokens[pos].kind == TK_POUND {
         let sp = pos;
-        pos = scan_inner_attribute(tokens, pos);
+        pos = scan_inner_attribute(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
     if pos < tokens.len() && _gale_kind_set_51(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_COMMA && pos + 2 < tokens.len() && tokens[pos + 2].kind == TK_COMMA {
         sol_80: {
-            pos = scan_expression(tokens, pos);
+            pos = scan_expression(tokens, pos, 0);
             if pos < 0 { break sol_80; }
             while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
                 let sp = pos;
@@ -13135,7 +13135,7 @@ fn scan_struct_expr_tuple(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_81: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_81; }
                         pos += 1;
-                        pos = scan_expression(tokens, pos);
+                        pos = scan_expression(tokens, pos, 0);
                         if pos < 0 { break sg_81; }
                         break sg_81_done;
                     }
@@ -13149,14 +13149,14 @@ fn scan_struct_expr_tuple(tokens: &Array<Token>, pos: i32) -> i32 {
         }
     } else if pos < tokens.len() && _gale_kind_set_51(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_COMMA {
         sol_82: {
-            pos = scan_expression(tokens, pos);
+            pos = scan_expression(tokens, pos, 0);
             if pos < 0 { break sol_82; }
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sol_82; }
             pos += 1;
         }
     } else if pos < tokens.len() && _gale_kind_set_51(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_COMMA {
         sol_83: {
-            pos = scan_expression(tokens, pos);
+            pos = scan_expression(tokens, pos, 0);
             if pos < 0 { break sol_83; }
             while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
                 let sp = pos;
@@ -13164,7 +13164,7 @@ fn scan_struct_expr_tuple(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_84: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_84; }
                         pos += 1;
-                        pos = scan_expression(tokens, pos);
+                        pos = scan_expression(tokens, pos, 0);
                         if pos < 0 { break sg_84; }
                         break sg_84_done;
                     }
@@ -13176,7 +13176,7 @@ fn scan_struct_expr_tuple(tokens: &Array<Token>, pos: i32) -> i32 {
         }
     } else if pos < tokens.len() && _gale_kind_set_51(tokens[pos].kind) {
         sol_85: {
-            pos = scan_expression(tokens, pos);
+            pos = scan_expression(tokens, pos, 0);
             if pos < 0 { break sol_85; }
         }
     }
@@ -13185,14 +13185,14 @@ fn scan_struct_expr_tuple(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_struct_expr_unit(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_struct_expr_unit(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_path_in_expression(tokens, pos);
+    pos = scan_path_in_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_enumeration_variant_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_enumeration_variant_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -13200,19 +13200,19 @@ fn scan_enumeration_variant_expression(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_61(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_enum_expr_struct(tokens, pos);
+                pos = scan_enum_expr_struct(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_1: {
-                pos = scan_enum_expr_tuple(tokens, pos);
+                pos = scan_enum_expr_tuple(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_2: {
-                pos = scan_enum_expr_fieldless(tokens, pos);
+                pos = scan_enum_expr_fieldless(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -13224,15 +13224,15 @@ fn scan_enumeration_variant_expression(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_enum_expr_struct(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_enum_expr_struct(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_path_in_expression(tokens, pos);
+    pos = scan_path_in_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LCURLYBRACE { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_65(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_enum_expr_fields(tokens, pos);
+        pos = scan_enum_expr_fields(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_RCURLYBRACE { return -1; }
@@ -13240,9 +13240,9 @@ fn scan_enum_expr_struct(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_enum_expr_fields(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_enum_expr_fields(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_enum_expr_field(tokens, pos);
+    pos = scan_enum_expr_field(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
         let sp = pos;
@@ -13250,7 +13250,7 @@ fn scan_enum_expr_fields(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_86: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_86; }
                 pos += 1;
-                pos = scan_enum_expr_field(tokens, pos);
+                pos = scan_enum_expr_field(tokens, pos, 0);
                 if pos < 0 { break sg_86; }
                 break sg_86_done;
             }
@@ -13267,7 +13267,7 @@ fn scan_enum_expr_fields(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_enum_expr_field(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_enum_expr_field(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -13275,7 +13275,7 @@ fn scan_enum_expr_field(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_17(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -13287,13 +13287,13 @@ fn scan_enum_expr_field(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_87: {
                         pos = gp_87;
                         sg_87_0: {
-                            pos = scan_identifier(tokens, pos);
+                            pos = scan_identifier(tokens, pos, 0);
                             if pos < 0 { break sg_87_0; }
                             break sg_87;
                         }
                         pos = gp_87;
                         sg_87_1: {
-                            pos = scan_tuple_index(tokens, pos);
+                            pos = scan_tuple_index(tokens, pos, 0);
                             if pos < 0 { break sg_87_1; }
                             break sg_87;
                         }
@@ -13302,7 +13302,7 @@ fn scan_enum_expr_field(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_COLON { break try_1; }
                 pos += 1;
-                pos = scan_expression(tokens, pos);
+                pos = scan_expression(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -13316,13 +13316,13 @@ fn scan_enum_expr_field(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_88: {
                         pos = gp_88;
                         sg_88_0: {
-                            pos = scan_identifier(tokens, pos);
+                            pos = scan_identifier(tokens, pos, 0);
                             if pos < 0 { break sg_88_0; }
                             break sg_88;
                         }
                         pos = gp_88;
                         sg_88_1: {
-                            pos = scan_tuple_index(tokens, pos);
+                            pos = scan_tuple_index(tokens, pos, 0);
                             if pos < 0 { break sg_88_1; }
                             break sg_88;
                         }
@@ -13331,7 +13331,7 @@ fn scan_enum_expr_field(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_COLON { break try_1; }
                 pos += 1;
-                pos = scan_expression(tokens, pos);
+                pos = scan_expression(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -13343,15 +13343,15 @@ fn scan_enum_expr_field(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_enum_expr_tuple(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_enum_expr_tuple(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_path_in_expression(tokens, pos);
+    pos = scan_path_in_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_51(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_COMMA && pos + 2 < tokens.len() && tokens[pos + 2].kind == TK_COMMA {
         sol_89: {
-            pos = scan_expression(tokens, pos);
+            pos = scan_expression(tokens, pos, 0);
             if pos < 0 { break sol_89; }
             while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
                 let sp = pos;
@@ -13359,7 +13359,7 @@ fn scan_enum_expr_tuple(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_90: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_90; }
                         pos += 1;
-                        pos = scan_expression(tokens, pos);
+                        pos = scan_expression(tokens, pos, 0);
                         if pos < 0 { break sg_90; }
                         break sg_90_done;
                     }
@@ -13373,14 +13373,14 @@ fn scan_enum_expr_tuple(tokens: &Array<Token>, pos: i32) -> i32 {
         }
     } else if pos < tokens.len() && _gale_kind_set_51(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_COMMA {
         sol_91: {
-            pos = scan_expression(tokens, pos);
+            pos = scan_expression(tokens, pos, 0);
             if pos < 0 { break sol_91; }
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sol_91; }
             pos += 1;
         }
     } else if pos < tokens.len() && _gale_kind_set_51(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_COMMA {
         sol_92: {
-            pos = scan_expression(tokens, pos);
+            pos = scan_expression(tokens, pos, 0);
             if pos < 0 { break sol_92; }
             while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
                 let sp = pos;
@@ -13388,7 +13388,7 @@ fn scan_enum_expr_tuple(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_93: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_93; }
                         pos += 1;
-                        pos = scan_expression(tokens, pos);
+                        pos = scan_expression(tokens, pos, 0);
                         if pos < 0 { break sg_93; }
                         break sg_93_done;
                     }
@@ -13400,7 +13400,7 @@ fn scan_enum_expr_tuple(tokens: &Array<Token>, pos: i32) -> i32 {
         }
     } else if pos < tokens.len() && _gale_kind_set_51(tokens[pos].kind) {
         sol_94: {
-            pos = scan_expression(tokens, pos);
+            pos = scan_expression(tokens, pos, 0);
             if pos < 0 { break sol_94; }
         }
     }
@@ -13409,16 +13409,16 @@ fn scan_enum_expr_tuple(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_enum_expr_fieldless(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_enum_expr_fieldless(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_path_in_expression(tokens, pos);
+    pos = scan_path_in_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_call_params(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_call_params(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_expression(tokens, pos);
+    pos = scan_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
         let sp = pos;
@@ -13426,7 +13426,7 @@ fn scan_call_params(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_95: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_95; }
                 pos += 1;
-                pos = scan_expression(tokens, pos);
+                pos = scan_expression(tokens, pos, 0);
                 if pos < 0 { break sg_95; }
                 break sg_95_done;
             }
@@ -13443,7 +13443,7 @@ fn scan_call_params(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_closure_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_closure_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_KW_MOVE {
         let sp = pos;
@@ -13466,7 +13466,7 @@ fn scan_closure_expression(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos < tokens.len() && _gale_kind_set_67(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_closure_parameters(tokens, pos);
+                    pos = scan_closure_parameters(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_OR { break sg_96_1; }
@@ -13482,7 +13482,7 @@ fn scan_closure_expression(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_97: {
             pos = gp_97;
             sg_97_0: {
-                pos = scan_expression(tokens, pos);
+                pos = scan_expression(tokens, pos, 0);
                 if pos < 0 { break sg_97_0; }
                 break sg_97;
             }
@@ -13490,9 +13490,9 @@ fn scan_closure_expression(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_97_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_RARROW { break sg_97_1; }
                 pos += 1;
-                pos = scan_type_no_bounds(tokens, pos);
+                pos = scan_type_no_bounds(tokens, pos, 0);
                 if pos < 0 { break sg_97_1; }
-                pos = scan_block_expression(tokens, pos);
+                pos = scan_block_expression(tokens, pos, 0);
                 if pos < 0 { break sg_97_1; }
                 break sg_97;
             }
@@ -13502,9 +13502,9 @@ fn scan_closure_expression(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_closure_parameters(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_closure_parameters(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_closure_param(tokens, pos);
+    pos = scan_closure_param(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
         let sp = pos;
@@ -13512,7 +13512,7 @@ fn scan_closure_parameters(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_98: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_98; }
                 pos += 1;
-                pos = scan_closure_param(tokens, pos);
+                pos = scan_closure_param(tokens, pos, 0);
                 if pos < 0 { break sg_98; }
                 break sg_98_done;
             }
@@ -13529,15 +13529,15 @@ fn scan_closure_parameters(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_closure_param(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_closure_param(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && tokens[pos].kind == TK_POUND {
         let sp = pos;
-        pos = scan_outer_attribute(tokens, pos);
+        pos = scan_outer_attribute(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
-    pos = scan_pattern(tokens, pos);
+    pos = scan_pattern(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_COLON {
         let sp = pos;
@@ -13545,7 +13545,7 @@ fn scan_closure_param(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_99: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_COLON { break sg_99; }
                 pos += 1;
-                pos = scan_type_(tokens, pos);
+                pos = scan_type_(tokens, pos, 0);
                 if pos < 0 { break sg_99; }
                 break sg_99_done;
             }
@@ -13556,11 +13556,11 @@ fn scan_closure_param(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_loop_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_loop_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_LIFETIME_OR_LABEL {
         let sp = pos;
-        pos = scan_loop_label(tokens, pos);
+        pos = scan_loop_label(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     let gp_100 = pos;
@@ -13570,25 +13570,25 @@ fn scan_loop_expression(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_100: {
             pos = gp_100;
             sg_100_0: {
-                pos = scan_infinite_loop_expression(tokens, pos);
+                pos = scan_infinite_loop_expression(tokens, pos, 0);
                 if pos < 0 { break sg_100_0; }
                 break sg_100;
             }
             pos = gp_100;
             sg_100_1: {
-                pos = scan_predicate_loop_expression(tokens, pos);
+                pos = scan_predicate_loop_expression(tokens, pos, 0);
                 if pos < 0 { break sg_100_1; }
                 if pos > sg_100_best { sg_100_best = pos; }
             }
             pos = gp_100;
             sg_100_2: {
-                pos = scan_predicate_pattern_loop_expression(tokens, pos);
+                pos = scan_predicate_pattern_loop_expression(tokens, pos, 0);
                 if pos < 0 { break sg_100_2; }
                 if pos > sg_100_best { sg_100_best = pos; }
             }
             pos = gp_100;
             sg_100_3: {
-                pos = scan_iterator_loop_expression(tokens, pos);
+                pos = scan_iterator_loop_expression(tokens, pos, 0);
                 if pos < 0 { break sg_100_3; }
                 break sg_100;
             }
@@ -13599,59 +13599,59 @@ fn scan_loop_expression(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_infinite_loop_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_infinite_loop_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_LOOP { return -1; }
     pos += 1;
-    pos = scan_block_expression(tokens, pos);
+    pos = scan_block_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_predicate_loop_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_predicate_loop_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_WHILE { return -1; }
     pos += 1;
-    pos = scan_expression(tokens, pos);
+    pos = scan_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_block_expression(tokens, pos);
+    pos = scan_block_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_predicate_pattern_loop_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_predicate_pattern_loop_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_WHILE { return -1; }
     pos += 1;
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_LET { return -1; }
     pos += 1;
-    pos = scan_pattern(tokens, pos);
+    pos = scan_pattern(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EQ { return -1; }
     pos += 1;
-    pos = scan_expression(tokens, pos);
+    pos = scan_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_block_expression(tokens, pos);
+    pos = scan_block_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_iterator_loop_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_iterator_loop_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_FOR { return -1; }
     pos += 1;
-    pos = scan_pattern(tokens, pos);
+    pos = scan_pattern(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_IN { return -1; }
     pos += 1;
-    pos = scan_expression(tokens, pos);
+    pos = scan_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_block_expression(tokens, pos);
+    pos = scan_block_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_loop_label(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_loop_label(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIFETIME_OR_LABEL { return -1; }
     pos += 1;
@@ -13660,13 +13660,13 @@ fn scan_loop_label(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_if_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_if_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_IF { return -1; }
     pos += 1;
-    pos = scan_expression(tokens, pos);
+    pos = scan_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_block_expression(tokens, pos);
+    pos = scan_block_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_KW_ELSE {
         let sp = pos;
@@ -13681,19 +13681,19 @@ fn scan_if_expression(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_102: {
                         pos = gp_102;
                         sg_102_0: {
-                            pos = scan_block_expression(tokens, pos);
+                            pos = scan_block_expression(tokens, pos, 0);
                             if pos < 0 { break sg_102_0; }
                             break sg_102;
                         }
                         pos = gp_102;
                         sg_102_1: {
-                            pos = scan_if_expression(tokens, pos);
+                            pos = scan_if_expression(tokens, pos, 0);
                             if pos < 0 { break sg_102_1; }
                             if pos > sg_102_best { sg_102_best = pos; }
                         }
                         pos = gp_102;
                         sg_102_2: {
-                            pos = scan_if_let_expression(tokens, pos);
+                            pos = scan_if_let_expression(tokens, pos, 0);
                             if pos < 0 { break sg_102_2; }
                             if pos > sg_102_best { sg_102_best = pos; }
                         }
@@ -13710,19 +13710,19 @@ fn scan_if_expression(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_if_let_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_if_let_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_IF { return -1; }
     pos += 1;
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_LET { return -1; }
     pos += 1;
-    pos = scan_pattern(tokens, pos);
+    pos = scan_pattern(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EQ { return -1; }
     pos += 1;
-    pos = scan_expression(tokens, pos);
+    pos = scan_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_block_expression(tokens, pos);
+    pos = scan_block_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_KW_ELSE {
         let sp = pos;
@@ -13737,19 +13737,19 @@ fn scan_if_let_expression(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_104: {
                         pos = gp_104;
                         sg_104_0: {
-                            pos = scan_block_expression(tokens, pos);
+                            pos = scan_block_expression(tokens, pos, 0);
                             if pos < 0 { break sg_104_0; }
                             break sg_104;
                         }
                         pos = gp_104;
                         sg_104_1: {
-                            pos = scan_if_expression(tokens, pos);
+                            pos = scan_if_expression(tokens, pos, 0);
                             if pos < 0 { break sg_104_1; }
                             if pos > sg_104_best { sg_104_best = pos; }
                         }
                         pos = gp_104;
                         sg_104_2: {
-                            pos = scan_if_let_expression(tokens, pos);
+                            pos = scan_if_let_expression(tokens, pos, 0);
                             if pos < 0 { break sg_104_2; }
                             if pos > sg_104_best { sg_104_best = pos; }
                         }
@@ -13766,23 +13766,23 @@ fn scan_if_let_expression(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_match_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_match_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_MATCH { return -1; }
     pos += 1;
-    pos = scan_expression(tokens, pos);
+    pos = scan_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LCURLYBRACE { return -1; }
     pos += 1;
     while pos < tokens.len() && tokens[pos].kind == TK_POUND {
         let sp = pos;
-        pos = scan_inner_attribute(tokens, pos);
+        pos = scan_inner_attribute(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
     if pos < tokens.len() && _gale_kind_set_71(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_match_arms(tokens, pos);
+        pos = scan_match_arms(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_RCURLYBRACE { return -1; }
@@ -13790,17 +13790,17 @@ fn scan_match_expression(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_match_arms(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_match_arms(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && _gale_kind_set_71(tokens[pos].kind) {
         let sp = pos;
         sg_105_done: {
             sg_105: {
-                pos = scan_match_arm(tokens, pos);
+                pos = scan_match_arm(tokens, pos, 0);
                 if pos < 0 { break sg_105; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_FATARROW { break sg_105; }
                 pos += 1;
-                pos = scan_match_arm_expression(tokens, pos);
+                pos = scan_match_arm_expression(tokens, pos, 0);
                 if pos < 0 { break sg_105; }
                 break sg_105_done;
             }
@@ -13809,11 +13809,11 @@ fn scan_match_arms(tokens: &Array<Token>, pos: i32) -> i32 {
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
-    pos = scan_match_arm(tokens, pos);
+    pos = scan_match_arm(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_FATARROW { return -1; }
     pos += 1;
-    pos = scan_expression(tokens, pos);
+    pos = scan_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_COMMA {
         let sp = pos;
@@ -13823,7 +13823,7 @@ fn scan_match_arms(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_match_arm_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_match_arm_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -13831,7 +13831,7 @@ fn scan_match_arm_expression(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_46(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_expression(tokens, pos);
+                pos = scan_expression(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break try_0; }
                 pos += 1;
@@ -13839,7 +13839,7 @@ fn scan_match_arm_expression(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_1: {
-                pos = scan_expression_with_block(tokens, pos);
+                pos = scan_expression_with_block(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos < tokens.len() && tokens[pos].kind == TK_COMMA {
                     let sp = pos;
@@ -13852,7 +13852,7 @@ fn scan_match_arm_expression(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_47(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_expression(tokens, pos);
+                pos = scan_expression(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break try_0; }
                 pos += 1;
@@ -13866,41 +13866,41 @@ fn scan_match_arm_expression(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_match_arm(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_match_arm(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && tokens[pos].kind == TK_POUND {
         let sp = pos;
-        pos = scan_outer_attribute(tokens, pos);
+        pos = scan_outer_attribute(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
-    pos = scan_pattern(tokens, pos);
+    pos = scan_pattern(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_KW_IF {
         let sp = pos;
-        pos = scan_match_arm_guard(tokens, pos);
+        pos = scan_match_arm_guard(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     return pos;
 }
 
-fn scan_match_arm_guard(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_match_arm_guard(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_IF { return -1; }
     pos += 1;
-    pos = scan_expression(tokens, pos);
+    pos = scan_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_pattern(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_OR {
         let sp = pos;
         if pos >= tokens.len() || tokens[pos].kind != TK_OR { pos = -1; } else { pos += 1; }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_pattern_no_top_alt(tokens, pos);
+    pos = scan_pattern_no_top_alt(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_OR {
         let sp = pos;
@@ -13908,7 +13908,7 @@ fn scan_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_106: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_OR { break sg_106; }
                 pos += 1;
-                pos = scan_pattern_no_top_alt(tokens, pos);
+                pos = scan_pattern_no_top_alt(tokens, pos, 0);
                 if pos < 0 { break sg_106; }
                 break sg_106_done;
             }
@@ -13920,7 +13920,7 @@ fn scan_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_pattern_no_top_alt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_pattern_no_top_alt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -13928,7 +13928,7 @@ fn scan_pattern_no_top_alt(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_72(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_pattern_without_range(tokens, pos);
+                pos = scan_pattern_without_range(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -13936,13 +13936,13 @@ fn scan_pattern_no_top_alt(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_73(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_pattern_without_range(tokens, pos);
+                pos = scan_pattern_without_range(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_1: {
-                pos = scan_range_pattern(tokens, pos);
+                pos = scan_range_pattern(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -13954,7 +13954,7 @@ fn scan_pattern_no_top_alt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_pattern_without_range(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_pattern_without_range(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -13962,7 +13962,7 @@ fn scan_pattern_without_range(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_74(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_literal_pattern(tokens, pos);
+                pos = scan_literal_pattern(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -13970,7 +13970,7 @@ fn scan_pattern_without_range(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_75(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_identifier_pattern(tokens, pos);
+                pos = scan_identifier_pattern(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -13978,31 +13978,31 @@ fn scan_pattern_without_range(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_17(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_identifier_pattern(tokens, pos);
+                pos = scan_identifier_pattern(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_5: {
-                pos = scan_struct_pattern(tokens, pos);
+                pos = scan_struct_pattern(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 break scan_alts;
             }
             pos = start;
             try_6: {
-                pos = scan_tuple_struct_pattern(tokens, pos);
+                pos = scan_tuple_struct_pattern(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 break scan_alts;
             }
             pos = start;
             try_10: {
-                pos = scan_path_pattern(tokens, pos);
+                pos = scan_path_pattern(tokens, pos, 0);
                 if pos < 0 { break try_10; }
                 break scan_alts;
             }
             pos = start;
             try_11: {
-                pos = scan_macro_invocation(tokens, pos);
+                pos = scan_macro_invocation(tokens, pos, 0);
                 if pos < 0 { break try_11; }
                 break scan_alts;
             }
@@ -14010,7 +14010,7 @@ fn scan_pattern_without_range(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_UNDERSCORE {
             pos = start;
             try_2: {
-                pos = scan_wildcard_pattern(tokens, pos);
+                pos = scan_wildcard_pattern(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -14018,7 +14018,7 @@ fn scan_pattern_without_range(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_DOTDOT {
             pos = start;
             try_3: {
-                pos = scan_rest_pattern(tokens, pos);
+                pos = scan_rest_pattern(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -14026,7 +14026,7 @@ fn scan_pattern_without_range(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_49(alt_kind) {
             pos = start;
             try_4: {
-                pos = scan_reference_pattern(tokens, pos);
+                pos = scan_reference_pattern(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 break scan_alts;
             }
@@ -14034,25 +14034,25 @@ fn scan_pattern_without_range(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_76(alt_kind) {
             pos = start;
             try_5: {
-                pos = scan_struct_pattern(tokens, pos);
+                pos = scan_struct_pattern(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 break scan_alts;
             }
             pos = start;
             try_6: {
-                pos = scan_tuple_struct_pattern(tokens, pos);
+                pos = scan_tuple_struct_pattern(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 break scan_alts;
             }
             pos = start;
             try_10: {
-                pos = scan_path_pattern(tokens, pos);
+                pos = scan_path_pattern(tokens, pos, 0);
                 if pos < 0 { break try_10; }
                 break scan_alts;
             }
             pos = start;
             try_11: {
-                pos = scan_macro_invocation(tokens, pos);
+                pos = scan_macro_invocation(tokens, pos, 0);
                 if pos < 0 { break try_11; }
                 break scan_alts;
             }
@@ -14060,19 +14060,19 @@ fn scan_pattern_without_range(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_KW_SELFTYPE {
             pos = start;
             try_5: {
-                pos = scan_struct_pattern(tokens, pos);
+                pos = scan_struct_pattern(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 break scan_alts;
             }
             pos = start;
             try_6: {
-                pos = scan_tuple_struct_pattern(tokens, pos);
+                pos = scan_tuple_struct_pattern(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 break scan_alts;
             }
             pos = start;
             try_10: {
-                pos = scan_path_pattern(tokens, pos);
+                pos = scan_path_pattern(tokens, pos, 0);
                 if pos < 0 { break try_10; }
                 break scan_alts;
             }
@@ -14080,13 +14080,13 @@ fn scan_pattern_without_range(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LPAREN {
             pos = start;
             try_7: {
-                pos = scan_tuple_pattern(tokens, pos);
+                pos = scan_tuple_pattern(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 break scan_alts;
             }
             pos = start;
             try_8: {
-                pos = scan_grouped_pattern(tokens, pos);
+                pos = scan_grouped_pattern(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
@@ -14094,7 +14094,7 @@ fn scan_pattern_without_range(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LSQUAREBRACKET {
             pos = start;
             try_9: {
-                pos = scan_slice_pattern(tokens, pos);
+                pos = scan_slice_pattern(tokens, pos, 0);
                 if pos < 0 { break try_9; }
                 break scan_alts;
             }
@@ -14102,7 +14102,7 @@ fn scan_pattern_without_range(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LT {
             pos = start;
             try_10: {
-                pos = scan_path_pattern(tokens, pos);
+                pos = scan_path_pattern(tokens, pos, 0);
                 if pos < 0 { break try_10; }
                 break scan_alts;
             }
@@ -14114,7 +14114,7 @@ fn scan_pattern_without_range(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_literal_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_literal_pattern(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -14240,7 +14240,7 @@ fn scan_literal_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_identifier_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_identifier_pattern(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_KW_REF {
         let sp = pos;
@@ -14252,7 +14252,7 @@ fn scan_identifier_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
         if pos >= tokens.len() || tokens[pos].kind != TK_KW_MUT { pos = -1; } else { pos += 1; }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_AT {
         let sp = pos;
@@ -14260,7 +14260,7 @@ fn scan_identifier_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_107: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_AT { break sg_107; }
                 pos += 1;
-                pos = scan_pattern(tokens, pos);
+                pos = scan_pattern(tokens, pos, 0);
                 if pos < 0 { break sg_107; }
                 break sg_107_done;
             }
@@ -14271,21 +14271,21 @@ fn scan_identifier_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_wildcard_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_wildcard_pattern(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_UNDERSCORE { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_rest_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_rest_pattern(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_DOTDOT { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_range_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_range_pattern(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -14293,27 +14293,27 @@ fn scan_range_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_73(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_range_pattern_bound(tokens, pos);
+                pos = scan_range_pattern_bound(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_DOTDOTEQ { break try_0; }
                 pos += 1;
-                pos = scan_range_pattern_bound(tokens, pos);
+                pos = scan_range_pattern_bound(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_2: {
-                pos = scan_range_pattern_bound(tokens, pos);
+                pos = scan_range_pattern_bound(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_DOTDOTDOT { break try_2; }
                 pos += 1;
-                pos = scan_range_pattern_bound(tokens, pos);
+                pos = scan_range_pattern_bound(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
             pos = start;
             try_1: {
-                pos = scan_range_pattern_bound(tokens, pos);
+                pos = scan_range_pattern_bound(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_DOTDOT { break try_1; }
                 pos += 1;
@@ -14327,7 +14327,7 @@ fn scan_range_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_range_pattern_bound(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_range_pattern_bound(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -14401,7 +14401,7 @@ fn scan_range_pattern_bound(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_77(alt_kind) {
             pos = start;
             try_4: {
-                pos = scan_path_pattern(tokens, pos);
+                pos = scan_path_pattern(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 break scan_alts;
             }
@@ -14413,7 +14413,7 @@ fn scan_range_pattern_bound(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_reference_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_reference_pattern(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     let gp_108 = pos;
     sg_108: {
@@ -14436,20 +14436,20 @@ fn scan_reference_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
         if pos >= tokens.len() || tokens[pos].kind != TK_KW_MUT { pos = -1; } else { pos += 1; }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_pattern_without_range(tokens, pos);
+    pos = scan_pattern_without_range(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_struct_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_struct_pattern(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_path_in_expression(tokens, pos);
+    pos = scan_path_in_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LCURLYBRACE { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_78(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_struct_pattern_elements(tokens, pos);
+        pos = scan_struct_pattern_elements(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_RCURLYBRACE { return -1; }
@@ -14457,7 +14457,7 @@ fn scan_struct_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_struct_pattern_elements(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_struct_pattern_elements(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -14465,19 +14465,19 @@ fn scan_struct_pattern_elements(tokens: &Array<Token>, pos: i32) -> i32 {
         if alt_kind == TK_POUND {
             pos = start;
             try_1: {
-                pos = scan_struct_pattern_et_cetera(tokens, pos);
+                pos = scan_struct_pattern_et_cetera(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_0: {
-                pos = scan_struct_pattern_fields(tokens, pos);
+                pos = scan_struct_pattern_fields(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos < tokens.len() && tokens[pos].kind == TK_COMMA && pos + 1 < tokens.len() && _gale_kind_set_79(tokens[pos + 1].kind) {
                     sol_109: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sol_109; }
                         pos += 1;
-                        pos = scan_struct_pattern_et_cetera(tokens, pos);
+                        pos = scan_struct_pattern_et_cetera(tokens, pos, 0);
                         if pos < 0 { break sol_109; }
                     }
                 } else if pos < tokens.len() && tokens[pos].kind == TK_COMMA {
@@ -14492,13 +14492,13 @@ fn scan_struct_pattern_elements(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_80(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_struct_pattern_fields(tokens, pos);
+                pos = scan_struct_pattern_fields(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos < tokens.len() && tokens[pos].kind == TK_COMMA && pos + 1 < tokens.len() && _gale_kind_set_79(tokens[pos + 1].kind) {
                     sol_111: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sol_111; }
                         pos += 1;
-                        pos = scan_struct_pattern_et_cetera(tokens, pos);
+                        pos = scan_struct_pattern_et_cetera(tokens, pos, 0);
                         if pos < 0 { break sol_111; }
                     }
                 } else if pos < tokens.len() && tokens[pos].kind == TK_COMMA {
@@ -14513,7 +14513,7 @@ fn scan_struct_pattern_elements(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_DOTDOT {
             pos = start;
             try_1: {
-                pos = scan_struct_pattern_et_cetera(tokens, pos);
+                pos = scan_struct_pattern_et_cetera(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -14525,9 +14525,9 @@ fn scan_struct_pattern_elements(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_struct_pattern_fields(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_struct_pattern_fields(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_struct_pattern_field(tokens, pos);
+    pos = scan_struct_pattern_field(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
         let sp = pos;
@@ -14535,7 +14535,7 @@ fn scan_struct_pattern_fields(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_113: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_113; }
                 pos += 1;
-                pos = scan_struct_pattern_field(tokens, pos);
+                pos = scan_struct_pattern_field(tokens, pos, 0);
                 if pos < 0 { break sg_113; }
                 break sg_113_done;
             }
@@ -14547,11 +14547,11 @@ fn scan_struct_pattern_fields(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_struct_pattern_field(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_struct_pattern_field(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && tokens[pos].kind == TK_POUND {
         let sp = pos;
-        pos = scan_outer_attribute(tokens, pos);
+        pos = scan_outer_attribute(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -14562,21 +14562,21 @@ fn scan_struct_pattern_field(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_114: {
             pos = gp_114;
             sg_114_0: {
-                pos = scan_tuple_index(tokens, pos);
+                pos = scan_tuple_index(tokens, pos, 0);
                 if pos < 0 { break sg_114_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_COLON { break sg_114_0; }
                 pos += 1;
-                pos = scan_pattern(tokens, pos);
+                pos = scan_pattern(tokens, pos, 0);
                 if pos < 0 { break sg_114_0; }
                 break sg_114;
             }
             pos = gp_114;
             sg_114_1: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break sg_114_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_COLON { break sg_114_1; }
                 pos += 1;
-                pos = scan_pattern(tokens, pos);
+                pos = scan_pattern(tokens, pos, 0);
                 if pos < 0 { break sg_114_1; }
                 if pos > sg_114_best { sg_114_best = pos; }
             }
@@ -14592,7 +14592,7 @@ fn scan_struct_pattern_field(tokens: &Array<Token>, pos: i32) -> i32 {
                     if pos >= tokens.len() || tokens[pos].kind != TK_KW_MUT { pos = -1; } else { pos += 1; }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break sg_114_2; }
                 if pos > sg_114_best { sg_114_best = pos; }
             }
@@ -14603,11 +14603,11 @@ fn scan_struct_pattern_field(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_struct_pattern_et_cetera(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_struct_pattern_et_cetera(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && tokens[pos].kind == TK_POUND {
         let sp = pos;
-        pos = scan_outer_attribute(tokens, pos);
+        pos = scan_outer_attribute(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -14616,15 +14616,15 @@ fn scan_struct_pattern_et_cetera(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_tuple_struct_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_tuple_struct_pattern(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_path_in_expression(tokens, pos);
+    pos = scan_path_in_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_81(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_tuple_struct_items(tokens, pos);
+        pos = scan_tuple_struct_items(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { return -1; }
@@ -14632,9 +14632,9 @@ fn scan_tuple_struct_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_tuple_struct_items(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_tuple_struct_items(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_pattern(tokens, pos);
+    pos = scan_pattern(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
         let sp = pos;
@@ -14642,7 +14642,7 @@ fn scan_tuple_struct_items(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_115: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_115; }
                 pos += 1;
-                pos = scan_pattern(tokens, pos);
+                pos = scan_pattern(tokens, pos, 0);
                 if pos < 0 { break sg_115; }
                 break sg_115_done;
             }
@@ -14659,13 +14659,13 @@ fn scan_tuple_struct_items(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_tuple_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_tuple_pattern(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_81(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_tuple_pattern_items(tokens, pos);
+        pos = scan_tuple_pattern_items(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { return -1; }
@@ -14673,7 +14673,7 @@ fn scan_tuple_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_tuple_pattern_items(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_tuple_pattern_items(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -14681,13 +14681,13 @@ fn scan_tuple_pattern_items(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_82(alt_kind) {
             pos = start;
             try_2: {
-                pos = scan_pattern(tokens, pos);
+                pos = scan_pattern(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 sg_116_done: {
                     sg_116: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_116; }
                         pos += 1;
-                        pos = scan_pattern(tokens, pos);
+                        pos = scan_pattern(tokens, pos, 0);
                         if pos < 0 { break sg_116; }
                         break sg_116_done;
                     }
@@ -14699,7 +14699,7 @@ fn scan_tuple_pattern_items(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_117: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_117; }
                             pos += 1;
-                            pos = scan_pattern(tokens, pos);
+                            pos = scan_pattern(tokens, pos, 0);
                             if pos < 0 { break sg_117; }
                             break sg_117_done;
                         }
@@ -14717,7 +14717,7 @@ fn scan_tuple_pattern_items(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_0: {
-                pos = scan_pattern(tokens, pos);
+                pos = scan_pattern(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break try_0; }
                 pos += 1;
@@ -14727,19 +14727,19 @@ fn scan_tuple_pattern_items(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_DOTDOT {
             pos = start;
             try_1: {
-                pos = scan_rest_pattern(tokens, pos);
+                pos = scan_rest_pattern(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_2: {
-                pos = scan_pattern(tokens, pos);
+                pos = scan_pattern(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 sg_118_done: {
                     sg_118: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_118; }
                         pos += 1;
-                        pos = scan_pattern(tokens, pos);
+                        pos = scan_pattern(tokens, pos, 0);
                         if pos < 0 { break sg_118; }
                         break sg_118_done;
                     }
@@ -14751,7 +14751,7 @@ fn scan_tuple_pattern_items(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_119: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_119; }
                             pos += 1;
-                            pos = scan_pattern(tokens, pos);
+                            pos = scan_pattern(tokens, pos, 0);
                             if pos < 0 { break sg_119; }
                             break sg_119_done;
                         }
@@ -14769,7 +14769,7 @@ fn scan_tuple_pattern_items(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_0: {
-                pos = scan_pattern(tokens, pos);
+                pos = scan_pattern(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break try_0; }
                 pos += 1;
@@ -14783,24 +14783,24 @@ fn scan_tuple_pattern_items(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_grouped_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_grouped_pattern(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
     pos += 1;
-    pos = scan_pattern(tokens, pos);
+    pos = scan_pattern(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_slice_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_slice_pattern(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LSQUAREBRACKET { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_81(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_slice_pattern_items(tokens, pos);
+        pos = scan_slice_pattern_items(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_RSQUAREBRACKET { return -1; }
@@ -14808,9 +14808,9 @@ fn scan_slice_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_slice_pattern_items(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_slice_pattern_items(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_pattern(tokens, pos);
+    pos = scan_pattern(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
         let sp = pos;
@@ -14818,7 +14818,7 @@ fn scan_slice_pattern_items(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_120: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_120; }
                 pos += 1;
-                pos = scan_pattern(tokens, pos);
+                pos = scan_pattern(tokens, pos, 0);
                 if pos < 0 { break sg_120; }
                 break sg_120_done;
             }
@@ -14835,7 +14835,7 @@ fn scan_slice_pattern_items(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_path_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_path_pattern(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -14843,7 +14843,7 @@ fn scan_path_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_61(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_path_in_expression(tokens, pos);
+                pos = scan_path_in_expression(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -14851,7 +14851,7 @@ fn scan_path_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LT {
             pos = start;
             try_1: {
-                pos = scan_qualified_path_in_expression(tokens, pos);
+                pos = scan_qualified_path_in_expression(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -14863,7 +14863,7 @@ fn scan_path_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_type_(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_type_(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -14871,13 +14871,13 @@ fn scan_type_(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_83(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_type_no_bounds(tokens, pos);
+                pos = scan_type_no_bounds(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_2: {
-                pos = scan_trait_object_type(tokens, pos);
+                pos = scan_trait_object_type(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -14885,13 +14885,13 @@ fn scan_type_(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_KW_IMPL {
             pos = start;
             try_0: {
-                pos = scan_type_no_bounds(tokens, pos);
+                pos = scan_type_no_bounds(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_1: {
-                pos = scan_impl_trait_type(tokens, pos);
+                pos = scan_impl_trait_type(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -14899,7 +14899,7 @@ fn scan_type_(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_84(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_type_no_bounds(tokens, pos);
+                pos = scan_type_no_bounds(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -14907,7 +14907,7 @@ fn scan_type_(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_26(alt_kind) {
             pos = start;
             try_2: {
-                pos = scan_trait_object_type(tokens, pos);
+                pos = scan_trait_object_type(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -14919,7 +14919,7 @@ fn scan_type_(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_type_no_bounds(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_type_no_bounds(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -14927,19 +14927,19 @@ fn scan_type_no_bounds(tokens: &Array<Token>, pos: i32) -> i32 {
         if alt_kind == TK_LPAREN {
             pos = start;
             try_0: {
-                pos = scan_parenthesized_type(tokens, pos);
+                pos = scan_parenthesized_type(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_2: {
-                pos = scan_trait_object_type_one_bound(tokens, pos);
+                pos = scan_trait_object_type_one_bound(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
             pos = start;
             try_4: {
-                pos = scan_tuple_type(tokens, pos);
+                pos = scan_tuple_type(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 break scan_alts;
             }
@@ -14947,7 +14947,7 @@ fn scan_type_no_bounds(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_KW_IMPL {
             pos = start;
             try_1: {
-                pos = scan_impl_trait_type_one_bound(tokens, pos);
+                pos = scan_impl_trait_type_one_bound(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -14955,7 +14955,7 @@ fn scan_type_no_bounds(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_85(alt_kind) {
             pos = start;
             try_2: {
-                pos = scan_trait_object_type_one_bound(tokens, pos);
+                pos = scan_trait_object_type_one_bound(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -14963,13 +14963,13 @@ fn scan_type_no_bounds(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_KW_FOR {
             pos = start;
             try_2: {
-                pos = scan_trait_object_type_one_bound(tokens, pos);
+                pos = scan_trait_object_type_one_bound(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
             pos = start;
             try_12: {
-                pos = scan_bare_function_type(tokens, pos);
+                pos = scan_bare_function_type(tokens, pos, 0);
                 if pos < 0 { break try_12; }
                 break scan_alts;
             }
@@ -14977,19 +14977,19 @@ fn scan_type_no_bounds(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_9(alt_kind) {
             pos = start;
             try_2: {
-                pos = scan_trait_object_type_one_bound(tokens, pos);
+                pos = scan_trait_object_type_one_bound(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
             pos = start;
             try_3: {
-                pos = scan_type_path(tokens, pos);
+                pos = scan_type_path(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
             pos = start;
             try_13: {
-                pos = scan_macro_invocation(tokens, pos);
+                pos = scan_macro_invocation(tokens, pos, 0);
                 if pos < 0 { break try_13; }
                 break scan_alts;
             }
@@ -14997,13 +14997,13 @@ fn scan_type_no_bounds(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_KW_SELFTYPE {
             pos = start;
             try_2: {
-                pos = scan_trait_object_type_one_bound(tokens, pos);
+                pos = scan_trait_object_type_one_bound(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
             pos = start;
             try_3: {
-                pos = scan_type_path(tokens, pos);
+                pos = scan_type_path(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -15011,7 +15011,7 @@ fn scan_type_no_bounds(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_NOT {
             pos = start;
             try_5: {
-                pos = scan_never_type(tokens, pos);
+                pos = scan_never_type(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 break scan_alts;
             }
@@ -15019,7 +15019,7 @@ fn scan_type_no_bounds(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_STAR {
             pos = start;
             try_6: {
-                pos = scan_raw_pointer_type(tokens, pos);
+                pos = scan_raw_pointer_type(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 break scan_alts;
             }
@@ -15027,7 +15027,7 @@ fn scan_type_no_bounds(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_AND {
             pos = start;
             try_7: {
-                pos = scan_reference_type(tokens, pos);
+                pos = scan_reference_type(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 break scan_alts;
             }
@@ -15035,13 +15035,13 @@ fn scan_type_no_bounds(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LSQUAREBRACKET {
             pos = start;
             try_8: {
-                pos = scan_array_type(tokens, pos);
+                pos = scan_array_type(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
             pos = start;
             try_9: {
-                pos = scan_slice_type(tokens, pos);
+                pos = scan_slice_type(tokens, pos, 0);
                 if pos < 0 { break try_9; }
                 break scan_alts;
             }
@@ -15049,7 +15049,7 @@ fn scan_type_no_bounds(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_UNDERSCORE {
             pos = start;
             try_10: {
-                pos = scan_inferred_type(tokens, pos);
+                pos = scan_inferred_type(tokens, pos, 0);
                 if pos < 0 { break try_10; }
                 break scan_alts;
             }
@@ -15057,7 +15057,7 @@ fn scan_type_no_bounds(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LT {
             pos = start;
             try_11: {
-                pos = scan_qualified_path_in_type(tokens, pos);
+                pos = scan_qualified_path_in_type(tokens, pos, 0);
                 if pos < 0 { break try_11; }
                 break scan_alts;
             }
@@ -15065,7 +15065,7 @@ fn scan_type_no_bounds(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_86(alt_kind) {
             pos = start;
             try_12: {
-                pos = scan_bare_function_type(tokens, pos);
+                pos = scan_bare_function_type(tokens, pos, 0);
                 if pos < 0 { break try_12; }
                 break scan_alts;
             }
@@ -15077,25 +15077,25 @@ fn scan_type_no_bounds(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_parenthesized_type(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_parenthesized_type(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
     pos += 1;
-    pos = scan_type_(tokens, pos);
+    pos = scan_type_(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_never_type(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_never_type(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_NOT { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_tuple_type(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_tuple_type(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
     pos += 1;
@@ -15103,7 +15103,7 @@ fn scan_tuple_type(tokens: &Array<Token>, pos: i32) -> i32 {
         sol_121: {
             sg_122_done: {
                 sg_122: {
-                    pos = scan_type_(tokens, pos);
+                    pos = scan_type_(tokens, pos, 0);
                     if pos < 0 { break sg_122; }
                     if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_122; }
                     pos += 1;
@@ -15115,7 +15115,7 @@ fn scan_tuple_type(tokens: &Array<Token>, pos: i32) -> i32 {
                 let sp = pos;
                 sg_123_done: {
                     sg_123: {
-                        pos = scan_type_(tokens, pos);
+                        pos = scan_type_(tokens, pos, 0);
                         if pos < 0 { break sg_123; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_123; }
                         pos += 1;
@@ -15126,14 +15126,14 @@ fn scan_tuple_type(tokens: &Array<Token>, pos: i32) -> i32 {
                 if pos < 0 { pos = sp; break; }
                 if pos == sp { break; }
             }
-            pos = scan_type_(tokens, pos);
+            pos = scan_type_(tokens, pos, 0);
             if pos < 0 { break sol_121; }
         }
     } else if pos < tokens.len() && _gale_kind_set_38(tokens[pos].kind) {
         sol_124: {
             sg_125_done: {
                 sg_125: {
-                    pos = scan_type_(tokens, pos);
+                    pos = scan_type_(tokens, pos, 0);
                     if pos < 0 { break sg_125; }
                     if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_125; }
                     pos += 1;
@@ -15145,7 +15145,7 @@ fn scan_tuple_type(tokens: &Array<Token>, pos: i32) -> i32 {
                 let sp = pos;
                 sg_126_done: {
                     sg_126: {
-                        pos = scan_type_(tokens, pos);
+                        pos = scan_type_(tokens, pos, 0);
                         if pos < 0 { break sg_126; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_126; }
                         pos += 1;
@@ -15163,39 +15163,39 @@ fn scan_tuple_type(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_array_type(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_array_type(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LSQUAREBRACKET { return -1; }
     pos += 1;
-    pos = scan_type_(tokens, pos);
+    pos = scan_type_(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { return -1; }
     pos += 1;
-    pos = scan_expression(tokens, pos);
+    pos = scan_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_RSQUAREBRACKET { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_slice_type(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_slice_type(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LSQUAREBRACKET { return -1; }
     pos += 1;
-    pos = scan_type_(tokens, pos);
+    pos = scan_type_(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_RSQUAREBRACKET { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_reference_type(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_reference_type(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_AND { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_26(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_lifetime(tokens, pos);
+        pos = scan_lifetime(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos < tokens.len() && tokens[pos].kind == TK_KW_MUT {
@@ -15203,12 +15203,12 @@ fn scan_reference_type(tokens: &Array<Token>, pos: i32) -> i32 {
         if pos >= tokens.len() || tokens[pos].kind != TK_KW_MUT { pos = -1; } else { pos += 1; }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_type_no_bounds(tokens, pos);
+    pos = scan_type_no_bounds(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_raw_pointer_type(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_raw_pointer_type(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_STAR { return -1; }
     pos += 1;
@@ -15228,19 +15228,19 @@ fn scan_raw_pointer_type(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         return -1;
     }
-    pos = scan_type_no_bounds(tokens, pos);
+    pos = scan_type_no_bounds(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_bare_function_type(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_bare_function_type(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_KW_FOR {
         let sp = pos;
-        pos = scan_for_lifetimes(tokens, pos);
+        pos = scan_for_lifetimes(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
-    pos = scan_function_type_qualifiers(tokens, pos);
+    pos = scan_function_type_qualifiers(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_FN { return -1; }
     pos += 1;
@@ -15248,20 +15248,20 @@ fn scan_bare_function_type(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_87(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_function_parameters_maybe_named_variadic(tokens, pos);
+        pos = scan_function_parameters_maybe_named_variadic(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { return -1; }
     pos += 1;
     if pos < tokens.len() && tokens[pos].kind == TK_RARROW {
         let sp = pos;
-        pos = scan_bare_function_return_type(tokens, pos);
+        pos = scan_bare_function_return_type(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     return pos;
 }
 
-fn scan_function_type_qualifiers(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_function_type_qualifiers(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_KW_UNSAFE {
         let sp = pos;
@@ -15272,7 +15272,7 @@ fn scan_function_type_qualifiers(tokens: &Array<Token>, pos: i32) -> i32 {
         sol_128: {
             if pos >= tokens.len() || tokens[pos].kind != TK_KW_EXTERN { break sol_128; }
             pos += 1;
-            pos = scan_abi(tokens, pos);
+            pos = scan_abi(tokens, pos, 0);
             if pos < 0 { break sol_128; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_KW_EXTERN {
@@ -15284,16 +15284,16 @@ fn scan_function_type_qualifiers(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_bare_function_return_type(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_bare_function_return_type(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_RARROW { return -1; }
     pos += 1;
-    pos = scan_type_no_bounds(tokens, pos);
+    pos = scan_type_no_bounds(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_function_parameters_maybe_named_variadic(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_function_parameters_maybe_named_variadic(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -15301,13 +15301,13 @@ fn scan_function_parameters_maybe_named_variadic(tokens: &Array<Token>, pos: i32
         if _gale_kind_set_87(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_maybe_named_function_parameters(tokens, pos);
+                pos = scan_maybe_named_function_parameters(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_1: {
-                pos = scan_maybe_named_function_parameters_variadic(tokens, pos);
+                pos = scan_maybe_named_function_parameters_variadic(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -15319,9 +15319,9 @@ fn scan_function_parameters_maybe_named_variadic(tokens: &Array<Token>, pos: i32
     return pos;
 }
 
-fn scan_maybe_named_function_parameters(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_maybe_named_function_parameters(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_maybe_named_param(tokens, pos);
+    pos = scan_maybe_named_param(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
         let sp = pos;
@@ -15329,7 +15329,7 @@ fn scan_maybe_named_function_parameters(tokens: &Array<Token>, pos: i32) -> i32 
             sg_130: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_130; }
                 pos += 1;
-                pos = scan_maybe_named_param(tokens, pos);
+                pos = scan_maybe_named_param(tokens, pos, 0);
                 if pos < 0 { break sg_130; }
                 break sg_130_done;
             }
@@ -15346,11 +15346,11 @@ fn scan_maybe_named_function_parameters(tokens: &Array<Token>, pos: i32) -> i32 
     return pos;
 }
 
-fn scan_maybe_named_param(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_maybe_named_param(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && tokens[pos].kind == TK_POUND {
         let sp = pos;
-        pos = scan_outer_attribute(tokens, pos);
+        pos = scan_outer_attribute(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -15364,7 +15364,7 @@ fn scan_maybe_named_param(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_132: {
                         pos = gp_132;
                         sg_132_0: {
-                            pos = scan_identifier(tokens, pos);
+                            pos = scan_identifier(tokens, pos, 0);
                             if pos < 0 { break sg_132_0; }
                             break sg_132;
                         }
@@ -15385,18 +15385,18 @@ fn scan_maybe_named_param(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_type_(tokens, pos);
+    pos = scan_type_(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_maybe_named_function_parameters_variadic(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_maybe_named_function_parameters_variadic(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && _gale_kind_set_87(tokens[pos].kind) {
         let sp = pos;
         sg_133_done: {
             sg_133: {
-                pos = scan_maybe_named_param(tokens, pos);
+                pos = scan_maybe_named_param(tokens, pos, 0);
                 if pos < 0 { break sg_133; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_133; }
                 pos += 1;
@@ -15407,13 +15407,13 @@ fn scan_maybe_named_function_parameters_variadic(tokens: &Array<Token>, pos: i32
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
-    pos = scan_maybe_named_param(tokens, pos);
+    pos = scan_maybe_named_param(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { return -1; }
     pos += 1;
     while pos < tokens.len() && tokens[pos].kind == TK_POUND {
         let sp = pos;
-        pos = scan_outer_attribute(tokens, pos);
+        pos = scan_outer_attribute(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -15422,58 +15422,58 @@ fn scan_maybe_named_function_parameters_variadic(tokens: &Array<Token>, pos: i32
     return pos;
 }
 
-fn scan_trait_object_type(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_trait_object_type(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_KW_DYN {
         let sp = pos;
         if pos >= tokens.len() || tokens[pos].kind != TK_KW_DYN { pos = -1; } else { pos += 1; }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_type_param_bounds(tokens, pos);
+    pos = scan_type_param_bounds(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_trait_object_type_one_bound(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_trait_object_type_one_bound(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_KW_DYN {
         let sp = pos;
         if pos >= tokens.len() || tokens[pos].kind != TK_KW_DYN { pos = -1; } else { pos += 1; }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_trait_bound(tokens, pos);
+    pos = scan_trait_bound(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_impl_trait_type(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_impl_trait_type(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_IMPL { return -1; }
     pos += 1;
-    pos = scan_type_param_bounds(tokens, pos);
+    pos = scan_type_param_bounds(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_impl_trait_type_one_bound(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_impl_trait_type_one_bound(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_IMPL { return -1; }
     pos += 1;
-    pos = scan_trait_bound(tokens, pos);
+    pos = scan_trait_bound(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_inferred_type(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_inferred_type(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_UNDERSCORE { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_type_param_bounds(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_type_param_bounds(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_type_param_bound(tokens, pos);
+    pos = scan_type_param_bound(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_PLUS {
         let sp = pos;
@@ -15481,7 +15481,7 @@ fn scan_type_param_bounds(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_134: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_PLUS { break sg_134; }
                 pos += 1;
-                pos = scan_type_param_bound(tokens, pos);
+                pos = scan_type_param_bound(tokens, pos, 0);
                 if pos < 0 { break sg_134; }
                 break sg_134_done;
             }
@@ -15498,7 +15498,7 @@ fn scan_type_param_bounds(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_type_param_bound(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_type_param_bound(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -15506,7 +15506,7 @@ fn scan_type_param_bound(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_26(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_lifetime(tokens, pos);
+                pos = scan_lifetime(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -15514,7 +15514,7 @@ fn scan_type_param_bound(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_88(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_trait_bound(tokens, pos);
+                pos = scan_trait_bound(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -15526,7 +15526,7 @@ fn scan_type_param_bound(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_trait_bound(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_trait_bound(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -15541,10 +15541,10 @@ fn scan_trait_bound(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos < tokens.len() && tokens[pos].kind == TK_KW_FOR {
                     let sp = pos;
-                    pos = scan_for_lifetimes(tokens, pos);
+                    pos = scan_for_lifetimes(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_type_path(tokens, pos);
+                pos = scan_type_path(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -15561,10 +15561,10 @@ fn scan_trait_bound(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos < tokens.len() && tokens[pos].kind == TK_KW_FOR {
                     let sp = pos;
-                    pos = scan_for_lifetimes(tokens, pos);
+                    pos = scan_for_lifetimes(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_type_path(tokens, pos);
+                pos = scan_type_path(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { break try_1; }
                 pos += 1;
@@ -15578,13 +15578,13 @@ fn scan_trait_bound(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_lifetime_bounds(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_lifetime_bounds(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && _gale_kind_set_26(tokens[pos].kind) {
         let sp = pos;
         sg_135_done: {
             sg_135: {
-                pos = scan_lifetime(tokens, pos);
+                pos = scan_lifetime(tokens, pos, 0);
                 if pos < 0 { break sg_135; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_PLUS { break sg_135; }
                 pos += 1;
@@ -15597,27 +15597,27 @@ fn scan_lifetime_bounds(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     if pos < tokens.len() && _gale_kind_set_26(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_lifetime(tokens, pos);
+        pos = scan_lifetime(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     return pos;
 }
 
-fn scan_lifetime(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_lifetime(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_26(tokens[pos].kind) {
         return pos + 1;
     }
     return -1;
 }
 
-fn scan_simple_path(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_simple_path(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_PATHSEP {
         let sp = pos;
         if pos >= tokens.len() || tokens[pos].kind != TK_PATHSEP { pos = -1; } else { pos += 1; }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_simple_path_segment(tokens, pos);
+    pos = scan_simple_path_segment(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_PATHSEP {
         let sp = pos;
@@ -15625,7 +15625,7 @@ fn scan_simple_path(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_136: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_PATHSEP { break sg_136; }
                 pos += 1;
-                pos = scan_simple_path_segment(tokens, pos);
+                pos = scan_simple_path_segment(tokens, pos, 0);
                 if pos < 0 { break sg_136; }
                 break sg_136_done;
             }
@@ -15637,7 +15637,7 @@ fn scan_simple_path(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_simple_path_segment(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_simple_path_segment(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -15645,7 +15645,7 @@ fn scan_simple_path_segment(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_17(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -15689,14 +15689,14 @@ fn scan_simple_path_segment(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_path_in_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_path_in_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_PATHSEP {
         let sp = pos;
         if pos >= tokens.len() || tokens[pos].kind != TK_PATHSEP { pos = -1; } else { pos += 1; }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_path_expr_segment(tokens, pos);
+    pos = scan_path_expr_segment(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_PATHSEP {
         let sp = pos;
@@ -15704,7 +15704,7 @@ fn scan_path_in_expression(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_137: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_PATHSEP { break sg_137; }
                 pos += 1;
-                pos = scan_path_expr_segment(tokens, pos);
+                pos = scan_path_expr_segment(tokens, pos, 0);
                 if pos < 0 { break sg_137; }
                 break sg_137_done;
             }
@@ -15716,9 +15716,9 @@ fn scan_path_in_expression(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_path_expr_segment(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_path_expr_segment(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_path_ident_segment(tokens, pos);
+    pos = scan_path_ident_segment(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_PATHSEP {
         let sp = pos;
@@ -15726,7 +15726,7 @@ fn scan_path_expr_segment(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_138: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_PATHSEP { break sg_138; }
                 pos += 1;
-                pos = scan_generic_args(tokens, pos);
+                pos = scan_generic_args(tokens, pos, 0);
                 if pos < 0 { break sg_138; }
                 break sg_138_done;
             }
@@ -15737,7 +15737,7 @@ fn scan_path_expr_segment(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_path_ident_segment(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_path_ident_segment(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -15745,7 +15745,7 @@ fn scan_path_ident_segment(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_17(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -15797,7 +15797,7 @@ fn scan_path_ident_segment(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_generic_args(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_generic_args(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -15807,7 +15807,7 @@ fn scan_generic_args(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LT { break try_1; }
                 pos += 1;
-                pos = scan_generic_args_lifetimes(tokens, pos);
+                pos = scan_generic_args_lifetimes(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos < tokens.len() && tokens[pos].kind == TK_COMMA {
                     let sp = pos;
@@ -15815,7 +15815,7 @@ fn scan_generic_args(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_139: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_139; }
                             pos += 1;
-                            pos = scan_generic_args_types(tokens, pos);
+                            pos = scan_generic_args_types(tokens, pos, 0);
                             if pos < 0 { break sg_139; }
                             break sg_139_done;
                         }
@@ -15829,7 +15829,7 @@ fn scan_generic_args(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_140: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_140; }
                             pos += 1;
-                            pos = scan_generic_args_bindings(tokens, pos);
+                            pos = scan_generic_args_bindings(tokens, pos, 0);
                             if pos < 0 { break sg_140; }
                             break sg_140_done;
                         }
@@ -15850,7 +15850,7 @@ fn scan_generic_args(tokens: &Array<Token>, pos: i32) -> i32 {
             try_2: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LT { break try_2; }
                 pos += 1;
-                pos = scan_generic_args_types(tokens, pos);
+                pos = scan_generic_args_types(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 if pos < tokens.len() && tokens[pos].kind == TK_COMMA {
                     let sp = pos;
@@ -15858,7 +15858,7 @@ fn scan_generic_args(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_141: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_141; }
                             pos += 1;
-                            pos = scan_generic_args_bindings(tokens, pos);
+                            pos = scan_generic_args_bindings(tokens, pos, 0);
                             if pos < 0 { break sg_141; }
                             break sg_141_done;
                         }
@@ -15883,7 +15883,7 @@ fn scan_generic_args(tokens: &Array<Token>, pos: i32) -> i32 {
                     let sp = pos;
                     sg_142_done: {
                         sg_142: {
-                            pos = scan_generic_arg(tokens, pos);
+                            pos = scan_generic_arg(tokens, pos, 0);
                             if pos < 0 { break sg_142; }
                             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_142; }
                             pos += 1;
@@ -15894,7 +15894,7 @@ fn scan_generic_args(tokens: &Array<Token>, pos: i32) -> i32 {
                     if pos < 0 { pos = sp; break; }
                     if pos == sp { break; }
                 }
-                pos = scan_generic_arg(tokens, pos);
+                pos = scan_generic_arg(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 if pos < tokens.len() && tokens[pos].kind == TK_COMMA {
                     let sp = pos;
@@ -15921,7 +15921,7 @@ fn scan_generic_args(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_generic_arg(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_generic_arg(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -15929,13 +15929,13 @@ fn scan_generic_arg(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_26(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_lifetime(tokens, pos);
+                pos = scan_lifetime(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_1: {
-                pos = scan_type_(tokens, pos);
+                pos = scan_type_(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -15943,7 +15943,7 @@ fn scan_generic_arg(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_91(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_type_(tokens, pos);
+                pos = scan_type_(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -15951,19 +15951,19 @@ fn scan_generic_arg(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_17(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_type_(tokens, pos);
+                pos = scan_type_(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_2: {
-                pos = scan_generic_args_const(tokens, pos);
+                pos = scan_generic_args_const(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
             pos = start;
             try_3: {
-                pos = scan_generic_args_binding(tokens, pos);
+                pos = scan_generic_args_binding(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -15971,13 +15971,13 @@ fn scan_generic_arg(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_92(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_type_(tokens, pos);
+                pos = scan_type_(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_2: {
-                pos = scan_generic_args_const(tokens, pos);
+                pos = scan_generic_args_const(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -15985,7 +15985,7 @@ fn scan_generic_arg(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_93(alt_kind) {
             pos = start;
             try_2: {
-                pos = scan_generic_args_const(tokens, pos);
+                pos = scan_generic_args_const(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -15997,7 +15997,7 @@ fn scan_generic_arg(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_generic_args_const(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_generic_args_const(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -16005,7 +16005,7 @@ fn scan_generic_args_const(tokens: &Array<Token>, pos: i32) -> i32 {
         if alt_kind == TK_LCURLYBRACE {
             pos = start;
             try_0: {
-                pos = scan_block_expression(tokens, pos);
+                pos = scan_block_expression(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -16018,7 +16018,7 @@ fn scan_generic_args_const(tokens: &Array<Token>, pos: i32) -> i32 {
                     if pos >= tokens.len() || tokens[pos].kind != TK_MINUS { pos = -1; } else { pos += 1; }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_literal_expression(tokens, pos);
+                pos = scan_literal_expression(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -16026,7 +16026,7 @@ fn scan_generic_args_const(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_94(alt_kind) {
             pos = start;
             try_2: {
-                pos = scan_simple_path_segment(tokens, pos);
+                pos = scan_simple_path_segment(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -16038,9 +16038,9 @@ fn scan_generic_args_const(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_generic_args_lifetimes(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_generic_args_lifetimes(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_lifetime(tokens, pos);
+    pos = scan_lifetime(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
         let sp = pos;
@@ -16048,7 +16048,7 @@ fn scan_generic_args_lifetimes(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_143: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_143; }
                 pos += 1;
-                pos = scan_lifetime(tokens, pos);
+                pos = scan_lifetime(tokens, pos, 0);
                 if pos < 0 { break sg_143; }
                 break sg_143_done;
             }
@@ -16060,9 +16060,9 @@ fn scan_generic_args_lifetimes(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_generic_args_types(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_generic_args_types(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_type_(tokens, pos);
+    pos = scan_type_(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
         let sp = pos;
@@ -16070,7 +16070,7 @@ fn scan_generic_args_types(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_144: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_144; }
                 pos += 1;
-                pos = scan_type_(tokens, pos);
+                pos = scan_type_(tokens, pos, 0);
                 if pos < 0 { break sg_144; }
                 break sg_144_done;
             }
@@ -16082,9 +16082,9 @@ fn scan_generic_args_types(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_generic_args_bindings(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_generic_args_bindings(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_generic_args_binding(tokens, pos);
+    pos = scan_generic_args_binding(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
         let sp = pos;
@@ -16092,7 +16092,7 @@ fn scan_generic_args_bindings(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_145: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_145; }
                 pos += 1;
-                pos = scan_generic_args_binding(tokens, pos);
+                pos = scan_generic_args_binding(tokens, pos, 0);
                 if pos < 0 { break sg_145; }
                 break sg_145_done;
             }
@@ -16104,26 +16104,26 @@ fn scan_generic_args_bindings(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_generic_args_binding(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_generic_args_binding(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_EQ { return -1; }
     pos += 1;
-    pos = scan_type_(tokens, pos);
+    pos = scan_type_(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_qualified_path_in_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_qualified_path_in_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_qualified_path_type(tokens, pos);
+    pos = scan_qualified_path_type(tokens, pos, 0);
     if pos < 0 { return -1; }
     sg_146_done: {
         sg_146: {
             if pos >= tokens.len() || tokens[pos].kind != TK_PATHSEP { break sg_146; }
             pos += 1;
-            pos = scan_path_expr_segment(tokens, pos);
+            pos = scan_path_expr_segment(tokens, pos, 0);
             if pos < 0 { break sg_146; }
             break sg_146_done;
         }
@@ -16135,7 +16135,7 @@ fn scan_qualified_path_in_expression(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_147: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_PATHSEP { break sg_147; }
                 pos += 1;
-                pos = scan_path_expr_segment(tokens, pos);
+                pos = scan_path_expr_segment(tokens, pos, 0);
                 if pos < 0 { break sg_147; }
                 break sg_147_done;
             }
@@ -16147,11 +16147,11 @@ fn scan_qualified_path_in_expression(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_qualified_path_type(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_qualified_path_type(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LT { return -1; }
     pos += 1;
-    pos = scan_type_(tokens, pos);
+    pos = scan_type_(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_KW_AS {
         let sp = pos;
@@ -16159,7 +16159,7 @@ fn scan_qualified_path_type(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_148: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_KW_AS { break sg_148; }
                 pos += 1;
-                pos = scan_type_path(tokens, pos);
+                pos = scan_type_path(tokens, pos, 0);
                 if pos < 0 { break sg_148; }
                 break sg_148_done;
             }
@@ -16172,15 +16172,15 @@ fn scan_qualified_path_type(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_qualified_path_in_type(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_qualified_path_in_type(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_qualified_path_type(tokens, pos);
+    pos = scan_qualified_path_type(tokens, pos, 0);
     if pos < 0 { return -1; }
     sg_149_done: {
         sg_149: {
             if pos >= tokens.len() || tokens[pos].kind != TK_PATHSEP { break sg_149; }
             pos += 1;
-            pos = scan_type_path_segment(tokens, pos);
+            pos = scan_type_path_segment(tokens, pos, 0);
             if pos < 0 { break sg_149; }
             break sg_149_done;
         }
@@ -16192,7 +16192,7 @@ fn scan_qualified_path_in_type(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_150: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_PATHSEP { break sg_150; }
                 pos += 1;
-                pos = scan_type_path_segment(tokens, pos);
+                pos = scan_type_path_segment(tokens, pos, 0);
                 if pos < 0 { break sg_150; }
                 break sg_150_done;
             }
@@ -16204,14 +16204,14 @@ fn scan_qualified_path_in_type(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_type_path(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_type_path(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_PATHSEP {
         let sp = pos;
         if pos >= tokens.len() || tokens[pos].kind != TK_PATHSEP { pos = -1; } else { pos += 1; }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_type_path_segment(tokens, pos);
+    pos = scan_type_path_segment(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_PATHSEP {
         let sp = pos;
@@ -16219,7 +16219,7 @@ fn scan_type_path(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_151: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_PATHSEP { break sg_151; }
                 pos += 1;
-                pos = scan_type_path_segment(tokens, pos);
+                pos = scan_type_path_segment(tokens, pos, 0);
                 if pos < 0 { break sg_151; }
                 break sg_151_done;
             }
@@ -16231,9 +16231,9 @@ fn scan_type_path(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_type_path_segment(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_type_path_segment(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_path_ident_segment(tokens, pos);
+    pos = scan_path_ident_segment(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_PATHSEP {
         let sp = pos;
@@ -16246,13 +16246,13 @@ fn scan_type_path_segment(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_152: {
             pos = gp_152;
             sg_152_0: {
-                pos = scan_generic_args(tokens, pos);
+                pos = scan_generic_args(tokens, pos, 0);
                 if pos < 0 { break sg_152_0; }
                 break sg_152;
             }
             pos = gp_152;
             sg_152_1: {
-                pos = scan_type_path_fn(tokens, pos);
+                pos = scan_type_path_fn(tokens, pos, 0);
                 if pos < 0 { break sg_152_1; }
                 break sg_152;
             }
@@ -16263,13 +16263,13 @@ fn scan_type_path_segment(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_type_path_fn(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_type_path_fn(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_38(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_type_path_inputs(tokens, pos);
+        pos = scan_type_path_inputs(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { return -1; }
@@ -16280,7 +16280,7 @@ fn scan_type_path_fn(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_153: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_RARROW { break sg_153; }
                 pos += 1;
-                pos = scan_type_(tokens, pos);
+                pos = scan_type_(tokens, pos, 0);
                 if pos < 0 { break sg_153; }
                 break sg_153_done;
             }
@@ -16291,9 +16291,9 @@ fn scan_type_path_fn(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_type_path_inputs(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_type_path_inputs(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_type_(tokens, pos);
+    pos = scan_type_(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
         let sp = pos;
@@ -16301,7 +16301,7 @@ fn scan_type_path_inputs(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_154: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_154; }
                 pos += 1;
-                pos = scan_type_(tokens, pos);
+                pos = scan_type_(tokens, pos, 0);
                 if pos < 0 { break sg_154; }
                 break sg_154_done;
             }
@@ -16318,7 +16318,7 @@ fn scan_type_path_inputs(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_visibility(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_visibility(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_KW_PUB { return -1; }
     pos += 1;
@@ -16354,7 +16354,7 @@ fn scan_visibility(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_156_3: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_KW_IN { break sg_156_3; }
                             pos += 1;
-                            pos = scan_simple_path(tokens, pos);
+                            pos = scan_simple_path(tokens, pos, 0);
                             if pos < 0 { break sg_156_3; }
                             break sg_156;
                         }
@@ -16372,21 +16372,21 @@ fn scan_visibility(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_identifier(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_identifier(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_17(tokens[pos].kind) {
         return pos + 1;
     }
     return -1;
 }
 
-fn scan_keyword(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_keyword(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_97(tokens[pos].kind) {
         return pos + 1;
     }
     return -1;
 }
 
-fn scan_macro_identifier_like_token(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_macro_identifier_like_token(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -16394,7 +16394,7 @@ fn scan_macro_identifier_like_token(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_97(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_keyword(tokens, pos);
+                pos = scan_keyword(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -16402,7 +16402,7 @@ fn scan_macro_identifier_like_token(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_98(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -16410,7 +16410,7 @@ fn scan_macro_identifier_like_token(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_KW_MACRORULES {
             pos = start;
             try_1: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -16452,21 +16452,21 @@ fn scan_macro_identifier_like_token(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_macro_literal_token(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_macro_literal_token(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_literal_expression(tokens, pos);
+    pos = scan_literal_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_macro_punctuation_token(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_macro_punctuation_token(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_7(tokens[pos].kind) {
         return pos + 1;
     }
     return -1;
 }
 
-fn scan_shl(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_shl(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LT { return -1; }
     pos += 1;
@@ -16475,7 +16475,7 @@ fn scan_shl(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_shr(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_shr(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_GT { return -1; }
     pos += 1;
@@ -16492,7 +16492,7 @@ fn parse_crate(p: &mut Parser) -> Result<CrateNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_inner_attribute(tokens, pos);
+            pos = scan_inner_attribute(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -16507,7 +16507,7 @@ fn parse_crate(p: &mut Parser) -> Result<CrateNode, ParseError> {
         rep_scan_2: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_item(tokens, pos);
+            pos = scan_item(tokens, pos, 0);
             if pos < 0 { break rep_scan_2; }
             if pos <= p.pos { break rep_scan_2; }
             rep_scan_pos_2 = pos;
@@ -16549,7 +16549,7 @@ fn parse_delim_token_tree(p: &mut Parser) -> Result<DelimTokenTreeNode, ParseErr
             rep_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_token_tree(tokens, pos);
+                pos = scan_token_tree(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -16574,7 +16574,7 @@ fn parse_delim_token_tree(p: &mut Parser) -> Result<DelimTokenTreeNode, ParseErr
             rep_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_token_tree(tokens, pos);
+                pos = scan_token_tree(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -16599,7 +16599,7 @@ fn parse_delim_token_tree(p: &mut Parser) -> Result<DelimTokenTreeNode, ParseErr
             rep_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_token_tree(tokens, pos);
+                pos = scan_token_tree(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -16635,7 +16635,7 @@ fn parse_token_tree(p: &mut Parser) -> Result<TokenTreeNode, ParseError> {
                 rep_scan: {
                     let tokens = &p.tokens;
                     let mut pos: i32 = p.pos;
-                    pos = scan_token_tree_token(tokens, pos);
+                    pos = scan_token_tree_token(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -16676,7 +16676,7 @@ fn parse_token_tree_token_bt_1(p: &mut Parser) -> Result<TokenTreeTokenNode, Par
 
 fn parse_token_tree_token_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_macro_literal_token(tokens, pos);
+    pos = scan_macro_literal_token(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -16692,7 +16692,7 @@ fn parse_token_tree_token_bt_0(p: &mut Parser) -> Result<TokenTreeTokenNode, Par
 
 fn parse_token_tree_token_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_macro_identifier_like_token(tokens, pos);
+    pos = scan_macro_identifier_like_token(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -16768,7 +16768,7 @@ fn parse_macro_invocation_semi_bt_0(p: &mut Parser) -> Result<MacroInvocationSem
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_token_tree(tokens, pos);
+            pos = scan_token_tree(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -16792,7 +16792,7 @@ fn parse_macro_invocation_semi_bt_0(p: &mut Parser) -> Result<MacroInvocationSem
 
 fn parse_macro_invocation_semi_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_simple_path(tokens, pos);
+    pos = scan_simple_path(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_NOT { return -1; }
     pos += 1;
@@ -16800,7 +16800,7 @@ fn parse_macro_invocation_semi_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     while pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_token_tree(tokens, pos);
+        pos = scan_token_tree(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -16822,7 +16822,7 @@ fn parse_macro_invocation_semi_bt_1(p: &mut Parser) -> Result<MacroInvocationSem
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_token_tree(tokens, pos);
+            pos = scan_token_tree(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -16846,7 +16846,7 @@ fn parse_macro_invocation_semi_bt_1(p: &mut Parser) -> Result<MacroInvocationSem
 
 fn parse_macro_invocation_semi_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_simple_path(tokens, pos);
+    pos = scan_simple_path(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_NOT { return -1; }
     pos += 1;
@@ -16854,7 +16854,7 @@ fn parse_macro_invocation_semi_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     while pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_token_tree(tokens, pos);
+        pos = scan_token_tree(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -16876,7 +16876,7 @@ fn parse_macro_invocation_semi_bt_2(p: &mut Parser) -> Result<MacroInvocationSem
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_token_tree(tokens, pos);
+            pos = scan_token_tree(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -16898,7 +16898,7 @@ fn parse_macro_invocation_semi_bt_2(p: &mut Parser) -> Result<MacroInvocationSem
 
 fn parse_macro_invocation_semi_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_simple_path(tokens, pos);
+    pos = scan_simple_path(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_NOT { return -1; }
     pos += 1;
@@ -16906,7 +16906,7 @@ fn parse_macro_invocation_semi_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     while pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_token_tree(tokens, pos);
+        pos = scan_token_tree(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -17031,7 +17031,7 @@ fn parse_macro_rules(p: &mut Parser) -> Result<MacroRulesNode, ParseError> {
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { break rep_scan; }
             pos += 1;
-            pos = scan_macro_rule(tokens, pos);
+            pos = scan_macro_rule(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -17083,7 +17083,7 @@ fn parse_macro_matcher(p: &mut Parser) -> Result<MacroMatcherNode, ParseError> {
             rep_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_macro_match(tokens, pos);
+                pos = scan_macro_match(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -17108,7 +17108,7 @@ fn parse_macro_matcher(p: &mut Parser) -> Result<MacroMatcherNode, ParseError> {
             rep_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_macro_match(tokens, pos);
+                pos = scan_macro_match(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -17133,7 +17133,7 @@ fn parse_macro_matcher(p: &mut Parser) -> Result<MacroMatcherNode, ParseError> {
             rep_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_macro_match(tokens, pos);
+                pos = scan_macro_match(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -17169,7 +17169,7 @@ fn parse_macro_match_bt_3(p: &mut Parser) -> Result<MacroMatchNode, ParseError> 
             rep_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_macro_match(tokens, pos);
+                pos = scan_macro_match(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -17205,11 +17205,11 @@ fn parse_macro_match_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
     pos += 1;
-    pos = scan_macro_match(tokens, pos);
+    pos = scan_macro_match(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_macro_match(tokens, pos);
+        pos = scan_macro_match(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -17217,10 +17217,10 @@ fn parse_macro_match_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_11(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_macro_rep_sep(tokens, pos);
+        pos = scan_macro_rep_sep(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
-    pos = scan_macro_rep_op(tokens, pos);
+    pos = scan_macro_rep_op(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -17263,7 +17263,7 @@ fn parse_macro_match_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_157: {
             pos = gp_157;
             sg_157_0: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break sg_157_0; }
                 break sg_157;
             }
@@ -17278,7 +17278,7 @@ fn parse_macro_match_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_COLON { return -1; }
     pos += 1;
-    pos = scan_macro_frag_spec(tokens, pos);
+    pos = scan_macro_frag_spec(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -17295,7 +17295,7 @@ fn parse_macro_match(p: &mut Parser) -> Result<MacroMatchNode, ParseError> {
                 rep_scan: {
                     let tokens = &p.tokens;
                     let mut pos: i32 = p.pos;
-                    pos = scan_macro_match_token(tokens, pos);
+                    pos = scan_macro_match_token(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -17343,7 +17343,7 @@ fn parse_macro_match_token_bt_1(p: &mut Parser) -> Result<MacroMatchTokenNode, P
 
 fn parse_macro_match_token_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_macro_literal_token(tokens, pos);
+    pos = scan_macro_literal_token(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -17359,7 +17359,7 @@ fn parse_macro_match_token_bt_0(p: &mut Parser) -> Result<MacroMatchTokenNode, P
 
 fn parse_macro_match_token_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_macro_identifier_like_token(tokens, pos);
+    pos = scan_macro_identifier_like_token(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -17437,7 +17437,7 @@ fn parse_macro_rep_sep_bt_1(p: &mut Parser) -> Result<MacroRepSepNode, ParseErro
 
 fn parse_macro_rep_sep_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_macro_literal_token(tokens, pos);
+    pos = scan_macro_literal_token(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -17453,7 +17453,7 @@ fn parse_macro_rep_sep_bt_0(p: &mut Parser) -> Result<MacroRepSepNode, ParseErro
 
 fn parse_macro_rep_sep_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_macro_identifier_like_token(tokens, pos);
+    pos = scan_macro_identifier_like_token(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -17559,7 +17559,7 @@ fn parse_item(p: &mut Parser) -> Result<ItemNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_outer_attribute(tokens, pos);
+            pos = scan_outer_attribute(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -17601,7 +17601,7 @@ fn parse_vis_item(p: &mut Parser) -> Result<VisItemNode, ParseError> {
             gd_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_module(tokens, pos);
+                pos = scan_module(tokens, pos, 0);
                 if pos < 0 { break gd_scan; }
                 gd_winner = 0;
                 break gd_dispatch;
@@ -17609,7 +17609,7 @@ fn parse_vis_item(p: &mut Parser) -> Result<VisItemNode, ParseError> {
             gd_scan_2: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_extern_crate(tokens, pos);
+                pos = scan_extern_crate(tokens, pos, 0);
                 if pos < 0 { break gd_scan_2; }
                 gd_winner = 1;
                 break gd_dispatch;
@@ -17617,7 +17617,7 @@ fn parse_vis_item(p: &mut Parser) -> Result<VisItemNode, ParseError> {
             gd_scan_3: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_function_(tokens, pos);
+                pos = scan_function_(tokens, pos, 0);
                 if pos < 0 { break gd_scan_3; }
                 gd_winner = 2;
                 break gd_dispatch;
@@ -17625,7 +17625,7 @@ fn parse_vis_item(p: &mut Parser) -> Result<VisItemNode, ParseError> {
             gd_scan_4: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_constant_item(tokens, pos);
+                pos = scan_constant_item(tokens, pos, 0);
                 if pos < 0 { break gd_scan_4; }
                 gd_winner = 3;
                 break gd_dispatch;
@@ -17633,7 +17633,7 @@ fn parse_vis_item(p: &mut Parser) -> Result<VisItemNode, ParseError> {
             gd_scan_5: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_trait_(tokens, pos);
+                pos = scan_trait_(tokens, pos, 0);
                 if pos < 0 { break gd_scan_5; }
                 gd_winner = 4;
                 break gd_dispatch;
@@ -17641,7 +17641,7 @@ fn parse_vis_item(p: &mut Parser) -> Result<VisItemNode, ParseError> {
             gd_scan_6: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_implementation(tokens, pos);
+                pos = scan_implementation(tokens, pos, 0);
                 if pos < 0 { break gd_scan_6; }
                 gd_winner = 5;
                 break gd_dispatch;
@@ -17707,7 +17707,7 @@ fn parse_macro_item_bt_1(p: &mut Parser) -> Result<MacroItemNode, ParseError> {
 
 fn parse_macro_item_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_macro_rules_definition(tokens, pos);
+    pos = scan_macro_rules_definition(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -17723,7 +17723,7 @@ fn parse_macro_item_bt_0(p: &mut Parser) -> Result<MacroItemNode, ParseError> {
 
 fn parse_macro_item_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_macro_invocation_semi(tokens, pos);
+    pos = scan_macro_invocation_semi(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -17790,7 +17790,7 @@ fn parse_module(p: &mut Parser) -> Result<ModuleNode, ParseError> {
             rep_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_inner_attribute(tokens, pos);
+                pos = scan_inner_attribute(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -17805,7 +17805,7 @@ fn parse_module(p: &mut Parser) -> Result<ModuleNode, ParseError> {
             rep_scan_2: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_item(tokens, pos);
+                pos = scan_item(tokens, pos, 0);
                 if pos < 0 { break rep_scan_2; }
                 if pos <= p.pos { break rep_scan_2; }
                 rep_scan_pos_2 = pos;
@@ -17951,7 +17951,7 @@ fn parse_use_tree_bt_1(p: &mut Parser) -> Result<UseTreeNode, ParseError> {
 
 fn parse_use_tree_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_simple_path(tokens, pos);
+    pos = scan_simple_path(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_KW_AS {
         let sp = pos;
@@ -17965,7 +17965,7 @@ fn parse_use_tree_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_159: {
                         pos = gp_159;
                         sg_159_0: {
-                            pos = scan_identifier(tokens, pos);
+                            pos = scan_identifier(tokens, pos, 0);
                             if pos < 0 { break sg_159_0; }
                             break sg_159;
                         }
@@ -18032,7 +18032,7 @@ fn parse_use_tree_bt_0(p: &mut Parser) -> Result<UseTreeNode, ParseError> {
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
                     pos += 1;
-                    pos = scan_use_tree(tokens, pos);
+                    pos = scan_use_tree(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -18083,7 +18083,7 @@ fn parse_use_tree_bt_0(p: &mut Parser) -> Result<UseTreeNode, ParseError> {
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
                     pos += 1;
-                    pos = scan_use_tree(tokens, pos);
+                    pos = scan_use_tree(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -18136,7 +18136,7 @@ fn parse_use_tree_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && _gale_kind_set_9(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_PATHSEP {
         sol_160: {
-            pos = scan_simple_path(tokens, pos);
+            pos = scan_simple_path(tokens, pos, 0);
             if pos < 0 { break sol_160; }
             if pos >= tokens.len() || tokens[pos].kind != TK_PATHSEP { break sol_160; }
             pos += 1;
@@ -18163,7 +18163,7 @@ fn parse_use_tree_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos < tokens.len() && _gale_kind_set_20(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_COMMA && pos + 2 < tokens.len() && tokens[pos + 2].kind == TK_COMMA {
                     sol_163: {
-                        pos = scan_use_tree(tokens, pos);
+                        pos = scan_use_tree(tokens, pos, 0);
                         if pos < 0 { break sol_163; }
                         while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
                             let sp = pos;
@@ -18171,7 +18171,7 @@ fn parse_use_tree_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
                                 sg_164: {
                                     if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_164; }
                                     pos += 1;
-                                    pos = scan_use_tree(tokens, pos);
+                                    pos = scan_use_tree(tokens, pos, 0);
                                     if pos < 0 { break sg_164; }
                                     break sg_164_done;
                                 }
@@ -18185,14 +18185,14 @@ fn parse_use_tree_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                 } else if pos < tokens.len() && _gale_kind_set_20(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_COMMA {
                     sol_165: {
-                        pos = scan_use_tree(tokens, pos);
+                        pos = scan_use_tree(tokens, pos, 0);
                         if pos < 0 { break sol_165; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sol_165; }
                         pos += 1;
                     }
                 } else if pos < tokens.len() && _gale_kind_set_20(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_COMMA {
                     sol_166: {
-                        pos = scan_use_tree(tokens, pos);
+                        pos = scan_use_tree(tokens, pos, 0);
                         if pos < 0 { break sol_166; }
                         while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
                             let sp = pos;
@@ -18200,7 +18200,7 @@ fn parse_use_tree_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
                                 sg_167: {
                                     if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_167; }
                                     pos += 1;
-                                    pos = scan_use_tree(tokens, pos);
+                                    pos = scan_use_tree(tokens, pos, 0);
                                     if pos < 0 { break sg_167; }
                                     break sg_167_done;
                                 }
@@ -18212,7 +18212,7 @@ fn parse_use_tree_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                 } else if pos < tokens.len() && _gale_kind_set_20(tokens[pos].kind) {
                     sol_168: {
-                        pos = scan_use_tree(tokens, pos);
+                        pos = scan_use_tree(tokens, pos, 0);
                         if pos < 0 { break sol_168; }
                     }
                 }
@@ -18398,7 +18398,7 @@ fn parse_function_parameters_bt_1(p: &mut Parser) -> Result<FunctionParametersNo
     opt_scan: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_self_param(tokens, pos);
+        pos = scan_self_param(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break opt_scan; }
         pos += 1;
@@ -18424,7 +18424,7 @@ fn parse_function_parameters_bt_1(p: &mut Parser) -> Result<FunctionParametersNo
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_function_param(tokens, pos);
+            pos = scan_function_param(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -18459,7 +18459,7 @@ fn parse_function_parameters_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_169_done: {
             sg_169: {
-                pos = scan_self_param(tokens, pos);
+                pos = scan_self_param(tokens, pos, 0);
                 if pos < 0 { break sg_169; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_169; }
                 pos += 1;
@@ -18469,7 +18469,7 @@ fn parse_function_parameters_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_function_param(tokens, pos);
+    pos = scan_function_param(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
         let sp = pos;
@@ -18477,7 +18477,7 @@ fn parse_function_parameters_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_170: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_170; }
                 pos += 1;
-                pos = scan_function_param(tokens, pos);
+                pos = scan_function_param(tokens, pos, 0);
                 if pos < 0 { break sg_170; }
                 break sg_170_done;
             }
@@ -18512,7 +18512,7 @@ fn parse_function_parameters_bt_0(p: &mut Parser) -> Result<FunctionParametersNo
 
 fn parse_function_parameters_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_self_param(tokens, pos);
+    pos = scan_self_param(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_COMMA {
         let sp = pos;
@@ -18567,7 +18567,7 @@ fn parse_self_param(p: &mut Parser) -> Result<SelfParamNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_outer_attribute(tokens, pos);
+            pos = scan_outer_attribute(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -18584,7 +18584,7 @@ fn parse_self_param(p: &mut Parser) -> Result<SelfParamNode, ParseError> {
             gd_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_shorthand_self(tokens, pos);
+                pos = scan_shorthand_self(tokens, pos, 0);
                 if pos < 0 { break gd_scan; }
                 gd_winner = 0;
                 break gd_dispatch;
@@ -18667,7 +18667,7 @@ fn parse_function_param(p: &mut Parser) -> Result<FunctionParamNode, ParseError>
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_outer_attribute(tokens, pos);
+            pos = scan_outer_attribute(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -18684,7 +18684,7 @@ fn parse_function_param(p: &mut Parser) -> Result<FunctionParamNode, ParseError>
             gd_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_function_param_pattern(tokens, pos);
+                pos = scan_function_param_pattern(tokens, pos, 0);
                 if pos < 0 { break gd_scan; }
                 gd_winner = 0;
                 break gd_dispatch;
@@ -18802,7 +18802,7 @@ fn parse_struct__bt_0(p: &mut Parser) -> Result<StructNode, ParseError> {
 
 fn parse_struct__scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_struct_struct(tokens, pos);
+    pos = scan_struct_struct(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -18818,7 +18818,7 @@ fn parse_struct__bt_1(p: &mut Parser) -> Result<StructNode, ParseError> {
 
 fn parse_struct__scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_tuple_struct(tokens, pos);
+    pos = scan_tuple_struct(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -18956,7 +18956,7 @@ fn parse_struct_fields(p: &mut Parser) -> Result<StructFieldsNode, ParseError> {
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_struct_field(tokens, pos);
+            pos = scan_struct_field(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -18992,7 +18992,7 @@ fn parse_struct_field(p: &mut Parser) -> Result<StructFieldNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_outer_attribute(tokens, pos);
+            pos = scan_outer_attribute(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -19031,7 +19031,7 @@ fn parse_tuple_fields(p: &mut Parser) -> Result<TupleFieldsNode, ParseError> {
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_tuple_field(tokens, pos);
+            pos = scan_tuple_field(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -19067,7 +19067,7 @@ fn parse_tuple_field(p: &mut Parser) -> Result<TupleFieldNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_outer_attribute(tokens, pos);
+            pos = scan_outer_attribute(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -19138,7 +19138,7 @@ fn parse_enum_items(p: &mut Parser) -> Result<EnumItemsNode, ParseError> {
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_enum_item(tokens, pos);
+            pos = scan_enum_item(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -19174,7 +19174,7 @@ fn parse_enum_item(p: &mut Parser) -> Result<EnumItemNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_outer_attribute(tokens, pos);
+            pos = scan_outer_attribute(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -19198,19 +19198,19 @@ fn parse_enum_item(p: &mut Parser) -> Result<EnumItemNode, ParseError> {
         sg_171: {
             pos = gp_171;
             sg_171_0: {
-                pos = scan_enum_item_tuple(tokens, pos);
+                pos = scan_enum_item_tuple(tokens, pos, 0);
                 if pos < 0 { break sg_171_0; }
                 break sg_171;
             }
             pos = gp_171;
             sg_171_1: {
-                pos = scan_enum_item_struct(tokens, pos);
+                pos = scan_enum_item_struct(tokens, pos, 0);
                 if pos < 0 { break sg_171_1; }
                 break sg_171;
             }
             pos = gp_171;
             sg_171_2: {
-                pos = scan_enum_item_discriminant(tokens, pos);
+                pos = scan_enum_item_discriminant(tokens, pos, 0);
                 if pos < 0 { break sg_171_2; }
                 break sg_171;
             }
@@ -19443,7 +19443,7 @@ fn parse_trait_(p: &mut Parser) -> Result<TraitNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_inner_attribute(tokens, pos);
+            pos = scan_inner_attribute(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -19458,7 +19458,7 @@ fn parse_trait_(p: &mut Parser) -> Result<TraitNode, ParseError> {
         rep_scan_2: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_associated_item(tokens, pos);
+            pos = scan_associated_item(tokens, pos, 0);
             if pos < 0 { break rep_scan_2; }
             if pos <= p.pos { break rep_scan_2; }
             rep_scan_pos_2 = pos;
@@ -19494,7 +19494,7 @@ fn parse_implementation_bt_0(p: &mut Parser) -> Result<ImplementationNode, Parse
 
 fn parse_implementation_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_inherent_impl(tokens, pos);
+    pos = scan_inherent_impl(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -19510,7 +19510,7 @@ fn parse_implementation_bt_1(p: &mut Parser) -> Result<ImplementationNode, Parse
 
 fn parse_implementation_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_trait_impl(tokens, pos);
+    pos = scan_trait_impl(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -19570,7 +19570,7 @@ fn parse_inherent_impl(p: &mut Parser) -> Result<InherentImplNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_inner_attribute(tokens, pos);
+            pos = scan_inner_attribute(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -19585,7 +19585,7 @@ fn parse_inherent_impl(p: &mut Parser) -> Result<InherentImplNode, ParseError> {
         rep_scan_2: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_associated_item(tokens, pos);
+            pos = scan_associated_item(tokens, pos, 0);
             if pos < 0 { break rep_scan_2; }
             if pos <= p.pos { break rep_scan_2; }
             rep_scan_pos_2 = pos;
@@ -19645,7 +19645,7 @@ fn parse_trait_impl(p: &mut Parser) -> Result<TraitImplNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_inner_attribute(tokens, pos);
+            pos = scan_inner_attribute(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -19660,7 +19660,7 @@ fn parse_trait_impl(p: &mut Parser) -> Result<TraitImplNode, ParseError> {
         rep_scan_2: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_associated_item(tokens, pos);
+            pos = scan_associated_item(tokens, pos, 0);
             if pos < 0 { break rep_scan_2; }
             if pos <= p.pos { break rep_scan_2; }
             rep_scan_pos_2 = pos;
@@ -19709,7 +19709,7 @@ fn parse_extern_block(p: &mut Parser) -> Result<ExternBlockNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_inner_attribute(tokens, pos);
+            pos = scan_inner_attribute(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -19724,7 +19724,7 @@ fn parse_extern_block(p: &mut Parser) -> Result<ExternBlockNode, ParseError> {
         rep_scan_2: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_external_item(tokens, pos);
+            pos = scan_external_item(tokens, pos, 0);
             if pos < 0 { break rep_scan_2; }
             if pos <= p.pos { break rep_scan_2; }
             rep_scan_pos_2 = pos;
@@ -19754,7 +19754,7 @@ fn parse_external_item(p: &mut Parser) -> Result<ExternalItemNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_outer_attribute(tokens, pos);
+            pos = scan_outer_attribute(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -19810,7 +19810,7 @@ fn parse_generic_params(p: &mut Parser) -> Result<GenericParamsNode, ParseError>
             rep_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_generic_param(tokens, pos);
+                pos = scan_generic_param(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
                 pos += 1;
@@ -19861,7 +19861,7 @@ fn parse_generic_params(p: &mut Parser) -> Result<GenericParamsNode, ParseError>
             rep_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_generic_param(tokens, pos);
+                pos = scan_generic_param(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
                 pos += 1;
@@ -19915,7 +19915,7 @@ fn parse_generic_param(p: &mut Parser) -> Result<GenericParamNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_outer_attribute(tokens, pos);
+            pos = scan_outer_attribute(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -19932,7 +19932,7 @@ fn parse_generic_param(p: &mut Parser) -> Result<GenericParamNode, ParseError> {
             gd_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_lifetime_param(tokens, pos);
+                pos = scan_lifetime_param(tokens, pos, 0);
                 if pos < 0 { break gd_scan; }
                 gd_winner = 0;
                 break gd_dispatch;
@@ -20054,7 +20054,7 @@ fn parse_where_clause(p: &mut Parser) -> Result<WhereClauseNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_where_clause_item(tokens, pos);
+            pos = scan_where_clause_item(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
             pos += 1;
@@ -20095,7 +20095,7 @@ fn parse_where_clause_item_bt_0(p: &mut Parser) -> Result<WhereClauseItemNode, P
 
 fn parse_where_clause_item_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_lifetime_where_clause_item(tokens, pos);
+    pos = scan_lifetime_where_clause_item(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -20111,7 +20111,7 @@ fn parse_where_clause_item_bt_1(p: &mut Parser) -> Result<WhereClauseItemNode, P
 
 fn parse_where_clause_item_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_type_bound_where_clause_item(tokens, pos);
+    pos = scan_type_bound_where_clause_item(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -20205,7 +20205,7 @@ fn parse_associated_item(p: &mut Parser) -> Result<AssociatedItemNode, ParseErro
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_outer_attribute(tokens, pos);
+            pos = scan_outer_attribute(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -20239,7 +20239,7 @@ fn parse_associated_item(p: &mut Parser) -> Result<AssociatedItemNode, ParseErro
                 gd_scan: {
                     let tokens = &p.tokens;
                     let mut pos: i32 = p.pos;
-                    pos = scan_constant_item(tokens, pos);
+                    pos = scan_constant_item(tokens, pos, 0);
                     if pos < 0 { break gd_scan; }
                     gd_winner = 0;
                     break gd_dispatch;
@@ -20352,7 +20352,7 @@ fn parse_statement_bt_2(p: &mut Parser) -> Result<StatementNode, ParseError> {
 
 fn parse_statement_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_let_statement(tokens, pos);
+    pos = scan_let_statement(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -20368,7 +20368,7 @@ fn parse_statement_bt_4(p: &mut Parser) -> Result<StatementNode, ParseError> {
 
 fn parse_statement_scan_4(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_macro_invocation_semi(tokens, pos);
+    pos = scan_macro_invocation_semi(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -20384,7 +20384,7 @@ fn parse_statement_bt_1(p: &mut Parser) -> Result<StatementNode, ParseError> {
 
 fn parse_statement_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_item(tokens, pos);
+    pos = scan_item(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -20400,7 +20400,7 @@ fn parse_statement_bt_3(p: &mut Parser) -> Result<StatementNode, ParseError> {
 
 fn parse_statement_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_expression_statement(tokens, pos);
+    pos = scan_expression_statement(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -20521,7 +20521,7 @@ fn parse_let_statement(p: &mut Parser) -> Result<LetStatementNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_outer_attribute(tokens, pos);
+            pos = scan_outer_attribute(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -20584,7 +20584,7 @@ fn parse_expression_statement_bt_1(p: &mut Parser) -> Result<ExpressionStatement
 
 fn parse_expression_statement_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_expression_with_block(tokens, pos);
+    pos = scan_expression_with_block(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_SEMI {
         let sp = pos;
@@ -20607,7 +20607,7 @@ fn parse_expression_statement_bt_0(p: &mut Parser) -> Result<ExpressionStatement
 
 fn parse_expression_statement_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_expression(tokens, pos);
+    pos = scan_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { return -1; }
     pos += 1;
@@ -20662,7 +20662,7 @@ fn parse_expression_bt_38(p: &mut Parser) -> Result<ExpressionNode, ParseError> 
 
 fn parse_expression_scan_38(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_expression_with_block(tokens, pos);
+    pos = scan_expression_with_block(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -20677,7 +20677,7 @@ fn parse_expression_bt_0(p: &mut Parser) -> Result<ExpressionNode, ParseError> {
             rep_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_outer_attribute(tokens, pos);
+                pos = scan_outer_attribute(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -20698,15 +20698,15 @@ fn parse_expression_bt_0(p: &mut Parser) -> Result<ExpressionNode, ParseError> {
 
 fn parse_expression_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_outer_attribute(tokens, pos);
+    pos = scan_outer_attribute(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_POUND {
         let sp = pos;
-        pos = scan_outer_attribute(tokens, pos);
+        pos = scan_outer_attribute(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
-    pos = scan_expression_atom(tokens, pos);
+    pos = scan_expression(tokens, pos, 2147483647);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -20722,7 +20722,7 @@ fn parse_expression_bt_39(p: &mut Parser) -> Result<ExpressionNode, ParseError> 
 
 fn parse_expression_scan_39(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_macro_invocation(tokens, pos);
+    pos = scan_macro_invocation(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -20738,7 +20738,7 @@ fn parse_expression_bt_36(p: &mut Parser) -> Result<ExpressionNode, ParseError> 
 
 fn parse_expression_scan_36(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_enumeration_variant_expression(tokens, pos);
+    pos = scan_enumeration_variant_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -20754,7 +20754,7 @@ fn parse_expression_bt_35(p: &mut Parser) -> Result<ExpressionNode, ParseError> 
 
 fn parse_expression_scan_35(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_struct_expression(tokens, pos);
+    pos = scan_struct_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -20770,7 +20770,7 @@ fn parse_expression_bt_2(p: &mut Parser) -> Result<ExpressionNode, ParseError> {
 
 fn parse_expression_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_path_expression(tokens, pos);
+    pos = scan_path_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -20784,7 +20784,7 @@ fn parse_expression_bt_32(p: &mut Parser) -> Result<ExpressionNode, ParseError> 
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_inner_attribute(tokens, pos);
+            pos = scan_inner_attribute(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -20810,11 +20810,11 @@ fn parse_expression_scan_32(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     while pos < tokens.len() && tokens[pos].kind == TK_POUND {
         let sp = pos;
-        pos = scan_inner_attribute(tokens, pos);
+        pos = scan_inner_attribute(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
-    pos = scan_expression(tokens, pos);
+    pos = scan_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { return -1; }
     pos += 1;
@@ -20830,7 +20830,7 @@ fn parse_expression_bt_34(p: &mut Parser) -> Result<ExpressionNode, ParseError> 
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_inner_attribute(tokens, pos);
+            pos = scan_inner_attribute(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -20861,13 +20861,13 @@ fn parse_expression_scan_34(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     while pos < tokens.len() && tokens[pos].kind == TK_POUND {
         let sp = pos;
-        pos = scan_inner_attribute(tokens, pos);
+        pos = scan_inner_attribute(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
     if pos < tokens.len() && _gale_kind_set_51(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_tuple_elements(tokens, pos);
+        pos = scan_tuple_elements(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { return -1; }
@@ -21129,7 +21129,7 @@ fn parse_expression_atom(p: &mut Parser) -> Result<ExpressionNode, ParseError> {
             rep_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_inner_attribute(tokens, pos);
+                pos = scan_inner_attribute(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -21757,7 +21757,7 @@ fn parse_expression_with_block_bt_5(p: &mut Parser) -> Result<ExpressionWithBloc
 
 fn parse_expression_with_block_scan_5(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_if_expression(tokens, pos);
+    pos = scan_if_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -21773,7 +21773,7 @@ fn parse_expression_with_block_bt_6(p: &mut Parser) -> Result<ExpressionWithBloc
 
 fn parse_expression_with_block_scan_6(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_if_let_expression(tokens, pos);
+    pos = scan_if_let_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -21790,7 +21790,7 @@ fn parse_expression_with_block(p: &mut Parser) -> Result<ExpressionWithBlockNode
                 rep_scan: {
                     let tokens = &p.tokens;
                     let mut pos: i32 = p.pos;
-                    pos = scan_outer_attribute(tokens, pos);
+                    pos = scan_outer_attribute(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -21972,7 +21972,7 @@ fn parse_block_expression(p: &mut Parser) -> Result<BlockExpressionNode, ParseEr
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_inner_attribute(tokens, pos);
+            pos = scan_inner_attribute(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -22008,7 +22008,7 @@ fn parse_statements_bt_1(p: &mut Parser) -> Result<StatementsNode, ParseError> {
 
 fn parse_statements_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_expression(tokens, pos);
+    pos = scan_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -22023,7 +22023,7 @@ fn parse_statements_bt_0(p: &mut Parser) -> Result<StatementsNode, ParseError> {
             rep_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_statement(tokens, pos);
+                pos = scan_statement(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -22049,17 +22049,17 @@ fn parse_statements_bt_0(p: &mut Parser) -> Result<StatementsNode, ParseError> {
 
 fn parse_statements_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_statement(tokens, pos);
+    pos = scan_statement(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && _gale_kind_set_62(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_statement(tokens, pos);
+        pos = scan_statement(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
     if pos < tokens.len() && _gale_kind_set_51(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression(tokens, pos);
+        pos = scan_expression(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     return pos;
@@ -22142,7 +22142,7 @@ fn parse_array_elements_bt_0(p: &mut Parser) -> Result<ArrayElementsNode, ParseE
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_expression(tokens, pos);
+            pos = scan_expression(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -22172,7 +22172,7 @@ fn parse_array_elements_bt_0(p: &mut Parser) -> Result<ArrayElementsNode, ParseE
 
 fn parse_array_elements_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_expression(tokens, pos);
+    pos = scan_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_COMMA {
         let sp = pos;
@@ -22180,7 +22180,7 @@ fn parse_array_elements_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_172: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_172; }
                 pos += 1;
-                pos = scan_expression(tokens, pos);
+                pos = scan_expression(tokens, pos, 0);
                 if pos < 0 { break sg_172; }
                 break sg_172_done;
             }
@@ -22212,11 +22212,11 @@ fn parse_array_elements_bt_1(p: &mut Parser) -> Result<ArrayElementsNode, ParseE
 
 fn parse_array_elements_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_expression(tokens, pos);
+    pos = scan_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_SEMI { return -1; }
     pos += 1;
-    pos = scan_expression(tokens, pos);
+    pos = scan_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -22266,7 +22266,7 @@ fn parse_tuple_elements(p: &mut Parser) -> Result<TupleElementsNode, ParseError>
             rep_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_expression(tokens, pos);
+                pos = scan_expression(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
                 pos += 1;
@@ -22317,7 +22317,7 @@ fn parse_struct_expression_bt_0(p: &mut Parser) -> Result<StructExpressionNode, 
 
 fn parse_struct_expression_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_struct_expr_struct(tokens, pos);
+    pos = scan_struct_expr_struct(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -22333,7 +22333,7 @@ fn parse_struct_expression_bt_1(p: &mut Parser) -> Result<StructExpressionNode, 
 
 fn parse_struct_expression_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_struct_expr_tuple(tokens, pos);
+    pos = scan_struct_expr_tuple(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -22349,7 +22349,7 @@ fn parse_struct_expression_bt_2(p: &mut Parser) -> Result<StructExpressionNode, 
 
 fn parse_struct_expression_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_struct_expr_unit(tokens, pos);
+    pos = scan_struct_expr_unit(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -22407,7 +22407,7 @@ fn parse_struct_expr_struct(p: &mut Parser) -> Result<StructExprStructNode, Pars
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_inner_attribute(tokens, pos);
+            pos = scan_inner_attribute(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -22424,13 +22424,13 @@ fn parse_struct_expr_struct(p: &mut Parser) -> Result<StructExprStructNode, Pars
         sg_173: {
             pos = gp_173;
             sg_173_0: {
-                pos = scan_struct_expr_fields(tokens, pos);
+                pos = scan_struct_expr_fields(tokens, pos, 0);
                 if pos < 0 { break sg_173_0; }
                 break sg_173;
             }
             pos = gp_173;
             sg_173_1: {
-                pos = scan_struct_base(tokens, pos);
+                pos = scan_struct_base(tokens, pos, 0);
                 if pos < 0 { break sg_173_1; }
                 break sg_173;
             }
@@ -22472,7 +22472,7 @@ fn parse_struct_expr_fields(p: &mut Parser) -> Result<StructExprFieldsNode, Pars
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_struct_expr_field(tokens, pos);
+            pos = scan_struct_expr_field(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -22496,7 +22496,7 @@ fn parse_struct_expr_fields(p: &mut Parser) -> Result<StructExprFieldsNode, Pars
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break gd_scan; }
                 pos += 1;
-                pos = scan_struct_base(tokens, pos);
+                pos = scan_struct_base(tokens, pos, 0);
                 if pos < 0 { break gd_scan; }
                 gd_winner = 0;
                 break gd_dispatch;
@@ -22538,7 +22538,7 @@ fn parse_struct_expr_field(p: &mut Parser) -> Result<StructExprFieldNode, ParseE
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_outer_attribute(tokens, pos);
+            pos = scan_outer_attribute(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -22555,7 +22555,7 @@ fn parse_struct_expr_field(p: &mut Parser) -> Result<StructExprFieldNode, ParseE
             gd_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break gd_scan; }
                 gd_winner = 0;
                 break gd_dispatch;
@@ -22615,7 +22615,7 @@ fn parse_struct_expr_tuple(p: &mut Parser) -> Result<StructExprTupleNode, ParseE
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_inner_attribute(tokens, pos);
+            pos = scan_inner_attribute(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -22634,7 +22634,7 @@ fn parse_struct_expr_tuple(p: &mut Parser) -> Result<StructExprTupleNode, ParseE
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_expression(tokens, pos);
+                pos = scan_expression(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -22685,7 +22685,7 @@ fn parse_struct_expr_tuple(p: &mut Parser) -> Result<StructExprTupleNode, ParseE
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_expression(tokens, pos);
+                pos = scan_expression(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -22750,7 +22750,7 @@ fn parse_enumeration_variant_expression_bt_0(p: &mut Parser) -> Result<Enumerati
 
 fn parse_enumeration_variant_expression_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_enum_expr_struct(tokens, pos);
+    pos = scan_enum_expr_struct(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -22766,7 +22766,7 @@ fn parse_enumeration_variant_expression_bt_1(p: &mut Parser) -> Result<Enumerati
 
 fn parse_enumeration_variant_expression_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_enum_expr_tuple(tokens, pos);
+    pos = scan_enum_expr_tuple(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -22782,7 +22782,7 @@ fn parse_enumeration_variant_expression_bt_2(p: &mut Parser) -> Result<Enumerati
 
 fn parse_enumeration_variant_expression_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_enum_expr_fieldless(tokens, pos);
+    pos = scan_enum_expr_fieldless(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -22861,7 +22861,7 @@ fn parse_enum_expr_fields(p: &mut Parser) -> Result<EnumExprFieldsNode, ParseErr
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_enum_expr_field(tokens, pos);
+            pos = scan_enum_expr_field(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -22900,7 +22900,7 @@ fn parse_enum_expr_field_bt_0(p: &mut Parser) -> Result<EnumExprFieldNode, Parse
 
 fn parse_enum_expr_field_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -22935,13 +22935,13 @@ fn parse_enum_expr_field_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_174: {
             pos = gp_174;
             sg_174_0: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break sg_174_0; }
                 break sg_174;
             }
             pos = gp_174;
             sg_174_1: {
-                pos = scan_tuple_index(tokens, pos);
+                pos = scan_tuple_index(tokens, pos, 0);
                 if pos < 0 { break sg_174_1; }
                 break sg_174;
             }
@@ -22950,7 +22950,7 @@ fn parse_enum_expr_field_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_COLON { return -1; }
     pos += 1;
-    pos = scan_expression(tokens, pos);
+    pos = scan_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -22996,7 +22996,7 @@ fn parse_enum_expr_tuple(p: &mut Parser) -> Result<EnumExprTupleNode, ParseError
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_expression(tokens, pos);
+                pos = scan_expression(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -23047,7 +23047,7 @@ fn parse_enum_expr_tuple(p: &mut Parser) -> Result<EnumExprTupleNode, ParseError
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_expression(tokens, pos);
+                pos = scan_expression(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -23111,7 +23111,7 @@ fn parse_call_params(p: &mut Parser) -> Result<CallParamsNode, ParseError> {
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_expression(tokens, pos);
+            pos = scan_expression(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -23207,7 +23207,7 @@ fn parse_closure_parameters(p: &mut Parser) -> Result<ClosureParametersNode, Par
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_closure_param(tokens, pos);
+            pos = scan_closure_param(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -23243,7 +23243,7 @@ fn parse_closure_param(p: &mut Parser) -> Result<ClosureParamNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_outer_attribute(tokens, pos);
+            pos = scan_outer_attribute(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -23291,7 +23291,7 @@ fn parse_loop_expression(p: &mut Parser) -> Result<LoopExpressionNode, ParseErro
             gd_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_predicate_loop_expression(tokens, pos);
+                pos = scan_predicate_loop_expression(tokens, pos, 0);
                 if pos < 0 { break gd_scan; }
                 gd_winner = 0;
                 break gd_dispatch;
@@ -23405,7 +23405,7 @@ fn parse_if_expression(p: &mut Parser) -> Result<IfExpressionNode, ParseError> {
                 gd_scan: {
                     let tokens = &p.tokens;
                     let mut pos: i32 = p.pos;
-                    pos = scan_if_expression(tokens, pos);
+                    pos = scan_if_expression(tokens, pos, 0);
                     if pos < 0 { break gd_scan; }
                     gd_winner = 0;
                     break gd_dispatch;
@@ -23458,7 +23458,7 @@ fn parse_if_let_expression(p: &mut Parser) -> Result<IfLetExpressionNode, ParseE
                 gd_scan: {
                     let tokens = &p.tokens;
                     let mut pos: i32 = p.pos;
-                    pos = scan_if_expression(tokens, pos);
+                    pos = scan_if_expression(tokens, pos, 0);
                     if pos < 0 { break gd_scan; }
                     gd_winner = 0;
                     break gd_dispatch;
@@ -23504,7 +23504,7 @@ fn parse_match_expression(p: &mut Parser) -> Result<MatchExpressionNode, ParseEr
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_inner_attribute(tokens, pos);
+            pos = scan_inner_attribute(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -23539,11 +23539,11 @@ fn parse_match_arms(p: &mut Parser) -> Result<MatchArmsNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_match_arm(tokens, pos);
+            pos = scan_match_arm(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos >= tokens.len() || tokens[pos].kind != TK_FATARROW { break rep_scan; }
             pos += 1;
-            pos = scan_match_arm_expression(tokens, pos);
+            pos = scan_match_arm_expression(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -23596,7 +23596,7 @@ fn parse_match_arm_expression_bt_1(p: &mut Parser) -> Result<MatchArmExpressionN
 
 fn parse_match_arm_expression_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_expression_with_block(tokens, pos);
+    pos = scan_expression_with_block(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_COMMA {
         let sp = pos;
@@ -23619,7 +23619,7 @@ fn parse_match_arm_expression_bt_0(p: &mut Parser) -> Result<MatchArmExpressionN
 
 fn parse_match_arm_expression_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_expression(tokens, pos);
+    pos = scan_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { return -1; }
     pos += 1;
@@ -23671,7 +23671,7 @@ fn parse_match_arm(p: &mut Parser) -> Result<MatchArmNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_outer_attribute(tokens, pos);
+            pos = scan_outer_attribute(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -23723,7 +23723,7 @@ fn parse_pattern(p: &mut Parser) -> Result<PatternNode, ParseError> {
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_OR { break rep_scan; }
             pos += 1;
-            pos = scan_pattern_no_top_alt(tokens, pos);
+            pos = scan_pattern_no_top_alt(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -23756,7 +23756,7 @@ fn parse_pattern_no_top_alt_bt_1(p: &mut Parser) -> Result<PatternNoTopAltNode, 
 
 fn parse_pattern_no_top_alt_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_range_pattern(tokens, pos);
+    pos = scan_range_pattern(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -23772,7 +23772,7 @@ fn parse_pattern_no_top_alt_bt_0(p: &mut Parser) -> Result<PatternNoTopAltNode, 
 
 fn parse_pattern_no_top_alt_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_pattern_without_range(tokens, pos);
+    pos = scan_pattern_without_range(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -23825,7 +23825,7 @@ fn parse_pattern_without_range_bt_1(p: &mut Parser) -> Result<PatternWithoutRang
 
 fn parse_pattern_without_range_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_identifier_pattern(tokens, pos);
+    pos = scan_identifier_pattern(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -23841,7 +23841,7 @@ fn parse_pattern_without_range_bt_11(p: &mut Parser) -> Result<PatternWithoutRan
 
 fn parse_pattern_without_range_scan_11(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_macro_invocation(tokens, pos);
+    pos = scan_macro_invocation(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -23857,7 +23857,7 @@ fn parse_pattern_without_range_bt_6(p: &mut Parser) -> Result<PatternWithoutRang
 
 fn parse_pattern_without_range_scan_6(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_tuple_struct_pattern(tokens, pos);
+    pos = scan_tuple_struct_pattern(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -23873,7 +23873,7 @@ fn parse_pattern_without_range_bt_5(p: &mut Parser) -> Result<PatternWithoutRang
 
 fn parse_pattern_without_range_scan_5(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_struct_pattern(tokens, pos);
+    pos = scan_struct_pattern(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -23889,7 +23889,7 @@ fn parse_pattern_without_range_bt_10(p: &mut Parser) -> Result<PatternWithoutRan
 
 fn parse_pattern_without_range_scan_10(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_path_pattern(tokens, pos);
+    pos = scan_path_pattern(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -23905,7 +23905,7 @@ fn parse_pattern_without_range_bt_7(p: &mut Parser) -> Result<PatternWithoutRang
 
 fn parse_pattern_without_range_scan_7(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_tuple_pattern(tokens, pos);
+    pos = scan_tuple_pattern(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -23921,7 +23921,7 @@ fn parse_pattern_without_range_bt_8(p: &mut Parser) -> Result<PatternWithoutRang
 
 fn parse_pattern_without_range_scan_8(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_grouped_pattern(tokens, pos);
+    pos = scan_grouped_pattern(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -24320,11 +24320,11 @@ fn parse_range_pattern_bt_0(p: &mut Parser) -> Result<RangePatternNode, ParseErr
 
 fn parse_range_pattern_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_range_pattern_bound(tokens, pos);
+    pos = scan_range_pattern_bound(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_DOTDOTEQ { return -1; }
     pos += 1;
-    pos = scan_range_pattern_bound(tokens, pos);
+    pos = scan_range_pattern_bound(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -24344,11 +24344,11 @@ fn parse_range_pattern_bt_2(p: &mut Parser) -> Result<RangePatternNode, ParseErr
 
 fn parse_range_pattern_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_range_pattern_bound(tokens, pos);
+    pos = scan_range_pattern_bound(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_DOTDOTDOT { return -1; }
     pos += 1;
-    pos = scan_range_pattern_bound(tokens, pos);
+    pos = scan_range_pattern_bound(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -24366,7 +24366,7 @@ fn parse_range_pattern_bt_1(p: &mut Parser) -> Result<RangePatternNode, ParseErr
 
 fn parse_range_pattern_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_range_pattern_bound(tokens, pos);
+    pos = scan_range_pattern_bound(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_DOTDOT { return -1; }
     pos += 1;
@@ -24565,7 +24565,7 @@ fn parse_struct_pattern_elements_bt_1(p: &mut Parser) -> Result<StructPatternEle
 
 fn parse_struct_pattern_elements_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_struct_pattern_et_cetera(tokens, pos);
+    pos = scan_struct_pattern_et_cetera(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -24598,13 +24598,13 @@ fn parse_struct_pattern_elements_bt_0(p: &mut Parser) -> Result<StructPatternEle
 
 fn parse_struct_pattern_elements_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_struct_pattern_fields(tokens, pos);
+    pos = scan_struct_pattern_fields(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_COMMA && pos + 1 < tokens.len() && _gale_kind_set_79(tokens[pos + 1].kind) {
         sol_175: {
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sol_175; }
             pos += 1;
-            pos = scan_struct_pattern_et_cetera(tokens, pos);
+            pos = scan_struct_pattern_et_cetera(tokens, pos, 0);
             if pos < 0 { break sol_175; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_COMMA {
@@ -24666,7 +24666,7 @@ fn parse_struct_pattern_fields(p: &mut Parser) -> Result<StructPatternFieldsNode
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_struct_pattern_field(tokens, pos);
+            pos = scan_struct_pattern_field(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -24695,7 +24695,7 @@ fn parse_struct_pattern_field(p: &mut Parser) -> Result<StructPatternFieldNode, 
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_outer_attribute(tokens, pos);
+            pos = scan_outer_attribute(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -24721,11 +24721,11 @@ fn parse_struct_pattern_field(p: &mut Parser) -> Result<StructPatternFieldNode, 
             gd_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break gd_scan; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_COLON { break gd_scan; }
                 pos += 1;
-                pos = scan_pattern(tokens, pos);
+                pos = scan_pattern(tokens, pos, 0);
                 if pos < 0 { break gd_scan; }
                 gd_winner = 0;
                 break gd_dispatch;
@@ -24777,7 +24777,7 @@ fn parse_struct_pattern_et_cetera(p: &mut Parser) -> Result<StructPatternEtCeter
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_outer_attribute(tokens, pos);
+            pos = scan_outer_attribute(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -24825,7 +24825,7 @@ fn parse_tuple_struct_items(p: &mut Parser) -> Result<TupleStructItemsNode, Pars
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_pattern(tokens, pos);
+            pos = scan_pattern(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -24882,7 +24882,7 @@ fn parse_tuple_pattern_items_bt_1(p: &mut Parser) -> Result<TuplePatternItemsNod
 
 fn parse_tuple_pattern_items_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_rest_pattern(tokens, pos);
+    pos = scan_rest_pattern(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -24900,7 +24900,7 @@ fn parse_tuple_pattern_items_bt_2(p: &mut Parser) -> Result<TuplePatternItemsNod
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_pattern(tokens, pos);
+                pos = scan_pattern(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -24932,13 +24932,13 @@ fn parse_tuple_pattern_items_bt_2(p: &mut Parser) -> Result<TuplePatternItemsNod
 
 fn parse_tuple_pattern_items_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_pattern(tokens, pos);
+    pos = scan_pattern(tokens, pos, 0);
     if pos < 0 { return -1; }
     sg_177_done: {
         sg_177: {
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_177; }
             pos += 1;
-            pos = scan_pattern(tokens, pos);
+            pos = scan_pattern(tokens, pos, 0);
             if pos < 0 { break sg_177; }
             break sg_177_done;
         }
@@ -24950,7 +24950,7 @@ fn parse_tuple_pattern_items_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_178: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_178; }
                 pos += 1;
-                pos = scan_pattern(tokens, pos);
+                pos = scan_pattern(tokens, pos, 0);
                 if pos < 0 { break sg_178; }
                 break sg_178_done;
             }
@@ -24980,7 +24980,7 @@ fn parse_tuple_pattern_items_bt_0(p: &mut Parser) -> Result<TuplePatternItemsNod
 
 fn parse_tuple_pattern_items_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_pattern(tokens, pos);
+    pos = scan_pattern(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { return -1; }
     pos += 1;
@@ -25094,7 +25094,7 @@ fn parse_slice_pattern_items(p: &mut Parser) -> Result<SlicePatternItemsNode, Pa
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_pattern(tokens, pos);
+            pos = scan_pattern(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -25157,7 +25157,7 @@ fn parse_type__bt_1(p: &mut Parser) -> Result<TypeNode, ParseError> {
 
 fn parse_type__scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_impl_trait_type(tokens, pos);
+    pos = scan_impl_trait_type(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -25173,7 +25173,7 @@ fn parse_type__bt_2(p: &mut Parser) -> Result<TypeNode, ParseError> {
 
 fn parse_type__scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_trait_object_type(tokens, pos);
+    pos = scan_trait_object_type(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -25189,7 +25189,7 @@ fn parse_type__bt_0(p: &mut Parser) -> Result<TypeNode, ParseError> {
 
 fn parse_type__scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_type_no_bounds(tokens, pos);
+    pos = scan_type_no_bounds(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -25266,7 +25266,7 @@ fn parse_type_no_bounds_bt_0(p: &mut Parser) -> Result<TypeNoBoundsNode, ParseEr
 
 fn parse_type_no_bounds_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_parenthesized_type(tokens, pos);
+    pos = scan_parenthesized_type(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -25282,7 +25282,7 @@ fn parse_type_no_bounds_bt_4(p: &mut Parser) -> Result<TypeNoBoundsNode, ParseEr
 
 fn parse_type_no_bounds_scan_4(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_tuple_type(tokens, pos);
+    pos = scan_tuple_type(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -25298,7 +25298,7 @@ fn parse_type_no_bounds_bt_12(p: &mut Parser) -> Result<TypeNoBoundsNode, ParseE
 
 fn parse_type_no_bounds_scan_12(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_bare_function_type(tokens, pos);
+    pos = scan_bare_function_type(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -25314,7 +25314,7 @@ fn parse_type_no_bounds_bt_13(p: &mut Parser) -> Result<TypeNoBoundsNode, ParseE
 
 fn parse_type_no_bounds_scan_13(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_macro_invocation(tokens, pos);
+    pos = scan_macro_invocation(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -25330,7 +25330,7 @@ fn parse_type_no_bounds_bt_3(p: &mut Parser) -> Result<TypeNoBoundsNode, ParseEr
 
 fn parse_type_no_bounds_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_type_path(tokens, pos);
+    pos = scan_type_path(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -25346,7 +25346,7 @@ fn parse_type_no_bounds_bt_2(p: &mut Parser) -> Result<TypeNoBoundsNode, ParseEr
 
 fn parse_type_no_bounds_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_trait_object_type_one_bound(tokens, pos);
+    pos = scan_trait_object_type_one_bound(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -25362,7 +25362,7 @@ fn parse_type_no_bounds_bt_8(p: &mut Parser) -> Result<TypeNoBoundsNode, ParseEr
 
 fn parse_type_no_bounds_scan_8(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_array_type(tokens, pos);
+    pos = scan_array_type(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -25378,7 +25378,7 @@ fn parse_type_no_bounds_bt_9(p: &mut Parser) -> Result<TypeNoBoundsNode, ParseEr
 
 fn parse_type_no_bounds_scan_9(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_slice_type(tokens, pos);
+    pos = scan_slice_type(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -25605,7 +25605,7 @@ fn parse_tuple_type(p: &mut Parser) -> Result<TupleTypeNode, ParseError> {
                 rep_scan: {
                     let tokens = &p.tokens;
                     let mut pos: i32 = p.pos;
-                    pos = scan_type_(tokens, pos);
+                    pos = scan_type_(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
                     pos += 1;
@@ -25643,7 +25643,7 @@ fn parse_tuple_type(p: &mut Parser) -> Result<TupleTypeNode, ParseError> {
                 rep_scan: {
                     let tokens = &p.tokens;
                     let mut pos: i32 = p.pos;
-                    pos = scan_type_(tokens, pos);
+                    pos = scan_type_(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
                     pos += 1;
@@ -25836,7 +25836,7 @@ fn parse_function_parameters_maybe_named_variadic_bt_0(p: &mut Parser) -> Result
 
 fn parse_function_parameters_maybe_named_variadic_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_maybe_named_function_parameters(tokens, pos);
+    pos = scan_maybe_named_function_parameters(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -25852,7 +25852,7 @@ fn parse_function_parameters_maybe_named_variadic_bt_1(p: &mut Parser) -> Result
 
 fn parse_function_parameters_maybe_named_variadic_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_maybe_named_function_parameters_variadic(tokens, pos);
+    pos = scan_maybe_named_function_parameters_variadic(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -25903,7 +25903,7 @@ fn parse_maybe_named_function_parameters(p: &mut Parser) -> Result<MaybeNamedFun
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_maybe_named_param(tokens, pos);
+            pos = scan_maybe_named_param(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -25939,7 +25939,7 @@ fn parse_maybe_named_param(p: &mut Parser) -> Result<MaybeNamedParamNode, ParseE
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_outer_attribute(tokens, pos);
+            pos = scan_outer_attribute(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -25958,7 +25958,7 @@ fn parse_maybe_named_param(p: &mut Parser) -> Result<MaybeNamedParamNode, ParseE
             sg_179: {
                 pos = gp_179;
                 sg_179_0: {
-                    pos = scan_identifier(tokens, pos);
+                    pos = scan_identifier(tokens, pos, 0);
                     if pos < 0 { break sg_179_0; }
                     break sg_179;
                 }
@@ -26016,7 +26016,7 @@ fn parse_maybe_named_function_parameters_variadic(p: &mut Parser) -> Result<Mayb
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_maybe_named_param(tokens, pos);
+            pos = scan_maybe_named_param(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
             pos += 1;
@@ -26040,7 +26040,7 @@ fn parse_maybe_named_function_parameters_variadic(p: &mut Parser) -> Result<Mayb
         rep_scan_2: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_outer_attribute(tokens, pos);
+            pos = scan_outer_attribute(tokens, pos, 0);
             if pos < 0 { break rep_scan_2; }
             if pos <= p.pos { break rep_scan_2; }
             rep_scan_pos_2 = pos;
@@ -26134,7 +26134,7 @@ fn parse_type_param_bounds(p: &mut Parser) -> Result<TypeParamBoundsNode, ParseE
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_PLUS { break rep_scan; }
             pos += 1;
-            pos = scan_type_param_bound(tokens, pos);
+            pos = scan_type_param_bound(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -26250,7 +26250,7 @@ fn parse_lifetime_bounds(p: &mut Parser) -> Result<LifetimeBoundsNode, ParseErro
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_lifetime(tokens, pos);
+            pos = scan_lifetime(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos >= tokens.len() || tokens[pos].kind != TK_PLUS { break rep_scan; }
             pos += 1;
@@ -26327,7 +26327,7 @@ fn parse_simple_path(p: &mut Parser) -> Result<SimplePathNode, ParseError> {
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_PATHSEP { break rep_scan; }
             pos += 1;
-            pos = scan_simple_path_segment(tokens, pos);
+            pos = scan_simple_path_segment(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -26411,7 +26411,7 @@ fn parse_path_in_expression(p: &mut Parser) -> Result<PathInExpressionNode, Pars
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_PATHSEP { break rep_scan; }
             pos += 1;
-            pos = scan_path_expr_segment(tokens, pos);
+            pos = scan_path_expr_segment(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -26554,7 +26554,7 @@ fn parse_generic_args_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LT { return -1; }
     pos += 1;
-    pos = scan_generic_args_lifetimes(tokens, pos);
+    pos = scan_generic_args_lifetimes(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_COMMA {
         let sp = pos;
@@ -26562,7 +26562,7 @@ fn parse_generic_args_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_180: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_180; }
                 pos += 1;
-                pos = scan_generic_args_types(tokens, pos);
+                pos = scan_generic_args_types(tokens, pos, 0);
                 if pos < 0 { break sg_180; }
                 break sg_180_done;
             }
@@ -26576,7 +26576,7 @@ fn parse_generic_args_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_181: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_181; }
                 pos += 1;
-                pos = scan_generic_args_bindings(tokens, pos);
+                pos = scan_generic_args_bindings(tokens, pos, 0);
                 if pos < 0 { break sg_181; }
                 break sg_181_done;
             }
@@ -26630,7 +26630,7 @@ fn parse_generic_args_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LT { return -1; }
     pos += 1;
-    pos = scan_generic_args_types(tokens, pos);
+    pos = scan_generic_args_types(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_COMMA {
         let sp = pos;
@@ -26638,7 +26638,7 @@ fn parse_generic_args_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_182: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_182; }
                 pos += 1;
-                pos = scan_generic_args_bindings(tokens, pos);
+                pos = scan_generic_args_bindings(tokens, pos, 0);
                 if pos < 0 { break sg_182; }
                 break sg_182_done;
             }
@@ -26665,7 +26665,7 @@ fn parse_generic_args_bt_3(p: &mut Parser) -> Result<GenericArgsNode, ParseError
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_generic_arg(tokens, pos);
+            pos = scan_generic_arg(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
             pos += 1;
@@ -26707,7 +26707,7 @@ fn parse_generic_args_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_183_done: {
             sg_183: {
-                pos = scan_generic_arg(tokens, pos);
+                pos = scan_generic_arg(tokens, pos, 0);
                 if pos < 0 { break sg_183; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break sg_183; }
                 pos += 1;
@@ -26718,7 +26718,7 @@ fn parse_generic_args_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
-    pos = scan_generic_arg(tokens, pos);
+    pos = scan_generic_arg(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_COMMA {
         let sp = pos;
@@ -26810,7 +26810,7 @@ fn parse_generic_arg_bt_0(p: &mut Parser) -> Result<GenericArgNode, ParseError> 
 
 fn parse_generic_arg_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_lifetime(tokens, pos);
+    pos = scan_lifetime(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -26826,7 +26826,7 @@ fn parse_generic_arg_bt_3(p: &mut Parser) -> Result<GenericArgNode, ParseError> 
 
 fn parse_generic_arg_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_generic_args_binding(tokens, pos);
+    pos = scan_generic_args_binding(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -26842,7 +26842,7 @@ fn parse_generic_arg_bt_2(p: &mut Parser) -> Result<GenericArgNode, ParseError> 
 
 fn parse_generic_arg_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_generic_args_const(tokens, pos);
+    pos = scan_generic_args_const(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -26858,7 +26858,7 @@ fn parse_generic_arg_bt_1(p: &mut Parser) -> Result<GenericArgNode, ParseError> 
 
 fn parse_generic_arg_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_type_(tokens, pos);
+    pos = scan_type_(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -27003,7 +27003,7 @@ fn parse_generic_args_lifetimes(p: &mut Parser) -> Result<GenericArgsLifetimesNo
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_lifetime(tokens, pos);
+            pos = scan_lifetime(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -27035,7 +27035,7 @@ fn parse_generic_args_types(p: &mut Parser) -> Result<GenericArgsTypesNode, Pars
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_type_(tokens, pos);
+            pos = scan_type_(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -27067,7 +27067,7 @@ fn parse_generic_args_bindings(p: &mut Parser) -> Result<GenericArgsBindingsNode
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_generic_args_binding(tokens, pos);
+            pos = scan_generic_args_binding(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -27114,7 +27114,7 @@ fn parse_qualified_path_in_expression(p: &mut Parser) -> Result<QualifiedPathInE
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_PATHSEP { break rep_scan; }
                 pos += 1;
-                pos = scan_path_expr_segment(tokens, pos);
+                pos = scan_path_expr_segment(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -27175,7 +27175,7 @@ fn parse_qualified_path_in_type(p: &mut Parser) -> Result<QualifiedPathInTypeNod
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_PATHSEP { break rep_scan; }
                 pos += 1;
-                pos = scan_type_path_segment(tokens, pos);
+                pos = scan_type_path_segment(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -27215,7 +27215,7 @@ fn parse_type_path(p: &mut Parser) -> Result<TypePathNode, ParseError> {
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_PATHSEP { break rep_scan; }
             pos += 1;
-            pos = scan_type_path_segment(tokens, pos);
+            pos = scan_type_path_segment(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -27254,13 +27254,13 @@ fn parse_type_path_segment(p: &mut Parser) -> Result<TypePathSegmentNode, ParseE
         sg_184: {
             pos = gp_184;
             sg_184_0: {
-                pos = scan_generic_args(tokens, pos);
+                pos = scan_generic_args(tokens, pos, 0);
                 if pos < 0 { break sg_184_0; }
                 break sg_184;
             }
             pos = gp_184;
             sg_184_1: {
-                pos = scan_type_path_fn(tokens, pos);
+                pos = scan_type_path_fn(tokens, pos, 0);
                 if pos < 0 { break sg_184_1; }
                 break sg_184;
             }
@@ -27329,7 +27329,7 @@ fn parse_type_path_inputs(p: &mut Parser) -> Result<TypePathInputsNode, ParseErr
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_type_(tokens, pos);
+            pos = scan_type_(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -27828,7 +27828,7 @@ fn parse_macro_identifier_like_token_bt_1(p: &mut Parser) -> Result<MacroIdentif
 
 fn parse_macro_identifier_like_token_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }

--- a/package-gale/tests/generated/rust/rust.wado
+++ b/package-gale/tests/generated/rust/rust.wado
@@ -20748,7 +20748,7 @@ fn parse_expression_bt_0(p: &mut Parser) -> Result<ExpressionNode, ParseError> {
         let outer_attribute = parse_outer_attribute(p)?;
         outer_attribute_list.push(outer_attribute);
     }
-    let expression = parse_expression(p)?;
+    let expression = parse_expression(p, 22)?;
     return Result::<ExpressionNode, ParseError>::Ok(ExpressionNode::AttributedExpression(ExpressionAttributedExpression {
         span: Span::new(start, p.last_end()),
         outer_attribute_list,
@@ -21053,7 +21053,7 @@ fn parse_expression_atom(p: &mut Parser) -> Result<ExpressionNode, ParseError> {
         } else {
             null
         };
-        let expression = parse_expression(p)?;
+        let expression = parse_expression(p, 15)?;
         return Result::<ExpressionNode, ParseError>::Ok(ExpressionNode::BorrowExpression(ExpressionBorrowExpression {
             span: Span::new(start, p.last_end()),
             and_or_andand,
@@ -21063,7 +21063,7 @@ fn parse_expression_atom(p: &mut Parser) -> Result<ExpressionNode, ParseError> {
     }
     if kind == TK_STAR {
         let star = p.expect(TK_STAR)?;
-        let expression = parse_expression(p)?;
+        let expression = parse_expression(p, 15)?;
         return Result::<ExpressionNode, ParseError>::Ok(ExpressionNode::DereferenceExpression(ExpressionDereferenceExpression {
             span: Span::new(start, p.last_end()),
             star,
@@ -21072,7 +21072,7 @@ fn parse_expression_atom(p: &mut Parser) -> Result<ExpressionNode, ParseError> {
     }
     if _gale_kind_set_50(kind) {
         let minus_or_not = p.advance();
-        let expression = parse_expression(p)?;
+        let expression = parse_expression(p, 15)?;
         return Result::<ExpressionNode, ParseError>::Ok(ExpressionNode::NegationExpression(ExpressionNegationExpression {
             span: Span::new(start, p.last_end()),
             minus_or_not,
@@ -21095,7 +21095,7 @@ fn parse_expression_atom(p: &mut Parser) -> Result<ExpressionNode, ParseError> {
     }
     if kind == TK_DOTDOTEQ {
         let dotdoteq = p.expect(TK_DOTDOTEQ)?;
-        let expression = parse_expression(p)?;
+        let expression = parse_expression(p, 4)?;
         return Result::<ExpressionNode, ParseError>::Ok(ExpressionNode::RangeExpression2(ExpressionRangeExpression2 {
             span: Span::new(start, p.last_end()),
             dotdoteq,

--- a/package-gale/tests/generated/sexpression/sexpression.g4.kiln.json
+++ b/package-gale/tests/generated/sexpression/sexpression.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/sexpression/sexpression.wado",
-      "hash": "18f981e32bcfaeae77c739aeef79642d72c5828ec3b9178795c7514ab2758163",
+      "hash": "c1b56ccfb5539027269cf2a32d256c2868221ce8c17354979c4b65d244552517",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/sexpression/sexpression.wado
+++ b/package-gale/tests/generated/sexpression/sexpression.wado
@@ -1124,11 +1124,11 @@ impl Parser {
     }
 }
 
-fn scan_sexpr(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_sexpr(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && _gale_kind_set_0(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_item(tokens, pos);
+        pos = scan_item(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -1137,7 +1137,7 @@ fn scan_sexpr(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_item(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_item(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -1145,7 +1145,7 @@ fn scan_item(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_1(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_atom(tokens, pos);
+                pos = scan_atom(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -1155,11 +1155,11 @@ fn scan_item(tokens: &Array<Token>, pos: i32) -> i32 {
             try_2: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { break try_2; }
                 pos += 1;
-                pos = scan_item(tokens, pos);
+                pos = scan_item(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_DOT { break try_2; }
                 pos += 1;
-                pos = scan_item(tokens, pos);
+                pos = scan_item(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { break try_2; }
                 pos += 1;
@@ -1167,7 +1167,7 @@ fn scan_item(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_1: {
-                pos = scan_list_(tokens, pos);
+                pos = scan_list_(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -1179,13 +1179,13 @@ fn scan_item(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_list_(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_list_(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
     pos += 1;
     while pos < tokens.len() && _gale_kind_set_0(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_item(tokens, pos);
+        pos = scan_item(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -1194,7 +1194,7 @@ fn scan_list_(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_atom(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_atom(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         return pos + 1;
     }
@@ -1209,7 +1209,7 @@ fn parse_sexpr(p: &mut Parser) -> Result<SexprNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_item(tokens, pos);
+            pos = scan_item(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -1247,11 +1247,11 @@ fn parse_item_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LPAREN { return -1; }
     pos += 1;
-    pos = scan_item(tokens, pos);
+    pos = scan_item(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_DOT { return -1; }
     pos += 1;
-    pos = scan_item(tokens, pos);
+    pos = scan_item(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_RPAREN { return -1; }
     pos += 1;
@@ -1269,7 +1269,7 @@ fn parse_item_bt_1(p: &mut Parser) -> Result<ItemNode, ParseError> {
 
 fn parse_item_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_list_(tokens, pos);
+    pos = scan_list_(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -1325,7 +1325,7 @@ fn parse_list_(p: &mut Parser) -> Result<ListNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_item(tokens, pos);
+            pos = scan_item(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;

--- a/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/sqlite/sqlite.wado",
-      "hash": "025e827bc9335ad502b8063840c5438ddce0dbc44c0e8541a0fb89a7a785c2f8",
+      "hash": "813ad4026b0633887076b6e5db16566168db257f63a0dd8cb860b9cfe564594b",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/sqlite/sqlite.wado",
-      "hash": "12bbbb328a467f17829b616f08a57c97e6551739b17888456ee33ecb9b737b52",
+      "hash": "025e827bc9335ad502b8063840c5438ddce0dbc44c0e8541a0fb89a7a785c2f8",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/sqlite/sqlite.wado",
-      "hash": "a5baffeaa7bcda3a710019c75e8a69a38b6c3902d97808a287a7f5c879d09fed",
+      "hash": "12bbbb328a467f17829b616f08a57c97e6551739b17888456ee33ecb9b737b52",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/sqlite/sqlite.wado
+++ b/package-gale/tests/generated/sqlite/sqlite.wado
@@ -15472,7 +15472,7 @@ fn parse_expr_bt_15(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let start = p.peek().span.start;
     let k_cast = p.expect(TK_K_CAST)?;
     let lparen = p.expect(TK_LIT_LPAREN)?;
-    let expr = parse_expr(p)?;
+    let expr = parse_expr(p, 6)?;
     let k_as = p.expect(TK_K_AS)?;
     let type_name = parse_type_name(p)?;
     let rparen = p.expect(TK_LIT_RPAREN)?;
@@ -15508,7 +15508,7 @@ fn parse_expr_bt_22(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let start = p.peek().span.start;
     let k_case = p.expect(TK_K_CASE)?;
     let expr: Option<ExprNode> = if _gale_kind_set_27(p.peek_kind()) {
-        let expr = parse_expr(p)?;
+        let expr = parse_expr(p, 1)?;
         Option::<ExprNode>::Some(expr)
     } else {
         null
@@ -15536,9 +15536,9 @@ fn parse_expr_bt_22(p: &mut Parser) -> Result<ExprNode, ParseError> {
         }
         _plus_first = false;
         let k_when = p.expect(TK_K_WHEN)?;
-        let expr = parse_expr(p)?;
+        let expr = parse_expr(p, 1)?;
         let k_then = p.expect(TK_K_THEN)?;
-        let expr_2 = parse_expr(p)?;
+        let expr_2 = parse_expr(p, 1)?;
         let k_when_expr_k_then_expr = KWhenExprKThenExprItem {
             k_when,
             expr,
@@ -15549,7 +15549,7 @@ fn parse_expr_bt_22(p: &mut Parser) -> Result<ExprNode, ParseError> {
     }
     let k_else_expr: Option<KElseExprItem> = if p.peek_kind() == TK_K_ELSE {
         let k_else = p.expect(TK_K_ELSE)?;
-        let expr = parse_expr(p)?;
+        let expr = parse_expr(p, 1)?;
         let k_else_expr = KElseExprItem {
             k_else,
             expr,
@@ -15689,7 +15689,7 @@ fn parse_expr_scan_21(tokens: &Array<Token>, pos: i32) -> i32 {
 fn parse_expr_bt_14(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let start = p.peek().span.start;
     let lparen = p.expect(TK_LIT_LPAREN)?;
-    let expr = parse_expr(p)?;
+    let expr = parse_expr(p, 6)?;
     let rparen = p.expect(TK_LIT_RPAREN)?;
     return Result::<ExprNode, ParseError>::Ok(ExprNode::Alt14(ExprAlt14 {
         span: Span::new(start, p.last_end()),
@@ -15796,7 +15796,7 @@ fn parse_expr_bt_13(p: &mut Parser) -> Result<ExprNode, ParseError> {
             } else {
                 null
             };
-            let expr = parse_expr(p)?;
+            let expr = parse_expr(p, 6)?;
             let mut comma_expr_list: Array<CommaExprItem> = [];
             loop {
                 let mut rep_scan_pos: i32 = -1;
@@ -15898,7 +15898,7 @@ fn parse_expr_scan_13(tokens: &Array<Token>, pos: i32) -> i32 {
 fn parse_expr_bt_3(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let start = p.peek().span.start;
     let unary_operator = parse_unary_operator(p)?;
-    let expr = parse_expr(p)?;
+    let expr = parse_expr(p, 15)?;
     return Result::<ExprNode, ParseError>::Ok(ExprNode::Alt3(ExprAlt3 {
         span: Span::new(start, p.last_end()),
         unary_operator,

--- a/package-gale/tests/generated/sqlite/sqlite.wado
+++ b/package-gale/tests/generated/sqlite/sqlite.wado
@@ -15472,7 +15472,7 @@ fn parse_expr_bt_15(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let start = p.peek().span.start;
     let k_cast = p.expect(TK_K_CAST)?;
     let lparen = p.expect(TK_LIT_LPAREN)?;
-    let expr = parse_expr(p, 6)?;
+    let expr = parse_expr(p)?;
     let k_as = p.expect(TK_K_AS)?;
     let type_name = parse_type_name(p)?;
     let rparen = p.expect(TK_LIT_RPAREN)?;
@@ -15508,7 +15508,7 @@ fn parse_expr_bt_22(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let start = p.peek().span.start;
     let k_case = p.expect(TK_K_CASE)?;
     let expr: Option<ExprNode> = if _gale_kind_set_27(p.peek_kind()) {
-        let expr = parse_expr(p, 1)?;
+        let expr = parse_expr(p)?;
         Option::<ExprNode>::Some(expr)
     } else {
         null
@@ -15536,9 +15536,9 @@ fn parse_expr_bt_22(p: &mut Parser) -> Result<ExprNode, ParseError> {
         }
         _plus_first = false;
         let k_when = p.expect(TK_K_WHEN)?;
-        let expr = parse_expr(p, 1)?;
+        let expr = parse_expr(p)?;
         let k_then = p.expect(TK_K_THEN)?;
-        let expr_2 = parse_expr(p, 1)?;
+        let expr_2 = parse_expr(p)?;
         let k_when_expr_k_then_expr = KWhenExprKThenExprItem {
             k_when,
             expr,
@@ -15549,7 +15549,7 @@ fn parse_expr_bt_22(p: &mut Parser) -> Result<ExprNode, ParseError> {
     }
     let k_else_expr: Option<KElseExprItem> = if p.peek_kind() == TK_K_ELSE {
         let k_else = p.expect(TK_K_ELSE)?;
-        let expr = parse_expr(p, 1)?;
+        let expr = parse_expr(p)?;
         let k_else_expr = KElseExprItem {
             k_else,
             expr,
@@ -15689,7 +15689,7 @@ fn parse_expr_scan_21(tokens: &Array<Token>, pos: i32) -> i32 {
 fn parse_expr_bt_14(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let start = p.peek().span.start;
     let lparen = p.expect(TK_LIT_LPAREN)?;
-    let expr = parse_expr(p, 6)?;
+    let expr = parse_expr(p)?;
     let rparen = p.expect(TK_LIT_RPAREN)?;
     return Result::<ExprNode, ParseError>::Ok(ExprNode::Alt14(ExprAlt14 {
         span: Span::new(start, p.last_end()),
@@ -15796,7 +15796,7 @@ fn parse_expr_bt_13(p: &mut Parser) -> Result<ExprNode, ParseError> {
             } else {
                 null
             };
-            let expr = parse_expr(p, 6)?;
+            let expr = parse_expr(p)?;
             let mut comma_expr_list: Array<CommaExprItem> = [];
             loop {
                 let mut rep_scan_pos: i32 = -1;
@@ -15910,7 +15910,7 @@ fn parse_expr_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     pos = scan_unary_operator(tokens, pos);
     if pos < 0 { return -1; }
-    pos = scan_expr(tokens, pos);
+    pos = scan_expr_atom(tokens, pos);
     if pos < 0 { return -1; }
     return pos;
 }

--- a/package-gale/tests/generated/sqlite/sqlite.wado
+++ b/package-gale/tests/generated/sqlite/sqlite.wado
@@ -4848,7 +4848,7 @@ impl Parser {
     }
 }
 
-fn scan_parse(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_parse(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && _gale_kind_set_0(tokens[pos].kind) {
         let sp = pos;
@@ -4856,13 +4856,13 @@ fn scan_parse(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_0: {
             pos = gp_0;
             sg_0_0: {
-                pos = scan_sql_stmt_list(tokens, pos);
+                pos = scan_sql_stmt_list(tokens, pos, 0);
                 if pos < 0 { break sg_0_0; }
                 break sg_0;
             }
             pos = gp_0;
             sg_0_1: {
-                pos = scan_error(tokens, pos);
+                pos = scan_error(tokens, pos, 0);
                 if pos < 0 { break sg_0_1; }
                 break sg_0;
             }
@@ -4876,14 +4876,14 @@ fn scan_parse(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_error(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_error(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_UNEXPECTED_CHAR { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_sql_stmt_list(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_sql_stmt_list(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_SEMI {
         let sp = pos;
@@ -4891,7 +4891,7 @@ fn scan_sql_stmt_list(tokens: &Array<Token>, pos: i32) -> i32 {
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
-    pos = scan_sql_stmt(tokens, pos);
+    pos = scan_sql_stmt(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_SEMI {
         let sp = pos;
@@ -4905,7 +4905,7 @@ fn scan_sql_stmt_list(tokens: &Array<Token>, pos: i32) -> i32 {
                     if pos < 0 { pos = sp; break; }
                     if pos == sp { break; }
                 }
-                pos = scan_sql_stmt(tokens, pos);
+                pos = scan_sql_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_1; }
                 break sg_1_done;
             }
@@ -4923,7 +4923,7 @@ fn scan_sql_stmt_list(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_sql_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_sql_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_K_EXPLAIN && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_K_QUERY && pos + 2 < tokens.len() && tokens[pos + 2].kind == TK_K_PLAN {
         sol_2: {
@@ -4947,181 +4947,181 @@ fn scan_sql_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_4: {
             pos = gp_4;
             sg_4_0: {
-                pos = scan_alter_table_stmt(tokens, pos);
+                pos = scan_alter_table_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_0; }
                 break sg_4;
             }
             pos = gp_4;
             sg_4_1: {
-                pos = scan_analyze_stmt(tokens, pos);
+                pos = scan_analyze_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_1; }
                 break sg_4;
             }
             pos = gp_4;
             sg_4_2: {
-                pos = scan_attach_stmt(tokens, pos);
+                pos = scan_attach_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_2; }
                 break sg_4;
             }
             pos = gp_4;
             sg_4_3: {
-                pos = scan_begin_stmt(tokens, pos);
+                pos = scan_begin_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_3; }
                 break sg_4;
             }
             pos = gp_4;
             sg_4_4: {
-                pos = scan_commit_stmt(tokens, pos);
+                pos = scan_commit_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_4; }
                 break sg_4;
             }
             pos = gp_4;
             sg_4_5: {
-                pos = scan_compound_select_stmt(tokens, pos);
+                pos = scan_compound_select_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_5; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_6: {
-                pos = scan_create_index_stmt(tokens, pos);
+                pos = scan_create_index_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_6; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_7: {
-                pos = scan_create_table_stmt(tokens, pos);
+                pos = scan_create_table_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_7; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_8: {
-                pos = scan_create_trigger_stmt(tokens, pos);
+                pos = scan_create_trigger_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_8; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_9: {
-                pos = scan_create_view_stmt(tokens, pos);
+                pos = scan_create_view_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_9; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_10: {
-                pos = scan_create_virtual_table_stmt(tokens, pos);
+                pos = scan_create_virtual_table_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_10; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_11: {
-                pos = scan_delete_stmt(tokens, pos);
+                pos = scan_delete_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_11; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_12: {
-                pos = scan_delete_stmt_limited(tokens, pos);
+                pos = scan_delete_stmt_limited(tokens, pos, 0);
                 if pos < 0 { break sg_4_12; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_13: {
-                pos = scan_detach_stmt(tokens, pos);
+                pos = scan_detach_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_13; }
                 break sg_4;
             }
             pos = gp_4;
             sg_4_14: {
-                pos = scan_drop_index_stmt(tokens, pos);
+                pos = scan_drop_index_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_14; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_15: {
-                pos = scan_drop_table_stmt(tokens, pos);
+                pos = scan_drop_table_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_15; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_16: {
-                pos = scan_drop_trigger_stmt(tokens, pos);
+                pos = scan_drop_trigger_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_16; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_17: {
-                pos = scan_drop_view_stmt(tokens, pos);
+                pos = scan_drop_view_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_17; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_18: {
-                pos = scan_factored_select_stmt(tokens, pos);
+                pos = scan_factored_select_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_18; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_19: {
-                pos = scan_insert_stmt(tokens, pos);
+                pos = scan_insert_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_19; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_20: {
-                pos = scan_pragma_stmt(tokens, pos);
+                pos = scan_pragma_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_20; }
                 break sg_4;
             }
             pos = gp_4;
             sg_4_21: {
-                pos = scan_reindex_stmt(tokens, pos);
+                pos = scan_reindex_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_21; }
                 break sg_4;
             }
             pos = gp_4;
             sg_4_22: {
-                pos = scan_release_stmt(tokens, pos);
+                pos = scan_release_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_22; }
                 break sg_4;
             }
             pos = gp_4;
             sg_4_23: {
-                pos = scan_rollback_stmt(tokens, pos);
+                pos = scan_rollback_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_23; }
                 break sg_4;
             }
             pos = gp_4;
             sg_4_24: {
-                pos = scan_savepoint_stmt(tokens, pos);
+                pos = scan_savepoint_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_24; }
                 break sg_4;
             }
             pos = gp_4;
             sg_4_25: {
-                pos = scan_simple_select_stmt(tokens, pos);
+                pos = scan_simple_select_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_25; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_26: {
-                pos = scan_select_stmt(tokens, pos);
+                pos = scan_select_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_26; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_27: {
-                pos = scan_update_stmt(tokens, pos);
+                pos = scan_update_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_27; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_28: {
-                pos = scan_update_stmt_limited(tokens, pos);
+                pos = scan_update_stmt_limited(tokens, pos, 0);
                 if pos < 0 { break sg_4_28; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_29: {
-                pos = scan_vacuum_stmt(tokens, pos);
+                pos = scan_vacuum_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_29; }
                 break sg_4;
             }
@@ -5132,7 +5132,7 @@ fn scan_sql_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_alter_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_alter_table_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_ALTER { return -1; }
     pos += 1;
@@ -5142,7 +5142,7 @@ fn scan_alter_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_5_done: {
             sg_5: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_5; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_5; }
                 pos += 1;
@@ -5152,7 +5152,7 @@ fn scan_alter_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_table_name(tokens, pos);
+    pos = scan_table_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     let gp_6 = pos;
     let sgk_6 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -5164,7 +5164,7 @@ fn scan_alter_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_TO { break sg_6_0; }
                 pos += 1;
-                pos = scan_new_table_name(tokens, pos);
+                pos = scan_new_table_name(tokens, pos, 0);
                 if pos < 0 { break sg_6_0; }
                 break sg_6;
             }
@@ -5177,7 +5177,7 @@ fn scan_alter_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                     if pos >= tokens.len() || tokens[pos].kind != TK_K_COLUMN { pos = -1; } else { pos += 1; }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_column_def(tokens, pos);
+                pos = scan_column_def(tokens, pos, 0);
                 if pos < 0 { break sg_6_1; }
                 break sg_6;
             }
@@ -5187,7 +5187,7 @@ fn scan_alter_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_analyze_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_analyze_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_ANALYZE { return -1; }
     pos += 1;
@@ -5198,23 +5198,23 @@ fn scan_analyze_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_7: {
             pos = gp_7;
             sg_7_0: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_7_0; }
                 if pos > sg_7_best { sg_7_best = pos; }
             }
             pos = gp_7;
             sg_7_1: {
-                pos = scan_table_or_index_name(tokens, pos);
+                pos = scan_table_or_index_name(tokens, pos, 0);
                 if pos < 0 { break sg_7_1; }
                 if pos > sg_7_best { sg_7_best = pos; }
             }
             pos = gp_7;
             sg_7_2: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_7_2; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_7_2; }
                 pos += 1;
-                pos = scan_table_or_index_name(tokens, pos);
+                pos = scan_table_or_index_name(tokens, pos, 0);
                 if pos < 0 { break sg_7_2; }
                 if pos > sg_7_best { sg_7_best = pos; }
             }
@@ -5226,7 +5226,7 @@ fn scan_analyze_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_attach_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_attach_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_ATTACH { return -1; }
     pos += 1;
@@ -5235,16 +5235,16 @@ fn scan_attach_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         if pos >= tokens.len() || tokens[pos].kind != TK_K_DATABASE { pos = -1; } else { pos += 1; }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_expr(tokens, pos);
+    pos = scan_expr(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { return -1; }
     pos += 1;
-    pos = scan_database_name(tokens, pos);
+    pos = scan_database_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_begin_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_begin_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_BEGIN { return -1; }
     pos += 1;
@@ -5278,7 +5278,7 @@ fn scan_begin_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         sol_9: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_TRANSACTION { break sol_9; }
             pos += 1;
-            pos = scan_transaction_name(tokens, pos);
+            pos = scan_transaction_name(tokens, pos, 0);
             if pos < 0 { break sol_9; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_K_TRANSACTION {
@@ -5290,7 +5290,7 @@ fn scan_begin_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_commit_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_commit_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     let gp_11 = pos;
     sg_11: {
@@ -5312,7 +5312,7 @@ fn scan_commit_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         sol_12: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_TRANSACTION { break sol_12; }
             pos += 1;
-            pos = scan_transaction_name(tokens, pos);
+            pos = scan_transaction_name(tokens, pos, 0);
             if pos < 0 { break sol_12; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_K_TRANSACTION {
@@ -5324,14 +5324,14 @@ fn scan_commit_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_compound_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_compound_select_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_K_WITH {
         let sp = pos;
-        pos = scan_with_clause(tokens, pos);
+        pos = scan_with_clause(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
-    pos = scan_select_core(tokens, pos);
+    pos = scan_select_core(tokens, pos, 0);
     if pos < 0 { return -1; }
     sg_14_done: {
         sg_14: {
@@ -5365,7 +5365,7 @@ fn scan_compound_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                     pos = gp_15;
                 }
             }
-            pos = scan_select_core(tokens, pos);
+            pos = scan_select_core(tokens, pos, 0);
             if pos < 0 { break sg_14; }
             break sg_14_done;
         }
@@ -5405,7 +5405,7 @@ fn scan_compound_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                         pos = gp_17;
                     }
                 }
-                pos = scan_select_core(tokens, pos);
+                pos = scan_select_core(tokens, pos, 0);
                 if pos < 0 { break sg_16; }
                 break sg_16_done;
             }
@@ -5422,7 +5422,7 @@ fn scan_compound_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sg_18; }
                 pos += 1;
-                pos = scan_ordering_term(tokens, pos);
+                pos = scan_ordering_term(tokens, pos, 0);
                 if pos < 0 { break sg_18; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -5430,7 +5430,7 @@ fn scan_compound_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_19: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_19; }
                             pos += 1;
-                            pos = scan_ordering_term(tokens, pos);
+                            pos = scan_ordering_term(tokens, pos, 0);
                             if pos < 0 { break sg_19; }
                             break sg_19_done;
                         }
@@ -5449,7 +5449,7 @@ fn scan_compound_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         sol_20: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break sol_20; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_20; }
             let gp_21 = pos;
             sg_21: {
@@ -5467,21 +5467,21 @@ fn scan_compound_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 break sol_20;
             }
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_20; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_K_LIMIT && pos + 1 < tokens.len() && _gale_kind_set_6(tokens[pos + 1].kind) {
         sol_22: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break sol_22; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_22; }
         }
     }
     return pos;
 }
 
-fn scan_create_index_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_create_index_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_CREATE { return -1; }
     pos += 1;
@@ -5512,7 +5512,7 @@ fn scan_create_index_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_24_done: {
             sg_24: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_24; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_24; }
                 pos += 1;
@@ -5522,15 +5522,15 @@ fn scan_create_index_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_index_name(tokens, pos);
+    pos = scan_index_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_K_ON { return -1; }
     pos += 1;
-    pos = scan_table_name(tokens, pos);
+    pos = scan_table_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_indexed_column(tokens, pos);
+    pos = scan_indexed_column(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -5538,7 +5538,7 @@ fn scan_create_index_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_25: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_25; }
                 pos += 1;
-                pos = scan_indexed_column(tokens, pos);
+                pos = scan_indexed_column(tokens, pos, 0);
                 if pos < 0 { break sg_25; }
                 break sg_25_done;
             }
@@ -5555,7 +5555,7 @@ fn scan_create_index_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_26: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_WHERE { break sg_26; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_26; }
                 break sg_26_done;
             }
@@ -5566,7 +5566,7 @@ fn scan_create_index_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_create_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_create_table_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_CREATE { return -1; }
     pos += 1;
@@ -5612,7 +5612,7 @@ fn scan_create_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_29_done: {
             sg_29: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_29; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_29; }
                 pos += 1;
@@ -5622,7 +5622,7 @@ fn scan_create_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_table_name(tokens, pos);
+    pos = scan_table_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     let gp_30 = pos;
     let sgk_30 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -5632,7 +5632,7 @@ fn scan_create_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_30_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_30_0; }
                 pos += 1;
-                pos = scan_column_def(tokens, pos);
+                pos = scan_column_def(tokens, pos, 0);
                 if pos < 0 { break sg_30_0; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -5640,7 +5640,7 @@ fn scan_create_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_31: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_31; }
                             pos += 1;
-                            pos = scan_column_def(tokens, pos);
+                            pos = scan_column_def(tokens, pos, 0);
                             if pos < 0 { break sg_31; }
                             break sg_31_done;
                         }
@@ -5655,7 +5655,7 @@ fn scan_create_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_32: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_32; }
                             pos += 1;
-                            pos = scan_table_constraint(tokens, pos);
+                            pos = scan_table_constraint(tokens, pos, 0);
                             if pos < 0 { break sg_32; }
                             break sg_32_done;
                         }
@@ -5686,7 +5686,7 @@ fn scan_create_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_30_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { break sg_30_1; }
                 pos += 1;
-                pos = scan_select_stmt(tokens, pos);
+                pos = scan_select_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_30_1; }
                 break sg_30;
             }
@@ -5696,7 +5696,7 @@ fn scan_create_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_create_trigger_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_create_trigger_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_CREATE { return -1; }
     pos += 1;
@@ -5742,7 +5742,7 @@ fn scan_create_trigger_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_36_done: {
             sg_36: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_36; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_36; }
                 pos += 1;
@@ -5752,7 +5752,7 @@ fn scan_create_trigger_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_trigger_name(tokens, pos);
+    pos = scan_trigger_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && _gale_kind_set_10(tokens[pos].kind) {
         let sp = pos;
@@ -5808,7 +5808,7 @@ fn scan_create_trigger_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_39: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_K_OF { break sg_39; }
                             pos += 1;
-                            pos = scan_column_name(tokens, pos);
+                            pos = scan_column_name(tokens, pos, 0);
                             if pos < 0 { break sg_39; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -5816,7 +5816,7 @@ fn scan_create_trigger_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_40: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_40; }
                                         pos += 1;
-                                        pos = scan_column_name(tokens, pos);
+                                        pos = scan_column_name(tokens, pos, 0);
                                         if pos < 0 { break sg_40; }
                                         break sg_40_done;
                                     }
@@ -5842,7 +5842,7 @@ fn scan_create_trigger_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_41_done: {
             sg_41: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_41; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_41; }
                 pos += 1;
@@ -5852,7 +5852,7 @@ fn scan_create_trigger_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_table_name(tokens, pos);
+    pos = scan_table_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_K_FOR {
         let sp = pos;
@@ -5876,7 +5876,7 @@ fn scan_create_trigger_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_43: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_WHEN { break sg_43; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_43; }
                 break sg_43_done;
             }
@@ -5895,25 +5895,25 @@ fn scan_create_trigger_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                 sg_45: {
                     pos = gp_45;
                     sg_45_0: {
-                        pos = scan_update_stmt(tokens, pos);
+                        pos = scan_update_stmt(tokens, pos, 0);
                         if pos < 0 { break sg_45_0; }
                         if pos > sg_45_best { sg_45_best = pos; }
                     }
                     pos = gp_45;
                     sg_45_1: {
-                        pos = scan_insert_stmt(tokens, pos);
+                        pos = scan_insert_stmt(tokens, pos, 0);
                         if pos < 0 { break sg_45_1; }
                         if pos > sg_45_best { sg_45_best = pos; }
                     }
                     pos = gp_45;
                     sg_45_2: {
-                        pos = scan_delete_stmt(tokens, pos);
+                        pos = scan_delete_stmt(tokens, pos, 0);
                         if pos < 0 { break sg_45_2; }
                         if pos > sg_45_best { sg_45_best = pos; }
                     }
                     pos = gp_45;
                     sg_45_3: {
-                        pos = scan_select_stmt(tokens, pos);
+                        pos = scan_select_stmt(tokens, pos, 0);
                         if pos < 0 { break sg_45_3; }
                         if pos > sg_45_best { sg_45_best = pos; }
                     }
@@ -5938,25 +5938,25 @@ fn scan_create_trigger_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_47: {
                         pos = gp_47;
                         sg_47_0: {
-                            pos = scan_update_stmt(tokens, pos);
+                            pos = scan_update_stmt(tokens, pos, 0);
                             if pos < 0 { break sg_47_0; }
                             if pos > sg_47_best { sg_47_best = pos; }
                         }
                         pos = gp_47;
                         sg_47_1: {
-                            pos = scan_insert_stmt(tokens, pos);
+                            pos = scan_insert_stmt(tokens, pos, 0);
                             if pos < 0 { break sg_47_1; }
                             if pos > sg_47_best { sg_47_best = pos; }
                         }
                         pos = gp_47;
                         sg_47_2: {
-                            pos = scan_delete_stmt(tokens, pos);
+                            pos = scan_delete_stmt(tokens, pos, 0);
                             if pos < 0 { break sg_47_2; }
                             if pos > sg_47_best { sg_47_best = pos; }
                         }
                         pos = gp_47;
                         sg_47_3: {
-                            pos = scan_select_stmt(tokens, pos);
+                            pos = scan_select_stmt(tokens, pos, 0);
                             if pos < 0 { break sg_47_3; }
                             if pos > sg_47_best { sg_47_best = pos; }
                         }
@@ -5978,7 +5978,7 @@ fn scan_create_trigger_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_create_view_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_create_view_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_CREATE { return -1; }
     pos += 1;
@@ -6024,7 +6024,7 @@ fn scan_create_view_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_50_done: {
             sg_50: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_50; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_50; }
                 pos += 1;
@@ -6034,16 +6034,16 @@ fn scan_create_view_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_view_name(tokens, pos);
+    pos = scan_view_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { return -1; }
     pos += 1;
-    pos = scan_select_stmt(tokens, pos);
+    pos = scan_select_stmt(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_create_virtual_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_create_virtual_table_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_CREATE { return -1; }
     pos += 1;
@@ -6071,7 +6071,7 @@ fn scan_create_virtual_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_52_done: {
             sg_52: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_52; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_52; }
                 pos += 1;
@@ -6081,11 +6081,11 @@ fn scan_create_virtual_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_table_name(tokens, pos);
+    pos = scan_table_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_K_USING { return -1; }
     pos += 1;
-    pos = scan_module_name(tokens, pos);
+    pos = scan_module_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_LPAREN {
         let sp = pos;
@@ -6093,7 +6093,7 @@ fn scan_create_virtual_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_53: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_53; }
                 pos += 1;
-                pos = scan_module_argument(tokens, pos);
+                pos = scan_module_argument(tokens, pos, 0);
                 if pos < 0 { break sg_53; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -6101,7 +6101,7 @@ fn scan_create_virtual_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_54: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_54; }
                             pos += 1;
-                            pos = scan_module_argument(tokens, pos);
+                            pos = scan_module_argument(tokens, pos, 0);
                             if pos < 0 { break sg_54; }
                             break sg_54_done;
                         }
@@ -6121,18 +6121,18 @@ fn scan_create_virtual_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_delete_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_delete_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_K_WITH {
         let sp = pos;
-        pos = scan_with_clause(tokens, pos);
+        pos = scan_with_clause(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_K_DELETE { return -1; }
     pos += 1;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_FROM { return -1; }
     pos += 1;
-    pos = scan_qualified_table_name(tokens, pos);
+    pos = scan_qualified_table_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_K_WHERE {
         let sp = pos;
@@ -6140,7 +6140,7 @@ fn scan_delete_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_55: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_WHERE { break sg_55; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_55; }
                 break sg_55_done;
             }
@@ -6151,18 +6151,18 @@ fn scan_delete_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_delete_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_delete_stmt_limited(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_K_WITH {
         let sp = pos;
-        pos = scan_with_clause(tokens, pos);
+        pos = scan_with_clause(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_K_DELETE { return -1; }
     pos += 1;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_FROM { return -1; }
     pos += 1;
-    pos = scan_qualified_table_name(tokens, pos);
+    pos = scan_qualified_table_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_K_WHERE {
         let sp = pos;
@@ -6170,7 +6170,7 @@ fn scan_delete_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_56: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_WHERE { break sg_56; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_56; }
                 break sg_56_done;
             }
@@ -6184,7 +6184,7 @@ fn scan_delete_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
             pos += 1;
             if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sol_57; }
             pos += 1;
-            pos = scan_ordering_term(tokens, pos);
+            pos = scan_ordering_term(tokens, pos, 0);
             if pos < 0 { break sol_57; }
             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                 let sp = pos;
@@ -6192,7 +6192,7 @@ fn scan_delete_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_58: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_58; }
                         pos += 1;
-                        pos = scan_ordering_term(tokens, pos);
+                        pos = scan_ordering_term(tokens, pos, 0);
                         if pos < 0 { break sg_58; }
                         break sg_58_done;
                     }
@@ -6203,7 +6203,7 @@ fn scan_delete_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break sol_57; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_57; }
             let gp_59 = pos;
             sg_59: {
@@ -6221,14 +6221,14 @@ fn scan_delete_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 break sol_57;
             }
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_57; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_K_LIMIT && pos + 1 < tokens.len() && _gale_kind_set_6(tokens[pos + 1].kind) && pos + 2 < tokens.len() && _gale_kind_set_7(tokens[pos + 2].kind) && pos + 3 < tokens.len() && _gale_kind_set_6(tokens[pos + 3].kind) {
         sol_60: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break sol_60; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_60; }
             let gp_61 = pos;
             sg_61: {
@@ -6246,7 +6246,7 @@ fn scan_delete_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 break sol_60;
             }
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_60; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_K_ORDER && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_K_BY && pos + 2 < tokens.len() && _gale_kind_set_6(tokens[pos + 2].kind) && pos + 3 < tokens.len() && tokens[pos + 3].kind == TK_LIT_COMMA && pos + 4 < tokens.len() && tokens[pos + 4].kind == TK_K_LIMIT && pos + 5 < tokens.len() && _gale_kind_set_6(tokens[pos + 5].kind) {
@@ -6255,7 +6255,7 @@ fn scan_delete_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
             pos += 1;
             if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sol_62; }
             pos += 1;
-            pos = scan_ordering_term(tokens, pos);
+            pos = scan_ordering_term(tokens, pos, 0);
             if pos < 0 { break sol_62; }
             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                 let sp = pos;
@@ -6263,7 +6263,7 @@ fn scan_delete_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_63: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_63; }
                         pos += 1;
-                        pos = scan_ordering_term(tokens, pos);
+                        pos = scan_ordering_term(tokens, pos, 0);
                         if pos < 0 { break sg_63; }
                         break sg_63_done;
                     }
@@ -6274,21 +6274,21 @@ fn scan_delete_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break sol_62; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_62; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_K_LIMIT && pos + 1 < tokens.len() && _gale_kind_set_6(tokens[pos + 1].kind) {
         sol_64: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break sol_64; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_64; }
         }
     }
     return pos;
 }
 
-fn scan_detach_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_detach_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_DETACH { return -1; }
     pos += 1;
@@ -6297,12 +6297,12 @@ fn scan_detach_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         if pos >= tokens.len() || tokens[pos].kind != TK_K_DATABASE { pos = -1; } else { pos += 1; }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_database_name(tokens, pos);
+    pos = scan_database_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_drop_index_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_drop_index_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_DROP { return -1; }
     pos += 1;
@@ -6326,7 +6326,7 @@ fn scan_drop_index_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_66_done: {
             sg_66: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_66; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_66; }
                 pos += 1;
@@ -6336,12 +6336,12 @@ fn scan_drop_index_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_index_name(tokens, pos);
+    pos = scan_index_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_drop_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_drop_table_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_DROP { return -1; }
     pos += 1;
@@ -6365,7 +6365,7 @@ fn scan_drop_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_68_done: {
             sg_68: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_68; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_68; }
                 pos += 1;
@@ -6375,12 +6375,12 @@ fn scan_drop_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_table_name(tokens, pos);
+    pos = scan_table_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_drop_trigger_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_drop_trigger_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_DROP { return -1; }
     pos += 1;
@@ -6404,7 +6404,7 @@ fn scan_drop_trigger_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_70_done: {
             sg_70: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_70; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_70; }
                 pos += 1;
@@ -6414,12 +6414,12 @@ fn scan_drop_trigger_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_trigger_name(tokens, pos);
+    pos = scan_trigger_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_drop_view_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_drop_view_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_DROP { return -1; }
     pos += 1;
@@ -6443,7 +6443,7 @@ fn scan_drop_view_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_72_done: {
             sg_72: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_72; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_72; }
                 pos += 1;
@@ -6453,27 +6453,27 @@ fn scan_drop_view_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_view_name(tokens, pos);
+    pos = scan_view_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_factored_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_factored_select_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_K_WITH {
         let sp = pos;
-        pos = scan_with_clause(tokens, pos);
+        pos = scan_with_clause(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
-    pos = scan_select_core(tokens, pos);
+    pos = scan_select_core(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && _gale_kind_set_5(tokens[pos].kind) {
         let sp = pos;
         sg_73_done: {
             sg_73: {
-                pos = scan_compound_operator(tokens, pos);
+                pos = scan_compound_operator(tokens, pos, 0);
                 if pos < 0 { break sg_73; }
-                pos = scan_select_core(tokens, pos);
+                pos = scan_select_core(tokens, pos, 0);
                 if pos < 0 { break sg_73; }
                 break sg_73_done;
             }
@@ -6490,7 +6490,7 @@ fn scan_factored_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sg_74; }
                 pos += 1;
-                pos = scan_ordering_term(tokens, pos);
+                pos = scan_ordering_term(tokens, pos, 0);
                 if pos < 0 { break sg_74; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -6498,7 +6498,7 @@ fn scan_factored_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_75: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_75; }
                             pos += 1;
-                            pos = scan_ordering_term(tokens, pos);
+                            pos = scan_ordering_term(tokens, pos, 0);
                             if pos < 0 { break sg_75; }
                             break sg_75_done;
                         }
@@ -6517,7 +6517,7 @@ fn scan_factored_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         sol_76: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break sol_76; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_76; }
             let gp_77 = pos;
             sg_77: {
@@ -6535,25 +6535,25 @@ fn scan_factored_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 break sol_76;
             }
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_76; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_K_LIMIT && pos + 1 < tokens.len() && _gale_kind_set_6(tokens[pos + 1].kind) {
         sol_78: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break sol_78; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_78; }
         }
     }
     return pos;
 }
 
-fn scan_insert_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_insert_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_K_WITH {
         let sp = pos;
-        pos = scan_with_clause(tokens, pos);
+        pos = scan_with_clause(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     let gp_79 = pos;
@@ -6633,7 +6633,7 @@ fn scan_insert_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_80_done: {
             sg_80: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_80; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_80; }
                 pos += 1;
@@ -6643,7 +6643,7 @@ fn scan_insert_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_table_name(tokens, pos);
+    pos = scan_table_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_LPAREN {
         let sp = pos;
@@ -6651,7 +6651,7 @@ fn scan_insert_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_81: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_81; }
                 pos += 1;
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break sg_81; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -6659,7 +6659,7 @@ fn scan_insert_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_82: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_82; }
                             pos += 1;
-                            pos = scan_column_name(tokens, pos);
+                            pos = scan_column_name(tokens, pos, 0);
                             if pos < 0 { break sg_82; }
                             break sg_82_done;
                         }
@@ -6687,7 +6687,7 @@ fn scan_insert_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_83_0; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_83_0; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -6695,7 +6695,7 @@ fn scan_insert_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_84: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_84; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_84; }
                             break sg_84_done;
                         }
@@ -6714,7 +6714,7 @@ fn scan_insert_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                             pos += 1;
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_85; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_85; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -6722,7 +6722,7 @@ fn scan_insert_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_86: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_86; }
                                         pos += 1;
-                                        pos = scan_expr(tokens, pos);
+                                        pos = scan_expr(tokens, pos, 0);
                                         if pos < 0 { break sg_86; }
                                         break sg_86_done;
                                     }
@@ -6744,7 +6744,7 @@ fn scan_insert_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = gp_83;
             sg_83_1: {
-                pos = scan_select_stmt(tokens, pos);
+                pos = scan_select_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_83_1; }
                 if pos > sg_83_best { sg_83_best = pos; }
             }
@@ -6763,7 +6763,7 @@ fn scan_insert_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_pragma_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_pragma_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_PRAGMA { return -1; }
     pos += 1;
@@ -6771,7 +6771,7 @@ fn scan_pragma_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_87_done: {
             sg_87: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_87; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_87; }
                 pos += 1;
@@ -6781,7 +6781,7 @@ fn scan_pragma_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_pragma_name(tokens, pos);
+    pos = scan_pragma_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && _gale_kind_set_16(tokens[pos].kind) {
         let sp = pos;
@@ -6791,7 +6791,7 @@ fn scan_pragma_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_88_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQ { break sg_88_0; }
                 pos += 1;
-                pos = scan_pragma_value(tokens, pos);
+                pos = scan_pragma_value(tokens, pos, 0);
                 if pos < 0 { break sg_88_0; }
                 break sg_88;
             }
@@ -6799,7 +6799,7 @@ fn scan_pragma_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_88_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_88_1; }
                 pos += 1;
-                pos = scan_pragma_value(tokens, pos);
+                pos = scan_pragma_value(tokens, pos, 0);
                 if pos < 0 { break sg_88_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_88_1; }
                 pos += 1;
@@ -6812,7 +6812,7 @@ fn scan_pragma_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_reindex_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_reindex_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_REINDEX { return -1; }
     pos += 1;
@@ -6823,7 +6823,7 @@ fn scan_reindex_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_89: {
             pos = gp_89;
             sg_89_0: {
-                pos = scan_collation_name(tokens, pos);
+                pos = scan_collation_name(tokens, pos, 0);
                 if pos < 0 { break sg_89_0; }
                 if pos > sg_89_best { sg_89_best = pos; }
             }
@@ -6833,7 +6833,7 @@ fn scan_reindex_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                     let sp = pos;
                     sg_90_done: {
                         sg_90: {
-                            pos = scan_database_name(tokens, pos);
+                            pos = scan_database_name(tokens, pos, 0);
                             if pos < 0 { break sg_90; }
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_90; }
                             pos += 1;
@@ -6850,13 +6850,13 @@ fn scan_reindex_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_91: {
                         pos = gp_91;
                         sg_91_0: {
-                            pos = scan_table_name(tokens, pos);
+                            pos = scan_table_name(tokens, pos, 0);
                             if pos < 0 { break sg_91_0; }
                             if pos > sg_91_best { sg_91_best = pos; }
                         }
                         pos = gp_91;
                         sg_91_1: {
-                            pos = scan_index_name(tokens, pos);
+                            pos = scan_index_name(tokens, pos, 0);
                             if pos < 0 { break sg_91_1; }
                             if pos > sg_91_best { sg_91_best = pos; }
                         }
@@ -6874,7 +6874,7 @@ fn scan_reindex_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_release_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_release_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_RELEASE { return -1; }
     pos += 1;
@@ -6883,12 +6883,12 @@ fn scan_release_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         if pos >= tokens.len() || tokens[pos].kind != TK_K_SAVEPOINT { pos = -1; } else { pos += 1; }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_savepoint_name(tokens, pos);
+    pos = scan_savepoint_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_rollback_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_rollback_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_ROLLBACK { return -1; }
     pos += 1;
@@ -6896,7 +6896,7 @@ fn scan_rollback_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         sol_92: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_TRANSACTION { break sol_92; }
             pos += 1;
-            pos = scan_transaction_name(tokens, pos);
+            pos = scan_transaction_name(tokens, pos, 0);
             if pos < 0 { break sol_92; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_K_TRANSACTION {
@@ -6911,37 +6911,37 @@ fn scan_rollback_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
             pos += 1;
             if pos >= tokens.len() || tokens[pos].kind != TK_K_SAVEPOINT { break sol_94; }
             pos += 1;
-            pos = scan_savepoint_name(tokens, pos);
+            pos = scan_savepoint_name(tokens, pos, 0);
             if pos < 0 { break sol_94; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_K_TO && pos + 1 < tokens.len() && _gale_kind_set_2(tokens[pos + 1].kind) {
         sol_95: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_TO { break sol_95; }
             pos += 1;
-            pos = scan_savepoint_name(tokens, pos);
+            pos = scan_savepoint_name(tokens, pos, 0);
             if pos < 0 { break sol_95; }
         }
     }
     return pos;
 }
 
-fn scan_savepoint_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_savepoint_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_SAVEPOINT { return -1; }
     pos += 1;
-    pos = scan_savepoint_name(tokens, pos);
+    pos = scan_savepoint_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_simple_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_simple_select_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_K_WITH {
         let sp = pos;
-        pos = scan_with_clause(tokens, pos);
+        pos = scan_with_clause(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
-    pos = scan_select_core(tokens, pos);
+    pos = scan_select_core(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_K_ORDER {
         let sp = pos;
@@ -6951,7 +6951,7 @@ fn scan_simple_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sg_96; }
                 pos += 1;
-                pos = scan_ordering_term(tokens, pos);
+                pos = scan_ordering_term(tokens, pos, 0);
                 if pos < 0 { break sg_96; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -6959,7 +6959,7 @@ fn scan_simple_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_97: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_97; }
                             pos += 1;
-                            pos = scan_ordering_term(tokens, pos);
+                            pos = scan_ordering_term(tokens, pos, 0);
                             if pos < 0 { break sg_97; }
                             break sg_97_done;
                         }
@@ -6978,7 +6978,7 @@ fn scan_simple_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         sol_98: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break sol_98; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_98; }
             let gp_99 = pos;
             sg_99: {
@@ -6996,36 +6996,36 @@ fn scan_simple_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 break sol_98;
             }
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_98; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_K_LIMIT && pos + 1 < tokens.len() && _gale_kind_set_6(tokens[pos + 1].kind) {
         sol_100: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break sol_100; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_100; }
         }
     }
     return pos;
 }
 
-fn scan_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_select_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_K_WITH {
         let sp = pos;
-        pos = scan_with_clause(tokens, pos);
+        pos = scan_with_clause(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
-    pos = scan_select_or_values(tokens, pos);
+    pos = scan_select_or_values(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && _gale_kind_set_5(tokens[pos].kind) {
         let sp = pos;
         sg_101_done: {
             sg_101: {
-                pos = scan_compound_operator(tokens, pos);
+                pos = scan_compound_operator(tokens, pos, 0);
                 if pos < 0 { break sg_101; }
-                pos = scan_select_or_values(tokens, pos);
+                pos = scan_select_or_values(tokens, pos, 0);
                 if pos < 0 { break sg_101; }
                 break sg_101_done;
             }
@@ -7042,7 +7042,7 @@ fn scan_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sg_102; }
                 pos += 1;
-                pos = scan_ordering_term(tokens, pos);
+                pos = scan_ordering_term(tokens, pos, 0);
                 if pos < 0 { break sg_102; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -7050,7 +7050,7 @@ fn scan_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_103: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_103; }
                             pos += 1;
-                            pos = scan_ordering_term(tokens, pos);
+                            pos = scan_ordering_term(tokens, pos, 0);
                             if pos < 0 { break sg_103; }
                             break sg_103_done;
                         }
@@ -7069,7 +7069,7 @@ fn scan_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         sol_104: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break sol_104; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_104; }
             let gp_105 = pos;
             sg_105: {
@@ -7087,21 +7087,21 @@ fn scan_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 break sol_104;
             }
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_104; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_K_LIMIT && pos + 1 < tokens.len() && _gale_kind_set_6(tokens[pos + 1].kind) {
         sol_106: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break sol_106; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_106; }
         }
     }
     return pos;
 }
 
-fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_select_or_values(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -7131,7 +7131,7 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_result_column(tokens, pos);
+                pos = scan_result_column(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -7139,7 +7139,7 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_108: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_108; }
                             pos += 1;
-                            pos = scan_result_column(tokens, pos);
+                            pos = scan_result_column(tokens, pos, 0);
                             if pos < 0 { break sg_108; }
                             break sg_108_done;
                         }
@@ -7161,7 +7161,7 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                                 sg_110: {
                                     pos = gp_110;
                                     sg_110_0: {
-                                        pos = scan_table_or_subquery(tokens, pos);
+                                        pos = scan_table_or_subquery(tokens, pos, 0);
                                         if pos < 0 { break sg_110_0; }
                                         while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                             let sp = pos;
@@ -7169,7 +7169,7 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                                                 sg_111: {
                                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_111; }
                                                     pos += 1;
-                                                    pos = scan_table_or_subquery(tokens, pos);
+                                                    pos = scan_table_or_subquery(tokens, pos, 0);
                                                     if pos < 0 { break sg_111; }
                                                     break sg_111_done;
                                                 }
@@ -7182,7 +7182,7 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                                     }
                                     pos = gp_110;
                                     sg_110_1: {
-                                        pos = scan_join_clause(tokens, pos);
+                                        pos = scan_join_clause(tokens, pos, 0);
                                         if pos < 0 { break sg_110_1; }
                                         if pos > sg_110_best { sg_110_best = pos; }
                                     }
@@ -7202,7 +7202,7 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_112: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_K_WHERE { break sg_112; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_112; }
                             break sg_112_done;
                         }
@@ -7216,7 +7216,7 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                         pos += 1;
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sol_113; }
                         pos += 1;
-                        pos = scan_expr(tokens, pos);
+                        pos = scan_expr(tokens, pos, 0);
                         if pos < 0 { break sol_113; }
                         while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                             let sp = pos;
@@ -7224,7 +7224,7 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                                 sg_114: {
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_114; }
                                     pos += 1;
-                                    pos = scan_expr(tokens, pos);
+                                    pos = scan_expr(tokens, pos, 0);
                                     if pos < 0 { break sg_114; }
                                     break sg_114_done;
                                 }
@@ -7235,7 +7235,7 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                         }
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_HAVING { break sol_113; }
                         pos += 1;
-                        pos = scan_expr(tokens, pos);
+                        pos = scan_expr(tokens, pos, 0);
                         if pos < 0 { break sol_113; }
                     }
                 } else if pos < tokens.len() && tokens[pos].kind == TK_K_GROUP && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_K_BY && pos + 2 < tokens.len() && _gale_kind_set_6(tokens[pos + 2].kind) && pos + 3 < tokens.len() && tokens[pos + 3].kind == TK_K_HAVING && pos + 4 < tokens.len() && _gale_kind_set_6(tokens[pos + 4].kind) {
@@ -7244,11 +7244,11 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                         pos += 1;
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sol_115; }
                         pos += 1;
-                        pos = scan_expr(tokens, pos);
+                        pos = scan_expr(tokens, pos, 0);
                         if pos < 0 { break sol_115; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_HAVING { break sol_115; }
                         pos += 1;
-                        pos = scan_expr(tokens, pos);
+                        pos = scan_expr(tokens, pos, 0);
                         if pos < 0 { break sol_115; }
                     }
                 } else if pos < tokens.len() && tokens[pos].kind == TK_K_GROUP && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_K_BY && pos + 2 < tokens.len() && _gale_kind_set_6(tokens[pos + 2].kind) && pos + 3 < tokens.len() && tokens[pos + 3].kind == TK_LIT_COMMA {
@@ -7257,7 +7257,7 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                         pos += 1;
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sol_116; }
                         pos += 1;
-                        pos = scan_expr(tokens, pos);
+                        pos = scan_expr(tokens, pos, 0);
                         if pos < 0 { break sol_116; }
                         while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                             let sp = pos;
@@ -7265,7 +7265,7 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                                 sg_117: {
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_117; }
                                     pos += 1;
-                                    pos = scan_expr(tokens, pos);
+                                    pos = scan_expr(tokens, pos, 0);
                                     if pos < 0 { break sg_117; }
                                     break sg_117_done;
                                 }
@@ -7281,7 +7281,7 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                         pos += 1;
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sol_118; }
                         pos += 1;
-                        pos = scan_expr(tokens, pos);
+                        pos = scan_expr(tokens, pos, 0);
                         if pos < 0 { break sol_118; }
                     }
                 }
@@ -7295,7 +7295,7 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_1; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -7303,7 +7303,7 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_119: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_119; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_119; }
                             break sg_119_done;
                         }
@@ -7322,7 +7322,7 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                             pos += 1;
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_120; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_120; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -7330,7 +7330,7 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_121: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_121; }
                                         pos += 1;
-                                        pos = scan_expr(tokens, pos);
+                                        pos = scan_expr(tokens, pos, 0);
                                         if pos < 0 { break sg_121; }
                                         break sg_121_done;
                                     }
@@ -7358,11 +7358,11 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_update_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_update_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_K_WITH {
         let sp = pos;
-        pos = scan_with_clause(tokens, pos);
+        pos = scan_with_clause(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_K_UPDATE { return -1; }
@@ -7417,15 +7417,15 @@ fn scan_update_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_qualified_table_name(tokens, pos);
+    pos = scan_qualified_table_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_K_SET { return -1; }
     pos += 1;
-    pos = scan_column_name(tokens, pos);
+    pos = scan_column_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQ { return -1; }
     pos += 1;
-    pos = scan_expr(tokens, pos);
+    pos = scan_expr(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -7433,11 +7433,11 @@ fn scan_update_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_123: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_123; }
                 pos += 1;
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break sg_123; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQ { break sg_123; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_123; }
                 break sg_123_done;
             }
@@ -7452,7 +7452,7 @@ fn scan_update_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_124: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_WHERE { break sg_124; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_124; }
                 break sg_124_done;
             }
@@ -7463,11 +7463,11 @@ fn scan_update_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_update_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_update_stmt_limited(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_K_WITH {
         let sp = pos;
-        pos = scan_with_clause(tokens, pos);
+        pos = scan_with_clause(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_K_UPDATE { return -1; }
@@ -7522,15 +7522,15 @@ fn scan_update_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_qualified_table_name(tokens, pos);
+    pos = scan_qualified_table_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_K_SET { return -1; }
     pos += 1;
-    pos = scan_column_name(tokens, pos);
+    pos = scan_column_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQ { return -1; }
     pos += 1;
-    pos = scan_expr(tokens, pos);
+    pos = scan_expr(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -7538,11 +7538,11 @@ fn scan_update_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_126: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_126; }
                 pos += 1;
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break sg_126; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQ { break sg_126; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_126; }
                 break sg_126_done;
             }
@@ -7557,7 +7557,7 @@ fn scan_update_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_127: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_WHERE { break sg_127; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_127; }
                 break sg_127_done;
             }
@@ -7571,7 +7571,7 @@ fn scan_update_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
             pos += 1;
             if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sol_128; }
             pos += 1;
-            pos = scan_ordering_term(tokens, pos);
+            pos = scan_ordering_term(tokens, pos, 0);
             if pos < 0 { break sol_128; }
             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                 let sp = pos;
@@ -7579,7 +7579,7 @@ fn scan_update_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_129: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_129; }
                         pos += 1;
-                        pos = scan_ordering_term(tokens, pos);
+                        pos = scan_ordering_term(tokens, pos, 0);
                         if pos < 0 { break sg_129; }
                         break sg_129_done;
                     }
@@ -7590,7 +7590,7 @@ fn scan_update_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break sol_128; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_128; }
             let gp_130 = pos;
             sg_130: {
@@ -7608,14 +7608,14 @@ fn scan_update_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 break sol_128;
             }
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_128; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_K_LIMIT && pos + 1 < tokens.len() && _gale_kind_set_6(tokens[pos + 1].kind) && pos + 2 < tokens.len() && _gale_kind_set_7(tokens[pos + 2].kind) && pos + 3 < tokens.len() && _gale_kind_set_6(tokens[pos + 3].kind) {
         sol_131: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break sol_131; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_131; }
             let gp_132 = pos;
             sg_132: {
@@ -7633,7 +7633,7 @@ fn scan_update_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 break sol_131;
             }
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_131; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_K_ORDER && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_K_BY && pos + 2 < tokens.len() && _gale_kind_set_6(tokens[pos + 2].kind) && pos + 3 < tokens.len() && tokens[pos + 3].kind == TK_LIT_COMMA && pos + 4 < tokens.len() && tokens[pos + 4].kind == TK_K_LIMIT && pos + 5 < tokens.len() && _gale_kind_set_6(tokens[pos + 5].kind) {
@@ -7642,7 +7642,7 @@ fn scan_update_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
             pos += 1;
             if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sol_133; }
             pos += 1;
-            pos = scan_ordering_term(tokens, pos);
+            pos = scan_ordering_term(tokens, pos, 0);
             if pos < 0 { break sol_133; }
             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                 let sp = pos;
@@ -7650,7 +7650,7 @@ fn scan_update_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_134: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_134; }
                         pos += 1;
-                        pos = scan_ordering_term(tokens, pos);
+                        pos = scan_ordering_term(tokens, pos, 0);
                         if pos < 0 { break sg_134; }
                         break sg_134_done;
                     }
@@ -7661,52 +7661,52 @@ fn scan_update_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break sol_133; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_133; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_K_LIMIT && pos + 1 < tokens.len() && _gale_kind_set_6(tokens[pos + 1].kind) {
         sol_135: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break sol_135; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_135; }
         }
     }
     return pos;
 }
 
-fn scan_vacuum_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_vacuum_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_VACUUM { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_column_def(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_column_def(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_column_name(tokens, pos);
+    pos = scan_column_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && _gale_kind_set_18(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_type_name(tokens, pos);
+        pos = scan_type_name(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     while pos < tokens.len() && _gale_kind_set_19(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_column_constraint(tokens, pos);
+        pos = scan_column_constraint(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
     return pos;
 }
 
-fn scan_type_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_type_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_name(tokens, pos);
+    pos = scan_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_name(tokens, pos);
+        pos = scan_name(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -7719,7 +7719,7 @@ fn scan_type_name(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_136_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_136_0; }
                 pos += 1;
-                pos = scan_signed_number(tokens, pos);
+                pos = scan_signed_number(tokens, pos, 0);
                 if pos < 0 { break sg_136_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_136_0; }
                 pos += 1;
@@ -7729,11 +7729,11 @@ fn scan_type_name(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_136_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_136_1; }
                 pos += 1;
-                pos = scan_signed_number(tokens, pos);
+                pos = scan_signed_number(tokens, pos, 0);
                 if pos < 0 { break sg_136_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_136_1; }
                 pos += 1;
-                pos = scan_signed_number(tokens, pos);
+                pos = scan_signed_number(tokens, pos, 0);
                 if pos < 0 { break sg_136_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_136_1; }
                 pos += 1;
@@ -7747,7 +7747,7 @@ fn scan_type_name(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_column_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_column_constraint(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_K_CONSTRAINT {
         let sp = pos;
@@ -7755,7 +7755,7 @@ fn scan_column_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_137: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_CONSTRAINT { break sg_137; }
                 pos += 1;
-                pos = scan_name(tokens, pos);
+                pos = scan_name(tokens, pos, 0);
                 if pos < 0 { break sg_137; }
                 break sg_137_done;
             }
@@ -7793,7 +7793,7 @@ fn scan_column_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_conflict_clause(tokens, pos);
+                pos = scan_conflict_clause(tokens, pos, 0);
                 if pos < 0 { break sg_138_0; }
                 if pos < tokens.len() && tokens[pos].kind == TK_K_AUTOINCREMENT {
                     let sp = pos;
@@ -7811,7 +7811,7 @@ fn scan_column_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_NULL { break sg_138_1; }
                 pos += 1;
-                pos = scan_conflict_clause(tokens, pos);
+                pos = scan_conflict_clause(tokens, pos, 0);
                 if pos < 0 { break sg_138_1; }
                 break sg_138;
             }
@@ -7819,7 +7819,7 @@ fn scan_column_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_138_2: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_UNIQUE { break sg_138_2; }
                 pos += 1;
-                pos = scan_conflict_clause(tokens, pos);
+                pos = scan_conflict_clause(tokens, pos, 0);
                 if pos < 0 { break sg_138_2; }
                 break sg_138;
             }
@@ -7829,7 +7829,7 @@ fn scan_column_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_138_3; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_138_3; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_138_3; }
                 pos += 1;
@@ -7846,13 +7846,13 @@ fn scan_column_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_140: {
                         pos = gp_140;
                         sg_140_0: {
-                            pos = scan_signed_number(tokens, pos);
+                            pos = scan_signed_number(tokens, pos, 0);
                             if pos < 0 { break sg_140_0; }
                             if pos > sg_140_best { sg_140_best = pos; }
                         }
                         pos = gp_140;
                         sg_140_1: {
-                            pos = scan_literal_value(tokens, pos);
+                            pos = scan_literal_value(tokens, pos, 0);
                             if pos < 0 { break sg_140_1; }
                             if pos > sg_140_best { sg_140_best = pos; }
                         }
@@ -7860,7 +7860,7 @@ fn scan_column_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_140_2: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_140_2; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_140_2; }
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_140_2; }
                             pos += 1;
@@ -7876,13 +7876,13 @@ fn scan_column_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_138_5: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_COLLATE { break sg_138_5; }
                 pos += 1;
-                pos = scan_collation_name(tokens, pos);
+                pos = scan_collation_name(tokens, pos, 0);
                 if pos < 0 { break sg_138_5; }
                 break sg_138;
             }
             pos = gp_138;
             sg_138_6: {
-                pos = scan_foreign_key_clause(tokens, pos);
+                pos = scan_foreign_key_clause(tokens, pos, 0);
                 if pos < 0 { break sg_138_6; }
                 break sg_138;
             }
@@ -7892,7 +7892,7 @@ fn scan_column_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_conflict_clause(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_conflict_clause(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_K_ON {
         let sp = pos;
@@ -7953,7 +7953,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_23(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_literal_value(tokens, pos);
+                pos = scan_literal_value(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -7961,13 +7961,13 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_24(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_literal_value(tokens, pos);
+                pos = scan_literal_value(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_4: {
-                pos = scan_function_name(tokens, pos);
+                pos = scan_function_name(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_4; }
                 pos += 1;
@@ -7982,7 +7982,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                 if pos >= tokens.len() || tokens[pos].kind != TK_K_DISTINCT { pos = -1; } else { pos += 1; }
                                 if pos < 0 { pos = sp; }
                             }
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_143_0; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -7990,7 +7990,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_144: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_144; }
                                         pos += 1;
-                                        pos = scan_expr(tokens, pos);
+                                        pos = scan_expr(tokens, pos, 0);
                                         if pos < 0 { break sg_144; }
                                         break sg_144_done;
                                     }
@@ -8019,24 +8019,24 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_2: {
                 if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT && pos + 2 < tokens.len() && _gale_kind_set_2(tokens[pos + 2].kind) && pos + 3 < tokens.len() && tokens[pos + 3].kind == TK_LIT_DOT {
                     sol_145: {
-                        pos = scan_database_name(tokens, pos);
+                        pos = scan_database_name(tokens, pos, 0);
                         if pos < 0 { break sol_145; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_145; }
                         pos += 1;
-                        pos = scan_table_name(tokens, pos);
+                        pos = scan_table_name(tokens, pos, 0);
                         if pos < 0 { break sol_145; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_145; }
                         pos += 1;
                     }
                 } else if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT {
                     sol_146: {
-                        pos = scan_table_name(tokens, pos);
+                        pos = scan_table_name(tokens, pos, 0);
                         if pos < 0 { break sol_146; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_146; }
                         pos += 1;
                     }
                 }
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -8052,7 +8052,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_26(alt_kind) {
             pos = start;
             try_4: {
-                pos = scan_function_name(tokens, pos);
+                pos = scan_function_name(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_4; }
                 pos += 1;
@@ -8067,7 +8067,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                 if pos >= tokens.len() || tokens[pos].kind != TK_K_DISTINCT { pos = -1; } else { pos += 1; }
                                 if pos < 0 { pos = sp; }
                             }
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_147_0; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -8075,7 +8075,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_148: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_148; }
                                         pos += 1;
-                                        pos = scan_expr(tokens, pos);
+                                        pos = scan_expr(tokens, pos, 0);
                                         if pos < 0 { break sg_148; }
                                         break sg_148_done;
                                     }
@@ -8104,24 +8104,24 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_2: {
                 if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT && pos + 2 < tokens.len() && _gale_kind_set_2(tokens[pos + 2].kind) && pos + 3 < tokens.len() && tokens[pos + 3].kind == TK_LIT_DOT {
                     sol_149: {
-                        pos = scan_database_name(tokens, pos);
+                        pos = scan_database_name(tokens, pos, 0);
                         if pos < 0 { break sol_149; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_149; }
                         pos += 1;
-                        pos = scan_table_name(tokens, pos);
+                        pos = scan_table_name(tokens, pos, 0);
                         if pos < 0 { break sol_149; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_149; }
                         pos += 1;
                     }
                 } else if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT {
                     sol_150: {
-                        pos = scan_table_name(tokens, pos);
+                        pos = scan_table_name(tokens, pos, 0);
                         if pos < 0 { break sol_150; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_150; }
                         pos += 1;
                     }
                 }
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -8133,18 +8133,18 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos < tokens.len() && _gale_kind_set_27(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_expr(tokens, pos);
+                    pos = scan_expr(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 sg_151_done: {
                     sg_151: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_WHEN { break sg_151; }
                         pos += 1;
-                        pos = scan_expr(tokens, pos);
+                        pos = scan_expr(tokens, pos, 0);
                         if pos < 0 { break sg_151; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_THEN { break sg_151; }
                         pos += 1;
-                        pos = scan_expr(tokens, pos);
+                        pos = scan_expr(tokens, pos, 0);
                         if pos < 0 { break sg_151; }
                         break sg_151_done;
                     }
@@ -8156,11 +8156,11 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_152: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_K_WHEN { break sg_152; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_152; }
                             if pos >= tokens.len() || tokens[pos].kind != TK_K_THEN { break sg_152; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_152; }
                             break sg_152_done;
                         }
@@ -8175,7 +8175,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_153: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_K_ELSE { break sg_153; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_153; }
                             break sg_153_done;
                         }
@@ -8189,7 +8189,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_4: {
-                pos = scan_function_name(tokens, pos);
+                pos = scan_function_name(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_4; }
                 pos += 1;
@@ -8204,7 +8204,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                 if pos >= tokens.len() || tokens[pos].kind != TK_K_DISTINCT { pos = -1; } else { pos += 1; }
                                 if pos < 0 { pos = sp; }
                             }
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_154_0; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -8212,7 +8212,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_155: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_155; }
                                         pos += 1;
-                                        pos = scan_expr(tokens, pos);
+                                        pos = scan_expr(tokens, pos, 0);
                                         if pos < 0 { break sg_155; }
                                         break sg_155_done;
                                     }
@@ -8241,24 +8241,24 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_2: {
                 if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT && pos + 2 < tokens.len() && _gale_kind_set_2(tokens[pos + 2].kind) && pos + 3 < tokens.len() && tokens[pos + 3].kind == TK_LIT_DOT {
                     sol_156: {
-                        pos = scan_database_name(tokens, pos);
+                        pos = scan_database_name(tokens, pos, 0);
                         if pos < 0 { break sol_156; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_156; }
                         pos += 1;
-                        pos = scan_table_name(tokens, pos);
+                        pos = scan_table_name(tokens, pos, 0);
                         if pos < 0 { break sol_156; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_156; }
                         pos += 1;
                     }
                 } else if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT {
                     sol_157: {
-                        pos = scan_table_name(tokens, pos);
+                        pos = scan_table_name(tokens, pos, 0);
                         if pos < 0 { break sol_157; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_157; }
                         pos += 1;
                     }
                 }
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -8270,11 +8270,11 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_6; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { break try_6; }
                 pos += 1;
-                pos = scan_type_name(tokens, pos);
+                pos = scan_type_name(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_6; }
                 pos += 1;
@@ -8282,7 +8282,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_4: {
-                pos = scan_function_name(tokens, pos);
+                pos = scan_function_name(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_4; }
                 pos += 1;
@@ -8297,7 +8297,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                 if pos >= tokens.len() || tokens[pos].kind != TK_K_DISTINCT { pos = -1; } else { pos += 1; }
                                 if pos < 0 { pos = sp; }
                             }
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_158_0; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -8305,7 +8305,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_159: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_159; }
                                         pos += 1;
-                                        pos = scan_expr(tokens, pos);
+                                        pos = scan_expr(tokens, pos, 0);
                                         if pos < 0 { break sg_159; }
                                         break sg_159_done;
                                     }
@@ -8334,24 +8334,24 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_2: {
                 if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT && pos + 2 < tokens.len() && _gale_kind_set_2(tokens[pos + 2].kind) && pos + 3 < tokens.len() && tokens[pos + 3].kind == TK_LIT_DOT {
                     sol_160: {
-                        pos = scan_database_name(tokens, pos);
+                        pos = scan_database_name(tokens, pos, 0);
                         if pos < 0 { break sol_160; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_160; }
                         pos += 1;
-                        pos = scan_table_name(tokens, pos);
+                        pos = scan_table_name(tokens, pos, 0);
                         if pos < 0 { break sol_160; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_160; }
                         pos += 1;
                     }
                 } else if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT {
                     sol_161: {
-                        pos = scan_table_name(tokens, pos);
+                        pos = scan_table_name(tokens, pos, 0);
                         if pos < 0 { break sol_161; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_161; }
                         pos += 1;
                     }
                 }
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -8374,7 +8374,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_7; }
                 pos += 1;
-                pos = scan_select_stmt(tokens, pos);
+                pos = scan_select_stmt(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_7; }
                 pos += 1;
@@ -8382,7 +8382,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_4: {
-                pos = scan_function_name(tokens, pos);
+                pos = scan_function_name(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_4; }
                 pos += 1;
@@ -8397,7 +8397,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                 if pos >= tokens.len() || tokens[pos].kind != TK_K_DISTINCT { pos = -1; } else { pos += 1; }
                                 if pos < 0 { pos = sp; }
                             }
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_164_0; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -8405,7 +8405,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_165: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_165; }
                                         pos += 1;
-                                        pos = scan_expr(tokens, pos);
+                                        pos = scan_expr(tokens, pos, 0);
                                         if pos < 0 { break sg_165; }
                                         break sg_165_done;
                                     }
@@ -8434,24 +8434,24 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_2: {
                 if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT && pos + 2 < tokens.len() && _gale_kind_set_2(tokens[pos + 2].kind) && pos + 3 < tokens.len() && tokens[pos + 3].kind == TK_LIT_DOT {
                     sol_166: {
-                        pos = scan_database_name(tokens, pos);
+                        pos = scan_database_name(tokens, pos, 0);
                         if pos < 0 { break sol_166; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_166; }
                         pos += 1;
-                        pos = scan_table_name(tokens, pos);
+                        pos = scan_table_name(tokens, pos, 0);
                         if pos < 0 { break sol_166; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_166; }
                         pos += 1;
                     }
                 } else if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT {
                     sol_167: {
-                        pos = scan_table_name(tokens, pos);
+                        pos = scan_table_name(tokens, pos, 0);
                         if pos < 0 { break sol_167; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_167; }
                         pos += 1;
                     }
                 }
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -8474,7 +8474,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_7; }
                 pos += 1;
-                pos = scan_select_stmt(tokens, pos);
+                pos = scan_select_stmt(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_7; }
                 pos += 1;
@@ -8482,7 +8482,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_4: {
-                pos = scan_function_name(tokens, pos);
+                pos = scan_function_name(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_4; }
                 pos += 1;
@@ -8497,7 +8497,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                 if pos >= tokens.len() || tokens[pos].kind != TK_K_DISTINCT { pos = -1; } else { pos += 1; }
                                 if pos < 0 { pos = sp; }
                             }
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_170_0; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -8505,7 +8505,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_171: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_171; }
                                         pos += 1;
-                                        pos = scan_expr(tokens, pos);
+                                        pos = scan_expr(tokens, pos, 0);
                                         if pos < 0 { break sg_171; }
                                         break sg_171_done;
                                     }
@@ -8534,32 +8534,32 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_2: {
                 if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT && pos + 2 < tokens.len() && _gale_kind_set_2(tokens[pos + 2].kind) && pos + 3 < tokens.len() && tokens[pos + 3].kind == TK_LIT_DOT {
                     sol_172: {
-                        pos = scan_database_name(tokens, pos);
+                        pos = scan_database_name(tokens, pos, 0);
                         if pos < 0 { break sol_172; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_172; }
                         pos += 1;
-                        pos = scan_table_name(tokens, pos);
+                        pos = scan_table_name(tokens, pos, 0);
                         if pos < 0 { break sol_172; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_172; }
                         pos += 1;
                     }
                 } else if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT {
                     sol_173: {
-                        pos = scan_table_name(tokens, pos);
+                        pos = scan_table_name(tokens, pos, 0);
                         if pos < 0 { break sol_173; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_173; }
                         pos += 1;
                     }
                 }
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
             pos = start;
             try_3: {
-                pos = scan_unary_operator(tokens, pos);
+                pos = scan_unary_operator(tokens, pos, 0);
                 if pos < 0 { break try_3; }
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -8567,13 +8567,13 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_K_RAISE {
             pos = start;
             try_9: {
-                pos = scan_raise_function(tokens, pos);
+                pos = scan_raise_function(tokens, pos, 0);
                 if pos < 0 { break try_9; }
                 break scan_alts;
             }
             pos = start;
             try_4: {
-                pos = scan_function_name(tokens, pos);
+                pos = scan_function_name(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_4; }
                 pos += 1;
@@ -8588,7 +8588,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                 if pos >= tokens.len() || tokens[pos].kind != TK_K_DISTINCT { pos = -1; } else { pos += 1; }
                                 if pos < 0 { pos = sp; }
                             }
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_174_0; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -8596,7 +8596,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_175: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_175; }
                                         pos += 1;
-                                        pos = scan_expr(tokens, pos);
+                                        pos = scan_expr(tokens, pos, 0);
                                         if pos < 0 { break sg_175; }
                                         break sg_175_done;
                                     }
@@ -8625,24 +8625,24 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_2: {
                 if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT && pos + 2 < tokens.len() && _gale_kind_set_2(tokens[pos + 2].kind) && pos + 3 < tokens.len() && tokens[pos + 3].kind == TK_LIT_DOT {
                     sol_176: {
-                        pos = scan_database_name(tokens, pos);
+                        pos = scan_database_name(tokens, pos, 0);
                         if pos < 0 { break sol_176; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_176; }
                         pos += 1;
-                        pos = scan_table_name(tokens, pos);
+                        pos = scan_table_name(tokens, pos, 0);
                         if pos < 0 { break sol_176; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_176; }
                         pos += 1;
                     }
                 } else if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT {
                     sol_177: {
-                        pos = scan_table_name(tokens, pos);
+                        pos = scan_table_name(tokens, pos, 0);
                         if pos < 0 { break sol_177; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_177; }
                         pos += 1;
                     }
                 }
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -8665,7 +8665,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_7; }
                 pos += 1;
-                pos = scan_select_stmt(tokens, pos);
+                pos = scan_select_stmt(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_7; }
                 pos += 1;
@@ -8675,7 +8675,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_5: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_5; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_5; }
                 pos += 1;
@@ -8683,7 +8683,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_4: {
-                pos = scan_function_name(tokens, pos);
+                pos = scan_function_name(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_4; }
                 pos += 1;
@@ -8698,7 +8698,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                 if pos >= tokens.len() || tokens[pos].kind != TK_K_DISTINCT { pos = -1; } else { pos += 1; }
                                 if pos < 0 { pos = sp; }
                             }
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_180_0; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -8706,7 +8706,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_181: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_181; }
                                         pos += 1;
-                                        pos = scan_expr(tokens, pos);
+                                        pos = scan_expr(tokens, pos, 0);
                                         if pos < 0 { break sg_181; }
                                         break sg_181_done;
                                     }
@@ -8735,24 +8735,24 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_2: {
                 if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT && pos + 2 < tokens.len() && _gale_kind_set_2(tokens[pos + 2].kind) && pos + 3 < tokens.len() && tokens[pos + 3].kind == TK_LIT_DOT {
                     sol_182: {
-                        pos = scan_database_name(tokens, pos);
+                        pos = scan_database_name(tokens, pos, 0);
                         if pos < 0 { break sol_182; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_182; }
                         pos += 1;
-                        pos = scan_table_name(tokens, pos);
+                        pos = scan_table_name(tokens, pos, 0);
                         if pos < 0 { break sol_182; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_182; }
                         pos += 1;
                     }
                 } else if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT {
                     sol_183: {
-                        pos = scan_table_name(tokens, pos);
+                        pos = scan_table_name(tokens, pos, 0);
                         if pos < 0 { break sol_183; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_183; }
                         pos += 1;
                     }
                 }
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -8760,9 +8760,9 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_29(alt_kind) {
             pos = start;
             try_3: {
-                pos = scan_unary_operator(tokens, pos);
+                pos = scan_unary_operator(tokens, pos, 0);
                 if pos < 0 { break try_3; }
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -8965,13 +8965,13 @@ fn scan_expr_lr_10(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_190: {
                         pos = gp_190;
                         sg_190_0: {
-                            pos = scan_select_stmt(tokens, pos);
+                            pos = scan_select_stmt(tokens, pos, 0);
                             if pos < 0 { break sg_190_0; }
                             if pos > sg_190_best { sg_190_best = pos; }
                         }
                         pos = gp_190;
                         sg_190_1: {
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_190_1; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -8979,7 +8979,7 @@ fn scan_expr_lr_10(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_191: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_191; }
                                         pos += 1;
-                                        pos = scan_expr(tokens, pos);
+                                        pos = scan_expr(tokens, pos, 0);
                                         if pos < 0 { break sg_191; }
                                         break sg_191_done;
                                     }
@@ -9005,7 +9005,7 @@ fn scan_expr_lr_10(tokens: &Array<Token>, pos: i32) -> i32 {
                     let sp = pos;
                     sg_192_done: {
                         sg_192: {
-                            pos = scan_database_name(tokens, pos);
+                            pos = scan_database_name(tokens, pos, 0);
                             if pos < 0 { break sg_192; }
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_192; }
                             pos += 1;
@@ -9015,7 +9015,7 @@ fn scan_expr_lr_10(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_table_name(tokens, pos);
+                pos = scan_table_name(tokens, pos, 0);
                 if pos < 0 { break sg_189_1; }
                 if pos > sg_189_best { sg_189_best = pos; }
             }
@@ -9048,7 +9048,7 @@ fn scan_expr_lr_16(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_COLLATE { return -1; }
     pos += 1;
-    pos = scan_collation_name(tokens, pos);
+    pos = scan_collation_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -9096,7 +9096,7 @@ fn scan_expr_lr_17(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_194: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_ESCAPE { break sg_194; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_194; }
                 break sg_194_done;
             }
@@ -9342,11 +9342,11 @@ fn scan_expr(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     return pos;
 }
 
-fn scan_foreign_key_clause(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_foreign_key_clause(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_REFERENCES { return -1; }
     pos += 1;
-    pos = scan_foreign_table(tokens, pos);
+    pos = scan_foreign_table(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_LPAREN {
         let sp = pos;
@@ -9354,7 +9354,7 @@ fn scan_foreign_key_clause(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_196: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_196; }
                 pos += 1;
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break sg_196; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -9362,7 +9362,7 @@ fn scan_foreign_key_clause(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_197: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_197; }
                             pos += 1;
-                            pos = scan_column_name(tokens, pos);
+                            pos = scan_column_name(tokens, pos, 0);
                             if pos < 0 { break sg_197; }
                             break sg_197_done;
                         }
@@ -9458,7 +9458,7 @@ fn scan_foreign_key_clause(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_199_1: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_K_MATCH { break sg_199_1; }
                             pos += 1;
-                            pos = scan_name(tokens, pos);
+                            pos = scan_name(tokens, pos, 0);
                             if pos < 0 { break sg_199_1; }
                             break sg_199;
                         }
@@ -9550,7 +9550,7 @@ fn scan_foreign_key_clause(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_raise_function(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_raise_function(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_RAISE { return -1; }
     pos += 1;
@@ -9592,7 +9592,7 @@ fn scan_raise_function(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_208_1; }
                 pos += 1;
-                pos = scan_error_message(tokens, pos);
+                pos = scan_error_message(tokens, pos, 0);
                 if pos < 0 { break sg_208_1; }
                 break sg_208;
             }
@@ -9604,9 +9604,9 @@ fn scan_raise_function(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_indexed_column(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_indexed_column(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_column_name(tokens, pos);
+    pos = scan_column_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_K_COLLATE {
         let sp = pos;
@@ -9614,7 +9614,7 @@ fn scan_indexed_column(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_210: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_COLLATE { break sg_210; }
                 pos += 1;
-                pos = scan_collation_name(tokens, pos);
+                pos = scan_collation_name(tokens, pos, 0);
                 if pos < 0 { break sg_210; }
                 break sg_210_done;
             }
@@ -9645,7 +9645,7 @@ fn scan_indexed_column(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_table_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_table_constraint(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_K_CONSTRAINT {
         let sp = pos;
@@ -9653,7 +9653,7 @@ fn scan_table_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_212: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_CONSTRAINT { break sg_212; }
                 pos += 1;
-                pos = scan_name(tokens, pos);
+                pos = scan_name(tokens, pos, 0);
                 if pos < 0 { break sg_212; }
                 break sg_212_done;
             }
@@ -9690,7 +9690,7 @@ fn scan_table_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_213_0; }
                 pos += 1;
-                pos = scan_indexed_column(tokens, pos);
+                pos = scan_indexed_column(tokens, pos, 0);
                 if pos < 0 { break sg_213_0; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -9698,7 +9698,7 @@ fn scan_table_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_215: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_215; }
                             pos += 1;
-                            pos = scan_indexed_column(tokens, pos);
+                            pos = scan_indexed_column(tokens, pos, 0);
                             if pos < 0 { break sg_215; }
                             break sg_215_done;
                         }
@@ -9709,7 +9709,7 @@ fn scan_table_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_213_0; }
                 pos += 1;
-                pos = scan_conflict_clause(tokens, pos);
+                pos = scan_conflict_clause(tokens, pos, 0);
                 if pos < 0 { break sg_213_0; }
                 break sg_213;
             }
@@ -9719,7 +9719,7 @@ fn scan_table_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_213_1; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_213_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_213_1; }
                 pos += 1;
@@ -9733,7 +9733,7 @@ fn scan_table_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_213_2; }
                 pos += 1;
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break sg_213_2; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -9741,7 +9741,7 @@ fn scan_table_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_216: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_216; }
                             pos += 1;
-                            pos = scan_column_name(tokens, pos);
+                            pos = scan_column_name(tokens, pos, 0);
                             if pos < 0 { break sg_216; }
                             break sg_216_done;
                         }
@@ -9752,7 +9752,7 @@ fn scan_table_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_213_2; }
                 pos += 1;
-                pos = scan_foreign_key_clause(tokens, pos);
+                pos = scan_foreign_key_clause(tokens, pos, 0);
                 if pos < 0 { break sg_213_2; }
                 break sg_213;
             }
@@ -9762,7 +9762,7 @@ fn scan_table_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_with_clause(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_with_clause(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_WITH { return -1; }
     pos += 1;
@@ -9771,7 +9771,7 @@ fn scan_with_clause(tokens: &Array<Token>, pos: i32) -> i32 {
         if pos >= tokens.len() || tokens[pos].kind != TK_K_RECURSIVE { pos = -1; } else { pos += 1; }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_common_table_expression(tokens, pos);
+    pos = scan_common_table_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -9779,7 +9779,7 @@ fn scan_with_clause(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_217: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_217; }
                 pos += 1;
-                pos = scan_common_table_expression(tokens, pos);
+                pos = scan_common_table_expression(tokens, pos, 0);
                 if pos < 0 { break sg_217; }
                 break sg_217_done;
             }
@@ -9791,13 +9791,13 @@ fn scan_with_clause(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_qualified_table_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_qualified_table_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) {
         let sp = pos;
         sg_218_done: {
             sg_218: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_218; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_218; }
                 pos += 1;
@@ -9807,7 +9807,7 @@ fn scan_qualified_table_name(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_table_name(tokens, pos);
+    pos = scan_table_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && _gale_kind_set_44(tokens[pos].kind) {
         let sp = pos;
@@ -9819,7 +9819,7 @@ fn scan_qualified_table_name(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sg_219_0; }
                 pos += 1;
-                pos = scan_index_name(tokens, pos);
+                pos = scan_index_name(tokens, pos, 0);
                 if pos < 0 { break sg_219_0; }
                 break sg_219;
             }
@@ -9838,9 +9838,9 @@ fn scan_qualified_table_name(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_ordering_term(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_ordering_term(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_expr(tokens, pos);
+    pos = scan_expr(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_K_COLLATE {
         let sp = pos;
@@ -9848,7 +9848,7 @@ fn scan_ordering_term(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_220: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_COLLATE { break sg_220; }
                 pos += 1;
-                pos = scan_collation_name(tokens, pos);
+                pos = scan_collation_name(tokens, pos, 0);
                 if pos < 0 { break sg_220; }
                 break sg_220_done;
             }
@@ -9879,7 +9879,7 @@ fn scan_ordering_term(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_pragma_value(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_pragma_value(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -9887,7 +9887,7 @@ fn scan_pragma_value(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_45(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_signed_number(tokens, pos);
+                pos = scan_signed_number(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -9895,7 +9895,7 @@ fn scan_pragma_value(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_46(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_name(tokens, pos);
+                pos = scan_name(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -9903,7 +9903,7 @@ fn scan_pragma_value(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_STRING_LITERAL {
             pos = start;
             try_1: {
-                pos = scan_name(tokens, pos);
+                pos = scan_name(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -9921,9 +9921,9 @@ fn scan_pragma_value(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_common_table_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_common_table_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_table_name(tokens, pos);
+    pos = scan_table_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_LPAREN {
         let sp = pos;
@@ -9931,7 +9931,7 @@ fn scan_common_table_expression(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_222: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_222; }
                 pos += 1;
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break sg_222; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -9939,7 +9939,7 @@ fn scan_common_table_expression(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_223: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_223; }
                             pos += 1;
-                            pos = scan_column_name(tokens, pos);
+                            pos = scan_column_name(tokens, pos, 0);
                             if pos < 0 { break sg_223; }
                             break sg_223_done;
                         }
@@ -9960,14 +9960,14 @@ fn scan_common_table_expression(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_select_stmt(tokens, pos);
+    pos = scan_select_stmt(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_result_column(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_result_column(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -9983,7 +9983,7 @@ fn scan_result_column(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_2(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_table_name(tokens, pos);
+                pos = scan_table_name(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break try_1; }
                 pos += 1;
@@ -9993,18 +9993,18 @@ fn scan_result_column(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_2: {
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 if pos < tokens.len() && tokens[pos].kind == TK_K_AS && pos + 1 < tokens.len() && _gale_kind_set_48(tokens[pos + 1].kind) {
                     sol_224: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { break sol_224; }
                         pos += 1;
-                        pos = scan_column_alias(tokens, pos);
+                        pos = scan_column_alias(tokens, pos, 0);
                         if pos < 0 { break sol_224; }
                     }
                 } else if pos < tokens.len() && _gale_kind_set_48(tokens[pos].kind) {
                     sol_225: {
-                        pos = scan_column_alias(tokens, pos);
+                        pos = scan_column_alias(tokens, pos, 0);
                         if pos < 0 { break sol_225; }
                     }
                 }
@@ -10014,18 +10014,18 @@ fn scan_result_column(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_49(alt_kind) {
             pos = start;
             try_2: {
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 if pos < tokens.len() && tokens[pos].kind == TK_K_AS && pos + 1 < tokens.len() && _gale_kind_set_48(tokens[pos + 1].kind) {
                     sol_226: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { break sol_226; }
                         pos += 1;
-                        pos = scan_column_alias(tokens, pos);
+                        pos = scan_column_alias(tokens, pos, 0);
                         if pos < 0 { break sol_226; }
                     }
                 } else if pos < tokens.len() && _gale_kind_set_48(tokens[pos].kind) {
                     sol_227: {
-                        pos = scan_column_alias(tokens, pos);
+                        pos = scan_column_alias(tokens, pos, 0);
                         if pos < 0 { break sol_227; }
                     }
                 }
@@ -10039,7 +10039,7 @@ fn scan_result_column(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -10051,7 +10051,7 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                     let sp = pos;
                     sg_228_done: {
                         sg_228: {
-                            pos = scan_schema_name(tokens, pos);
+                            pos = scan_schema_name(tokens, pos, 0);
                             if pos < 0 { break sg_228; }
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_228; }
                             pos += 1;
@@ -10061,7 +10061,7 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_table_function_name(tokens, pos);
+                pos = scan_table_function_name(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_1; }
                 pos += 1;
@@ -10069,7 +10069,7 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                     let sp = pos;
                     sg_229_done: {
                         sg_229: {
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_229; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -10077,7 +10077,7 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_230: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_230; }
                                         pos += 1;
-                                        pos = scan_expr(tokens, pos);
+                                        pos = scan_expr(tokens, pos, 0);
                                         if pos < 0 { break sg_230; }
                                         break sg_230_done;
                                     }
@@ -10098,12 +10098,12 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                     sol_231: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { break sol_231; }
                         pos += 1;
-                        pos = scan_table_alias(tokens, pos);
+                        pos = scan_table_alias(tokens, pos, 0);
                         if pos < 0 { break sol_231; }
                     }
                 } else if pos < tokens.len() && _gale_kind_set_52(tokens[pos].kind) {
                     sol_232: {
-                        pos = scan_table_alias(tokens, pos);
+                        pos = scan_table_alias(tokens, pos, 0);
                         if pos < 0 { break sol_232; }
                     }
                 }
@@ -10115,7 +10115,7 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                     let sp = pos;
                     sg_233_done: {
                         sg_233: {
-                            pos = scan_schema_name(tokens, pos);
+                            pos = scan_schema_name(tokens, pos, 0);
                             if pos < 0 { break sg_233; }
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_233; }
                             pos += 1;
@@ -10125,18 +10125,18 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_table_name(tokens, pos);
+                pos = scan_table_name(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos < tokens.len() && tokens[pos].kind == TK_K_AS && pos + 1 < tokens.len() && _gale_kind_set_52(tokens[pos + 1].kind) {
                     sol_234: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { break sol_234; }
                         pos += 1;
-                        pos = scan_table_alias(tokens, pos);
+                        pos = scan_table_alias(tokens, pos, 0);
                         if pos < 0 { break sol_234; }
                     }
                 } else if pos < tokens.len() && _gale_kind_set_52(tokens[pos].kind) {
                     sol_235: {
-                        pos = scan_table_alias(tokens, pos);
+                        pos = scan_table_alias(tokens, pos, 0);
                         if pos < 0 { break sol_235; }
                     }
                 }
@@ -10150,7 +10150,7 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                             pos += 1;
                             if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sg_236_0; }
                             pos += 1;
-                            pos = scan_index_name(tokens, pos);
+                            pos = scan_index_name(tokens, pos, 0);
                             if pos < 0 { break sg_236_0; }
                             break sg_236;
                         }
@@ -10174,7 +10174,7 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
             try_3: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_3; }
                 pos += 1;
-                pos = scan_select_stmt(tokens, pos);
+                pos = scan_select_stmt(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_3; }
                 pos += 1;
@@ -10182,12 +10182,12 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                     sol_237: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { break sol_237; }
                         pos += 1;
-                        pos = scan_table_alias(tokens, pos);
+                        pos = scan_table_alias(tokens, pos, 0);
                         if pos < 0 { break sol_237; }
                     }
                 } else if pos < tokens.len() && _gale_kind_set_52(tokens[pos].kind) {
                     sol_238: {
-                        pos = scan_table_alias(tokens, pos);
+                        pos = scan_table_alias(tokens, pos, 0);
                         if pos < 0 { break sol_238; }
                     }
                 }
@@ -10204,7 +10204,7 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_239: {
                         pos = gp_239;
                         sg_239_0: {
-                            pos = scan_table_or_subquery(tokens, pos);
+                            pos = scan_table_or_subquery(tokens, pos, 0);
                             if pos < 0 { break sg_239_0; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -10212,7 +10212,7 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_240: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_240; }
                                         pos += 1;
-                                        pos = scan_table_or_subquery(tokens, pos);
+                                        pos = scan_table_or_subquery(tokens, pos, 0);
                                         if pos < 0 { break sg_240; }
                                         break sg_240_done;
                                     }
@@ -10225,7 +10225,7 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                         }
                         pos = gp_239;
                         sg_239_1: {
-                            pos = scan_join_clause(tokens, pos);
+                            pos = scan_join_clause(tokens, pos, 0);
                             if pos < 0 { break sg_239_1; }
                             if pos > sg_239_best { sg_239_best = pos; }
                         }
@@ -10243,7 +10243,7 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                     let sp = pos;
                     sg_241_done: {
                         sg_241: {
-                            pos = scan_schema_name(tokens, pos);
+                            pos = scan_schema_name(tokens, pos, 0);
                             if pos < 0 { break sg_241; }
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_241; }
                             pos += 1;
@@ -10253,7 +10253,7 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_table_function_name(tokens, pos);
+                pos = scan_table_function_name(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_1; }
                 pos += 1;
@@ -10261,7 +10261,7 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                     let sp = pos;
                     sg_242_done: {
                         sg_242: {
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_242; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -10269,7 +10269,7 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_243: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_243; }
                                         pos += 1;
-                                        pos = scan_expr(tokens, pos);
+                                        pos = scan_expr(tokens, pos, 0);
                                         if pos < 0 { break sg_243; }
                                         break sg_243_done;
                                     }
@@ -10290,12 +10290,12 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                     sol_244: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { break sol_244; }
                         pos += 1;
-                        pos = scan_table_alias(tokens, pos);
+                        pos = scan_table_alias(tokens, pos, 0);
                         if pos < 0 { break sol_244; }
                     }
                 } else if pos < tokens.len() && _gale_kind_set_52(tokens[pos].kind) {
                     sol_245: {
-                        pos = scan_table_alias(tokens, pos);
+                        pos = scan_table_alias(tokens, pos, 0);
                         if pos < 0 { break sol_245; }
                     }
                 }
@@ -10307,7 +10307,7 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                     let sp = pos;
                     sg_246_done: {
                         sg_246: {
-                            pos = scan_schema_name(tokens, pos);
+                            pos = scan_schema_name(tokens, pos, 0);
                             if pos < 0 { break sg_246; }
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_246; }
                             pos += 1;
@@ -10317,18 +10317,18 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_table_name(tokens, pos);
+                pos = scan_table_name(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos < tokens.len() && tokens[pos].kind == TK_K_AS && pos + 1 < tokens.len() && _gale_kind_set_52(tokens[pos + 1].kind) {
                     sol_247: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { break sol_247; }
                         pos += 1;
-                        pos = scan_table_alias(tokens, pos);
+                        pos = scan_table_alias(tokens, pos, 0);
                         if pos < 0 { break sol_247; }
                     }
                 } else if pos < tokens.len() && _gale_kind_set_52(tokens[pos].kind) {
                     sol_248: {
-                        pos = scan_table_alias(tokens, pos);
+                        pos = scan_table_alias(tokens, pos, 0);
                         if pos < 0 { break sol_248; }
                     }
                 }
@@ -10342,7 +10342,7 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                             pos += 1;
                             if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sg_249_0; }
                             pos += 1;
-                            pos = scan_index_name(tokens, pos);
+                            pos = scan_index_name(tokens, pos, 0);
                             if pos < 0 { break sg_249_0; }
                             break sg_249;
                         }
@@ -10368,19 +10368,19 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_join_clause(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_join_clause(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_table_or_subquery(tokens, pos);
+    pos = scan_table_or_subquery(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && _gale_kind_set_53(tokens[pos].kind) {
         let sp = pos;
         sg_250_done: {
             sg_250: {
-                pos = scan_join_operator(tokens, pos);
+                pos = scan_join_operator(tokens, pos, 0);
                 if pos < 0 { break sg_250; }
-                pos = scan_table_or_subquery(tokens, pos);
+                pos = scan_table_or_subquery(tokens, pos, 0);
                 if pos < 0 { break sg_250; }
-                pos = scan_join_constraint(tokens, pos);
+                pos = scan_join_constraint(tokens, pos, 0);
                 if pos < 0 { break sg_250; }
                 break sg_250_done;
             }
@@ -10392,7 +10392,7 @@ fn scan_join_clause(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_join_operator(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_join_operator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -10456,7 +10456,7 @@ fn scan_join_operator(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_join_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_join_constraint(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && _gale_kind_set_56(tokens[pos].kind) {
         let sp = pos;
@@ -10466,7 +10466,7 @@ fn scan_join_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_252_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_ON { break sg_252_0; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_252_0; }
                 break sg_252;
             }
@@ -10476,7 +10476,7 @@ fn scan_join_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_252_1; }
                 pos += 1;
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break sg_252_1; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -10484,7 +10484,7 @@ fn scan_join_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_253: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_253; }
                             pos += 1;
-                            pos = scan_column_name(tokens, pos);
+                            pos = scan_column_name(tokens, pos, 0);
                             if pos < 0 { break sg_253; }
                             break sg_253_done;
                         }
@@ -10504,7 +10504,7 @@ fn scan_join_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_select_core(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -10534,7 +10534,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_result_column(tokens, pos);
+                pos = scan_result_column(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -10542,7 +10542,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_255: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_255; }
                             pos += 1;
-                            pos = scan_result_column(tokens, pos);
+                            pos = scan_result_column(tokens, pos, 0);
                             if pos < 0 { break sg_255; }
                             break sg_255_done;
                         }
@@ -10564,7 +10564,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                                 sg_257: {
                                     pos = gp_257;
                                     sg_257_0: {
-                                        pos = scan_table_or_subquery(tokens, pos);
+                                        pos = scan_table_or_subquery(tokens, pos, 0);
                                         if pos < 0 { break sg_257_0; }
                                         while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                             let sp = pos;
@@ -10572,7 +10572,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                                                 sg_258: {
                                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_258; }
                                                     pos += 1;
-                                                    pos = scan_table_or_subquery(tokens, pos);
+                                                    pos = scan_table_or_subquery(tokens, pos, 0);
                                                     if pos < 0 { break sg_258; }
                                                     break sg_258_done;
                                                 }
@@ -10585,7 +10585,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                                     }
                                     pos = gp_257;
                                     sg_257_1: {
-                                        pos = scan_join_clause(tokens, pos);
+                                        pos = scan_join_clause(tokens, pos, 0);
                                         if pos < 0 { break sg_257_1; }
                                         if pos > sg_257_best { sg_257_best = pos; }
                                     }
@@ -10605,7 +10605,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_259: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_K_WHERE { break sg_259; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_259; }
                             break sg_259_done;
                         }
@@ -10619,7 +10619,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                         pos += 1;
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sol_260; }
                         pos += 1;
-                        pos = scan_expr(tokens, pos);
+                        pos = scan_expr(tokens, pos, 0);
                         if pos < 0 { break sol_260; }
                         while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                             let sp = pos;
@@ -10627,7 +10627,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                                 sg_261: {
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_261; }
                                     pos += 1;
-                                    pos = scan_expr(tokens, pos);
+                                    pos = scan_expr(tokens, pos, 0);
                                     if pos < 0 { break sg_261; }
                                     break sg_261_done;
                                 }
@@ -10638,7 +10638,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                         }
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_HAVING { break sol_260; }
                         pos += 1;
-                        pos = scan_expr(tokens, pos);
+                        pos = scan_expr(tokens, pos, 0);
                         if pos < 0 { break sol_260; }
                     }
                 } else if pos < tokens.len() && tokens[pos].kind == TK_K_GROUP && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_K_BY && pos + 2 < tokens.len() && _gale_kind_set_6(tokens[pos + 2].kind) && pos + 3 < tokens.len() && tokens[pos + 3].kind == TK_K_HAVING && pos + 4 < tokens.len() && _gale_kind_set_6(tokens[pos + 4].kind) {
@@ -10647,11 +10647,11 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                         pos += 1;
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sol_262; }
                         pos += 1;
-                        pos = scan_expr(tokens, pos);
+                        pos = scan_expr(tokens, pos, 0);
                         if pos < 0 { break sol_262; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_HAVING { break sol_262; }
                         pos += 1;
-                        pos = scan_expr(tokens, pos);
+                        pos = scan_expr(tokens, pos, 0);
                         if pos < 0 { break sol_262; }
                     }
                 } else if pos < tokens.len() && tokens[pos].kind == TK_K_GROUP && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_K_BY && pos + 2 < tokens.len() && _gale_kind_set_6(tokens[pos + 2].kind) && pos + 3 < tokens.len() && tokens[pos + 3].kind == TK_LIT_COMMA {
@@ -10660,7 +10660,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                         pos += 1;
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sol_263; }
                         pos += 1;
-                        pos = scan_expr(tokens, pos);
+                        pos = scan_expr(tokens, pos, 0);
                         if pos < 0 { break sol_263; }
                         while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                             let sp = pos;
@@ -10668,7 +10668,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                                 sg_264: {
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_264; }
                                     pos += 1;
-                                    pos = scan_expr(tokens, pos);
+                                    pos = scan_expr(tokens, pos, 0);
                                     if pos < 0 { break sg_264; }
                                     break sg_264_done;
                                 }
@@ -10684,7 +10684,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                         pos += 1;
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sol_265; }
                         pos += 1;
-                        pos = scan_expr(tokens, pos);
+                        pos = scan_expr(tokens, pos, 0);
                         if pos < 0 { break sol_265; }
                     }
                 }
@@ -10698,7 +10698,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_1; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -10706,7 +10706,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_266: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_266; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_266; }
                             break sg_266_done;
                         }
@@ -10725,7 +10725,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                             pos += 1;
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_267; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_267; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -10733,7 +10733,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_268: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_268; }
                                         pos += 1;
-                                        pos = scan_expr(tokens, pos);
+                                        pos = scan_expr(tokens, pos, 0);
                                         if pos < 0 { break sg_268; }
                                         break sg_268_done;
                                     }
@@ -10761,7 +10761,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_compound_operator(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_compound_operator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -10805,7 +10805,7 @@ fn scan_compound_operator(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_signed_number(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_signed_number(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && _gale_kind_set_32(tokens[pos].kind) {
         let sp = pos;
@@ -10832,28 +10832,28 @@ fn scan_signed_number(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_literal_value(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_literal_value(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_57(tokens[pos].kind) {
         return pos + 1;
     }
     return -1;
 }
 
-fn scan_unary_operator(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_unary_operator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_58(tokens[pos].kind) {
         return pos + 1;
     }
     return -1;
 }
 
-fn scan_error_message(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_error_message(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_STRING_LITERAL { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_module_argument(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_module_argument(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -10861,7 +10861,7 @@ fn scan_module_argument(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_49(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -10869,13 +10869,13 @@ fn scan_module_argument(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_2(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_1: {
-                pos = scan_column_def(tokens, pos);
+                pos = scan_column_def(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -10887,140 +10887,140 @@ fn scan_module_argument(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_column_alias(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_column_alias(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_48(tokens[pos].kind) {
         return pos + 1;
     }
     return -1;
 }
 
-fn scan_keyword(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_keyword(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_59(tokens[pos].kind) {
         return pos + 1;
     }
     return -1;
 }
 
-fn scan_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_function_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_function_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_database_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_database_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_schema_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_schema_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_table_function_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_table_function_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_table_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_table_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_table_or_index_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_table_or_index_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_new_table_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_new_table_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_column_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_column_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_collation_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_collation_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_foreign_table(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_foreign_table(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_index_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_index_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_trigger_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_trigger_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_view_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_view_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_module_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_module_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_pragma_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_pragma_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_savepoint_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_savepoint_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_table_alias(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_table_alias(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -11046,7 +11046,7 @@ fn scan_table_alias(tokens: &Array<Token>, pos: i32) -> i32 {
             try_2: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_2; }
                 pos += 1;
-                pos = scan_table_alias(tokens, pos);
+                pos = scan_table_alias(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_2; }
                 pos += 1;
@@ -11060,14 +11060,14 @@ fn scan_table_alias(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_transaction_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_transaction_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_any_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_any_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -11083,7 +11083,7 @@ fn scan_any_name(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_59(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_keyword(tokens, pos);
+                pos = scan_keyword(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -11101,7 +11101,7 @@ fn scan_any_name(tokens: &Array<Token>, pos: i32) -> i32 {
             try_3: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_3; }
                 pos += 1;
-                pos = scan_any_name(tokens, pos);
+                pos = scan_any_name(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_3; }
                 pos += 1;
@@ -11127,13 +11127,13 @@ fn parse_parse(p: &mut Parser) -> Result<ParseNode, ParseError> {
             sg_270: {
                 pos = gp_270;
                 sg_270_0: {
-                    pos = scan_sql_stmt_list(tokens, pos);
+                    pos = scan_sql_stmt_list(tokens, pos, 0);
                     if pos < 0 { break sg_270_0; }
                     break sg_270;
                 }
                 pos = gp_270;
                 sg_270_1: {
-                    pos = scan_error(tokens, pos);
+                    pos = scan_error(tokens, pos, 0);
                     if pos < 0 { break sg_270_1; }
                     break sg_270;
                 }
@@ -11201,7 +11201,7 @@ fn parse_sql_stmt_list(p: &mut Parser) -> Result<SqlStmtListNode, ParseError> {
                 if pos < 0 { pos = sp; break; }
                 if pos == sp { break; }
             }
-            pos = scan_sql_stmt(tokens, pos);
+            pos = scan_sql_stmt(tokens, pos, 0);
             if pos < 0 { break rep_scan_2; }
             if pos <= p.pos { break rep_scan_2; }
             rep_scan_pos_2 = pos;
@@ -11303,7 +11303,7 @@ fn parse_sql_stmt(p: &mut Parser) -> Result<SqlStmtNode, ParseError> {
             gd_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_compound_select_stmt(tokens, pos);
+                pos = scan_compound_select_stmt(tokens, pos, 0);
                 if pos < 0 { break gd_scan; }
                 gd_winner = 0;
                 break gd_dispatch;
@@ -11311,7 +11311,7 @@ fn parse_sql_stmt(p: &mut Parser) -> Result<SqlStmtNode, ParseError> {
             gd_scan_2: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_delete_stmt(tokens, pos);
+                pos = scan_delete_stmt(tokens, pos, 0);
                 if pos < 0 { break gd_scan_2; }
                 gd_winner = 1;
                 break gd_dispatch;
@@ -11319,7 +11319,7 @@ fn parse_sql_stmt(p: &mut Parser) -> Result<SqlStmtNode, ParseError> {
             gd_scan_3: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_delete_stmt_limited(tokens, pos);
+                pos = scan_delete_stmt_limited(tokens, pos, 0);
                 if pos < 0 { break gd_scan_3; }
                 gd_winner = 2;
                 break gd_dispatch;
@@ -11327,7 +11327,7 @@ fn parse_sql_stmt(p: &mut Parser) -> Result<SqlStmtNode, ParseError> {
             gd_scan_4: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_factored_select_stmt(tokens, pos);
+                pos = scan_factored_select_stmt(tokens, pos, 0);
                 if pos < 0 { break gd_scan_4; }
                 gd_winner = 3;
                 break gd_dispatch;
@@ -11335,7 +11335,7 @@ fn parse_sql_stmt(p: &mut Parser) -> Result<SqlStmtNode, ParseError> {
             gd_scan_5: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_insert_stmt(tokens, pos);
+                pos = scan_insert_stmt(tokens, pos, 0);
                 if pos < 0 { break gd_scan_5; }
                 gd_winner = 4;
                 break gd_dispatch;
@@ -11343,7 +11343,7 @@ fn parse_sql_stmt(p: &mut Parser) -> Result<SqlStmtNode, ParseError> {
             gd_scan_6: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_simple_select_stmt(tokens, pos);
+                pos = scan_simple_select_stmt(tokens, pos, 0);
                 if pos < 0 { break gd_scan_6; }
                 gd_winner = 5;
                 break gd_dispatch;
@@ -11351,7 +11351,7 @@ fn parse_sql_stmt(p: &mut Parser) -> Result<SqlStmtNode, ParseError> {
             gd_scan_7: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_select_stmt(tokens, pos);
+                pos = scan_select_stmt(tokens, pos, 0);
                 if pos < 0 { break gd_scan_7; }
                 gd_winner = 6;
                 break gd_dispatch;
@@ -11359,7 +11359,7 @@ fn parse_sql_stmt(p: &mut Parser) -> Result<SqlStmtNode, ParseError> {
             gd_scan_8: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_update_stmt(tokens, pos);
+                pos = scan_update_stmt(tokens, pos, 0);
                 if pos < 0 { break gd_scan_8; }
                 gd_winner = 7;
                 break gd_dispatch;
@@ -11399,7 +11399,7 @@ fn parse_sql_stmt(p: &mut Parser) -> Result<SqlStmtNode, ParseError> {
             gd_scan_9: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_create_index_stmt(tokens, pos);
+                pos = scan_create_index_stmt(tokens, pos, 0);
                 if pos < 0 { break gd_scan_9; }
                 gd_winner_2 = 0;
                 break gd_dispatch_2;
@@ -11407,7 +11407,7 @@ fn parse_sql_stmt(p: &mut Parser) -> Result<SqlStmtNode, ParseError> {
             gd_scan_10: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_create_table_stmt(tokens, pos);
+                pos = scan_create_table_stmt(tokens, pos, 0);
                 if pos < 0 { break gd_scan_10; }
                 gd_winner_2 = 1;
                 break gd_dispatch_2;
@@ -11415,7 +11415,7 @@ fn parse_sql_stmt(p: &mut Parser) -> Result<SqlStmtNode, ParseError> {
             gd_scan_11: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_create_trigger_stmt(tokens, pos);
+                pos = scan_create_trigger_stmt(tokens, pos, 0);
                 if pos < 0 { break gd_scan_11; }
                 gd_winner_2 = 2;
                 break gd_dispatch_2;
@@ -11423,7 +11423,7 @@ fn parse_sql_stmt(p: &mut Parser) -> Result<SqlStmtNode, ParseError> {
             gd_scan_12: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_create_view_stmt(tokens, pos);
+                pos = scan_create_view_stmt(tokens, pos, 0);
                 if pos < 0 { break gd_scan_12; }
                 gd_winner_2 = 3;
                 break gd_dispatch_2;
@@ -11454,7 +11454,7 @@ fn parse_sql_stmt(p: &mut Parser) -> Result<SqlStmtNode, ParseError> {
             gd_scan_13: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_drop_index_stmt(tokens, pos);
+                pos = scan_drop_index_stmt(tokens, pos, 0);
                 if pos < 0 { break gd_scan_13; }
                 gd_winner_3 = 0;
                 break gd_dispatch_3;
@@ -11462,7 +11462,7 @@ fn parse_sql_stmt(p: &mut Parser) -> Result<SqlStmtNode, ParseError> {
             gd_scan_14: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_drop_table_stmt(tokens, pos);
+                pos = scan_drop_table_stmt(tokens, pos, 0);
                 if pos < 0 { break gd_scan_14; }
                 gd_winner_3 = 1;
                 break gd_dispatch_3;
@@ -11470,7 +11470,7 @@ fn parse_sql_stmt(p: &mut Parser) -> Result<SqlStmtNode, ParseError> {
             gd_scan_15: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_drop_trigger_stmt(tokens, pos);
+                pos = scan_drop_trigger_stmt(tokens, pos, 0);
                 if pos < 0 { break gd_scan_15; }
                 gd_winner_3 = 2;
                 break gd_dispatch_3;
@@ -11524,7 +11524,7 @@ fn parse_alter_table_stmt(p: &mut Parser) -> Result<AlterTableStmtNode, ParseErr
     opt_scan: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_database_name(tokens, pos);
+        pos = scan_database_name(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan; }
         pos += 1;
@@ -11591,23 +11591,23 @@ fn parse_analyze_stmt(p: &mut Parser) -> Result<AnalyzeStmtNode, ParseError> {
         sg_271: {
             pos = gp_271;
             sg_271_0: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_271_0; }
                 if pos > sg_271_best { sg_271_best = pos; }
             }
             pos = gp_271;
             sg_271_1: {
-                pos = scan_table_or_index_name(tokens, pos);
+                pos = scan_table_or_index_name(tokens, pos, 0);
                 if pos < 0 { break sg_271_1; }
                 if pos > sg_271_best { sg_271_best = pos; }
             }
             pos = gp_271;
             sg_271_2: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_271_2; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_271_2; }
                 pos += 1;
-                pos = scan_table_or_index_name(tokens, pos);
+                pos = scan_table_or_index_name(tokens, pos, 0);
                 if pos < 0 { break sg_271_2; }
                 if pos > sg_271_best { sg_271_best = pos; }
             }
@@ -11625,7 +11625,7 @@ fn parse_analyze_stmt(p: &mut Parser) -> Result<AnalyzeStmtNode, ParseError> {
                 gd_scan: {
                     let tokens = &p.tokens;
                     let mut pos: i32 = p.pos;
-                    pos = scan_database_name(tokens, pos);
+                    pos = scan_database_name(tokens, pos, 0);
                     if pos < 0 { break gd_scan; }
                     gd_winner = 0;
                     break gd_dispatch;
@@ -11633,7 +11633,7 @@ fn parse_analyze_stmt(p: &mut Parser) -> Result<AnalyzeStmtNode, ParseError> {
                 gd_scan_2: {
                     let tokens = &p.tokens;
                     let mut pos: i32 = p.pos;
-                    pos = scan_table_or_index_name(tokens, pos);
+                    pos = scan_table_or_index_name(tokens, pos, 0);
                     if pos < 0 { break gd_scan_2; }
                     gd_winner = 1;
                     break gd_dispatch;
@@ -11831,7 +11831,7 @@ fn parse_compound_select_stmt(p: &mut Parser) -> Result<CompoundSelectStmtNode, 
                         pos = gp_273;
                     }
                 }
-                pos = scan_select_core(tokens, pos);
+                pos = scan_select_core(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -11884,7 +11884,7 @@ fn parse_compound_select_stmt(p: &mut Parser) -> Result<CompoundSelectStmtNode, 
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_ordering_term(tokens, pos);
+                pos = scan_ordering_term(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -11931,7 +11931,7 @@ fn parse_compound_select_stmt(p: &mut Parser) -> Result<CompoundSelectStmtNode, 
                 }
                 break opt_scan;
             }
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break opt_scan; }
             opt_scan_pos = pos;
         }
@@ -11992,7 +11992,7 @@ fn parse_create_index_stmt(p: &mut Parser) -> Result<CreateIndexStmtNode, ParseE
     opt_scan: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_database_name(tokens, pos);
+        pos = scan_database_name(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan; }
         pos += 1;
@@ -12022,7 +12022,7 @@ fn parse_create_index_stmt(p: &mut Parser) -> Result<CreateIndexStmtNode, ParseE
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_indexed_column(tokens, pos);
+            pos = scan_indexed_column(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -12115,7 +12115,7 @@ fn parse_create_table_stmt(p: &mut Parser) -> Result<CreateTableStmtNode, ParseE
     opt_scan_2: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_database_name(tokens, pos);
+        pos = scan_database_name(tokens, pos, 0);
         if pos < 0 { break opt_scan_2; }
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan_2; }
         pos += 1;
@@ -12156,7 +12156,7 @@ fn parse_create_table_stmt(p: &mut Parser) -> Result<CreateTableStmtNode, ParseE
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_table_constraint(tokens, pos);
+                pos = scan_table_constraint(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -12260,7 +12260,7 @@ fn parse_create_trigger_stmt(p: &mut Parser) -> Result<CreateTriggerStmtNode, Pa
     opt_scan_2: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_database_name(tokens, pos);
+        pos = scan_database_name(tokens, pos, 0);
         if pos < 0 { break opt_scan_2; }
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan_2; }
         pos += 1;
@@ -12356,7 +12356,7 @@ fn parse_create_trigger_stmt(p: &mut Parser) -> Result<CreateTriggerStmtNode, Pa
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                     pos += 1;
-                    pos = scan_column_name(tokens, pos);
+                    pos = scan_column_name(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -12390,7 +12390,7 @@ fn parse_create_trigger_stmt(p: &mut Parser) -> Result<CreateTriggerStmtNode, Pa
     opt_scan_4: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_database_name(tokens, pos);
+        pos = scan_database_name(tokens, pos, 0);
         if pos < 0 { break opt_scan_4; }
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan_4; }
         pos += 1;
@@ -12448,25 +12448,25 @@ fn parse_create_trigger_stmt(p: &mut Parser) -> Result<CreateTriggerStmtNode, Pa
                     sg_278: {
                         pos = gp_278;
                         sg_278_0: {
-                            pos = scan_update_stmt(tokens, pos);
+                            pos = scan_update_stmt(tokens, pos, 0);
                             if pos < 0 { break sg_278_0; }
                             if pos > sg_278_best { sg_278_best = pos; }
                         }
                         pos = gp_278;
                         sg_278_1: {
-                            pos = scan_insert_stmt(tokens, pos);
+                            pos = scan_insert_stmt(tokens, pos, 0);
                             if pos < 0 { break sg_278_1; }
                             if pos > sg_278_best { sg_278_best = pos; }
                         }
                         pos = gp_278;
                         sg_278_2: {
-                            pos = scan_delete_stmt(tokens, pos);
+                            pos = scan_delete_stmt(tokens, pos, 0);
                             if pos < 0 { break sg_278_2; }
                             if pos > sg_278_best { sg_278_best = pos; }
                         }
                         pos = gp_278;
                         sg_278_3: {
-                            pos = scan_select_stmt(tokens, pos);
+                            pos = scan_select_stmt(tokens, pos, 0);
                             if pos < 0 { break sg_278_3; }
                             if pos > sg_278_best { sg_278_best = pos; }
                         }
@@ -12490,7 +12490,7 @@ fn parse_create_trigger_stmt(p: &mut Parser) -> Result<CreateTriggerStmtNode, Pa
                 gd_scan: {
                     let tokens = &p.tokens;
                     let mut pos: i32 = p.pos;
-                    pos = scan_update_stmt(tokens, pos);
+                    pos = scan_update_stmt(tokens, pos, 0);
                     if pos < 0 { break gd_scan; }
                     gd_winner = 0;
                     break gd_dispatch;
@@ -12498,7 +12498,7 @@ fn parse_create_trigger_stmt(p: &mut Parser) -> Result<CreateTriggerStmtNode, Pa
                 gd_scan_2: {
                     let tokens = &p.tokens;
                     let mut pos: i32 = p.pos;
-                    pos = scan_insert_stmt(tokens, pos);
+                    pos = scan_insert_stmt(tokens, pos, 0);
                     if pos < 0 { break gd_scan_2; }
                     gd_winner = 1;
                     break gd_dispatch;
@@ -12506,7 +12506,7 @@ fn parse_create_trigger_stmt(p: &mut Parser) -> Result<CreateTriggerStmtNode, Pa
                 gd_scan_3: {
                     let tokens = &p.tokens;
                     let mut pos: i32 = p.pos;
-                    pos = scan_delete_stmt(tokens, pos);
+                    pos = scan_delete_stmt(tokens, pos, 0);
                     if pos < 0 { break gd_scan_3; }
                     gd_winner = 2;
                     break gd_dispatch;
@@ -12605,7 +12605,7 @@ fn parse_create_view_stmt(p: &mut Parser) -> Result<CreateViewStmtNode, ParseErr
     opt_scan_2: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_database_name(tokens, pos);
+        pos = scan_database_name(tokens, pos, 0);
         if pos < 0 { break opt_scan_2; }
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan_2; }
         pos += 1;
@@ -12660,7 +12660,7 @@ fn parse_create_virtual_table_stmt(p: &mut Parser) -> Result<CreateVirtualTableS
     opt_scan: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_database_name(tokens, pos);
+        pos = scan_database_name(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan; }
         pos += 1;
@@ -12691,7 +12691,7 @@ fn parse_create_virtual_table_stmt(p: &mut Parser) -> Result<CreateVirtualTableS
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_module_argument(tokens, pos);
+                pos = scan_module_argument(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -12797,7 +12797,7 @@ fn parse_delete_stmt_limited(p: &mut Parser) -> Result<DeleteStmtLimitedNode, Pa
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                     pos += 1;
-                    pos = scan_ordering_term(tokens, pos);
+                    pos = scan_ordering_term(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -12843,7 +12843,7 @@ fn parse_delete_stmt_limited(p: &mut Parser) -> Result<DeleteStmtLimitedNode, Pa
                 }
                 break opt_scan;
             }
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break opt_scan; }
             opt_scan_pos = pos;
         }
@@ -12889,7 +12889,7 @@ fn parse_delete_stmt_limited(p: &mut Parser) -> Result<DeleteStmtLimitedNode, Pa
                 }
                 break opt_scan;
             }
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break opt_scan; }
             opt_scan_pos = pos;
         }
@@ -12924,7 +12924,7 @@ fn parse_delete_stmt_limited(p: &mut Parser) -> Result<DeleteStmtLimitedNode, Pa
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                     pos += 1;
-                    pos = scan_ordering_term(tokens, pos);
+                    pos = scan_ordering_term(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -13021,7 +13021,7 @@ fn parse_drop_index_stmt(p: &mut Parser) -> Result<DropIndexStmtNode, ParseError
     opt_scan: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_database_name(tokens, pos);
+        pos = scan_database_name(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan; }
         pos += 1;
@@ -13068,7 +13068,7 @@ fn parse_drop_table_stmt(p: &mut Parser) -> Result<DropTableStmtNode, ParseError
     opt_scan: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_database_name(tokens, pos);
+        pos = scan_database_name(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan; }
         pos += 1;
@@ -13115,7 +13115,7 @@ fn parse_drop_trigger_stmt(p: &mut Parser) -> Result<DropTriggerStmtNode, ParseE
     opt_scan: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_database_name(tokens, pos);
+        pos = scan_database_name(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan; }
         pos += 1;
@@ -13162,7 +13162,7 @@ fn parse_drop_view_stmt(p: &mut Parser) -> Result<DropViewStmtNode, ParseError> 
     opt_scan: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_database_name(tokens, pos);
+        pos = scan_database_name(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan; }
         pos += 1;
@@ -13205,9 +13205,9 @@ fn parse_factored_select_stmt(p: &mut Parser) -> Result<FactoredSelectStmtNode, 
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_compound_operator(tokens, pos);
+            pos = scan_compound_operator(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
-            pos = scan_select_core(tokens, pos);
+            pos = scan_select_core(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -13233,7 +13233,7 @@ fn parse_factored_select_stmt(p: &mut Parser) -> Result<FactoredSelectStmtNode, 
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_ordering_term(tokens, pos);
+                pos = scan_ordering_term(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -13280,7 +13280,7 @@ fn parse_factored_select_stmt(p: &mut Parser) -> Result<FactoredSelectStmtNode, 
                 }
                 break opt_scan;
             }
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break opt_scan; }
             opt_scan_pos = pos;
         }
@@ -13451,7 +13451,7 @@ fn parse_insert_stmt(p: &mut Parser) -> Result<InsertStmtNode, ParseError> {
     opt_scan: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_database_name(tokens, pos);
+        pos = scan_database_name(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan; }
         pos += 1;
@@ -13480,7 +13480,7 @@ fn parse_insert_stmt(p: &mut Parser) -> Result<InsertStmtNode, ParseError> {
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -13517,7 +13517,7 @@ fn parse_insert_stmt(p: &mut Parser) -> Result<InsertStmtNode, ParseError> {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break gd_scan_6; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break gd_scan_6; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -13525,7 +13525,7 @@ fn parse_insert_stmt(p: &mut Parser) -> Result<InsertStmtNode, ParseError> {
                         sg_283: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_283; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_283; }
                             break sg_283_done;
                         }
@@ -13544,7 +13544,7 @@ fn parse_insert_stmt(p: &mut Parser) -> Result<InsertStmtNode, ParseError> {
                             pos += 1;
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_284; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_284; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -13552,7 +13552,7 @@ fn parse_insert_stmt(p: &mut Parser) -> Result<InsertStmtNode, ParseError> {
                                     sg_285: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_285; }
                                         pos += 1;
-                                        pos = scan_expr(tokens, pos);
+                                        pos = scan_expr(tokens, pos, 0);
                                         if pos < 0 { break sg_285; }
                                         break sg_285_done;
                                     }
@@ -13586,7 +13586,7 @@ fn parse_insert_stmt(p: &mut Parser) -> Result<InsertStmtNode, ParseError> {
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                     pos += 1;
-                    pos = scan_expr(tokens, pos);
+                    pos = scan_expr(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -13611,7 +13611,7 @@ fn parse_insert_stmt(p: &mut Parser) -> Result<InsertStmtNode, ParseError> {
                     pos += 1;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break rep_scan_2; }
                     pos += 1;
-                    pos = scan_expr(tokens, pos);
+                    pos = scan_expr(tokens, pos, 0);
                     if pos < 0 { break rep_scan_2; }
                     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                         let sp = pos;
@@ -13619,7 +13619,7 @@ fn parse_insert_stmt(p: &mut Parser) -> Result<InsertStmtNode, ParseError> {
                             sg_286: {
                                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_286; }
                                 pos += 1;
-                                pos = scan_expr(tokens, pos);
+                                pos = scan_expr(tokens, pos, 0);
                                 if pos < 0 { break sg_286; }
                                 break sg_286_done;
                             }
@@ -13645,7 +13645,7 @@ fn parse_insert_stmt(p: &mut Parser) -> Result<InsertStmtNode, ParseError> {
                         let mut pos: i32 = p.pos;
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                         pos += 1;
-                        pos = scan_expr(tokens, pos);
+                        pos = scan_expr(tokens, pos, 0);
                         if pos < 0 { break rep_scan; }
                         if pos <= p.pos { break rep_scan; }
                         rep_scan_pos = pos;
@@ -13711,7 +13711,7 @@ fn parse_pragma_stmt(p: &mut Parser) -> Result<PragmaStmtNode, ParseError> {
     opt_scan: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_database_name(tokens, pos);
+        pos = scan_database_name(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan; }
         pos += 1;
@@ -13739,7 +13739,7 @@ fn parse_pragma_stmt(p: &mut Parser) -> Result<PragmaStmtNode, ParseError> {
             sg_287_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQ { break sg_287_0; }
                 pos += 1;
-                pos = scan_pragma_value(tokens, pos);
+                pos = scan_pragma_value(tokens, pos, 0);
                 if pos < 0 { break sg_287_0; }
                 break sg_287;
             }
@@ -13747,7 +13747,7 @@ fn parse_pragma_stmt(p: &mut Parser) -> Result<PragmaStmtNode, ParseError> {
             sg_287_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_287_1; }
                 pos += 1;
-                pos = scan_pragma_value(tokens, pos);
+                pos = scan_pragma_value(tokens, pos, 0);
                 if pos < 0 { break sg_287_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_287_1; }
                 pos += 1;
@@ -13800,7 +13800,7 @@ fn parse_reindex_stmt(p: &mut Parser) -> Result<ReindexStmtNode, ParseError> {
         sg_288: {
             pos = gp_288;
             sg_288_0: {
-                pos = scan_collation_name(tokens, pos);
+                pos = scan_collation_name(tokens, pos, 0);
                 if pos < 0 { break sg_288_0; }
                 if pos > sg_288_best { sg_288_best = pos; }
             }
@@ -13810,7 +13810,7 @@ fn parse_reindex_stmt(p: &mut Parser) -> Result<ReindexStmtNode, ParseError> {
                     let sp = pos;
                     sg_289_done: {
                         sg_289: {
-                            pos = scan_database_name(tokens, pos);
+                            pos = scan_database_name(tokens, pos, 0);
                             if pos < 0 { break sg_289; }
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_289; }
                             pos += 1;
@@ -13827,13 +13827,13 @@ fn parse_reindex_stmt(p: &mut Parser) -> Result<ReindexStmtNode, ParseError> {
                     sg_290: {
                         pos = gp_290;
                         sg_290_0: {
-                            pos = scan_table_name(tokens, pos);
+                            pos = scan_table_name(tokens, pos, 0);
                             if pos < 0 { break sg_290_0; }
                             if pos > sg_290_best { sg_290_best = pos; }
                         }
                         pos = gp_290;
                         sg_290_1: {
-                            pos = scan_index_name(tokens, pos);
+                            pos = scan_index_name(tokens, pos, 0);
                             if pos < 0 { break sg_290_1; }
                             if pos > sg_290_best { sg_290_best = pos; }
                         }
@@ -13857,7 +13857,7 @@ fn parse_reindex_stmt(p: &mut Parser) -> Result<ReindexStmtNode, ParseError> {
                 gd_scan: {
                     let tokens = &p.tokens;
                     let mut pos: i32 = p.pos;
-                    pos = scan_collation_name(tokens, pos);
+                    pos = scan_collation_name(tokens, pos, 0);
                     if pos < 0 { break gd_scan; }
                     gd_winner = 0;
                     break gd_dispatch;
@@ -13873,7 +13873,7 @@ fn parse_reindex_stmt(p: &mut Parser) -> Result<ReindexStmtNode, ParseError> {
                 opt_scan: {
                     let tokens = &p.tokens;
                     let mut pos: i32 = p.pos;
-                    pos = scan_database_name(tokens, pos);
+                    pos = scan_database_name(tokens, pos, 0);
                     if pos < 0 { break opt_scan; }
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan; }
                     pos += 1;
@@ -13898,7 +13898,7 @@ fn parse_reindex_stmt(p: &mut Parser) -> Result<ReindexStmtNode, ParseError> {
                         gd_scan: {
                             let tokens = &p.tokens;
                             let mut pos: i32 = p.pos;
-                            pos = scan_table_name(tokens, pos);
+                            pos = scan_table_name(tokens, pos, 0);
                             if pos < 0 { break gd_scan; }
                             gd_winner = 0;
                             break gd_dispatch;
@@ -14029,7 +14029,7 @@ fn parse_simple_select_stmt(p: &mut Parser) -> Result<SimpleSelectStmtNode, Pars
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_ordering_term(tokens, pos);
+                pos = scan_ordering_term(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -14076,7 +14076,7 @@ fn parse_simple_select_stmt(p: &mut Parser) -> Result<SimpleSelectStmtNode, Pars
                 }
                 break opt_scan;
             }
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break opt_scan; }
             opt_scan_pos = pos;
         }
@@ -14124,9 +14124,9 @@ fn parse_select_stmt(p: &mut Parser) -> Result<SelectStmtNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_compound_operator(tokens, pos);
+            pos = scan_compound_operator(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
-            pos = scan_select_or_values(tokens, pos);
+            pos = scan_select_or_values(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -14152,7 +14152,7 @@ fn parse_select_stmt(p: &mut Parser) -> Result<SelectStmtNode, ParseError> {
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_ordering_term(tokens, pos);
+                pos = scan_ordering_term(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -14199,7 +14199,7 @@ fn parse_select_stmt(p: &mut Parser) -> Result<SelectStmtNode, ParseError> {
                 }
                 break opt_scan;
             }
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break opt_scan; }
             opt_scan_pos = pos;
         }
@@ -14275,7 +14275,7 @@ fn parse_select_or_values(p: &mut Parser) -> Result<SelectOrValuesNode, ParseErr
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_result_column(tokens, pos);
+                pos = scan_result_column(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -14299,7 +14299,7 @@ fn parse_select_or_values(p: &mut Parser) -> Result<SelectOrValuesNode, ParseErr
                     gd_scan: {
                         let tokens = &p.tokens;
                         let mut pos: i32 = p.pos;
-                        pos = scan_join_clause(tokens, pos);
+                        pos = scan_join_clause(tokens, pos, 0);
                         if pos < 0 { break gd_scan; }
                         gd_winner = 0;
                         break gd_dispatch;
@@ -14320,7 +14320,7 @@ fn parse_select_or_values(p: &mut Parser) -> Result<SelectOrValuesNode, ParseErr
                             let mut pos: i32 = p.pos;
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                             pos += 1;
-                            pos = scan_table_or_subquery(tokens, pos);
+                            pos = scan_table_or_subquery(tokens, pos, 0);
                             if pos < 0 { break rep_scan; }
                             if pos <= p.pos { break rep_scan; }
                             rep_scan_pos = pos;
@@ -14372,7 +14372,7 @@ fn parse_select_or_values(p: &mut Parser) -> Result<SelectOrValuesNode, ParseErr
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                     pos += 1;
-                    pos = scan_expr(tokens, pos);
+                    pos = scan_expr(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -14431,7 +14431,7 @@ fn parse_select_or_values(p: &mut Parser) -> Result<SelectOrValuesNode, ParseErr
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -14456,7 +14456,7 @@ fn parse_select_or_values(p: &mut Parser) -> Result<SelectOrValuesNode, ParseErr
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break rep_scan_2; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break rep_scan_2; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -14464,7 +14464,7 @@ fn parse_select_or_values(p: &mut Parser) -> Result<SelectOrValuesNode, ParseErr
                         sg_294: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_294; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_294; }
                             break sg_294_done;
                         }
@@ -14490,7 +14490,7 @@ fn parse_select_or_values(p: &mut Parser) -> Result<SelectOrValuesNode, ParseErr
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                     pos += 1;
-                    pos = scan_expr(tokens, pos);
+                    pos = scan_expr(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -14697,11 +14697,11 @@ fn parse_update_stmt(p: &mut Parser) -> Result<UpdateStmtNode, ParseError> {
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_column_name(tokens, pos);
+            pos = scan_column_name(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQ { break rep_scan; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -14911,11 +14911,11 @@ fn parse_update_stmt_limited(p: &mut Parser) -> Result<UpdateStmtLimitedNode, Pa
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_column_name(tokens, pos);
+            pos = scan_column_name(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQ { break rep_scan; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -14957,7 +14957,7 @@ fn parse_update_stmt_limited(p: &mut Parser) -> Result<UpdateStmtLimitedNode, Pa
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                     pos += 1;
-                    pos = scan_ordering_term(tokens, pos);
+                    pos = scan_ordering_term(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -15003,7 +15003,7 @@ fn parse_update_stmt_limited(p: &mut Parser) -> Result<UpdateStmtLimitedNode, Pa
                 }
                 break opt_scan;
             }
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break opt_scan; }
             opt_scan_pos = pos;
         }
@@ -15049,7 +15049,7 @@ fn parse_update_stmt_limited(p: &mut Parser) -> Result<UpdateStmtLimitedNode, Pa
                 }
                 break opt_scan;
             }
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break opt_scan; }
             opt_scan_pos = pos;
         }
@@ -15084,7 +15084,7 @@ fn parse_update_stmt_limited(p: &mut Parser) -> Result<UpdateStmtLimitedNode, Pa
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                     pos += 1;
-                    pos = scan_ordering_term(tokens, pos);
+                    pos = scan_ordering_term(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -15173,7 +15173,7 @@ fn parse_column_def(p: &mut Parser) -> Result<ColumnDefNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_column_constraint(tokens, pos);
+            pos = scan_column_constraint(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -15205,7 +15205,7 @@ fn parse_type_name(p: &mut Parser) -> Result<TypeNameNode, ParseError> {
             sg_299_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_299_0; }
                 pos += 1;
-                pos = scan_signed_number(tokens, pos);
+                pos = scan_signed_number(tokens, pos, 0);
                 if pos < 0 { break sg_299_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_299_0; }
                 pos += 1;
@@ -15215,11 +15215,11 @@ fn parse_type_name(p: &mut Parser) -> Result<TypeNameNode, ParseError> {
             sg_299_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_299_1; }
                 pos += 1;
-                pos = scan_signed_number(tokens, pos);
+                pos = scan_signed_number(tokens, pos, 0);
                 if pos < 0 { break sg_299_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_299_1; }
                 pos += 1;
-                pos = scan_signed_number(tokens, pos);
+                pos = scan_signed_number(tokens, pos, 0);
                 if pos < 0 { break sg_299_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_299_1; }
                 pos += 1;
@@ -15241,11 +15241,11 @@ fn parse_type_name(p: &mut Parser) -> Result<TypeNameNode, ParseError> {
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break gd_scan; }
                     pos += 1;
-                    pos = scan_signed_number(tokens, pos);
+                    pos = scan_signed_number(tokens, pos, 0);
                     if pos < 0 { break gd_scan; }
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break gd_scan; }
                     pos += 1;
-                    pos = scan_signed_number(tokens, pos);
+                    pos = scan_signed_number(tokens, pos, 0);
                     if pos < 0 { break gd_scan; }
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break gd_scan; }
                     pos += 1;
@@ -15394,7 +15394,7 @@ fn parse_column_constraint(p: &mut Parser) -> Result<ColumnConstraintNode, Parse
                 gd_scan: {
                     let tokens = &p.tokens;
                     let mut pos: i32 = p.pos;
-                    pos = scan_signed_number(tokens, pos);
+                    pos = scan_signed_number(tokens, pos, 0);
                     if pos < 0 { break gd_scan; }
                     gd_winner = 0;
                     break gd_dispatch;
@@ -15493,11 +15493,11 @@ fn parse_expr_scan_15(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_expr(tokens, pos);
+    pos = scan_expr(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { return -1; }
     pos += 1;
-    pos = scan_type_name(tokens, pos);
+    pos = scan_type_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
@@ -15523,11 +15523,11 @@ fn parse_expr_bt_22(p: &mut Parser) -> Result<ExprNode, ParseError> {
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_WHEN { break rep_scan; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_THEN { break rep_scan; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -15575,18 +15575,18 @@ fn parse_expr_scan_22(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_27(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expr(tokens, pos);
+        pos = scan_expr(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     sg_301_done: {
         sg_301: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_WHEN { break sg_301; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sg_301; }
             if pos >= tokens.len() || tokens[pos].kind != TK_K_THEN { break sg_301; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sg_301; }
             break sg_301_done;
         }
@@ -15598,11 +15598,11 @@ fn parse_expr_scan_22(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_302: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_WHEN { break sg_302; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_302; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_THEN { break sg_302; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_302; }
                 break sg_302_done;
             }
@@ -15617,7 +15617,7 @@ fn parse_expr_scan_22(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_303: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_ELSE { break sg_303; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_303; }
                 break sg_303_done;
             }
@@ -15679,7 +15679,7 @@ fn parse_expr_scan_21(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_select_stmt(tokens, pos);
+    pos = scan_select_stmt(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
@@ -15703,7 +15703,7 @@ fn parse_expr_scan_14(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_expr(tokens, pos);
+    pos = scan_expr(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
@@ -15721,7 +15721,7 @@ fn parse_expr_bt_23(p: &mut Parser) -> Result<ExprNode, ParseError> {
 
 fn parse_expr_scan_23(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_raise_function(tokens, pos);
+    pos = scan_raise_function(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -15737,7 +15737,7 @@ fn parse_expr_bt_0(p: &mut Parser) -> Result<ExprNode, ParseError> {
 
 fn parse_expr_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_literal_value(tokens, pos);
+    pos = scan_literal_value(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -15759,7 +15759,7 @@ fn parse_expr_bt_13(p: &mut Parser) -> Result<ExprNode, ParseError> {
                     if pos >= tokens.len() || tokens[pos].kind != TK_K_DISTINCT { pos = -1; } else { pos += 1; }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_306_0; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -15767,7 +15767,7 @@ fn parse_expr_bt_13(p: &mut Parser) -> Result<ExprNode, ParseError> {
                         sg_307: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_307; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_307; }
                             break sg_307_done;
                         }
@@ -15805,7 +15805,7 @@ fn parse_expr_bt_13(p: &mut Parser) -> Result<ExprNode, ParseError> {
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                     pos += 1;
-                    pos = scan_expr(tokens, pos);
+                    pos = scan_expr(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -15846,7 +15846,7 @@ fn parse_expr_bt_13(p: &mut Parser) -> Result<ExprNode, ParseError> {
 
 fn parse_expr_scan_13(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_function_name(tokens, pos);
+    pos = scan_function_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
@@ -15861,7 +15861,7 @@ fn parse_expr_scan_13(tokens: &Array<Token>, pos: i32) -> i32 {
                     if pos >= tokens.len() || tokens[pos].kind != TK_K_DISTINCT { pos = -1; } else { pos += 1; }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_308_0; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -15869,7 +15869,7 @@ fn parse_expr_scan_13(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_309: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_309; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_309; }
                             break sg_309_done;
                         }
@@ -15908,9 +15908,9 @@ fn parse_expr_bt_3(p: &mut Parser) -> Result<ExprNode, ParseError> {
 
 fn parse_expr_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_unary_operator(tokens, pos);
+    pos = scan_unary_operator(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_expr_atom(tokens, pos);
+    pos = scan_expr(tokens, pos, 2147483647);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -15922,7 +15922,7 @@ fn parse_expr_bt_2(p: &mut Parser) -> Result<ExprNode, ParseError> {
         opt_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_database_name(tokens, pos);
+            pos = scan_database_name(tokens, pos, 0);
             if pos < 0 { break opt_scan; }
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan; }
             pos += 1;
@@ -15972,24 +15972,24 @@ fn parse_expr_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT && pos + 2 < tokens.len() && _gale_kind_set_2(tokens[pos + 2].kind) && pos + 3 < tokens.len() && tokens[pos + 3].kind == TK_LIT_DOT {
         sol_310: {
-            pos = scan_database_name(tokens, pos);
+            pos = scan_database_name(tokens, pos, 0);
             if pos < 0 { break sol_310; }
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_310; }
             pos += 1;
-            pos = scan_table_name(tokens, pos);
+            pos = scan_table_name(tokens, pos, 0);
             if pos < 0 { break sol_310; }
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_310; }
             pos += 1;
         }
     } else if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT {
         sol_311: {
-            pos = scan_table_name(tokens, pos);
+            pos = scan_table_name(tokens, pos, 0);
             if pos < 0 { break sol_311; }
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_311; }
             pos += 1;
         }
     }
-    pos = scan_column_name(tokens, pos);
+    pos = scan_column_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -16357,13 +16357,13 @@ fn parse_expr_lr_10(p: &mut Parser, left: ExprNode, start: i32) -> Result<ExprNo
                     sg_312: {
                         pos = gp_312;
                         sg_312_0: {
-                            pos = scan_select_stmt(tokens, pos);
+                            pos = scan_select_stmt(tokens, pos, 0);
                             if pos < 0 { break sg_312_0; }
                             if pos > sg_312_best { sg_312_best = pos; }
                         }
                         pos = gp_312;
                         sg_312_1: {
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_312_1; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -16371,7 +16371,7 @@ fn parse_expr_lr_10(p: &mut Parser, left: ExprNode, start: i32) -> Result<ExprNo
                                     sg_313: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_313; }
                                         pos += 1;
-                                        pos = scan_expr(tokens, pos);
+                                        pos = scan_expr(tokens, pos, 0);
                                         if pos < 0 { break sg_313; }
                                         break sg_313_done;
                                     }
@@ -16404,13 +16404,13 @@ fn parse_expr_lr_10(p: &mut Parser, left: ExprNode, start: i32) -> Result<ExprNo
                 sg_314: {
                     pos = gp_314;
                     sg_314_0: {
-                        pos = scan_select_stmt(tokens, pos);
+                        pos = scan_select_stmt(tokens, pos, 0);
                         if pos < 0 { break sg_314_0; }
                         if pos > sg_314_best { sg_314_best = pos; }
                     }
                     pos = gp_314;
                     sg_314_1: {
-                        pos = scan_expr(tokens, pos);
+                        pos = scan_expr(tokens, pos, 0);
                         if pos < 0 { break sg_314_1; }
                         while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                             let sp = pos;
@@ -16418,7 +16418,7 @@ fn parse_expr_lr_10(p: &mut Parser, left: ExprNode, start: i32) -> Result<ExprNo
                                 sg_315: {
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_315; }
                                     pos += 1;
-                                    pos = scan_expr(tokens, pos);
+                                    pos = scan_expr(tokens, pos, 0);
                                     if pos < 0 { break sg_315; }
                                     break sg_315_done;
                                 }
@@ -16443,7 +16443,7 @@ fn parse_expr_lr_10(p: &mut Parser, left: ExprNode, start: i32) -> Result<ExprNo
                         gd_scan: {
                             let tokens = &p.tokens;
                             let mut pos: i32 = p.pos;
-                            pos = scan_select_stmt(tokens, pos);
+                            pos = scan_select_stmt(tokens, pos, 0);
                             if pos < 0 { break gd_scan; }
                             gd_winner = 0;
                             break gd_dispatch;
@@ -16464,7 +16464,7 @@ fn parse_expr_lr_10(p: &mut Parser, left: ExprNode, start: i32) -> Result<ExprNo
                                 let mut pos: i32 = p.pos;
                                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                                 pos += 1;
-                                pos = scan_expr(tokens, pos);
+                                pos = scan_expr(tokens, pos, 0);
                                 if pos < 0 { break rep_scan; }
                                 if pos <= p.pos { break rep_scan; }
                                 rep_scan_pos = pos;
@@ -16503,7 +16503,7 @@ fn parse_expr_lr_10(p: &mut Parser, left: ExprNode, start: i32) -> Result<ExprNo
             opt_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break opt_scan; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan; }
                 pos += 1;
@@ -16832,7 +16832,7 @@ fn parse_foreign_key_clause(p: &mut Parser) -> Result<ForeignKeyClauseNode, Pars
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -16937,7 +16937,7 @@ fn parse_foreign_key_clause(p: &mut Parser) -> Result<ForeignKeyClauseNode, Pars
                     sg_316_1: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_MATCH { break sg_316_1; }
                         pos += 1;
-                        pos = scan_name(tokens, pos);
+                        pos = scan_name(tokens, pos, 0);
                         if pos < 0 { break sg_316_1; }
                         break sg_316;
                     }
@@ -17340,7 +17340,7 @@ fn parse_table_constraint(p: &mut Parser) -> Result<TableConstraintNode, ParseEr
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_indexed_column(tokens, pos);
+                pos = scan_indexed_column(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -17388,7 +17388,7 @@ fn parse_table_constraint(p: &mut Parser) -> Result<TableConstraintNode, ParseEr
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -17440,7 +17440,7 @@ fn parse_with_clause(p: &mut Parser) -> Result<WithClauseNode, ParseError> {
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_common_table_expression(tokens, pos);
+            pos = scan_common_table_expression(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -17469,7 +17469,7 @@ fn parse_qualified_table_name(p: &mut Parser) -> Result<QualifiedTableNameNode, 
     opt_scan: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_database_name(tokens, pos);
+        pos = scan_database_name(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan; }
         pos += 1;
@@ -17499,7 +17499,7 @@ fn parse_qualified_table_name(p: &mut Parser) -> Result<QualifiedTableNameNode, 
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sg_322_0; }
                 pos += 1;
-                pos = scan_index_name(tokens, pos);
+                pos = scan_index_name(tokens, pos, 0);
                 if pos < 0 { break sg_322_0; }
                 break sg_322;
             }
@@ -17606,7 +17606,7 @@ fn parse_pragma_value_bt_1(p: &mut Parser) -> Result<PragmaValueNode, ParseError
 
 fn parse_pragma_value_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_name(tokens, pos);
+    pos = scan_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -17685,7 +17685,7 @@ fn parse_common_table_expression(p: &mut Parser) -> Result<CommonTableExpression
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -17740,7 +17740,7 @@ fn parse_result_column_bt_1(p: &mut Parser) -> Result<ResultColumnNode, ParseErr
 
 fn parse_result_column_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_table_name(tokens, pos);
+    pos = scan_table_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
     pos += 1;
@@ -17785,18 +17785,18 @@ fn parse_result_column_bt_2(p: &mut Parser) -> Result<ResultColumnNode, ParseErr
 
 fn parse_result_column_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_expr(tokens, pos);
+    pos = scan_expr(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_K_AS && pos + 1 < tokens.len() && _gale_kind_set_48(tokens[pos + 1].kind) {
         sol_324: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { break sol_324; }
             pos += 1;
-            pos = scan_column_alias(tokens, pos);
+            pos = scan_column_alias(tokens, pos, 0);
             if pos < 0 { break sol_324; }
         }
     } else if pos < tokens.len() && _gale_kind_set_48(tokens[pos].kind) {
         sol_325: {
-            pos = scan_column_alias(tokens, pos);
+            pos = scan_column_alias(tokens, pos, 0);
             if pos < 0 { break sol_325; }
         }
     }
@@ -17889,7 +17889,7 @@ fn parse_table_or_subquery_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_select_stmt(tokens, pos);
+    pos = scan_select_stmt(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
@@ -17897,12 +17897,12 @@ fn parse_table_or_subquery_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
         sol_326: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { break sol_326; }
             pos += 1;
-            pos = scan_table_alias(tokens, pos);
+            pos = scan_table_alias(tokens, pos, 0);
             if pos < 0 { break sol_326; }
         }
     } else if pos < tokens.len() && _gale_kind_set_52(tokens[pos].kind) {
         sol_327: {
-            pos = scan_table_alias(tokens, pos);
+            pos = scan_table_alias(tokens, pos, 0);
             if pos < 0 { break sol_327; }
         }
     }
@@ -17920,7 +17920,7 @@ fn parse_table_or_subquery_bt_2(p: &mut Parser) -> Result<TableOrSubqueryNode, P
             gd_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_join_clause(tokens, pos);
+                pos = scan_join_clause(tokens, pos, 0);
                 if pos < 0 { break gd_scan; }
                 gd_winner = 0;
                 break gd_dispatch;
@@ -17941,7 +17941,7 @@ fn parse_table_or_subquery_bt_2(p: &mut Parser) -> Result<TableOrSubqueryNode, P
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                     pos += 1;
-                    pos = scan_table_or_subquery(tokens, pos);
+                    pos = scan_table_or_subquery(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -17982,7 +17982,7 @@ fn parse_table_or_subquery_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_328: {
             pos = gp_328;
             sg_328_0: {
-                pos = scan_table_or_subquery(tokens, pos);
+                pos = scan_table_or_subquery(tokens, pos, 0);
                 if pos < 0 { break sg_328_0; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -17990,7 +17990,7 @@ fn parse_table_or_subquery_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_329: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_329; }
                             pos += 1;
-                            pos = scan_table_or_subquery(tokens, pos);
+                            pos = scan_table_or_subquery(tokens, pos, 0);
                             if pos < 0 { break sg_329; }
                             break sg_329_done;
                         }
@@ -18003,7 +18003,7 @@ fn parse_table_or_subquery_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = gp_328;
             sg_328_1: {
-                pos = scan_join_clause(tokens, pos);
+                pos = scan_join_clause(tokens, pos, 0);
                 if pos < 0 { break sg_328_1; }
                 if pos > sg_328_best { sg_328_best = pos; }
             }
@@ -18022,7 +18022,7 @@ fn parse_table_or_subquery_bt_1(p: &mut Parser) -> Result<TableOrSubqueryNode, P
     opt_scan: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_schema_name(tokens, pos);
+        pos = scan_schema_name(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan; }
         pos += 1;
@@ -18045,7 +18045,7 @@ fn parse_table_or_subquery_bt_1(p: &mut Parser) -> Result<TableOrSubqueryNode, P
     opt_scan_2: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_expr(tokens, pos);
+        pos = scan_expr(tokens, pos, 0);
         if pos < 0 { break opt_scan_2; }
         while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
             let sp = pos;
@@ -18053,7 +18053,7 @@ fn parse_table_or_subquery_bt_1(p: &mut Parser) -> Result<TableOrSubqueryNode, P
                 sg_330: {
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_330; }
                     pos += 1;
-                    pos = scan_expr(tokens, pos);
+                    pos = scan_expr(tokens, pos, 0);
                     if pos < 0 { break sg_330; }
                     break sg_330_done;
                 }
@@ -18074,7 +18074,7 @@ fn parse_table_or_subquery_bt_1(p: &mut Parser) -> Result<TableOrSubqueryNode, P
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -18138,7 +18138,7 @@ fn parse_table_or_subquery_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_331_done: {
             sg_331: {
-                pos = scan_schema_name(tokens, pos);
+                pos = scan_schema_name(tokens, pos, 0);
                 if pos < 0 { break sg_331; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_331; }
                 pos += 1;
@@ -18148,7 +18148,7 @@ fn parse_table_or_subquery_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_table_function_name(tokens, pos);
+    pos = scan_table_function_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
@@ -18156,7 +18156,7 @@ fn parse_table_or_subquery_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_332_done: {
             sg_332: {
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_332; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -18164,7 +18164,7 @@ fn parse_table_or_subquery_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_333: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_333; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_333; }
                             break sg_333_done;
                         }
@@ -18185,12 +18185,12 @@ fn parse_table_or_subquery_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
         sol_334: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { break sol_334; }
             pos += 1;
-            pos = scan_table_alias(tokens, pos);
+            pos = scan_table_alias(tokens, pos, 0);
             if pos < 0 { break sol_334; }
         }
     } else if pos < tokens.len() && _gale_kind_set_52(tokens[pos].kind) {
         sol_335: {
-            pos = scan_table_alias(tokens, pos);
+            pos = scan_table_alias(tokens, pos, 0);
             if pos < 0 { break sol_335; }
         }
     }
@@ -18203,7 +18203,7 @@ fn parse_table_or_subquery_bt_0(p: &mut Parser) -> Result<TableOrSubqueryNode, P
     opt_scan: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_schema_name(tokens, pos);
+        pos = scan_schema_name(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan; }
         pos += 1;
@@ -18257,7 +18257,7 @@ fn parse_table_or_subquery_bt_0(p: &mut Parser) -> Result<TableOrSubqueryNode, P
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sg_336_0; }
                 pos += 1;
-                pos = scan_index_name(tokens, pos);
+                pos = scan_index_name(tokens, pos, 0);
                 if pos < 0 { break sg_336_0; }
                 break sg_336;
             }
@@ -18310,7 +18310,7 @@ fn parse_table_or_subquery_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_337_done: {
             sg_337: {
-                pos = scan_schema_name(tokens, pos);
+                pos = scan_schema_name(tokens, pos, 0);
                 if pos < 0 { break sg_337; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_337; }
                 pos += 1;
@@ -18320,18 +18320,18 @@ fn parse_table_or_subquery_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_table_name(tokens, pos);
+    pos = scan_table_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_K_AS && pos + 1 < tokens.len() && _gale_kind_set_52(tokens[pos + 1].kind) {
         sol_338: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { break sol_338; }
             pos += 1;
-            pos = scan_table_alias(tokens, pos);
+            pos = scan_table_alias(tokens, pos, 0);
             if pos < 0 { break sol_338; }
         }
     } else if pos < tokens.len() && _gale_kind_set_52(tokens[pos].kind) {
         sol_339: {
-            pos = scan_table_alias(tokens, pos);
+            pos = scan_table_alias(tokens, pos, 0);
             if pos < 0 { break sol_339; }
         }
     }
@@ -18345,7 +18345,7 @@ fn parse_table_or_subquery_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sg_340_0; }
                 pos += 1;
-                pos = scan_index_name(tokens, pos);
+                pos = scan_index_name(tokens, pos, 0);
                 if pos < 0 { break sg_340_0; }
                 break sg_340;
             }
@@ -18446,11 +18446,11 @@ fn parse_join_clause(p: &mut Parser) -> Result<JoinClauseNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_join_operator(tokens, pos);
+            pos = scan_join_operator(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
-            pos = scan_table_or_subquery(tokens, pos);
+            pos = scan_table_or_subquery(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
-            pos = scan_join_constraint(tokens, pos);
+            pos = scan_join_constraint(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -18578,7 +18578,7 @@ fn parse_join_constraint(p: &mut Parser) -> Result<JoinConstraintNode, ParseErro
             sg_342_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_ON { break sg_342_0; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_342_0; }
                 break sg_342;
             }
@@ -18588,7 +18588,7 @@ fn parse_join_constraint(p: &mut Parser) -> Result<JoinConstraintNode, ParseErro
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_342_1; }
                 pos += 1;
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break sg_342_1; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -18596,7 +18596,7 @@ fn parse_join_constraint(p: &mut Parser) -> Result<JoinConstraintNode, ParseErro
                         sg_343: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_343; }
                             pos += 1;
-                            pos = scan_column_name(tokens, pos);
+                            pos = scan_column_name(tokens, pos, 0);
                             if pos < 0 { break sg_343; }
                             break sg_343_done;
                         }
@@ -18633,7 +18633,7 @@ fn parse_join_constraint(p: &mut Parser) -> Result<JoinConstraintNode, ParseErro
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                     pos += 1;
-                    pos = scan_column_name(tokens, pos);
+                    pos = scan_column_name(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -18708,7 +18708,7 @@ fn parse_select_core(p: &mut Parser) -> Result<SelectCoreNode, ParseError> {
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_result_column(tokens, pos);
+                pos = scan_result_column(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -18732,7 +18732,7 @@ fn parse_select_core(p: &mut Parser) -> Result<SelectCoreNode, ParseError> {
                     gd_scan: {
                         let tokens = &p.tokens;
                         let mut pos: i32 = p.pos;
-                        pos = scan_join_clause(tokens, pos);
+                        pos = scan_join_clause(tokens, pos, 0);
                         if pos < 0 { break gd_scan; }
                         gd_winner = 0;
                         break gd_dispatch;
@@ -18753,7 +18753,7 @@ fn parse_select_core(p: &mut Parser) -> Result<SelectCoreNode, ParseError> {
                             let mut pos: i32 = p.pos;
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                             pos += 1;
-                            pos = scan_table_or_subquery(tokens, pos);
+                            pos = scan_table_or_subquery(tokens, pos, 0);
                             if pos < 0 { break rep_scan; }
                             if pos <= p.pos { break rep_scan; }
                             rep_scan_pos = pos;
@@ -18805,7 +18805,7 @@ fn parse_select_core(p: &mut Parser) -> Result<SelectCoreNode, ParseError> {
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                     pos += 1;
-                    pos = scan_expr(tokens, pos);
+                    pos = scan_expr(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -18864,7 +18864,7 @@ fn parse_select_core(p: &mut Parser) -> Result<SelectCoreNode, ParseError> {
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -18889,7 +18889,7 @@ fn parse_select_core(p: &mut Parser) -> Result<SelectCoreNode, ParseError> {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break rep_scan_2; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break rep_scan_2; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -18897,7 +18897,7 @@ fn parse_select_core(p: &mut Parser) -> Result<SelectCoreNode, ParseError> {
                         sg_345: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_345; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_345; }
                             break sg_345_done;
                         }
@@ -18923,7 +18923,7 @@ fn parse_select_core(p: &mut Parser) -> Result<SelectCoreNode, ParseError> {
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                     pos += 1;
-                    pos = scan_expr(tokens, pos);
+                    pos = scan_expr(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -19190,7 +19190,7 @@ fn parse_module_argument_bt_1(p: &mut Parser) -> Result<ModuleArgumentNode, Pars
 
 fn parse_module_argument_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_column_def(tokens, pos);
+    pos = scan_column_def(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -19206,7 +19206,7 @@ fn parse_module_argument_bt_0(p: &mut Parser) -> Result<ModuleArgumentNode, Pars
 
 fn parse_module_argument_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_expr(tokens, pos);
+    pos = scan_expr(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }

--- a/package-gale/tests/generated/sqlite_highlight/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite_highlight/SQLite.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/sqlite_highlight/sqlite.wado",
-      "hash": "05cabe3ca535e268dc3a3b6877220a86e10b83ef21ec3c8258449906b31c2b42",
+      "hash": "ead69d1f3c83d885192325187629e84157b0d500f41dc30a1b2cf26f65b60a02",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/sqlite_highlight/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite_highlight/SQLite.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/sqlite_highlight/sqlite.wado",
-      "hash": "d11dad4c30ac0c7b6890e16aced30311be007383258f48333674ae32af002a64",
+      "hash": "0f68bb64eb900a55437213ed086b057f50698ca07c2baedfcf13500b9c2ed285",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/sqlite_highlight/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite_highlight/SQLite.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/sqlite_highlight/sqlite.wado",
-      "hash": "ead69d1f3c83d885192325187629e84157b0d500f41dc30a1b2cf26f65b60a02",
+      "hash": "d11dad4c30ac0c7b6890e16aced30311be007383258f48333674ae32af002a64",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/sqlite_highlight/sqlite.wado
+++ b/package-gale/tests/generated/sqlite_highlight/sqlite.wado
@@ -15472,7 +15472,7 @@ fn parse_expr_bt_15(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let start = p.peek().span.start;
     let k_cast = p.expect(TK_K_CAST)?;
     let lparen = p.expect(TK_LIT_LPAREN)?;
-    let expr = parse_expr(p)?;
+    let expr = parse_expr(p, 6)?;
     let k_as = p.expect(TK_K_AS)?;
     let type_name = parse_type_name(p)?;
     let rparen = p.expect(TK_LIT_RPAREN)?;
@@ -15508,7 +15508,7 @@ fn parse_expr_bt_22(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let start = p.peek().span.start;
     let k_case = p.expect(TK_K_CASE)?;
     let expr: Option<ExprNode> = if _gale_kind_set_27(p.peek_kind()) {
-        let expr = parse_expr(p)?;
+        let expr = parse_expr(p, 1)?;
         Option::<ExprNode>::Some(expr)
     } else {
         null
@@ -15536,9 +15536,9 @@ fn parse_expr_bt_22(p: &mut Parser) -> Result<ExprNode, ParseError> {
         }
         _plus_first = false;
         let k_when = p.expect(TK_K_WHEN)?;
-        let expr = parse_expr(p)?;
+        let expr = parse_expr(p, 1)?;
         let k_then = p.expect(TK_K_THEN)?;
-        let expr_2 = parse_expr(p)?;
+        let expr_2 = parse_expr(p, 1)?;
         let k_when_expr_k_then_expr = KWhenExprKThenExprItem {
             k_when,
             expr,
@@ -15549,7 +15549,7 @@ fn parse_expr_bt_22(p: &mut Parser) -> Result<ExprNode, ParseError> {
     }
     let k_else_expr: Option<KElseExprItem> = if p.peek_kind() == TK_K_ELSE {
         let k_else = p.expect(TK_K_ELSE)?;
-        let expr = parse_expr(p)?;
+        let expr = parse_expr(p, 1)?;
         let k_else_expr = KElseExprItem {
             k_else,
             expr,
@@ -15689,7 +15689,7 @@ fn parse_expr_scan_21(tokens: &Array<Token>, pos: i32) -> i32 {
 fn parse_expr_bt_14(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let start = p.peek().span.start;
     let lparen = p.expect(TK_LIT_LPAREN)?;
-    let expr = parse_expr(p)?;
+    let expr = parse_expr(p, 6)?;
     let rparen = p.expect(TK_LIT_RPAREN)?;
     return Result::<ExprNode, ParseError>::Ok(ExprNode::Alt14(ExprAlt14 {
         span: Span::new(start, p.last_end()),
@@ -15796,7 +15796,7 @@ fn parse_expr_bt_13(p: &mut Parser) -> Result<ExprNode, ParseError> {
             } else {
                 null
             };
-            let expr = parse_expr(p)?;
+            let expr = parse_expr(p, 6)?;
             let mut comma_expr_list: Array<CommaExprItem> = [];
             loop {
                 let mut rep_scan_pos: i32 = -1;
@@ -15898,7 +15898,7 @@ fn parse_expr_scan_13(tokens: &Array<Token>, pos: i32) -> i32 {
 fn parse_expr_bt_3(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let start = p.peek().span.start;
     let unary_operator = parse_unary_operator(p)?;
-    let expr = parse_expr(p)?;
+    let expr = parse_expr(p, 15)?;
     return Result::<ExprNode, ParseError>::Ok(ExprNode::Alt3(ExprAlt3 {
         span: Span::new(start, p.last_end()),
         unary_operator,

--- a/package-gale/tests/generated/sqlite_highlight/sqlite.wado
+++ b/package-gale/tests/generated/sqlite_highlight/sqlite.wado
@@ -15472,7 +15472,7 @@ fn parse_expr_bt_15(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let start = p.peek().span.start;
     let k_cast = p.expect(TK_K_CAST)?;
     let lparen = p.expect(TK_LIT_LPAREN)?;
-    let expr = parse_expr(p, 6)?;
+    let expr = parse_expr(p)?;
     let k_as = p.expect(TK_K_AS)?;
     let type_name = parse_type_name(p)?;
     let rparen = p.expect(TK_LIT_RPAREN)?;
@@ -15508,7 +15508,7 @@ fn parse_expr_bt_22(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let start = p.peek().span.start;
     let k_case = p.expect(TK_K_CASE)?;
     let expr: Option<ExprNode> = if _gale_kind_set_27(p.peek_kind()) {
-        let expr = parse_expr(p, 1)?;
+        let expr = parse_expr(p)?;
         Option::<ExprNode>::Some(expr)
     } else {
         null
@@ -15536,9 +15536,9 @@ fn parse_expr_bt_22(p: &mut Parser) -> Result<ExprNode, ParseError> {
         }
         _plus_first = false;
         let k_when = p.expect(TK_K_WHEN)?;
-        let expr = parse_expr(p, 1)?;
+        let expr = parse_expr(p)?;
         let k_then = p.expect(TK_K_THEN)?;
-        let expr_2 = parse_expr(p, 1)?;
+        let expr_2 = parse_expr(p)?;
         let k_when_expr_k_then_expr = KWhenExprKThenExprItem {
             k_when,
             expr,
@@ -15549,7 +15549,7 @@ fn parse_expr_bt_22(p: &mut Parser) -> Result<ExprNode, ParseError> {
     }
     let k_else_expr: Option<KElseExprItem> = if p.peek_kind() == TK_K_ELSE {
         let k_else = p.expect(TK_K_ELSE)?;
-        let expr = parse_expr(p, 1)?;
+        let expr = parse_expr(p)?;
         let k_else_expr = KElseExprItem {
             k_else,
             expr,
@@ -15689,7 +15689,7 @@ fn parse_expr_scan_21(tokens: &Array<Token>, pos: i32) -> i32 {
 fn parse_expr_bt_14(p: &mut Parser) -> Result<ExprNode, ParseError> {
     let start = p.peek().span.start;
     let lparen = p.expect(TK_LIT_LPAREN)?;
-    let expr = parse_expr(p, 6)?;
+    let expr = parse_expr(p)?;
     let rparen = p.expect(TK_LIT_RPAREN)?;
     return Result::<ExprNode, ParseError>::Ok(ExprNode::Alt14(ExprAlt14 {
         span: Span::new(start, p.last_end()),
@@ -15796,7 +15796,7 @@ fn parse_expr_bt_13(p: &mut Parser) -> Result<ExprNode, ParseError> {
             } else {
                 null
             };
-            let expr = parse_expr(p, 6)?;
+            let expr = parse_expr(p)?;
             let mut comma_expr_list: Array<CommaExprItem> = [];
             loop {
                 let mut rep_scan_pos: i32 = -1;
@@ -15910,7 +15910,7 @@ fn parse_expr_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     pos = scan_unary_operator(tokens, pos);
     if pos < 0 { return -1; }
-    pos = scan_expr(tokens, pos);
+    pos = scan_expr_atom(tokens, pos);
     if pos < 0 { return -1; }
     return pos;
 }

--- a/package-gale/tests/generated/sqlite_highlight/sqlite.wado
+++ b/package-gale/tests/generated/sqlite_highlight/sqlite.wado
@@ -4848,7 +4848,7 @@ impl Parser {
     }
 }
 
-fn scan_parse(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_parse(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && _gale_kind_set_0(tokens[pos].kind) {
         let sp = pos;
@@ -4856,13 +4856,13 @@ fn scan_parse(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_0: {
             pos = gp_0;
             sg_0_0: {
-                pos = scan_sql_stmt_list(tokens, pos);
+                pos = scan_sql_stmt_list(tokens, pos, 0);
                 if pos < 0 { break sg_0_0; }
                 break sg_0;
             }
             pos = gp_0;
             sg_0_1: {
-                pos = scan_error(tokens, pos);
+                pos = scan_error(tokens, pos, 0);
                 if pos < 0 { break sg_0_1; }
                 break sg_0;
             }
@@ -4876,14 +4876,14 @@ fn scan_parse(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_error(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_error(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_UNEXPECTED_CHAR { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_sql_stmt_list(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_sql_stmt_list(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_SEMI {
         let sp = pos;
@@ -4891,7 +4891,7 @@ fn scan_sql_stmt_list(tokens: &Array<Token>, pos: i32) -> i32 {
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
-    pos = scan_sql_stmt(tokens, pos);
+    pos = scan_sql_stmt(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_SEMI {
         let sp = pos;
@@ -4905,7 +4905,7 @@ fn scan_sql_stmt_list(tokens: &Array<Token>, pos: i32) -> i32 {
                     if pos < 0 { pos = sp; break; }
                     if pos == sp { break; }
                 }
-                pos = scan_sql_stmt(tokens, pos);
+                pos = scan_sql_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_1; }
                 break sg_1_done;
             }
@@ -4923,7 +4923,7 @@ fn scan_sql_stmt_list(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_sql_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_sql_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_K_EXPLAIN && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_K_QUERY && pos + 2 < tokens.len() && tokens[pos + 2].kind == TK_K_PLAN {
         sol_2: {
@@ -4947,181 +4947,181 @@ fn scan_sql_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_4: {
             pos = gp_4;
             sg_4_0: {
-                pos = scan_alter_table_stmt(tokens, pos);
+                pos = scan_alter_table_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_0; }
                 break sg_4;
             }
             pos = gp_4;
             sg_4_1: {
-                pos = scan_analyze_stmt(tokens, pos);
+                pos = scan_analyze_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_1; }
                 break sg_4;
             }
             pos = gp_4;
             sg_4_2: {
-                pos = scan_attach_stmt(tokens, pos);
+                pos = scan_attach_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_2; }
                 break sg_4;
             }
             pos = gp_4;
             sg_4_3: {
-                pos = scan_begin_stmt(tokens, pos);
+                pos = scan_begin_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_3; }
                 break sg_4;
             }
             pos = gp_4;
             sg_4_4: {
-                pos = scan_commit_stmt(tokens, pos);
+                pos = scan_commit_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_4; }
                 break sg_4;
             }
             pos = gp_4;
             sg_4_5: {
-                pos = scan_compound_select_stmt(tokens, pos);
+                pos = scan_compound_select_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_5; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_6: {
-                pos = scan_create_index_stmt(tokens, pos);
+                pos = scan_create_index_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_6; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_7: {
-                pos = scan_create_table_stmt(tokens, pos);
+                pos = scan_create_table_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_7; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_8: {
-                pos = scan_create_trigger_stmt(tokens, pos);
+                pos = scan_create_trigger_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_8; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_9: {
-                pos = scan_create_view_stmt(tokens, pos);
+                pos = scan_create_view_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_9; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_10: {
-                pos = scan_create_virtual_table_stmt(tokens, pos);
+                pos = scan_create_virtual_table_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_10; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_11: {
-                pos = scan_delete_stmt(tokens, pos);
+                pos = scan_delete_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_11; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_12: {
-                pos = scan_delete_stmt_limited(tokens, pos);
+                pos = scan_delete_stmt_limited(tokens, pos, 0);
                 if pos < 0 { break sg_4_12; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_13: {
-                pos = scan_detach_stmt(tokens, pos);
+                pos = scan_detach_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_13; }
                 break sg_4;
             }
             pos = gp_4;
             sg_4_14: {
-                pos = scan_drop_index_stmt(tokens, pos);
+                pos = scan_drop_index_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_14; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_15: {
-                pos = scan_drop_table_stmt(tokens, pos);
+                pos = scan_drop_table_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_15; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_16: {
-                pos = scan_drop_trigger_stmt(tokens, pos);
+                pos = scan_drop_trigger_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_16; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_17: {
-                pos = scan_drop_view_stmt(tokens, pos);
+                pos = scan_drop_view_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_17; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_18: {
-                pos = scan_factored_select_stmt(tokens, pos);
+                pos = scan_factored_select_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_18; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_19: {
-                pos = scan_insert_stmt(tokens, pos);
+                pos = scan_insert_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_19; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_20: {
-                pos = scan_pragma_stmt(tokens, pos);
+                pos = scan_pragma_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_20; }
                 break sg_4;
             }
             pos = gp_4;
             sg_4_21: {
-                pos = scan_reindex_stmt(tokens, pos);
+                pos = scan_reindex_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_21; }
                 break sg_4;
             }
             pos = gp_4;
             sg_4_22: {
-                pos = scan_release_stmt(tokens, pos);
+                pos = scan_release_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_22; }
                 break sg_4;
             }
             pos = gp_4;
             sg_4_23: {
-                pos = scan_rollback_stmt(tokens, pos);
+                pos = scan_rollback_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_23; }
                 break sg_4;
             }
             pos = gp_4;
             sg_4_24: {
-                pos = scan_savepoint_stmt(tokens, pos);
+                pos = scan_savepoint_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_24; }
                 break sg_4;
             }
             pos = gp_4;
             sg_4_25: {
-                pos = scan_simple_select_stmt(tokens, pos);
+                pos = scan_simple_select_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_25; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_26: {
-                pos = scan_select_stmt(tokens, pos);
+                pos = scan_select_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_26; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_27: {
-                pos = scan_update_stmt(tokens, pos);
+                pos = scan_update_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_27; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_28: {
-                pos = scan_update_stmt_limited(tokens, pos);
+                pos = scan_update_stmt_limited(tokens, pos, 0);
                 if pos < 0 { break sg_4_28; }
                 if pos > sg_4_best { sg_4_best = pos; }
             }
             pos = gp_4;
             sg_4_29: {
-                pos = scan_vacuum_stmt(tokens, pos);
+                pos = scan_vacuum_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_4_29; }
                 break sg_4;
             }
@@ -5132,7 +5132,7 @@ fn scan_sql_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_alter_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_alter_table_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_ALTER { return -1; }
     pos += 1;
@@ -5142,7 +5142,7 @@ fn scan_alter_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_5_done: {
             sg_5: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_5; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_5; }
                 pos += 1;
@@ -5152,7 +5152,7 @@ fn scan_alter_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_table_name(tokens, pos);
+    pos = scan_table_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     let gp_6 = pos;
     let sgk_6 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -5164,7 +5164,7 @@ fn scan_alter_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_TO { break sg_6_0; }
                 pos += 1;
-                pos = scan_new_table_name(tokens, pos);
+                pos = scan_new_table_name(tokens, pos, 0);
                 if pos < 0 { break sg_6_0; }
                 break sg_6;
             }
@@ -5177,7 +5177,7 @@ fn scan_alter_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                     if pos >= tokens.len() || tokens[pos].kind != TK_K_COLUMN { pos = -1; } else { pos += 1; }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_column_def(tokens, pos);
+                pos = scan_column_def(tokens, pos, 0);
                 if pos < 0 { break sg_6_1; }
                 break sg_6;
             }
@@ -5187,7 +5187,7 @@ fn scan_alter_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_analyze_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_analyze_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_ANALYZE { return -1; }
     pos += 1;
@@ -5198,23 +5198,23 @@ fn scan_analyze_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_7: {
             pos = gp_7;
             sg_7_0: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_7_0; }
                 if pos > sg_7_best { sg_7_best = pos; }
             }
             pos = gp_7;
             sg_7_1: {
-                pos = scan_table_or_index_name(tokens, pos);
+                pos = scan_table_or_index_name(tokens, pos, 0);
                 if pos < 0 { break sg_7_1; }
                 if pos > sg_7_best { sg_7_best = pos; }
             }
             pos = gp_7;
             sg_7_2: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_7_2; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_7_2; }
                 pos += 1;
-                pos = scan_table_or_index_name(tokens, pos);
+                pos = scan_table_or_index_name(tokens, pos, 0);
                 if pos < 0 { break sg_7_2; }
                 if pos > sg_7_best { sg_7_best = pos; }
             }
@@ -5226,7 +5226,7 @@ fn scan_analyze_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_attach_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_attach_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_ATTACH { return -1; }
     pos += 1;
@@ -5235,16 +5235,16 @@ fn scan_attach_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         if pos >= tokens.len() || tokens[pos].kind != TK_K_DATABASE { pos = -1; } else { pos += 1; }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_expr(tokens, pos);
+    pos = scan_expr(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { return -1; }
     pos += 1;
-    pos = scan_database_name(tokens, pos);
+    pos = scan_database_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_begin_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_begin_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_BEGIN { return -1; }
     pos += 1;
@@ -5278,7 +5278,7 @@ fn scan_begin_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         sol_9: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_TRANSACTION { break sol_9; }
             pos += 1;
-            pos = scan_transaction_name(tokens, pos);
+            pos = scan_transaction_name(tokens, pos, 0);
             if pos < 0 { break sol_9; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_K_TRANSACTION {
@@ -5290,7 +5290,7 @@ fn scan_begin_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_commit_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_commit_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     let gp_11 = pos;
     sg_11: {
@@ -5312,7 +5312,7 @@ fn scan_commit_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         sol_12: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_TRANSACTION { break sol_12; }
             pos += 1;
-            pos = scan_transaction_name(tokens, pos);
+            pos = scan_transaction_name(tokens, pos, 0);
             if pos < 0 { break sol_12; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_K_TRANSACTION {
@@ -5324,14 +5324,14 @@ fn scan_commit_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_compound_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_compound_select_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_K_WITH {
         let sp = pos;
-        pos = scan_with_clause(tokens, pos);
+        pos = scan_with_clause(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
-    pos = scan_select_core(tokens, pos);
+    pos = scan_select_core(tokens, pos, 0);
     if pos < 0 { return -1; }
     sg_14_done: {
         sg_14: {
@@ -5365,7 +5365,7 @@ fn scan_compound_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                     pos = gp_15;
                 }
             }
-            pos = scan_select_core(tokens, pos);
+            pos = scan_select_core(tokens, pos, 0);
             if pos < 0 { break sg_14; }
             break sg_14_done;
         }
@@ -5405,7 +5405,7 @@ fn scan_compound_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                         pos = gp_17;
                     }
                 }
-                pos = scan_select_core(tokens, pos);
+                pos = scan_select_core(tokens, pos, 0);
                 if pos < 0 { break sg_16; }
                 break sg_16_done;
             }
@@ -5422,7 +5422,7 @@ fn scan_compound_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sg_18; }
                 pos += 1;
-                pos = scan_ordering_term(tokens, pos);
+                pos = scan_ordering_term(tokens, pos, 0);
                 if pos < 0 { break sg_18; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -5430,7 +5430,7 @@ fn scan_compound_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_19: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_19; }
                             pos += 1;
-                            pos = scan_ordering_term(tokens, pos);
+                            pos = scan_ordering_term(tokens, pos, 0);
                             if pos < 0 { break sg_19; }
                             break sg_19_done;
                         }
@@ -5449,7 +5449,7 @@ fn scan_compound_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         sol_20: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break sol_20; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_20; }
             let gp_21 = pos;
             sg_21: {
@@ -5467,21 +5467,21 @@ fn scan_compound_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 break sol_20;
             }
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_20; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_K_LIMIT && pos + 1 < tokens.len() && _gale_kind_set_6(tokens[pos + 1].kind) {
         sol_22: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break sol_22; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_22; }
         }
     }
     return pos;
 }
 
-fn scan_create_index_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_create_index_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_CREATE { return -1; }
     pos += 1;
@@ -5512,7 +5512,7 @@ fn scan_create_index_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_24_done: {
             sg_24: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_24; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_24; }
                 pos += 1;
@@ -5522,15 +5522,15 @@ fn scan_create_index_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_index_name(tokens, pos);
+    pos = scan_index_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_K_ON { return -1; }
     pos += 1;
-    pos = scan_table_name(tokens, pos);
+    pos = scan_table_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_indexed_column(tokens, pos);
+    pos = scan_indexed_column(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -5538,7 +5538,7 @@ fn scan_create_index_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_25: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_25; }
                 pos += 1;
-                pos = scan_indexed_column(tokens, pos);
+                pos = scan_indexed_column(tokens, pos, 0);
                 if pos < 0 { break sg_25; }
                 break sg_25_done;
             }
@@ -5555,7 +5555,7 @@ fn scan_create_index_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_26: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_WHERE { break sg_26; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_26; }
                 break sg_26_done;
             }
@@ -5566,7 +5566,7 @@ fn scan_create_index_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_create_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_create_table_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_CREATE { return -1; }
     pos += 1;
@@ -5612,7 +5612,7 @@ fn scan_create_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_29_done: {
             sg_29: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_29; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_29; }
                 pos += 1;
@@ -5622,7 +5622,7 @@ fn scan_create_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_table_name(tokens, pos);
+    pos = scan_table_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     let gp_30 = pos;
     let sgk_30 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -5632,7 +5632,7 @@ fn scan_create_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_30_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_30_0; }
                 pos += 1;
-                pos = scan_column_def(tokens, pos);
+                pos = scan_column_def(tokens, pos, 0);
                 if pos < 0 { break sg_30_0; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -5640,7 +5640,7 @@ fn scan_create_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_31: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_31; }
                             pos += 1;
-                            pos = scan_column_def(tokens, pos);
+                            pos = scan_column_def(tokens, pos, 0);
                             if pos < 0 { break sg_31; }
                             break sg_31_done;
                         }
@@ -5655,7 +5655,7 @@ fn scan_create_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_32: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_32; }
                             pos += 1;
-                            pos = scan_table_constraint(tokens, pos);
+                            pos = scan_table_constraint(tokens, pos, 0);
                             if pos < 0 { break sg_32; }
                             break sg_32_done;
                         }
@@ -5686,7 +5686,7 @@ fn scan_create_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_30_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { break sg_30_1; }
                 pos += 1;
-                pos = scan_select_stmt(tokens, pos);
+                pos = scan_select_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_30_1; }
                 break sg_30;
             }
@@ -5696,7 +5696,7 @@ fn scan_create_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_create_trigger_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_create_trigger_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_CREATE { return -1; }
     pos += 1;
@@ -5742,7 +5742,7 @@ fn scan_create_trigger_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_36_done: {
             sg_36: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_36; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_36; }
                 pos += 1;
@@ -5752,7 +5752,7 @@ fn scan_create_trigger_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_trigger_name(tokens, pos);
+    pos = scan_trigger_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && _gale_kind_set_10(tokens[pos].kind) {
         let sp = pos;
@@ -5808,7 +5808,7 @@ fn scan_create_trigger_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_39: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_K_OF { break sg_39; }
                             pos += 1;
-                            pos = scan_column_name(tokens, pos);
+                            pos = scan_column_name(tokens, pos, 0);
                             if pos < 0 { break sg_39; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -5816,7 +5816,7 @@ fn scan_create_trigger_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_40: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_40; }
                                         pos += 1;
-                                        pos = scan_column_name(tokens, pos);
+                                        pos = scan_column_name(tokens, pos, 0);
                                         if pos < 0 { break sg_40; }
                                         break sg_40_done;
                                     }
@@ -5842,7 +5842,7 @@ fn scan_create_trigger_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_41_done: {
             sg_41: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_41; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_41; }
                 pos += 1;
@@ -5852,7 +5852,7 @@ fn scan_create_trigger_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_table_name(tokens, pos);
+    pos = scan_table_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_K_FOR {
         let sp = pos;
@@ -5876,7 +5876,7 @@ fn scan_create_trigger_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_43: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_WHEN { break sg_43; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_43; }
                 break sg_43_done;
             }
@@ -5895,25 +5895,25 @@ fn scan_create_trigger_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                 sg_45: {
                     pos = gp_45;
                     sg_45_0: {
-                        pos = scan_update_stmt(tokens, pos);
+                        pos = scan_update_stmt(tokens, pos, 0);
                         if pos < 0 { break sg_45_0; }
                         if pos > sg_45_best { sg_45_best = pos; }
                     }
                     pos = gp_45;
                     sg_45_1: {
-                        pos = scan_insert_stmt(tokens, pos);
+                        pos = scan_insert_stmt(tokens, pos, 0);
                         if pos < 0 { break sg_45_1; }
                         if pos > sg_45_best { sg_45_best = pos; }
                     }
                     pos = gp_45;
                     sg_45_2: {
-                        pos = scan_delete_stmt(tokens, pos);
+                        pos = scan_delete_stmt(tokens, pos, 0);
                         if pos < 0 { break sg_45_2; }
                         if pos > sg_45_best { sg_45_best = pos; }
                     }
                     pos = gp_45;
                     sg_45_3: {
-                        pos = scan_select_stmt(tokens, pos);
+                        pos = scan_select_stmt(tokens, pos, 0);
                         if pos < 0 { break sg_45_3; }
                         if pos > sg_45_best { sg_45_best = pos; }
                     }
@@ -5938,25 +5938,25 @@ fn scan_create_trigger_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_47: {
                         pos = gp_47;
                         sg_47_0: {
-                            pos = scan_update_stmt(tokens, pos);
+                            pos = scan_update_stmt(tokens, pos, 0);
                             if pos < 0 { break sg_47_0; }
                             if pos > sg_47_best { sg_47_best = pos; }
                         }
                         pos = gp_47;
                         sg_47_1: {
-                            pos = scan_insert_stmt(tokens, pos);
+                            pos = scan_insert_stmt(tokens, pos, 0);
                             if pos < 0 { break sg_47_1; }
                             if pos > sg_47_best { sg_47_best = pos; }
                         }
                         pos = gp_47;
                         sg_47_2: {
-                            pos = scan_delete_stmt(tokens, pos);
+                            pos = scan_delete_stmt(tokens, pos, 0);
                             if pos < 0 { break sg_47_2; }
                             if pos > sg_47_best { sg_47_best = pos; }
                         }
                         pos = gp_47;
                         sg_47_3: {
-                            pos = scan_select_stmt(tokens, pos);
+                            pos = scan_select_stmt(tokens, pos, 0);
                             if pos < 0 { break sg_47_3; }
                             if pos > sg_47_best { sg_47_best = pos; }
                         }
@@ -5978,7 +5978,7 @@ fn scan_create_trigger_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_create_view_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_create_view_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_CREATE { return -1; }
     pos += 1;
@@ -6024,7 +6024,7 @@ fn scan_create_view_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_50_done: {
             sg_50: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_50; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_50; }
                 pos += 1;
@@ -6034,16 +6034,16 @@ fn scan_create_view_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_view_name(tokens, pos);
+    pos = scan_view_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { return -1; }
     pos += 1;
-    pos = scan_select_stmt(tokens, pos);
+    pos = scan_select_stmt(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_create_virtual_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_create_virtual_table_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_CREATE { return -1; }
     pos += 1;
@@ -6071,7 +6071,7 @@ fn scan_create_virtual_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_52_done: {
             sg_52: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_52; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_52; }
                 pos += 1;
@@ -6081,11 +6081,11 @@ fn scan_create_virtual_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_table_name(tokens, pos);
+    pos = scan_table_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_K_USING { return -1; }
     pos += 1;
-    pos = scan_module_name(tokens, pos);
+    pos = scan_module_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_LPAREN {
         let sp = pos;
@@ -6093,7 +6093,7 @@ fn scan_create_virtual_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_53: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_53; }
                 pos += 1;
-                pos = scan_module_argument(tokens, pos);
+                pos = scan_module_argument(tokens, pos, 0);
                 if pos < 0 { break sg_53; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -6101,7 +6101,7 @@ fn scan_create_virtual_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_54: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_54; }
                             pos += 1;
-                            pos = scan_module_argument(tokens, pos);
+                            pos = scan_module_argument(tokens, pos, 0);
                             if pos < 0 { break sg_54; }
                             break sg_54_done;
                         }
@@ -6121,18 +6121,18 @@ fn scan_create_virtual_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_delete_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_delete_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_K_WITH {
         let sp = pos;
-        pos = scan_with_clause(tokens, pos);
+        pos = scan_with_clause(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_K_DELETE { return -1; }
     pos += 1;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_FROM { return -1; }
     pos += 1;
-    pos = scan_qualified_table_name(tokens, pos);
+    pos = scan_qualified_table_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_K_WHERE {
         let sp = pos;
@@ -6140,7 +6140,7 @@ fn scan_delete_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_55: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_WHERE { break sg_55; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_55; }
                 break sg_55_done;
             }
@@ -6151,18 +6151,18 @@ fn scan_delete_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_delete_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_delete_stmt_limited(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_K_WITH {
         let sp = pos;
-        pos = scan_with_clause(tokens, pos);
+        pos = scan_with_clause(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_K_DELETE { return -1; }
     pos += 1;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_FROM { return -1; }
     pos += 1;
-    pos = scan_qualified_table_name(tokens, pos);
+    pos = scan_qualified_table_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_K_WHERE {
         let sp = pos;
@@ -6170,7 +6170,7 @@ fn scan_delete_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_56: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_WHERE { break sg_56; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_56; }
                 break sg_56_done;
             }
@@ -6184,7 +6184,7 @@ fn scan_delete_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
             pos += 1;
             if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sol_57; }
             pos += 1;
-            pos = scan_ordering_term(tokens, pos);
+            pos = scan_ordering_term(tokens, pos, 0);
             if pos < 0 { break sol_57; }
             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                 let sp = pos;
@@ -6192,7 +6192,7 @@ fn scan_delete_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_58: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_58; }
                         pos += 1;
-                        pos = scan_ordering_term(tokens, pos);
+                        pos = scan_ordering_term(tokens, pos, 0);
                         if pos < 0 { break sg_58; }
                         break sg_58_done;
                     }
@@ -6203,7 +6203,7 @@ fn scan_delete_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break sol_57; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_57; }
             let gp_59 = pos;
             sg_59: {
@@ -6221,14 +6221,14 @@ fn scan_delete_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 break sol_57;
             }
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_57; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_K_LIMIT && pos + 1 < tokens.len() && _gale_kind_set_6(tokens[pos + 1].kind) && pos + 2 < tokens.len() && _gale_kind_set_7(tokens[pos + 2].kind) && pos + 3 < tokens.len() && _gale_kind_set_6(tokens[pos + 3].kind) {
         sol_60: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break sol_60; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_60; }
             let gp_61 = pos;
             sg_61: {
@@ -6246,7 +6246,7 @@ fn scan_delete_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 break sol_60;
             }
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_60; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_K_ORDER && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_K_BY && pos + 2 < tokens.len() && _gale_kind_set_6(tokens[pos + 2].kind) && pos + 3 < tokens.len() && tokens[pos + 3].kind == TK_LIT_COMMA && pos + 4 < tokens.len() && tokens[pos + 4].kind == TK_K_LIMIT && pos + 5 < tokens.len() && _gale_kind_set_6(tokens[pos + 5].kind) {
@@ -6255,7 +6255,7 @@ fn scan_delete_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
             pos += 1;
             if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sol_62; }
             pos += 1;
-            pos = scan_ordering_term(tokens, pos);
+            pos = scan_ordering_term(tokens, pos, 0);
             if pos < 0 { break sol_62; }
             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                 let sp = pos;
@@ -6263,7 +6263,7 @@ fn scan_delete_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_63: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_63; }
                         pos += 1;
-                        pos = scan_ordering_term(tokens, pos);
+                        pos = scan_ordering_term(tokens, pos, 0);
                         if pos < 0 { break sg_63; }
                         break sg_63_done;
                     }
@@ -6274,21 +6274,21 @@ fn scan_delete_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break sol_62; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_62; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_K_LIMIT && pos + 1 < tokens.len() && _gale_kind_set_6(tokens[pos + 1].kind) {
         sol_64: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break sol_64; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_64; }
         }
     }
     return pos;
 }
 
-fn scan_detach_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_detach_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_DETACH { return -1; }
     pos += 1;
@@ -6297,12 +6297,12 @@ fn scan_detach_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         if pos >= tokens.len() || tokens[pos].kind != TK_K_DATABASE { pos = -1; } else { pos += 1; }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_database_name(tokens, pos);
+    pos = scan_database_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_drop_index_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_drop_index_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_DROP { return -1; }
     pos += 1;
@@ -6326,7 +6326,7 @@ fn scan_drop_index_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_66_done: {
             sg_66: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_66; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_66; }
                 pos += 1;
@@ -6336,12 +6336,12 @@ fn scan_drop_index_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_index_name(tokens, pos);
+    pos = scan_index_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_drop_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_drop_table_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_DROP { return -1; }
     pos += 1;
@@ -6365,7 +6365,7 @@ fn scan_drop_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_68_done: {
             sg_68: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_68; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_68; }
                 pos += 1;
@@ -6375,12 +6375,12 @@ fn scan_drop_table_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_table_name(tokens, pos);
+    pos = scan_table_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_drop_trigger_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_drop_trigger_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_DROP { return -1; }
     pos += 1;
@@ -6404,7 +6404,7 @@ fn scan_drop_trigger_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_70_done: {
             sg_70: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_70; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_70; }
                 pos += 1;
@@ -6414,12 +6414,12 @@ fn scan_drop_trigger_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_trigger_name(tokens, pos);
+    pos = scan_trigger_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_drop_view_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_drop_view_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_DROP { return -1; }
     pos += 1;
@@ -6443,7 +6443,7 @@ fn scan_drop_view_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_72_done: {
             sg_72: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_72; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_72; }
                 pos += 1;
@@ -6453,27 +6453,27 @@ fn scan_drop_view_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_view_name(tokens, pos);
+    pos = scan_view_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_factored_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_factored_select_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_K_WITH {
         let sp = pos;
-        pos = scan_with_clause(tokens, pos);
+        pos = scan_with_clause(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
-    pos = scan_select_core(tokens, pos);
+    pos = scan_select_core(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && _gale_kind_set_5(tokens[pos].kind) {
         let sp = pos;
         sg_73_done: {
             sg_73: {
-                pos = scan_compound_operator(tokens, pos);
+                pos = scan_compound_operator(tokens, pos, 0);
                 if pos < 0 { break sg_73; }
-                pos = scan_select_core(tokens, pos);
+                pos = scan_select_core(tokens, pos, 0);
                 if pos < 0 { break sg_73; }
                 break sg_73_done;
             }
@@ -6490,7 +6490,7 @@ fn scan_factored_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sg_74; }
                 pos += 1;
-                pos = scan_ordering_term(tokens, pos);
+                pos = scan_ordering_term(tokens, pos, 0);
                 if pos < 0 { break sg_74; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -6498,7 +6498,7 @@ fn scan_factored_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_75: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_75; }
                             pos += 1;
-                            pos = scan_ordering_term(tokens, pos);
+                            pos = scan_ordering_term(tokens, pos, 0);
                             if pos < 0 { break sg_75; }
                             break sg_75_done;
                         }
@@ -6517,7 +6517,7 @@ fn scan_factored_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         sol_76: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break sol_76; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_76; }
             let gp_77 = pos;
             sg_77: {
@@ -6535,25 +6535,25 @@ fn scan_factored_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 break sol_76;
             }
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_76; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_K_LIMIT && pos + 1 < tokens.len() && _gale_kind_set_6(tokens[pos + 1].kind) {
         sol_78: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break sol_78; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_78; }
         }
     }
     return pos;
 }
 
-fn scan_insert_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_insert_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_K_WITH {
         let sp = pos;
-        pos = scan_with_clause(tokens, pos);
+        pos = scan_with_clause(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     let gp_79 = pos;
@@ -6633,7 +6633,7 @@ fn scan_insert_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_80_done: {
             sg_80: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_80; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_80; }
                 pos += 1;
@@ -6643,7 +6643,7 @@ fn scan_insert_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_table_name(tokens, pos);
+    pos = scan_table_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_LPAREN {
         let sp = pos;
@@ -6651,7 +6651,7 @@ fn scan_insert_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_81: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_81; }
                 pos += 1;
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break sg_81; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -6659,7 +6659,7 @@ fn scan_insert_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_82: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_82; }
                             pos += 1;
-                            pos = scan_column_name(tokens, pos);
+                            pos = scan_column_name(tokens, pos, 0);
                             if pos < 0 { break sg_82; }
                             break sg_82_done;
                         }
@@ -6687,7 +6687,7 @@ fn scan_insert_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_83_0; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_83_0; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -6695,7 +6695,7 @@ fn scan_insert_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_84: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_84; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_84; }
                             break sg_84_done;
                         }
@@ -6714,7 +6714,7 @@ fn scan_insert_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                             pos += 1;
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_85; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_85; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -6722,7 +6722,7 @@ fn scan_insert_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_86: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_86; }
                                         pos += 1;
-                                        pos = scan_expr(tokens, pos);
+                                        pos = scan_expr(tokens, pos, 0);
                                         if pos < 0 { break sg_86; }
                                         break sg_86_done;
                                     }
@@ -6744,7 +6744,7 @@ fn scan_insert_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = gp_83;
             sg_83_1: {
-                pos = scan_select_stmt(tokens, pos);
+                pos = scan_select_stmt(tokens, pos, 0);
                 if pos < 0 { break sg_83_1; }
                 if pos > sg_83_best { sg_83_best = pos; }
             }
@@ -6763,7 +6763,7 @@ fn scan_insert_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_pragma_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_pragma_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_PRAGMA { return -1; }
     pos += 1;
@@ -6771,7 +6771,7 @@ fn scan_pragma_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_87_done: {
             sg_87: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_87; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_87; }
                 pos += 1;
@@ -6781,7 +6781,7 @@ fn scan_pragma_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_pragma_name(tokens, pos);
+    pos = scan_pragma_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && _gale_kind_set_16(tokens[pos].kind) {
         let sp = pos;
@@ -6791,7 +6791,7 @@ fn scan_pragma_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_88_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQ { break sg_88_0; }
                 pos += 1;
-                pos = scan_pragma_value(tokens, pos);
+                pos = scan_pragma_value(tokens, pos, 0);
                 if pos < 0 { break sg_88_0; }
                 break sg_88;
             }
@@ -6799,7 +6799,7 @@ fn scan_pragma_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_88_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_88_1; }
                 pos += 1;
-                pos = scan_pragma_value(tokens, pos);
+                pos = scan_pragma_value(tokens, pos, 0);
                 if pos < 0 { break sg_88_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_88_1; }
                 pos += 1;
@@ -6812,7 +6812,7 @@ fn scan_pragma_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_reindex_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_reindex_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_REINDEX { return -1; }
     pos += 1;
@@ -6823,7 +6823,7 @@ fn scan_reindex_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_89: {
             pos = gp_89;
             sg_89_0: {
-                pos = scan_collation_name(tokens, pos);
+                pos = scan_collation_name(tokens, pos, 0);
                 if pos < 0 { break sg_89_0; }
                 if pos > sg_89_best { sg_89_best = pos; }
             }
@@ -6833,7 +6833,7 @@ fn scan_reindex_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                     let sp = pos;
                     sg_90_done: {
                         sg_90: {
-                            pos = scan_database_name(tokens, pos);
+                            pos = scan_database_name(tokens, pos, 0);
                             if pos < 0 { break sg_90; }
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_90; }
                             pos += 1;
@@ -6850,13 +6850,13 @@ fn scan_reindex_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_91: {
                         pos = gp_91;
                         sg_91_0: {
-                            pos = scan_table_name(tokens, pos);
+                            pos = scan_table_name(tokens, pos, 0);
                             if pos < 0 { break sg_91_0; }
                             if pos > sg_91_best { sg_91_best = pos; }
                         }
                         pos = gp_91;
                         sg_91_1: {
-                            pos = scan_index_name(tokens, pos);
+                            pos = scan_index_name(tokens, pos, 0);
                             if pos < 0 { break sg_91_1; }
                             if pos > sg_91_best { sg_91_best = pos; }
                         }
@@ -6874,7 +6874,7 @@ fn scan_reindex_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_release_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_release_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_RELEASE { return -1; }
     pos += 1;
@@ -6883,12 +6883,12 @@ fn scan_release_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         if pos >= tokens.len() || tokens[pos].kind != TK_K_SAVEPOINT { pos = -1; } else { pos += 1; }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_savepoint_name(tokens, pos);
+    pos = scan_savepoint_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_rollback_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_rollback_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_ROLLBACK { return -1; }
     pos += 1;
@@ -6896,7 +6896,7 @@ fn scan_rollback_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         sol_92: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_TRANSACTION { break sol_92; }
             pos += 1;
-            pos = scan_transaction_name(tokens, pos);
+            pos = scan_transaction_name(tokens, pos, 0);
             if pos < 0 { break sol_92; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_K_TRANSACTION {
@@ -6911,37 +6911,37 @@ fn scan_rollback_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
             pos += 1;
             if pos >= tokens.len() || tokens[pos].kind != TK_K_SAVEPOINT { break sol_94; }
             pos += 1;
-            pos = scan_savepoint_name(tokens, pos);
+            pos = scan_savepoint_name(tokens, pos, 0);
             if pos < 0 { break sol_94; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_K_TO && pos + 1 < tokens.len() && _gale_kind_set_2(tokens[pos + 1].kind) {
         sol_95: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_TO { break sol_95; }
             pos += 1;
-            pos = scan_savepoint_name(tokens, pos);
+            pos = scan_savepoint_name(tokens, pos, 0);
             if pos < 0 { break sol_95; }
         }
     }
     return pos;
 }
 
-fn scan_savepoint_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_savepoint_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_SAVEPOINT { return -1; }
     pos += 1;
-    pos = scan_savepoint_name(tokens, pos);
+    pos = scan_savepoint_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_simple_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_simple_select_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_K_WITH {
         let sp = pos;
-        pos = scan_with_clause(tokens, pos);
+        pos = scan_with_clause(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
-    pos = scan_select_core(tokens, pos);
+    pos = scan_select_core(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_K_ORDER {
         let sp = pos;
@@ -6951,7 +6951,7 @@ fn scan_simple_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sg_96; }
                 pos += 1;
-                pos = scan_ordering_term(tokens, pos);
+                pos = scan_ordering_term(tokens, pos, 0);
                 if pos < 0 { break sg_96; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -6959,7 +6959,7 @@ fn scan_simple_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_97: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_97; }
                             pos += 1;
-                            pos = scan_ordering_term(tokens, pos);
+                            pos = scan_ordering_term(tokens, pos, 0);
                             if pos < 0 { break sg_97; }
                             break sg_97_done;
                         }
@@ -6978,7 +6978,7 @@ fn scan_simple_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         sol_98: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break sol_98; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_98; }
             let gp_99 = pos;
             sg_99: {
@@ -6996,36 +6996,36 @@ fn scan_simple_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 break sol_98;
             }
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_98; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_K_LIMIT && pos + 1 < tokens.len() && _gale_kind_set_6(tokens[pos + 1].kind) {
         sol_100: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break sol_100; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_100; }
         }
     }
     return pos;
 }
 
-fn scan_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_select_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_K_WITH {
         let sp = pos;
-        pos = scan_with_clause(tokens, pos);
+        pos = scan_with_clause(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
-    pos = scan_select_or_values(tokens, pos);
+    pos = scan_select_or_values(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && _gale_kind_set_5(tokens[pos].kind) {
         let sp = pos;
         sg_101_done: {
             sg_101: {
-                pos = scan_compound_operator(tokens, pos);
+                pos = scan_compound_operator(tokens, pos, 0);
                 if pos < 0 { break sg_101; }
-                pos = scan_select_or_values(tokens, pos);
+                pos = scan_select_or_values(tokens, pos, 0);
                 if pos < 0 { break sg_101; }
                 break sg_101_done;
             }
@@ -7042,7 +7042,7 @@ fn scan_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sg_102; }
                 pos += 1;
-                pos = scan_ordering_term(tokens, pos);
+                pos = scan_ordering_term(tokens, pos, 0);
                 if pos < 0 { break sg_102; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -7050,7 +7050,7 @@ fn scan_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_103: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_103; }
                             pos += 1;
-                            pos = scan_ordering_term(tokens, pos);
+                            pos = scan_ordering_term(tokens, pos, 0);
                             if pos < 0 { break sg_103; }
                             break sg_103_done;
                         }
@@ -7069,7 +7069,7 @@ fn scan_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         sol_104: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break sol_104; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_104; }
             let gp_105 = pos;
             sg_105: {
@@ -7087,21 +7087,21 @@ fn scan_select_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 break sol_104;
             }
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_104; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_K_LIMIT && pos + 1 < tokens.len() && _gale_kind_set_6(tokens[pos + 1].kind) {
         sol_106: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break sol_106; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_106; }
         }
     }
     return pos;
 }
 
-fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_select_or_values(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -7131,7 +7131,7 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_result_column(tokens, pos);
+                pos = scan_result_column(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -7139,7 +7139,7 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_108: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_108; }
                             pos += 1;
-                            pos = scan_result_column(tokens, pos);
+                            pos = scan_result_column(tokens, pos, 0);
                             if pos < 0 { break sg_108; }
                             break sg_108_done;
                         }
@@ -7161,7 +7161,7 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                                 sg_110: {
                                     pos = gp_110;
                                     sg_110_0: {
-                                        pos = scan_table_or_subquery(tokens, pos);
+                                        pos = scan_table_or_subquery(tokens, pos, 0);
                                         if pos < 0 { break sg_110_0; }
                                         while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                             let sp = pos;
@@ -7169,7 +7169,7 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                                                 sg_111: {
                                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_111; }
                                                     pos += 1;
-                                                    pos = scan_table_or_subquery(tokens, pos);
+                                                    pos = scan_table_or_subquery(tokens, pos, 0);
                                                     if pos < 0 { break sg_111; }
                                                     break sg_111_done;
                                                 }
@@ -7182,7 +7182,7 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                                     }
                                     pos = gp_110;
                                     sg_110_1: {
-                                        pos = scan_join_clause(tokens, pos);
+                                        pos = scan_join_clause(tokens, pos, 0);
                                         if pos < 0 { break sg_110_1; }
                                         if pos > sg_110_best { sg_110_best = pos; }
                                     }
@@ -7202,7 +7202,7 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_112: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_K_WHERE { break sg_112; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_112; }
                             break sg_112_done;
                         }
@@ -7216,7 +7216,7 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                         pos += 1;
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sol_113; }
                         pos += 1;
-                        pos = scan_expr(tokens, pos);
+                        pos = scan_expr(tokens, pos, 0);
                         if pos < 0 { break sol_113; }
                         while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                             let sp = pos;
@@ -7224,7 +7224,7 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                                 sg_114: {
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_114; }
                                     pos += 1;
-                                    pos = scan_expr(tokens, pos);
+                                    pos = scan_expr(tokens, pos, 0);
                                     if pos < 0 { break sg_114; }
                                     break sg_114_done;
                                 }
@@ -7235,7 +7235,7 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                         }
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_HAVING { break sol_113; }
                         pos += 1;
-                        pos = scan_expr(tokens, pos);
+                        pos = scan_expr(tokens, pos, 0);
                         if pos < 0 { break sol_113; }
                     }
                 } else if pos < tokens.len() && tokens[pos].kind == TK_K_GROUP && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_K_BY && pos + 2 < tokens.len() && _gale_kind_set_6(tokens[pos + 2].kind) && pos + 3 < tokens.len() && tokens[pos + 3].kind == TK_K_HAVING && pos + 4 < tokens.len() && _gale_kind_set_6(tokens[pos + 4].kind) {
@@ -7244,11 +7244,11 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                         pos += 1;
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sol_115; }
                         pos += 1;
-                        pos = scan_expr(tokens, pos);
+                        pos = scan_expr(tokens, pos, 0);
                         if pos < 0 { break sol_115; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_HAVING { break sol_115; }
                         pos += 1;
-                        pos = scan_expr(tokens, pos);
+                        pos = scan_expr(tokens, pos, 0);
                         if pos < 0 { break sol_115; }
                     }
                 } else if pos < tokens.len() && tokens[pos].kind == TK_K_GROUP && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_K_BY && pos + 2 < tokens.len() && _gale_kind_set_6(tokens[pos + 2].kind) && pos + 3 < tokens.len() && tokens[pos + 3].kind == TK_LIT_COMMA {
@@ -7257,7 +7257,7 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                         pos += 1;
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sol_116; }
                         pos += 1;
-                        pos = scan_expr(tokens, pos);
+                        pos = scan_expr(tokens, pos, 0);
                         if pos < 0 { break sol_116; }
                         while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                             let sp = pos;
@@ -7265,7 +7265,7 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                                 sg_117: {
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_117; }
                                     pos += 1;
-                                    pos = scan_expr(tokens, pos);
+                                    pos = scan_expr(tokens, pos, 0);
                                     if pos < 0 { break sg_117; }
                                     break sg_117_done;
                                 }
@@ -7281,7 +7281,7 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                         pos += 1;
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sol_118; }
                         pos += 1;
-                        pos = scan_expr(tokens, pos);
+                        pos = scan_expr(tokens, pos, 0);
                         if pos < 0 { break sol_118; }
                     }
                 }
@@ -7295,7 +7295,7 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_1; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -7303,7 +7303,7 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_119: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_119; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_119; }
                             break sg_119_done;
                         }
@@ -7322,7 +7322,7 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                             pos += 1;
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_120; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_120; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -7330,7 +7330,7 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_121: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_121; }
                                         pos += 1;
-                                        pos = scan_expr(tokens, pos);
+                                        pos = scan_expr(tokens, pos, 0);
                                         if pos < 0 { break sg_121; }
                                         break sg_121_done;
                                     }
@@ -7358,11 +7358,11 @@ fn scan_select_or_values(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_update_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_update_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_K_WITH {
         let sp = pos;
-        pos = scan_with_clause(tokens, pos);
+        pos = scan_with_clause(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_K_UPDATE { return -1; }
@@ -7417,15 +7417,15 @@ fn scan_update_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_qualified_table_name(tokens, pos);
+    pos = scan_qualified_table_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_K_SET { return -1; }
     pos += 1;
-    pos = scan_column_name(tokens, pos);
+    pos = scan_column_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQ { return -1; }
     pos += 1;
-    pos = scan_expr(tokens, pos);
+    pos = scan_expr(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -7433,11 +7433,11 @@ fn scan_update_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_123: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_123; }
                 pos += 1;
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break sg_123; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQ { break sg_123; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_123; }
                 break sg_123_done;
             }
@@ -7452,7 +7452,7 @@ fn scan_update_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_124: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_WHERE { break sg_124; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_124; }
                 break sg_124_done;
             }
@@ -7463,11 +7463,11 @@ fn scan_update_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_update_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_update_stmt_limited(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_K_WITH {
         let sp = pos;
-        pos = scan_with_clause(tokens, pos);
+        pos = scan_with_clause(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_K_UPDATE { return -1; }
@@ -7522,15 +7522,15 @@ fn scan_update_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_qualified_table_name(tokens, pos);
+    pos = scan_qualified_table_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_K_SET { return -1; }
     pos += 1;
-    pos = scan_column_name(tokens, pos);
+    pos = scan_column_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQ { return -1; }
     pos += 1;
-    pos = scan_expr(tokens, pos);
+    pos = scan_expr(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -7538,11 +7538,11 @@ fn scan_update_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_126: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_126; }
                 pos += 1;
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break sg_126; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQ { break sg_126; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_126; }
                 break sg_126_done;
             }
@@ -7557,7 +7557,7 @@ fn scan_update_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_127: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_WHERE { break sg_127; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_127; }
                 break sg_127_done;
             }
@@ -7571,7 +7571,7 @@ fn scan_update_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
             pos += 1;
             if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sol_128; }
             pos += 1;
-            pos = scan_ordering_term(tokens, pos);
+            pos = scan_ordering_term(tokens, pos, 0);
             if pos < 0 { break sol_128; }
             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                 let sp = pos;
@@ -7579,7 +7579,7 @@ fn scan_update_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_129: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_129; }
                         pos += 1;
-                        pos = scan_ordering_term(tokens, pos);
+                        pos = scan_ordering_term(tokens, pos, 0);
                         if pos < 0 { break sg_129; }
                         break sg_129_done;
                     }
@@ -7590,7 +7590,7 @@ fn scan_update_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break sol_128; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_128; }
             let gp_130 = pos;
             sg_130: {
@@ -7608,14 +7608,14 @@ fn scan_update_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 break sol_128;
             }
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_128; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_K_LIMIT && pos + 1 < tokens.len() && _gale_kind_set_6(tokens[pos + 1].kind) && pos + 2 < tokens.len() && _gale_kind_set_7(tokens[pos + 2].kind) && pos + 3 < tokens.len() && _gale_kind_set_6(tokens[pos + 3].kind) {
         sol_131: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break sol_131; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_131; }
             let gp_132 = pos;
             sg_132: {
@@ -7633,7 +7633,7 @@ fn scan_update_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 break sol_131;
             }
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_131; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_K_ORDER && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_K_BY && pos + 2 < tokens.len() && _gale_kind_set_6(tokens[pos + 2].kind) && pos + 3 < tokens.len() && tokens[pos + 3].kind == TK_LIT_COMMA && pos + 4 < tokens.len() && tokens[pos + 4].kind == TK_K_LIMIT && pos + 5 < tokens.len() && _gale_kind_set_6(tokens[pos + 5].kind) {
@@ -7642,7 +7642,7 @@ fn scan_update_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
             pos += 1;
             if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sol_133; }
             pos += 1;
-            pos = scan_ordering_term(tokens, pos);
+            pos = scan_ordering_term(tokens, pos, 0);
             if pos < 0 { break sol_133; }
             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                 let sp = pos;
@@ -7650,7 +7650,7 @@ fn scan_update_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_134: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_134; }
                         pos += 1;
-                        pos = scan_ordering_term(tokens, pos);
+                        pos = scan_ordering_term(tokens, pos, 0);
                         if pos < 0 { break sg_134; }
                         break sg_134_done;
                     }
@@ -7661,52 +7661,52 @@ fn scan_update_stmt_limited(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break sol_133; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_133; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_K_LIMIT && pos + 1 < tokens.len() && _gale_kind_set_6(tokens[pos + 1].kind) {
         sol_135: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_LIMIT { break sol_135; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sol_135; }
         }
     }
     return pos;
 }
 
-fn scan_vacuum_stmt(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_vacuum_stmt(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_VACUUM { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_column_def(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_column_def(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_column_name(tokens, pos);
+    pos = scan_column_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && _gale_kind_set_18(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_type_name(tokens, pos);
+        pos = scan_type_name(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     while pos < tokens.len() && _gale_kind_set_19(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_column_constraint(tokens, pos);
+        pos = scan_column_constraint(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
     return pos;
 }
 
-fn scan_type_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_type_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_name(tokens, pos);
+    pos = scan_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_name(tokens, pos);
+        pos = scan_name(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -7719,7 +7719,7 @@ fn scan_type_name(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_136_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_136_0; }
                 pos += 1;
-                pos = scan_signed_number(tokens, pos);
+                pos = scan_signed_number(tokens, pos, 0);
                 if pos < 0 { break sg_136_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_136_0; }
                 pos += 1;
@@ -7729,11 +7729,11 @@ fn scan_type_name(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_136_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_136_1; }
                 pos += 1;
-                pos = scan_signed_number(tokens, pos);
+                pos = scan_signed_number(tokens, pos, 0);
                 if pos < 0 { break sg_136_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_136_1; }
                 pos += 1;
-                pos = scan_signed_number(tokens, pos);
+                pos = scan_signed_number(tokens, pos, 0);
                 if pos < 0 { break sg_136_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_136_1; }
                 pos += 1;
@@ -7747,7 +7747,7 @@ fn scan_type_name(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_column_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_column_constraint(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_K_CONSTRAINT {
         let sp = pos;
@@ -7755,7 +7755,7 @@ fn scan_column_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_137: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_CONSTRAINT { break sg_137; }
                 pos += 1;
-                pos = scan_name(tokens, pos);
+                pos = scan_name(tokens, pos, 0);
                 if pos < 0 { break sg_137; }
                 break sg_137_done;
             }
@@ -7793,7 +7793,7 @@ fn scan_column_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_conflict_clause(tokens, pos);
+                pos = scan_conflict_clause(tokens, pos, 0);
                 if pos < 0 { break sg_138_0; }
                 if pos < tokens.len() && tokens[pos].kind == TK_K_AUTOINCREMENT {
                     let sp = pos;
@@ -7811,7 +7811,7 @@ fn scan_column_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_NULL { break sg_138_1; }
                 pos += 1;
-                pos = scan_conflict_clause(tokens, pos);
+                pos = scan_conflict_clause(tokens, pos, 0);
                 if pos < 0 { break sg_138_1; }
                 break sg_138;
             }
@@ -7819,7 +7819,7 @@ fn scan_column_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_138_2: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_UNIQUE { break sg_138_2; }
                 pos += 1;
-                pos = scan_conflict_clause(tokens, pos);
+                pos = scan_conflict_clause(tokens, pos, 0);
                 if pos < 0 { break sg_138_2; }
                 break sg_138;
             }
@@ -7829,7 +7829,7 @@ fn scan_column_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_138_3; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_138_3; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_138_3; }
                 pos += 1;
@@ -7846,13 +7846,13 @@ fn scan_column_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_140: {
                         pos = gp_140;
                         sg_140_0: {
-                            pos = scan_signed_number(tokens, pos);
+                            pos = scan_signed_number(tokens, pos, 0);
                             if pos < 0 { break sg_140_0; }
                             if pos > sg_140_best { sg_140_best = pos; }
                         }
                         pos = gp_140;
                         sg_140_1: {
-                            pos = scan_literal_value(tokens, pos);
+                            pos = scan_literal_value(tokens, pos, 0);
                             if pos < 0 { break sg_140_1; }
                             if pos > sg_140_best { sg_140_best = pos; }
                         }
@@ -7860,7 +7860,7 @@ fn scan_column_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_140_2: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_140_2; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_140_2; }
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_140_2; }
                             pos += 1;
@@ -7876,13 +7876,13 @@ fn scan_column_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_138_5: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_COLLATE { break sg_138_5; }
                 pos += 1;
-                pos = scan_collation_name(tokens, pos);
+                pos = scan_collation_name(tokens, pos, 0);
                 if pos < 0 { break sg_138_5; }
                 break sg_138;
             }
             pos = gp_138;
             sg_138_6: {
-                pos = scan_foreign_key_clause(tokens, pos);
+                pos = scan_foreign_key_clause(tokens, pos, 0);
                 if pos < 0 { break sg_138_6; }
                 break sg_138;
             }
@@ -7892,7 +7892,7 @@ fn scan_column_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_conflict_clause(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_conflict_clause(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_K_ON {
         let sp = pos;
@@ -7953,7 +7953,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_23(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_literal_value(tokens, pos);
+                pos = scan_literal_value(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -7961,13 +7961,13 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_24(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_literal_value(tokens, pos);
+                pos = scan_literal_value(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_4: {
-                pos = scan_function_name(tokens, pos);
+                pos = scan_function_name(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_4; }
                 pos += 1;
@@ -7982,7 +7982,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                 if pos >= tokens.len() || tokens[pos].kind != TK_K_DISTINCT { pos = -1; } else { pos += 1; }
                                 if pos < 0 { pos = sp; }
                             }
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_143_0; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -7990,7 +7990,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_144: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_144; }
                                         pos += 1;
-                                        pos = scan_expr(tokens, pos);
+                                        pos = scan_expr(tokens, pos, 0);
                                         if pos < 0 { break sg_144; }
                                         break sg_144_done;
                                     }
@@ -8019,24 +8019,24 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_2: {
                 if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT && pos + 2 < tokens.len() && _gale_kind_set_2(tokens[pos + 2].kind) && pos + 3 < tokens.len() && tokens[pos + 3].kind == TK_LIT_DOT {
                     sol_145: {
-                        pos = scan_database_name(tokens, pos);
+                        pos = scan_database_name(tokens, pos, 0);
                         if pos < 0 { break sol_145; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_145; }
                         pos += 1;
-                        pos = scan_table_name(tokens, pos);
+                        pos = scan_table_name(tokens, pos, 0);
                         if pos < 0 { break sol_145; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_145; }
                         pos += 1;
                     }
                 } else if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT {
                     sol_146: {
-                        pos = scan_table_name(tokens, pos);
+                        pos = scan_table_name(tokens, pos, 0);
                         if pos < 0 { break sol_146; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_146; }
                         pos += 1;
                     }
                 }
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -8052,7 +8052,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_26(alt_kind) {
             pos = start;
             try_4: {
-                pos = scan_function_name(tokens, pos);
+                pos = scan_function_name(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_4; }
                 pos += 1;
@@ -8067,7 +8067,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                 if pos >= tokens.len() || tokens[pos].kind != TK_K_DISTINCT { pos = -1; } else { pos += 1; }
                                 if pos < 0 { pos = sp; }
                             }
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_147_0; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -8075,7 +8075,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_148: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_148; }
                                         pos += 1;
-                                        pos = scan_expr(tokens, pos);
+                                        pos = scan_expr(tokens, pos, 0);
                                         if pos < 0 { break sg_148; }
                                         break sg_148_done;
                                     }
@@ -8104,24 +8104,24 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_2: {
                 if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT && pos + 2 < tokens.len() && _gale_kind_set_2(tokens[pos + 2].kind) && pos + 3 < tokens.len() && tokens[pos + 3].kind == TK_LIT_DOT {
                     sol_149: {
-                        pos = scan_database_name(tokens, pos);
+                        pos = scan_database_name(tokens, pos, 0);
                         if pos < 0 { break sol_149; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_149; }
                         pos += 1;
-                        pos = scan_table_name(tokens, pos);
+                        pos = scan_table_name(tokens, pos, 0);
                         if pos < 0 { break sol_149; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_149; }
                         pos += 1;
                     }
                 } else if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT {
                     sol_150: {
-                        pos = scan_table_name(tokens, pos);
+                        pos = scan_table_name(tokens, pos, 0);
                         if pos < 0 { break sol_150; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_150; }
                         pos += 1;
                     }
                 }
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -8133,18 +8133,18 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos < tokens.len() && _gale_kind_set_27(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_expr(tokens, pos);
+                    pos = scan_expr(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 sg_151_done: {
                     sg_151: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_WHEN { break sg_151; }
                         pos += 1;
-                        pos = scan_expr(tokens, pos);
+                        pos = scan_expr(tokens, pos, 0);
                         if pos < 0 { break sg_151; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_THEN { break sg_151; }
                         pos += 1;
-                        pos = scan_expr(tokens, pos);
+                        pos = scan_expr(tokens, pos, 0);
                         if pos < 0 { break sg_151; }
                         break sg_151_done;
                     }
@@ -8156,11 +8156,11 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_152: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_K_WHEN { break sg_152; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_152; }
                             if pos >= tokens.len() || tokens[pos].kind != TK_K_THEN { break sg_152; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_152; }
                             break sg_152_done;
                         }
@@ -8175,7 +8175,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_153: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_K_ELSE { break sg_153; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_153; }
                             break sg_153_done;
                         }
@@ -8189,7 +8189,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_4: {
-                pos = scan_function_name(tokens, pos);
+                pos = scan_function_name(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_4; }
                 pos += 1;
@@ -8204,7 +8204,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                 if pos >= tokens.len() || tokens[pos].kind != TK_K_DISTINCT { pos = -1; } else { pos += 1; }
                                 if pos < 0 { pos = sp; }
                             }
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_154_0; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -8212,7 +8212,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_155: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_155; }
                                         pos += 1;
-                                        pos = scan_expr(tokens, pos);
+                                        pos = scan_expr(tokens, pos, 0);
                                         if pos < 0 { break sg_155; }
                                         break sg_155_done;
                                     }
@@ -8241,24 +8241,24 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_2: {
                 if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT && pos + 2 < tokens.len() && _gale_kind_set_2(tokens[pos + 2].kind) && pos + 3 < tokens.len() && tokens[pos + 3].kind == TK_LIT_DOT {
                     sol_156: {
-                        pos = scan_database_name(tokens, pos);
+                        pos = scan_database_name(tokens, pos, 0);
                         if pos < 0 { break sol_156; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_156; }
                         pos += 1;
-                        pos = scan_table_name(tokens, pos);
+                        pos = scan_table_name(tokens, pos, 0);
                         if pos < 0 { break sol_156; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_156; }
                         pos += 1;
                     }
                 } else if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT {
                     sol_157: {
-                        pos = scan_table_name(tokens, pos);
+                        pos = scan_table_name(tokens, pos, 0);
                         if pos < 0 { break sol_157; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_157; }
                         pos += 1;
                     }
                 }
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -8270,11 +8270,11 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_6; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { break try_6; }
                 pos += 1;
-                pos = scan_type_name(tokens, pos);
+                pos = scan_type_name(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_6; }
                 pos += 1;
@@ -8282,7 +8282,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_4: {
-                pos = scan_function_name(tokens, pos);
+                pos = scan_function_name(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_4; }
                 pos += 1;
@@ -8297,7 +8297,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                 if pos >= tokens.len() || tokens[pos].kind != TK_K_DISTINCT { pos = -1; } else { pos += 1; }
                                 if pos < 0 { pos = sp; }
                             }
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_158_0; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -8305,7 +8305,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_159: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_159; }
                                         pos += 1;
-                                        pos = scan_expr(tokens, pos);
+                                        pos = scan_expr(tokens, pos, 0);
                                         if pos < 0 { break sg_159; }
                                         break sg_159_done;
                                     }
@@ -8334,24 +8334,24 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_2: {
                 if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT && pos + 2 < tokens.len() && _gale_kind_set_2(tokens[pos + 2].kind) && pos + 3 < tokens.len() && tokens[pos + 3].kind == TK_LIT_DOT {
                     sol_160: {
-                        pos = scan_database_name(tokens, pos);
+                        pos = scan_database_name(tokens, pos, 0);
                         if pos < 0 { break sol_160; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_160; }
                         pos += 1;
-                        pos = scan_table_name(tokens, pos);
+                        pos = scan_table_name(tokens, pos, 0);
                         if pos < 0 { break sol_160; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_160; }
                         pos += 1;
                     }
                 } else if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT {
                     sol_161: {
-                        pos = scan_table_name(tokens, pos);
+                        pos = scan_table_name(tokens, pos, 0);
                         if pos < 0 { break sol_161; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_161; }
                         pos += 1;
                     }
                 }
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -8374,7 +8374,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_7; }
                 pos += 1;
-                pos = scan_select_stmt(tokens, pos);
+                pos = scan_select_stmt(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_7; }
                 pos += 1;
@@ -8382,7 +8382,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_4: {
-                pos = scan_function_name(tokens, pos);
+                pos = scan_function_name(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_4; }
                 pos += 1;
@@ -8397,7 +8397,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                 if pos >= tokens.len() || tokens[pos].kind != TK_K_DISTINCT { pos = -1; } else { pos += 1; }
                                 if pos < 0 { pos = sp; }
                             }
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_164_0; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -8405,7 +8405,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_165: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_165; }
                                         pos += 1;
-                                        pos = scan_expr(tokens, pos);
+                                        pos = scan_expr(tokens, pos, 0);
                                         if pos < 0 { break sg_165; }
                                         break sg_165_done;
                                     }
@@ -8434,24 +8434,24 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_2: {
                 if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT && pos + 2 < tokens.len() && _gale_kind_set_2(tokens[pos + 2].kind) && pos + 3 < tokens.len() && tokens[pos + 3].kind == TK_LIT_DOT {
                     sol_166: {
-                        pos = scan_database_name(tokens, pos);
+                        pos = scan_database_name(tokens, pos, 0);
                         if pos < 0 { break sol_166; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_166; }
                         pos += 1;
-                        pos = scan_table_name(tokens, pos);
+                        pos = scan_table_name(tokens, pos, 0);
                         if pos < 0 { break sol_166; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_166; }
                         pos += 1;
                     }
                 } else if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT {
                     sol_167: {
-                        pos = scan_table_name(tokens, pos);
+                        pos = scan_table_name(tokens, pos, 0);
                         if pos < 0 { break sol_167; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_167; }
                         pos += 1;
                     }
                 }
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -8474,7 +8474,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_7; }
                 pos += 1;
-                pos = scan_select_stmt(tokens, pos);
+                pos = scan_select_stmt(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_7; }
                 pos += 1;
@@ -8482,7 +8482,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_4: {
-                pos = scan_function_name(tokens, pos);
+                pos = scan_function_name(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_4; }
                 pos += 1;
@@ -8497,7 +8497,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                 if pos >= tokens.len() || tokens[pos].kind != TK_K_DISTINCT { pos = -1; } else { pos += 1; }
                                 if pos < 0 { pos = sp; }
                             }
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_170_0; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -8505,7 +8505,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_171: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_171; }
                                         pos += 1;
-                                        pos = scan_expr(tokens, pos);
+                                        pos = scan_expr(tokens, pos, 0);
                                         if pos < 0 { break sg_171; }
                                         break sg_171_done;
                                     }
@@ -8534,32 +8534,32 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_2: {
                 if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT && pos + 2 < tokens.len() && _gale_kind_set_2(tokens[pos + 2].kind) && pos + 3 < tokens.len() && tokens[pos + 3].kind == TK_LIT_DOT {
                     sol_172: {
-                        pos = scan_database_name(tokens, pos);
+                        pos = scan_database_name(tokens, pos, 0);
                         if pos < 0 { break sol_172; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_172; }
                         pos += 1;
-                        pos = scan_table_name(tokens, pos);
+                        pos = scan_table_name(tokens, pos, 0);
                         if pos < 0 { break sol_172; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_172; }
                         pos += 1;
                     }
                 } else if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT {
                     sol_173: {
-                        pos = scan_table_name(tokens, pos);
+                        pos = scan_table_name(tokens, pos, 0);
                         if pos < 0 { break sol_173; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_173; }
                         pos += 1;
                     }
                 }
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
             pos = start;
             try_3: {
-                pos = scan_unary_operator(tokens, pos);
+                pos = scan_unary_operator(tokens, pos, 0);
                 if pos < 0 { break try_3; }
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -8567,13 +8567,13 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_K_RAISE {
             pos = start;
             try_9: {
-                pos = scan_raise_function(tokens, pos);
+                pos = scan_raise_function(tokens, pos, 0);
                 if pos < 0 { break try_9; }
                 break scan_alts;
             }
             pos = start;
             try_4: {
-                pos = scan_function_name(tokens, pos);
+                pos = scan_function_name(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_4; }
                 pos += 1;
@@ -8588,7 +8588,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                 if pos >= tokens.len() || tokens[pos].kind != TK_K_DISTINCT { pos = -1; } else { pos += 1; }
                                 if pos < 0 { pos = sp; }
                             }
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_174_0; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -8596,7 +8596,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_175: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_175; }
                                         pos += 1;
-                                        pos = scan_expr(tokens, pos);
+                                        pos = scan_expr(tokens, pos, 0);
                                         if pos < 0 { break sg_175; }
                                         break sg_175_done;
                                     }
@@ -8625,24 +8625,24 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_2: {
                 if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT && pos + 2 < tokens.len() && _gale_kind_set_2(tokens[pos + 2].kind) && pos + 3 < tokens.len() && tokens[pos + 3].kind == TK_LIT_DOT {
                     sol_176: {
-                        pos = scan_database_name(tokens, pos);
+                        pos = scan_database_name(tokens, pos, 0);
                         if pos < 0 { break sol_176; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_176; }
                         pos += 1;
-                        pos = scan_table_name(tokens, pos);
+                        pos = scan_table_name(tokens, pos, 0);
                         if pos < 0 { break sol_176; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_176; }
                         pos += 1;
                     }
                 } else if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT {
                     sol_177: {
-                        pos = scan_table_name(tokens, pos);
+                        pos = scan_table_name(tokens, pos, 0);
                         if pos < 0 { break sol_177; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_177; }
                         pos += 1;
                     }
                 }
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -8665,7 +8665,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_7; }
                 pos += 1;
-                pos = scan_select_stmt(tokens, pos);
+                pos = scan_select_stmt(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_7; }
                 pos += 1;
@@ -8675,7 +8675,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_5: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_5; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_5; }
                 pos += 1;
@@ -8683,7 +8683,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_4: {
-                pos = scan_function_name(tokens, pos);
+                pos = scan_function_name(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_4; }
                 pos += 1;
@@ -8698,7 +8698,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                 if pos >= tokens.len() || tokens[pos].kind != TK_K_DISTINCT { pos = -1; } else { pos += 1; }
                                 if pos < 0 { pos = sp; }
                             }
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_180_0; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -8706,7 +8706,7 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_181: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_181; }
                                         pos += 1;
-                                        pos = scan_expr(tokens, pos);
+                                        pos = scan_expr(tokens, pos, 0);
                                         if pos < 0 { break sg_181; }
                                         break sg_181_done;
                                     }
@@ -8735,24 +8735,24 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_2: {
                 if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT && pos + 2 < tokens.len() && _gale_kind_set_2(tokens[pos + 2].kind) && pos + 3 < tokens.len() && tokens[pos + 3].kind == TK_LIT_DOT {
                     sol_182: {
-                        pos = scan_database_name(tokens, pos);
+                        pos = scan_database_name(tokens, pos, 0);
                         if pos < 0 { break sol_182; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_182; }
                         pos += 1;
-                        pos = scan_table_name(tokens, pos);
+                        pos = scan_table_name(tokens, pos, 0);
                         if pos < 0 { break sol_182; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_182; }
                         pos += 1;
                     }
                 } else if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT {
                     sol_183: {
-                        pos = scan_table_name(tokens, pos);
+                        pos = scan_table_name(tokens, pos, 0);
                         if pos < 0 { break sol_183; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_183; }
                         pos += 1;
                     }
                 }
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -8760,9 +8760,9 @@ fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_29(alt_kind) {
             pos = start;
             try_3: {
-                pos = scan_unary_operator(tokens, pos);
+                pos = scan_unary_operator(tokens, pos, 0);
                 if pos < 0 { break try_3; }
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -8965,13 +8965,13 @@ fn scan_expr_lr_10(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_190: {
                         pos = gp_190;
                         sg_190_0: {
-                            pos = scan_select_stmt(tokens, pos);
+                            pos = scan_select_stmt(tokens, pos, 0);
                             if pos < 0 { break sg_190_0; }
                             if pos > sg_190_best { sg_190_best = pos; }
                         }
                         pos = gp_190;
                         sg_190_1: {
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_190_1; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -8979,7 +8979,7 @@ fn scan_expr_lr_10(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_191: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_191; }
                                         pos += 1;
-                                        pos = scan_expr(tokens, pos);
+                                        pos = scan_expr(tokens, pos, 0);
                                         if pos < 0 { break sg_191; }
                                         break sg_191_done;
                                     }
@@ -9005,7 +9005,7 @@ fn scan_expr_lr_10(tokens: &Array<Token>, pos: i32) -> i32 {
                     let sp = pos;
                     sg_192_done: {
                         sg_192: {
-                            pos = scan_database_name(tokens, pos);
+                            pos = scan_database_name(tokens, pos, 0);
                             if pos < 0 { break sg_192; }
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_192; }
                             pos += 1;
@@ -9015,7 +9015,7 @@ fn scan_expr_lr_10(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_table_name(tokens, pos);
+                pos = scan_table_name(tokens, pos, 0);
                 if pos < 0 { break sg_189_1; }
                 if pos > sg_189_best { sg_189_best = pos; }
             }
@@ -9048,7 +9048,7 @@ fn scan_expr_lr_16(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_COLLATE { return -1; }
     pos += 1;
-    pos = scan_collation_name(tokens, pos);
+    pos = scan_collation_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -9096,7 +9096,7 @@ fn scan_expr_lr_17(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_194: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_ESCAPE { break sg_194; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_194; }
                 break sg_194_done;
             }
@@ -9342,11 +9342,11 @@ fn scan_expr(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     return pos;
 }
 
-fn scan_foreign_key_clause(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_foreign_key_clause(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_REFERENCES { return -1; }
     pos += 1;
-    pos = scan_foreign_table(tokens, pos);
+    pos = scan_foreign_table(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_LPAREN {
         let sp = pos;
@@ -9354,7 +9354,7 @@ fn scan_foreign_key_clause(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_196: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_196; }
                 pos += 1;
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break sg_196; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -9362,7 +9362,7 @@ fn scan_foreign_key_clause(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_197: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_197; }
                             pos += 1;
-                            pos = scan_column_name(tokens, pos);
+                            pos = scan_column_name(tokens, pos, 0);
                             if pos < 0 { break sg_197; }
                             break sg_197_done;
                         }
@@ -9458,7 +9458,7 @@ fn scan_foreign_key_clause(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_199_1: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_K_MATCH { break sg_199_1; }
                             pos += 1;
-                            pos = scan_name(tokens, pos);
+                            pos = scan_name(tokens, pos, 0);
                             if pos < 0 { break sg_199_1; }
                             break sg_199;
                         }
@@ -9550,7 +9550,7 @@ fn scan_foreign_key_clause(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_raise_function(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_raise_function(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_RAISE { return -1; }
     pos += 1;
@@ -9592,7 +9592,7 @@ fn scan_raise_function(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_208_1; }
                 pos += 1;
-                pos = scan_error_message(tokens, pos);
+                pos = scan_error_message(tokens, pos, 0);
                 if pos < 0 { break sg_208_1; }
                 break sg_208;
             }
@@ -9604,9 +9604,9 @@ fn scan_raise_function(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_indexed_column(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_indexed_column(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_column_name(tokens, pos);
+    pos = scan_column_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_K_COLLATE {
         let sp = pos;
@@ -9614,7 +9614,7 @@ fn scan_indexed_column(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_210: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_COLLATE { break sg_210; }
                 pos += 1;
-                pos = scan_collation_name(tokens, pos);
+                pos = scan_collation_name(tokens, pos, 0);
                 if pos < 0 { break sg_210; }
                 break sg_210_done;
             }
@@ -9645,7 +9645,7 @@ fn scan_indexed_column(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_table_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_table_constraint(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_K_CONSTRAINT {
         let sp = pos;
@@ -9653,7 +9653,7 @@ fn scan_table_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_212: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_CONSTRAINT { break sg_212; }
                 pos += 1;
-                pos = scan_name(tokens, pos);
+                pos = scan_name(tokens, pos, 0);
                 if pos < 0 { break sg_212; }
                 break sg_212_done;
             }
@@ -9690,7 +9690,7 @@ fn scan_table_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_213_0; }
                 pos += 1;
-                pos = scan_indexed_column(tokens, pos);
+                pos = scan_indexed_column(tokens, pos, 0);
                 if pos < 0 { break sg_213_0; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -9698,7 +9698,7 @@ fn scan_table_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_215: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_215; }
                             pos += 1;
-                            pos = scan_indexed_column(tokens, pos);
+                            pos = scan_indexed_column(tokens, pos, 0);
                             if pos < 0 { break sg_215; }
                             break sg_215_done;
                         }
@@ -9709,7 +9709,7 @@ fn scan_table_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_213_0; }
                 pos += 1;
-                pos = scan_conflict_clause(tokens, pos);
+                pos = scan_conflict_clause(tokens, pos, 0);
                 if pos < 0 { break sg_213_0; }
                 break sg_213;
             }
@@ -9719,7 +9719,7 @@ fn scan_table_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_213_1; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_213_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_213_1; }
                 pos += 1;
@@ -9733,7 +9733,7 @@ fn scan_table_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_213_2; }
                 pos += 1;
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break sg_213_2; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -9741,7 +9741,7 @@ fn scan_table_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_216: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_216; }
                             pos += 1;
-                            pos = scan_column_name(tokens, pos);
+                            pos = scan_column_name(tokens, pos, 0);
                             if pos < 0 { break sg_216; }
                             break sg_216_done;
                         }
@@ -9752,7 +9752,7 @@ fn scan_table_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_213_2; }
                 pos += 1;
-                pos = scan_foreign_key_clause(tokens, pos);
+                pos = scan_foreign_key_clause(tokens, pos, 0);
                 if pos < 0 { break sg_213_2; }
                 break sg_213;
             }
@@ -9762,7 +9762,7 @@ fn scan_table_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_with_clause(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_with_clause(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_K_WITH { return -1; }
     pos += 1;
@@ -9771,7 +9771,7 @@ fn scan_with_clause(tokens: &Array<Token>, pos: i32) -> i32 {
         if pos >= tokens.len() || tokens[pos].kind != TK_K_RECURSIVE { pos = -1; } else { pos += 1; }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_common_table_expression(tokens, pos);
+    pos = scan_common_table_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -9779,7 +9779,7 @@ fn scan_with_clause(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_217: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_217; }
                 pos += 1;
-                pos = scan_common_table_expression(tokens, pos);
+                pos = scan_common_table_expression(tokens, pos, 0);
                 if pos < 0 { break sg_217; }
                 break sg_217_done;
             }
@@ -9791,13 +9791,13 @@ fn scan_with_clause(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_qualified_table_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_qualified_table_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) {
         let sp = pos;
         sg_218_done: {
             sg_218: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_218; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_218; }
                 pos += 1;
@@ -9807,7 +9807,7 @@ fn scan_qualified_table_name(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_table_name(tokens, pos);
+    pos = scan_table_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && _gale_kind_set_44(tokens[pos].kind) {
         let sp = pos;
@@ -9819,7 +9819,7 @@ fn scan_qualified_table_name(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sg_219_0; }
                 pos += 1;
-                pos = scan_index_name(tokens, pos);
+                pos = scan_index_name(tokens, pos, 0);
                 if pos < 0 { break sg_219_0; }
                 break sg_219;
             }
@@ -9838,9 +9838,9 @@ fn scan_qualified_table_name(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_ordering_term(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_ordering_term(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_expr(tokens, pos);
+    pos = scan_expr(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_K_COLLATE {
         let sp = pos;
@@ -9848,7 +9848,7 @@ fn scan_ordering_term(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_220: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_COLLATE { break sg_220; }
                 pos += 1;
-                pos = scan_collation_name(tokens, pos);
+                pos = scan_collation_name(tokens, pos, 0);
                 if pos < 0 { break sg_220; }
                 break sg_220_done;
             }
@@ -9879,7 +9879,7 @@ fn scan_ordering_term(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_pragma_value(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_pragma_value(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -9887,7 +9887,7 @@ fn scan_pragma_value(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_45(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_signed_number(tokens, pos);
+                pos = scan_signed_number(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -9895,7 +9895,7 @@ fn scan_pragma_value(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_46(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_name(tokens, pos);
+                pos = scan_name(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -9903,7 +9903,7 @@ fn scan_pragma_value(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_STRING_LITERAL {
             pos = start;
             try_1: {
-                pos = scan_name(tokens, pos);
+                pos = scan_name(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -9921,9 +9921,9 @@ fn scan_pragma_value(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_common_table_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_common_table_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_table_name(tokens, pos);
+    pos = scan_table_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_LPAREN {
         let sp = pos;
@@ -9931,7 +9931,7 @@ fn scan_common_table_expression(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_222: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_222; }
                 pos += 1;
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break sg_222; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -9939,7 +9939,7 @@ fn scan_common_table_expression(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_223: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_223; }
                             pos += 1;
-                            pos = scan_column_name(tokens, pos);
+                            pos = scan_column_name(tokens, pos, 0);
                             if pos < 0 { break sg_223; }
                             break sg_223_done;
                         }
@@ -9960,14 +9960,14 @@ fn scan_common_table_expression(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_select_stmt(tokens, pos);
+    pos = scan_select_stmt(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_result_column(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_result_column(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -9983,7 +9983,7 @@ fn scan_result_column(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_2(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_table_name(tokens, pos);
+                pos = scan_table_name(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break try_1; }
                 pos += 1;
@@ -9993,18 +9993,18 @@ fn scan_result_column(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_2: {
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 if pos < tokens.len() && tokens[pos].kind == TK_K_AS && pos + 1 < tokens.len() && _gale_kind_set_48(tokens[pos + 1].kind) {
                     sol_224: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { break sol_224; }
                         pos += 1;
-                        pos = scan_column_alias(tokens, pos);
+                        pos = scan_column_alias(tokens, pos, 0);
                         if pos < 0 { break sol_224; }
                     }
                 } else if pos < tokens.len() && _gale_kind_set_48(tokens[pos].kind) {
                     sol_225: {
-                        pos = scan_column_alias(tokens, pos);
+                        pos = scan_column_alias(tokens, pos, 0);
                         if pos < 0 { break sol_225; }
                     }
                 }
@@ -10014,18 +10014,18 @@ fn scan_result_column(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_49(alt_kind) {
             pos = start;
             try_2: {
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 if pos < tokens.len() && tokens[pos].kind == TK_K_AS && pos + 1 < tokens.len() && _gale_kind_set_48(tokens[pos + 1].kind) {
                     sol_226: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { break sol_226; }
                         pos += 1;
-                        pos = scan_column_alias(tokens, pos);
+                        pos = scan_column_alias(tokens, pos, 0);
                         if pos < 0 { break sol_226; }
                     }
                 } else if pos < tokens.len() && _gale_kind_set_48(tokens[pos].kind) {
                     sol_227: {
-                        pos = scan_column_alias(tokens, pos);
+                        pos = scan_column_alias(tokens, pos, 0);
                         if pos < 0 { break sol_227; }
                     }
                 }
@@ -10039,7 +10039,7 @@ fn scan_result_column(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -10051,7 +10051,7 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                     let sp = pos;
                     sg_228_done: {
                         sg_228: {
-                            pos = scan_schema_name(tokens, pos);
+                            pos = scan_schema_name(tokens, pos, 0);
                             if pos < 0 { break sg_228; }
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_228; }
                             pos += 1;
@@ -10061,7 +10061,7 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_table_function_name(tokens, pos);
+                pos = scan_table_function_name(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_1; }
                 pos += 1;
@@ -10069,7 +10069,7 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                     let sp = pos;
                     sg_229_done: {
                         sg_229: {
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_229; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -10077,7 +10077,7 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_230: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_230; }
                                         pos += 1;
-                                        pos = scan_expr(tokens, pos);
+                                        pos = scan_expr(tokens, pos, 0);
                                         if pos < 0 { break sg_230; }
                                         break sg_230_done;
                                     }
@@ -10098,12 +10098,12 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                     sol_231: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { break sol_231; }
                         pos += 1;
-                        pos = scan_table_alias(tokens, pos);
+                        pos = scan_table_alias(tokens, pos, 0);
                         if pos < 0 { break sol_231; }
                     }
                 } else if pos < tokens.len() && _gale_kind_set_52(tokens[pos].kind) {
                     sol_232: {
-                        pos = scan_table_alias(tokens, pos);
+                        pos = scan_table_alias(tokens, pos, 0);
                         if pos < 0 { break sol_232; }
                     }
                 }
@@ -10115,7 +10115,7 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                     let sp = pos;
                     sg_233_done: {
                         sg_233: {
-                            pos = scan_schema_name(tokens, pos);
+                            pos = scan_schema_name(tokens, pos, 0);
                             if pos < 0 { break sg_233; }
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_233; }
                             pos += 1;
@@ -10125,18 +10125,18 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_table_name(tokens, pos);
+                pos = scan_table_name(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos < tokens.len() && tokens[pos].kind == TK_K_AS && pos + 1 < tokens.len() && _gale_kind_set_52(tokens[pos + 1].kind) {
                     sol_234: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { break sol_234; }
                         pos += 1;
-                        pos = scan_table_alias(tokens, pos);
+                        pos = scan_table_alias(tokens, pos, 0);
                         if pos < 0 { break sol_234; }
                     }
                 } else if pos < tokens.len() && _gale_kind_set_52(tokens[pos].kind) {
                     sol_235: {
-                        pos = scan_table_alias(tokens, pos);
+                        pos = scan_table_alias(tokens, pos, 0);
                         if pos < 0 { break sol_235; }
                     }
                 }
@@ -10150,7 +10150,7 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                             pos += 1;
                             if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sg_236_0; }
                             pos += 1;
-                            pos = scan_index_name(tokens, pos);
+                            pos = scan_index_name(tokens, pos, 0);
                             if pos < 0 { break sg_236_0; }
                             break sg_236;
                         }
@@ -10174,7 +10174,7 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
             try_3: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_3; }
                 pos += 1;
-                pos = scan_select_stmt(tokens, pos);
+                pos = scan_select_stmt(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_3; }
                 pos += 1;
@@ -10182,12 +10182,12 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                     sol_237: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { break sol_237; }
                         pos += 1;
-                        pos = scan_table_alias(tokens, pos);
+                        pos = scan_table_alias(tokens, pos, 0);
                         if pos < 0 { break sol_237; }
                     }
                 } else if pos < tokens.len() && _gale_kind_set_52(tokens[pos].kind) {
                     sol_238: {
-                        pos = scan_table_alias(tokens, pos);
+                        pos = scan_table_alias(tokens, pos, 0);
                         if pos < 0 { break sol_238; }
                     }
                 }
@@ -10204,7 +10204,7 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_239: {
                         pos = gp_239;
                         sg_239_0: {
-                            pos = scan_table_or_subquery(tokens, pos);
+                            pos = scan_table_or_subquery(tokens, pos, 0);
                             if pos < 0 { break sg_239_0; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -10212,7 +10212,7 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_240: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_240; }
                                         pos += 1;
-                                        pos = scan_table_or_subquery(tokens, pos);
+                                        pos = scan_table_or_subquery(tokens, pos, 0);
                                         if pos < 0 { break sg_240; }
                                         break sg_240_done;
                                     }
@@ -10225,7 +10225,7 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                         }
                         pos = gp_239;
                         sg_239_1: {
-                            pos = scan_join_clause(tokens, pos);
+                            pos = scan_join_clause(tokens, pos, 0);
                             if pos < 0 { break sg_239_1; }
                             if pos > sg_239_best { sg_239_best = pos; }
                         }
@@ -10243,7 +10243,7 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                     let sp = pos;
                     sg_241_done: {
                         sg_241: {
-                            pos = scan_schema_name(tokens, pos);
+                            pos = scan_schema_name(tokens, pos, 0);
                             if pos < 0 { break sg_241; }
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_241; }
                             pos += 1;
@@ -10253,7 +10253,7 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_table_function_name(tokens, pos);
+                pos = scan_table_function_name(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_1; }
                 pos += 1;
@@ -10261,7 +10261,7 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                     let sp = pos;
                     sg_242_done: {
                         sg_242: {
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_242; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -10269,7 +10269,7 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_243: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_243; }
                                         pos += 1;
-                                        pos = scan_expr(tokens, pos);
+                                        pos = scan_expr(tokens, pos, 0);
                                         if pos < 0 { break sg_243; }
                                         break sg_243_done;
                                     }
@@ -10290,12 +10290,12 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                     sol_244: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { break sol_244; }
                         pos += 1;
-                        pos = scan_table_alias(tokens, pos);
+                        pos = scan_table_alias(tokens, pos, 0);
                         if pos < 0 { break sol_244; }
                     }
                 } else if pos < tokens.len() && _gale_kind_set_52(tokens[pos].kind) {
                     sol_245: {
-                        pos = scan_table_alias(tokens, pos);
+                        pos = scan_table_alias(tokens, pos, 0);
                         if pos < 0 { break sol_245; }
                     }
                 }
@@ -10307,7 +10307,7 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                     let sp = pos;
                     sg_246_done: {
                         sg_246: {
-                            pos = scan_schema_name(tokens, pos);
+                            pos = scan_schema_name(tokens, pos, 0);
                             if pos < 0 { break sg_246; }
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_246; }
                             pos += 1;
@@ -10317,18 +10317,18 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_table_name(tokens, pos);
+                pos = scan_table_name(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos < tokens.len() && tokens[pos].kind == TK_K_AS && pos + 1 < tokens.len() && _gale_kind_set_52(tokens[pos + 1].kind) {
                     sol_247: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { break sol_247; }
                         pos += 1;
-                        pos = scan_table_alias(tokens, pos);
+                        pos = scan_table_alias(tokens, pos, 0);
                         if pos < 0 { break sol_247; }
                     }
                 } else if pos < tokens.len() && _gale_kind_set_52(tokens[pos].kind) {
                     sol_248: {
-                        pos = scan_table_alias(tokens, pos);
+                        pos = scan_table_alias(tokens, pos, 0);
                         if pos < 0 { break sol_248; }
                     }
                 }
@@ -10342,7 +10342,7 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
                             pos += 1;
                             if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sg_249_0; }
                             pos += 1;
-                            pos = scan_index_name(tokens, pos);
+                            pos = scan_index_name(tokens, pos, 0);
                             if pos < 0 { break sg_249_0; }
                             break sg_249;
                         }
@@ -10368,19 +10368,19 @@ fn scan_table_or_subquery(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_join_clause(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_join_clause(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_table_or_subquery(tokens, pos);
+    pos = scan_table_or_subquery(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && _gale_kind_set_53(tokens[pos].kind) {
         let sp = pos;
         sg_250_done: {
             sg_250: {
-                pos = scan_join_operator(tokens, pos);
+                pos = scan_join_operator(tokens, pos, 0);
                 if pos < 0 { break sg_250; }
-                pos = scan_table_or_subquery(tokens, pos);
+                pos = scan_table_or_subquery(tokens, pos, 0);
                 if pos < 0 { break sg_250; }
-                pos = scan_join_constraint(tokens, pos);
+                pos = scan_join_constraint(tokens, pos, 0);
                 if pos < 0 { break sg_250; }
                 break sg_250_done;
             }
@@ -10392,7 +10392,7 @@ fn scan_join_clause(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_join_operator(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_join_operator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -10456,7 +10456,7 @@ fn scan_join_operator(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_join_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_join_constraint(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && _gale_kind_set_56(tokens[pos].kind) {
         let sp = pos;
@@ -10466,7 +10466,7 @@ fn scan_join_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_252_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_ON { break sg_252_0; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_252_0; }
                 break sg_252;
             }
@@ -10476,7 +10476,7 @@ fn scan_join_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_252_1; }
                 pos += 1;
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break sg_252_1; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -10484,7 +10484,7 @@ fn scan_join_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_253: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_253; }
                             pos += 1;
-                            pos = scan_column_name(tokens, pos);
+                            pos = scan_column_name(tokens, pos, 0);
                             if pos < 0 { break sg_253; }
                             break sg_253_done;
                         }
@@ -10504,7 +10504,7 @@ fn scan_join_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_select_core(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -10534,7 +10534,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_result_column(tokens, pos);
+                pos = scan_result_column(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -10542,7 +10542,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_255: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_255; }
                             pos += 1;
-                            pos = scan_result_column(tokens, pos);
+                            pos = scan_result_column(tokens, pos, 0);
                             if pos < 0 { break sg_255; }
                             break sg_255_done;
                         }
@@ -10564,7 +10564,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                                 sg_257: {
                                     pos = gp_257;
                                     sg_257_0: {
-                                        pos = scan_table_or_subquery(tokens, pos);
+                                        pos = scan_table_or_subquery(tokens, pos, 0);
                                         if pos < 0 { break sg_257_0; }
                                         while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                             let sp = pos;
@@ -10572,7 +10572,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                                                 sg_258: {
                                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_258; }
                                                     pos += 1;
-                                                    pos = scan_table_or_subquery(tokens, pos);
+                                                    pos = scan_table_or_subquery(tokens, pos, 0);
                                                     if pos < 0 { break sg_258; }
                                                     break sg_258_done;
                                                 }
@@ -10585,7 +10585,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                                     }
                                     pos = gp_257;
                                     sg_257_1: {
-                                        pos = scan_join_clause(tokens, pos);
+                                        pos = scan_join_clause(tokens, pos, 0);
                                         if pos < 0 { break sg_257_1; }
                                         if pos > sg_257_best { sg_257_best = pos; }
                                     }
@@ -10605,7 +10605,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_259: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_K_WHERE { break sg_259; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_259; }
                             break sg_259_done;
                         }
@@ -10619,7 +10619,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                         pos += 1;
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sol_260; }
                         pos += 1;
-                        pos = scan_expr(tokens, pos);
+                        pos = scan_expr(tokens, pos, 0);
                         if pos < 0 { break sol_260; }
                         while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                             let sp = pos;
@@ -10627,7 +10627,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                                 sg_261: {
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_261; }
                                     pos += 1;
-                                    pos = scan_expr(tokens, pos);
+                                    pos = scan_expr(tokens, pos, 0);
                                     if pos < 0 { break sg_261; }
                                     break sg_261_done;
                                 }
@@ -10638,7 +10638,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                         }
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_HAVING { break sol_260; }
                         pos += 1;
-                        pos = scan_expr(tokens, pos);
+                        pos = scan_expr(tokens, pos, 0);
                         if pos < 0 { break sol_260; }
                     }
                 } else if pos < tokens.len() && tokens[pos].kind == TK_K_GROUP && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_K_BY && pos + 2 < tokens.len() && _gale_kind_set_6(tokens[pos + 2].kind) && pos + 3 < tokens.len() && tokens[pos + 3].kind == TK_K_HAVING && pos + 4 < tokens.len() && _gale_kind_set_6(tokens[pos + 4].kind) {
@@ -10647,11 +10647,11 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                         pos += 1;
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sol_262; }
                         pos += 1;
-                        pos = scan_expr(tokens, pos);
+                        pos = scan_expr(tokens, pos, 0);
                         if pos < 0 { break sol_262; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_HAVING { break sol_262; }
                         pos += 1;
-                        pos = scan_expr(tokens, pos);
+                        pos = scan_expr(tokens, pos, 0);
                         if pos < 0 { break sol_262; }
                     }
                 } else if pos < tokens.len() && tokens[pos].kind == TK_K_GROUP && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_K_BY && pos + 2 < tokens.len() && _gale_kind_set_6(tokens[pos + 2].kind) && pos + 3 < tokens.len() && tokens[pos + 3].kind == TK_LIT_COMMA {
@@ -10660,7 +10660,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                         pos += 1;
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sol_263; }
                         pos += 1;
-                        pos = scan_expr(tokens, pos);
+                        pos = scan_expr(tokens, pos, 0);
                         if pos < 0 { break sol_263; }
                         while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                             let sp = pos;
@@ -10668,7 +10668,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                                 sg_264: {
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_264; }
                                     pos += 1;
-                                    pos = scan_expr(tokens, pos);
+                                    pos = scan_expr(tokens, pos, 0);
                                     if pos < 0 { break sg_264; }
                                     break sg_264_done;
                                 }
@@ -10684,7 +10684,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                         pos += 1;
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sol_265; }
                         pos += 1;
-                        pos = scan_expr(tokens, pos);
+                        pos = scan_expr(tokens, pos, 0);
                         if pos < 0 { break sol_265; }
                     }
                 }
@@ -10698,7 +10698,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_1; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -10706,7 +10706,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_266: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_266; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_266; }
                             break sg_266_done;
                         }
@@ -10725,7 +10725,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                             pos += 1;
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_267; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_267; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -10733,7 +10733,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
                                     sg_268: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_268; }
                                         pos += 1;
-                                        pos = scan_expr(tokens, pos);
+                                        pos = scan_expr(tokens, pos, 0);
                                         if pos < 0 { break sg_268; }
                                         break sg_268_done;
                                     }
@@ -10761,7 +10761,7 @@ fn scan_select_core(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_compound_operator(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_compound_operator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -10805,7 +10805,7 @@ fn scan_compound_operator(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_signed_number(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_signed_number(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && _gale_kind_set_32(tokens[pos].kind) {
         let sp = pos;
@@ -10832,28 +10832,28 @@ fn scan_signed_number(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_literal_value(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_literal_value(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_57(tokens[pos].kind) {
         return pos + 1;
     }
     return -1;
 }
 
-fn scan_unary_operator(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_unary_operator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_58(tokens[pos].kind) {
         return pos + 1;
     }
     return -1;
 }
 
-fn scan_error_message(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_error_message(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_STRING_LITERAL { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_module_argument(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_module_argument(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -10861,7 +10861,7 @@ fn scan_module_argument(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_49(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -10869,13 +10869,13 @@ fn scan_module_argument(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_2(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_1: {
-                pos = scan_column_def(tokens, pos);
+                pos = scan_column_def(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -10887,140 +10887,140 @@ fn scan_module_argument(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_column_alias(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_column_alias(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_48(tokens[pos].kind) {
         return pos + 1;
     }
     return -1;
 }
 
-fn scan_keyword(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_keyword(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_59(tokens[pos].kind) {
         return pos + 1;
     }
     return -1;
 }
 
-fn scan_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_function_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_function_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_database_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_database_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_schema_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_schema_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_table_function_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_table_function_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_table_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_table_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_table_or_index_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_table_or_index_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_new_table_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_new_table_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_column_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_column_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_collation_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_collation_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_foreign_table(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_foreign_table(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_index_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_index_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_trigger_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_trigger_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_view_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_view_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_module_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_module_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_pragma_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_pragma_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_savepoint_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_savepoint_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_table_alias(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_table_alias(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -11046,7 +11046,7 @@ fn scan_table_alias(tokens: &Array<Token>, pos: i32) -> i32 {
             try_2: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_2; }
                 pos += 1;
-                pos = scan_table_alias(tokens, pos);
+                pos = scan_table_alias(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_2; }
                 pos += 1;
@@ -11060,14 +11060,14 @@ fn scan_table_alias(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_transaction_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_transaction_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_any_name(tokens, pos);
+    pos = scan_any_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_any_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_any_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -11083,7 +11083,7 @@ fn scan_any_name(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_59(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_keyword(tokens, pos);
+                pos = scan_keyword(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -11101,7 +11101,7 @@ fn scan_any_name(tokens: &Array<Token>, pos: i32) -> i32 {
             try_3: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_3; }
                 pos += 1;
-                pos = scan_any_name(tokens, pos);
+                pos = scan_any_name(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_3; }
                 pos += 1;
@@ -11127,13 +11127,13 @@ fn parse_parse(p: &mut Parser) -> Result<ParseNode, ParseError> {
             sg_270: {
                 pos = gp_270;
                 sg_270_0: {
-                    pos = scan_sql_stmt_list(tokens, pos);
+                    pos = scan_sql_stmt_list(tokens, pos, 0);
                     if pos < 0 { break sg_270_0; }
                     break sg_270;
                 }
                 pos = gp_270;
                 sg_270_1: {
-                    pos = scan_error(tokens, pos);
+                    pos = scan_error(tokens, pos, 0);
                     if pos < 0 { break sg_270_1; }
                     break sg_270;
                 }
@@ -11201,7 +11201,7 @@ fn parse_sql_stmt_list(p: &mut Parser) -> Result<SqlStmtListNode, ParseError> {
                 if pos < 0 { pos = sp; break; }
                 if pos == sp { break; }
             }
-            pos = scan_sql_stmt(tokens, pos);
+            pos = scan_sql_stmt(tokens, pos, 0);
             if pos < 0 { break rep_scan_2; }
             if pos <= p.pos { break rep_scan_2; }
             rep_scan_pos_2 = pos;
@@ -11303,7 +11303,7 @@ fn parse_sql_stmt(p: &mut Parser) -> Result<SqlStmtNode, ParseError> {
             gd_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_compound_select_stmt(tokens, pos);
+                pos = scan_compound_select_stmt(tokens, pos, 0);
                 if pos < 0 { break gd_scan; }
                 gd_winner = 0;
                 break gd_dispatch;
@@ -11311,7 +11311,7 @@ fn parse_sql_stmt(p: &mut Parser) -> Result<SqlStmtNode, ParseError> {
             gd_scan_2: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_delete_stmt(tokens, pos);
+                pos = scan_delete_stmt(tokens, pos, 0);
                 if pos < 0 { break gd_scan_2; }
                 gd_winner = 1;
                 break gd_dispatch;
@@ -11319,7 +11319,7 @@ fn parse_sql_stmt(p: &mut Parser) -> Result<SqlStmtNode, ParseError> {
             gd_scan_3: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_delete_stmt_limited(tokens, pos);
+                pos = scan_delete_stmt_limited(tokens, pos, 0);
                 if pos < 0 { break gd_scan_3; }
                 gd_winner = 2;
                 break gd_dispatch;
@@ -11327,7 +11327,7 @@ fn parse_sql_stmt(p: &mut Parser) -> Result<SqlStmtNode, ParseError> {
             gd_scan_4: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_factored_select_stmt(tokens, pos);
+                pos = scan_factored_select_stmt(tokens, pos, 0);
                 if pos < 0 { break gd_scan_4; }
                 gd_winner = 3;
                 break gd_dispatch;
@@ -11335,7 +11335,7 @@ fn parse_sql_stmt(p: &mut Parser) -> Result<SqlStmtNode, ParseError> {
             gd_scan_5: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_insert_stmt(tokens, pos);
+                pos = scan_insert_stmt(tokens, pos, 0);
                 if pos < 0 { break gd_scan_5; }
                 gd_winner = 4;
                 break gd_dispatch;
@@ -11343,7 +11343,7 @@ fn parse_sql_stmt(p: &mut Parser) -> Result<SqlStmtNode, ParseError> {
             gd_scan_6: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_simple_select_stmt(tokens, pos);
+                pos = scan_simple_select_stmt(tokens, pos, 0);
                 if pos < 0 { break gd_scan_6; }
                 gd_winner = 5;
                 break gd_dispatch;
@@ -11351,7 +11351,7 @@ fn parse_sql_stmt(p: &mut Parser) -> Result<SqlStmtNode, ParseError> {
             gd_scan_7: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_select_stmt(tokens, pos);
+                pos = scan_select_stmt(tokens, pos, 0);
                 if pos < 0 { break gd_scan_7; }
                 gd_winner = 6;
                 break gd_dispatch;
@@ -11359,7 +11359,7 @@ fn parse_sql_stmt(p: &mut Parser) -> Result<SqlStmtNode, ParseError> {
             gd_scan_8: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_update_stmt(tokens, pos);
+                pos = scan_update_stmt(tokens, pos, 0);
                 if pos < 0 { break gd_scan_8; }
                 gd_winner = 7;
                 break gd_dispatch;
@@ -11399,7 +11399,7 @@ fn parse_sql_stmt(p: &mut Parser) -> Result<SqlStmtNode, ParseError> {
             gd_scan_9: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_create_index_stmt(tokens, pos);
+                pos = scan_create_index_stmt(tokens, pos, 0);
                 if pos < 0 { break gd_scan_9; }
                 gd_winner_2 = 0;
                 break gd_dispatch_2;
@@ -11407,7 +11407,7 @@ fn parse_sql_stmt(p: &mut Parser) -> Result<SqlStmtNode, ParseError> {
             gd_scan_10: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_create_table_stmt(tokens, pos);
+                pos = scan_create_table_stmt(tokens, pos, 0);
                 if pos < 0 { break gd_scan_10; }
                 gd_winner_2 = 1;
                 break gd_dispatch_2;
@@ -11415,7 +11415,7 @@ fn parse_sql_stmt(p: &mut Parser) -> Result<SqlStmtNode, ParseError> {
             gd_scan_11: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_create_trigger_stmt(tokens, pos);
+                pos = scan_create_trigger_stmt(tokens, pos, 0);
                 if pos < 0 { break gd_scan_11; }
                 gd_winner_2 = 2;
                 break gd_dispatch_2;
@@ -11423,7 +11423,7 @@ fn parse_sql_stmt(p: &mut Parser) -> Result<SqlStmtNode, ParseError> {
             gd_scan_12: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_create_view_stmt(tokens, pos);
+                pos = scan_create_view_stmt(tokens, pos, 0);
                 if pos < 0 { break gd_scan_12; }
                 gd_winner_2 = 3;
                 break gd_dispatch_2;
@@ -11454,7 +11454,7 @@ fn parse_sql_stmt(p: &mut Parser) -> Result<SqlStmtNode, ParseError> {
             gd_scan_13: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_drop_index_stmt(tokens, pos);
+                pos = scan_drop_index_stmt(tokens, pos, 0);
                 if pos < 0 { break gd_scan_13; }
                 gd_winner_3 = 0;
                 break gd_dispatch_3;
@@ -11462,7 +11462,7 @@ fn parse_sql_stmt(p: &mut Parser) -> Result<SqlStmtNode, ParseError> {
             gd_scan_14: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_drop_table_stmt(tokens, pos);
+                pos = scan_drop_table_stmt(tokens, pos, 0);
                 if pos < 0 { break gd_scan_14; }
                 gd_winner_3 = 1;
                 break gd_dispatch_3;
@@ -11470,7 +11470,7 @@ fn parse_sql_stmt(p: &mut Parser) -> Result<SqlStmtNode, ParseError> {
             gd_scan_15: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_drop_trigger_stmt(tokens, pos);
+                pos = scan_drop_trigger_stmt(tokens, pos, 0);
                 if pos < 0 { break gd_scan_15; }
                 gd_winner_3 = 2;
                 break gd_dispatch_3;
@@ -11524,7 +11524,7 @@ fn parse_alter_table_stmt(p: &mut Parser) -> Result<AlterTableStmtNode, ParseErr
     opt_scan: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_database_name(tokens, pos);
+        pos = scan_database_name(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan; }
         pos += 1;
@@ -11591,23 +11591,23 @@ fn parse_analyze_stmt(p: &mut Parser) -> Result<AnalyzeStmtNode, ParseError> {
         sg_271: {
             pos = gp_271;
             sg_271_0: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_271_0; }
                 if pos > sg_271_best { sg_271_best = pos; }
             }
             pos = gp_271;
             sg_271_1: {
-                pos = scan_table_or_index_name(tokens, pos);
+                pos = scan_table_or_index_name(tokens, pos, 0);
                 if pos < 0 { break sg_271_1; }
                 if pos > sg_271_best { sg_271_best = pos; }
             }
             pos = gp_271;
             sg_271_2: {
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break sg_271_2; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_271_2; }
                 pos += 1;
-                pos = scan_table_or_index_name(tokens, pos);
+                pos = scan_table_or_index_name(tokens, pos, 0);
                 if pos < 0 { break sg_271_2; }
                 if pos > sg_271_best { sg_271_best = pos; }
             }
@@ -11625,7 +11625,7 @@ fn parse_analyze_stmt(p: &mut Parser) -> Result<AnalyzeStmtNode, ParseError> {
                 gd_scan: {
                     let tokens = &p.tokens;
                     let mut pos: i32 = p.pos;
-                    pos = scan_database_name(tokens, pos);
+                    pos = scan_database_name(tokens, pos, 0);
                     if pos < 0 { break gd_scan; }
                     gd_winner = 0;
                     break gd_dispatch;
@@ -11633,7 +11633,7 @@ fn parse_analyze_stmt(p: &mut Parser) -> Result<AnalyzeStmtNode, ParseError> {
                 gd_scan_2: {
                     let tokens = &p.tokens;
                     let mut pos: i32 = p.pos;
-                    pos = scan_table_or_index_name(tokens, pos);
+                    pos = scan_table_or_index_name(tokens, pos, 0);
                     if pos < 0 { break gd_scan_2; }
                     gd_winner = 1;
                     break gd_dispatch;
@@ -11831,7 +11831,7 @@ fn parse_compound_select_stmt(p: &mut Parser) -> Result<CompoundSelectStmtNode, 
                         pos = gp_273;
                     }
                 }
-                pos = scan_select_core(tokens, pos);
+                pos = scan_select_core(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -11884,7 +11884,7 @@ fn parse_compound_select_stmt(p: &mut Parser) -> Result<CompoundSelectStmtNode, 
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_ordering_term(tokens, pos);
+                pos = scan_ordering_term(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -11931,7 +11931,7 @@ fn parse_compound_select_stmt(p: &mut Parser) -> Result<CompoundSelectStmtNode, 
                 }
                 break opt_scan;
             }
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break opt_scan; }
             opt_scan_pos = pos;
         }
@@ -11992,7 +11992,7 @@ fn parse_create_index_stmt(p: &mut Parser) -> Result<CreateIndexStmtNode, ParseE
     opt_scan: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_database_name(tokens, pos);
+        pos = scan_database_name(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan; }
         pos += 1;
@@ -12022,7 +12022,7 @@ fn parse_create_index_stmt(p: &mut Parser) -> Result<CreateIndexStmtNode, ParseE
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_indexed_column(tokens, pos);
+            pos = scan_indexed_column(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -12115,7 +12115,7 @@ fn parse_create_table_stmt(p: &mut Parser) -> Result<CreateTableStmtNode, ParseE
     opt_scan_2: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_database_name(tokens, pos);
+        pos = scan_database_name(tokens, pos, 0);
         if pos < 0 { break opt_scan_2; }
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan_2; }
         pos += 1;
@@ -12156,7 +12156,7 @@ fn parse_create_table_stmt(p: &mut Parser) -> Result<CreateTableStmtNode, ParseE
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_table_constraint(tokens, pos);
+                pos = scan_table_constraint(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -12260,7 +12260,7 @@ fn parse_create_trigger_stmt(p: &mut Parser) -> Result<CreateTriggerStmtNode, Pa
     opt_scan_2: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_database_name(tokens, pos);
+        pos = scan_database_name(tokens, pos, 0);
         if pos < 0 { break opt_scan_2; }
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan_2; }
         pos += 1;
@@ -12356,7 +12356,7 @@ fn parse_create_trigger_stmt(p: &mut Parser) -> Result<CreateTriggerStmtNode, Pa
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                     pos += 1;
-                    pos = scan_column_name(tokens, pos);
+                    pos = scan_column_name(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -12390,7 +12390,7 @@ fn parse_create_trigger_stmt(p: &mut Parser) -> Result<CreateTriggerStmtNode, Pa
     opt_scan_4: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_database_name(tokens, pos);
+        pos = scan_database_name(tokens, pos, 0);
         if pos < 0 { break opt_scan_4; }
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan_4; }
         pos += 1;
@@ -12448,25 +12448,25 @@ fn parse_create_trigger_stmt(p: &mut Parser) -> Result<CreateTriggerStmtNode, Pa
                     sg_278: {
                         pos = gp_278;
                         sg_278_0: {
-                            pos = scan_update_stmt(tokens, pos);
+                            pos = scan_update_stmt(tokens, pos, 0);
                             if pos < 0 { break sg_278_0; }
                             if pos > sg_278_best { sg_278_best = pos; }
                         }
                         pos = gp_278;
                         sg_278_1: {
-                            pos = scan_insert_stmt(tokens, pos);
+                            pos = scan_insert_stmt(tokens, pos, 0);
                             if pos < 0 { break sg_278_1; }
                             if pos > sg_278_best { sg_278_best = pos; }
                         }
                         pos = gp_278;
                         sg_278_2: {
-                            pos = scan_delete_stmt(tokens, pos);
+                            pos = scan_delete_stmt(tokens, pos, 0);
                             if pos < 0 { break sg_278_2; }
                             if pos > sg_278_best { sg_278_best = pos; }
                         }
                         pos = gp_278;
                         sg_278_3: {
-                            pos = scan_select_stmt(tokens, pos);
+                            pos = scan_select_stmt(tokens, pos, 0);
                             if pos < 0 { break sg_278_3; }
                             if pos > sg_278_best { sg_278_best = pos; }
                         }
@@ -12490,7 +12490,7 @@ fn parse_create_trigger_stmt(p: &mut Parser) -> Result<CreateTriggerStmtNode, Pa
                 gd_scan: {
                     let tokens = &p.tokens;
                     let mut pos: i32 = p.pos;
-                    pos = scan_update_stmt(tokens, pos);
+                    pos = scan_update_stmt(tokens, pos, 0);
                     if pos < 0 { break gd_scan; }
                     gd_winner = 0;
                     break gd_dispatch;
@@ -12498,7 +12498,7 @@ fn parse_create_trigger_stmt(p: &mut Parser) -> Result<CreateTriggerStmtNode, Pa
                 gd_scan_2: {
                     let tokens = &p.tokens;
                     let mut pos: i32 = p.pos;
-                    pos = scan_insert_stmt(tokens, pos);
+                    pos = scan_insert_stmt(tokens, pos, 0);
                     if pos < 0 { break gd_scan_2; }
                     gd_winner = 1;
                     break gd_dispatch;
@@ -12506,7 +12506,7 @@ fn parse_create_trigger_stmt(p: &mut Parser) -> Result<CreateTriggerStmtNode, Pa
                 gd_scan_3: {
                     let tokens = &p.tokens;
                     let mut pos: i32 = p.pos;
-                    pos = scan_delete_stmt(tokens, pos);
+                    pos = scan_delete_stmt(tokens, pos, 0);
                     if pos < 0 { break gd_scan_3; }
                     gd_winner = 2;
                     break gd_dispatch;
@@ -12605,7 +12605,7 @@ fn parse_create_view_stmt(p: &mut Parser) -> Result<CreateViewStmtNode, ParseErr
     opt_scan_2: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_database_name(tokens, pos);
+        pos = scan_database_name(tokens, pos, 0);
         if pos < 0 { break opt_scan_2; }
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan_2; }
         pos += 1;
@@ -12660,7 +12660,7 @@ fn parse_create_virtual_table_stmt(p: &mut Parser) -> Result<CreateVirtualTableS
     opt_scan: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_database_name(tokens, pos);
+        pos = scan_database_name(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan; }
         pos += 1;
@@ -12691,7 +12691,7 @@ fn parse_create_virtual_table_stmt(p: &mut Parser) -> Result<CreateVirtualTableS
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_module_argument(tokens, pos);
+                pos = scan_module_argument(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -12797,7 +12797,7 @@ fn parse_delete_stmt_limited(p: &mut Parser) -> Result<DeleteStmtLimitedNode, Pa
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                     pos += 1;
-                    pos = scan_ordering_term(tokens, pos);
+                    pos = scan_ordering_term(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -12843,7 +12843,7 @@ fn parse_delete_stmt_limited(p: &mut Parser) -> Result<DeleteStmtLimitedNode, Pa
                 }
                 break opt_scan;
             }
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break opt_scan; }
             opt_scan_pos = pos;
         }
@@ -12889,7 +12889,7 @@ fn parse_delete_stmt_limited(p: &mut Parser) -> Result<DeleteStmtLimitedNode, Pa
                 }
                 break opt_scan;
             }
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break opt_scan; }
             opt_scan_pos = pos;
         }
@@ -12924,7 +12924,7 @@ fn parse_delete_stmt_limited(p: &mut Parser) -> Result<DeleteStmtLimitedNode, Pa
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                     pos += 1;
-                    pos = scan_ordering_term(tokens, pos);
+                    pos = scan_ordering_term(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -13021,7 +13021,7 @@ fn parse_drop_index_stmt(p: &mut Parser) -> Result<DropIndexStmtNode, ParseError
     opt_scan: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_database_name(tokens, pos);
+        pos = scan_database_name(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan; }
         pos += 1;
@@ -13068,7 +13068,7 @@ fn parse_drop_table_stmt(p: &mut Parser) -> Result<DropTableStmtNode, ParseError
     opt_scan: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_database_name(tokens, pos);
+        pos = scan_database_name(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan; }
         pos += 1;
@@ -13115,7 +13115,7 @@ fn parse_drop_trigger_stmt(p: &mut Parser) -> Result<DropTriggerStmtNode, ParseE
     opt_scan: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_database_name(tokens, pos);
+        pos = scan_database_name(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan; }
         pos += 1;
@@ -13162,7 +13162,7 @@ fn parse_drop_view_stmt(p: &mut Parser) -> Result<DropViewStmtNode, ParseError> 
     opt_scan: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_database_name(tokens, pos);
+        pos = scan_database_name(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan; }
         pos += 1;
@@ -13205,9 +13205,9 @@ fn parse_factored_select_stmt(p: &mut Parser) -> Result<FactoredSelectStmtNode, 
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_compound_operator(tokens, pos);
+            pos = scan_compound_operator(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
-            pos = scan_select_core(tokens, pos);
+            pos = scan_select_core(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -13233,7 +13233,7 @@ fn parse_factored_select_stmt(p: &mut Parser) -> Result<FactoredSelectStmtNode, 
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_ordering_term(tokens, pos);
+                pos = scan_ordering_term(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -13280,7 +13280,7 @@ fn parse_factored_select_stmt(p: &mut Parser) -> Result<FactoredSelectStmtNode, 
                 }
                 break opt_scan;
             }
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break opt_scan; }
             opt_scan_pos = pos;
         }
@@ -13451,7 +13451,7 @@ fn parse_insert_stmt(p: &mut Parser) -> Result<InsertStmtNode, ParseError> {
     opt_scan: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_database_name(tokens, pos);
+        pos = scan_database_name(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan; }
         pos += 1;
@@ -13480,7 +13480,7 @@ fn parse_insert_stmt(p: &mut Parser) -> Result<InsertStmtNode, ParseError> {
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -13517,7 +13517,7 @@ fn parse_insert_stmt(p: &mut Parser) -> Result<InsertStmtNode, ParseError> {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break gd_scan_6; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break gd_scan_6; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -13525,7 +13525,7 @@ fn parse_insert_stmt(p: &mut Parser) -> Result<InsertStmtNode, ParseError> {
                         sg_283: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_283; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_283; }
                             break sg_283_done;
                         }
@@ -13544,7 +13544,7 @@ fn parse_insert_stmt(p: &mut Parser) -> Result<InsertStmtNode, ParseError> {
                             pos += 1;
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_284; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_284; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -13552,7 +13552,7 @@ fn parse_insert_stmt(p: &mut Parser) -> Result<InsertStmtNode, ParseError> {
                                     sg_285: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_285; }
                                         pos += 1;
-                                        pos = scan_expr(tokens, pos);
+                                        pos = scan_expr(tokens, pos, 0);
                                         if pos < 0 { break sg_285; }
                                         break sg_285_done;
                                     }
@@ -13586,7 +13586,7 @@ fn parse_insert_stmt(p: &mut Parser) -> Result<InsertStmtNode, ParseError> {
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                     pos += 1;
-                    pos = scan_expr(tokens, pos);
+                    pos = scan_expr(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -13611,7 +13611,7 @@ fn parse_insert_stmt(p: &mut Parser) -> Result<InsertStmtNode, ParseError> {
                     pos += 1;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break rep_scan_2; }
                     pos += 1;
-                    pos = scan_expr(tokens, pos);
+                    pos = scan_expr(tokens, pos, 0);
                     if pos < 0 { break rep_scan_2; }
                     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                         let sp = pos;
@@ -13619,7 +13619,7 @@ fn parse_insert_stmt(p: &mut Parser) -> Result<InsertStmtNode, ParseError> {
                             sg_286: {
                                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_286; }
                                 pos += 1;
-                                pos = scan_expr(tokens, pos);
+                                pos = scan_expr(tokens, pos, 0);
                                 if pos < 0 { break sg_286; }
                                 break sg_286_done;
                             }
@@ -13645,7 +13645,7 @@ fn parse_insert_stmt(p: &mut Parser) -> Result<InsertStmtNode, ParseError> {
                         let mut pos: i32 = p.pos;
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                         pos += 1;
-                        pos = scan_expr(tokens, pos);
+                        pos = scan_expr(tokens, pos, 0);
                         if pos < 0 { break rep_scan; }
                         if pos <= p.pos { break rep_scan; }
                         rep_scan_pos = pos;
@@ -13711,7 +13711,7 @@ fn parse_pragma_stmt(p: &mut Parser) -> Result<PragmaStmtNode, ParseError> {
     opt_scan: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_database_name(tokens, pos);
+        pos = scan_database_name(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan; }
         pos += 1;
@@ -13739,7 +13739,7 @@ fn parse_pragma_stmt(p: &mut Parser) -> Result<PragmaStmtNode, ParseError> {
             sg_287_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQ { break sg_287_0; }
                 pos += 1;
-                pos = scan_pragma_value(tokens, pos);
+                pos = scan_pragma_value(tokens, pos, 0);
                 if pos < 0 { break sg_287_0; }
                 break sg_287;
             }
@@ -13747,7 +13747,7 @@ fn parse_pragma_stmt(p: &mut Parser) -> Result<PragmaStmtNode, ParseError> {
             sg_287_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_287_1; }
                 pos += 1;
-                pos = scan_pragma_value(tokens, pos);
+                pos = scan_pragma_value(tokens, pos, 0);
                 if pos < 0 { break sg_287_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_287_1; }
                 pos += 1;
@@ -13800,7 +13800,7 @@ fn parse_reindex_stmt(p: &mut Parser) -> Result<ReindexStmtNode, ParseError> {
         sg_288: {
             pos = gp_288;
             sg_288_0: {
-                pos = scan_collation_name(tokens, pos);
+                pos = scan_collation_name(tokens, pos, 0);
                 if pos < 0 { break sg_288_0; }
                 if pos > sg_288_best { sg_288_best = pos; }
             }
@@ -13810,7 +13810,7 @@ fn parse_reindex_stmt(p: &mut Parser) -> Result<ReindexStmtNode, ParseError> {
                     let sp = pos;
                     sg_289_done: {
                         sg_289: {
-                            pos = scan_database_name(tokens, pos);
+                            pos = scan_database_name(tokens, pos, 0);
                             if pos < 0 { break sg_289; }
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_289; }
                             pos += 1;
@@ -13827,13 +13827,13 @@ fn parse_reindex_stmt(p: &mut Parser) -> Result<ReindexStmtNode, ParseError> {
                     sg_290: {
                         pos = gp_290;
                         sg_290_0: {
-                            pos = scan_table_name(tokens, pos);
+                            pos = scan_table_name(tokens, pos, 0);
                             if pos < 0 { break sg_290_0; }
                             if pos > sg_290_best { sg_290_best = pos; }
                         }
                         pos = gp_290;
                         sg_290_1: {
-                            pos = scan_index_name(tokens, pos);
+                            pos = scan_index_name(tokens, pos, 0);
                             if pos < 0 { break sg_290_1; }
                             if pos > sg_290_best { sg_290_best = pos; }
                         }
@@ -13857,7 +13857,7 @@ fn parse_reindex_stmt(p: &mut Parser) -> Result<ReindexStmtNode, ParseError> {
                 gd_scan: {
                     let tokens = &p.tokens;
                     let mut pos: i32 = p.pos;
-                    pos = scan_collation_name(tokens, pos);
+                    pos = scan_collation_name(tokens, pos, 0);
                     if pos < 0 { break gd_scan; }
                     gd_winner = 0;
                     break gd_dispatch;
@@ -13873,7 +13873,7 @@ fn parse_reindex_stmt(p: &mut Parser) -> Result<ReindexStmtNode, ParseError> {
                 opt_scan: {
                     let tokens = &p.tokens;
                     let mut pos: i32 = p.pos;
-                    pos = scan_database_name(tokens, pos);
+                    pos = scan_database_name(tokens, pos, 0);
                     if pos < 0 { break opt_scan; }
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan; }
                     pos += 1;
@@ -13898,7 +13898,7 @@ fn parse_reindex_stmt(p: &mut Parser) -> Result<ReindexStmtNode, ParseError> {
                         gd_scan: {
                             let tokens = &p.tokens;
                             let mut pos: i32 = p.pos;
-                            pos = scan_table_name(tokens, pos);
+                            pos = scan_table_name(tokens, pos, 0);
                             if pos < 0 { break gd_scan; }
                             gd_winner = 0;
                             break gd_dispatch;
@@ -14029,7 +14029,7 @@ fn parse_simple_select_stmt(p: &mut Parser) -> Result<SimpleSelectStmtNode, Pars
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_ordering_term(tokens, pos);
+                pos = scan_ordering_term(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -14076,7 +14076,7 @@ fn parse_simple_select_stmt(p: &mut Parser) -> Result<SimpleSelectStmtNode, Pars
                 }
                 break opt_scan;
             }
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break opt_scan; }
             opt_scan_pos = pos;
         }
@@ -14124,9 +14124,9 @@ fn parse_select_stmt(p: &mut Parser) -> Result<SelectStmtNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_compound_operator(tokens, pos);
+            pos = scan_compound_operator(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
-            pos = scan_select_or_values(tokens, pos);
+            pos = scan_select_or_values(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -14152,7 +14152,7 @@ fn parse_select_stmt(p: &mut Parser) -> Result<SelectStmtNode, ParseError> {
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_ordering_term(tokens, pos);
+                pos = scan_ordering_term(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -14199,7 +14199,7 @@ fn parse_select_stmt(p: &mut Parser) -> Result<SelectStmtNode, ParseError> {
                 }
                 break opt_scan;
             }
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break opt_scan; }
             opt_scan_pos = pos;
         }
@@ -14275,7 +14275,7 @@ fn parse_select_or_values(p: &mut Parser) -> Result<SelectOrValuesNode, ParseErr
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_result_column(tokens, pos);
+                pos = scan_result_column(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -14299,7 +14299,7 @@ fn parse_select_or_values(p: &mut Parser) -> Result<SelectOrValuesNode, ParseErr
                     gd_scan: {
                         let tokens = &p.tokens;
                         let mut pos: i32 = p.pos;
-                        pos = scan_join_clause(tokens, pos);
+                        pos = scan_join_clause(tokens, pos, 0);
                         if pos < 0 { break gd_scan; }
                         gd_winner = 0;
                         break gd_dispatch;
@@ -14320,7 +14320,7 @@ fn parse_select_or_values(p: &mut Parser) -> Result<SelectOrValuesNode, ParseErr
                             let mut pos: i32 = p.pos;
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                             pos += 1;
-                            pos = scan_table_or_subquery(tokens, pos);
+                            pos = scan_table_or_subquery(tokens, pos, 0);
                             if pos < 0 { break rep_scan; }
                             if pos <= p.pos { break rep_scan; }
                             rep_scan_pos = pos;
@@ -14372,7 +14372,7 @@ fn parse_select_or_values(p: &mut Parser) -> Result<SelectOrValuesNode, ParseErr
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                     pos += 1;
-                    pos = scan_expr(tokens, pos);
+                    pos = scan_expr(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -14431,7 +14431,7 @@ fn parse_select_or_values(p: &mut Parser) -> Result<SelectOrValuesNode, ParseErr
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -14456,7 +14456,7 @@ fn parse_select_or_values(p: &mut Parser) -> Result<SelectOrValuesNode, ParseErr
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break rep_scan_2; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break rep_scan_2; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -14464,7 +14464,7 @@ fn parse_select_or_values(p: &mut Parser) -> Result<SelectOrValuesNode, ParseErr
                         sg_294: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_294; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_294; }
                             break sg_294_done;
                         }
@@ -14490,7 +14490,7 @@ fn parse_select_or_values(p: &mut Parser) -> Result<SelectOrValuesNode, ParseErr
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                     pos += 1;
-                    pos = scan_expr(tokens, pos);
+                    pos = scan_expr(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -14697,11 +14697,11 @@ fn parse_update_stmt(p: &mut Parser) -> Result<UpdateStmtNode, ParseError> {
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_column_name(tokens, pos);
+            pos = scan_column_name(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQ { break rep_scan; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -14911,11 +14911,11 @@ fn parse_update_stmt_limited(p: &mut Parser) -> Result<UpdateStmtLimitedNode, Pa
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_column_name(tokens, pos);
+            pos = scan_column_name(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQ { break rep_scan; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -14957,7 +14957,7 @@ fn parse_update_stmt_limited(p: &mut Parser) -> Result<UpdateStmtLimitedNode, Pa
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                     pos += 1;
-                    pos = scan_ordering_term(tokens, pos);
+                    pos = scan_ordering_term(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -15003,7 +15003,7 @@ fn parse_update_stmt_limited(p: &mut Parser) -> Result<UpdateStmtLimitedNode, Pa
                 }
                 break opt_scan;
             }
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break opt_scan; }
             opt_scan_pos = pos;
         }
@@ -15049,7 +15049,7 @@ fn parse_update_stmt_limited(p: &mut Parser) -> Result<UpdateStmtLimitedNode, Pa
                 }
                 break opt_scan;
             }
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break opt_scan; }
             opt_scan_pos = pos;
         }
@@ -15084,7 +15084,7 @@ fn parse_update_stmt_limited(p: &mut Parser) -> Result<UpdateStmtLimitedNode, Pa
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                     pos += 1;
-                    pos = scan_ordering_term(tokens, pos);
+                    pos = scan_ordering_term(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -15173,7 +15173,7 @@ fn parse_column_def(p: &mut Parser) -> Result<ColumnDefNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_column_constraint(tokens, pos);
+            pos = scan_column_constraint(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -15205,7 +15205,7 @@ fn parse_type_name(p: &mut Parser) -> Result<TypeNameNode, ParseError> {
             sg_299_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_299_0; }
                 pos += 1;
-                pos = scan_signed_number(tokens, pos);
+                pos = scan_signed_number(tokens, pos, 0);
                 if pos < 0 { break sg_299_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_299_0; }
                 pos += 1;
@@ -15215,11 +15215,11 @@ fn parse_type_name(p: &mut Parser) -> Result<TypeNameNode, ParseError> {
             sg_299_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_299_1; }
                 pos += 1;
-                pos = scan_signed_number(tokens, pos);
+                pos = scan_signed_number(tokens, pos, 0);
                 if pos < 0 { break sg_299_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_299_1; }
                 pos += 1;
-                pos = scan_signed_number(tokens, pos);
+                pos = scan_signed_number(tokens, pos, 0);
                 if pos < 0 { break sg_299_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sg_299_1; }
                 pos += 1;
@@ -15241,11 +15241,11 @@ fn parse_type_name(p: &mut Parser) -> Result<TypeNameNode, ParseError> {
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break gd_scan; }
                     pos += 1;
-                    pos = scan_signed_number(tokens, pos);
+                    pos = scan_signed_number(tokens, pos, 0);
                     if pos < 0 { break gd_scan; }
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break gd_scan; }
                     pos += 1;
-                    pos = scan_signed_number(tokens, pos);
+                    pos = scan_signed_number(tokens, pos, 0);
                     if pos < 0 { break gd_scan; }
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break gd_scan; }
                     pos += 1;
@@ -15394,7 +15394,7 @@ fn parse_column_constraint(p: &mut Parser) -> Result<ColumnConstraintNode, Parse
                 gd_scan: {
                     let tokens = &p.tokens;
                     let mut pos: i32 = p.pos;
-                    pos = scan_signed_number(tokens, pos);
+                    pos = scan_signed_number(tokens, pos, 0);
                     if pos < 0 { break gd_scan; }
                     gd_winner = 0;
                     break gd_dispatch;
@@ -15493,11 +15493,11 @@ fn parse_expr_scan_15(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_expr(tokens, pos);
+    pos = scan_expr(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { return -1; }
     pos += 1;
-    pos = scan_type_name(tokens, pos);
+    pos = scan_type_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
@@ -15523,11 +15523,11 @@ fn parse_expr_bt_22(p: &mut Parser) -> Result<ExprNode, ParseError> {
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_WHEN { break rep_scan; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_THEN { break rep_scan; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -15575,18 +15575,18 @@ fn parse_expr_scan_22(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_27(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expr(tokens, pos);
+        pos = scan_expr(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     sg_301_done: {
         sg_301: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_WHEN { break sg_301; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sg_301; }
             if pos >= tokens.len() || tokens[pos].kind != TK_K_THEN { break sg_301; }
             pos += 1;
-            pos = scan_expr(tokens, pos);
+            pos = scan_expr(tokens, pos, 0);
             if pos < 0 { break sg_301; }
             break sg_301_done;
         }
@@ -15598,11 +15598,11 @@ fn parse_expr_scan_22(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_302: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_WHEN { break sg_302; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_302; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_THEN { break sg_302; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_302; }
                 break sg_302_done;
             }
@@ -15617,7 +15617,7 @@ fn parse_expr_scan_22(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_303: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_ELSE { break sg_303; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_303; }
                 break sg_303_done;
             }
@@ -15679,7 +15679,7 @@ fn parse_expr_scan_21(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_select_stmt(tokens, pos);
+    pos = scan_select_stmt(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
@@ -15703,7 +15703,7 @@ fn parse_expr_scan_14(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_expr(tokens, pos);
+    pos = scan_expr(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
@@ -15721,7 +15721,7 @@ fn parse_expr_bt_23(p: &mut Parser) -> Result<ExprNode, ParseError> {
 
 fn parse_expr_scan_23(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_raise_function(tokens, pos);
+    pos = scan_raise_function(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -15737,7 +15737,7 @@ fn parse_expr_bt_0(p: &mut Parser) -> Result<ExprNode, ParseError> {
 
 fn parse_expr_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_literal_value(tokens, pos);
+    pos = scan_literal_value(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -15759,7 +15759,7 @@ fn parse_expr_bt_13(p: &mut Parser) -> Result<ExprNode, ParseError> {
                     if pos >= tokens.len() || tokens[pos].kind != TK_K_DISTINCT { pos = -1; } else { pos += 1; }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_306_0; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -15767,7 +15767,7 @@ fn parse_expr_bt_13(p: &mut Parser) -> Result<ExprNode, ParseError> {
                         sg_307: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_307; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_307; }
                             break sg_307_done;
                         }
@@ -15805,7 +15805,7 @@ fn parse_expr_bt_13(p: &mut Parser) -> Result<ExprNode, ParseError> {
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                     pos += 1;
-                    pos = scan_expr(tokens, pos);
+                    pos = scan_expr(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -15846,7 +15846,7 @@ fn parse_expr_bt_13(p: &mut Parser) -> Result<ExprNode, ParseError> {
 
 fn parse_expr_scan_13(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_function_name(tokens, pos);
+    pos = scan_function_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
@@ -15861,7 +15861,7 @@ fn parse_expr_scan_13(tokens: &Array<Token>, pos: i32) -> i32 {
                     if pos >= tokens.len() || tokens[pos].kind != TK_K_DISTINCT { pos = -1; } else { pos += 1; }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_308_0; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -15869,7 +15869,7 @@ fn parse_expr_scan_13(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_309: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_309; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_309; }
                             break sg_309_done;
                         }
@@ -15908,9 +15908,9 @@ fn parse_expr_bt_3(p: &mut Parser) -> Result<ExprNode, ParseError> {
 
 fn parse_expr_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_unary_operator(tokens, pos);
+    pos = scan_unary_operator(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_expr_atom(tokens, pos);
+    pos = scan_expr(tokens, pos, 2147483647);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -15922,7 +15922,7 @@ fn parse_expr_bt_2(p: &mut Parser) -> Result<ExprNode, ParseError> {
         opt_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_database_name(tokens, pos);
+            pos = scan_database_name(tokens, pos, 0);
             if pos < 0 { break opt_scan; }
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan; }
             pos += 1;
@@ -15972,24 +15972,24 @@ fn parse_expr_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT && pos + 2 < tokens.len() && _gale_kind_set_2(tokens[pos + 2].kind) && pos + 3 < tokens.len() && tokens[pos + 3].kind == TK_LIT_DOT {
         sol_310: {
-            pos = scan_database_name(tokens, pos);
+            pos = scan_database_name(tokens, pos, 0);
             if pos < 0 { break sol_310; }
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_310; }
             pos += 1;
-            pos = scan_table_name(tokens, pos);
+            pos = scan_table_name(tokens, pos, 0);
             if pos < 0 { break sol_310; }
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_310; }
             pos += 1;
         }
     } else if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_DOT {
         sol_311: {
-            pos = scan_table_name(tokens, pos);
+            pos = scan_table_name(tokens, pos, 0);
             if pos < 0 { break sol_311; }
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sol_311; }
             pos += 1;
         }
     }
-    pos = scan_column_name(tokens, pos);
+    pos = scan_column_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -16357,13 +16357,13 @@ fn parse_expr_lr_10(p: &mut Parser, left: ExprNode, start: i32) -> Result<ExprNo
                     sg_312: {
                         pos = gp_312;
                         sg_312_0: {
-                            pos = scan_select_stmt(tokens, pos);
+                            pos = scan_select_stmt(tokens, pos, 0);
                             if pos < 0 { break sg_312_0; }
                             if pos > sg_312_best { sg_312_best = pos; }
                         }
                         pos = gp_312;
                         sg_312_1: {
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_312_1; }
                             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                                 let sp = pos;
@@ -16371,7 +16371,7 @@ fn parse_expr_lr_10(p: &mut Parser, left: ExprNode, start: i32) -> Result<ExprNo
                                     sg_313: {
                                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_313; }
                                         pos += 1;
-                                        pos = scan_expr(tokens, pos);
+                                        pos = scan_expr(tokens, pos, 0);
                                         if pos < 0 { break sg_313; }
                                         break sg_313_done;
                                     }
@@ -16404,13 +16404,13 @@ fn parse_expr_lr_10(p: &mut Parser, left: ExprNode, start: i32) -> Result<ExprNo
                 sg_314: {
                     pos = gp_314;
                     sg_314_0: {
-                        pos = scan_select_stmt(tokens, pos);
+                        pos = scan_select_stmt(tokens, pos, 0);
                         if pos < 0 { break sg_314_0; }
                         if pos > sg_314_best { sg_314_best = pos; }
                     }
                     pos = gp_314;
                     sg_314_1: {
-                        pos = scan_expr(tokens, pos);
+                        pos = scan_expr(tokens, pos, 0);
                         if pos < 0 { break sg_314_1; }
                         while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                             let sp = pos;
@@ -16418,7 +16418,7 @@ fn parse_expr_lr_10(p: &mut Parser, left: ExprNode, start: i32) -> Result<ExprNo
                                 sg_315: {
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_315; }
                                     pos += 1;
-                                    pos = scan_expr(tokens, pos);
+                                    pos = scan_expr(tokens, pos, 0);
                                     if pos < 0 { break sg_315; }
                                     break sg_315_done;
                                 }
@@ -16443,7 +16443,7 @@ fn parse_expr_lr_10(p: &mut Parser, left: ExprNode, start: i32) -> Result<ExprNo
                         gd_scan: {
                             let tokens = &p.tokens;
                             let mut pos: i32 = p.pos;
-                            pos = scan_select_stmt(tokens, pos);
+                            pos = scan_select_stmt(tokens, pos, 0);
                             if pos < 0 { break gd_scan; }
                             gd_winner = 0;
                             break gd_dispatch;
@@ -16464,7 +16464,7 @@ fn parse_expr_lr_10(p: &mut Parser, left: ExprNode, start: i32) -> Result<ExprNo
                                 let mut pos: i32 = p.pos;
                                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                                 pos += 1;
-                                pos = scan_expr(tokens, pos);
+                                pos = scan_expr(tokens, pos, 0);
                                 if pos < 0 { break rep_scan; }
                                 if pos <= p.pos { break rep_scan; }
                                 rep_scan_pos = pos;
@@ -16503,7 +16503,7 @@ fn parse_expr_lr_10(p: &mut Parser, left: ExprNode, start: i32) -> Result<ExprNo
             opt_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_database_name(tokens, pos);
+                pos = scan_database_name(tokens, pos, 0);
                 if pos < 0 { break opt_scan; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan; }
                 pos += 1;
@@ -16832,7 +16832,7 @@ fn parse_foreign_key_clause(p: &mut Parser) -> Result<ForeignKeyClauseNode, Pars
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -16937,7 +16937,7 @@ fn parse_foreign_key_clause(p: &mut Parser) -> Result<ForeignKeyClauseNode, Pars
                     sg_316_1: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_K_MATCH { break sg_316_1; }
                         pos += 1;
-                        pos = scan_name(tokens, pos);
+                        pos = scan_name(tokens, pos, 0);
                         if pos < 0 { break sg_316_1; }
                         break sg_316;
                     }
@@ -17340,7 +17340,7 @@ fn parse_table_constraint(p: &mut Parser) -> Result<TableConstraintNode, ParseEr
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_indexed_column(tokens, pos);
+                pos = scan_indexed_column(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -17388,7 +17388,7 @@ fn parse_table_constraint(p: &mut Parser) -> Result<TableConstraintNode, ParseEr
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -17440,7 +17440,7 @@ fn parse_with_clause(p: &mut Parser) -> Result<WithClauseNode, ParseError> {
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_common_table_expression(tokens, pos);
+            pos = scan_common_table_expression(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -17469,7 +17469,7 @@ fn parse_qualified_table_name(p: &mut Parser) -> Result<QualifiedTableNameNode, 
     opt_scan: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_database_name(tokens, pos);
+        pos = scan_database_name(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan; }
         pos += 1;
@@ -17499,7 +17499,7 @@ fn parse_qualified_table_name(p: &mut Parser) -> Result<QualifiedTableNameNode, 
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sg_322_0; }
                 pos += 1;
-                pos = scan_index_name(tokens, pos);
+                pos = scan_index_name(tokens, pos, 0);
                 if pos < 0 { break sg_322_0; }
                 break sg_322;
             }
@@ -17606,7 +17606,7 @@ fn parse_pragma_value_bt_1(p: &mut Parser) -> Result<PragmaValueNode, ParseError
 
 fn parse_pragma_value_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_name(tokens, pos);
+    pos = scan_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -17685,7 +17685,7 @@ fn parse_common_table_expression(p: &mut Parser) -> Result<CommonTableExpression
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -17740,7 +17740,7 @@ fn parse_result_column_bt_1(p: &mut Parser) -> Result<ResultColumnNode, ParseErr
 
 fn parse_result_column_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_table_name(tokens, pos);
+    pos = scan_table_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
     pos += 1;
@@ -17785,18 +17785,18 @@ fn parse_result_column_bt_2(p: &mut Parser) -> Result<ResultColumnNode, ParseErr
 
 fn parse_result_column_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_expr(tokens, pos);
+    pos = scan_expr(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_K_AS && pos + 1 < tokens.len() && _gale_kind_set_48(tokens[pos + 1].kind) {
         sol_324: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { break sol_324; }
             pos += 1;
-            pos = scan_column_alias(tokens, pos);
+            pos = scan_column_alias(tokens, pos, 0);
             if pos < 0 { break sol_324; }
         }
     } else if pos < tokens.len() && _gale_kind_set_48(tokens[pos].kind) {
         sol_325: {
-            pos = scan_column_alias(tokens, pos);
+            pos = scan_column_alias(tokens, pos, 0);
             if pos < 0 { break sol_325; }
         }
     }
@@ -17889,7 +17889,7 @@ fn parse_table_or_subquery_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_select_stmt(tokens, pos);
+    pos = scan_select_stmt(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
@@ -17897,12 +17897,12 @@ fn parse_table_or_subquery_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
         sol_326: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { break sol_326; }
             pos += 1;
-            pos = scan_table_alias(tokens, pos);
+            pos = scan_table_alias(tokens, pos, 0);
             if pos < 0 { break sol_326; }
         }
     } else if pos < tokens.len() && _gale_kind_set_52(tokens[pos].kind) {
         sol_327: {
-            pos = scan_table_alias(tokens, pos);
+            pos = scan_table_alias(tokens, pos, 0);
             if pos < 0 { break sol_327; }
         }
     }
@@ -17920,7 +17920,7 @@ fn parse_table_or_subquery_bt_2(p: &mut Parser) -> Result<TableOrSubqueryNode, P
             gd_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_join_clause(tokens, pos);
+                pos = scan_join_clause(tokens, pos, 0);
                 if pos < 0 { break gd_scan; }
                 gd_winner = 0;
                 break gd_dispatch;
@@ -17941,7 +17941,7 @@ fn parse_table_or_subquery_bt_2(p: &mut Parser) -> Result<TableOrSubqueryNode, P
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                     pos += 1;
-                    pos = scan_table_or_subquery(tokens, pos);
+                    pos = scan_table_or_subquery(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -17982,7 +17982,7 @@ fn parse_table_or_subquery_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_328: {
             pos = gp_328;
             sg_328_0: {
-                pos = scan_table_or_subquery(tokens, pos);
+                pos = scan_table_or_subquery(tokens, pos, 0);
                 if pos < 0 { break sg_328_0; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -17990,7 +17990,7 @@ fn parse_table_or_subquery_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_329: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_329; }
                             pos += 1;
-                            pos = scan_table_or_subquery(tokens, pos);
+                            pos = scan_table_or_subquery(tokens, pos, 0);
                             if pos < 0 { break sg_329; }
                             break sg_329_done;
                         }
@@ -18003,7 +18003,7 @@ fn parse_table_or_subquery_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = gp_328;
             sg_328_1: {
-                pos = scan_join_clause(tokens, pos);
+                pos = scan_join_clause(tokens, pos, 0);
                 if pos < 0 { break sg_328_1; }
                 if pos > sg_328_best { sg_328_best = pos; }
             }
@@ -18022,7 +18022,7 @@ fn parse_table_or_subquery_bt_1(p: &mut Parser) -> Result<TableOrSubqueryNode, P
     opt_scan: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_schema_name(tokens, pos);
+        pos = scan_schema_name(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan; }
         pos += 1;
@@ -18045,7 +18045,7 @@ fn parse_table_or_subquery_bt_1(p: &mut Parser) -> Result<TableOrSubqueryNode, P
     opt_scan_2: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_expr(tokens, pos);
+        pos = scan_expr(tokens, pos, 0);
         if pos < 0 { break opt_scan_2; }
         while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
             let sp = pos;
@@ -18053,7 +18053,7 @@ fn parse_table_or_subquery_bt_1(p: &mut Parser) -> Result<TableOrSubqueryNode, P
                 sg_330: {
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_330; }
                     pos += 1;
-                    pos = scan_expr(tokens, pos);
+                    pos = scan_expr(tokens, pos, 0);
                     if pos < 0 { break sg_330; }
                     break sg_330_done;
                 }
@@ -18074,7 +18074,7 @@ fn parse_table_or_subquery_bt_1(p: &mut Parser) -> Result<TableOrSubqueryNode, P
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -18138,7 +18138,7 @@ fn parse_table_or_subquery_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_331_done: {
             sg_331: {
-                pos = scan_schema_name(tokens, pos);
+                pos = scan_schema_name(tokens, pos, 0);
                 if pos < 0 { break sg_331; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_331; }
                 pos += 1;
@@ -18148,7 +18148,7 @@ fn parse_table_or_subquery_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_table_function_name(tokens, pos);
+    pos = scan_table_function_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
@@ -18156,7 +18156,7 @@ fn parse_table_or_subquery_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_332_done: {
             sg_332: {
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_332; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -18164,7 +18164,7 @@ fn parse_table_or_subquery_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_333: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_333; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_333; }
                             break sg_333_done;
                         }
@@ -18185,12 +18185,12 @@ fn parse_table_or_subquery_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
         sol_334: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { break sol_334; }
             pos += 1;
-            pos = scan_table_alias(tokens, pos);
+            pos = scan_table_alias(tokens, pos, 0);
             if pos < 0 { break sol_334; }
         }
     } else if pos < tokens.len() && _gale_kind_set_52(tokens[pos].kind) {
         sol_335: {
-            pos = scan_table_alias(tokens, pos);
+            pos = scan_table_alias(tokens, pos, 0);
             if pos < 0 { break sol_335; }
         }
     }
@@ -18203,7 +18203,7 @@ fn parse_table_or_subquery_bt_0(p: &mut Parser) -> Result<TableOrSubqueryNode, P
     opt_scan: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_schema_name(tokens, pos);
+        pos = scan_schema_name(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break opt_scan; }
         pos += 1;
@@ -18257,7 +18257,7 @@ fn parse_table_or_subquery_bt_0(p: &mut Parser) -> Result<TableOrSubqueryNode, P
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sg_336_0; }
                 pos += 1;
-                pos = scan_index_name(tokens, pos);
+                pos = scan_index_name(tokens, pos, 0);
                 if pos < 0 { break sg_336_0; }
                 break sg_336;
             }
@@ -18310,7 +18310,7 @@ fn parse_table_or_subquery_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_337_done: {
             sg_337: {
-                pos = scan_schema_name(tokens, pos);
+                pos = scan_schema_name(tokens, pos, 0);
                 if pos < 0 { break sg_337; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_337; }
                 pos += 1;
@@ -18320,18 +18320,18 @@ fn parse_table_or_subquery_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_table_name(tokens, pos);
+    pos = scan_table_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_K_AS && pos + 1 < tokens.len() && _gale_kind_set_52(tokens[pos + 1].kind) {
         sol_338: {
             if pos >= tokens.len() || tokens[pos].kind != TK_K_AS { break sol_338; }
             pos += 1;
-            pos = scan_table_alias(tokens, pos);
+            pos = scan_table_alias(tokens, pos, 0);
             if pos < 0 { break sol_338; }
         }
     } else if pos < tokens.len() && _gale_kind_set_52(tokens[pos].kind) {
         sol_339: {
-            pos = scan_table_alias(tokens, pos);
+            pos = scan_table_alias(tokens, pos, 0);
             if pos < 0 { break sol_339; }
         }
     }
@@ -18345,7 +18345,7 @@ fn parse_table_or_subquery_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_BY { break sg_340_0; }
                 pos += 1;
-                pos = scan_index_name(tokens, pos);
+                pos = scan_index_name(tokens, pos, 0);
                 if pos < 0 { break sg_340_0; }
                 break sg_340;
             }
@@ -18446,11 +18446,11 @@ fn parse_join_clause(p: &mut Parser) -> Result<JoinClauseNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_join_operator(tokens, pos);
+            pos = scan_join_operator(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
-            pos = scan_table_or_subquery(tokens, pos);
+            pos = scan_table_or_subquery(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
-            pos = scan_join_constraint(tokens, pos);
+            pos = scan_join_constraint(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -18578,7 +18578,7 @@ fn parse_join_constraint(p: &mut Parser) -> Result<JoinConstraintNode, ParseErro
             sg_342_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_K_ON { break sg_342_0; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break sg_342_0; }
                 break sg_342;
             }
@@ -18588,7 +18588,7 @@ fn parse_join_constraint(p: &mut Parser) -> Result<JoinConstraintNode, ParseErro
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sg_342_1; }
                 pos += 1;
-                pos = scan_column_name(tokens, pos);
+                pos = scan_column_name(tokens, pos, 0);
                 if pos < 0 { break sg_342_1; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -18596,7 +18596,7 @@ fn parse_join_constraint(p: &mut Parser) -> Result<JoinConstraintNode, ParseErro
                         sg_343: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_343; }
                             pos += 1;
-                            pos = scan_column_name(tokens, pos);
+                            pos = scan_column_name(tokens, pos, 0);
                             if pos < 0 { break sg_343; }
                             break sg_343_done;
                         }
@@ -18633,7 +18633,7 @@ fn parse_join_constraint(p: &mut Parser) -> Result<JoinConstraintNode, ParseErro
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                     pos += 1;
-                    pos = scan_column_name(tokens, pos);
+                    pos = scan_column_name(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -18708,7 +18708,7 @@ fn parse_select_core(p: &mut Parser) -> Result<SelectCoreNode, ParseError> {
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_result_column(tokens, pos);
+                pos = scan_result_column(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -18732,7 +18732,7 @@ fn parse_select_core(p: &mut Parser) -> Result<SelectCoreNode, ParseError> {
                     gd_scan: {
                         let tokens = &p.tokens;
                         let mut pos: i32 = p.pos;
-                        pos = scan_join_clause(tokens, pos);
+                        pos = scan_join_clause(tokens, pos, 0);
                         if pos < 0 { break gd_scan; }
                         gd_winner = 0;
                         break gd_dispatch;
@@ -18753,7 +18753,7 @@ fn parse_select_core(p: &mut Parser) -> Result<SelectCoreNode, ParseError> {
                             let mut pos: i32 = p.pos;
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                             pos += 1;
-                            pos = scan_table_or_subquery(tokens, pos);
+                            pos = scan_table_or_subquery(tokens, pos, 0);
                             if pos < 0 { break rep_scan; }
                             if pos <= p.pos { break rep_scan; }
                             rep_scan_pos = pos;
@@ -18805,7 +18805,7 @@ fn parse_select_core(p: &mut Parser) -> Result<SelectCoreNode, ParseError> {
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                     pos += 1;
-                    pos = scan_expr(tokens, pos);
+                    pos = scan_expr(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -18864,7 +18864,7 @@ fn parse_select_core(p: &mut Parser) -> Result<SelectCoreNode, ParseError> {
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -18889,7 +18889,7 @@ fn parse_select_core(p: &mut Parser) -> Result<SelectCoreNode, ParseError> {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break rep_scan_2; }
                 pos += 1;
-                pos = scan_expr(tokens, pos);
+                pos = scan_expr(tokens, pos, 0);
                 if pos < 0 { break rep_scan_2; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -18897,7 +18897,7 @@ fn parse_select_core(p: &mut Parser) -> Result<SelectCoreNode, ParseError> {
                         sg_345: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_345; }
                             pos += 1;
-                            pos = scan_expr(tokens, pos);
+                            pos = scan_expr(tokens, pos, 0);
                             if pos < 0 { break sg_345; }
                             break sg_345_done;
                         }
@@ -18923,7 +18923,7 @@ fn parse_select_core(p: &mut Parser) -> Result<SelectCoreNode, ParseError> {
                     let mut pos: i32 = p.pos;
                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                     pos += 1;
-                    pos = scan_expr(tokens, pos);
+                    pos = scan_expr(tokens, pos, 0);
                     if pos < 0 { break rep_scan; }
                     if pos <= p.pos { break rep_scan; }
                     rep_scan_pos = pos;
@@ -19190,7 +19190,7 @@ fn parse_module_argument_bt_1(p: &mut Parser) -> Result<ModuleArgumentNode, Pars
 
 fn parse_module_argument_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_column_def(tokens, pos);
+    pos = scan_column_def(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -19206,7 +19206,7 @@ fn parse_module_argument_bt_0(p: &mut Parser) -> Result<ModuleArgumentNode, Pars
 
 fn parse_module_argument_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_expr(tokens, pos);
+    pos = scan_expr(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }

--- a/package-gale/tests/generated/typescript/TypeScriptLexer.g4.kiln.json
+++ b/package-gale/tests/generated/typescript/TypeScriptLexer.g4.kiln.json
@@ -17,7 +17,7 @@
   "outputs": [
     {
       "path": "tests/generated/typescript/type_script.wado",
-      "hash": "479e8429101c74f3a765c14612e04a516736c3cd50116f2cd0ea0b84b0455c1b",
+      "hash": "229d1cc4492a457b5ce894aac7a8c1b826b588650e48fcaf4038dc597c154ebe",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/typescript/TypeScriptLexer.g4.kiln.json
+++ b/package-gale/tests/generated/typescript/TypeScriptLexer.g4.kiln.json
@@ -17,7 +17,7 @@
   "outputs": [
     {
       "path": "tests/generated/typescript/type_script.wado",
-      "hash": "229d1cc4492a457b5ce894aac7a8c1b826b588650e48fcaf4038dc597c154ebe",
+      "hash": "64dac739b8aa386a2a14b1bcf648697fba6782b57ffcde256243a53a3dbcec0a",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/typescript/TypeScriptLexer.g4.kiln.json
+++ b/package-gale/tests/generated/typescript/TypeScriptLexer.g4.kiln.json
@@ -17,7 +17,7 @@
   "outputs": [
     {
       "path": "tests/generated/typescript/type_script.wado",
-      "hash": "b2f36c6303482de8cf003bbba42d324d799f1618e33565b2c6eb8ccfde806ae6",
+      "hash": "479e8429101c74f3a765c14612e04a516736c3cd50116f2cd0ea0b84b0455c1b",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/typescript/type_script.wado
+++ b/package-gale/tests/generated/typescript/type_script.wado
@@ -7950,16 +7950,16 @@ impl Parser {
     }
 }
 
-fn scan_initializer(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_initializer(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQ { return -1; }
     pos += 1;
-    pos = scan_single_expression(tokens, pos);
+    pos = scan_single_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_binding_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_binding_pattern(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     let gp_0 = pos;
     let sgk_0 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -7967,13 +7967,13 @@ fn scan_binding_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_0: {
             pos = gp_0;
             sg_0_0: {
-                pos = scan_array_literal(tokens, pos);
+                pos = scan_array_literal(tokens, pos, 0);
                 if pos < 0 { break sg_0_0; }
                 break sg_0;
             }
             pos = gp_0;
             sg_0_1: {
-                pos = scan_object_literal(tokens, pos);
+                pos = scan_object_literal(tokens, pos, 0);
                 if pos < 0 { break sg_0_1; }
                 break sg_0;
             }
@@ -7983,13 +7983,13 @@ fn scan_binding_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_type_parameters(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_type_parameters(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LT { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_1(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_type_parameter_list(tokens, pos);
+        pos = scan_type_parameter_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_GT { return -1; }
@@ -7997,9 +7997,9 @@ fn scan_type_parameters(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_type_parameter_list(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_type_parameter_list(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_type_parameter(tokens, pos);
+    pos = scan_type_parameter(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -8007,7 +8007,7 @@ fn scan_type_parameter_list(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_1; }
                 pos += 1;
-                pos = scan_type_parameter(tokens, pos);
+                pos = scan_type_parameter(tokens, pos, 0);
                 if pos < 0 { break sg_1; }
                 break sg_1_done;
             }
@@ -8019,7 +8019,7 @@ fn scan_type_parameter_list(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_type_parameter(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_type_parameter(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -8027,21 +8027,21 @@ fn scan_type_parameter(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_2(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQ { break try_1; }
                 pos += 1;
-                pos = scan_type_argument(tokens, pos);
+                pos = scan_type_argument(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_0: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos < tokens.len() && tokens[pos].kind == TK_LIT_EXTENDS {
                     let sp = pos;
-                    pos = scan_constraint(tokens, pos);
+                    pos = scan_constraint(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break scan_alts;
@@ -8050,7 +8050,7 @@ fn scan_type_parameter(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_LT {
             pos = start;
             try_2: {
-                pos = scan_type_parameters(tokens, pos);
+                pos = scan_type_parameters(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -8062,22 +8062,22 @@ fn scan_type_parameter(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_constraint(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_constraint(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EXTENDS { return -1; }
     pos += 1;
-    pos = scan_type_(tokens, pos);
+    pos = scan_type_(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_type_arguments(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_type_arguments(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LT { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_3(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_type_argument_list(tokens, pos);
+        pos = scan_type_argument_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_GT { return -1; }
@@ -8085,9 +8085,9 @@ fn scan_type_arguments(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_type_argument_list(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_type_argument_list(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_type_argument(tokens, pos);
+    pos = scan_type_argument(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -8095,7 +8095,7 @@ fn scan_type_argument_list(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_2: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_2; }
                 pos += 1;
-                pos = scan_type_argument(tokens, pos);
+                pos = scan_type_argument(tokens, pos, 0);
                 if pos < 0 { break sg_2; }
                 break sg_2_done;
             }
@@ -8107,14 +8107,14 @@ fn scan_type_argument_list(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_type_argument(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_type_argument(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_type_(tokens, pos);
+    pos = scan_type_(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_type_(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_type_(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -8142,7 +8142,7 @@ fn scan_type_(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_union_or_intersection_or_primary_type(tokens, pos);
+                pos = scan_union_or_intersection_or_primary_type(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -8150,7 +8150,7 @@ fn scan_type_(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_LPAREN {
             pos = start;
             try_1: {
-                pos = scan_function_type(tokens, pos);
+                pos = scan_function_type(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -8176,7 +8176,7 @@ fn scan_type_(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_union_or_intersection_or_primary_type(tokens, pos);
+                pos = scan_union_or_intersection_or_primary_type(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -8184,13 +8184,13 @@ fn scan_type_(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_LT {
             pos = start;
             try_1: {
-                pos = scan_function_type(tokens, pos);
+                pos = scan_function_type(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_3: {
-                pos = scan_type_generic(tokens, pos);
+                pos = scan_type_generic(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -8198,7 +8198,7 @@ fn scan_type_(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_NEW {
             pos = start;
             try_2: {
-                pos = scan_constructor_type(tokens, pos);
+                pos = scan_constructor_type(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -8212,7 +8212,7 @@ fn scan_type_(tokens: &Array<Token>, pos: i32) -> i32 {
 
 fn scan_union_or_intersection_or_primary_type_atom(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_primary_type(tokens, pos);
+    pos = scan_primary_type(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -8271,7 +8271,7 @@ fn scan_primary_type_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_0; }
                 pos += 1;
-                pos = scan_type_(tokens, pos);
+                pos = scan_type_(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_0; }
                 pos += 1;
@@ -8281,23 +8281,23 @@ fn scan_primary_type_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_6(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_predefined_type(tokens, pos);
+                pos = scan_predefined_type(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_2: {
-                pos = scan_type_reference(tokens, pos);
+                pos = scan_type_reference(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
             pos = start;
             try_7: {
-                pos = scan_type_reference(tokens, pos);
+                pos = scan_type_reference(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_Is { break try_7; }
                 pos += 1;
-                pos = scan_primary_type(tokens, pos);
+                pos = scan_primary_type(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 break scan_alts;
             }
@@ -8305,7 +8305,7 @@ fn scan_primary_type_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_7(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_predefined_type(tokens, pos);
+                pos = scan_predefined_type(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -8313,17 +8313,17 @@ fn scan_primary_type_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_8(alt_kind) {
             pos = start;
             try_2: {
-                pos = scan_type_reference(tokens, pos);
+                pos = scan_type_reference(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
             pos = start;
             try_7: {
-                pos = scan_type_reference(tokens, pos);
+                pos = scan_type_reference(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_Is { break try_7; }
                 pos += 1;
-                pos = scan_primary_type(tokens, pos);
+                pos = scan_primary_type(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 break scan_alts;
             }
@@ -8333,23 +8333,23 @@ fn scan_primary_type_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_8: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_KeyOf { break try_8; }
                 pos += 1;
-                pos = scan_primary_type(tokens, pos);
+                pos = scan_primary_type(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
             pos = start;
             try_2: {
-                pos = scan_type_reference(tokens, pos);
+                pos = scan_type_reference(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
             pos = start;
             try_7: {
-                pos = scan_type_reference(tokens, pos);
+                pos = scan_type_reference(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_Is { break try_7; }
                 pos += 1;
-                pos = scan_primary_type(tokens, pos);
+                pos = scan_primary_type(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 break scan_alts;
             }
@@ -8357,7 +8357,7 @@ fn scan_primary_type_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_LBRACE {
             pos = start;
             try_3: {
-                pos = scan_object_type(tokens, pos);
+                pos = scan_object_type(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -8367,7 +8367,7 @@ fn scan_primary_type_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_4: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break try_4; }
                 pos += 1;
-                pos = scan_tuple_element_types(tokens, pos);
+                pos = scan_tuple_element_types(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break try_4; }
                 pos += 1;
@@ -8377,7 +8377,7 @@ fn scan_primary_type_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_TYPEOF {
             pos = start;
             try_5: {
-                pos = scan_type_query(tokens, pos);
+                pos = scan_type_query(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 break scan_alts;
             }
@@ -8403,7 +8403,7 @@ fn scan_primary_type_lr_4(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_9(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_primary_type(tokens, pos);
+        pos = scan_primary_type(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { return -1; }
@@ -8430,7 +8430,7 @@ fn scan_primary_type(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 
     return pos;
 }
 
-fn scan_predefined_type(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_predefined_type(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -8551,27 +8551,27 @@ fn scan_predefined_type(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_type_reference(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_type_reference(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_type_name(tokens, pos);
+    pos = scan_type_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_LT {
         let sp = pos;
-        pos = scan_type_generic(tokens, pos);
+        pos = scan_type_generic(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     return pos;
 }
 
-fn scan_type_generic(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_type_generic(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LT { return -1; }
     pos += 1;
-    pos = scan_type_argument_list(tokens, pos);
+    pos = scan_type_argument_list(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_LT {
         let sp = pos;
-        pos = scan_type_generic(tokens, pos);
+        pos = scan_type_generic(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_GT { return -1; }
@@ -8579,7 +8579,7 @@ fn scan_type_generic(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_type_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_type_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -8587,13 +8587,13 @@ fn scan_type_name(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_2(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_1: {
-                pos = scan_namespace_name(tokens, pos);
+                pos = scan_namespace_name(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -8605,13 +8605,13 @@ fn scan_type_name(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_object_type(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_object_type(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_11(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_type_body(tokens, pos);
+        pos = scan_type_body(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
@@ -8619,9 +8619,9 @@ fn scan_object_type(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_type_body(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_type_body(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_type_member_list(tokens, pos);
+    pos = scan_type_member_list(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && _gale_kind_set_12(tokens[pos].kind) {
         let sp = pos;
@@ -8646,9 +8646,9 @@ fn scan_type_body(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_type_member_list(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_type_member_list(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_type_member(tokens, pos);
+    pos = scan_type_member(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && _gale_kind_set_12(tokens[pos].kind) {
         let sp = pos;
@@ -8670,7 +8670,7 @@ fn scan_type_member_list(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     break sg_6;
                 }
-                pos = scan_type_member(tokens, pos);
+                pos = scan_type_member(tokens, pos, 0);
                 if pos < 0 { break sg_6; }
                 break sg_6_done;
             }
@@ -8682,7 +8682,7 @@ fn scan_type_member_list(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_type_member(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_type_member(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -8690,13 +8690,13 @@ fn scan_type_member(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_13(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_property_signatur(tokens, pos);
+                pos = scan_property_signatur(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_4: {
-                pos = scan_method_signature(tokens, pos);
+                pos = scan_method_signature(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 if pos < tokens.len() && tokens[pos].kind == TK_LIT_EQGT {
                     let sp = pos;
@@ -8704,7 +8704,7 @@ fn scan_type_member(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_8: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQGT { break sg_8; }
                             pos += 1;
-                            pos = scan_type_(tokens, pos);
+                            pos = scan_type_(tokens, pos, 0);
                             if pos < 0 { break sg_8; }
                             break sg_8_done;
                         }
@@ -8718,19 +8718,19 @@ fn scan_type_member(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_LBRACKET {
             pos = start;
             try_0: {
-                pos = scan_property_signatur(tokens, pos);
+                pos = scan_property_signatur(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_3: {
-                pos = scan_index_signature(tokens, pos);
+                pos = scan_index_signature(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
             pos = start;
             try_4: {
-                pos = scan_method_signature(tokens, pos);
+                pos = scan_method_signature(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 if pos < tokens.len() && tokens[pos].kind == TK_LIT_EQGT {
                     let sp = pos;
@@ -8738,7 +8738,7 @@ fn scan_type_member(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_9: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQGT { break sg_9; }
                             pos += 1;
-                            pos = scan_type_(tokens, pos);
+                            pos = scan_type_(tokens, pos, 0);
                             if pos < 0 { break sg_9; }
                             break sg_9_done;
                         }
@@ -8752,7 +8752,7 @@ fn scan_type_member(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_14(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_call_signature(tokens, pos);
+                pos = scan_call_signature(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -8760,7 +8760,7 @@ fn scan_type_member(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_NEW {
             pos = start;
             try_2: {
-                pos = scan_construct_signature(tokens, pos);
+                pos = scan_construct_signature(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -8772,9 +8772,9 @@ fn scan_type_member(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_array_type(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_array_type(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_primary_type(tokens, pos);
+    pos = scan_primary_type(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { return -1; }
     pos += 1;
@@ -8783,20 +8783,20 @@ fn scan_array_type(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_tuple_type(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_tuple_type(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { return -1; }
     pos += 1;
-    pos = scan_tuple_element_types(tokens, pos);
+    pos = scan_tuple_element_types(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_tuple_element_types(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_tuple_element_types(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_type_(tokens, pos);
+    pos = scan_type_(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -8804,7 +8804,7 @@ fn scan_tuple_element_types(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_10: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_10; }
                 pos += 1;
-                pos = scan_type_(tokens, pos);
+                pos = scan_type_(tokens, pos, 0);
                 if pos < 0 { break sg_10; }
                 break sg_10_done;
             }
@@ -8821,64 +8821,64 @@ fn scan_tuple_element_types(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_function_type(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_function_type(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_LT {
         let sp = pos;
-        pos = scan_type_parameters(tokens, pos);
+        pos = scan_type_parameters(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_15(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_parameter_list(tokens, pos);
+        pos = scan_parameter_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQGT { return -1; }
     pos += 1;
-    pos = scan_type_(tokens, pos);
+    pos = scan_type_(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_constructor_type(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_constructor_type(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_NEW { return -1; }
     pos += 1;
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_LT {
         let sp = pos;
-        pos = scan_type_parameters(tokens, pos);
+        pos = scan_type_parameters(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_15(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_parameter_list(tokens, pos);
+        pos = scan_parameter_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQGT { return -1; }
     pos += 1;
-    pos = scan_type_(tokens, pos);
+    pos = scan_type_(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_type_query(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_type_query(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_TYPEOF { return -1; }
     pos += 1;
-    pos = scan_type_query_expression(tokens, pos);
+    pos = scan_type_query_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_type_query_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_type_query_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -8886,7 +8886,7 @@ fn scan_type_query_expression(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_2(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -8894,7 +8894,7 @@ fn scan_type_query_expression(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 sg_11_done: {
                     sg_11: {
-                        pos = scan_identifier_name(tokens, pos);
+                        pos = scan_identifier_name(tokens, pos, 0);
                         if pos < 0 { break sg_11; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_11; }
                         pos += 1;
@@ -8906,7 +8906,7 @@ fn scan_type_query_expression(tokens: &Array<Token>, pos: i32) -> i32 {
                     let sp = pos;
                     sg_12_done: {
                         sg_12: {
-                            pos = scan_identifier_name(tokens, pos);
+                            pos = scan_identifier_name(tokens, pos, 0);
                             if pos < 0 { break sg_12; }
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_12; }
                             pos += 1;
@@ -8917,7 +8917,7 @@ fn scan_type_query_expression(tokens: &Array<Token>, pos: i32) -> i32 {
                     if pos < 0 { pos = sp; break; }
                     if pos == sp { break; }
                 }
-                pos = scan_identifier_name(tokens, pos);
+                pos = scan_identifier_name(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -8927,7 +8927,7 @@ fn scan_type_query_expression(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 sg_13_done: {
                     sg_13: {
-                        pos = scan_identifier_name(tokens, pos);
+                        pos = scan_identifier_name(tokens, pos, 0);
                         if pos < 0 { break sg_13; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_13; }
                         pos += 1;
@@ -8939,7 +8939,7 @@ fn scan_type_query_expression(tokens: &Array<Token>, pos: i32) -> i32 {
                     let sp = pos;
                     sg_14_done: {
                         sg_14: {
-                            pos = scan_identifier_name(tokens, pos);
+                            pos = scan_identifier_name(tokens, pos, 0);
                             if pos < 0 { break sg_14; }
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_14; }
                             pos += 1;
@@ -8950,7 +8950,7 @@ fn scan_type_query_expression(tokens: &Array<Token>, pos: i32) -> i32 {
                     if pos < 0 { pos = sp; break; }
                     if pos == sp { break; }
                 }
-                pos = scan_identifier_name(tokens, pos);
+                pos = scan_identifier_name(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -8962,14 +8962,14 @@ fn scan_type_query_expression(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_property_signatur(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_property_signatur(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_ReadOnly {
         let sp = pos;
         if pos >= tokens.len() || tokens[pos].kind != TK_ReadOnly { pos = -1; } else { pos += 1; }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_property_name(tokens, pos);
+    pos = scan_property_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_QUESTION {
         let sp = pos;
@@ -8978,7 +8978,7 @@ fn scan_property_signatur(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_COLON {
         let sp = pos;
-        pos = scan_type_annotation(tokens, pos);
+        pos = scan_type_annotation(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_EQGT {
@@ -8987,7 +8987,7 @@ fn scan_property_signatur(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_15: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQGT { break sg_15; }
                 pos += 1;
-                pos = scan_type_(tokens, pos);
+                pos = scan_type_(tokens, pos, 0);
                 if pos < 0 { break sg_15; }
                 break sg_15_done;
             }
@@ -8998,40 +8998,40 @@ fn scan_property_signatur(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_type_annotation(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_type_annotation(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { return -1; }
     pos += 1;
-    pos = scan_type_(tokens, pos);
+    pos = scan_type_(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_call_signature(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_call_signature(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_LT {
         let sp = pos;
-        pos = scan_type_parameters(tokens, pos);
+        pos = scan_type_parameters(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_15(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_parameter_list(tokens, pos);
+        pos = scan_parameter_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_COLON {
         let sp = pos;
-        pos = scan_type_annotation(tokens, pos);
+        pos = scan_type_annotation(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     return pos;
 }
 
-fn scan_parameter_list(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_parameter_list(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -9039,7 +9039,7 @@ fn scan_parameter_list(tokens: &Array<Token>, pos: i32) -> i32 {
         if alt_kind == TK_LIT_DOTDOTDOT {
             pos = start;
             try_0: {
-                pos = scan_rest_parameter(tokens, pos);
+                pos = scan_rest_parameter(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -9047,7 +9047,7 @@ fn scan_parameter_list(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_18(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_parameter(tokens, pos);
+                pos = scan_parameter(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -9055,7 +9055,7 @@ fn scan_parameter_list(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_16: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_16; }
                             pos += 1;
-                            pos = scan_parameter(tokens, pos);
+                            pos = scan_parameter(tokens, pos, 0);
                             if pos < 0 { break sg_16; }
                             break sg_16_done;
                         }
@@ -9070,7 +9070,7 @@ fn scan_parameter_list(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_17: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_17; }
                             pos += 1;
-                            pos = scan_rest_parameter(tokens, pos);
+                            pos = scan_rest_parameter(tokens, pos, 0);
                             if pos < 0 { break sg_17; }
                             break sg_17_done;
                         }
@@ -9093,9 +9093,9 @@ fn scan_parameter_list(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_required_parameter_list(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_required_parameter_list(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_required_parameter(tokens, pos);
+    pos = scan_required_parameter(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -9103,7 +9103,7 @@ fn scan_required_parameter_list(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_18: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_18; }
                 pos += 1;
-                pos = scan_required_parameter(tokens, pos);
+                pos = scan_required_parameter(tokens, pos, 0);
                 if pos < 0 { break sg_18; }
                 break sg_18_done;
             }
@@ -9115,7 +9115,7 @@ fn scan_required_parameter_list(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_parameter(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_parameter(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -9123,13 +9123,13 @@ fn scan_parameter(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_18(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_required_parameter(tokens, pos);
+                pos = scan_required_parameter(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_1: {
-                pos = scan_optional_parameter(tokens, pos);
+                pos = scan_optional_parameter(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -9141,16 +9141,16 @@ fn scan_parameter(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_optional_parameter(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_optional_parameter(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_AT {
         let sp = pos;
-        pos = scan_decorator_list(tokens, pos);
+        pos = scan_decorator_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     sg_19_done: {
         sg_19: {
-            pos = scan_identifier_or_pattern(tokens, pos);
+            pos = scan_identifier_or_pattern(tokens, pos, 0);
             if pos < 0 { break sg_19; }
             let gp_20 = pos;
             let sgk_20 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -9162,7 +9162,7 @@ fn scan_optional_parameter(tokens: &Array<Token>, pos: i32) -> i32 {
                         pos += 1;
                         if pos < tokens.len() && tokens[pos].kind == TK_LIT_COLON {
                             let sp = pos;
-                            pos = scan_type_annotation(tokens, pos);
+                            pos = scan_type_annotation(tokens, pos, 0);
                             if pos < 0 { pos = sp; }
                         }
                         break sg_20;
@@ -9171,10 +9171,10 @@ fn scan_optional_parameter(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_20_1: {
                         if pos < tokens.len() && tokens[pos].kind == TK_LIT_COLON {
                             let sp = pos;
-                            pos = scan_type_annotation(tokens, pos);
+                            pos = scan_type_annotation(tokens, pos, 0);
                             if pos < 0 { pos = sp; }
                         }
-                        pos = scan_initializer(tokens, pos);
+                        pos = scan_initializer(tokens, pos, 0);
                         if pos < 0 { break sg_20_1; }
                         break sg_20;
                     }
@@ -9188,45 +9188,45 @@ fn scan_optional_parameter(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_rest_parameter(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_rest_parameter(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOTDOTDOT { return -1; }
     pos += 1;
-    pos = scan_single_expression(tokens, pos);
+    pos = scan_single_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_COLON {
         let sp = pos;
-        pos = scan_type_annotation(tokens, pos);
+        pos = scan_type_annotation(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     return pos;
 }
 
-fn scan_required_parameter(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_required_parameter(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_AT {
         let sp = pos;
-        pos = scan_decorator_list(tokens, pos);
+        pos = scan_decorator_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
-    pos = scan_identifier_or_pattern(tokens, pos);
+    pos = scan_identifier_or_pattern(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_COLON {
         let sp = pos;
-        pos = scan_type_annotation(tokens, pos);
+        pos = scan_type_annotation(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     return pos;
 }
 
-fn scan_accessibility_modifier(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_accessibility_modifier(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_20(tokens[pos].kind) {
         return pos + 1;
     }
     return -1;
 }
 
-fn scan_identifier_or_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_identifier_or_pattern(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -9234,7 +9234,7 @@ fn scan_identifier_or_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_16(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_identifier_name(tokens, pos);
+                pos = scan_identifier_name(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -9242,7 +9242,7 @@ fn scan_identifier_or_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_0(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_binding_pattern(tokens, pos);
+                pos = scan_binding_pattern(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -9254,37 +9254,37 @@ fn scan_identifier_or_pattern(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_construct_signature(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_construct_signature(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_NEW { return -1; }
     pos += 1;
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_LT {
         let sp = pos;
-        pos = scan_type_parameters(tokens, pos);
+        pos = scan_type_parameters(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_15(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_parameter_list(tokens, pos);
+        pos = scan_parameter_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_COLON {
         let sp = pos;
-        pos = scan_type_annotation(tokens, pos);
+        pos = scan_type_annotation(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     return pos;
 }
 
-fn scan_index_signature(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_index_signature(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { return -1; }
     pos += 1;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { return -1; }
     pos += 1;
@@ -9306,26 +9306,26 @@ fn scan_index_signature(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { return -1; }
     pos += 1;
-    pos = scan_type_annotation(tokens, pos);
+    pos = scan_type_annotation(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_method_signature(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_method_signature(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_property_name(tokens, pos);
+    pos = scan_property_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_QUESTION {
         let sp = pos;
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_QUESTION { pos = -1; } else { pos += 1; }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_call_signature(tokens, pos);
+    pos = scan_call_signature(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_type_alias_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_type_alias_declaration(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_Export {
         let sp = pos;
@@ -9334,27 +9334,27 @@ fn scan_type_alias_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_TYPE { return -1; }
     pos += 1;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_LT {
         let sp = pos;
-        pos = scan_type_parameters(tokens, pos);
+        pos = scan_type_parameters(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQ { return -1; }
     pos += 1;
-    pos = scan_type_(tokens, pos);
+    pos = scan_type_(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_eos(tokens, pos);
+    pos = scan_eos(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_constructor_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_constructor_declaration(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && _gale_kind_set_20(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_accessibility_modifier(tokens, pos);
+        pos = scan_accessibility_modifier(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_Constructor { return -1; }
@@ -9363,7 +9363,7 @@ fn scan_constructor_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_21(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_formal_parameter_list(tokens, pos);
+        pos = scan_formal_parameter_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
@@ -9378,7 +9378,7 @@ fn scan_constructor_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_23: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { break sg_23; }
                         pos += 1;
-                        pos = scan_function_body(tokens, pos);
+                        pos = scan_function_body(tokens, pos, 0);
                         if pos < 0 { break sg_23; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { break sg_23; }
                         pos += 1;
@@ -9401,7 +9401,7 @@ fn scan_constructor_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_interface_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_interface_declaration(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_Export {
         let sp = pos;
@@ -9415,19 +9415,19 @@ fn scan_interface_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_Interface { return -1; }
     pos += 1;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_LT {
         let sp = pos;
-        pos = scan_type_parameters(tokens, pos);
+        pos = scan_type_parameters(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos < tokens.len() && tokens[pos].kind == TK_Extends {
         let sp = pos;
-        pos = scan_interface_extends_clause(tokens, pos);
+        pos = scan_interface_extends_clause(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
-    pos = scan_object_type(tokens, pos);
+    pos = scan_object_type(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_SemiColon {
         let sp = pos;
@@ -9437,18 +9437,18 @@ fn scan_interface_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_interface_extends_clause(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_interface_extends_clause(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Extends { return -1; }
     pos += 1;
-    pos = scan_class_or_interface_type_list(tokens, pos);
+    pos = scan_class_or_interface_type_list(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_class_or_interface_type_list(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_class_or_interface_type_list(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_type_reference(tokens, pos);
+    pos = scan_type_reference(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -9456,7 +9456,7 @@ fn scan_class_or_interface_type_list(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_24: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_24; }
                 pos += 1;
-                pos = scan_type_reference(tokens, pos);
+                pos = scan_type_reference(tokens, pos, 0);
                 if pos < 0 { break sg_24; }
                 break sg_24_done;
             }
@@ -9468,7 +9468,7 @@ fn scan_class_or_interface_type_list(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_enum_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_enum_declaration(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_Const {
         let sp = pos;
@@ -9477,13 +9477,13 @@ fn scan_enum_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_Enum { return -1; }
     pos += 1;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_23(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_enum_body(tokens, pos);
+        pos = scan_enum_body(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
@@ -9491,9 +9491,9 @@ fn scan_enum_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_enum_body(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_enum_body(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_enum_member_list(tokens, pos);
+    pos = scan_enum_member_list(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -9503,9 +9503,9 @@ fn scan_enum_body(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_enum_member_list(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_enum_member_list(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_enum_member(tokens, pos);
+    pos = scan_enum_member(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -9513,7 +9513,7 @@ fn scan_enum_member_list(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_25: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_25; }
                 pos += 1;
-                pos = scan_enum_member(tokens, pos);
+                pos = scan_enum_member(tokens, pos, 0);
                 if pos < 0 { break sg_25; }
                 break sg_25_done;
             }
@@ -9525,9 +9525,9 @@ fn scan_enum_member_list(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_enum_member(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_enum_member(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_property_name(tokens, pos);
+    pos = scan_property_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_EQ {
         let sp = pos;
@@ -9535,7 +9535,7 @@ fn scan_enum_member(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_26: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQ { break sg_26; }
                 pos += 1;
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break sg_26; }
                 break sg_26_done;
             }
@@ -9546,7 +9546,7 @@ fn scan_enum_member(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_namespace_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_namespace_declaration(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_Declare {
         let sp = pos;
@@ -9555,13 +9555,13 @@ fn scan_namespace_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_Namespace { return -1; }
     pos += 1;
-    pos = scan_namespace_name(tokens, pos);
+    pos = scan_namespace_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_24(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_statement_list(tokens, pos);
+        pos = scan_statement_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
@@ -9569,9 +9569,9 @@ fn scan_namespace_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_namespace_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_namespace_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_DOT {
         let sp = pos;
@@ -9585,7 +9585,7 @@ fn scan_namespace_name(tokens: &Array<Token>, pos: i32) -> i32 {
                     if pos < 0 { pos = sp; break; }
                     if pos == sp { break; }
                 }
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break sg_27; }
                 break sg_27_done;
             }
@@ -9597,33 +9597,33 @@ fn scan_namespace_name(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_import_alias_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_import_alias_declaration(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQ { return -1; }
     pos += 1;
-    pos = scan_namespace_name(tokens, pos);
+    pos = scan_namespace_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_SemiColon { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_decorator_list(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_decorator_list(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_decorator(tokens, pos);
+    pos = scan_decorator(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_AT {
         let sp = pos;
-        pos = scan_decorator(tokens, pos);
+        pos = scan_decorator(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
     return pos;
 }
 
-fn scan_decorator(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_decorator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_AT { return -1; }
     pos += 1;
@@ -9634,13 +9634,13 @@ fn scan_decorator(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_28: {
             pos = gp_28;
             sg_28_0: {
-                pos = scan_decorator_member_expression(tokens, pos);
+                pos = scan_decorator_member_expression(tokens, pos, 0);
                 if pos < 0 { break sg_28_0; }
                 if pos > sg_28_best { sg_28_best = pos; }
             }
             pos = gp_28;
             sg_28_1: {
-                pos = scan_decorator_call_expression(tokens, pos);
+                pos = scan_decorator_call_expression(tokens, pos, 0);
                 if pos < 0 { break sg_28_1; }
                 if pos > sg_28_best { sg_28_best = pos; }
             }
@@ -9659,7 +9659,7 @@ fn scan_decorator_member_expression_atom(tokens: &Array<Token>, pos: i32) -> i32
         if _gale_kind_set_2(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -9669,7 +9669,7 @@ fn scan_decorator_member_expression_atom(tokens: &Array<Token>, pos: i32) -> i32
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_1; }
                 pos += 1;
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_1; }
                 pos += 1;
@@ -9687,7 +9687,7 @@ fn scan_decorator_member_expression_lr_1(tokens: &Array<Token>, pos: i32) -> i32
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { return -1; }
     pos += 1;
-    pos = scan_identifier_name(tokens, pos);
+    pos = scan_identifier_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -9711,20 +9711,20 @@ fn scan_decorator_member_expression(tokens: &Array<Token>, pos: i32, min_prec: i
     return pos;
 }
 
-fn scan_decorator_call_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_decorator_call_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_decorator_member_expression(tokens, pos);
+    pos = scan_decorator_member_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_arguments(tokens, pos);
+    pos = scan_arguments(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_program(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_program(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && _gale_kind_set_24(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_source_elements(tokens, pos);
+        pos = scan_source_elements(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
@@ -9732,19 +9732,19 @@ fn scan_program(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_source_element(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_source_element(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_Export {
         let sp = pos;
         if pos >= tokens.len() || tokens[pos].kind != TK_Export { pos = -1; } else { pos += 1; }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_statement(tokens, pos);
+    pos = scan_statement(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_statement(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -9752,19 +9752,19 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         if alt_kind == TK_LIT_LBRACE {
             pos = start;
             try_0: {
-                pos = scan_block(tokens, pos);
+                pos = scan_block(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_1: {
-                pos = scan_variable_statement(tokens, pos);
+                pos = scan_variable_statement(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_8: {
-                pos = scan_expression_statement(tokens, pos);
+                pos = scan_expression_statement(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
@@ -9772,19 +9772,19 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_26(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_variable_statement(tokens, pos);
+                pos = scan_variable_statement(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_8: {
-                pos = scan_expression_statement(tokens, pos);
+                pos = scan_expression_statement(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
             pos = start;
             try_23: {
-                pos = scan_arrow_function_declaration(tokens, pos);
+                pos = scan_arrow_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_23; }
                 break scan_alts;
             }
@@ -9792,25 +9792,25 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Const {
             pos = start;
             try_1: {
-                pos = scan_variable_statement(tokens, pos);
+                pos = scan_variable_statement(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_8: {
-                pos = scan_expression_statement(tokens, pos);
+                pos = scan_expression_statement(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
             pos = start;
             try_23: {
-                pos = scan_arrow_function_declaration(tokens, pos);
+                pos = scan_arrow_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_23; }
                 break scan_alts;
             }
             pos = start;
             try_26: {
-                pos = scan_enum_declaration(tokens, pos);
+                pos = scan_enum_declaration(tokens, pos, 0);
                 if pos < 0 { break try_26; }
                 break scan_alts;
             }
@@ -9818,25 +9818,25 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_27(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_variable_statement(tokens, pos);
+                pos = scan_variable_statement(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_8: {
-                pos = scan_expression_statement(tokens, pos);
+                pos = scan_expression_statement(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
             pos = start;
             try_18: {
-                pos = scan_labelled_statement(tokens, pos);
+                pos = scan_labelled_statement(tokens, pos, 0);
                 if pos < 0 { break try_18; }
                 break scan_alts;
             }
             pos = start;
             try_23: {
-                pos = scan_arrow_function_declaration(tokens, pos);
+                pos = scan_arrow_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_23; }
                 break scan_alts;
             }
@@ -9844,37 +9844,37 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Async {
             pos = start;
             try_1: {
-                pos = scan_variable_statement(tokens, pos);
+                pos = scan_variable_statement(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_7: {
-                pos = scan_function_declaration(tokens, pos);
+                pos = scan_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 break scan_alts;
             }
             pos = start;
             try_8: {
-                pos = scan_expression_statement(tokens, pos);
+                pos = scan_expression_statement(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
             pos = start;
             try_18: {
-                pos = scan_labelled_statement(tokens, pos);
+                pos = scan_labelled_statement(tokens, pos, 0);
                 if pos < 0 { break try_18; }
                 break scan_alts;
             }
             pos = start;
             try_23: {
-                pos = scan_arrow_function_declaration(tokens, pos);
+                pos = scan_arrow_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_23; }
                 break scan_alts;
             }
             pos = start;
             try_24: {
-                pos = scan_generator_function_declaration(tokens, pos);
+                pos = scan_generator_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_24; }
                 break scan_alts;
             }
@@ -9882,31 +9882,31 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Yield {
             pos = start;
             try_1: {
-                pos = scan_variable_statement(tokens, pos);
+                pos = scan_variable_statement(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_8: {
-                pos = scan_expression_statement(tokens, pos);
+                pos = scan_expression_statement(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
             pos = start;
             try_16: {
-                pos = scan_yield_statement(tokens, pos);
+                pos = scan_yield_statement(tokens, pos, 0);
                 if pos < 0 { break try_16; }
                 break scan_alts;
             }
             pos = start;
             try_18: {
-                pos = scan_labelled_statement(tokens, pos);
+                pos = scan_labelled_statement(tokens, pos, 0);
                 if pos < 0 { break try_18; }
                 break scan_alts;
             }
             pos = start;
             try_23: {
-                pos = scan_arrow_function_declaration(tokens, pos);
+                pos = scan_arrow_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_23; }
                 break scan_alts;
             }
@@ -9914,31 +9914,31 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Namespace {
             pos = start;
             try_1: {
-                pos = scan_variable_statement(tokens, pos);
+                pos = scan_variable_statement(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_8: {
-                pos = scan_expression_statement(tokens, pos);
+                pos = scan_expression_statement(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
             pos = start;
             try_10: {
-                pos = scan_namespace_declaration(tokens, pos);
+                pos = scan_namespace_declaration(tokens, pos, 0);
                 if pos < 0 { break try_10; }
                 break scan_alts;
             }
             pos = start;
             try_18: {
-                pos = scan_labelled_statement(tokens, pos);
+                pos = scan_labelled_statement(tokens, pos, 0);
                 if pos < 0 { break try_18; }
                 break scan_alts;
             }
             pos = start;
             try_23: {
-                pos = scan_arrow_function_declaration(tokens, pos);
+                pos = scan_arrow_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_23; }
                 break scan_alts;
             }
@@ -9946,37 +9946,37 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Abstract {
             pos = start;
             try_1: {
-                pos = scan_variable_statement(tokens, pos);
+                pos = scan_variable_statement(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_5: {
-                pos = scan_abstract_declaration(tokens, pos);
+                pos = scan_abstract_declaration(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 break scan_alts;
             }
             pos = start;
             try_6: {
-                pos = scan_class_declaration(tokens, pos);
+                pos = scan_class_declaration(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 break scan_alts;
             }
             pos = start;
             try_8: {
-                pos = scan_expression_statement(tokens, pos);
+                pos = scan_expression_statement(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
             pos = start;
             try_18: {
-                pos = scan_labelled_statement(tokens, pos);
+                pos = scan_labelled_statement(tokens, pos, 0);
                 if pos < 0 { break try_18; }
                 break scan_alts;
             }
             pos = start;
             try_23: {
-                pos = scan_arrow_function_declaration(tokens, pos);
+                pos = scan_arrow_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_23; }
                 break scan_alts;
             }
@@ -9984,19 +9984,19 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Declare {
             pos = start;
             try_1: {
-                pos = scan_variable_statement(tokens, pos);
+                pos = scan_variable_statement(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_9: {
-                pos = scan_interface_declaration(tokens, pos);
+                pos = scan_interface_declaration(tokens, pos, 0);
                 if pos < 0 { break try_9; }
                 break scan_alts;
             }
             pos = start;
             try_10: {
-                pos = scan_namespace_declaration(tokens, pos);
+                pos = scan_namespace_declaration(tokens, pos, 0);
                 if pos < 0 { break try_10; }
                 break scan_alts;
             }
@@ -10004,19 +10004,19 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Import {
             pos = start;
             try_2: {
-                pos = scan_import_statement(tokens, pos);
+                pos = scan_import_statement(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
             pos = start;
             try_8: {
-                pos = scan_expression_statement(tokens, pos);
+                pos = scan_expression_statement(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
             pos = start;
             try_23: {
-                pos = scan_arrow_function_declaration(tokens, pos);
+                pos = scan_arrow_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_23; }
                 break scan_alts;
             }
@@ -10026,43 +10026,43 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
             try_27: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_Export { break try_27; }
                 pos += 1;
-                pos = scan_statement(tokens, pos);
+                pos = scan_statement(tokens, pos, 0);
                 if pos < 0 { break try_27; }
                 break scan_alts;
             }
             pos = start;
             try_6: {
-                pos = scan_class_declaration(tokens, pos);
+                pos = scan_class_declaration(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 break scan_alts;
             }
             pos = start;
             try_8: {
-                pos = scan_expression_statement(tokens, pos);
+                pos = scan_expression_statement(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
             pos = start;
             try_9: {
-                pos = scan_interface_declaration(tokens, pos);
+                pos = scan_interface_declaration(tokens, pos, 0);
                 if pos < 0 { break try_9; }
                 break scan_alts;
             }
             pos = start;
             try_23: {
-                pos = scan_arrow_function_declaration(tokens, pos);
+                pos = scan_arrow_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_23; }
                 break scan_alts;
             }
             pos = start;
             try_25: {
-                pos = scan_type_alias_declaration(tokens, pos);
+                pos = scan_type_alias_declaration(tokens, pos, 0);
                 if pos < 0 { break try_25; }
                 break scan_alts;
             }
             pos = start;
             try_3: {
-                pos = scan_export_statement(tokens, pos);
+                pos = scan_export_statement(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -10070,7 +10070,7 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_SemiColon {
             pos = start;
             try_4: {
-                pos = scan_empty_statement_(tokens, pos);
+                pos = scan_empty_statement_(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 break scan_alts;
             }
@@ -10078,7 +10078,7 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_AT {
             pos = start;
             try_6: {
-                pos = scan_class_declaration(tokens, pos);
+                pos = scan_class_declaration(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 break scan_alts;
             }
@@ -10086,19 +10086,19 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Class {
             pos = start;
             try_6: {
-                pos = scan_class_declaration(tokens, pos);
+                pos = scan_class_declaration(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 break scan_alts;
             }
             pos = start;
             try_8: {
-                pos = scan_expression_statement(tokens, pos);
+                pos = scan_expression_statement(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
             pos = start;
             try_23: {
-                pos = scan_arrow_function_declaration(tokens, pos);
+                pos = scan_arrow_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_23; }
                 break scan_alts;
             }
@@ -10106,25 +10106,25 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Function_ {
             pos = start;
             try_7: {
-                pos = scan_function_declaration(tokens, pos);
+                pos = scan_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 break scan_alts;
             }
             pos = start;
             try_8: {
-                pos = scan_expression_statement(tokens, pos);
+                pos = scan_expression_statement(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
             pos = start;
             try_23: {
-                pos = scan_arrow_function_declaration(tokens, pos);
+                pos = scan_arrow_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_23; }
                 break scan_alts;
             }
             pos = start;
             try_24: {
-                pos = scan_generator_function_declaration(tokens, pos);
+                pos = scan_generator_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_24; }
                 break scan_alts;
             }
@@ -10132,19 +10132,19 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Break {
             pos = start;
             try_8: {
-                pos = scan_expression_statement(tokens, pos);
+                pos = scan_expression_statement(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
             pos = start;
             try_14: {
-                pos = scan_break_statement(tokens, pos);
+                pos = scan_break_statement(tokens, pos, 0);
                 if pos < 0 { break try_14; }
                 break scan_alts;
             }
             pos = start;
             try_23: {
-                pos = scan_arrow_function_declaration(tokens, pos);
+                pos = scan_arrow_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_23; }
                 break scan_alts;
             }
@@ -10152,19 +10152,19 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_28(alt_kind) {
             pos = start;
             try_8: {
-                pos = scan_expression_statement(tokens, pos);
+                pos = scan_expression_statement(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
             pos = start;
             try_12: {
-                pos = scan_iteration_statement(tokens, pos);
+                pos = scan_iteration_statement(tokens, pos, 0);
                 if pos < 0 { break try_12; }
                 break scan_alts;
             }
             pos = start;
             try_23: {
-                pos = scan_arrow_function_declaration(tokens, pos);
+                pos = scan_arrow_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_23; }
                 break scan_alts;
             }
@@ -10172,13 +10172,13 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_29(alt_kind) {
             pos = start;
             try_8: {
-                pos = scan_expression_statement(tokens, pos);
+                pos = scan_expression_statement(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
             pos = start;
             try_23: {
-                pos = scan_arrow_function_declaration(tokens, pos);
+                pos = scan_arrow_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_23; }
                 break scan_alts;
             }
@@ -10186,19 +10186,19 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Return {
             pos = start;
             try_8: {
-                pos = scan_expression_statement(tokens, pos);
+                pos = scan_expression_statement(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
             pos = start;
             try_15: {
-                pos = scan_return_statement(tokens, pos);
+                pos = scan_return_statement(tokens, pos, 0);
                 if pos < 0 { break try_15; }
                 break scan_alts;
             }
             pos = start;
             try_23: {
-                pos = scan_arrow_function_declaration(tokens, pos);
+                pos = scan_arrow_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_23; }
                 break scan_alts;
             }
@@ -10206,19 +10206,19 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Continue {
             pos = start;
             try_8: {
-                pos = scan_expression_statement(tokens, pos);
+                pos = scan_expression_statement(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
             pos = start;
             try_13: {
-                pos = scan_continue_statement(tokens, pos);
+                pos = scan_continue_statement(tokens, pos, 0);
                 if pos < 0 { break try_13; }
                 break scan_alts;
             }
             pos = start;
             try_23: {
-                pos = scan_arrow_function_declaration(tokens, pos);
+                pos = scan_arrow_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_23; }
                 break scan_alts;
             }
@@ -10226,19 +10226,19 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Switch {
             pos = start;
             try_8: {
-                pos = scan_expression_statement(tokens, pos);
+                pos = scan_expression_statement(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
             pos = start;
             try_19: {
-                pos = scan_switch_statement(tokens, pos);
+                pos = scan_switch_statement(tokens, pos, 0);
                 if pos < 0 { break try_19; }
                 break scan_alts;
             }
             pos = start;
             try_23: {
-                pos = scan_arrow_function_declaration(tokens, pos);
+                pos = scan_arrow_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_23; }
                 break scan_alts;
             }
@@ -10246,19 +10246,19 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Debugger {
             pos = start;
             try_8: {
-                pos = scan_expression_statement(tokens, pos);
+                pos = scan_expression_statement(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
             pos = start;
             try_22: {
-                pos = scan_debugger_statement(tokens, pos);
+                pos = scan_debugger_statement(tokens, pos, 0);
                 if pos < 0 { break try_22; }
                 break scan_alts;
             }
             pos = start;
             try_23: {
-                pos = scan_arrow_function_declaration(tokens, pos);
+                pos = scan_arrow_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_23; }
                 break scan_alts;
             }
@@ -10266,19 +10266,19 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_With {
             pos = start;
             try_8: {
-                pos = scan_expression_statement(tokens, pos);
+                pos = scan_expression_statement(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
             pos = start;
             try_17: {
-                pos = scan_with_statement(tokens, pos);
+                pos = scan_with_statement(tokens, pos, 0);
                 if pos < 0 { break try_17; }
                 break scan_alts;
             }
             pos = start;
             try_23: {
-                pos = scan_arrow_function_declaration(tokens, pos);
+                pos = scan_arrow_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_23; }
                 break scan_alts;
             }
@@ -10286,19 +10286,19 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_If {
             pos = start;
             try_8: {
-                pos = scan_expression_statement(tokens, pos);
+                pos = scan_expression_statement(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
             pos = start;
             try_11: {
-                pos = scan_if_statement(tokens, pos);
+                pos = scan_if_statement(tokens, pos, 0);
                 if pos < 0 { break try_11; }
                 break scan_alts;
             }
             pos = start;
             try_23: {
-                pos = scan_arrow_function_declaration(tokens, pos);
+                pos = scan_arrow_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_23; }
                 break scan_alts;
             }
@@ -10306,19 +10306,19 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Throw {
             pos = start;
             try_8: {
-                pos = scan_expression_statement(tokens, pos);
+                pos = scan_expression_statement(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
             pos = start;
             try_20: {
-                pos = scan_throw_statement(tokens, pos);
+                pos = scan_throw_statement(tokens, pos, 0);
                 if pos < 0 { break try_20; }
                 break scan_alts;
             }
             pos = start;
             try_23: {
-                pos = scan_arrow_function_declaration(tokens, pos);
+                pos = scan_arrow_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_23; }
                 break scan_alts;
             }
@@ -10326,19 +10326,19 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Try {
             pos = start;
             try_8: {
-                pos = scan_expression_statement(tokens, pos);
+                pos = scan_expression_statement(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
             pos = start;
             try_21: {
-                pos = scan_try_statement(tokens, pos);
+                pos = scan_try_statement(tokens, pos, 0);
                 if pos < 0 { break try_21; }
                 break scan_alts;
             }
             pos = start;
             try_23: {
-                pos = scan_arrow_function_declaration(tokens, pos);
+                pos = scan_arrow_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_23; }
                 break scan_alts;
             }
@@ -10346,19 +10346,19 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Enum {
             pos = start;
             try_8: {
-                pos = scan_expression_statement(tokens, pos);
+                pos = scan_expression_statement(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
             pos = start;
             try_23: {
-                pos = scan_arrow_function_declaration(tokens, pos);
+                pos = scan_arrow_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_23; }
                 break scan_alts;
             }
             pos = start;
             try_26: {
-                pos = scan_enum_declaration(tokens, pos);
+                pos = scan_enum_declaration(tokens, pos, 0);
                 if pos < 0 { break try_26; }
                 break scan_alts;
             }
@@ -10366,19 +10366,19 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Interface {
             pos = start;
             try_8: {
-                pos = scan_expression_statement(tokens, pos);
+                pos = scan_expression_statement(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
             pos = start;
             try_9: {
-                pos = scan_interface_declaration(tokens, pos);
+                pos = scan_interface_declaration(tokens, pos, 0);
                 if pos < 0 { break try_9; }
                 break scan_alts;
             }
             pos = start;
             try_23: {
-                pos = scan_arrow_function_declaration(tokens, pos);
+                pos = scan_arrow_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_23; }
                 break scan_alts;
             }
@@ -10386,7 +10386,7 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_30(alt_kind) {
             pos = start;
             try_8: {
-                pos = scan_expression_statement(tokens, pos);
+                pos = scan_expression_statement(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
@@ -10394,13 +10394,13 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_YieldStar {
             pos = start;
             try_8: {
-                pos = scan_expression_statement(tokens, pos);
+                pos = scan_expression_statement(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
             pos = start;
             try_16: {
-                pos = scan_yield_statement(tokens, pos);
+                pos = scan_yield_statement(tokens, pos, 0);
                 if pos < 0 { break try_16; }
                 break scan_alts;
             }
@@ -10408,7 +10408,7 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_TYPE {
             pos = start;
             try_25: {
-                pos = scan_type_alias_declaration(tokens, pos);
+                pos = scan_type_alias_declaration(tokens, pos, 0);
                 if pos < 0 { break try_25; }
                 break scan_alts;
             }
@@ -10420,13 +10420,13 @@ fn scan_statement(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_block(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_block(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_24(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_statement_list(tokens, pos);
+        pos = scan_statement_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
@@ -10434,20 +10434,20 @@ fn scan_block(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_statement_list(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_statement_list(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_statement(tokens, pos);
+    pos = scan_statement(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && _gale_kind_set_24(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_statement(tokens, pos);
+        pos = scan_statement(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
     return pos;
 }
 
-fn scan_abstract_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_abstract_declaration(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Abstract { return -1; }
     pos += 1;
@@ -10458,15 +10458,15 @@ fn scan_abstract_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_29: {
             pos = gp_29;
             sg_29_0: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break sg_29_0; }
-                pos = scan_call_signature(tokens, pos);
+                pos = scan_call_signature(tokens, pos, 0);
                 if pos < 0 { break sg_29_0; }
                 if pos > sg_29_best { sg_29_best = pos; }
             }
             pos = gp_29;
             sg_29_1: {
-                pos = scan_variable_statement(tokens, pos);
+                pos = scan_variable_statement(tokens, pos, 0);
                 if pos < 0 { break sg_29_1; }
                 if pos > sg_29_best { sg_29_best = pos; }
             }
@@ -10474,21 +10474,21 @@ fn scan_abstract_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
             pos = gp_29;
         }
     }
-    pos = scan_eos(tokens, pos);
+    pos = scan_eos(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_import_statement(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_import_statement(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Import { return -1; }
     pos += 1;
-    pos = scan_import_from_block(tokens, pos);
+    pos = scan_import_from_block(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_import_from_block(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_import_from_block(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -10502,22 +10502,22 @@ fn scan_import_from_block(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_30: {
                         pos = gp_30;
                         sg_30_0: {
-                            pos = scan_import_namespace(tokens, pos);
+                            pos = scan_import_namespace(tokens, pos, 0);
                             if pos < 0 { break sg_30_0; }
                             break sg_30;
                         }
                         pos = gp_30;
                         sg_30_1: {
-                            pos = scan_import_module_items(tokens, pos);
+                            pos = scan_import_module_items(tokens, pos, 0);
                             if pos < 0 { break sg_30_1; }
                             break sg_30;
                         }
                         pos = gp_30;
                     }
                 }
-                pos = scan_import_from(tokens, pos);
+                pos = scan_import_from(tokens, pos, 0);
                 if pos < 0 { break try_0; }
-                pos = scan_eos(tokens, pos);
+                pos = scan_eos(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -10527,7 +10527,7 @@ fn scan_import_from_block(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_StringLiteral { break try_1; }
                 pos += 1;
-                pos = scan_eos(tokens, pos);
+                pos = scan_eos(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -10539,7 +10539,7 @@ fn scan_import_from_block(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_import_module_items(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_import_module_items(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
     pos += 1;
@@ -10547,7 +10547,7 @@ fn scan_import_module_items(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_31_done: {
             sg_31: {
-                pos = scan_import_alias_name(tokens, pos);
+                pos = scan_import_alias_name(tokens, pos, 0);
                 if pos < 0 { break sg_31; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_31; }
                 pos += 1;
@@ -10560,14 +10560,14 @@ fn scan_import_module_items(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     if pos < tokens.len() && _gale_kind_set_33(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_COMMA {
         sol_32: {
-            pos = scan_import_alias_name(tokens, pos);
+            pos = scan_import_alias_name(tokens, pos, 0);
             if pos < 0 { break sol_32; }
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sol_32; }
             pos += 1;
         }
     } else if pos < tokens.len() && _gale_kind_set_33(tokens[pos].kind) {
         sol_33: {
-            pos = scan_import_alias_name(tokens, pos);
+            pos = scan_import_alias_name(tokens, pos, 0);
             if pos < 0 { break sol_33; }
         }
     }
@@ -10576,9 +10576,9 @@ fn scan_import_module_items(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_import_alias_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_import_alias_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_module_export_name(tokens, pos);
+    pos = scan_module_export_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_As {
         let sp = pos;
@@ -10586,7 +10586,7 @@ fn scan_import_alias_name(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_34: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_As { break sg_34; }
                 pos += 1;
-                pos = scan_imported_binding(tokens, pos);
+                pos = scan_imported_binding(tokens, pos, 0);
                 if pos < 0 { break sg_34; }
                 break sg_34_done;
             }
@@ -10597,7 +10597,7 @@ fn scan_import_alias_name(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_module_export_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_module_export_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -10605,7 +10605,7 @@ fn scan_module_export_name(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_16(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_identifier_name(tokens, pos);
+                pos = scan_identifier_name(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -10625,23 +10625,23 @@ fn scan_module_export_name(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_imported_binding(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_imported_binding(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_34(tokens[pos].kind) {
         return pos + 1;
     }
     return -1;
 }
 
-fn scan_import_default(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_import_default(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_alias_name(tokens, pos);
+    pos = scan_alias_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_import_namespace(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_import_namespace(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     let gp_35 = pos;
     let sgk_35 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -10655,7 +10655,7 @@ fn scan_import_namespace(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = gp_35;
             sg_35_1: {
-                pos = scan_identifier_name(tokens, pos);
+                pos = scan_identifier_name(tokens, pos, 0);
                 if pos < 0 { break sg_35_1; }
                 break sg_35;
             }
@@ -10668,7 +10668,7 @@ fn scan_import_namespace(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_36: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_As { break sg_36; }
                 pos += 1;
-                pos = scan_identifier_name(tokens, pos);
+                pos = scan_identifier_name(tokens, pos, 0);
                 if pos < 0 { break sg_36; }
                 break sg_36_done;
             }
@@ -10679,7 +10679,7 @@ fn scan_import_namespace(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_import_from(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_import_from(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_From { return -1; }
     pos += 1;
@@ -10688,9 +10688,9 @@ fn scan_import_from(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_alias_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_alias_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_identifier_name(tokens, pos);
+    pos = scan_identifier_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_As {
         let sp = pos;
@@ -10698,7 +10698,7 @@ fn scan_alias_name(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_37: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_As { break sg_37; }
                 pos += 1;
-                pos = scan_identifier_name(tokens, pos);
+                pos = scan_identifier_name(tokens, pos, 0);
                 if pos < 0 { break sg_37; }
                 break sg_37_done;
             }
@@ -10709,7 +10709,7 @@ fn scan_alias_name(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_export_statement(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_export_statement(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -10731,13 +10731,13 @@ fn scan_export_statement(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_38: {
                         pos = gp_38;
                         sg_38_0: {
-                            pos = scan_export_from_block(tokens, pos);
+                            pos = scan_export_from_block(tokens, pos, 0);
                             if pos < 0 { break sg_38_0; }
                             if pos > sg_38_best { sg_38_best = pos; }
                         }
                         pos = gp_38;
                         sg_38_1: {
-                            pos = scan_declaration(tokens, pos);
+                            pos = scan_declaration(tokens, pos, 0);
                             if pos < 0 { break sg_38_1; }
                             if pos > sg_38_best { sg_38_best = pos; }
                         }
@@ -10745,7 +10745,7 @@ fn scan_export_statement(tokens: &Array<Token>, pos: i32) -> i32 {
                         pos = gp_38;
                     }
                 }
-                pos = scan_eos(tokens, pos);
+                pos = scan_eos(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -10755,9 +10755,9 @@ fn scan_export_statement(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_Default { break try_1; }
                 pos += 1;
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break try_1; }
-                pos = scan_eos(tokens, pos);
+                pos = scan_eos(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -10769,7 +10769,7 @@ fn scan_export_statement(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_export_from_block(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_export_from_block(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -10777,11 +10777,11 @@ fn scan_export_from_block(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_35(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_import_namespace(tokens, pos);
+                pos = scan_import_namespace(tokens, pos, 0);
                 if pos < 0 { break try_0; }
-                pos = scan_import_from(tokens, pos);
+                pos = scan_import_from(tokens, pos, 0);
                 if pos < 0 { break try_0; }
-                pos = scan_eos(tokens, pos);
+                pos = scan_eos(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -10789,14 +10789,14 @@ fn scan_export_from_block(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_LBRACE {
             pos = start;
             try_1: {
-                pos = scan_export_module_items(tokens, pos);
+                pos = scan_export_module_items(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos < tokens.len() && tokens[pos].kind == TK_From {
                     let sp = pos;
-                    pos = scan_import_from(tokens, pos);
+                    pos = scan_import_from(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_eos(tokens, pos);
+                pos = scan_eos(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -10808,7 +10808,7 @@ fn scan_export_from_block(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_export_module_items(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_export_module_items(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
     pos += 1;
@@ -10816,7 +10816,7 @@ fn scan_export_module_items(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_39_done: {
             sg_39: {
-                pos = scan_export_alias_name(tokens, pos);
+                pos = scan_export_alias_name(tokens, pos, 0);
                 if pos < 0 { break sg_39; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_39; }
                 pos += 1;
@@ -10829,14 +10829,14 @@ fn scan_export_module_items(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     if pos < tokens.len() && _gale_kind_set_33(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_COMMA {
         sol_40: {
-            pos = scan_export_alias_name(tokens, pos);
+            pos = scan_export_alias_name(tokens, pos, 0);
             if pos < 0 { break sol_40; }
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sol_40; }
             pos += 1;
         }
     } else if pos < tokens.len() && _gale_kind_set_33(tokens[pos].kind) {
         sol_41: {
-            pos = scan_export_alias_name(tokens, pos);
+            pos = scan_export_alias_name(tokens, pos, 0);
             if pos < 0 { break sol_41; }
         }
     }
@@ -10845,9 +10845,9 @@ fn scan_export_module_items(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_export_alias_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_export_alias_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_module_export_name(tokens, pos);
+    pos = scan_module_export_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_As {
         let sp = pos;
@@ -10855,7 +10855,7 @@ fn scan_export_alias_name(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_42: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_As { break sg_42; }
                 pos += 1;
-                pos = scan_module_export_name(tokens, pos);
+                pos = scan_module_export_name(tokens, pos, 0);
                 if pos < 0 { break sg_42; }
                 break sg_42_done;
             }
@@ -10866,7 +10866,7 @@ fn scan_export_alias_name(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_declaration(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -10874,7 +10874,7 @@ fn scan_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_37(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_variable_statement(tokens, pos);
+                pos = scan_variable_statement(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -10882,13 +10882,13 @@ fn scan_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Async {
             pos = start;
             try_0: {
-                pos = scan_variable_statement(tokens, pos);
+                pos = scan_variable_statement(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_2: {
-                pos = scan_function_declaration(tokens, pos);
+                pos = scan_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -10896,13 +10896,13 @@ fn scan_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Abstract {
             pos = start;
             try_0: {
-                pos = scan_variable_statement(tokens, pos);
+                pos = scan_variable_statement(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_1: {
-                pos = scan_class_declaration(tokens, pos);
+                pos = scan_class_declaration(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -10910,7 +10910,7 @@ fn scan_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_38(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_class_declaration(tokens, pos);
+                pos = scan_class_declaration(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -10918,7 +10918,7 @@ fn scan_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Function_ {
             pos = start;
             try_2: {
-                pos = scan_function_declaration(tokens, pos);
+                pos = scan_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -10930,7 +10930,7 @@ fn scan_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_variable_statement(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_variable_statement(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -10940,12 +10940,12 @@ fn scan_variable_statement(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos < tokens.len() && _gale_kind_set_20(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_accessibility_modifier(tokens, pos);
+                    pos = scan_accessibility_modifier(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 if pos < tokens.len() && _gale_kind_set_39(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_var_modifier(tokens, pos);
+                    pos = scan_var_modifier(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 if pos < tokens.len() && tokens[pos].kind == TK_ReadOnly {
@@ -10953,7 +10953,7 @@ fn scan_variable_statement(tokens: &Array<Token>, pos: i32) -> i32 {
                     if pos >= tokens.len() || tokens[pos].kind != TK_ReadOnly { pos = -1; } else { pos += 1; }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_variable_declaration_list(tokens, pos);
+                pos = scan_variable_declaration_list(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos < tokens.len() && tokens[pos].kind == TK_SemiColon {
                     let sp = pos;
@@ -10964,14 +10964,14 @@ fn scan_variable_statement(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_0: {
-                pos = scan_binding_pattern(tokens, pos);
+                pos = scan_binding_pattern(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos < tokens.len() && tokens[pos].kind == TK_LIT_COLON {
                     let sp = pos;
-                    pos = scan_type_annotation(tokens, pos);
+                    pos = scan_type_annotation(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_initializer(tokens, pos);
+                pos = scan_initializer(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos < tokens.len() && tokens[pos].kind == TK_SemiColon {
                     let sp = pos;
@@ -10986,12 +10986,12 @@ fn scan_variable_statement(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos < tokens.len() && _gale_kind_set_20(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_accessibility_modifier(tokens, pos);
+                    pos = scan_accessibility_modifier(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 if pos < tokens.len() && _gale_kind_set_39(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_var_modifier(tokens, pos);
+                    pos = scan_var_modifier(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 if pos < tokens.len() && tokens[pos].kind == TK_ReadOnly {
@@ -10999,7 +10999,7 @@ fn scan_variable_statement(tokens: &Array<Token>, pos: i32) -> i32 {
                     if pos >= tokens.len() || tokens[pos].kind != TK_ReadOnly { pos = -1; } else { pos += 1; }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_variable_declaration_list(tokens, pos);
+                pos = scan_variable_declaration_list(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos < tokens.len() && tokens[pos].kind == TK_SemiColon {
                     let sp = pos;
@@ -11016,10 +11016,10 @@ fn scan_variable_statement(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos < tokens.len() && _gale_kind_set_39(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_var_modifier(tokens, pos);
+                    pos = scan_var_modifier(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_variable_declaration_list(tokens, pos);
+                pos = scan_variable_declaration_list(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 if pos < tokens.len() && tokens[pos].kind == TK_SemiColon {
                     let sp = pos;
@@ -11036,9 +11036,9 @@ fn scan_variable_statement(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_variable_declaration_list(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_variable_declaration_list(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_variable_declaration(tokens, pos);
+    pos = scan_variable_declaration(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -11046,7 +11046,7 @@ fn scan_variable_declaration_list(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_43: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_43; }
                 pos += 1;
-                pos = scan_variable_declaration(tokens, pos);
+                pos = scan_variable_declaration(tokens, pos, 0);
                 if pos < 0 { break sg_43; }
                 break sg_43_done;
             }
@@ -11058,7 +11058,7 @@ fn scan_variable_declaration_list(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_variable_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_variable_declaration(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     let gp_44 = pos;
     let sgk_44 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -11066,19 +11066,19 @@ fn scan_variable_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_44: {
             pos = gp_44;
             sg_44_0: {
-                pos = scan_identifier_or_key_word(tokens, pos);
+                pos = scan_identifier_or_key_word(tokens, pos, 0);
                 if pos < 0 { break sg_44_0; }
                 break sg_44;
             }
             pos = gp_44;
             sg_44_1: {
-                pos = scan_array_literal(tokens, pos);
+                pos = scan_array_literal(tokens, pos, 0);
                 if pos < 0 { break sg_44_1; }
                 break sg_44;
             }
             pos = gp_44;
             sg_44_2: {
-                pos = scan_object_literal(tokens, pos);
+                pos = scan_object_literal(tokens, pos, 0);
                 if pos < 0 { break sg_44_2; }
                 break sg_44;
             }
@@ -11087,44 +11087,44 @@ fn scan_variable_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_COLON {
         let sp = pos;
-        pos = scan_type_annotation(tokens, pos);
+        pos = scan_type_annotation(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos < tokens.len() && _gale_kind_set_42(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_single_expression(tokens, pos);
+        pos = scan_single_expression(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_EQ && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_LT && pos + 2 < tokens.len() && _gale_kind_set_42(tokens[pos + 2].kind) {
         sol_45: {
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQ { break sol_45; }
             pos += 1;
-            pos = scan_type_parameters(tokens, pos);
+            pos = scan_type_parameters(tokens, pos, 0);
             if pos < 0 { break sol_45; }
-            pos = scan_single_expression(tokens, pos);
+            pos = scan_single_expression(tokens, pos, 0);
             if pos < 0 { break sol_45; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_LIT_EQ && pos + 1 < tokens.len() && _gale_kind_set_42(tokens[pos + 1].kind) {
         sol_46: {
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQ { break sol_46; }
             pos += 1;
-            pos = scan_single_expression(tokens, pos);
+            pos = scan_single_expression(tokens, pos, 0);
             if pos < 0 { break sol_46; }
         }
     }
     return pos;
 }
 
-fn scan_empty_statement_(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_empty_statement_(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_SemiColon { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_expression_statement(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_expression_statement(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_expression_sequence(tokens, pos);
+    pos = scan_expression_sequence(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_SemiColon {
         let sp = pos;
@@ -11134,17 +11134,17 @@ fn scan_expression_statement(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_if_statement(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_if_statement(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_If { return -1; }
     pos += 1;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_expression_sequence(tokens, pos);
+    pos = scan_expression_sequence(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_statement(tokens, pos);
+    pos = scan_statement(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_Else {
         let sp = pos;
@@ -11152,7 +11152,7 @@ fn scan_if_statement(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_47: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_Else { break sg_47; }
                 pos += 1;
-                pos = scan_statement(tokens, pos);
+                pos = scan_statement(tokens, pos, 0);
                 if pos < 0 { break sg_47; }
                 break sg_47_done;
             }
@@ -11163,7 +11163,7 @@ fn scan_if_statement(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_iteration_statement(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_iteration_statement(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -11173,17 +11173,17 @@ fn scan_iteration_statement(tokens: &Array<Token>, pos: i32) -> i32 {
             try_0: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_Do { break try_0; }
                 pos += 1;
-                pos = scan_statement(tokens, pos);
+                pos = scan_statement(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_While { break try_0; }
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_0; }
                 pos += 1;
-                pos = scan_expression_sequence(tokens, pos);
+                pos = scan_expression_sequence(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_0; }
                 pos += 1;
-                pos = scan_eos(tokens, pos);
+                pos = scan_eos(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -11195,11 +11195,11 @@ fn scan_iteration_statement(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_1; }
                 pos += 1;
-                pos = scan_expression_sequence(tokens, pos);
+                pos = scan_expression_sequence(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_1; }
                 pos += 1;
-                pos = scan_statement(tokens, pos);
+                pos = scan_statement(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -11211,27 +11211,27 @@ fn scan_iteration_statement(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_3; }
                 pos += 1;
-                pos = scan_var_modifier(tokens, pos);
+                pos = scan_var_modifier(tokens, pos, 0);
                 if pos < 0 { break try_3; }
-                pos = scan_variable_declaration_list(tokens, pos);
+                pos = scan_variable_declaration_list(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_SemiColon { break try_3; }
                 pos += 1;
                 if pos < tokens.len() && _gale_kind_set_42(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_expression_sequence(tokens, pos);
+                    pos = scan_expression_sequence(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_SemiColon { break try_3; }
                 pos += 1;
                 if pos < tokens.len() && _gale_kind_set_42(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_expression_sequence(tokens, pos);
+                    pos = scan_expression_sequence(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_3; }
                 pos += 1;
-                pos = scan_statement(tokens, pos);
+                pos = scan_statement(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -11246,13 +11246,13 @@ fn scan_iteration_statement(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_7; }
                 pos += 1;
-                pos = scan_var_modifier(tokens, pos);
+                pos = scan_var_modifier(tokens, pos, 0);
                 if pos < 0 { break try_7; }
-                pos = scan_variable_declaration(tokens, pos);
+                pos = scan_variable_declaration(tokens, pos, 0);
                 if pos < 0 { break try_7; }
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break try_7; }
-                pos = scan_expression_sequence(tokens, pos);
+                pos = scan_expression_sequence(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 if pos < tokens.len() && tokens[pos].kind == TK_As {
                     let sp = pos;
@@ -11260,7 +11260,7 @@ fn scan_iteration_statement(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_48: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_As { break sg_48; }
                             pos += 1;
-                            pos = scan_type_(tokens, pos);
+                            pos = scan_type_(tokens, pos, 0);
                             if pos < 0 { break sg_48; }
                             break sg_48_done;
                         }
@@ -11270,7 +11270,7 @@ fn scan_iteration_statement(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_7; }
                 pos += 1;
-                pos = scan_statement(tokens, pos);
+                pos = scan_statement(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 break scan_alts;
             }
@@ -11285,11 +11285,11 @@ fn scan_iteration_statement(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_6; }
                 pos += 1;
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break try_6; }
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break try_6; }
-                pos = scan_expression_sequence(tokens, pos);
+                pos = scan_expression_sequence(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 if pos < tokens.len() && tokens[pos].kind == TK_As {
                     let sp = pos;
@@ -11297,7 +11297,7 @@ fn scan_iteration_statement(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_49: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_As { break sg_49; }
                             pos += 1;
-                            pos = scan_type_(tokens, pos);
+                            pos = scan_type_(tokens, pos, 0);
                             if pos < 0 { break sg_49; }
                             break sg_49_done;
                         }
@@ -11307,7 +11307,7 @@ fn scan_iteration_statement(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_6; }
                 pos += 1;
-                pos = scan_statement(tokens, pos);
+                pos = scan_statement(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 break scan_alts;
             }
@@ -11319,26 +11319,26 @@ fn scan_iteration_statement(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos < tokens.len() && _gale_kind_set_42(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_expression_sequence(tokens, pos);
+                    pos = scan_expression_sequence(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_SemiColon { break try_2; }
                 pos += 1;
                 if pos < tokens.len() && _gale_kind_set_42(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_expression_sequence(tokens, pos);
+                    pos = scan_expression_sequence(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_SemiColon { break try_2; }
                 pos += 1;
                 if pos < tokens.len() && _gale_kind_set_42(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_expression_sequence(tokens, pos);
+                    pos = scan_expression_sequence(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_2; }
                 pos += 1;
-                pos = scan_statement(tokens, pos);
+                pos = scan_statement(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -11348,17 +11348,17 @@ fn scan_iteration_statement(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_5; }
                 pos += 1;
-                pos = scan_var_modifier(tokens, pos);
+                pos = scan_var_modifier(tokens, pos, 0);
                 if pos < 0 { break try_5; }
-                pos = scan_variable_declaration(tokens, pos);
+                pos = scan_variable_declaration(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_In { break try_5; }
                 pos += 1;
-                pos = scan_expression_sequence(tokens, pos);
+                pos = scan_expression_sequence(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_5; }
                 pos += 1;
-                pos = scan_statement(tokens, pos);
+                pos = scan_statement(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 break scan_alts;
             }
@@ -11368,15 +11368,15 @@ fn scan_iteration_statement(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_4; }
                 pos += 1;
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_In { break try_4; }
                 pos += 1;
-                pos = scan_expression_sequence(tokens, pos);
+                pos = scan_expression_sequence(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_4; }
                 pos += 1;
-                pos = scan_statement(tokens, pos);
+                pos = scan_statement(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 break scan_alts;
             }
@@ -11388,14 +11388,14 @@ fn scan_iteration_statement(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_var_modifier(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_var_modifier(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_39(tokens[pos].kind) {
         return pos + 1;
     }
     return -1;
 }
 
-fn scan_continue_statement(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_continue_statement(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Continue { return -1; }
     pos += 1;
@@ -11403,7 +11403,7 @@ fn scan_continue_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_50_done: {
             sg_50: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break sg_50; }
                 break sg_50_done;
             }
@@ -11411,12 +11411,12 @@ fn scan_continue_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_eos(tokens, pos);
+    pos = scan_eos(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_break_statement(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_break_statement(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Break { return -1; }
     pos += 1;
@@ -11424,7 +11424,7 @@ fn scan_break_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_51_done: {
             sg_51: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break sg_51; }
                 break sg_51_done;
             }
@@ -11432,12 +11432,12 @@ fn scan_break_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_eos(tokens, pos);
+    pos = scan_eos(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_return_statement(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_return_statement(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Return { return -1; }
     pos += 1;
@@ -11445,7 +11445,7 @@ fn scan_return_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_52_done: {
             sg_52: {
-                pos = scan_expression_sequence(tokens, pos);
+                pos = scan_expression_sequence(tokens, pos, 0);
                 if pos < 0 { break sg_52; }
                 break sg_52_done;
             }
@@ -11453,12 +11453,12 @@ fn scan_return_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_eos(tokens, pos);
+    pos = scan_eos(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_yield_statement(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_yield_statement(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     let gp_53 = pos;
     sg_53: {
@@ -11480,7 +11480,7 @@ fn scan_yield_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_54_done: {
             sg_54: {
-                pos = scan_expression_sequence(tokens, pos);
+                pos = scan_expression_sequence(tokens, pos, 0);
                 if pos < 0 { break sg_54; }
                 break sg_54_done;
             }
@@ -11488,60 +11488,60 @@ fn scan_yield_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_eos(tokens, pos);
+    pos = scan_eos(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_with_statement(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_with_statement(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_With { return -1; }
     pos += 1;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_expression_sequence(tokens, pos);
+    pos = scan_expression_sequence(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_statement(tokens, pos);
+    pos = scan_statement(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_switch_statement(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_switch_statement(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Switch { return -1; }
     pos += 1;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_expression_sequence(tokens, pos);
+    pos = scan_expression_sequence(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_case_block(tokens, pos);
+    pos = scan_case_block(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_case_block(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_case_block(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
     pos += 1;
     if pos < tokens.len() && tokens[pos].kind == TK_Case {
         let sp = pos;
-        pos = scan_case_clauses(tokens, pos);
+        pos = scan_case_clauses(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos < tokens.len() && tokens[pos].kind == TK_Default && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_Case {
         sol_55: {
-            pos = scan_default_clause(tokens, pos);
+            pos = scan_default_clause(tokens, pos, 0);
             if pos < 0 { break sol_55; }
-            pos = scan_case_clauses(tokens, pos);
+            pos = scan_case_clauses(tokens, pos, 0);
             if pos < 0 { break sol_55; }
         }
     } else if pos < tokens.len() && tokens[pos].kind == TK_Default {
         sol_56: {
-            pos = scan_default_clause(tokens, pos);
+            pos = scan_default_clause(tokens, pos, 0);
             if pos < 0 { break sol_56; }
         }
     }
@@ -11550,36 +11550,36 @@ fn scan_case_block(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_case_clauses(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_case_clauses(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_case_clause(tokens, pos);
+    pos = scan_case_clause(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_Case {
         let sp = pos;
-        pos = scan_case_clause(tokens, pos);
+        pos = scan_case_clause(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
     return pos;
 }
 
-fn scan_case_clause(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_case_clause(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Case { return -1; }
     pos += 1;
-    pos = scan_expression_sequence(tokens, pos);
+    pos = scan_expression_sequence(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_24(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_statement_list(tokens, pos);
+        pos = scan_statement_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     return pos;
 }
 
-fn scan_default_clause(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_default_clause(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Default { return -1; }
     pos += 1;
@@ -11587,39 +11587,39 @@ fn scan_default_clause(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_24(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_statement_list(tokens, pos);
+        pos = scan_statement_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     return pos;
 }
 
-fn scan_labelled_statement(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_labelled_statement(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { return -1; }
     pos += 1;
-    pos = scan_statement(tokens, pos);
+    pos = scan_statement(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_throw_statement(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_throw_statement(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Throw { return -1; }
     pos += 1;
-    pos = scan_expression_sequence(tokens, pos);
+    pos = scan_expression_sequence(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_eos(tokens, pos);
+    pos = scan_eos(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_try_statement(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_try_statement(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Try { return -1; }
     pos += 1;
-    pos = scan_block(tokens, pos);
+    pos = scan_block(tokens, pos, 0);
     if pos < 0 { return -1; }
     let gp_57 = pos;
     let sgk_57 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -11627,18 +11627,18 @@ fn scan_try_statement(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_57: {
             pos = gp_57;
             sg_57_0: {
-                pos = scan_catch_production(tokens, pos);
+                pos = scan_catch_production(tokens, pos, 0);
                 if pos < 0 { break sg_57_0; }
                 if pos < tokens.len() && tokens[pos].kind == TK_Finally {
                     let sp = pos;
-                    pos = scan_finally_production(tokens, pos);
+                    pos = scan_finally_production(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break sg_57;
             }
             pos = gp_57;
             sg_57_1: {
-                pos = scan_finally_production(tokens, pos);
+                pos = scan_finally_production(tokens, pos, 0);
                 if pos < 0 { break sg_57_1; }
                 break sg_57;
             }
@@ -11648,7 +11648,7 @@ fn scan_try_statement(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_catch_production(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_catch_production(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Catch { return -1; }
     pos += 1;
@@ -11656,9 +11656,9 @@ fn scan_catch_production(tokens: &Array<Token>, pos: i32) -> i32 {
         sol_58: {
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sol_58; }
             pos += 1;
-            pos = scan_identifier(tokens, pos);
+            pos = scan_identifier(tokens, pos, 0);
             if pos < 0 { break sol_58; }
-            pos = scan_type_annotation(tokens, pos);
+            pos = scan_type_annotation(tokens, pos, 0);
             if pos < 0 { break sol_58; }
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sol_58; }
             pos += 1;
@@ -11667,36 +11667,36 @@ fn scan_catch_production(tokens: &Array<Token>, pos: i32) -> i32 {
         sol_59: {
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break sol_59; }
             pos += 1;
-            pos = scan_identifier(tokens, pos);
+            pos = scan_identifier(tokens, pos, 0);
             if pos < 0 { break sol_59; }
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break sol_59; }
             pos += 1;
         }
     }
-    pos = scan_block(tokens, pos);
+    pos = scan_block(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_finally_production(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_finally_production(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Finally { return -1; }
     pos += 1;
-    pos = scan_block(tokens, pos);
+    pos = scan_block(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_debugger_statement(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_debugger_statement(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Debugger { return -1; }
     pos += 1;
-    pos = scan_eos(tokens, pos);
+    pos = scan_eos(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_function_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_function_declaration(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_Async {
         let sp = pos;
@@ -11710,9 +11710,9 @@ fn scan_function_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_STAR { pos = -1; } else { pos += 1; }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_call_signature(tokens, pos);
+    pos = scan_call_signature(tokens, pos, 0);
     if pos < 0 { return -1; }
     let gp_60 = pos;
     let sgk_60 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -11724,7 +11724,7 @@ fn scan_function_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_61: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { break sg_61; }
                         pos += 1;
-                        pos = scan_function_body(tokens, pos);
+                        pos = scan_function_body(tokens, pos, 0);
                         if pos < 0 { break sg_61; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { break sg_61; }
                         pos += 1;
@@ -11746,11 +11746,11 @@ fn scan_function_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_class_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_class_declaration(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_AT {
         let sp = pos;
-        pos = scan_decorator_list(tokens, pos);
+        pos = scan_decorator_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos < tokens.len() && tokens[pos].kind == TK_Export && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_Default {
@@ -11773,42 +11773,42 @@ fn scan_class_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_Class { return -1; }
     pos += 1;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_LT {
         let sp = pos;
-        pos = scan_type_parameters(tokens, pos);
+        pos = scan_type_parameters(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
-    pos = scan_class_heritage(tokens, pos);
+    pos = scan_class_heritage(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_class_tail(tokens, pos);
+    pos = scan_class_tail(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_class_heritage(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_class_heritage(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_Extends {
         let sp = pos;
-        pos = scan_class_extends_clause(tokens, pos);
+        pos = scan_class_extends_clause(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos < tokens.len() && tokens[pos].kind == TK_Implements {
         let sp = pos;
-        pos = scan_implements_clause(tokens, pos);
+        pos = scan_implements_clause(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     return pos;
 }
 
-fn scan_class_tail(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_class_tail(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
     pos += 1;
     while pos < tokens.len() && _gale_kind_set_24(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_class_element(tokens, pos);
+        pos = scan_class_element(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -11817,25 +11817,25 @@ fn scan_class_tail(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_class_extends_clause(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_class_extends_clause(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Extends { return -1; }
     pos += 1;
-    pos = scan_type_reference(tokens, pos);
+    pos = scan_type_reference(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_implements_clause(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_implements_clause(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Implements { return -1; }
     pos += 1;
-    pos = scan_class_or_interface_type_list(tokens, pos);
+    pos = scan_class_or_interface_type_list(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_class_element(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_class_element(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -11843,13 +11843,13 @@ fn scan_class_element(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_20(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_constructor_declaration(tokens, pos);
+                pos = scan_constructor_declaration(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_3: {
-                pos = scan_statement(tokens, pos);
+                pos = scan_statement(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -11857,10 +11857,10 @@ fn scan_class_element(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos < tokens.len() && tokens[pos].kind == TK_LIT_AT {
                     let sp = pos;
-                    pos = scan_decorator_list(tokens, pos);
+                    pos = scan_decorator_list(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_property_member_declaration(tokens, pos);
+                pos = scan_property_member_declaration(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -11868,13 +11868,13 @@ fn scan_class_element(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Constructor {
             pos = start;
             try_0: {
-                pos = scan_constructor_declaration(tokens, pos);
+                pos = scan_constructor_declaration(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_3: {
-                pos = scan_statement(tokens, pos);
+                pos = scan_statement(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -11882,7 +11882,7 @@ fn scan_class_element(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_44(alt_kind) {
             pos = start;
             try_3: {
-                pos = scan_statement(tokens, pos);
+                pos = scan_statement(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -11890,10 +11890,10 @@ fn scan_class_element(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos < tokens.len() && tokens[pos].kind == TK_LIT_AT {
                     let sp = pos;
-                    pos = scan_decorator_list(tokens, pos);
+                    pos = scan_decorator_list(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_property_member_declaration(tokens, pos);
+                pos = scan_property_member_declaration(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -11901,13 +11901,13 @@ fn scan_class_element(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_LBRACKET {
             pos = start;
             try_2: {
-                pos = scan_index_member_declaration(tokens, pos);
+                pos = scan_index_member_declaration(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
             pos = start;
             try_3: {
-                pos = scan_statement(tokens, pos);
+                pos = scan_statement(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -11915,7 +11915,7 @@ fn scan_class_element(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_45(alt_kind) {
             pos = start;
             try_3: {
-                pos = scan_statement(tokens, pos);
+                pos = scan_statement(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -11927,7 +11927,7 @@ fn scan_class_element(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_property_member_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_property_member_declaration(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -11935,9 +11935,9 @@ fn scan_property_member_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_46(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_property_member_base(tokens, pos);
+                pos = scan_property_member_base(tokens, pos, 0);
                 if pos < 0 { break try_0; }
-                pos = scan_property_name(tokens, pos);
+                pos = scan_property_name(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos < tokens.len() && tokens[pos].kind == TK_LIT_QUESTION {
                     let sp = pos;
@@ -11946,12 +11946,12 @@ fn scan_property_member_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos < tokens.len() && tokens[pos].kind == TK_LIT_COLON {
                     let sp = pos;
-                    pos = scan_type_annotation(tokens, pos);
+                    pos = scan_type_annotation(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 if pos < tokens.len() && tokens[pos].kind == TK_LIT_EQ {
                     let sp = pos;
-                    pos = scan_initializer(tokens, pos);
+                    pos = scan_initializer(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_SemiColon { break try_0; }
@@ -11960,11 +11960,11 @@ fn scan_property_member_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_1: {
-                pos = scan_property_member_base(tokens, pos);
+                pos = scan_property_member_base(tokens, pos, 0);
                 if pos < 0 { break try_1; }
-                pos = scan_property_name(tokens, pos);
+                pos = scan_property_name(tokens, pos, 0);
                 if pos < 0 { break try_1; }
-                pos = scan_call_signature(tokens, pos);
+                pos = scan_call_signature(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 let gp_64 = pos;
                 let sgk_64 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -11976,7 +11976,7 @@ fn scan_property_member_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
                                 sg_65: {
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { break sg_65; }
                                     pos += 1;
-                                    pos = scan_function_body(tokens, pos);
+                                    pos = scan_function_body(tokens, pos, 0);
                                     if pos < 0 { break sg_65; }
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { break sg_65; }
                                     pos += 1;
@@ -11999,7 +11999,7 @@ fn scan_property_member_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_2: {
-                pos = scan_property_member_base(tokens, pos);
+                pos = scan_property_member_base(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 let gp_66 = pos;
                 let sgk_66 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -12008,13 +12008,13 @@ fn scan_property_member_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_66: {
                         pos = gp_66;
                         sg_66_0: {
-                            pos = scan_get_accessor(tokens, pos);
+                            pos = scan_get_accessor(tokens, pos, 0);
                             if pos < 0 { break sg_66_0; }
                             if pos > sg_66_best { sg_66_best = pos; }
                         }
                         pos = gp_66;
                         sg_66_1: {
-                            pos = scan_set_accessor(tokens, pos);
+                            pos = scan_set_accessor(tokens, pos, 0);
                             if pos < 0 { break sg_66_1; }
                             if pos > sg_66_best { sg_66_best = pos; }
                         }
@@ -12028,15 +12028,15 @@ fn scan_property_member_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Abstract {
             pos = start;
             try_3: {
-                pos = scan_abstract_declaration(tokens, pos);
+                pos = scan_abstract_declaration(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
             pos = start;
             try_0: {
-                pos = scan_property_member_base(tokens, pos);
+                pos = scan_property_member_base(tokens, pos, 0);
                 if pos < 0 { break try_0; }
-                pos = scan_property_name(tokens, pos);
+                pos = scan_property_name(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos < tokens.len() && tokens[pos].kind == TK_LIT_QUESTION {
                     let sp = pos;
@@ -12045,12 +12045,12 @@ fn scan_property_member_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos < tokens.len() && tokens[pos].kind == TK_LIT_COLON {
                     let sp = pos;
-                    pos = scan_type_annotation(tokens, pos);
+                    pos = scan_type_annotation(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 if pos < tokens.len() && tokens[pos].kind == TK_LIT_EQ {
                     let sp = pos;
-                    pos = scan_initializer(tokens, pos);
+                    pos = scan_initializer(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_SemiColon { break try_0; }
@@ -12059,11 +12059,11 @@ fn scan_property_member_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_1: {
-                pos = scan_property_member_base(tokens, pos);
+                pos = scan_property_member_base(tokens, pos, 0);
                 if pos < 0 { break try_1; }
-                pos = scan_property_name(tokens, pos);
+                pos = scan_property_name(tokens, pos, 0);
                 if pos < 0 { break try_1; }
-                pos = scan_call_signature(tokens, pos);
+                pos = scan_call_signature(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 let gp_67 = pos;
                 let sgk_67 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -12075,7 +12075,7 @@ fn scan_property_member_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
                                 sg_68: {
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { break sg_68; }
                                     pos += 1;
-                                    pos = scan_function_body(tokens, pos);
+                                    pos = scan_function_body(tokens, pos, 0);
                                     if pos < 0 { break sg_68; }
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { break sg_68; }
                                     pos += 1;
@@ -12098,7 +12098,7 @@ fn scan_property_member_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_2: {
-                pos = scan_property_member_base(tokens, pos);
+                pos = scan_property_member_base(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 let gp_69 = pos;
                 let sgk_69 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -12107,13 +12107,13 @@ fn scan_property_member_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_69: {
                         pos = gp_69;
                         sg_69_0: {
-                            pos = scan_get_accessor(tokens, pos);
+                            pos = scan_get_accessor(tokens, pos, 0);
                             if pos < 0 { break sg_69_0; }
                             if pos > sg_69_best { sg_69_best = pos; }
                         }
                         pos = gp_69;
                         sg_69_1: {
-                            pos = scan_set_accessor(tokens, pos);
+                            pos = scan_set_accessor(tokens, pos, 0);
                             if pos < 0 { break sg_69_1; }
                             if pos > sg_69_best { sg_69_best = pos; }
                         }
@@ -12127,9 +12127,9 @@ fn scan_property_member_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_47(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_property_member_base(tokens, pos);
+                pos = scan_property_member_base(tokens, pos, 0);
                 if pos < 0 { break try_0; }
-                pos = scan_property_name(tokens, pos);
+                pos = scan_property_name(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos < tokens.len() && tokens[pos].kind == TK_LIT_QUESTION {
                     let sp = pos;
@@ -12138,12 +12138,12 @@ fn scan_property_member_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
                 }
                 if pos < tokens.len() && tokens[pos].kind == TK_LIT_COLON {
                     let sp = pos;
-                    pos = scan_type_annotation(tokens, pos);
+                    pos = scan_type_annotation(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 if pos < tokens.len() && tokens[pos].kind == TK_LIT_EQ {
                     let sp = pos;
-                    pos = scan_initializer(tokens, pos);
+                    pos = scan_initializer(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_SemiColon { break try_0; }
@@ -12152,11 +12152,11 @@ fn scan_property_member_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_1: {
-                pos = scan_property_member_base(tokens, pos);
+                pos = scan_property_member_base(tokens, pos, 0);
                 if pos < 0 { break try_1; }
-                pos = scan_property_name(tokens, pos);
+                pos = scan_property_name(tokens, pos, 0);
                 if pos < 0 { break try_1; }
-                pos = scan_call_signature(tokens, pos);
+                pos = scan_call_signature(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 let gp_70 = pos;
                 let sgk_70 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -12168,7 +12168,7 @@ fn scan_property_member_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
                                 sg_71: {
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { break sg_71; }
                                     pos += 1;
-                                    pos = scan_function_body(tokens, pos);
+                                    pos = scan_function_body(tokens, pos, 0);
                                     if pos < 0 { break sg_71; }
                                     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { break sg_71; }
                                     pos += 1;
@@ -12197,11 +12197,11 @@ fn scan_property_member_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_property_member_base(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_property_member_base(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && _gale_kind_set_20(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_accessibility_modifier(tokens, pos);
+        pos = scan_accessibility_modifier(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos < tokens.len() && tokens[pos].kind == TK_Async {
@@ -12222,16 +12222,16 @@ fn scan_property_member_base(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_index_member_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_index_member_declaration(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_index_signature(tokens, pos);
+    pos = scan_index_signature(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_SemiColon { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_generator_method(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_generator_method(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_Async {
         let sp = pos;
@@ -12250,27 +12250,27 @@ fn scan_generator_method(tokens: &Array<Token>, pos: i32) -> i32 {
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_STAR { pos = -1; } else { pos += 1; }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_property_name(tokens, pos);
+    pos = scan_property_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_21(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_formal_parameter_list(tokens, pos);
+        pos = scan_formal_parameter_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
     pos += 1;
-    pos = scan_function_body(tokens, pos);
+    pos = scan_function_body(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_generator_function_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_generator_function_declaration(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_Async {
         let sp = pos;
@@ -12283,32 +12283,32 @@ fn scan_generator_function_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_identifier(tokens, pos);
+        pos = scan_identifier(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_21(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_formal_parameter_list(tokens, pos);
+        pos = scan_formal_parameter_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
     pos += 1;
-    pos = scan_function_body(tokens, pos);
+    pos = scan_function_body(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_generator_block(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_generator_block(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
     pos += 1;
-    pos = scan_generator_definition(tokens, pos);
+    pos = scan_generator_definition(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -12316,7 +12316,7 @@ fn scan_generator_block(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_73: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_73; }
                 pos += 1;
-                pos = scan_generator_definition(tokens, pos);
+                pos = scan_generator_definition(tokens, pos, 0);
                 if pos < 0 { break sg_73; }
                 break sg_73_done;
             }
@@ -12335,20 +12335,20 @@ fn scan_generator_block(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_generator_definition(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_generator_definition(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_STAR { return -1; }
     pos += 1;
-    pos = scan_iterator_definition(tokens, pos);
+    pos = scan_iterator_definition(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_iterator_block(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_iterator_block(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
     pos += 1;
-    pos = scan_iterator_definition(tokens, pos);
+    pos = scan_iterator_definition(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -12356,7 +12356,7 @@ fn scan_iterator_block(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_74: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_74; }
                 pos += 1;
-                pos = scan_iterator_definition(tokens, pos);
+                pos = scan_iterator_definition(tokens, pos, 0);
                 if pos < 0 { break sg_74; }
                 break sg_74_done;
             }
@@ -12375,11 +12375,11 @@ fn scan_iterator_block(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_iterator_definition(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_iterator_definition(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { return -1; }
     pos += 1;
-    pos = scan_single_expression(tokens, pos);
+    pos = scan_single_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { return -1; }
     pos += 1;
@@ -12387,21 +12387,21 @@ fn scan_iterator_definition(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_21(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_formal_parameter_list(tokens, pos);
+        pos = scan_formal_parameter_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
     pos += 1;
-    pos = scan_function_body(tokens, pos);
+    pos = scan_function_body(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_class_element_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_class_element_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -12409,7 +12409,7 @@ fn scan_class_element_name(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_23(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_property_name(tokens, pos);
+                pos = scan_property_name(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -12417,7 +12417,7 @@ fn scan_class_element_name(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_HASH {
             pos = start;
             try_1: {
-                pos = scan_private_identifier(tokens, pos);
+                pos = scan_private_identifier(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -12429,16 +12429,16 @@ fn scan_class_element_name(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_private_identifier(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_private_identifier(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_HASH { return -1; }
     pos += 1;
-    pos = scan_identifier_name(tokens, pos);
+    pos = scan_identifier_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_formal_parameter_list(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_formal_parameter_list(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -12446,7 +12446,7 @@ fn scan_formal_parameter_list(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_48(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_formal_parameter_arg(tokens, pos);
+                pos = scan_formal_parameter_arg(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -12454,7 +12454,7 @@ fn scan_formal_parameter_list(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_75: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_75; }
                             pos += 1;
-                            pos = scan_formal_parameter_arg(tokens, pos);
+                            pos = scan_formal_parameter_arg(tokens, pos, 0);
                             if pos < 0 { break sg_75; }
                             break sg_75_done;
                         }
@@ -12469,7 +12469,7 @@ fn scan_formal_parameter_list(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_76: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_76; }
                             pos += 1;
-                            pos = scan_last_formal_parameter_arg(tokens, pos);
+                            pos = scan_last_formal_parameter_arg(tokens, pos, 0);
                             if pos < 0 { break sg_76; }
                             break sg_76_done;
                         }
@@ -12488,13 +12488,13 @@ fn scan_formal_parameter_list(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_LBRACKET {
             pos = start;
             try_2: {
-                pos = scan_array_literal(tokens, pos);
+                pos = scan_array_literal(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
             pos = start;
             try_0: {
-                pos = scan_formal_parameter_arg(tokens, pos);
+                pos = scan_formal_parameter_arg(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -12502,7 +12502,7 @@ fn scan_formal_parameter_list(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_77: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_77; }
                             pos += 1;
-                            pos = scan_formal_parameter_arg(tokens, pos);
+                            pos = scan_formal_parameter_arg(tokens, pos, 0);
                             if pos < 0 { break sg_77; }
                             break sg_77_done;
                         }
@@ -12517,7 +12517,7 @@ fn scan_formal_parameter_list(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_78: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_78; }
                             pos += 1;
-                            pos = scan_last_formal_parameter_arg(tokens, pos);
+                            pos = scan_last_formal_parameter_arg(tokens, pos, 0);
                             if pos < 0 { break sg_78; }
                             break sg_78_done;
                         }
@@ -12536,7 +12536,7 @@ fn scan_formal_parameter_list(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_LBRACE {
             pos = start;
             try_0: {
-                pos = scan_formal_parameter_arg(tokens, pos);
+                pos = scan_formal_parameter_arg(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                     let sp = pos;
@@ -12544,7 +12544,7 @@ fn scan_formal_parameter_list(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_79: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_79; }
                             pos += 1;
-                            pos = scan_formal_parameter_arg(tokens, pos);
+                            pos = scan_formal_parameter_arg(tokens, pos, 0);
                             if pos < 0 { break sg_79; }
                             break sg_79_done;
                         }
@@ -12559,7 +12559,7 @@ fn scan_formal_parameter_list(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_80: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_80; }
                             pos += 1;
-                            pos = scan_last_formal_parameter_arg(tokens, pos);
+                            pos = scan_last_formal_parameter_arg(tokens, pos, 0);
                             if pos < 0 { break sg_80; }
                             break sg_80_done;
                         }
@@ -12576,7 +12576,7 @@ fn scan_formal_parameter_list(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_3: {
-                pos = scan_object_literal(tokens, pos);
+                pos = scan_object_literal(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 if pos < tokens.len() && tokens[pos].kind == TK_LIT_COLON {
                     let sp = pos;
@@ -12584,7 +12584,7 @@ fn scan_formal_parameter_list(tokens: &Array<Token>, pos: i32) -> i32 {
                         sg_81: {
                             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { break sg_81; }
                             pos += 1;
-                            pos = scan_formal_parameter_list(tokens, pos);
+                            pos = scan_formal_parameter_list(tokens, pos, 0);
                             if pos < 0 { break sg_81; }
                             break sg_81_done;
                         }
@@ -12598,7 +12598,7 @@ fn scan_formal_parameter_list(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Ellipsis {
             pos = start;
             try_1: {
-                pos = scan_last_formal_parameter_arg(tokens, pos);
+                pos = scan_last_formal_parameter_arg(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -12610,14 +12610,14 @@ fn scan_formal_parameter_list(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_formal_parameter_arg(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_formal_parameter_arg(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_AT {
         let sp = pos;
-        pos = scan_decorator(tokens, pos);
+        pos = scan_decorator(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
-    pos = scan_assignable(tokens, pos);
+    pos = scan_assignable(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_QUESTION {
         let sp = pos;
@@ -12626,7 +12626,7 @@ fn scan_formal_parameter_arg(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_COLON {
         let sp = pos;
-        pos = scan_type_annotation(tokens, pos);
+        pos = scan_type_annotation(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_EQ {
@@ -12635,7 +12635,7 @@ fn scan_formal_parameter_arg(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_82: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQ { break sg_82; }
                 pos += 1;
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break sg_82; }
                 break sg_82_done;
             }
@@ -12646,50 +12646,50 @@ fn scan_formal_parameter_arg(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_last_formal_parameter_arg(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_last_formal_parameter_arg(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Ellipsis { return -1; }
     pos += 1;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_COLON {
         let sp = pos;
-        pos = scan_type_annotation(tokens, pos);
+        pos = scan_type_annotation(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     return pos;
 }
 
-fn scan_function_body(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_function_body(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && _gale_kind_set_24(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_source_elements(tokens, pos);
+        pos = scan_source_elements(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     return pos;
 }
 
-fn scan_source_elements(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_source_elements(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_source_element(tokens, pos);
+    pos = scan_source_element(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && _gale_kind_set_24(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_source_element(tokens, pos);
+        pos = scan_source_element(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
     return pos;
 }
 
-fn scan_array_literal(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_array_literal(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     sg_83_done: {
         sg_83: {
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break sg_83; }
             pos += 1;
-            pos = scan_element_list(tokens, pos);
+            pos = scan_element_list(tokens, pos, 0);
             if pos < 0 { break sg_83; }
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break sg_83; }
             pos += 1;
@@ -12700,7 +12700,7 @@ fn scan_array_literal(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_element_list(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_element_list(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -12710,7 +12710,7 @@ fn scan_element_list(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     if pos < tokens.len() && _gale_kind_set_49(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_array_element(tokens, pos);
+        pos = scan_array_element(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
@@ -12725,7 +12725,7 @@ fn scan_element_list(tokens: &Array<Token>, pos: i32) -> i32 {
                     if pos < 0 { pos = sp; break; }
                     if pos == sp { break; }
                 }
-                pos = scan_array_element(tokens, pos);
+                pos = scan_array_element(tokens, pos, 0);
                 if pos < 0 { break sg_84; }
                 break sg_84_done;
             }
@@ -12743,7 +12743,7 @@ fn scan_element_list(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_array_element(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_array_element(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_Ellipsis {
         let sp = pos;
@@ -12757,13 +12757,13 @@ fn scan_array_element(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_85: {
             pos = gp_85;
             sg_85_0: {
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break sg_85_0; }
                 if pos > sg_85_best { sg_85_best = pos; }
             }
             pos = gp_85;
             sg_85_1: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break sg_85_1; }
                 if pos > sg_85_best { sg_85_best = pos; }
             }
@@ -12779,13 +12779,13 @@ fn scan_array_element(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_object_literal(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_object_literal(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_50(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_COMMA && pos + 2 < tokens.len() && tokens[pos + 2].kind == TK_LIT_COMMA {
         sol_86: {
-            pos = scan_property_assignment(tokens, pos);
+            pos = scan_property_assignment(tokens, pos, 0);
             if pos < 0 { break sol_86; }
             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                 let sp = pos;
@@ -12793,7 +12793,7 @@ fn scan_object_literal(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_87: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_87; }
                         pos += 1;
-                        pos = scan_property_assignment(tokens, pos);
+                        pos = scan_property_assignment(tokens, pos, 0);
                         if pos < 0 { break sg_87; }
                         break sg_87_done;
                     }
@@ -12807,14 +12807,14 @@ fn scan_object_literal(tokens: &Array<Token>, pos: i32) -> i32 {
         }
     } else if pos < tokens.len() && _gale_kind_set_50(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_COMMA {
         sol_88: {
-            pos = scan_property_assignment(tokens, pos);
+            pos = scan_property_assignment(tokens, pos, 0);
             if pos < 0 { break sol_88; }
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sol_88; }
             pos += 1;
         }
     } else if pos < tokens.len() && _gale_kind_set_50(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_COMMA {
         sol_89: {
-            pos = scan_property_assignment(tokens, pos);
+            pos = scan_property_assignment(tokens, pos, 0);
             if pos < 0 { break sol_89; }
             while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
                 let sp = pos;
@@ -12822,7 +12822,7 @@ fn scan_object_literal(tokens: &Array<Token>, pos: i32) -> i32 {
                     sg_90: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_90; }
                         pos += 1;
-                        pos = scan_property_assignment(tokens, pos);
+                        pos = scan_property_assignment(tokens, pos, 0);
                         if pos < 0 { break sg_90; }
                         break sg_90_done;
                     }
@@ -12834,7 +12834,7 @@ fn scan_object_literal(tokens: &Array<Token>, pos: i32) -> i32 {
         }
     } else if pos < tokens.len() && _gale_kind_set_50(tokens[pos].kind) {
         sol_91: {
-            pos = scan_property_assignment(tokens, pos);
+            pos = scan_property_assignment(tokens, pos, 0);
             if pos < 0 { break sol_91; }
         }
     }
@@ -12843,7 +12843,7 @@ fn scan_object_literal(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_property_assignment(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_property_assignment(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -12851,31 +12851,31 @@ fn scan_property_assignment(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_2(alt_kind) {
             pos = start;
             try_2: {
-                pos = scan_get_accessor(tokens, pos);
+                pos = scan_get_accessor(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
             pos = start;
             try_3: {
-                pos = scan_set_accessor(tokens, pos);
+                pos = scan_set_accessor(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
             pos = start;
             try_4: {
-                pos = scan_generator_method(tokens, pos);
+                pos = scan_generator_method(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 break scan_alts;
             }
             pos = start;
             try_5: {
-                pos = scan_identifier_or_key_word(tokens, pos);
+                pos = scan_identifier_or_key_word(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 break scan_alts;
             }
             pos = start;
             try_0: {
-                pos = scan_property_name(tokens, pos);
+                pos = scan_property_name(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 let gp_92 = pos;
                 sg_92: {
@@ -12893,7 +12893,7 @@ fn scan_property_assignment(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     break try_0;
                 }
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -12904,7 +12904,7 @@ fn scan_property_assignment(tokens: &Array<Token>, pos: i32) -> i32 {
                     if pos >= tokens.len() || tokens[pos].kind != TK_Ellipsis { pos = -1; } else { pos += 1; }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 break scan_alts;
             }
@@ -12912,13 +12912,13 @@ fn scan_property_assignment(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_51(alt_kind) {
             pos = start;
             try_4: {
-                pos = scan_generator_method(tokens, pos);
+                pos = scan_generator_method(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 break scan_alts;
             }
             pos = start;
             try_0: {
-                pos = scan_property_name(tokens, pos);
+                pos = scan_property_name(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 let gp_93 = pos;
                 sg_93: {
@@ -12936,7 +12936,7 @@ fn scan_property_assignment(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     break try_0;
                 }
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -12947,7 +12947,7 @@ fn scan_property_assignment(tokens: &Array<Token>, pos: i32) -> i32 {
                     if pos >= tokens.len() || tokens[pos].kind != TK_Ellipsis { pos = -1; } else { pos += 1; }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 break scan_alts;
             }
@@ -12955,19 +12955,19 @@ fn scan_property_assignment(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Require {
             pos = start;
             try_4: {
-                pos = scan_generator_method(tokens, pos);
+                pos = scan_generator_method(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 break scan_alts;
             }
             pos = start;
             try_5: {
-                pos = scan_identifier_or_key_word(tokens, pos);
+                pos = scan_identifier_or_key_word(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 break scan_alts;
             }
             pos = start;
             try_0: {
-                pos = scan_property_name(tokens, pos);
+                pos = scan_property_name(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 let gp_94 = pos;
                 sg_94: {
@@ -12985,7 +12985,7 @@ fn scan_property_assignment(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     break try_0;
                 }
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -12996,7 +12996,7 @@ fn scan_property_assignment(tokens: &Array<Token>, pos: i32) -> i32 {
                     if pos >= tokens.len() || tokens[pos].kind != TK_Ellipsis { pos = -1; } else { pos += 1; }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 break scan_alts;
             }
@@ -13006,25 +13006,25 @@ fn scan_property_assignment(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break try_1; }
                 pos += 1;
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break try_1; }
                 pos += 1;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { break try_1; }
                 pos += 1;
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_4: {
-                pos = scan_generator_method(tokens, pos);
+                pos = scan_generator_method(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 break scan_alts;
             }
             pos = start;
             try_0: {
-                pos = scan_property_name(tokens, pos);
+                pos = scan_property_name(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 let gp_95 = pos;
                 sg_95: {
@@ -13042,7 +13042,7 @@ fn scan_property_assignment(tokens: &Array<Token>, pos: i32) -> i32 {
                     }
                     break try_0;
                 }
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -13053,7 +13053,7 @@ fn scan_property_assignment(tokens: &Array<Token>, pos: i32) -> i32 {
                     if pos >= tokens.len() || tokens[pos].kind != TK_Ellipsis { pos = -1; } else { pos += 1; }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 break scan_alts;
             }
@@ -13061,7 +13061,7 @@ fn scan_property_assignment(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_STAR {
             pos = start;
             try_4: {
-                pos = scan_generator_method(tokens, pos);
+                pos = scan_generator_method(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 break scan_alts;
             }
@@ -13074,7 +13074,7 @@ fn scan_property_assignment(tokens: &Array<Token>, pos: i32) -> i32 {
                     if pos >= tokens.len() || tokens[pos].kind != TK_Ellipsis { pos = -1; } else { pos += 1; }
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 break scan_alts;
             }
@@ -13082,7 +13082,7 @@ fn scan_property_assignment(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_DOTDOTDOT {
             pos = start;
             try_7: {
-                pos = scan_rest_parameter(tokens, pos);
+                pos = scan_rest_parameter(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 break scan_alts;
             }
@@ -13094,9 +13094,9 @@ fn scan_property_assignment(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_get_accessor(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_get_accessor(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_getter(tokens, pos);
+    pos = scan_getter(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
@@ -13104,41 +13104,41 @@ fn scan_get_accessor(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_COLON {
         let sp = pos;
-        pos = scan_type_annotation(tokens, pos);
+        pos = scan_type_annotation(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
     pos += 1;
-    pos = scan_function_body(tokens, pos);
+    pos = scan_function_body(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_set_accessor(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_set_accessor(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_setter(tokens, pos);
+    pos = scan_setter(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_21(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_formal_parameter_list(tokens, pos);
+        pos = scan_formal_parameter_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
     pos += 1;
-    pos = scan_function_body(tokens, pos);
+    pos = scan_function_body(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
     pos += 1;
     return pos;
 }
 
-fn scan_property_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_property_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -13146,7 +13146,7 @@ fn scan_property_name(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_16(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_identifier_name(tokens, pos);
+                pos = scan_identifier_name(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -13162,7 +13162,7 @@ fn scan_property_name(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_53(alt_kind) {
             pos = start;
             try_2: {
-                pos = scan_numeric_literal(tokens, pos);
+                pos = scan_numeric_literal(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -13172,7 +13172,7 @@ fn scan_property_name(tokens: &Array<Token>, pos: i32) -> i32 {
             try_3: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break try_3; }
                 pos += 1;
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break try_3; }
                 pos += 1;
@@ -13186,20 +13186,20 @@ fn scan_property_name(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_arguments(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_arguments(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_49(tokens[pos].kind) && pos + 1 < tokens.len() && tokens[pos + 1].kind == TK_LIT_COMMA {
         sol_96: {
-            pos = scan_argument_list(tokens, pos);
+            pos = scan_argument_list(tokens, pos, 0);
             if pos < 0 { break sol_96; }
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sol_96; }
             pos += 1;
         }
     } else if pos < tokens.len() && _gale_kind_set_49(tokens[pos].kind) {
         sol_97: {
-            pos = scan_argument_list(tokens, pos);
+            pos = scan_argument_list(tokens, pos, 0);
             if pos < 0 { break sol_97; }
         }
     }
@@ -13208,9 +13208,9 @@ fn scan_arguments(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_argument_list(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_argument_list(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_argument(tokens, pos);
+    pos = scan_argument(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -13218,7 +13218,7 @@ fn scan_argument_list(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_98: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_98; }
                 pos += 1;
-                pos = scan_argument(tokens, pos);
+                pos = scan_argument(tokens, pos, 0);
                 if pos < 0 { break sg_98; }
                 break sg_98_done;
             }
@@ -13230,7 +13230,7 @@ fn scan_argument_list(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_argument(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_argument(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_Ellipsis {
         let sp = pos;
@@ -13244,13 +13244,13 @@ fn scan_argument(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_99: {
             pos = gp_99;
             sg_99_0: {
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break sg_99_0; }
                 if pos > sg_99_best { sg_99_best = pos; }
             }
             pos = gp_99;
             sg_99_1: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break sg_99_1; }
                 if pos > sg_99_best { sg_99_best = pos; }
             }
@@ -13261,9 +13261,9 @@ fn scan_argument(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_expression_sequence(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_expression_sequence(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_single_expression(tokens, pos);
+    pos = scan_single_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -13271,7 +13271,7 @@ fn scan_expression_sequence(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_100: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_100; }
                 pos += 1;
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break sg_100; }
                 break sg_100_done;
             }
@@ -13291,23 +13291,23 @@ fn scan_single_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_54(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_anonymous_function(tokens, pos);
+                pos = scan_anonymous_function(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_16: {
-                pos = scan_generator_function_declaration(tokens, pos);
+                pos = scan_generator_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_16; }
                 break scan_alts;
             }
             pos = start;
             try_19: {
-                pos = scan_identifier_name(tokens, pos);
+                pos = scan_identifier_name(tokens, pos, 0);
                 if pos < 0 { break try_19; }
                 if pos < tokens.len() && _gale_kind_set_42(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_single_expression(tokens, pos);
+                    pos = scan_single_expression(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break scan_alts;
@@ -13316,17 +13316,17 @@ fn scan_single_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_55(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_anonymous_function(tokens, pos);
+                pos = scan_anonymous_function(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_19: {
-                pos = scan_identifier_name(tokens, pos);
+                pos = scan_identifier_name(tokens, pos, 0);
                 if pos < 0 { break try_19; }
                 if pos < tokens.len() && _gale_kind_set_42(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_single_expression(tokens, pos);
+                    pos = scan_single_expression(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break scan_alts;
@@ -13335,23 +13335,23 @@ fn scan_single_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Yield {
             pos = start;
             try_0: {
-                pos = scan_anonymous_function(tokens, pos);
+                pos = scan_anonymous_function(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_17: {
-                pos = scan_yield_statement(tokens, pos);
+                pos = scan_yield_statement(tokens, pos, 0);
                 if pos < 0 { break try_17; }
                 break scan_alts;
             }
             pos = start;
             try_19: {
-                pos = scan_identifier_name(tokens, pos);
+                pos = scan_identifier_name(tokens, pos, 0);
                 if pos < 0 { break try_19; }
                 if pos < tokens.len() && _gale_kind_set_42(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_single_expression(tokens, pos);
+                    pos = scan_single_expression(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break scan_alts;
@@ -13362,23 +13362,23 @@ fn scan_single_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_6: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_Typeof { break try_6; }
                 pos += 1;
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 break scan_alts;
             }
             pos = start;
             try_0: {
-                pos = scan_anonymous_function(tokens, pos);
+                pos = scan_anonymous_function(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_19: {
-                pos = scan_identifier_name(tokens, pos);
+                pos = scan_identifier_name(tokens, pos, 0);
                 if pos < 0 { break try_19; }
                 if pos < tokens.len() && _gale_kind_set_42(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_single_expression(tokens, pos);
+                    pos = scan_single_expression(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break scan_alts;
@@ -13389,14 +13389,14 @@ fn scan_single_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_2: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_New { break try_2; }
                 pos += 1;
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 if pos < tokens.len() && tokens[pos].kind == TK_LIT_LT {
                     let sp = pos;
-                    pos = scan_type_arguments(tokens, pos);
+                    pos = scan_type_arguments(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_arguments(tokens, pos);
+                pos = scan_arguments(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -13404,28 +13404,28 @@ fn scan_single_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_3: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_New { break try_3; }
                 pos += 1;
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 if pos < tokens.len() && tokens[pos].kind == TK_LIT_LT {
                     let sp = pos;
-                    pos = scan_type_arguments(tokens, pos);
+                    pos = scan_type_arguments(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break scan_alts;
             }
             pos = start;
             try_0: {
-                pos = scan_anonymous_function(tokens, pos);
+                pos = scan_anonymous_function(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_19: {
-                pos = scan_identifier_name(tokens, pos);
+                pos = scan_identifier_name(tokens, pos, 0);
                 if pos < 0 { break try_19; }
                 if pos < tokens.len() && _gale_kind_set_42(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_single_expression(tokens, pos);
+                    pos = scan_single_expression(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break scan_alts;
@@ -13436,23 +13436,23 @@ fn scan_single_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_5: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_Void { break try_5; }
                 pos += 1;
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 break scan_alts;
             }
             pos = start;
             try_0: {
-                pos = scan_anonymous_function(tokens, pos);
+                pos = scan_anonymous_function(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_19: {
-                pos = scan_identifier_name(tokens, pos);
+                pos = scan_identifier_name(tokens, pos, 0);
                 if pos < 0 { break try_19; }
                 if pos < tokens.len() && _gale_kind_set_42(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_single_expression(tokens, pos);
+                    pos = scan_single_expression(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break scan_alts;
@@ -13461,17 +13461,17 @@ fn scan_single_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_This {
             pos = start;
             try_0: {
-                pos = scan_anonymous_function(tokens, pos);
+                pos = scan_anonymous_function(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_19: {
-                pos = scan_identifier_name(tokens, pos);
+                pos = scan_identifier_name(tokens, pos, 0);
                 if pos < 0 { break try_19; }
                 if pos < tokens.len() && _gale_kind_set_42(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_single_expression(tokens, pos);
+                    pos = scan_single_expression(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break scan_alts;
@@ -13488,23 +13488,23 @@ fn scan_single_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_4: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_Delete { break try_4; }
                 pos += 1;
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break try_4; }
                 break scan_alts;
             }
             pos = start;
             try_0: {
-                pos = scan_anonymous_function(tokens, pos);
+                pos = scan_anonymous_function(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_19: {
-                pos = scan_identifier_name(tokens, pos);
+                pos = scan_identifier_name(tokens, pos, 0);
                 if pos < 0 { break try_19; }
                 if pos < tokens.len() && _gale_kind_set_42(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_single_expression(tokens, pos);
+                    pos = scan_single_expression(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break scan_alts;
@@ -13517,33 +13517,33 @@ fn scan_single_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_identifier(tokens, pos);
+                    pos = scan_identifier(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 if pos < tokens.len() && tokens[pos].kind == TK_LIT_LT {
                     let sp = pos;
-                    pos = scan_type_parameters(tokens, pos);
+                    pos = scan_type_parameters(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
-                pos = scan_class_heritage(tokens, pos);
+                pos = scan_class_heritage(tokens, pos, 0);
                 if pos < 0 { break try_1; }
-                pos = scan_class_tail(tokens, pos);
+                pos = scan_class_tail(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_0: {
-                pos = scan_anonymous_function(tokens, pos);
+                pos = scan_anonymous_function(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_19: {
-                pos = scan_identifier_name(tokens, pos);
+                pos = scan_identifier_name(tokens, pos, 0);
                 if pos < 0 { break try_19; }
                 if pos < tokens.len() && _gale_kind_set_42(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_single_expression(tokens, pos);
+                    pos = scan_single_expression(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break scan_alts;
@@ -13552,17 +13552,17 @@ fn scan_single_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_Super {
             pos = start;
             try_0: {
-                pos = scan_anonymous_function(tokens, pos);
+                pos = scan_anonymous_function(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_19: {
-                pos = scan_identifier_name(tokens, pos);
+                pos = scan_identifier_name(tokens, pos, 0);
                 if pos < 0 { break try_19; }
                 if pos < tokens.len() && _gale_kind_set_42(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_single_expression(tokens, pos);
+                    pos = scan_single_expression(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break scan_alts;
@@ -13579,23 +13579,23 @@ fn scan_single_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_13: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_Await { break try_13; }
                 pos += 1;
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break try_13; }
                 break scan_alts;
             }
             pos = start;
             try_0: {
-                pos = scan_anonymous_function(tokens, pos);
+                pos = scan_anonymous_function(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_19: {
-                pos = scan_identifier_name(tokens, pos);
+                pos = scan_identifier_name(tokens, pos, 0);
                 if pos < 0 { break try_19; }
                 if pos < tokens.len() && _gale_kind_set_42(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_single_expression(tokens, pos);
+                    pos = scan_single_expression(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break scan_alts;
@@ -13604,23 +13604,23 @@ fn scan_single_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_56(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_anonymous_function(tokens, pos);
+                pos = scan_anonymous_function(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_21: {
-                pos = scan_literal(tokens, pos);
+                pos = scan_literal(tokens, pos, 0);
                 if pos < 0 { break try_21; }
                 break scan_alts;
             }
             pos = start;
             try_19: {
-                pos = scan_identifier_name(tokens, pos);
+                pos = scan_identifier_name(tokens, pos, 0);
                 if pos < 0 { break try_19; }
                 if pos < tokens.len() && _gale_kind_set_42(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_single_expression(tokens, pos);
+                    pos = scan_single_expression(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break scan_alts;
@@ -13629,13 +13629,13 @@ fn scan_single_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_57(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_anonymous_function(tokens, pos);
+                pos = scan_anonymous_function(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_21: {
-                pos = scan_literal(tokens, pos);
+                pos = scan_literal(tokens, pos, 0);
                 if pos < 0 { break try_21; }
                 break scan_alts;
             }
@@ -13643,13 +13643,13 @@ fn scan_single_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_LBRACKET {
             pos = start;
             try_0: {
-                pos = scan_anonymous_function(tokens, pos);
+                pos = scan_anonymous_function(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_22: {
-                pos = scan_array_literal(tokens, pos);
+                pos = scan_array_literal(tokens, pos, 0);
                 if pos < 0 { break try_22; }
                 break scan_alts;
             }
@@ -13659,7 +13659,7 @@ fn scan_single_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_24: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_24; }
                 pos += 1;
-                pos = scan_expression_sequence(tokens, pos);
+                pos = scan_expression_sequence(tokens, pos, 0);
                 if pos < 0 { break try_24; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_24; }
                 pos += 1;
@@ -13667,7 +13667,7 @@ fn scan_single_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_0: {
-                pos = scan_anonymous_function(tokens, pos);
+                pos = scan_anonymous_function(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -13677,7 +13677,7 @@ fn scan_single_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_7: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_PLUSPLUS { break try_7; }
                 pos += 1;
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break try_7; }
                 break scan_alts;
             }
@@ -13687,7 +13687,7 @@ fn scan_single_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_8: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_MINUSMINUS { break try_8; }
                 pos += 1;
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break try_8; }
                 break scan_alts;
             }
@@ -13697,7 +13697,7 @@ fn scan_single_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_9: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_PLUS { break try_9; }
                 pos += 1;
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break try_9; }
                 break scan_alts;
             }
@@ -13707,7 +13707,7 @@ fn scan_single_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_10: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_MINUS { break try_10; }
                 pos += 1;
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break try_10; }
                 break scan_alts;
             }
@@ -13717,7 +13717,7 @@ fn scan_single_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_11: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_TILDE { break try_11; }
                 pos += 1;
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break try_11; }
                 break scan_alts;
             }
@@ -13727,7 +13727,7 @@ fn scan_single_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_12: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_BANG { break try_12; }
                 pos += 1;
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break try_12; }
                 break scan_alts;
             }
@@ -13735,19 +13735,19 @@ fn scan_single_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_LBRACE {
             pos = start;
             try_14: {
-                pos = scan_iterator_block(tokens, pos);
+                pos = scan_iterator_block(tokens, pos, 0);
                 if pos < 0 { break try_14; }
                 break scan_alts;
             }
             pos = start;
             try_15: {
-                pos = scan_generator_block(tokens, pos);
+                pos = scan_generator_block(tokens, pos, 0);
                 if pos < 0 { break try_15; }
                 break scan_alts;
             }
             pos = start;
             try_23: {
-                pos = scan_object_literal(tokens, pos);
+                pos = scan_object_literal(tokens, pos, 0);
                 if pos < 0 { break try_23; }
                 break scan_alts;
             }
@@ -13755,7 +13755,7 @@ fn scan_single_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_YieldStar {
             pos = start;
             try_17: {
-                pos = scan_yield_statement(tokens, pos);
+                pos = scan_yield_statement(tokens, pos, 0);
                 if pos < 0 { break try_17; }
                 break scan_alts;
             }
@@ -13763,7 +13763,7 @@ fn scan_single_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_58(alt_kind) {
             pos = start;
             try_21: {
-                pos = scan_literal(tokens, pos);
+                pos = scan_literal(tokens, pos, 0);
                 if pos < 0 { break try_21; }
                 break scan_alts;
             }
@@ -13771,11 +13771,11 @@ fn scan_single_expression_atom(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_LT {
             pos = start;
             try_25: {
-                pos = scan_type_arguments(tokens, pos);
+                pos = scan_type_arguments(tokens, pos, 0);
                 if pos < 0 { break try_25; }
                 if pos < tokens.len() && _gale_kind_set_42(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_expression_sequence(tokens, pos);
+                    pos = scan_expression_sequence(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 break scan_alts;
@@ -13797,7 +13797,7 @@ fn scan_single_expression_lr_2(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { return -1; }
     pos += 1;
-    pos = scan_expression_sequence(tokens, pos);
+    pos = scan_expression_sequence(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { return -1; }
     pos += 1;
@@ -13827,11 +13827,11 @@ fn scan_single_expression_lr_4(tokens: &Array<Token>, pos: i32) -> i32 {
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_HASH { pos = -1; } else { pos += 1; }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_identifier_name(tokens, pos);
+    pos = scan_identifier_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_LT {
         let sp = pos;
-        pos = scan_type_generic(tokens, pos);
+        pos = scan_type_generic(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     return pos;
@@ -13851,11 +13851,11 @@ fn scan_single_expression_lr_5(tokens: &Array<Token>, pos: i32) -> i32 {
         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_HASH { pos = -1; } else { pos += 1; }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_identifier_name(tokens, pos);
+    pos = scan_identifier_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_LT {
         let sp = pos;
-        pos = scan_type_generic(tokens, pos);
+        pos = scan_type_generic(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     return pos;
@@ -13863,7 +13863,7 @@ fn scan_single_expression_lr_5(tokens: &Array<Token>, pos: i32) -> i32 {
 
 fn scan_single_expression_lr_8(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_arguments(tokens, pos);
+    pos = scan_arguments(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -14149,7 +14149,7 @@ fn scan_single_expression_lr_36(tokens: &Array<Token>, pos: i32) -> i32 {
 
 fn scan_single_expression_lr_37(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_assignment_operator(tokens, pos);
+    pos = scan_assignment_operator(tokens, pos, 0);
     if pos < 0 { return -1; }
     pos = scan_single_expression(tokens, pos, 5);
     if pos < 0 { return -1; }
@@ -14158,7 +14158,7 @@ fn scan_single_expression_lr_37(tokens: &Array<Token>, pos: i32) -> i32 {
 
 fn scan_single_expression_lr_38(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_template_string_literal(tokens, pos);
+    pos = scan_template_string_literal(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -14167,7 +14167,7 @@ fn scan_single_expression_lr_51(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_As { return -1; }
     pos += 1;
-    pos = scan_as_expression(tokens, pos);
+    pos = scan_as_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -14450,7 +14450,7 @@ fn scan_single_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) ->
     return pos;
 }
 
-fn scan_as_expression(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_as_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -14458,13 +14458,13 @@ fn scan_as_expression(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_68(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
             pos = start;
             try_0: {
-                pos = scan_predefined_type(tokens, pos);
+                pos = scan_predefined_type(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 if pos < tokens.len() && tokens[pos].kind == TK_LIT_LBRACKET {
                     let sp = pos;
@@ -14486,7 +14486,7 @@ fn scan_as_expression(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_69(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -14498,7 +14498,7 @@ fn scan_as_expression(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_assignable(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_assignable(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -14506,7 +14506,7 @@ fn scan_assignable(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_70(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -14514,13 +14514,13 @@ fn scan_assignable(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_71(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_1: {
-                pos = scan_keyword(tokens, pos);
+                pos = scan_keyword(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -14528,7 +14528,7 @@ fn scan_assignable(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_72(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_keyword(tokens, pos);
+                pos = scan_keyword(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -14536,7 +14536,7 @@ fn scan_assignable(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_LBRACKET {
             pos = start;
             try_2: {
-                pos = scan_array_literal(tokens, pos);
+                pos = scan_array_literal(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -14544,7 +14544,7 @@ fn scan_assignable(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_LIT_LBRACE {
             pos = start;
             try_3: {
-                pos = scan_object_literal(tokens, pos);
+                pos = scan_object_literal(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -14556,7 +14556,7 @@ fn scan_assignable(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_anonymous_function(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_anonymous_function(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -14580,19 +14580,19 @@ fn scan_anonymous_function(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos < tokens.len() && _gale_kind_set_21(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_formal_parameter_list(tokens, pos);
+                    pos = scan_formal_parameter_list(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_1; }
                 pos += 1;
                 if pos < tokens.len() && tokens[pos].kind == TK_LIT_COLON {
                     let sp = pos;
-                    pos = scan_type_annotation(tokens, pos);
+                    pos = scan_type_annotation(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { break try_1; }
                 pos += 1;
-                pos = scan_function_body(tokens, pos);
+                pos = scan_function_body(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { break try_1; }
                 pos += 1;
@@ -14600,13 +14600,13 @@ fn scan_anonymous_function(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_0: {
-                pos = scan_function_declaration(tokens, pos);
+                pos = scan_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_2: {
-                pos = scan_arrow_function_declaration(tokens, pos);
+                pos = scan_arrow_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -14614,7 +14614,7 @@ fn scan_anonymous_function(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_73(alt_kind) {
             pos = start;
             try_2: {
-                pos = scan_arrow_function_declaration(tokens, pos);
+                pos = scan_arrow_function_declaration(tokens, pos, 0);
                 if pos < 0 { break try_2; }
                 break scan_alts;
             }
@@ -14626,28 +14626,28 @@ fn scan_anonymous_function(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_arrow_function_declaration(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_arrow_function_declaration(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_Async {
         let sp = pos;
         if pos >= tokens.len() || tokens[pos].kind != TK_Async { pos = -1; } else { pos += 1; }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_arrow_function_parameters(tokens, pos);
+    pos = scan_arrow_function_parameters(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_COLON {
         let sp = pos;
-        pos = scan_type_annotation(tokens, pos);
+        pos = scan_type_annotation(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQGT { return -1; }
     pos += 1;
-    pos = scan_arrow_function_body(tokens, pos);
+    pos = scan_arrow_function_body(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_arrow_function_parameters(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_arrow_function_parameters(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -14655,7 +14655,7 @@ fn scan_arrow_function_parameters(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_23(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_property_name(tokens, pos);
+                pos = scan_property_name(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -14667,7 +14667,7 @@ fn scan_arrow_function_parameters(tokens: &Array<Token>, pos: i32) -> i32 {
                 pos += 1;
                 if pos < tokens.len() && _gale_kind_set_21(tokens[pos].kind) {
                     let sp = pos;
-                    pos = scan_formal_parameter_list(tokens, pos);
+                    pos = scan_formal_parameter_list(tokens, pos, 0);
                     if pos < 0 { pos = sp; }
                 }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_1; }
@@ -14682,7 +14682,7 @@ fn scan_arrow_function_parameters(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_arrow_function_body(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_arrow_function_body(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -14690,7 +14690,7 @@ fn scan_arrow_function_body(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_74(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -14700,7 +14700,7 @@ fn scan_arrow_function_body(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { break try_1; }
                 pos += 1;
-                pos = scan_function_body(tokens, pos);
+                pos = scan_function_body(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { break try_1; }
                 pos += 1;
@@ -14708,7 +14708,7 @@ fn scan_arrow_function_body(tokens: &Array<Token>, pos: i32) -> i32 {
             }
             pos = start;
             try_0: {
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -14720,14 +14720,14 @@ fn scan_arrow_function_body(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_assignment_operator(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_assignment_operator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_67(tokens[pos].kind) {
         return pos + 1;
     }
     return -1;
 }
 
-fn scan_literal(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_literal(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -14759,7 +14759,7 @@ fn scan_literal(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_BackTick {
             pos = start;
             try_3: {
-                pos = scan_template_string_literal(tokens, pos);
+                pos = scan_template_string_literal(tokens, pos, 0);
                 if pos < 0 { break try_3; }
                 break scan_alts;
             }
@@ -14775,7 +14775,7 @@ fn scan_literal(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_53(alt_kind) {
             pos = start;
             try_5: {
-                pos = scan_numeric_literal(tokens, pos);
+                pos = scan_numeric_literal(tokens, pos, 0);
                 if pos < 0 { break try_5; }
                 break scan_alts;
             }
@@ -14783,7 +14783,7 @@ fn scan_literal(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_75(alt_kind) {
             pos = start;
             try_6: {
-                pos = scan_bigint_literal(tokens, pos);
+                pos = scan_bigint_literal(tokens, pos, 0);
                 if pos < 0 { break try_6; }
                 break scan_alts;
             }
@@ -14795,13 +14795,13 @@ fn scan_literal(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_template_string_literal(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_template_string_literal(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_BackTick { return -1; }
     pos += 1;
     while pos < tokens.len() && _gale_kind_set_76(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_template_string_atom(tokens, pos);
+        pos = scan_template_string_atom(tokens, pos, 0);
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
@@ -14810,7 +14810,7 @@ fn scan_template_string_literal(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_template_string_atom(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_template_string_atom(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -14828,7 +14828,7 @@ fn scan_template_string_atom(tokens: &Array<Token>, pos: i32) -> i32 {
             try_1: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_TemplateStringStartExpression { break try_1; }
                 pos += 1;
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_TemplateCloseBrace { break try_1; }
                 pos += 1;
@@ -14850,39 +14850,39 @@ fn scan_template_string_atom(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_numeric_literal(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_numeric_literal(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_53(tokens[pos].kind) {
         return pos + 1;
     }
     return -1;
 }
 
-fn scan_bigint_literal(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_bigint_literal(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_75(tokens[pos].kind) {
         return pos + 1;
     }
     return -1;
 }
 
-fn scan_getter(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_getter(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_class_element_name(tokens, pos);
+    pos = scan_class_element_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_setter(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_setter(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_class_element_name(tokens, pos);
+    pos = scan_class_element_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
 
-fn scan_identifier_name(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_identifier_name(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -14890,7 +14890,7 @@ fn scan_identifier_name(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_70(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -14898,13 +14898,13 @@ fn scan_identifier_name(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_71(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
             pos = start;
             try_1: {
-                pos = scan_reserved_word(tokens, pos);
+                pos = scan_reserved_word(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -14912,7 +14912,7 @@ fn scan_identifier_name(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if _gale_kind_set_17(alt_kind) {
             pos = start;
             try_1: {
-                pos = scan_reserved_word(tokens, pos);
+                pos = scan_reserved_word(tokens, pos, 0);
                 if pos < 0 { break try_1; }
                 break scan_alts;
             }
@@ -14924,14 +14924,14 @@ fn scan_identifier_name(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_identifier(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_identifier(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) {
         return pos + 1;
     }
     return -1;
 }
 
-fn scan_identifier_or_key_word(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_identifier_or_key_word(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -14939,7 +14939,7 @@ fn scan_identifier_or_key_word(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_77(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -14947,7 +14947,7 @@ fn scan_identifier_or_key_word(tokens: &Array<Token>, pos: i32) -> i32 {
         } else if alt_kind == TK_TypeAlias {
             pos = start;
             try_0: {
-                pos = scan_identifier(tokens, pos);
+                pos = scan_identifier(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -14973,7 +14973,7 @@ fn scan_identifier_or_key_word(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_reserved_word(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_reserved_word(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -14981,7 +14981,7 @@ fn scan_reserved_word(tokens: &Array<Token>, pos: i32) -> i32 {
         if _gale_kind_set_78(alt_kind) {
             pos = start;
             try_0: {
-                pos = scan_keyword(tokens, pos);
+                pos = scan_keyword(tokens, pos, 0);
                 if pos < 0 { break try_0; }
                 break scan_alts;
             }
@@ -15009,14 +15009,14 @@ fn scan_reserved_word(tokens: &Array<Token>, pos: i32) -> i32 {
     return pos;
 }
 
-fn scan_keyword(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_keyword(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     if pos < tokens.len() && _gale_kind_set_78(tokens[pos].kind) {
         return pos + 1;
     }
     return -1;
 }
 
-fn scan_eos(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_eos(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let start = pos;
     let mut pos = pos;
     let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -15126,7 +15126,7 @@ fn parse_type_parameter_list(p: &mut Parser) -> Result<TypeParameterListNode, Pa
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_type_parameter(tokens, pos);
+            pos = scan_type_parameter(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -15162,11 +15162,11 @@ fn parse_type_parameter_bt_1(p: &mut Parser) -> Result<TypeParameterNode, ParseE
 
 fn parse_type_parameter_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQ { return -1; }
     pos += 1;
-    pos = scan_type_argument(tokens, pos);
+    pos = scan_type_argument(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -15189,11 +15189,11 @@ fn parse_type_parameter_bt_0(p: &mut Parser) -> Result<TypeParameterNode, ParseE
 
 fn parse_type_parameter_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_EXTENDS {
         let sp = pos;
-        pos = scan_constraint(tokens, pos);
+        pos = scan_constraint(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     return pos;
@@ -15379,7 +15379,7 @@ fn parse_type_argument_list(p: &mut Parser) -> Result<TypeArgumentListNode, Pars
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_type_argument(tokens, pos);
+            pos = scan_type_argument(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -15420,7 +15420,7 @@ fn parse_type__bt_3(p: &mut Parser) -> Result<TypeNode, ParseError> {
 
 fn parse_type__scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_type_generic(tokens, pos);
+    pos = scan_type_generic(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -15436,7 +15436,7 @@ fn parse_type__bt_1(p: &mut Parser) -> Result<TypeNode, ParseError> {
 
 fn parse_type__scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_function_type(tokens, pos);
+    pos = scan_function_type(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -15501,7 +15501,7 @@ fn parse_type__scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_union_or_intersection_or_primary_type(tokens, pos);
+    pos = scan_union_or_intersection_or_primary_type(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -15650,7 +15650,7 @@ fn parse_primary_type_scan_9(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_KeyOf { return -1; }
     pos += 1;
-    pos = scan_primary_type_atom(tokens, pos);
+    pos = scan_primary_type(tokens, pos, 2147483647);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -15666,7 +15666,7 @@ fn parse_primary_type_bt_1(p: &mut Parser) -> Result<PrimaryTypeNode, ParseError
 
 fn parse_primary_type_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_predefined_type(tokens, pos);
+    pos = scan_predefined_type(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -15682,7 +15682,7 @@ fn parse_primary_type_bt_2(p: &mut Parser) -> Result<PrimaryTypeNode, ParseError
 
 fn parse_primary_type_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_type_reference(tokens, pos);
+    pos = scan_type_reference(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -15702,11 +15702,11 @@ fn parse_primary_type_bt_8(p: &mut Parser) -> Result<PrimaryTypeNode, ParseError
 
 fn parse_primary_type_scan_8(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_type_reference(tokens, pos);
+    pos = scan_type_reference(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_Is { return -1; }
     pos += 1;
-    pos = scan_primary_type_atom(tokens, pos);
+    pos = scan_primary_type(tokens, pos, 2147483647);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -16042,7 +16042,7 @@ fn parse_type_name_bt_0(p: &mut Parser) -> Result<TypeNameNode, ParseError> {
 
 fn parse_type_name_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -16058,7 +16058,7 @@ fn parse_type_name_bt_1(p: &mut Parser) -> Result<TypeNameNode, ParseError> {
 
 fn parse_type_name_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_namespace_name(tokens, pos);
+    pos = scan_namespace_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -16179,7 +16179,7 @@ fn parse_type_member_list(p: &mut Parser) -> Result<TypeMemberListNode, ParseErr
                 }
                 break rep_scan;
             }
-            pos = scan_type_member(tokens, pos);
+            pos = scan_type_member(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -16211,7 +16211,7 @@ fn parse_type_member_bt_3(p: &mut Parser) -> Result<TypeMemberNode, ParseError> 
 
 fn parse_type_member_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_index_signature(tokens, pos);
+    pos = scan_index_signature(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -16227,7 +16227,7 @@ fn parse_type_member_bt_0(p: &mut Parser) -> Result<TypeMemberNode, ParseError> 
 
 fn parse_type_member_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_property_signatur(tokens, pos);
+    pos = scan_property_signatur(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -16255,7 +16255,7 @@ fn parse_type_member_bt_4(p: &mut Parser) -> Result<TypeMemberNode, ParseError> 
 
 fn parse_type_member_scan_4(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_method_signature(tokens, pos);
+    pos = scan_method_signature(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_EQGT {
         let sp = pos;
@@ -16263,7 +16263,7 @@ fn parse_type_member_scan_4(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_111: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_EQGT { break sg_111; }
                 pos += 1;
-                pos = scan_type_(tokens, pos);
+                pos = scan_type_(tokens, pos, 0);
                 if pos < 0 { break sg_111; }
                 break sg_111_done;
             }
@@ -16390,7 +16390,7 @@ fn parse_tuple_element_types(p: &mut Parser) -> Result<TupleElementTypesNode, Pa
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_type_(tokens, pos);
+            pos = scan_type_(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -16500,7 +16500,7 @@ fn parse_type_query_expression_bt_0(p: &mut Parser) -> Result<TypeQueryExpressio
 
 fn parse_type_query_expression_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -16515,7 +16515,7 @@ fn parse_type_query_expression_bt_1(p: &mut Parser) -> Result<TypeQueryExpressio
             rep_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_identifier_name(tokens, pos);
+                pos = scan_identifier_name(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break rep_scan; }
                 pos += 1;
@@ -16545,7 +16545,7 @@ fn parse_type_query_expression_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     sg_112_done: {
         sg_112: {
-            pos = scan_identifier_name(tokens, pos);
+            pos = scan_identifier_name(tokens, pos, 0);
             if pos < 0 { break sg_112; }
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_112; }
             pos += 1;
@@ -16557,7 +16557,7 @@ fn parse_type_query_expression_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
         let sp = pos;
         sg_113_done: {
             sg_113: {
-                pos = scan_identifier_name(tokens, pos);
+                pos = scan_identifier_name(tokens, pos, 0);
                 if pos < 0 { break sg_113; }
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_DOT { break sg_113; }
                 pos += 1;
@@ -16568,7 +16568,7 @@ fn parse_type_query_expression_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
         if pos < 0 { pos = sp; break; }
         if pos == sp { break; }
     }
-    pos = scan_identifier_name(tokens, pos);
+    pos = scan_identifier_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -16773,7 +16773,7 @@ fn parse_parameter_list(p: &mut Parser) -> Result<ParameterListNode, ParseError>
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_parameter(tokens, pos);
+                pos = scan_parameter(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -16830,7 +16830,7 @@ fn parse_required_parameter_list(p: &mut Parser) -> Result<RequiredParameterList
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_required_parameter(tokens, pos);
+            pos = scan_required_parameter(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -16862,7 +16862,7 @@ fn parse_parameter_bt_0(p: &mut Parser) -> Result<ParameterNode, ParseError> {
 
 fn parse_parameter_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_required_parameter(tokens, pos);
+    pos = scan_required_parameter(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -16878,7 +16878,7 @@ fn parse_parameter_bt_1(p: &mut Parser) -> Result<ParameterNode, ParseError> {
 
 fn parse_parameter_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_optional_parameter(tokens, pos);
+    pos = scan_optional_parameter(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -17202,7 +17202,7 @@ fn parse_constructor_declaration(p: &mut Parser) -> Result<ConstructorDeclaratio
                     sg_115: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { break sg_115; }
                         pos += 1;
-                        pos = scan_function_body(tokens, pos);
+                        pos = scan_function_body(tokens, pos, 0);
                         if pos < 0 { break sg_115; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { break sg_115; }
                         pos += 1;
@@ -17326,7 +17326,7 @@ fn parse_class_or_interface_type_list(p: &mut Parser) -> Result<ClassOrInterface
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_type_reference(tokens, pos);
+            pos = scan_type_reference(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -17403,7 +17403,7 @@ fn parse_enum_member_list(p: &mut Parser) -> Result<EnumMemberListNode, ParseErr
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_enum_member(tokens, pos);
+            pos = scan_enum_member(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -17491,7 +17491,7 @@ fn parse_namespace_name(p: &mut Parser) -> Result<NamespaceNameNode, ParseError>
                 if pos < 0 { pos = sp; break; }
                 if pos == sp { break; }
             }
-            pos = scan_identifier(tokens, pos);
+            pos = scan_identifier(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -17555,7 +17555,7 @@ fn parse_decorator_list(p: &mut Parser) -> Result<DecoratorListNode, ParseError>
             rep_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_decorator(tokens, pos);
+                pos = scan_decorator(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -17583,7 +17583,7 @@ fn parse_decorator(p: &mut Parser) -> Result<DecoratorNode, ParseError> {
             gd_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_decorator_member_expression(tokens, pos);
+                pos = scan_decorator_member_expression(tokens, pos, 0);
                 if pos < 0 { break gd_scan; }
                 gd_winner = 0;
                 break gd_dispatch;
@@ -17720,7 +17720,7 @@ fn parse_statement_scan_27(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Export { return -1; }
     pos += 1;
-    pos = scan_statement(tokens, pos);
+    pos = scan_statement(tokens, pos, 2147483647);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -17736,7 +17736,7 @@ fn parse_statement_bt_2(p: &mut Parser) -> Result<StatementNode, ParseError> {
 
 fn parse_statement_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_import_statement(tokens, pos);
+    pos = scan_import_statement(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -17752,7 +17752,7 @@ fn parse_statement_bt_3(p: &mut Parser) -> Result<StatementNode, ParseError> {
 
 fn parse_statement_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_export_statement(tokens, pos);
+    pos = scan_export_statement(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -17768,7 +17768,7 @@ fn parse_statement_bt_5(p: &mut Parser) -> Result<StatementNode, ParseError> {
 
 fn parse_statement_scan_5(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_abstract_declaration(tokens, pos);
+    pos = scan_abstract_declaration(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -17784,7 +17784,7 @@ fn parse_statement_bt_11(p: &mut Parser) -> Result<StatementNode, ParseError> {
 
 fn parse_statement_scan_11(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_if_statement(tokens, pos);
+    pos = scan_if_statement(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -17800,7 +17800,7 @@ fn parse_statement_bt_13(p: &mut Parser) -> Result<StatementNode, ParseError> {
 
 fn parse_statement_scan_13(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_continue_statement(tokens, pos);
+    pos = scan_continue_statement(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -17816,7 +17816,7 @@ fn parse_statement_bt_14(p: &mut Parser) -> Result<StatementNode, ParseError> {
 
 fn parse_statement_scan_14(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_break_statement(tokens, pos);
+    pos = scan_break_statement(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -17832,7 +17832,7 @@ fn parse_statement_bt_15(p: &mut Parser) -> Result<StatementNode, ParseError> {
 
 fn parse_statement_scan_15(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_return_statement(tokens, pos);
+    pos = scan_return_statement(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -17848,7 +17848,7 @@ fn parse_statement_bt_17(p: &mut Parser) -> Result<StatementNode, ParseError> {
 
 fn parse_statement_scan_17(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_with_statement(tokens, pos);
+    pos = scan_with_statement(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -17864,7 +17864,7 @@ fn parse_statement_bt_19(p: &mut Parser) -> Result<StatementNode, ParseError> {
 
 fn parse_statement_scan_19(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_switch_statement(tokens, pos);
+    pos = scan_switch_statement(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -17880,7 +17880,7 @@ fn parse_statement_bt_20(p: &mut Parser) -> Result<StatementNode, ParseError> {
 
 fn parse_statement_scan_20(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_throw_statement(tokens, pos);
+    pos = scan_throw_statement(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -17896,7 +17896,7 @@ fn parse_statement_bt_21(p: &mut Parser) -> Result<StatementNode, ParseError> {
 
 fn parse_statement_scan_21(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_try_statement(tokens, pos);
+    pos = scan_try_statement(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -17912,7 +17912,7 @@ fn parse_statement_bt_22(p: &mut Parser) -> Result<StatementNode, ParseError> {
 
 fn parse_statement_scan_22(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_debugger_statement(tokens, pos);
+    pos = scan_debugger_statement(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -17928,7 +17928,7 @@ fn parse_statement_bt_0(p: &mut Parser) -> Result<StatementNode, ParseError> {
 
 fn parse_statement_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_block(tokens, pos);
+    pos = scan_block(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -17944,7 +17944,7 @@ fn parse_statement_bt_7(p: &mut Parser) -> Result<StatementNode, ParseError> {
 
 fn parse_statement_scan_7(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_function_declaration(tokens, pos);
+    pos = scan_function_declaration(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -17960,7 +17960,7 @@ fn parse_statement_bt_10(p: &mut Parser) -> Result<StatementNode, ParseError> {
 
 fn parse_statement_scan_10(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_namespace_declaration(tokens, pos);
+    pos = scan_namespace_declaration(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -17976,7 +17976,7 @@ fn parse_statement_bt_24(p: &mut Parser) -> Result<StatementNode, ParseError> {
 
 fn parse_statement_scan_24(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_generator_function_declaration(tokens, pos);
+    pos = scan_generator_function_declaration(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -17992,7 +17992,7 @@ fn parse_statement_bt_25(p: &mut Parser) -> Result<StatementNode, ParseError> {
 
 fn parse_statement_scan_25(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_type_alias_declaration(tokens, pos);
+    pos = scan_type_alias_declaration(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -18008,7 +18008,7 @@ fn parse_statement_bt_26(p: &mut Parser) -> Result<StatementNode, ParseError> {
 
 fn parse_statement_scan_26(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_enum_declaration(tokens, pos);
+    pos = scan_enum_declaration(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -18024,7 +18024,7 @@ fn parse_statement_bt_16(p: &mut Parser) -> Result<StatementNode, ParseError> {
 
 fn parse_statement_scan_16(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_yield_statement(tokens, pos);
+    pos = scan_yield_statement(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -18040,7 +18040,7 @@ fn parse_statement_bt_12(p: &mut Parser) -> Result<StatementNode, ParseError> {
 
 fn parse_statement_scan_12(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_iteration_statement(tokens, pos);
+    pos = scan_iteration_statement(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -18056,7 +18056,7 @@ fn parse_statement_bt_9(p: &mut Parser) -> Result<StatementNode, ParseError> {
 
 fn parse_statement_scan_9(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_interface_declaration(tokens, pos);
+    pos = scan_interface_declaration(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -18072,7 +18072,7 @@ fn parse_statement_bt_6(p: &mut Parser) -> Result<StatementNode, ParseError> {
 
 fn parse_statement_scan_6(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_class_declaration(tokens, pos);
+    pos = scan_class_declaration(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -18088,7 +18088,7 @@ fn parse_statement_bt_18(p: &mut Parser) -> Result<StatementNode, ParseError> {
 
 fn parse_statement_scan_18(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_labelled_statement(tokens, pos);
+    pos = scan_labelled_statement(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -18104,7 +18104,7 @@ fn parse_statement_bt_1(p: &mut Parser) -> Result<StatementNode, ParseError> {
 
 fn parse_statement_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_variable_statement(tokens, pos);
+    pos = scan_variable_statement(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -18120,7 +18120,7 @@ fn parse_statement_bt_23(p: &mut Parser) -> Result<StatementNode, ParseError> {
 
 fn parse_statement_scan_23(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_arrow_function_declaration(tokens, pos);
+    pos = scan_arrow_function_declaration(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -18136,7 +18136,7 @@ fn parse_statement_bt_8(p: &mut Parser) -> Result<StatementNode, ParseError> {
 
 fn parse_statement_scan_8(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_expression_statement(tokens, pos);
+    pos = scan_expression_statement(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -19125,7 +19125,7 @@ fn parse_statement_list(p: &mut Parser) -> Result<StatementListNode, ParseError>
             rep_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_statement(tokens, pos);
+                pos = scan_statement(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -19153,7 +19153,7 @@ fn parse_abstract_declaration(p: &mut Parser) -> Result<AbstractDeclarationNode,
             gd_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_variable_statement(tokens, pos);
+                pos = scan_variable_statement(tokens, pos, 0);
                 if pos < 0 { break gd_scan; }
                 gd_winner = 0;
                 break gd_dispatch;
@@ -19244,7 +19244,7 @@ fn parse_import_module_items(p: &mut Parser) -> Result<ImportModuleItemsNode, Pa
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_import_alias_name(tokens, pos);
+            pos = scan_import_alias_name(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
@@ -19464,7 +19464,7 @@ fn parse_export_statement_bt_0(p: &mut Parser) -> Result<ExportStatementNode, Pa
             gd_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_export_from_block(tokens, pos);
+                pos = scan_export_from_block(tokens, pos, 0);
                 if pos < 0 { break gd_scan; }
                 gd_winner = 0;
                 break gd_dispatch;
@@ -19505,13 +19505,13 @@ fn parse_export_statement_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
         sg_116: {
             pos = gp_116;
             sg_116_0: {
-                pos = scan_export_from_block(tokens, pos);
+                pos = scan_export_from_block(tokens, pos, 0);
                 if pos < 0 { break sg_116_0; }
                 if pos > sg_116_best { sg_116_best = pos; }
             }
             pos = gp_116;
             sg_116_1: {
-                pos = scan_declaration(tokens, pos);
+                pos = scan_declaration(tokens, pos, 0);
                 if pos < 0 { break sg_116_1; }
                 if pos > sg_116_best { sg_116_best = pos; }
             }
@@ -19519,7 +19519,7 @@ fn parse_export_statement_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
             pos = gp_116;
         }
     }
-    pos = scan_eos(tokens, pos);
+    pos = scan_eos(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -19545,9 +19545,9 @@ fn parse_export_statement_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos >= tokens.len() || tokens[pos].kind != TK_Default { return -1; }
     pos += 1;
-    pos = scan_single_expression(tokens, pos);
+    pos = scan_single_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_eos(tokens, pos);
+    pos = scan_eos(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -19631,7 +19631,7 @@ fn parse_export_module_items(p: &mut Parser) -> Result<ExportModuleItemsNode, Pa
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_export_alias_name(tokens, pos);
+            pos = scan_export_alias_name(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
@@ -19713,7 +19713,7 @@ fn parse_declaration_bt_2(p: &mut Parser) -> Result<DeclarationNode, ParseError>
 
 fn parse_declaration_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_function_declaration(tokens, pos);
+    pos = scan_function_declaration(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -19729,7 +19729,7 @@ fn parse_declaration_bt_1(p: &mut Parser) -> Result<DeclarationNode, ParseError>
 
 fn parse_declaration_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_class_declaration(tokens, pos);
+    pos = scan_class_declaration(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -19745,7 +19745,7 @@ fn parse_declaration_bt_0(p: &mut Parser) -> Result<DeclarationNode, ParseError>
 
 fn parse_declaration_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_variable_statement(tokens, pos);
+    pos = scan_variable_statement(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -19854,12 +19854,12 @@ fn parse_variable_statement_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && _gale_kind_set_20(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_accessibility_modifier(tokens, pos);
+        pos = scan_accessibility_modifier(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos < tokens.len() && _gale_kind_set_39(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_var_modifier(tokens, pos);
+        pos = scan_var_modifier(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos < tokens.len() && tokens[pos].kind == TK_ReadOnly {
@@ -19867,7 +19867,7 @@ fn parse_variable_statement_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
         if pos >= tokens.len() || tokens[pos].kind != TK_ReadOnly { pos = -1; } else { pos += 1; }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_variable_declaration_list(tokens, pos);
+    pos = scan_variable_declaration_list(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_SemiColon {
         let sp = pos;
@@ -19904,14 +19904,14 @@ fn parse_variable_statement_bt_0(p: &mut Parser) -> Result<VariableStatementNode
 
 fn parse_variable_statement_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_binding_pattern(tokens, pos);
+    pos = scan_binding_pattern(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_COLON {
         let sp = pos;
-        pos = scan_type_annotation(tokens, pos);
+        pos = scan_type_annotation(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
-    pos = scan_initializer(tokens, pos);
+    pos = scan_initializer(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_SemiColon {
         let sp = pos;
@@ -19992,7 +19992,7 @@ fn parse_variable_declaration_list(p: &mut Parser) -> Result<VariableDeclaration
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_variable_declaration(tokens, pos);
+            pos = scan_variable_declaration(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -20164,27 +20164,27 @@ fn parse_iteration_statement_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_var_modifier(tokens, pos);
+    pos = scan_var_modifier(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_variable_declaration_list(tokens, pos);
+    pos = scan_variable_declaration_list(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_SemiColon { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_42(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_sequence(tokens, pos);
+        pos = scan_expression_sequence(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_SemiColon { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_42(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_sequence(tokens, pos);
+        pos = scan_expression_sequence(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_statement(tokens, pos);
+    pos = scan_statement(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -20242,13 +20242,13 @@ fn parse_iteration_statement_scan_7(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_var_modifier(tokens, pos);
+    pos = scan_var_modifier(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_variable_declaration(tokens, pos);
+    pos = scan_variable_declaration(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_expression_sequence(tokens, pos);
+    pos = scan_expression_sequence(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_As {
         let sp = pos;
@@ -20256,7 +20256,7 @@ fn parse_iteration_statement_scan_7(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_117: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_As { break sg_117; }
                 pos += 1;
-                pos = scan_type_(tokens, pos);
+                pos = scan_type_(tokens, pos, 0);
                 if pos < 0 { break sg_117; }
                 break sg_117_done;
             }
@@ -20266,7 +20266,7 @@ fn parse_iteration_statement_scan_7(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_statement(tokens, pos);
+    pos = scan_statement(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -20322,11 +20322,11 @@ fn parse_iteration_statement_scan_6(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_single_expression(tokens, pos);
+    pos = scan_single_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_expression_sequence(tokens, pos);
+    pos = scan_expression_sequence(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_As {
         let sp = pos;
@@ -20334,7 +20334,7 @@ fn parse_iteration_statement_scan_6(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_118: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_As { break sg_118; }
                 pos += 1;
-                pos = scan_type_(tokens, pos);
+                pos = scan_type_(tokens, pos, 0);
                 if pos < 0 { break sg_118; }
                 break sg_118_done;
             }
@@ -20344,7 +20344,7 @@ fn parse_iteration_statement_scan_6(tokens: &Array<Token>, pos: i32) -> i32 {
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_statement(tokens, pos);
+    pos = scan_statement(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -20397,26 +20397,26 @@ fn parse_iteration_statement_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_42(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_sequence(tokens, pos);
+        pos = scan_expression_sequence(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_SemiColon { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_42(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_sequence(tokens, pos);
+        pos = scan_expression_sequence(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_SemiColon { return -1; }
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_42(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_expression_sequence(tokens, pos);
+        pos = scan_expression_sequence(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_statement(tokens, pos);
+    pos = scan_statement(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -20450,17 +20450,17 @@ fn parse_iteration_statement_scan_5(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_var_modifier(tokens, pos);
+    pos = scan_var_modifier(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_variable_declaration(tokens, pos);
+    pos = scan_variable_declaration(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_In { return -1; }
     pos += 1;
-    pos = scan_expression_sequence(tokens, pos);
+    pos = scan_expression_sequence(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_statement(tokens, pos);
+    pos = scan_statement(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -20492,15 +20492,15 @@ fn parse_iteration_statement_scan_4(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_single_expression(tokens, pos);
+    pos = scan_single_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_In { return -1; }
     pos += 1;
-    pos = scan_expression_sequence(tokens, pos);
+    pos = scan_expression_sequence(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
-    pos = scan_statement(tokens, pos);
+    pos = scan_statement(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -20642,7 +20642,7 @@ fn parse_continue_statement(p: &mut Parser) -> Result<ContinueStatementNode, Par
     opt_scan: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_identifier(tokens, pos);
+        pos = scan_identifier(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         opt_scan_pos = pos;
     }
@@ -20664,7 +20664,7 @@ fn parse_break_statement(p: &mut Parser) -> Result<BreakStatementNode, ParseErro
     opt_scan: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_identifier(tokens, pos);
+        pos = scan_identifier(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         opt_scan_pos = pos;
     }
@@ -20686,7 +20686,7 @@ fn parse_return_statement(p: &mut Parser) -> Result<ReturnStatementNode, ParseEr
     opt_scan: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_expression_sequence(tokens, pos);
+        pos = scan_expression_sequence(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         opt_scan_pos = pos;
     }
@@ -20708,7 +20708,7 @@ fn parse_yield_statement(p: &mut Parser) -> Result<YieldStatementNode, ParseErro
     opt_scan: {
         let tokens = &p.tokens;
         let mut pos: i32 = p.pos;
-        pos = scan_expression_sequence(tokens, pos);
+        pos = scan_expression_sequence(tokens, pos, 0);
         if pos < 0 { break opt_scan; }
         opt_scan_pos = pos;
     }
@@ -20810,7 +20810,7 @@ fn parse_case_clauses(p: &mut Parser) -> Result<CaseClausesNode, ParseError> {
             rep_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_case_clause(tokens, pos);
+                pos = scan_case_clause(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -21110,7 +21110,7 @@ fn parse_class_tail(p: &mut Parser) -> Result<ClassTailNode, ParseError> {
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_class_element(tokens, pos);
+            pos = scan_class_element(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -21161,7 +21161,7 @@ fn parse_class_element_bt_2(p: &mut Parser) -> Result<ClassElementNode, ParseErr
 
 fn parse_class_element_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_index_member_declaration(tokens, pos);
+    pos = scan_index_member_declaration(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -21177,7 +21177,7 @@ fn parse_class_element_bt_0(p: &mut Parser) -> Result<ClassElementNode, ParseErr
 
 fn parse_class_element_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_constructor_declaration(tokens, pos);
+    pos = scan_constructor_declaration(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -21193,7 +21193,7 @@ fn parse_class_element_bt_3(p: &mut Parser) -> Result<ClassElementNode, ParseErr
 
 fn parse_class_element_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_statement(tokens, pos);
+    pos = scan_statement(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -21218,10 +21218,10 @@ fn parse_class_element_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_AT {
         let sp = pos;
-        pos = scan_decorator_list(tokens, pos);
+        pos = scan_decorator_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
-    pos = scan_property_member_declaration(tokens, pos);
+    pos = scan_property_member_declaration(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -21373,9 +21373,9 @@ fn parse_property_member_declaration_bt_0(p: &mut Parser) -> Result<PropertyMemb
 
 fn parse_property_member_declaration_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_property_member_base(tokens, pos);
+    pos = scan_property_member_base(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_property_name(tokens, pos);
+    pos = scan_property_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_QUESTION {
         let sp = pos;
@@ -21384,12 +21384,12 @@ fn parse_property_member_declaration_scan_0(tokens: &Array<Token>, pos: i32) -> 
     }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_COLON {
         let sp = pos;
-        pos = scan_type_annotation(tokens, pos);
+        pos = scan_type_annotation(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_EQ {
         let sp = pos;
-        pos = scan_initializer(tokens, pos);
+        pos = scan_initializer(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_SemiColon { return -1; }
@@ -21434,11 +21434,11 @@ fn parse_property_member_declaration_bt_1(p: &mut Parser) -> Result<PropertyMemb
 
 fn parse_property_member_declaration_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_property_member_base(tokens, pos);
+    pos = scan_property_member_base(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_property_name(tokens, pos);
+    pos = scan_property_name(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_call_signature(tokens, pos);
+    pos = scan_call_signature(tokens, pos, 0);
     if pos < 0 { return -1; }
     let gp_119 = pos;
     let sgk_119 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -21450,7 +21450,7 @@ fn parse_property_member_declaration_scan_1(tokens: &Array<Token>, pos: i32) -> 
                     sg_120: {
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { break sg_120; }
                         pos += 1;
-                        pos = scan_function_body(tokens, pos);
+                        pos = scan_function_body(tokens, pos, 0);
                         if pos < 0 { break sg_120; }
                         if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { break sg_120; }
                         pos += 1;
@@ -21483,7 +21483,7 @@ fn parse_property_member_declaration_bt_2(p: &mut Parser) -> Result<PropertyMemb
             gd_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_get_accessor(tokens, pos);
+                pos = scan_get_accessor(tokens, pos, 0);
                 if pos < 0 { break gd_scan; }
                 gd_winner = 0;
                 break gd_dispatch;
@@ -21507,7 +21507,7 @@ fn parse_property_member_declaration_bt_2(p: &mut Parser) -> Result<PropertyMemb
 
 fn parse_property_member_declaration_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_property_member_base(tokens, pos);
+    pos = scan_property_member_base(tokens, pos, 0);
     if pos < 0 { return -1; }
     let gp_121 = pos;
     let sgk_121 = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
@@ -21516,13 +21516,13 @@ fn parse_property_member_declaration_scan_2(tokens: &Array<Token>, pos: i32) -> 
         sg_121: {
             pos = gp_121;
             sg_121_0: {
-                pos = scan_get_accessor(tokens, pos);
+                pos = scan_get_accessor(tokens, pos, 0);
                 if pos < 0 { break sg_121_0; }
                 if pos > sg_121_best { sg_121_best = pos; }
             }
             pos = gp_121;
             sg_121_1: {
-                pos = scan_set_accessor(tokens, pos);
+                pos = scan_set_accessor(tokens, pos, 0);
                 if pos < 0 { break sg_121_1; }
                 if pos > sg_121_best { sg_121_best = pos; }
             }
@@ -21719,7 +21719,7 @@ fn parse_generator_block(p: &mut Parser) -> Result<GeneratorBlockNode, ParseErro
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_generator_definition(tokens, pos);
+            pos = scan_generator_definition(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -21773,7 +21773,7 @@ fn parse_iterator_block(p: &mut Parser) -> Result<IteratorBlockNode, ParseError>
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_iterator_definition(tokens, pos);
+            pos = scan_iterator_definition(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -21880,7 +21880,7 @@ fn parse_formal_parameter_list_bt_2(p: &mut Parser) -> Result<FormalParameterLis
 
 fn parse_formal_parameter_list_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_array_literal(tokens, pos);
+    pos = scan_array_literal(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -21896,7 +21896,7 @@ fn parse_formal_parameter_list_bt_0(p: &mut Parser) -> Result<FormalParameterLis
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_formal_parameter_arg(tokens, pos);
+            pos = scan_formal_parameter_arg(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -21938,7 +21938,7 @@ fn parse_formal_parameter_list_bt_0(p: &mut Parser) -> Result<FormalParameterLis
 
 fn parse_formal_parameter_list_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_formal_parameter_arg(tokens, pos);
+    pos = scan_formal_parameter_arg(tokens, pos, 0);
     if pos < 0 { return -1; }
     while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
         let sp = pos;
@@ -21946,7 +21946,7 @@ fn parse_formal_parameter_list_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_122: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_122; }
                 pos += 1;
-                pos = scan_formal_parameter_arg(tokens, pos);
+                pos = scan_formal_parameter_arg(tokens, pos, 0);
                 if pos < 0 { break sg_122; }
                 break sg_122_done;
             }
@@ -21961,7 +21961,7 @@ fn parse_formal_parameter_list_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_123: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_123; }
                 pos += 1;
-                pos = scan_last_formal_parameter_arg(tokens, pos);
+                pos = scan_last_formal_parameter_arg(tokens, pos, 0);
                 if pos < 0 { break sg_123; }
                 break sg_123_done;
             }
@@ -22000,7 +22000,7 @@ fn parse_formal_parameter_list_bt_3(p: &mut Parser) -> Result<FormalParameterLis
 
 fn parse_formal_parameter_list_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_object_literal(tokens, pos);
+    pos = scan_object_literal(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_COLON {
         let sp = pos;
@@ -22008,7 +22008,7 @@ fn parse_formal_parameter_list_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
             sg_124: {
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { break sg_124; }
                 pos += 1;
-                pos = scan_formal_parameter_list(tokens, pos);
+                pos = scan_formal_parameter_list(tokens, pos, 0);
                 if pos < 0 { break sg_124; }
                 break sg_124_done;
             }
@@ -22171,7 +22171,7 @@ fn parse_source_elements(p: &mut Parser) -> Result<SourceElementsNode, ParseErro
             rep_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_source_element(tokens, pos);
+                pos = scan_source_element(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -22241,7 +22241,7 @@ fn parse_element_list(p: &mut Parser) -> Result<ElementListNode, ParseError> {
                 if pos < 0 { pos = sp; break; }
                 if pos == sp { break; }
             }
-            pos = scan_array_element(tokens, pos);
+            pos = scan_array_element(tokens, pos, 0);
             if pos < 0 { break rep_scan_2; }
             if pos <= p.pos { break rep_scan_2; }
             rep_scan_pos_2 = pos;
@@ -22313,7 +22313,7 @@ fn parse_array_element(p: &mut Parser) -> Result<ArrayElementNode, ParseError> {
             gd_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break gd_scan; }
                 gd_winner = 0;
                 break gd_dispatch;
@@ -22355,7 +22355,7 @@ fn parse_object_literal(p: &mut Parser) -> Result<ObjectLiteralNode, ParseError>
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_property_assignment(tokens, pos);
+                pos = scan_property_assignment(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -22406,7 +22406,7 @@ fn parse_object_literal(p: &mut Parser) -> Result<ObjectLiteralNode, ParseError>
                 let mut pos: i32 = p.pos;
                 if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
                 pos += 1;
-                pos = scan_property_assignment(tokens, pos);
+                pos = scan_property_assignment(tokens, pos, 0);
                 if pos < 0 { break rep_scan; }
                 if pos <= p.pos { break rep_scan; }
                 rep_scan_pos = pos;
@@ -22470,13 +22470,13 @@ fn parse_property_assignment_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { return -1; }
     pos += 1;
-    pos = scan_single_expression(tokens, pos);
+    pos = scan_single_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { return -1; }
     pos += 1;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COLON { return -1; }
     pos += 1;
-    pos = scan_single_expression(tokens, pos);
+    pos = scan_single_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -22492,7 +22492,7 @@ fn parse_property_assignment_bt_2(p: &mut Parser) -> Result<PropertyAssignmentNo
 
 fn parse_property_assignment_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_get_accessor(tokens, pos);
+    pos = scan_get_accessor(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -22508,7 +22508,7 @@ fn parse_property_assignment_bt_3(p: &mut Parser) -> Result<PropertyAssignmentNo
 
 fn parse_property_assignment_scan_3(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_set_accessor(tokens, pos);
+    pos = scan_set_accessor(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -22524,7 +22524,7 @@ fn parse_property_assignment_bt_5(p: &mut Parser) -> Result<PropertyAssignmentNo
 
 fn parse_property_assignment_scan_5(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_identifier_or_key_word(tokens, pos);
+    pos = scan_identifier_or_key_word(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -22540,7 +22540,7 @@ fn parse_property_assignment_bt_4(p: &mut Parser) -> Result<PropertyAssignmentNo
 
 fn parse_property_assignment_scan_4(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_generator_method(tokens, pos);
+    pos = scan_generator_method(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -22560,7 +22560,7 @@ fn parse_property_assignment_bt_0(p: &mut Parser) -> Result<PropertyAssignmentNo
 
 fn parse_property_assignment_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_property_name(tokens, pos);
+    pos = scan_property_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     let gp_125 = pos;
     sg_125: {
@@ -22578,7 +22578,7 @@ fn parse_property_assignment_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
         }
         return -1;
     }
-    pos = scan_single_expression(tokens, pos);
+    pos = scan_single_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -22606,7 +22606,7 @@ fn parse_property_assignment_scan_6(tokens: &Array<Token>, pos: i32) -> i32 {
         if pos >= tokens.len() || tokens[pos].kind != TK_Ellipsis { pos = -1; } else { pos += 1; }
         if pos < 0 { pos = sp; }
     }
-    pos = scan_single_expression(tokens, pos);
+    pos = scan_single_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -22936,7 +22936,7 @@ fn parse_argument_list(p: &mut Parser) -> Result<ArgumentListNode, ParseError> {
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_argument(tokens, pos);
+            pos = scan_argument(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -22973,7 +22973,7 @@ fn parse_argument(p: &mut Parser) -> Result<ArgumentNode, ParseError> {
             gd_scan: {
                 let tokens = &p.tokens;
                 let mut pos: i32 = p.pos;
-                pos = scan_single_expression(tokens, pos);
+                pos = scan_single_expression(tokens, pos, 0);
                 if pos < 0 { break gd_scan; }
                 gd_winner = 0;
                 break gd_dispatch;
@@ -23006,7 +23006,7 @@ fn parse_expression_sequence(p: &mut Parser) -> Result<ExpressionSequenceNode, P
             let mut pos: i32 = p.pos;
             if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
             pos += 1;
-            pos = scan_single_expression(tokens, pos);
+            pos = scan_single_expression(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -23060,17 +23060,17 @@ fn parse_single_expression_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_2(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_identifier(tokens, pos);
+        pos = scan_identifier(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_LT {
         let sp = pos;
-        pos = scan_type_parameters(tokens, pos);
+        pos = scan_type_parameters(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
-    pos = scan_class_heritage(tokens, pos);
+    pos = scan_class_heritage(tokens, pos, 0);
     if pos < 0 { return -1; }
-    pos = scan_class_tail(tokens, pos);
+    pos = scan_class_tail(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -23099,14 +23099,14 @@ fn parse_single_expression_scan_6(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_New { return -1; }
     pos += 1;
-    pos = scan_single_expression(tokens, pos);
+    pos = scan_single_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_LT {
         let sp = pos;
-        pos = scan_type_arguments(tokens, pos);
+        pos = scan_type_arguments(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
-    pos = scan_arguments(tokens, pos);
+    pos = scan_arguments(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -23133,11 +23133,11 @@ fn parse_single_expression_scan_7(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_New { return -1; }
     pos += 1;
-    pos = scan_single_expression(tokens, pos);
+    pos = scan_single_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_LT {
         let sp = pos;
-        pos = scan_type_arguments(tokens, pos);
+        pos = scan_type_arguments(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     return pos;
@@ -23160,7 +23160,7 @@ fn parse_single_expression_scan_49(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { return -1; }
     pos += 1;
-    pos = scan_expression_sequence(tokens, pos);
+    pos = scan_expression_sequence(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
@@ -23182,7 +23182,7 @@ fn parse_single_expression_scan_12(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Void { return -1; }
     pos += 1;
-    pos = scan_single_expression_atom(tokens, pos);
+    pos = scan_single_expression(tokens, pos, 2147483647);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -23202,7 +23202,7 @@ fn parse_single_expression_scan_13(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Typeof { return -1; }
     pos += 1;
-    pos = scan_single_expression_atom(tokens, pos);
+    pos = scan_single_expression(tokens, pos, 2147483647);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -23222,7 +23222,7 @@ fn parse_single_expression_scan_20(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Await { return -1; }
     pos += 1;
-    pos = scan_single_expression_atom(tokens, pos);
+    pos = scan_single_expression(tokens, pos, 2147483647);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -23242,7 +23242,7 @@ fn parse_single_expression_scan_11(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Delete { return -1; }
     pos += 1;
-    pos = scan_single_expression_atom(tokens, pos);
+    pos = scan_single_expression(tokens, pos, 2147483647);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -23258,7 +23258,7 @@ fn parse_single_expression_bt_47(p: &mut Parser) -> Result<SingleExpressionNode,
 
 fn parse_single_expression_scan_47(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_array_literal(tokens, pos);
+    pos = scan_array_literal(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -23274,7 +23274,7 @@ fn parse_single_expression_bt_41(p: &mut Parser) -> Result<SingleExpressionNode,
 
 fn parse_single_expression_scan_41(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_generator_function_declaration(tokens, pos);
+    pos = scan_generator_function_declaration(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -23290,7 +23290,7 @@ fn parse_single_expression_bt_42(p: &mut Parser) -> Result<SingleExpressionNode,
 
 fn parse_single_expression_scan_42(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_yield_statement(tokens, pos);
+    pos = scan_yield_statement(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -23306,7 +23306,7 @@ fn parse_single_expression_bt_46(p: &mut Parser) -> Result<SingleExpressionNode,
 
 fn parse_single_expression_scan_46(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_literal(tokens, pos);
+    pos = scan_literal(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -23322,7 +23322,7 @@ fn parse_single_expression_bt_0(p: &mut Parser) -> Result<SingleExpressionNode, 
 
 fn parse_single_expression_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_anonymous_function(tokens, pos);
+    pos = scan_anonymous_function(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -23345,11 +23345,11 @@ fn parse_single_expression_bt_44(p: &mut Parser) -> Result<SingleExpressionNode,
 
 fn parse_single_expression_scan_44(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_identifier_name(tokens, pos);
+    pos = scan_identifier_name(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && _gale_kind_set_42(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_single_expression(tokens, pos);
+        pos = scan_single_expression(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     return pos;
@@ -23398,7 +23398,7 @@ fn parse_single_expression_bt_39(p: &mut Parser) -> Result<SingleExpressionNode,
 
 fn parse_single_expression_scan_39(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_iterator_block(tokens, pos);
+    pos = scan_iterator_block(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -23414,7 +23414,7 @@ fn parse_single_expression_bt_40(p: &mut Parser) -> Result<SingleExpressionNode,
 
 fn parse_single_expression_scan_40(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_generator_block(tokens, pos);
+    pos = scan_generator_block(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -23430,7 +23430,7 @@ fn parse_single_expression_bt_48(p: &mut Parser) -> Result<SingleExpressionNode,
 
 fn parse_single_expression_scan_48(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_object_literal(tokens, pos);
+    pos = scan_object_literal(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -24605,7 +24605,7 @@ fn parse_as_expression_bt_1(p: &mut Parser) -> Result<AsExpressionNode, ParseErr
 
 fn parse_as_expression_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_single_expression(tokens, pos);
+    pos = scan_single_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -24633,7 +24633,7 @@ fn parse_as_expression_bt_0(p: &mut Parser) -> Result<AsExpressionNode, ParseErr
 
 fn parse_as_expression_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_predefined_type(tokens, pos);
+    pos = scan_predefined_type(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_LBRACKET {
         let sp = pos;
@@ -24700,7 +24700,7 @@ fn parse_assignable_bt_0(p: &mut Parser) -> Result<AssignableNode, ParseError> {
 
 fn parse_assignable_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -24716,7 +24716,7 @@ fn parse_assignable_bt_1(p: &mut Parser) -> Result<AssignableNode, ParseError> {
 
 fn parse_assignable_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_keyword(tokens, pos);
+    pos = scan_keyword(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -24839,19 +24839,19 @@ fn parse_anonymous_function_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     pos += 1;
     if pos < tokens.len() && _gale_kind_set_21(tokens[pos].kind) {
         let sp = pos;
-        pos = scan_formal_parameter_list(tokens, pos);
+        pos = scan_formal_parameter_list(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { return -1; }
     pos += 1;
     if pos < tokens.len() && tokens[pos].kind == TK_LIT_COLON {
         let sp = pos;
-        pos = scan_type_annotation(tokens, pos);
+        pos = scan_type_annotation(tokens, pos, 0);
         if pos < 0 { pos = sp; }
     }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
     pos += 1;
-    pos = scan_function_body(tokens, pos);
+    pos = scan_function_body(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
     pos += 1;
@@ -24869,7 +24869,7 @@ fn parse_anonymous_function_bt_0(p: &mut Parser) -> Result<AnonymousFunctionNode
 
 fn parse_anonymous_function_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_function_declaration(tokens, pos);
+    pos = scan_function_declaration(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -24885,7 +24885,7 @@ fn parse_anonymous_function_bt_2(p: &mut Parser) -> Result<AnonymousFunctionNode
 
 fn parse_anonymous_function_scan_2(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_arrow_function_declaration(tokens, pos);
+    pos = scan_arrow_function_declaration(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -25012,7 +25012,7 @@ fn parse_arrow_function_body_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACE { return -1; }
     pos += 1;
-    pos = scan_function_body(tokens, pos);
+    pos = scan_function_body(tokens, pos, 0);
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACE { return -1; }
     pos += 1;
@@ -25030,7 +25030,7 @@ fn parse_arrow_function_body_bt_0(p: &mut Parser) -> Result<ArrowFunctionBodyNod
 
 fn parse_arrow_function_body_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_single_expression(tokens, pos);
+    pos = scan_single_expression(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -25241,7 +25241,7 @@ fn parse_template_string_literal(p: &mut Parser) -> Result<TemplateStringLiteral
         rep_scan: {
             let tokens = &p.tokens;
             let mut pos: i32 = p.pos;
-            pos = scan_template_string_atom(tokens, pos);
+            pos = scan_template_string_atom(tokens, pos, 0);
             if pos < 0 { break rep_scan; }
             if pos <= p.pos { break rep_scan; }
             rep_scan_pos = pos;
@@ -25410,7 +25410,7 @@ fn parse_identifier_name_bt_0(p: &mut Parser) -> Result<IdentifierNameNode, Pars
 
 fn parse_identifier_name_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -25426,7 +25426,7 @@ fn parse_identifier_name_bt_1(p: &mut Parser) -> Result<IdentifierNameNode, Pars
 
 fn parse_identifier_name_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_reserved_word(tokens, pos);
+    pos = scan_reserved_word(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -25679,7 +25679,7 @@ fn parse_identifier_or_key_word_bt_0(p: &mut Parser) -> Result<IdentifierOrKeyWo
 
 fn parse_identifier_or_key_word_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
-    pos = scan_identifier(tokens, pos);
+    pos = scan_identifier(tokens, pos, 0);
     if pos < 0 { return -1; }
     return pos;
 }

--- a/package-gale/tests/generated/typescript/type_script.wado
+++ b/package-gale/tests/generated/typescript/type_script.wado
@@ -15638,7 +15638,7 @@ fn parse_union_or_intersection_or_primary_type(p: &mut Parser, min_prec: i32 = 0
 fn parse_primary_type_bt_9(p: &mut Parser) -> Result<PrimaryTypeNode, ParseError> {
     let start = p.peek().span.start;
     let keyof = p.expect(TK_KeyOf)?;
-    let primary_type = parse_primary_type(p)?;
+    let primary_type = parse_primary_type(p, 1)?;
     return Result::<PrimaryTypeNode, ParseError>::Ok(PrimaryTypeNode::KeyOfType(PrimaryTypeKeyOfType {
         span: Span::new(start, p.last_end()),
         keyof,
@@ -15691,7 +15691,7 @@ fn parse_primary_type_bt_8(p: &mut Parser) -> Result<PrimaryTypeNode, ParseError
     let start = p.peek().span.start;
     let type_reference = parse_type_reference(p)?;
     let is = p.expect(TK_Is)?;
-    let primary_type = parse_primary_type(p)?;
+    let primary_type = parse_primary_type(p, 1)?;
     return Result::<PrimaryTypeNode, ParseError>::Ok(PrimaryTypeNode::RedefinitionOfType(PrimaryTypeRedefinitionOfType {
         span: Span::new(start, p.last_end()),
         type_reference,
@@ -23078,7 +23078,7 @@ fn parse_single_expression_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
 fn parse_single_expression_bt_6(p: &mut Parser) -> Result<SingleExpressionNode, ParseError> {
     let start = p.peek().span.start;
     let new = p.expect(TK_New)?;
-    let single_expression = parse_single_expression(p)?;
+    let single_expression = parse_single_expression(p, 24)?;
     let type_arguments: Option<TypeArgumentsNode> = if p.peek_kind() == TK_LIT_LT {
         let type_arguments = parse_type_arguments(p)?;
         Option::<TypeArgumentsNode>::Some(type_arguments)
@@ -23114,7 +23114,7 @@ fn parse_single_expression_scan_6(tokens: &Array<Token>, pos: i32) -> i32 {
 fn parse_single_expression_bt_7(p: &mut Parser) -> Result<SingleExpressionNode, ParseError> {
     let start = p.peek().span.start;
     let new = p.expect(TK_New)?;
-    let single_expression = parse_single_expression(p)?;
+    let single_expression = parse_single_expression(p, 24)?;
     let type_arguments: Option<TypeArgumentsNode> = if p.peek_kind() == TK_LIT_LT {
         let type_arguments = parse_type_arguments(p)?;
         Option::<TypeArgumentsNode>::Some(type_arguments)
@@ -23170,7 +23170,7 @@ fn parse_single_expression_scan_49(tokens: &Array<Token>, pos: i32) -> i32 {
 fn parse_single_expression_bt_12(p: &mut Parser) -> Result<SingleExpressionNode, ParseError> {
     let start = p.peek().span.start;
     let void = p.expect(TK_Void)?;
-    let single_expression = parse_single_expression(p)?;
+    let single_expression = parse_single_expression(p, 21)?;
     return Result::<SingleExpressionNode, ParseError>::Ok(SingleExpressionNode::VoidExpression(SingleExpressionVoidExpression {
         span: Span::new(start, p.last_end()),
         void,
@@ -23190,7 +23190,7 @@ fn parse_single_expression_scan_12(tokens: &Array<Token>, pos: i32) -> i32 {
 fn parse_single_expression_bt_13(p: &mut Parser) -> Result<SingleExpressionNode, ParseError> {
     let start = p.peek().span.start;
     let typeof = p.expect(TK_Typeof)?;
-    let single_expression = parse_single_expression(p)?;
+    let single_expression = parse_single_expression(p, 21)?;
     return Result::<SingleExpressionNode, ParseError>::Ok(SingleExpressionNode::TypeofExpression(SingleExpressionTypeofExpression {
         span: Span::new(start, p.last_end()),
         typeof,
@@ -23210,7 +23210,7 @@ fn parse_single_expression_scan_13(tokens: &Array<Token>, pos: i32) -> i32 {
 fn parse_single_expression_bt_20(p: &mut Parser) -> Result<SingleExpressionNode, ParseError> {
     let start = p.peek().span.start;
     let await = p.expect(TK_Await)?;
-    let single_expression = parse_single_expression(p)?;
+    let single_expression = parse_single_expression(p, 21)?;
     return Result::<SingleExpressionNode, ParseError>::Ok(SingleExpressionNode::AwaitExpression(SingleExpressionAwaitExpression {
         span: Span::new(start, p.last_end()),
         await,
@@ -23230,7 +23230,7 @@ fn parse_single_expression_scan_20(tokens: &Array<Token>, pos: i32) -> i32 {
 fn parse_single_expression_bt_11(p: &mut Parser) -> Result<SingleExpressionNode, ParseError> {
     let start = p.peek().span.start;
     let delete = p.expect(TK_Delete)?;
-    let single_expression = parse_single_expression(p)?;
+    let single_expression = parse_single_expression(p, 21)?;
     return Result::<SingleExpressionNode, ParseError>::Ok(SingleExpressionNode::DeleteExpression(SingleExpressionDeleteExpression {
         span: Span::new(start, p.last_end()),
         delete,
@@ -23331,7 +23331,7 @@ fn parse_single_expression_bt_44(p: &mut Parser) -> Result<SingleExpressionNode,
     let start = p.peek().span.start;
     let identifier_name = parse_identifier_name(p)?;
     let single_expression: Option<SingleExpressionNode> = if _gale_kind_set_42(p.peek_kind()) {
-        let single_expression = parse_single_expression(p)?;
+        let single_expression = parse_single_expression(p, 3)?;
         Option::<SingleExpressionNode>::Some(single_expression)
     } else {
         null
@@ -23873,7 +23873,7 @@ fn parse_single_expression_atom(p: &mut Parser) -> Result<SingleExpressionNode, 
     }
     if kind == TK_LIT_PLUSPLUS {
         let lit_plusplus = p.expect(TK_LIT_PLUSPLUS)?;
-        let single_expression = parse_single_expression(p)?;
+        let single_expression = parse_single_expression(p, 21)?;
         return Result::<SingleExpressionNode, ParseError>::Ok(SingleExpressionNode::PreIncrementExpression(SingleExpressionPreIncrementExpression {
             span: Span::new(start, p.last_end()),
             lit_plusplus,
@@ -23882,7 +23882,7 @@ fn parse_single_expression_atom(p: &mut Parser) -> Result<SingleExpressionNode, 
     }
     if kind == TK_LIT_MINUSMINUS {
         let lit_minusminus = p.expect(TK_LIT_MINUSMINUS)?;
-        let single_expression = parse_single_expression(p)?;
+        let single_expression = parse_single_expression(p, 21)?;
         return Result::<SingleExpressionNode, ParseError>::Ok(SingleExpressionNode::PreDecreaseExpression(SingleExpressionPreDecreaseExpression {
             span: Span::new(start, p.last_end()),
             lit_minusminus,
@@ -23891,7 +23891,7 @@ fn parse_single_expression_atom(p: &mut Parser) -> Result<SingleExpressionNode, 
     }
     if kind == TK_LIT_PLUS {
         let plus = p.expect(TK_LIT_PLUS)?;
-        let single_expression = parse_single_expression(p)?;
+        let single_expression = parse_single_expression(p, 21)?;
         return Result::<SingleExpressionNode, ParseError>::Ok(SingleExpressionNode::UnaryPlusExpression(SingleExpressionUnaryPlusExpression {
             span: Span::new(start, p.last_end()),
             plus,
@@ -23900,7 +23900,7 @@ fn parse_single_expression_atom(p: &mut Parser) -> Result<SingleExpressionNode, 
     }
     if kind == TK_LIT_MINUS {
         let minus = p.expect(TK_LIT_MINUS)?;
-        let single_expression = parse_single_expression(p)?;
+        let single_expression = parse_single_expression(p, 21)?;
         return Result::<SingleExpressionNode, ParseError>::Ok(SingleExpressionNode::UnaryMinusExpression(SingleExpressionUnaryMinusExpression {
             span: Span::new(start, p.last_end()),
             minus,
@@ -23909,7 +23909,7 @@ fn parse_single_expression_atom(p: &mut Parser) -> Result<SingleExpressionNode, 
     }
     if kind == TK_LIT_TILDE {
         let tilde = p.expect(TK_LIT_TILDE)?;
-        let single_expression = parse_single_expression(p)?;
+        let single_expression = parse_single_expression(p, 21)?;
         return Result::<SingleExpressionNode, ParseError>::Ok(SingleExpressionNode::BitNotExpression(SingleExpressionBitNotExpression {
             span: Span::new(start, p.last_end()),
             tilde,
@@ -23918,7 +23918,7 @@ fn parse_single_expression_atom(p: &mut Parser) -> Result<SingleExpressionNode, 
     }
     if kind == TK_LIT_BANG {
         let bang = p.expect(TK_LIT_BANG)?;
-        let single_expression = parse_single_expression(p)?;
+        let single_expression = parse_single_expression(p, 21)?;
         return Result::<SingleExpressionNode, ParseError>::Ok(SingleExpressionNode::NotExpression(SingleExpressionNotExpression {
             span: Span::new(start, p.last_end()),
             bang,

--- a/package-gale/tests/generated/typescript/type_script.wado
+++ b/package-gale/tests/generated/typescript/type_script.wado
@@ -15650,7 +15650,7 @@ fn parse_primary_type_scan_9(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_KeyOf { return -1; }
     pos += 1;
-    pos = scan_primary_type(tokens, pos);
+    pos = scan_primary_type_atom(tokens, pos);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -15706,7 +15706,7 @@ fn parse_primary_type_scan_8(tokens: &Array<Token>, pos: i32) -> i32 {
     if pos < 0 { return -1; }
     if pos >= tokens.len() || tokens[pos].kind != TK_Is { return -1; }
     pos += 1;
-    pos = scan_primary_type(tokens, pos);
+    pos = scan_primary_type_atom(tokens, pos);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -15727,89 +15727,89 @@ fn parse_primary_type_atom(p: &mut Parser) -> Result<PrimaryTypeNode, ParseError
     }
     if _gale_kind_set_80(kind) {
         if p.peek_kind() == TK_KeyOf {
-            if _gale_kind_set_9(p.peek_at(1)) {
+            let _sd_tokens = &p.tokens;
+            let _sd_pos = p.pos;
+            let _sd_p_9 = parse_primary_type_scan_9(_sd_tokens, _sd_pos);
+            let _sd_p_2 = parse_primary_type_scan_2(_sd_tokens, _sd_pos);
+            let _sd_p_8 = parse_primary_type_scan_8(_sd_tokens, _sd_pos);
+            let mut _sd_best_i: i32 = -1;
+            let mut _sd_best_p: i32 = -1;
+            if _sd_p_9 > _sd_best_p {
+                _sd_best_p = _sd_p_9;
+                _sd_best_i = 9;
+            }
+            if _sd_p_2 > _sd_best_p {
+                _sd_best_p = _sd_p_2;
+                _sd_best_i = 2;
+            }
+            if _sd_p_8 > _sd_best_p {
+                _sd_best_p = _sd_p_8;
+                _sd_best_i = 8;
+            }
+            if _sd_best_i == 9 {
                 return parse_primary_type_bt_9(p);
-            } else if p.peek_at(1) == TK_Is {
+            }
+            if _sd_best_i == 2 {
+                return parse_primary_type_bt_2(p);
+            }
+            if _sd_best_i == 8 {
                 return parse_primary_type_bt_8(p);
             }
-        } else if p.peek_kind() == TK_Any {
-            if p.peek_at(1) == TK_Is {
+            return parse_primary_type_bt_8(p);
+        } else if _gale_kind_set_6(p.peek_kind()) {
+            let _sd_tokens = &p.tokens;
+            let _sd_pos = p.pos;
+            let _sd_p_1 = parse_primary_type_scan_1(_sd_tokens, _sd_pos);
+            let _sd_p_2 = parse_primary_type_scan_2(_sd_tokens, _sd_pos);
+            let _sd_p_8 = parse_primary_type_scan_8(_sd_tokens, _sd_pos);
+            let mut _sd_best_i: i32 = -1;
+            let mut _sd_best_p: i32 = -1;
+            if _sd_p_1 > _sd_best_p {
+                _sd_best_p = _sd_p_1;
+                _sd_best_i = 1;
+            }
+            if _sd_p_2 > _sd_best_p {
+                _sd_best_p = _sd_p_2;
+                _sd_best_i = 2;
+            }
+            if _sd_p_8 > _sd_best_p {
+                _sd_best_p = _sd_p_8;
+                _sd_best_i = 8;
+            }
+            if _sd_best_i == 1 {
+                return parse_primary_type_bt_1(p);
+            }
+            if _sd_best_i == 2 {
+                return parse_primary_type_bt_2(p);
+            }
+            if _sd_best_i == 8 {
                 return parse_primary_type_bt_8(p);
             }
+            return parse_primary_type_bt_8(p);
         } else if _gale_kind_set_7(p.peek_kind()) {
             return parse_primary_type_bt_1(p);
-        } else if p.peek_kind() == TK_Number {
-            if p.peek_at(1) == TK_Is {
+        } else if _gale_kind_set_8(p.peek_kind()) {
+            let _sd_tokens = &p.tokens;
+            let _sd_pos = p.pos;
+            let _sd_p_2 = parse_primary_type_scan_2(_sd_tokens, _sd_pos);
+            let _sd_p_8 = parse_primary_type_scan_8(_sd_tokens, _sd_pos);
+            let mut _sd_best_i: i32 = -1;
+            let mut _sd_best_p: i32 = -1;
+            if _sd_p_2 > _sd_best_p {
+                _sd_best_p = _sd_p_2;
+                _sd_best_i = 2;
+            }
+            if _sd_p_8 > _sd_best_p {
+                _sd_best_p = _sd_p_8;
+                _sd_best_i = 8;
+            }
+            if _sd_best_i == 2 {
+                return parse_primary_type_bt_2(p);
+            }
+            if _sd_best_i == 8 {
                 return parse_primary_type_bt_8(p);
             }
-        } else if p.peek_kind() == TK_Boolean {
-            if p.peek_at(1) == TK_Is {
-                return parse_primary_type_bt_8(p);
-            }
-        } else if p.peek_kind() == TK_String {
-            if p.peek_at(1) == TK_Is {
-                return parse_primary_type_bt_8(p);
-            }
-        } else if p.peek_kind() == TK_Unique {
-            if p.peek_at(1) == TK_Is {
-                return parse_primary_type_bt_8(p);
-            }
-        } else if p.peek_kind() == TK_Symbol {
-            if p.peek_at(1) == TK_Is {
-                return parse_primary_type_bt_8(p);
-            }
-        } else if p.peek_kind() == TK_Never {
-            if p.peek_at(1) == TK_Is {
-                return parse_primary_type_bt_8(p);
-            }
-        } else if p.peek_kind() == TK_Undefined {
-            if p.peek_at(1) == TK_Is {
-                return parse_primary_type_bt_8(p);
-            }
-        } else if p.peek_kind() == TK_Object {
-            if p.peek_at(1) == TK_Is {
-                return parse_primary_type_bt_8(p);
-            }
-        } else if p.peek_kind() == TK_Identifier {
-            if p.peek_at(1) == TK_Is {
-                return parse_primary_type_bt_8(p);
-            }
-        } else if p.peek_kind() == TK_Async {
-            if p.peek_at(1) == TK_Is {
-                return parse_primary_type_bt_8(p);
-            }
-        } else if p.peek_kind() == TK_As {
-            if p.peek_at(1) == TK_Is {
-                return parse_primary_type_bt_8(p);
-            }
-        } else if p.peek_kind() == TK_From {
-            if p.peek_at(1) == TK_Is {
-                return parse_primary_type_bt_8(p);
-            }
-        } else if p.peek_kind() == TK_Yield {
-            if p.peek_at(1) == TK_Is {
-                return parse_primary_type_bt_8(p);
-            }
-        } else if p.peek_kind() == TK_Of {
-            if p.peek_at(1) == TK_Is {
-                return parse_primary_type_bt_8(p);
-            }
-        } else if p.peek_kind() == TK_TypeAlias {
-            if p.peek_at(1) == TK_Is {
-                return parse_primary_type_bt_8(p);
-            }
-        } else if p.peek_kind() == TK_Constructor {
-            if p.peek_at(1) == TK_Is {
-                return parse_primary_type_bt_8(p);
-            }
-        } else if p.peek_kind() == TK_Namespace {
-            if p.peek_at(1) == TK_Is {
-                return parse_primary_type_bt_8(p);
-            }
-        } else if p.peek_kind() == TK_Abstract {
-            if p.peek_at(1) == TK_Is {
-                return parse_primary_type_bt_8(p);
-            }
+            return parse_primary_type_bt_8(p);
         }
     }
     if kind == TK_LIT_LBRACE {
@@ -23078,7 +23078,7 @@ fn parse_single_expression_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
 fn parse_single_expression_bt_6(p: &mut Parser) -> Result<SingleExpressionNode, ParseError> {
     let start = p.peek().span.start;
     let new = p.expect(TK_New)?;
-    let single_expression = parse_single_expression(p, 24)?;
+    let single_expression = parse_single_expression(p)?;
     let type_arguments: Option<TypeArgumentsNode> = if p.peek_kind() == TK_LIT_LT {
         let type_arguments = parse_type_arguments(p)?;
         Option::<TypeArgumentsNode>::Some(type_arguments)
@@ -23114,7 +23114,7 @@ fn parse_single_expression_scan_6(tokens: &Array<Token>, pos: i32) -> i32 {
 fn parse_single_expression_bt_7(p: &mut Parser) -> Result<SingleExpressionNode, ParseError> {
     let start = p.peek().span.start;
     let new = p.expect(TK_New)?;
-    let single_expression = parse_single_expression(p, 24)?;
+    let single_expression = parse_single_expression(p)?;
     let type_arguments: Option<TypeArgumentsNode> = if p.peek_kind() == TK_LIT_LT {
         let type_arguments = parse_type_arguments(p)?;
         Option::<TypeArgumentsNode>::Some(type_arguments)
@@ -23182,7 +23182,7 @@ fn parse_single_expression_scan_12(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Void { return -1; }
     pos += 1;
-    pos = scan_single_expression(tokens, pos);
+    pos = scan_single_expression_atom(tokens, pos);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -23202,7 +23202,7 @@ fn parse_single_expression_scan_13(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Typeof { return -1; }
     pos += 1;
-    pos = scan_single_expression(tokens, pos);
+    pos = scan_single_expression_atom(tokens, pos);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -23222,7 +23222,7 @@ fn parse_single_expression_scan_20(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Await { return -1; }
     pos += 1;
-    pos = scan_single_expression(tokens, pos);
+    pos = scan_single_expression_atom(tokens, pos);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -23242,7 +23242,7 @@ fn parse_single_expression_scan_11(tokens: &Array<Token>, pos: i32) -> i32 {
     let mut pos = pos;
     if pos >= tokens.len() || tokens[pos].kind != TK_Delete { return -1; }
     pos += 1;
-    pos = scan_single_expression(tokens, pos);
+    pos = scan_single_expression_atom(tokens, pos);
     if pos < 0 { return -1; }
     return pos;
 }
@@ -23331,7 +23331,7 @@ fn parse_single_expression_bt_44(p: &mut Parser) -> Result<SingleExpressionNode,
     let start = p.peek().span.start;
     let identifier_name = parse_identifier_name(p)?;
     let single_expression: Option<SingleExpressionNode> = if _gale_kind_set_42(p.peek_kind()) {
-        let single_expression = parse_single_expression(p, 3)?;
+        let single_expression = parse_single_expression(p)?;
         Option::<SingleExpressionNode>::Some(single_expression)
     } else {
         null

--- a/package-gale/tests/generated/unicode_props/unicode_props.g4.kiln.json
+++ b/package-gale/tests/generated/unicode_props/unicode_props.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/unicode_props/unicode_props.wado",
-      "hash": "7d8509ec4790168541823a5e767b24ee19bad7640c3aa4acc32fc4be636b736c",
+      "hash": "c469cd262ecf9a9d52b19e84b097fe007657abee5eb8277ee2a06c6f93493d7e",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/unicode_props/unicode_props.wado
+++ b/package-gale/tests/generated/unicode_props/unicode_props.wado
@@ -757,7 +757,7 @@ impl Parser {
     }
 }
 
-fn scan_line(tokens: &Array<Token>, pos: i32) -> i32 {
+fn scan_line(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
     let mut pos = pos;
     let gp_0 = pos;
     sg_0: {


### PR DESCRIPTION
## Summary

Closes 3 of the 13 `[stage_b_todo]` Stage-B tree-shape divergences in
`package-gale/tests/antlr4-compat/status.toml`:

- `LeftRecursion/Expressions_7`
- `LeftRecursion/PrefixAndOtherAlt_1`
- `LeftRecursion/PrefixAndOtherAlt_2`

Three independent gale codegen bugs sat behind these:

1. **Prefix-alt inner self-refs were called with `min_prec = 0`.** ANTLR4
   rewrites the prefix alt `'-' e` (and `('~'|'!') e`, `'(' typespec ')' e`)
   so the inner `e` gets the alt's own precedence. Gale was emitting a
   bare `parse_e(p)`, which let the LR loop attach binary operators below
   the prefix's precedence — `(s (e - (e (e a) + (e b))))` instead of
   ANTLR4's `(s (e (e - (e a)) + (e b)))`.

   Added `compute_prefix_self_ref_min_prec(rule, alt_idx)` and a new
   `is_prefix_alt` predicate that mirrors ANTLR4's
   `LeftRecursiveRuleWalker.g` definition (alt does NOT start with a
   self-reference, but its LAST element IS one — `'(' e ')'` is therefore
   an "other" alt, not a prefix alt). `gen_alt_body` call sites set
   `ctx.prefix_self_ref_min_prec` so `gen_element`'s RuleRef branch can
   emit `parse_<rule>(p, <prec>)` for the inner self-ref.

2. **`rule_is_single_token` mis-classified rules with nullable elements.**
   `literal: '-'? Integer` looks like one non-nullable terminal, so the
   check passed and SLL prediction collapsed `literal` to a single token.
   For input `-1`, `op expr` then appeared to be the unique alt at
   depth 1 even though `literal` also matched. Fixed by treating any
   nullable element as disqualifying — the rule's token count is not
   fixed once an optional terminal is reachable.

3. **bt-scan over-matched LR-rule references.** `parse_<rule>_scan_*`
   scanned its inner `RuleRef`s with the full `scan_<rule>` (which
   includes the LR suffix loop). For `op expr`'s scan, that meant the
   inner `expr` chased the whole binary cascade and reported a longer
   match than the sibling `literal` alt — the longest-match dispatch
   then committed to `op expr` instead of recognising the ambiguity
   and picking the earlier alt. The fix routes LR-rule references
   inside bt-scan to `scan_<rule>_atom` (atom only, no LR loop).

   The first cut applied this transform to **every** RuleRef walked by
   `gen_scan_elements`, which broke the existing `c1_select_case_bare`
   regression test (`SELECT CASE WHEN x>1 THEN 1 END FROM t;`) — inner
   `expr`s in `K_WHEN expr K_THEN expr` are bounded by surrounding
   tokens and need a full scan. The narrowed fix toggles atom-only on
   for the **last** element only when it is a self-reference to the
   current rule.

The final commit is a non-behavioural cleanup: `is_left_recursive` now
delegates to `is_self_ref_element`; `compute_prefix_self_ref_min_prec_alts`
is folded into the `(rule, alt_idx)` form via `ctx.find_rule`; the
`scan_for_prediction` boolean is replaced with an `i32`
`scan_ruleref_min_prec` so `gen_scan_element` always emits
`scan_<rule>(tokens, pos, <min_prec>)`. Non-LR `scan_<rule>` accept
(and ignore) a `min_prec: i32 = 0` parameter so the call site is
uniform regardless of LR-ness, and the `scan_call_name_for_ruleref` /
`rule_has_lr_alt` helpers go away.

## Side-effect: `driver_rust_test`

`tree_negation_scoping_with_boolean_and_comparison` had an expected
tree that depended on the bug — the test asserted that
`!true && 1 != 2 || false` parses as `!(true && 1 != 2 || false)` even
though Rust's `expression` rule places `NegationExpression` at alt
position 13 with all the boolean and comparison alts below it. With
the prefix-prec fix in place the inner `expression` of `!` now refuses
those lower-precedence operators, so the parse becomes
`((!true) && (1 != 2)) || false` and the expected tree is updated to
match.

## Test plan

- [x] `wado test package-gale` (full suite): 1023 passed, 0 failed,
      10 todo (was 1019/0/13 on `main` — three previously-`#[TODO]`
      Stage-B tests now pass).
- [x] Targeted regression check on `sqlite_case_when_test.wado`,
      `driver_rust_test.wado`, and the affected Stage-B tests.

## Remaining `[stage_b_todo]` (10)

For follow-up work, not in this PR:

- `LeftRecursion/JavaExpressions_{7,8,9,12}` — Java's 30-alt expression
  rule, parse `Result::Err`.
- `LeftRecursion/PrecedenceFilterConsidersContext` — ANTLR4 issue
  #509 precedence filter.
- `LeftRecursion/SemPredFailOption`, `ParserExec/{BuildParseTree_TRUE,
  PredictionMode_LL}`, `SemPredEvalParser/PredFromAltTestedInLoopBack_{1,2}`
  — Stage C territory (action-body translation / sem-pred enforcement).

https://claude.ai/code/session_016XnmwA61WxSEzuDUQXZNwV

---
_Generated by [Claude Code](https://claude.ai/code/session_016XnmwA61WxSEzuDUQXZNwV)_