### PR TITLE
Fix Stage B LR JavaExpressions, Kiln cache invalidation, Stage A empty-file suppression

### DIFF
--- a/package-gale/antlr4-compatibility.md
+++ b/package-gale/antlr4-compatibility.md
@@ -368,15 +368,20 @@ the underlying compiler / codegen bugs were both real:
 
 ### Future work
 
-- **Stage B for composite descriptors.** Descriptors with
-  `[slaveGrammar]` blocks are auto-skipped today because the
-  extractor's Stage B path emits a single-input Kiln directive
-  (`use ... with { generator: ... }`). Kiln itself already accepts
-  multiple inputs via `generator.inputs`, so closing this only needs
-  the extractor to (a) emit the `inputs` array with main + slave
-  paths and (b) drop the `parsed.slave_grammars.len() > 0`
-  short-circuit at the Stage B eligibility check. That unblocks the
-  CompositeLexers / CompositeParsers descriptors.
+- **Stage B for composite descriptors — Stage C dependency.** All
+  17 `CompositeLexers` / `CompositeParsers` descriptors are
+  auto-skipped today, but the bottleneck is _not_ multi-input
+  plumbing: every composite descriptor's `[output]` is a host-side
+  artefact rather than a parse tree. They split as `<writeln(...)>`
+  action-body prints (e.g. `S.a`, `M.b`, `T.y`), `Token.toString`
+  dumps (e.g. `[@0,0:2='abc',<1>,1:0]`), or empty `[output]`. None
+  of these survive `normalize_output_for_stage_b`. Even if the
+  extractor were updated to drop the `parsed.slave_grammars.len() > 0`
+  short-circuit and pass `inputs: [main, slave1, …]` to Kiln (which
+  already supports multi-input), every composite would land back at
+  the same auto-skip counter — the eligibility set stays at zero
+  until Stage C makes action bodies executable and the prints can be
+  reproduced. Re-evaluate this entry once Stage C lands.
 
 When Phase 2/3 surface further compiler bugs, follow the project
 rule from the top-level `CLAUDE.md`: write a minimum reproducible

--- a/package-gale/antlr4-compatibility.md
+++ b/package-gale/antlr4-compatibility.md
@@ -368,16 +368,15 @@ the underlying compiler / codegen bugs were both real:
 
 ### Future work
 
-- **Listeners category emit-suppression.** `Listeners` currently
-  emits a header-only Stage A test file with zero tests; once the
-  Stage A side gains the same tolerance Stage B already has
-  (auto-skip when nothing is left to emit), drop the empty files.
 - **Stage B for composite descriptors.** Descriptors with
-  `[slaveGrammar]` blocks are auto-skipped today because Kiln's
-  `use ... with { generator: ... }` directive only consumes one
-  `.g4` file. Adding multi-file pipeline support to Kiln (or
-  inlining slaves into the main grammar at extract time) would
-  unblock CompositeLexers / CompositeParsers descriptors.
+  `[slaveGrammar]` blocks are auto-skipped today because the
+  extractor's Stage B path emits a single-input Kiln directive
+  (`use ... with { generator: ... }`). Kiln itself already accepts
+  multiple inputs via `generator.inputs`, so closing this only needs
+  the extractor to (a) emit the `inputs` array with main + slave
+  paths and (b) drop the `parsed.slave_grammars.len() > 0`
+  short-circuit at the Stage B eligibility check. That unblocks the
+  CompositeLexers / CompositeParsers descriptors.
 
 When Phase 2/3 surface further compiler bugs, follow the project
 rule from the top-level `CLAUDE.md`: write a minimum reproducible

--- a/package-gale/scripts/extract_antlr4_descriptors.wado
+++ b/package-gale/scripts/extract_antlr4_descriptors.wado
@@ -366,8 +366,6 @@ fn read_file_to_string(dir: &Descriptor, path: &String) -> Result<String, ErrorC
         OpenFlags::none(),
         DescriptorFlags::Read,
     ).wait() {
-
-
         Ok(file) => file,
         Err(e) => {
             return Result::Err(e);
@@ -399,8 +397,6 @@ fn write_file_string(dir: &Descriptor, path: &String, content: &String) -> Resul
         OpenFlags::Create | OpenFlags::Truncate,
         DescriptorFlags::Read | DescriptorFlags::Write,
     ).wait() {
-
-
         Ok(f) => f,
         Err(e) => {
             return Result::Err(e);

--- a/package-gale/scripts/extract_antlr4_descriptors.wado
+++ b/package-gale/scripts/extract_antlr4_descriptors.wado
@@ -72,8 +72,7 @@ fn generator_attr() -> String {
 
 fn is_known_section(name: &String) -> bool {
     return match *name {
-        "notes" | "type" | "grammar" | "slaveGrammar" | "start"
-        | "input" | "output" | "errors" | "flags" | "skip" => true,
+        "notes" | "type" | "grammar" | "slaveGrammar" | "start" | "input" | "output" | "errors" | "flags" | "skip" => true,
         _ => false,
     };
 }
@@ -146,12 +145,23 @@ fn parse_descriptor_text(text: &String) -> ParsedDescriptor {
     for let p of pairs {
         let processed = post_process(&p.value);
         match p.name {
-            "grammar" => { grammar = unescape_st_text(&processed); },
-            "slaveGrammar" => { slaves.push(unescape_st_text(&processed)); },
-            "input" => { input = processed; },
-            "output" => { output = processed; },
-            "start" => { start = processed; },
-            _ => {},
+            "grammar" => {
+                grammar = unescape_st_text(&processed);
+            },
+            "slaveGrammar" => {
+                slaves.push(unescape_st_text(&processed));
+            },
+            "input" => {
+                input = processed;
+            },
+            "output" => {
+                output = processed;
+            },
+            "start" => {
+                start = processed;
+            },
+            _ => {
+            },
         }
     }
     return ParsedDescriptor {
@@ -205,7 +215,8 @@ fn section_header_of(line: &String) -> Option<String> {
         return null;
     }
     let last_idx = line.len() - 1;
-    if line.get_byte(last_idx) != 0x5D {  // ']'
+    if line.get_byte(last_idx) != 0x5D {
+        // ']'
         return null;
     }
     let candidate = line.substr_bytes(1, last_idx);
@@ -297,7 +308,9 @@ fn load_triage_maps(content: &Option<String>) -> TriageMaps {
     let mut stage_b = TriageMap::new();
     let text = match content {
         Some(t) => t,
-        None => return TriageMaps { stage_a, stage_b },
+        None => {
+            return TriageMaps { stage_a, stage_b };
+        },
     };
     let mut section: String = "";
     for let raw_line of text.lines() {
@@ -312,7 +325,9 @@ fn load_triage_maps(content: &Option<String>) -> TriageMaps {
         // Expect `"key" = "value"`
         let eq_idx = match line.find("=") {
             Some(i) => i,
-            None => { continue; },
+            None => {
+                continue;
+            },
         };
         let reason = unquote(&line.substr_bytes(eq_idx + 1, line.len()).trim());
         let key = unquote(&line.substr_bytes(0, eq_idx).trim());
@@ -321,7 +336,8 @@ fn load_triage_maps(content: &Option<String>) -> TriageMaps {
             "skip" => stage_a.entries.push(TriageEntry { key, triage: Triage::Skip(reason) }),
             "stage_b_todo" => stage_b.entries.push(TriageEntry { key, triage: Triage::Todo(reason) }),
             "stage_b_skip" => stage_b.entries.push(TriageEntry { key, triage: Triage::Skip(reason) }),
-            _ => {},
+            _ => {
+            },
         }
     }
     return TriageMaps { stage_a, stage_b };
@@ -350,8 +366,12 @@ fn read_file_to_string(dir: &Descriptor, path: &String) -> Result<String, ErrorC
         OpenFlags::none(),
         DescriptorFlags::Read,
     ).wait() {
+
+
         Ok(file) => file,
-        Err(e) => return Result::Err(e),
+        Err(e) => {
+            return Result::Err(e);
+        },
     };
     let [stream, done] = opened.read_via_stream(0 as Filesize);
     let mut bytes: Array<u8> = [];
@@ -379,8 +399,12 @@ fn write_file_string(dir: &Descriptor, path: &String, content: &String) -> Resul
         OpenFlags::Create | OpenFlags::Truncate,
         DescriptorFlags::Read | DescriptorFlags::Write,
     ).wait() {
+
+
         Ok(f) => f,
-        Err(e) => return Result::Err(e),
+        Err(e) => {
+            return Result::Err(e);
+        },
     };
     let bytes: Array<u8> = content.bytes().collect();
     let [rx, tx] = Stream::<u8>::new();
@@ -389,6 +413,13 @@ fn write_file_string(dir: &Descriptor, path: &String, content: &String) -> Resul
     tx.drop();
     sub.drop();
     return Result::Ok(());
+}
+
+/// Remove a regular file. `Err(NoEntry)` is treated like other errors — the
+/// caller decides whether a missing file is fatal (typical use is "best
+/// effort cleanup", where any failure is silently ignored).
+fn remove_file(dir: &Descriptor, path: &String) -> Result<(), ErrorCode> {
+    return dir.unlink_file_at(*path).wait();
 }
 
 fn ensure_dir(parent: &Descriptor, name: &String) -> Result<Descriptor, ErrorCode> {
@@ -403,11 +434,7 @@ fn ensure_dir(parent: &Descriptor, name: &String) -> Result<Descriptor, ErrorCod
 }
 
 fn open_dir(parent: &Descriptor, name: &String, mutate: bool) -> Result<Descriptor, ErrorCode> {
-    let flags = if mutate {
-        DescriptorFlags::Read | DescriptorFlags::MutateDirectory
-    } else {
-        DescriptorFlags::Read
-    };
+    let flags = if mutate { DescriptorFlags::Read | DescriptorFlags::MutateDirectory } else { DescriptorFlags::Read };
     return parent.open_at(
         PathFlags::none(),
         *name,
@@ -481,9 +508,15 @@ fn escape_for_wado_str(s: &String) -> String {
     let mut out = String::with_capacity(s.len());
     for let c of s.chars() {
         match c {
-            '\\' => { out.push_str("\\\\"); },
-            '"'  => { out.push_str("\\\""); },
-            _    => { out.push(c); },
+            '\\' => {
+                out.push_str("\\\\");
+            },
+            '"' => {
+                out.push_str("\\\"");
+            },
+            _ => {
+                out.push(c);
+            },
         }
     }
     return out;
@@ -515,12 +548,15 @@ fn emit_test_file_for_category(category: &String, entries: &Array<DescriptorEntr
     w.blank();
     for let e of entries {
         match &e.triage {
-            Skip(_) => { continue; },
+            Skip(_) => {
+                continue;
+            },
             Todo(reason) => {
                 w.line(&"#[TODO]");
                 w.line(&`// triage: {escape_for_wado_str(reason)}`);
             },
-            Pass => {},
+            Pass => {
+            },
         }
         w.begin(&`test "{*category}/{e.name}"`);
         w.line(&`let input = #include_str("./grammars/{e.g4_relpath}");`);
@@ -559,13 +595,7 @@ fn emit_test_file_for_category(category: &String, entries: &Array<DescriptorEntr
 /// `Skip` callers should not invoke this function at all; `Todo` causes
 /// the test to be `#[TODO]`-marked so a known-failing assertion is
 /// recorded on a separate axis from real failures (matches Stage A).
-fn emit_stage_b_test_file(
-    category: &String,
-    name: &String,
-    input: &String,
-    expected_tree: &String,
-    triage: &Triage,
-) -> String {
+fn emit_stage_b_test_file(category: &String, name: &String, input: &String, expected_tree: &String, triage: &Triage) -> String {
     let mut w = CodeWriter::new();
     w.line(&generator_attr());
     w.line(&"// Do not edit by hand — re-run the generator to regenerate.");
@@ -612,7 +642,9 @@ fn parse_cli_args(arguments: Array<String>) -> CliArgs {
     let mut categories: Array<String> = [];
     for let a of arguments {
         match a {
-            "all" => { want_all = true; },
+            "all" => {
+                want_all = true;
+            },
             _ => {
                 if !a.starts_with("-") {
                     categories.push(a);
@@ -818,9 +850,7 @@ export fn run() with Stdout, Stderr, Environment, Preopens {
             //     checking that the normalised output starts with `(<start>`.
             // Anything else is silently skipped (auto-skip counter); explicit
             // [stage_b_skip] / [stage_b_todo] entries override the default.
-            if parsed.output.is_empty()
-                || parsed.input.is_empty()
-                || parsed.slave_grammars.len() > 0 {
+            if parsed.output.is_empty() || parsed.input.is_empty() || parsed.slave_grammars.len() > 0 {
                 continue;
             }
             let normalised = match normalize_output_for_stage_b(&parsed.output) {
@@ -860,9 +890,19 @@ export fn run() with Stdout, Stderr, Environment, Preopens {
             stage_b_emitted += 1;
         }
 
-        // Emit the per-category test file.
-        let test_src = emit_test_file_for_category(category, &entries);
+        // Emit the per-category test file. Skip when nothing would land in
+        // the file (every descriptor in this category was `[skip]`-triaged) —
+        // a header-only file is dead weight and a pointless `wado test` no-op.
+        // Mirrors the Stage B side, which already skips emission when empty.
         let test_filename = `{category_to_snake(category)}_test.wado`;
+        if entries.is_empty() {
+            if let Err(_) = remove_file(&compat_dir, &test_filename) {
+                // No prior file is fine; only a real I/O failure would surface here.
+            }
+            println(`  empty: antlr4-compat/{test_filename} (no descriptors emitted; not writing)`);
+            continue;
+        }
+        let test_src = emit_test_file_for_category(category, &entries);
         if let Err(_) = write_file_string(&compat_dir, &test_filename, &test_src) {
             eprintln(`extract: cannot write {test_filename}`);
             continue;
@@ -934,7 +974,7 @@ fn normalize_output_for_stage_b(raw: &String) -> Option<String> {
 }
 
 fn is_tree_node_name_start(c: char) -> bool {
-    return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || c == '_';
+    return 'a' <= c && c <= 'z' || 'A' <= c && c <= 'Z' || c == '_';
 }
 
 test "normalize: clean parse tree passes through trimmed" {
@@ -1028,8 +1068,7 @@ test "normalize: line-noise output starting with paren but no name is rejected" 
 fn assert_triage_skip(maps: &TriageMaps, axis: &String, key: &String, expected_reason: &String) {
     let map = if *axis == "a" { &maps.stage_a } else { &maps.stage_b };
     if let Skip(reason) = &map.lookup(key) {
-        assert *reason == *expected_reason,
-            `axis {*axis} key '{*key}': expected Skip('{*expected_reason}'), got Skip('{*reason}')`;
+        assert *reason == *expected_reason, `axis {*axis} key '{*key}': expected Skip('{*expected_reason}'), got Skip('{*reason}')`;
     } else {
         panic(`axis {*axis} key '{*key}': expected Skip, got other`);
     }
@@ -1038,8 +1077,7 @@ fn assert_triage_skip(maps: &TriageMaps, axis: &String, key: &String, expected_r
 fn assert_triage_todo(maps: &TriageMaps, axis: &String, key: &String, expected_reason: &String) {
     let map = if *axis == "a" { &maps.stage_a } else { &maps.stage_b };
     if let Todo(reason) = &map.lookup(key) {
-        assert *reason == *expected_reason,
-            `axis {*axis} key '{*key}': expected Todo('{*expected_reason}'), got Todo('{*reason}')`;
+        assert *reason == *expected_reason, `axis {*axis} key '{*key}': expected Todo('{*expected_reason}'), got Todo('{*reason}')`;
     } else {
         panic(`axis {*axis} key '{*key}': expected Todo, got other`);
     }
@@ -1047,8 +1085,7 @@ fn assert_triage_todo(maps: &TriageMaps, axis: &String, key: &String, expected_r
 
 fn assert_triage_pass(maps: &TriageMaps, axis: &String, key: &String) {
     let map = if *axis == "a" { &maps.stage_a } else { &maps.stage_b };
-    assert map.lookup(key) matches { Pass },
-        `axis {*axis} key '{*key}': expected Pass, got other`;
+    assert map.lookup(key) matches { Pass }, `axis {*axis} key '{*key}': expected Pass, got other`;
 }
 
 test "triage: missing file yields empty maps on both axes" {

--- a/package-gale/scripts/extract_antlr4_descriptors.wado
+++ b/package-gale/scripts/extract_antlr4_descriptors.wado
@@ -769,6 +769,12 @@ export fn run() with Stdout, Stderr, Environment, Preopens {
 
         let txt_files = list_files_with_suffix(&cat_src_dir, &".txt");
         let mut entries: Array<DescriptorEntry> = [];
+        // Tracks per-category I/O / parse failures separately from triage
+        // skips. `entries.is_empty()` alone cannot distinguish "every
+        // descriptor was [skip]-triaged" (intentional, we want to drop
+        // the file) from "every descriptor errored out" (real failure;
+        // we must not silently delete the previous run's output).
+        let mut category_errors = 0;
 
         for let txt_name of &txt_files {
             // Strip ".txt" → descriptor name.
@@ -786,6 +792,7 @@ export fn run() with Stdout, Stderr, Environment, Preopens {
                 Ok(s) => s,
                 Err(_) => {
                     eprintln(`extract: cannot read {key}`);
+                    category_errors += 1;
                     continue;
                 },
             };
@@ -793,6 +800,7 @@ export fn run() with Stdout, Stderr, Environment, Preopens {
             let parsed = parse_descriptor_text(&raw);
             if parsed.grammar.is_empty() {
                 eprintln(`extract: {key} has no [grammar] section, skipping`);
+                category_errors += 1;
                 continue;
             }
 
@@ -800,6 +808,7 @@ export fn run() with Stdout, Stderr, Environment, Preopens {
             let g4_filename = `{base}.g4`;
             if let Err(_) = write_file_string(&cat_out_dir, &g4_filename, &parsed.grammar) {
                 eprintln(`extract: cannot write {key}.g4`);
+                category_errors += 1;
                 continue;
             }
 
@@ -887,11 +896,19 @@ export fn run() with Stdout, Stderr, Environment, Preopens {
         }
 
         // Emit the per-category test file. Skip when nothing would land in
-        // the file (every descriptor in this category was `[skip]`-triaged) —
-        // a header-only file is dead weight and a pointless `wado test` no-op.
-        // Mirrors the Stage B side, which already skips emission when empty.
+        // the file *and* no descriptor errored out along the way — i.e. the
+        // empty result is the intentional case where every descriptor was
+        // `[skip]`-triaged (currently only `Listeners`). When at least one
+        // descriptor failed to load / parse / write, leave any previous
+        // file in place: deleting it would silently hide the failure
+        // behind an `empty:` line, and rewriting it as a header-only stub
+        // would erase the last good run's coverage.
         let test_filename = `{category_to_snake(category)}_test.wado`;
         if entries.is_empty() {
+            if category_errors > 0 {
+                eprintln(`extract: {*category} had {category_errors} descriptor failure(s); leaving antlr4-compat/{test_filename} untouched`);
+                continue;
+            }
             if let Err(_) = remove_file(&compat_dir, &test_filename) {
                 // No prior file is fine; only a real I/O failure would surface here.
             }

--- a/package-gale/src/parser_gen.wado
+++ b/package-gale/src/parser_gen.wado
@@ -241,6 +241,12 @@ fn sll_closure(configs: &Array<SllConfig>) -> Array<SllConfig> {
 /// True when the config has fully consumed its elements and has no return
 /// frame to pop into — i.e. the alt's body is finished and any further token
 /// belongs to the calling context. Opaque configs (`pos < 0`) are not at-end.
+///
+/// The check walks `return_stack` from the most-recently-pushed frame back
+/// to the oldest, mirroring what a sequence of `pop_return` calls would
+/// expose. Walking by index keeps this O(n); the previous recursive
+/// implementation was O(n^2) because each `pop_return` rebuilt the entire
+/// surviving prefix of `return_stack` into a fresh `Array`.
 fn config_is_at_end(c: &SllConfig) -> bool {
     if c.pos < 0 {
         return false;
@@ -248,10 +254,15 @@ fn config_is_at_end(c: &SllConfig) -> bool {
     if c.pos < c.elements.len() {
         return false;
     }
-    if c.return_stack.is_empty() {
-        return true;
+    let mut i = c.return_stack.len();
+    while i > 0 {
+        i -= 1;
+        let frame = &c.return_stack[i];
+        if frame.pos < frame.elements.len() {
+            return false;
+        }
     }
-    return config_is_at_end(&pop_return(c));
+    return true;
 }
 
 

--- a/package-gale/src/parser_gen.wado
+++ b/package-gale/src/parser_gen.wado
@@ -238,6 +238,22 @@ fn sll_closure(configs: &Array<SllConfig>) -> Array<SllConfig> {
     return *configs;
 }
 
+/// True when the config has fully consumed its elements and has no return
+/// frame to pop into — i.e. the alt's body is finished and any further token
+/// belongs to the calling context. Opaque configs (`pos < 0`) are not at-end.
+fn config_is_at_end(c: &SllConfig) -> bool {
+    if c.pos < 0 {
+        return false;
+    }
+    if c.pos < c.elements.len() {
+        return false;
+    }
+    if c.return_stack.is_empty() {
+        return true;
+    }
+    return config_is_at_end(&pop_return(c));
+}
+
 
 /// Compute FIRST set of the current position in a config.
 /// Includes tokens from nullable elements that were skipped by closure.
@@ -648,7 +664,37 @@ fn build_sll_node(configs: &Array<SllConfig>, depth: i32, max_depth: i32, ctx: &
         }
     }
 
+    // Detect at-end configs: their alts are fully consumed at this depth and
+    // would simply return to the caller. They have empty FIRST sets, so the
+    // per-token loop above silently dropped them — that left the dispatcher
+    // missing a "default" path for tokens belonging to the calling context.
+    //
+    // Two cases:
+    //  * No explicit branches but exactly one at-end alt → that alt is the
+    //    only valid match at this point. Return Leaf so the caller commits.
+    //  * Both explicit branches and at-end alts → ambiguous in general.
+    //    A token-dispatch on the explicit branch is unsafe because the
+    //    branch can fail at parse time (e.g. typespec `ID '[' ']'` matches
+    //    the lookahead `[` but the body `[ ]` won't match `[ <e> ]`),
+    //    leaving the at-end alt as the only correct choice. Fall back to
+    //    Backtrack so the codegen's longest-match scan dispatch picks the
+    //    alt whose body actually parses (cf. ANTLR4's adaptive prediction).
+    //  * Multiple at-end alts → true ambiguity → Backtrack.
+    let mut at_end_alts: Array<i32> = [];
+    for let c of &closed {
+        if config_is_at_end(c) && !array_contains_i32(&at_end_alts, c.alt_index) {
+            at_end_alts.push(c.alt_index);
+        }
+    }
+
+    if at_end_alts.len() >= 1 && branches.len() >= 1 {
+        return PredictionNode::Backtrack(alts);
+    }
+
     if branches.len() == 0 {
+        if at_end_alts.len() == 1 {
+            return PredictionNode::Leaf(at_end_alts[0]);
+        }
         return PredictionNode::Backtrack(alts);
     }
     return PredictionNode::Dispatch(PredictionDispatch { depth, branches });

--- a/package-gale/tests/antlr4-compat/listeners_test.wado
+++ b/package-gale/tests/antlr4-compat/listeners_test.wado
@@ -1,8 +1,0 @@
-#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado")]
-// Do not edit by hand — re-run the generator to regenerate.
-//
-// Source category: Listeners (ANTLR4 runtime-testsuite).
-// Triage data: package-gale/tests/antlr4-compat/status.toml
-
-use { parse } from "../../src/g4/parser.wado";
-

--- a/package-gale/tests/antlr4-compat/stage_b/LeftRecursion/JavaExpressions_12_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b/LeftRecursion/JavaExpressions_12_test.wado
@@ -14,8 +14,6 @@ use t from "../../grammars/LeftRecursion/JavaExpressions_12.g4"
     };
 use { normalize_tree } from "../../grammars/LeftRecursion/JavaExpressions_12.g4";
 
-#[TODO]
-// triage: Stage B test parse fails with Result::Err — investigation pending
 test "stage_b: LeftRecursion/JavaExpressions_12" {
     let input = "new T[((n-1) * x) + 1]";
     let expected = "(s (e new (typespec T) [ (e (e ( (e (e ( (e (e n) - (e 1)) )) * (e x)) )) + (e 1)) ]))";

--- a/package-gale/tests/antlr4-compat/stage_b/LeftRecursion/JavaExpressions_7_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b/LeftRecursion/JavaExpressions_7_test.wado
@@ -14,8 +14,6 @@ use t from "../../grammars/LeftRecursion/JavaExpressions_7.g4"
     };
 use { normalize_tree } from "../../grammars/LeftRecursion/JavaExpressions_7.g4";
 
-#[TODO]
-// triage: Stage B test parse fails with Result::Err — investigation pending
 test "stage_b: LeftRecursion/JavaExpressions_7" {
     let input = "(T)x";
     let expected = "(s (e ( (typespec T) ) (e x)))";

--- a/package-gale/tests/antlr4-compat/stage_b/LeftRecursion/JavaExpressions_8_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b/LeftRecursion/JavaExpressions_8_test.wado
@@ -14,8 +14,6 @@ use t from "../../grammars/LeftRecursion/JavaExpressions_8.g4"
     };
 use { normalize_tree } from "../../grammars/LeftRecursion/JavaExpressions_8.g4";
 
-#[TODO]
-// triage: Stage B test parse fails with Result::Err — investigation pending
 test "stage_b: LeftRecursion/JavaExpressions_8" {
     let input = "new A().b";
     let expected = "(s (e (e new (typespec A) ( )) . b))";

--- a/package-gale/tests/antlr4-compat/stage_b/LeftRecursion/JavaExpressions_9_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b/LeftRecursion/JavaExpressions_9_test.wado
@@ -14,8 +14,6 @@ use t from "../../grammars/LeftRecursion/JavaExpressions_9.g4"
     };
 use { normalize_tree } from "../../grammars/LeftRecursion/JavaExpressions_9.g4";
 
-#[TODO]
-// triage: Stage B test parse fails with Result::Err — investigation pending
 test "stage_b: LeftRecursion/JavaExpressions_9" {
     let input = "(T)t.f()";
     let expected = "(s (e (e ( (typespec T) ) (e (e t) . f)) ( )))";

--- a/package-gale/tests/antlr4-compat/status.toml
+++ b/package-gale/tests/antlr4-compat/status.toml
@@ -43,10 +43,6 @@
 "ParserErrors/SingleTokenDeletionConsumption" = "trailing <! ... !> StringTemplate comment outside any rule — testsuite descriptor artifact, not a self-contained .g4"
 
 [stage_b_todo]
-"LeftRecursion/JavaExpressions_7" = "Stage B test parse fails with Result::Err — investigation pending"
-"LeftRecursion/JavaExpressions_8" = "Stage B test parse fails with Result::Err — investigation pending"
-"LeftRecursion/JavaExpressions_9" = "Stage B test parse fails with Result::Err — investigation pending"
-"LeftRecursion/JavaExpressions_12" = "Stage B test parse fails with Result::Err — investigation pending"
 "LeftRecursion/PrecedenceFilterConsidersContext" = "Stage B test parse fails with Result::Err — precedence filter behaviour gap"
 "LeftRecursion/SemPredFailOption" = "Stage B parse-tree shape diverges because action bodies are skipped (the predicate guard is dropped) — Stage C territory"
 "ParserExec/BuildParseTree_TRUE" = "Stage B test parse fails or tree shape diverges — investigation pending"

--- a/package-gale/tests/driver_at_end_alt_gaps_test.wado
+++ b/package-gale/tests/driver_at_end_alt_gaps_test.wado
@@ -1,0 +1,47 @@
+use g from "./grammars/at_end_alt_gaps.g4"
+    with {
+        generator: {
+            module: "../src/generator.wado",
+            options: { highlight: false },
+            output_dir: "tests/generated/at_end_alt_gaps",
+        },
+    };
+use { normalize_tree } from "./grammars/at_end_alt_gaps.g4";
+
+fn assert_tree(input: &String, expected: &String) {
+    let root = g::parse(input).unwrap();
+    let tree = g::to_tree(&root);
+    let actual = tree.to_string_tree();
+    let norm = normalize_tree(expected);
+    assert actual == norm, `\ninput:    {*input}\nexpected: {norm}\nactual:   {actual}`;
+}
+
+test "paren caller: typespec commits to bare ID alt" {
+    assert_tree(&"(T)", &"
+        (prog (entry ( (typespec T) )))
+    ");
+}
+
+test "paren caller: typespec commits to ID '[' ']' alt" {
+    assert_tree(&"(T[])", &"
+        (prog (entry ( (typespec T [ ]) )))
+    ");
+}
+
+test "index caller: typespec must pick bare ID alt despite '[' lookahead" {
+    // The trap: at depth=1 in typespec (after consuming `T`), the next token
+    // is `[`. The dropped at-end alt 0 should win here because alt 1's body
+    // `[ ]` does not match the input `[1`.
+    assert_tree(&"new T[1]", &"
+        (prog (entry new (typespec T) [ 1 ]))
+    ");
+}
+
+test "interleaved entries exercise both dispatch paths in one parse" {
+    assert_tree(&"(T) new T[1] (T[])", &"
+        (prog
+          (entry ( (typespec T) ))
+          (entry new (typespec T) [ 1 ])
+          (entry ( (typespec T [ ]) )))
+    ");
+}

--- a/package-gale/tests/generated/antlr4/ANTLRv4Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4/ANTLRv4Lexer.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-6fd58782d32cfb10",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "grammars/ANTLRv4Lexer.g4",
     "hash": "30bd52b58a5916a63041f501c2d45358431c5c379f1ed3e8a3fbbb311f3572bd"

--- a/package-gale/tests/generated/antlr4/ANTLRv4Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4/ANTLRv4Lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6fd58782d32cfb10",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "grammars/ANTLRv4Lexer.g4",
     "hash": "30bd52b58a5916a63041f501c2d45358431c5c379f1ed3e8a3fbbb311f3572bd"

--- a/package-gale/tests/generated/antlr4/ANTLRv4Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4/ANTLRv4Lexer.g4.kiln.json
@@ -17,7 +17,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4/antlrv4.wado",
-      "hash": "2286c951bdc22845f111ae4378bcd120634f6ff765d263309ff9c4212792bc2f",
+      "hash": "19ba4fd528c206fb6398df08031855aa7f3db7217e86c6bc308d9bd9fb88f8e0",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4/antlrv4.wado
+++ b/package-gale/tests/generated/antlr4/antlrv4.wado
@@ -5957,14 +5957,28 @@ fn parse_delegate_grammar(p: &mut Parser) -> Result<DelegateGrammarNode, ParseEr
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if _gale_kind_set_1(kind) {
-        if p.peek_kind() == TK_RULE_REF {
-            if p.peek_at(1) == TK_ASSIGN {
+        if _gale_kind_set_1(p.peek_kind()) {
+            let _sd_tokens = &p.tokens;
+            let _sd_pos = p.pos;
+            let _sd_p_1 = parse_delegate_grammar_scan_1(_sd_tokens, _sd_pos);
+            let _sd_p_0 = parse_delegate_grammar_scan_0(_sd_tokens, _sd_pos);
+            let mut _sd_best_i: i32 = -1;
+            let mut _sd_best_p: i32 = -1;
+            if _sd_p_1 > _sd_best_p {
+                _sd_best_p = _sd_p_1;
+                _sd_best_i = 1;
+            }
+            if _sd_p_0 > _sd_best_p {
+                _sd_best_p = _sd_p_0;
+                _sd_best_i = 0;
+            }
+            if _sd_best_i == 1 {
+                return parse_delegate_grammar_bt_1(p);
+            }
+            if _sd_best_i == 0 {
                 return parse_delegate_grammar_bt_0(p);
             }
-        } else if p.peek_kind() == TK_TOKEN_REF {
-            if p.peek_at(1) == TK_ASSIGN {
-                return parse_delegate_grammar_bt_0(p);
-            }
+            return parse_delegate_grammar_bt_0(p);
         }
     }
     return Result::<DelegateGrammarNode, ParseError>::Err(ParseError::new(
@@ -6876,18 +6890,28 @@ fn parse_lexer_command(p: &mut Parser) -> Result<LexerCommandNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if _gale_kind_set_11(kind) {
-        if p.peek_kind() == TK_RULE_REF {
-            if p.peek_at(1) == TK_LPAREN {
+        if _gale_kind_set_11(p.peek_kind()) {
+            let _sd_tokens = &p.tokens;
+            let _sd_pos = p.pos;
+            let _sd_p_1 = parse_lexer_command_scan_1(_sd_tokens, _sd_pos);
+            let _sd_p_0 = parse_lexer_command_scan_0(_sd_tokens, _sd_pos);
+            let mut _sd_best_i: i32 = -1;
+            let mut _sd_best_p: i32 = -1;
+            if _sd_p_1 > _sd_best_p {
+                _sd_best_p = _sd_p_1;
+                _sd_best_i = 1;
+            }
+            if _sd_p_0 > _sd_best_p {
+                _sd_best_p = _sd_p_0;
+                _sd_best_i = 0;
+            }
+            if _sd_best_i == 1 {
+                return parse_lexer_command_bt_1(p);
+            }
+            if _sd_best_i == 0 {
                 return parse_lexer_command_bt_0(p);
             }
-        } else if p.peek_kind() == TK_TOKEN_REF {
-            if p.peek_at(1) == TK_LPAREN {
-                return parse_lexer_command_bt_0(p);
-            }
-        } else if p.peek_kind() == TK_MODE {
-            if p.peek_at(1) == TK_LPAREN {
-                return parse_lexer_command_bt_0(p);
-            }
+            return parse_lexer_command_bt_0(p);
         }
     }
     return Result::<LexerCommandNode, ParseError>::Err(ParseError::new(

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-a6ec2b8f2ddde283",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_1.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a6ec2b8f2ddde283",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_1.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-61c5e70fcdb6da1f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_10.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-61c5e70fcdb6da1f",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_10.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-699ecb3a8f815e27",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_2.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-699ecb3a8f815e27",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_2.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-262e54587e9044c3",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_3.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-262e54587e9044c3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_3.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-a998eaa06c653a5b",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_4.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a998eaa06c653a5b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_4.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-fc22b0fc36d36630",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_5.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fc22b0fc36d36630",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_5.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2852af861801de26",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_6.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-2852af861801de26",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_6.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-320d631a0baf5c0b",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_7.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-320d631a0baf5c0b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_7.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-3bd4c5ea00e5572f",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_8.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3bd4c5ea00e5572f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_8.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-49d484703a919155",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_9.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-49d484703a919155",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_9.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-713ef5230fbaf9f1",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_1.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-713ef5230fbaf9f1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_1.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-558b311b80c4da10",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_2.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-558b311b80c4da10",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_2.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-c369756dc031bf12",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_3.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c369756dc031bf12",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_3.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-abed1c70b5e6c53f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_1.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-abed1c70b5e6c53f",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_1.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a1b502206053bf7a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_2.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-a1b502206053bf7a",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_2.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-68045ae831d55159",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_3.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-68045ae831d55159",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_3.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-678c469712c8fc23",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_4.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-678c469712c8fc23",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_4.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-16bc5e2c231c2ba8",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_5.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-16bc5e2c231c2ba8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_5.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c116bb1cfe62a2a8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_6.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-c116bb1cfe62a2a8",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_6.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0484794f535b91f2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_7.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-0484794f535b91f2",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_7.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fe2840241e9172a0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_1.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/t.wado",
-      "hash": "3627adfaf9cd2893ffb5325ae456204ce77015c8eee0d57f82b1842fa147b18b",
+      "hash": "46995ee431d72ad209ee60fe7cf69cf36a8d89fa603918be1d7ac6f9baacabcf",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-fe2840241e9172a0",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_1.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/t.wado
@@ -3256,22 +3256,50 @@ fn parse_typespec(p: &mut Parser) -> Result<TypespecNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind == TK_ID {
-        let id = p.expect(TK_ID)?;
-        if p.peek_kind() == TK_LIT_LBRACKET {
-            let lbracket = p.expect(TK_LIT_LBRACKET)?;
-            let rbracket = p.expect(TK_LIT_RBRACKET)?;
-            return Result::<TypespecNode, ParseError>::Ok(TypespecNode::Alt1(TypespecAlt1 {
-                span: Span::new(start, p.last_end()),
-                id,
-                lbracket,
-                rbracket,
-            }));
+        let _sd_tokens = &p.tokens;
+        let _sd_pos = p.pos;
+        let _sd_p_1 = parse_typespec_scan_1(_sd_tokens, _sd_pos);
+        let _sd_p_0 = parse_typespec_scan_0(_sd_tokens, _sd_pos);
+        let mut _sd_best_i: i32 = -1;
+        let mut _sd_best_p: i32 = -1;
+        if _sd_p_1 > _sd_best_p {
+            _sd_best_p = _sd_p_1;
+            _sd_best_i = 1;
         }
+        if _sd_p_0 > _sd_best_p {
+            _sd_best_p = _sd_p_0;
+            _sd_best_i = 0;
+        }
+        if _sd_best_i == 1 {
+            return parse_typespec_bt_1(p);
+        }
+        if _sd_best_i == 0 {
+            return parse_typespec_bt_0(p);
+        }
+        return parse_typespec_bt_0(p);
     }
     if kind == TK_LIT_INT {
-        if p.peek_kind() == TK_LIT_LBRACKET {
+        let _sd_tokens = &p.tokens;
+        let _sd_pos = p.pos;
+        let _sd_p_3 = parse_typespec_scan_3(_sd_tokens, _sd_pos);
+        let _sd_p_2 = parse_typespec_scan_2(_sd_tokens, _sd_pos);
+        let mut _sd_best_i: i32 = -1;
+        let mut _sd_best_p: i32 = -1;
+        if _sd_p_3 > _sd_best_p {
+            _sd_best_p = _sd_p_3;
+            _sd_best_i = 3;
+        }
+        if _sd_p_2 > _sd_best_p {
+            _sd_best_p = _sd_p_2;
+            _sd_best_i = 2;
+        }
+        if _sd_best_i == 3 {
             return parse_typespec_bt_3(p);
         }
+        if _sd_best_i == 2 {
+            return parse_typespec_bt_2(p);
+        }
+        return parse_typespec_bt_2(p);
     }
     return Result::<TypespecNode, ParseError>::Err(ParseError::new(
         "expected typespec",

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-235cd53ca8f4663a",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_10.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/t.wado",
-      "hash": "017f6b55acb3004e58427eb38d936fa71c1e7235103384134935a6d52fd5acb7",
+      "hash": "283c4587281d2f45f05d0e39dd826a16fc3893b886a193bd0755b9b69a962f70",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-235cd53ca8f4663a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_10.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/t.wado
@@ -3256,22 +3256,50 @@ fn parse_typespec(p: &mut Parser) -> Result<TypespecNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind == TK_ID {
-        let id = p.expect(TK_ID)?;
-        if p.peek_kind() == TK_LIT_LBRACKET {
-            let lbracket = p.expect(TK_LIT_LBRACKET)?;
-            let rbracket = p.expect(TK_LIT_RBRACKET)?;
-            return Result::<TypespecNode, ParseError>::Ok(TypespecNode::Alt1(TypespecAlt1 {
-                span: Span::new(start, p.last_end()),
-                id,
-                lbracket,
-                rbracket,
-            }));
+        let _sd_tokens = &p.tokens;
+        let _sd_pos = p.pos;
+        let _sd_p_1 = parse_typespec_scan_1(_sd_tokens, _sd_pos);
+        let _sd_p_0 = parse_typespec_scan_0(_sd_tokens, _sd_pos);
+        let mut _sd_best_i: i32 = -1;
+        let mut _sd_best_p: i32 = -1;
+        if _sd_p_1 > _sd_best_p {
+            _sd_best_p = _sd_p_1;
+            _sd_best_i = 1;
         }
+        if _sd_p_0 > _sd_best_p {
+            _sd_best_p = _sd_p_0;
+            _sd_best_i = 0;
+        }
+        if _sd_best_i == 1 {
+            return parse_typespec_bt_1(p);
+        }
+        if _sd_best_i == 0 {
+            return parse_typespec_bt_0(p);
+        }
+        return parse_typespec_bt_0(p);
     }
     if kind == TK_LIT_INT {
-        if p.peek_kind() == TK_LIT_LBRACKET {
+        let _sd_tokens = &p.tokens;
+        let _sd_pos = p.pos;
+        let _sd_p_3 = parse_typespec_scan_3(_sd_tokens, _sd_pos);
+        let _sd_p_2 = parse_typespec_scan_2(_sd_tokens, _sd_pos);
+        let mut _sd_best_i: i32 = -1;
+        let mut _sd_best_p: i32 = -1;
+        if _sd_p_3 > _sd_best_p {
+            _sd_best_p = _sd_p_3;
+            _sd_best_i = 3;
+        }
+        if _sd_p_2 > _sd_best_p {
+            _sd_best_p = _sd_p_2;
+            _sd_best_i = 2;
+        }
+        if _sd_best_i == 3 {
             return parse_typespec_bt_3(p);
         }
+        if _sd_best_i == 2 {
+            return parse_typespec_bt_2(p);
+        }
+        return parse_typespec_bt_2(p);
     }
     return Result::<TypespecNode, ParseError>::Err(ParseError::new(
         "expected typespec",

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ed84013859c673b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_11.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-ed84013859c673b1",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_11.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/t.wado",
-      "hash": "49f1275bf02bd13b615251804b803e1a7d8b9b702283e9da98a798af40f84c10",
+      "hash": "fce09b30bc615ae92af70e1059253d8a6058bdcda42a056964411a21ed9c9392",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/t.wado
@@ -3256,22 +3256,50 @@ fn parse_typespec(p: &mut Parser) -> Result<TypespecNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind == TK_ID {
-        let id = p.expect(TK_ID)?;
-        if p.peek_kind() == TK_LIT_LBRACKET {
-            let lbracket = p.expect(TK_LIT_LBRACKET)?;
-            let rbracket = p.expect(TK_LIT_RBRACKET)?;
-            return Result::<TypespecNode, ParseError>::Ok(TypespecNode::Alt1(TypespecAlt1 {
-                span: Span::new(start, p.last_end()),
-                id,
-                lbracket,
-                rbracket,
-            }));
+        let _sd_tokens = &p.tokens;
+        let _sd_pos = p.pos;
+        let _sd_p_1 = parse_typespec_scan_1(_sd_tokens, _sd_pos);
+        let _sd_p_0 = parse_typespec_scan_0(_sd_tokens, _sd_pos);
+        let mut _sd_best_i: i32 = -1;
+        let mut _sd_best_p: i32 = -1;
+        if _sd_p_1 > _sd_best_p {
+            _sd_best_p = _sd_p_1;
+            _sd_best_i = 1;
         }
+        if _sd_p_0 > _sd_best_p {
+            _sd_best_p = _sd_p_0;
+            _sd_best_i = 0;
+        }
+        if _sd_best_i == 1 {
+            return parse_typespec_bt_1(p);
+        }
+        if _sd_best_i == 0 {
+            return parse_typespec_bt_0(p);
+        }
+        return parse_typespec_bt_0(p);
     }
     if kind == TK_LIT_INT {
-        if p.peek_kind() == TK_LIT_LBRACKET {
+        let _sd_tokens = &p.tokens;
+        let _sd_pos = p.pos;
+        let _sd_p_3 = parse_typespec_scan_3(_sd_tokens, _sd_pos);
+        let _sd_p_2 = parse_typespec_scan_2(_sd_tokens, _sd_pos);
+        let mut _sd_best_i: i32 = -1;
+        let mut _sd_best_p: i32 = -1;
+        if _sd_p_3 > _sd_best_p {
+            _sd_best_p = _sd_p_3;
+            _sd_best_i = 3;
+        }
+        if _sd_p_2 > _sd_best_p {
+            _sd_best_p = _sd_p_2;
+            _sd_best_i = 2;
+        }
+        if _sd_best_i == 3 {
             return parse_typespec_bt_3(p);
         }
+        if _sd_best_i == 2 {
+            return parse_typespec_bt_2(p);
+        }
+        return parse_typespec_bt_2(p);
     }
     return Result::<TypespecNode, ParseError>::Err(ParseError::new(
         "expected typespec",

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-739357c31b4c8ca4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_12.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-739357c31b4c8ca4",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_12.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/t.wado",
-      "hash": "ef006e78d35a120655b7baa8abb2a069ffc36fb43611951ea777ee39fba7b979",
+      "hash": "32f5b98675941cd9064c799a058da6a8b2819688a2802445d774381c8a0852c7",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/t.wado
@@ -3256,22 +3256,50 @@ fn parse_typespec(p: &mut Parser) -> Result<TypespecNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind == TK_ID {
-        let id = p.expect(TK_ID)?;
-        if p.peek_kind() == TK_LIT_LBRACKET {
-            let lbracket = p.expect(TK_LIT_LBRACKET)?;
-            let rbracket = p.expect(TK_LIT_RBRACKET)?;
-            return Result::<TypespecNode, ParseError>::Ok(TypespecNode::Alt1(TypespecAlt1 {
-                span: Span::new(start, p.last_end()),
-                id,
-                lbracket,
-                rbracket,
-            }));
+        let _sd_tokens = &p.tokens;
+        let _sd_pos = p.pos;
+        let _sd_p_1 = parse_typespec_scan_1(_sd_tokens, _sd_pos);
+        let _sd_p_0 = parse_typespec_scan_0(_sd_tokens, _sd_pos);
+        let mut _sd_best_i: i32 = -1;
+        let mut _sd_best_p: i32 = -1;
+        if _sd_p_1 > _sd_best_p {
+            _sd_best_p = _sd_p_1;
+            _sd_best_i = 1;
         }
+        if _sd_p_0 > _sd_best_p {
+            _sd_best_p = _sd_p_0;
+            _sd_best_i = 0;
+        }
+        if _sd_best_i == 1 {
+            return parse_typespec_bt_1(p);
+        }
+        if _sd_best_i == 0 {
+            return parse_typespec_bt_0(p);
+        }
+        return parse_typespec_bt_0(p);
     }
     if kind == TK_LIT_INT {
-        if p.peek_kind() == TK_LIT_LBRACKET {
+        let _sd_tokens = &p.tokens;
+        let _sd_pos = p.pos;
+        let _sd_p_3 = parse_typespec_scan_3(_sd_tokens, _sd_pos);
+        let _sd_p_2 = parse_typespec_scan_2(_sd_tokens, _sd_pos);
+        let mut _sd_best_i: i32 = -1;
+        let mut _sd_best_p: i32 = -1;
+        if _sd_p_3 > _sd_best_p {
+            _sd_best_p = _sd_p_3;
+            _sd_best_i = 3;
+        }
+        if _sd_p_2 > _sd_best_p {
+            _sd_best_p = _sd_p_2;
+            _sd_best_i = 2;
+        }
+        if _sd_best_i == 3 {
             return parse_typespec_bt_3(p);
         }
+        if _sd_best_i == 2 {
+            return parse_typespec_bt_2(p);
+        }
+        return parse_typespec_bt_2(p);
     }
     return Result::<TypespecNode, ParseError>::Err(ParseError::new(
         "expected typespec",

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/t.wado",
-      "hash": "9e65229603bda8a6e0eba0ee7c51a79f9865f44b8e3da15ae6be57af93cb86db",
+      "hash": "189466b4c794e6e52f6c062f4a133841db8d61e25ed95423d7243b8327e7ad78",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-70a21a8410fad983",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_2.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-70a21a8410fad983",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_2.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/t.wado
@@ -3256,22 +3256,50 @@ fn parse_typespec(p: &mut Parser) -> Result<TypespecNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind == TK_ID {
-        let id = p.expect(TK_ID)?;
-        if p.peek_kind() == TK_LIT_LBRACKET {
-            let lbracket = p.expect(TK_LIT_LBRACKET)?;
-            let rbracket = p.expect(TK_LIT_RBRACKET)?;
-            return Result::<TypespecNode, ParseError>::Ok(TypespecNode::Alt1(TypespecAlt1 {
-                span: Span::new(start, p.last_end()),
-                id,
-                lbracket,
-                rbracket,
-            }));
+        let _sd_tokens = &p.tokens;
+        let _sd_pos = p.pos;
+        let _sd_p_1 = parse_typespec_scan_1(_sd_tokens, _sd_pos);
+        let _sd_p_0 = parse_typespec_scan_0(_sd_tokens, _sd_pos);
+        let mut _sd_best_i: i32 = -1;
+        let mut _sd_best_p: i32 = -1;
+        if _sd_p_1 > _sd_best_p {
+            _sd_best_p = _sd_p_1;
+            _sd_best_i = 1;
         }
+        if _sd_p_0 > _sd_best_p {
+            _sd_best_p = _sd_p_0;
+            _sd_best_i = 0;
+        }
+        if _sd_best_i == 1 {
+            return parse_typespec_bt_1(p);
+        }
+        if _sd_best_i == 0 {
+            return parse_typespec_bt_0(p);
+        }
+        return parse_typespec_bt_0(p);
     }
     if kind == TK_LIT_INT {
-        if p.peek_kind() == TK_LIT_LBRACKET {
+        let _sd_tokens = &p.tokens;
+        let _sd_pos = p.pos;
+        let _sd_p_3 = parse_typespec_scan_3(_sd_tokens, _sd_pos);
+        let _sd_p_2 = parse_typespec_scan_2(_sd_tokens, _sd_pos);
+        let mut _sd_best_i: i32 = -1;
+        let mut _sd_best_p: i32 = -1;
+        if _sd_p_3 > _sd_best_p {
+            _sd_best_p = _sd_p_3;
+            _sd_best_i = 3;
+        }
+        if _sd_p_2 > _sd_best_p {
+            _sd_best_p = _sd_p_2;
+            _sd_best_i = 2;
+        }
+        if _sd_best_i == 3 {
             return parse_typespec_bt_3(p);
         }
+        if _sd_best_i == 2 {
+            return parse_typespec_bt_2(p);
+        }
+        return parse_typespec_bt_2(p);
     }
     return Result::<TypespecNode, ParseError>::Err(ParseError::new(
         "expected typespec",

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-99bcc333174e8ead",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_5.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-99bcc333174e8ead",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_5.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/t.wado",
-      "hash": "d451941088c2c4757a1b43b0423a3ce220fb02999ea38be0d16d0fc3ce662b75",
+      "hash": "e4f44872d3c1e86b58723385ab9cf60380164b81e1b207cf78a669a4e7a7bfbc",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/t.wado
@@ -3256,22 +3256,50 @@ fn parse_typespec(p: &mut Parser) -> Result<TypespecNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind == TK_ID {
-        let id = p.expect(TK_ID)?;
-        if p.peek_kind() == TK_LIT_LBRACKET {
-            let lbracket = p.expect(TK_LIT_LBRACKET)?;
-            let rbracket = p.expect(TK_LIT_RBRACKET)?;
-            return Result::<TypespecNode, ParseError>::Ok(TypespecNode::Alt1(TypespecAlt1 {
-                span: Span::new(start, p.last_end()),
-                id,
-                lbracket,
-                rbracket,
-            }));
+        let _sd_tokens = &p.tokens;
+        let _sd_pos = p.pos;
+        let _sd_p_1 = parse_typespec_scan_1(_sd_tokens, _sd_pos);
+        let _sd_p_0 = parse_typespec_scan_0(_sd_tokens, _sd_pos);
+        let mut _sd_best_i: i32 = -1;
+        let mut _sd_best_p: i32 = -1;
+        if _sd_p_1 > _sd_best_p {
+            _sd_best_p = _sd_p_1;
+            _sd_best_i = 1;
         }
+        if _sd_p_0 > _sd_best_p {
+            _sd_best_p = _sd_p_0;
+            _sd_best_i = 0;
+        }
+        if _sd_best_i == 1 {
+            return parse_typespec_bt_1(p);
+        }
+        if _sd_best_i == 0 {
+            return parse_typespec_bt_0(p);
+        }
+        return parse_typespec_bt_0(p);
     }
     if kind == TK_LIT_INT {
-        if p.peek_kind() == TK_LIT_LBRACKET {
+        let _sd_tokens = &p.tokens;
+        let _sd_pos = p.pos;
+        let _sd_p_3 = parse_typespec_scan_3(_sd_tokens, _sd_pos);
+        let _sd_p_2 = parse_typespec_scan_2(_sd_tokens, _sd_pos);
+        let mut _sd_best_i: i32 = -1;
+        let mut _sd_best_p: i32 = -1;
+        if _sd_p_3 > _sd_best_p {
+            _sd_best_p = _sd_p_3;
+            _sd_best_i = 3;
+        }
+        if _sd_p_2 > _sd_best_p {
+            _sd_best_p = _sd_p_2;
+            _sd_best_i = 2;
+        }
+        if _sd_best_i == 3 {
             return parse_typespec_bt_3(p);
         }
+        if _sd_best_i == 2 {
+            return parse_typespec_bt_2(p);
+        }
+        return parse_typespec_bt_2(p);
     }
     return Result::<TypespecNode, ParseError>::Err(ParseError::new(
         "expected typespec",

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/t.wado",
-      "hash": "df0f11cef75ce860c50ee97178680f0d6026d2c0780e98c5fe57df90fc7f8345",
+      "hash": "5065cb4314f3324027591bbf93094dc85d03c3568247548b0ad522698d42397e",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-2f290cf17eba13e0",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_6.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2f290cf17eba13e0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_6.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/t.wado
@@ -3256,22 +3256,50 @@ fn parse_typespec(p: &mut Parser) -> Result<TypespecNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind == TK_ID {
-        let id = p.expect(TK_ID)?;
-        if p.peek_kind() == TK_LIT_LBRACKET {
-            let lbracket = p.expect(TK_LIT_LBRACKET)?;
-            let rbracket = p.expect(TK_LIT_RBRACKET)?;
-            return Result::<TypespecNode, ParseError>::Ok(TypespecNode::Alt1(TypespecAlt1 {
-                span: Span::new(start, p.last_end()),
-                id,
-                lbracket,
-                rbracket,
-            }));
+        let _sd_tokens = &p.tokens;
+        let _sd_pos = p.pos;
+        let _sd_p_1 = parse_typespec_scan_1(_sd_tokens, _sd_pos);
+        let _sd_p_0 = parse_typespec_scan_0(_sd_tokens, _sd_pos);
+        let mut _sd_best_i: i32 = -1;
+        let mut _sd_best_p: i32 = -1;
+        if _sd_p_1 > _sd_best_p {
+            _sd_best_p = _sd_p_1;
+            _sd_best_i = 1;
         }
+        if _sd_p_0 > _sd_best_p {
+            _sd_best_p = _sd_p_0;
+            _sd_best_i = 0;
+        }
+        if _sd_best_i == 1 {
+            return parse_typespec_bt_1(p);
+        }
+        if _sd_best_i == 0 {
+            return parse_typespec_bt_0(p);
+        }
+        return parse_typespec_bt_0(p);
     }
     if kind == TK_LIT_INT {
-        if p.peek_kind() == TK_LIT_LBRACKET {
+        let _sd_tokens = &p.tokens;
+        let _sd_pos = p.pos;
+        let _sd_p_3 = parse_typespec_scan_3(_sd_tokens, _sd_pos);
+        let _sd_p_2 = parse_typespec_scan_2(_sd_tokens, _sd_pos);
+        let mut _sd_best_i: i32 = -1;
+        let mut _sd_best_p: i32 = -1;
+        if _sd_p_3 > _sd_best_p {
+            _sd_best_p = _sd_p_3;
+            _sd_best_i = 3;
+        }
+        if _sd_p_2 > _sd_best_p {
+            _sd_best_p = _sd_p_2;
+            _sd_best_i = 2;
+        }
+        if _sd_best_i == 3 {
             return parse_typespec_bt_3(p);
         }
+        if _sd_best_i == 2 {
+            return parse_typespec_bt_2(p);
+        }
+        return parse_typespec_bt_2(p);
     }
     return Result::<TypespecNode, ParseError>::Err(ParseError::new(
         "expected typespec",

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/t.wado",
-      "hash": "55594194a4c89ae556a1a29f566a4d3e3271910c884adbc8104bd31d33e10d55",
+      "hash": "0f5e521e243ac617a1390712cf209595ac140aabe0483b2123ccaa07d4aae834",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bd943cd5ec077b75",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_7.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-bd943cd5ec077b75",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_7.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/t.wado
@@ -3256,22 +3256,50 @@ fn parse_typespec(p: &mut Parser) -> Result<TypespecNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind == TK_ID {
-        let id = p.expect(TK_ID)?;
-        if p.peek_kind() == TK_LIT_LBRACKET {
-            let lbracket = p.expect(TK_LIT_LBRACKET)?;
-            let rbracket = p.expect(TK_LIT_RBRACKET)?;
-            return Result::<TypespecNode, ParseError>::Ok(TypespecNode::Alt1(TypespecAlt1 {
-                span: Span::new(start, p.last_end()),
-                id,
-                lbracket,
-                rbracket,
-            }));
+        let _sd_tokens = &p.tokens;
+        let _sd_pos = p.pos;
+        let _sd_p_1 = parse_typespec_scan_1(_sd_tokens, _sd_pos);
+        let _sd_p_0 = parse_typespec_scan_0(_sd_tokens, _sd_pos);
+        let mut _sd_best_i: i32 = -1;
+        let mut _sd_best_p: i32 = -1;
+        if _sd_p_1 > _sd_best_p {
+            _sd_best_p = _sd_p_1;
+            _sd_best_i = 1;
         }
+        if _sd_p_0 > _sd_best_p {
+            _sd_best_p = _sd_p_0;
+            _sd_best_i = 0;
+        }
+        if _sd_best_i == 1 {
+            return parse_typespec_bt_1(p);
+        }
+        if _sd_best_i == 0 {
+            return parse_typespec_bt_0(p);
+        }
+        return parse_typespec_bt_0(p);
     }
     if kind == TK_LIT_INT {
-        if p.peek_kind() == TK_LIT_LBRACKET {
+        let _sd_tokens = &p.tokens;
+        let _sd_pos = p.pos;
+        let _sd_p_3 = parse_typespec_scan_3(_sd_tokens, _sd_pos);
+        let _sd_p_2 = parse_typespec_scan_2(_sd_tokens, _sd_pos);
+        let mut _sd_best_i: i32 = -1;
+        let mut _sd_best_p: i32 = -1;
+        if _sd_p_3 > _sd_best_p {
+            _sd_best_p = _sd_p_3;
+            _sd_best_i = 3;
+        }
+        if _sd_p_2 > _sd_best_p {
+            _sd_best_p = _sd_p_2;
+            _sd_best_i = 2;
+        }
+        if _sd_best_i == 3 {
             return parse_typespec_bt_3(p);
         }
+        if _sd_best_i == 2 {
+            return parse_typespec_bt_2(p);
+        }
+        return parse_typespec_bt_2(p);
     }
     return Result::<TypespecNode, ParseError>::Err(ParseError::new(
         "expected typespec",

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-6ad535192ef3e12f",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_8.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/t.wado",
-      "hash": "56ff892f3695278b28ee6a2ef989684ad328e0c3ccc74d812373cc1ae680b852",
+      "hash": "1820358b8341b2ca193aa9b6694528d50672552f2f152761fc3d0ef3e52ee50f",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6ad535192ef3e12f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_8.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/t.wado
@@ -3256,22 +3256,50 @@ fn parse_typespec(p: &mut Parser) -> Result<TypespecNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind == TK_ID {
-        let id = p.expect(TK_ID)?;
-        if p.peek_kind() == TK_LIT_LBRACKET {
-            let lbracket = p.expect(TK_LIT_LBRACKET)?;
-            let rbracket = p.expect(TK_LIT_RBRACKET)?;
-            return Result::<TypespecNode, ParseError>::Ok(TypespecNode::Alt1(TypespecAlt1 {
-                span: Span::new(start, p.last_end()),
-                id,
-                lbracket,
-                rbracket,
-            }));
+        let _sd_tokens = &p.tokens;
+        let _sd_pos = p.pos;
+        let _sd_p_1 = parse_typespec_scan_1(_sd_tokens, _sd_pos);
+        let _sd_p_0 = parse_typespec_scan_0(_sd_tokens, _sd_pos);
+        let mut _sd_best_i: i32 = -1;
+        let mut _sd_best_p: i32 = -1;
+        if _sd_p_1 > _sd_best_p {
+            _sd_best_p = _sd_p_1;
+            _sd_best_i = 1;
         }
+        if _sd_p_0 > _sd_best_p {
+            _sd_best_p = _sd_p_0;
+            _sd_best_i = 0;
+        }
+        if _sd_best_i == 1 {
+            return parse_typespec_bt_1(p);
+        }
+        if _sd_best_i == 0 {
+            return parse_typespec_bt_0(p);
+        }
+        return parse_typespec_bt_0(p);
     }
     if kind == TK_LIT_INT {
-        if p.peek_kind() == TK_LIT_LBRACKET {
+        let _sd_tokens = &p.tokens;
+        let _sd_pos = p.pos;
+        let _sd_p_3 = parse_typespec_scan_3(_sd_tokens, _sd_pos);
+        let _sd_p_2 = parse_typespec_scan_2(_sd_tokens, _sd_pos);
+        let mut _sd_best_i: i32 = -1;
+        let mut _sd_best_p: i32 = -1;
+        if _sd_p_3 > _sd_best_p {
+            _sd_best_p = _sd_p_3;
+            _sd_best_i = 3;
+        }
+        if _sd_p_2 > _sd_best_p {
+            _sd_best_p = _sd_p_2;
+            _sd_best_i = 2;
+        }
+        if _sd_best_i == 3 {
             return parse_typespec_bt_3(p);
         }
+        if _sd_best_i == 2 {
+            return parse_typespec_bt_2(p);
+        }
+        return parse_typespec_bt_2(p);
     }
     return Result::<TypespecNode, ParseError>::Err(ParseError::new(
         "expected typespec",

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-43dcc5eba0df7ec4",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_9.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-43dcc5eba0df7ec4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_9.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/t.wado",
-      "hash": "3705b15b65883004579723d5c03871783c8b84a6511be0f3ab98d39a8b11f9e3",
+      "hash": "df3cd2069816c988d5e11d77edb845edf7b373c57b05a821b3bd7afee892bc5a",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/t.wado
@@ -3256,22 +3256,50 @@ fn parse_typespec(p: &mut Parser) -> Result<TypespecNode, ParseError> {
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind == TK_ID {
-        let id = p.expect(TK_ID)?;
-        if p.peek_kind() == TK_LIT_LBRACKET {
-            let lbracket = p.expect(TK_LIT_LBRACKET)?;
-            let rbracket = p.expect(TK_LIT_RBRACKET)?;
-            return Result::<TypespecNode, ParseError>::Ok(TypespecNode::Alt1(TypespecAlt1 {
-                span: Span::new(start, p.last_end()),
-                id,
-                lbracket,
-                rbracket,
-            }));
+        let _sd_tokens = &p.tokens;
+        let _sd_pos = p.pos;
+        let _sd_p_1 = parse_typespec_scan_1(_sd_tokens, _sd_pos);
+        let _sd_p_0 = parse_typespec_scan_0(_sd_tokens, _sd_pos);
+        let mut _sd_best_i: i32 = -1;
+        let mut _sd_best_p: i32 = -1;
+        if _sd_p_1 > _sd_best_p {
+            _sd_best_p = _sd_p_1;
+            _sd_best_i = 1;
         }
+        if _sd_p_0 > _sd_best_p {
+            _sd_best_p = _sd_p_0;
+            _sd_best_i = 0;
+        }
+        if _sd_best_i == 1 {
+            return parse_typespec_bt_1(p);
+        }
+        if _sd_best_i == 0 {
+            return parse_typespec_bt_0(p);
+        }
+        return parse_typespec_bt_0(p);
     }
     if kind == TK_LIT_INT {
-        if p.peek_kind() == TK_LIT_LBRACKET {
+        let _sd_tokens = &p.tokens;
+        let _sd_pos = p.pos;
+        let _sd_p_3 = parse_typespec_scan_3(_sd_tokens, _sd_pos);
+        let _sd_p_2 = parse_typespec_scan_2(_sd_tokens, _sd_pos);
+        let mut _sd_best_i: i32 = -1;
+        let mut _sd_best_p: i32 = -1;
+        if _sd_p_3 > _sd_best_p {
+            _sd_best_p = _sd_p_3;
+            _sd_best_i = 3;
+        }
+        if _sd_p_2 > _sd_best_p {
+            _sd_best_p = _sd_p_2;
+            _sd_best_i = 2;
+        }
+        if _sd_best_i == 3 {
             return parse_typespec_bt_3(p);
         }
+        if _sd_best_i == 2 {
+            return parse_typespec_bt_2(p);
+        }
+        return parse_typespec_bt_2(p);
     }
     return Result::<TypespecNode, ParseError>::Err(ParseError::new(
         "expected typespec",

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-112c4a21992a04ed",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_1.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-112c4a21992a04ed",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_1.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-459d0b754845c21f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_2.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-459d0b754845c21f",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_2.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-1181507cda20d45b",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_3.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1181507cda20d45b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_3.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4b506a26b7b7c7b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_1.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-4b506a26b7b7c7b1",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_1.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-34e6293e9d4c3e83",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_2.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-34e6293e9d4c3e83",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_2.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b2467e37954af95c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_3.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-b2467e37954af95c",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_3.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-be8254158e713214",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_1.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-be8254158e713214",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_1.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-4fc8261d73da648f",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_2.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4fc8261d73da648f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_2.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-93334f393b16d8e0",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_3.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-93334f393b16d8e0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_3.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-e522638eb5f62a2f",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrecedenceFilterConsidersContext.g4",
     "hash": "c92df3158f9ed1c1b43de581aedaf3b0918fa525ff0258f855022b78585b860b"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e522638eb5f62a2f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrecedenceFilterConsidersContext.g4",
     "hash": "c92df3158f9ed1c1b43de581aedaf3b0918fa525ff0258f855022b78585b860b"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-709c12dbc0d22c0c",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrefixAndOtherAlt_1.g4",
     "hash": "f946ec43c09928b2aae968a817d4ff315478257d5700925eab82fd22d94714d8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-709c12dbc0d22c0c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrefixAndOtherAlt_1.g4",
     "hash": "f946ec43c09928b2aae968a817d4ff315478257d5700925eab82fd22d94714d8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1f6f1364b2571756",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrefixAndOtherAlt_2.g4",
     "hash": "f946ec43c09928b2aae968a817d4ff315478257d5700925eab82fd22d94714d8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-1f6f1364b2571756",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrefixAndOtherAlt_2.g4",
     "hash": "f946ec43c09928b2aae968a817d4ff315478257d5700925eab82fd22d94714d8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPred/SemPred.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPred/SemPred.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-960ef5ffa9d45556",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/SemPred.g4",
     "hash": "a19c17fc308f32463fe399a657b189a837ad4fa52afc1206ab0d1d8a38dcbe04"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPred/SemPred.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPred/SemPred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-960ef5ffa9d45556",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/SemPred.g4",
     "hash": "a19c17fc308f32463fe399a657b189a837ad4fa52afc1206ab0d1d8a38dcbe04"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPredFailOption/SemPredFailOption.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPredFailOption/SemPredFailOption.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a26551c8d0a65a59",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/SemPredFailOption.g4",
     "hash": "baacd97f45a8e197f2d9363c57506eebffd7f8862b34984e659ed317ac48a7d5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPredFailOption/SemPredFailOption.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPredFailOption/SemPredFailOption.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-a26551c8d0a65a59",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/SemPredFailOption.g4",
     "hash": "baacd97f45a8e197f2d9363c57506eebffd7f8862b34984e659ed317ac48a7d5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-5d3495c986bff9bd",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_1.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5d3495c986bff9bd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_1.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-33ccce79b79bf5e2",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_2.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-33ccce79b79bf5e2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_2.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6dcbc071fc2f601e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_3.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-6dcbc071fc2f601e",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_3.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-741313c066ff2cd5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_1.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-741313c066ff2cd5",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_1.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-381677e2c28357d8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_2.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-381677e2c28357d8",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_2.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4d665f3c7d50cbb6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_3.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-4d665f3c7d50cbb6",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_3.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-18d85335cd7b6ba7",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_4.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-18d85335cd7b6ba7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_4.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-6c0e1c831530f504",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_5.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6c0e1c831530f504",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_5.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d5dda292b3d95344",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_6.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-d5dda292b3d95344",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_6.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-bc586f7b630f85cb",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_7.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bc586f7b630f85cb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_7.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-b8fe4abc43e4380d",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_8.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b8fe4abc43e4380d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_8.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-ddd4f8db5f21632f",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_9.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ddd4f8db5f21632f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_9.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1a2ad3adca9a2a07",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_1.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-1a2ad3adca9a2a07",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_1.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-eed4df03ca7a51f5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_2.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-eed4df03ca7a51f5",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_2.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-bfcc2ec63de46569",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_3.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bfcc2ec63de46569",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_3.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-20cd1bcceb40fb33",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_4.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-20cd1bcceb40fb33",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_4.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-cfe1fc1849a20141",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_5.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-cfe1fc1849a20141",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_5.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-88482992acd5509f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_6.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-88482992acd5509f",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_6.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-78bbab6b273081fa",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_7.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-78bbab6b273081fa",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_7.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-03918ec747b14ad6",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_8.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-03918ec747b14ad6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_8.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-a66253165de20181",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_9.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a66253165de20181",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_9.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1d1b100d63f04166",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/ParserExec/BuildParseTree_TRUE.g4",
     "hash": "2a131cc48cdbfa4950f7c16ef0fcb51f4679926cabf71d403883a9fc01e9cb99"

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-1d1b100d63f04166",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/ParserExec/BuildParseTree_TRUE.g4",
     "hash": "2a131cc48cdbfa4950f7c16ef0fcb51f4679926cabf71d403883a9fc01e9cb99"

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-94c0b5df15a69680",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/ParserExec/PredictionIssue334.g4",
     "hash": "05f509013c98f1d1ef907d23c43aa328f3c9ee0ad9166b21ac03dbc715ee8542"

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-94c0b5df15a69680",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/ParserExec/PredictionIssue334.g4",
     "hash": "05f509013c98f1d1ef907d23c43aa328f3c9ee0ad9166b21ac03dbc715ee8542"

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-3ebf8faf7a4261df",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/ParserExec/PredictionMode_LL.g4",
     "hash": "8542495134a20f622112aa07fc5cd71fcc1b8e3669f41ff329126b355c4df7f4"

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3ebf8faf7a4261df",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/ParserExec/PredictionMode_LL.g4",
     "hash": "8542495134a20f622112aa07fc5cd71fcc1b8e3669f41ff329126b355c4df7f4"

--- a/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_1/PredFromAltTestedInLoopBack_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_1/PredFromAltTestedInLoopBack_1.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-3c84aa606fbeb863",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/PredFromAltTestedInLoopBack_1.g4",
     "hash": "b6144b334167648d1e1560be8a7590525c8b34cbba2e27d040c41026fa7c9323"

--- a/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_1/PredFromAltTestedInLoopBack_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_1/PredFromAltTestedInLoopBack_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3c84aa606fbeb863",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/PredFromAltTestedInLoopBack_1.g4",
     "hash": "b6144b334167648d1e1560be8a7590525c8b34cbba2e27d040c41026fa7c9323"

--- a/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-7f162199fbfa5a4d",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/PredFromAltTestedInLoopBack_2.g4",
     "hash": "b6144b334167648d1e1560be8a7590525c8b34cbba2e27d040c41026fa7c9323"

--- a/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7f162199fbfa5a4d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/PredFromAltTestedInLoopBack_2.g4",
     "hash": "b6144b334167648d1e1560be8a7590525c8b34cbba2e27d040c41026fa7c9323"

--- a/package-gale/tests/generated/at_end_alt_gaps/at_end_alt_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/at_end_alt_gaps/at_end_alt_gaps.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-105bcd36568c5dd8",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "grammars/at_end_alt_gaps.g4",
     "hash": "9cd47ca80f5762b4107f87ae05f1bce472bbfb8aca3c06ef0bdbf501ac519f82"

--- a/package-gale/tests/generated/at_end_alt_gaps/at_end_alt_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/at_end_alt_gaps/at_end_alt_gaps.g4.kiln.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "invocation": "kiln-105bcd36568c5dd8",
+  "generator": "local:src/generator.wado",
+  "primary": {
+    "path": "grammars/at_end_alt_gaps.g4",
+    "hash": "9cd47ca80f5762b4107f87ae05f1bce472bbfb8aca3c06ef0bdbf501ac519f82"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/at_end_alt_gaps/at_end_alt_gaps.wado",
+      "hash": "6ad00727bd2ff886f5d28fb5435569b1ecec89661b332f4c35fda49c792f3e29",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/at_end_alt_gaps/at_end_alt_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/at_end_alt_gaps/at_end_alt_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-105bcd36568c5dd8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "grammars/at_end_alt_gaps.g4",
     "hash": "9cd47ca80f5762b4107f87ae05f1bce472bbfb8aca3c06ef0bdbf501ac519f82"

--- a/package-gale/tests/generated/at_end_alt_gaps/at_end_alt_gaps.wado
+++ b/package-gale/tests/generated/at_end_alt_gaps/at_end_alt_gaps.wado
@@ -1,0 +1,1083 @@
+#![generated(by = "local:src/generator.wado", sources = ["grammars/at_end_alt_gaps.g4"])]
+#![generated(by = "gale", sources = ["AtEndAltGaps.g4"])]
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &Array<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &Array<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &Array<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: Array<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// ParseError represents a parse failure with location and expected tokens.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: Array<String>,
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: Array<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+}
+
+/// CstChild is either a terminal token or a non-terminal sub-tree.
+pub variant CstChild {
+    Token(Token),
+    Node(CstNode),
+}
+
+/// CstNode is a generic (untyped) concrete syntax tree node.
+pub struct CstNode {
+    pub name: String,
+    pub span: Span,
+    pub children: Array<CstChild>,
+}
+
+impl CstNode {
+    /// Produce an ANTLR4-style S-expression representation of this tree.
+    /// Rule nodes become `(name child1 child2 ...)`, tokens become their text.
+    /// Tokens with empty text (e.g. EOF) are omitted.
+    pub fn to_string_tree(&self) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(out: &mut String, node: &CstNode) {
+    out.push_str(`({node.name}`);
+    for let child of &node.children {
+        if let Token(t) = *child {
+            if !t.text.is_empty() {
+                out.push_str(` {t.text}`);
+            }
+        } else if let Node(n) = *child {
+            out.push_str(" ");
+            cst_to_string_tree_impl(out, n);
+        }
+    }
+    out.push_str(")");
+}
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Highlight override: when inside a specific rule, override the capture for a token kind.
+pub struct HighlightOverride {
+    pub rule_name: String,
+    pub token_kind: i32,
+    pub capture: String,
+}
+
+/// Highlight mapping: defaults by token kind + context-aware overrides.
+pub struct HighlightMapping {
+    pub defaults: Array<String>,
+    pub overrides: Array<HighlightOverride>,
+}
+
+/// A single highlight capture: a named range in the source text.
+pub struct HighlightCapture {
+    pub capture: String,
+    pub start: i32,
+    pub end: i32,
+}
+
+/// HighlightVisitor collects highlight captures during a CST walk.
+pub struct HighlightVisitor {
+    mapping: HighlightMapping,
+    rule_stack: Array<String>,
+    pub captures: Array<HighlightCapture>,
+}
+
+impl HighlightVisitor {
+    pub fn new(mapping: HighlightMapping) -> HighlightVisitor {
+        return HighlightVisitor { mapping, rule_stack: [], captures: [] };
+    }
+
+    fn classify(&self, kind: i32) -> String {
+        for let ov of &self.mapping.overrides {
+            if ov.token_kind == kind {
+                for let rule of &self.rule_stack {
+                    if *rule == ov.rule_name {
+                        return ov.capture;
+                    }
+                }
+            }
+        }
+        if kind >= 0 && kind < self.mapping.defaults.len() {
+            return self.mapping.defaults[kind];
+        }
+        return "";
+    }
+}
+
+impl Visitor for HighlightVisitor {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+        self.rule_stack.push(*name);
+    }
+
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+        if !self.rule_stack.is_empty() {
+            let last = self.rule_stack.len() - 1;
+            let mut new_stack: Array<String> = [];
+            for let mut i = 0; i < last; i += 1 {
+                new_stack.push(self.rule_stack[i]);
+            }
+            self.rule_stack = new_stack;
+        }
+    }
+
+    fn visit_token(&mut self, token: &Token) {
+        for let trivia of &token.leading_trivia {
+            let cap = self.classify(trivia.kind);
+            if !cap.is_empty() {
+                self.captures.push(HighlightCapture { capture: cap, start: trivia.span.start, end: trivia.span.end });
+            }
+        }
+        if token.text.is_empty() {
+            return;
+        }
+        let cap = self.classify(token.kind);
+        if !cap.is_empty() {
+            self.captures.push(HighlightCapture { capture: cap, start: token.span.start, end: token.span.end });
+        }
+    }
+}
+
+fn escape_html(out: &mut String, text: &String) {
+    for let c of text.chars() {
+        if c == '&' {
+            out.push_str("&amp;");
+        } else if c == '<' {
+            out.push_str("&lt;");
+        } else if c == '>' {
+            out.push_str("&gt;");
+        } else if c == '"' {
+            out.push_str("&quot;");
+        } else {
+            out.push(c);
+        }
+    }
+}
+
+fn escape_html_char(out: &mut String, c: char) {
+    if c == '&' {
+        out.push_str("&amp;");
+    } else if c == '<' {
+        out.push_str("&lt;");
+    } else if c == '>' {
+        out.push_str("&gt;");
+    } else if c == '"' {
+        out.push_str("&quot;");
+    } else {
+        out.push(c);
+    }
+}
+
+fn push_class(out: &mut String, capture: &String) {
+    for let c of capture.chars() {
+        if c == '.' {
+            out.push(' ');
+        } else {
+            out.push(c);
+        }
+    }
+}
+
+/// Produce a highlighted HTML fragment from source text and captures.
+/// Captures must be sorted by start position (as produced by HighlightVisitor).
+pub fn highlight_html(source: &String, captures: &Array<HighlightCapture>) -> String {
+    let mut out = String::with_capacity(source.len() * 5);
+    let mut pos = 0;
+    let mut iter = source.chars();
+    for let cap of captures {
+        while pos < cap.start {
+            if let Some(c) = iter.next() {
+                escape_html_char(&mut out, c);
+            }
+            pos += 1;
+        }
+        out.push_str("<span class=\"");
+        push_class(&mut out, &cap.capture);
+        out.push_str("\">");
+        let end = cap.end;
+        while pos < end {
+            if let Some(c) = iter.next() {
+                escape_html_char(&mut out, c);
+            }
+            pos += 1;
+        }
+        out.push_str("</span>");
+    }
+    while let Some(c) = iter.next() {
+        escape_html_char(&mut out, c);
+    }
+    return out;
+}
+
+fn substr(chars: &Array<char>, start: i32, end: i32) -> String {
+    let mut out = String::with_capacity(end - start);
+    let mut i = start;
+    while i < end && i < chars.len() {
+        out.push(chars[i]);
+        i += 1;
+    }
+    return out;
+}
+
+/// Visitor trait for walking typed CST nodes.
+/// Default methods are no-ops; override to add behavior.
+pub trait Visitor {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+    }
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+    }
+    fn visit_token(&mut self, token: &Token) {
+    }
+}
+
+/// TreeRecorder is a Visitor that records events for building a CstNode tree.
+pub struct TreeRecorder {
+    events: Array<TreeEvent>,
+}
+
+variant TreeEvent {
+    Enter(TreeEnterInfo),
+    Exit,
+    VisitToken(Token),
+}
+
+struct TreeEnterInfo {
+    name: String,
+    span: Span,
+}
+
+impl TreeRecorder {
+    pub fn new() -> TreeRecorder {
+        return TreeRecorder { events: [] };
+    }
+
+    pub fn build(&self) -> CstNode {
+        let mut pos = 0;
+        return tree_build_node(&self.events, &mut pos);
+    }
+}
+
+impl Visitor for TreeRecorder {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+        self.events.push(TreeEvent::Enter(TreeEnterInfo { name: *name, span: *span }));
+    }
+
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+        self.events.push(TreeEvent::Exit);
+    }
+
+    fn visit_token(&mut self, token: &Token) {
+        self.events.push(TreeEvent::VisitToken(*token));
+    }
+}
+
+fn tree_build_node(events: &Array<TreeEvent>, pos: &mut i32) -> CstNode {
+    if let Enter(info) = events[*pos] {
+        *pos += 1;
+        let mut children: Array<CstChild> = [];
+        loop {
+            if *pos >= events.len() {
+                break;
+            }
+            let ev = events[*pos];
+            if let Exit = ev {
+                *pos += 1;
+                break;
+            }
+            if let Enter(_) = ev {
+                children.push(CstChild::Node(tree_build_node(events, pos)));
+            } else if let VisitToken(t) = ev {
+                children.push(CstChild::Token(t));
+                *pos += 1;
+            }
+        }
+        return CstNode { name: info.name, span: info.span, children };
+    }
+    panic("TreeRecorder: expected Enter event");
+    return CstNode { name: "", span: Span::new(0, 0), children: [] };
+}
+
+pub enum TokenKind {
+    ID,
+    INT,
+    WS,
+    Eof,
+    Error,
+}
+
+pub struct ProgNode {
+    pub span: Span,
+    pub entry_list: Array<EntryNode>,
+    pub eof: Token,
+}
+
+pub variant EntryNode {
+    Alt0(EntryAlt0),
+    Alt1(EntryAlt1),
+}
+
+pub struct EntryAlt0 {
+    pub span: Span,
+    pub lparen: Token,
+    pub typespec: TypespecNode,
+    pub rparen: Token,
+}
+
+pub struct EntryAlt1 {
+    pub span: Span,
+    pub lit_new: Token,
+    pub typespec: TypespecNode,
+    pub lbracket: Token,
+    pub int: Token,
+    pub rbracket: Token,
+}
+
+pub variant TypespecNode {
+    Alt0(TypespecAlt0),
+    Alt1(TypespecAlt1),
+}
+
+pub struct TypespecAlt0 {
+    pub span: Span,
+    pub id: Token,
+}
+
+pub struct TypespecAlt1 {
+    pub span: Span,
+    pub id: Token,
+    pub lbracket: Token,
+    pub rbracket: Token,
+}
+
+global TK_ID: i32 = 0;
+global TK_INT: i32 = 1;
+global TK_WS: i32 = 2;
+global TK_EOF: i32 = 3;
+global TK_ERROR: i32 = 4;
+global TK_LIT_LPAREN: i32 = 5;
+global TK_LIT_RPAREN: i32 = 6;
+global TK_LIT_NEW: i32 = 7;
+global TK_LIT_LBRACKET: i32 = 8;
+global TK_LIT_RBRACKET: i32 = 9;
+
+struct Lexer {
+    chars: Array<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.chars().collect(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_id(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || !('A' <= chars[pos] <= 'Z') { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_int(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || !('0' <= chars[pos] <= '9') { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            if pos >= chars.len() || !('0' <= chars[pos] <= '9') { break rep_0; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_ws(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    let alts_saved_1 = pos;
+    let mut alts_ok_1 = false;
+    alts_1_0: {
+        pos = alts_saved_1;
+        if pos >= chars.len() || chars[pos] != ' ' { break alts_1_0; }
+        pos += 1;
+        alts_ok_1 = true;
+    }
+    if !alts_ok_1 {
+        alts_1_1: {
+            pos = alts_saved_1;
+            if pos >= chars.len() || chars[pos] != '\n' { break alts_1_1; }
+            pos += 1;
+            alts_ok_1 = true;
+        }
+    }
+    if !alts_ok_1 { return -1; }
+    return pos;
+}
+
+fn try_lit_lparen(chars: &Array<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '(' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_rparen(chars: &Array<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != ')' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_new(chars: &Array<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != 'n' { return -1; }
+    if pos + 1 >= chars.len() || chars[pos + 1] != 'e' { return -1; }
+    if pos + 2 >= chars.len() || chars[pos + 2] != 'w' { return -1; }
+    return pos + 3;
+}
+
+fn try_lit_lbracket(chars: &Array<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '[' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_rbracket(chars: &Array<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != ']' { return -1; }
+    return pos + 1;
+}
+
+pub fn tokenize(input: &String) -> Array<Token> {
+    let mut lexer = Lexer::new(input);
+    let mut tokens: Array<Token> = [];
+    let mut trivia: Array<Token> = [];
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == '\n' || first_char == ' ' {
+            end = try_ws(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if first_char == '(' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_LPAREN; }
+        } else if first_char == ')' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_RPAREN; }
+        } else if first_char == '[' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_LBRACKET; }
+        } else if first_char == ']' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_RBRACKET; }
+        } else if first_char == 'n' {
+            end = try_lit_new(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_NEW; }
+        } else if 'A' <= first_char <= 'Z' {
+            end = try_id(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else if '0' <= first_char <= '9' {
+            end = try_int(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        } else {
+            end = try_id(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+            end = try_int(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        }
+        if best_end <= start {
+            let tok = Token::with_trivia(TK_ERROR, lexer.slice(start, start + 1), Span::new(start, start + 1), trivia);
+            tokens.push(tok);
+            trivia = [];
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                trivia.push(Token::new(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end)));
+            } else {
+                let tok = Token::with_trivia(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), trivia);
+                tokens.push(tok);
+                trivia = [];
+            }
+            lexer.pos = best_end;
+        }
+    }
+    tokens.push(Token::with_trivia(TK_EOF, LexerSlice::empty(&lexer.chars), Span::new(lexer.pos, lexer.pos), trivia));
+    return tokens;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_ID => "ID",
+        TK_INT => "INT",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        TK_LIT_LPAREN => "TK_LIT_LPAREN",
+        TK_LIT_RPAREN => "TK_LIT_RPAREN",
+        TK_LIT_NEW => "TK_LIT_NEW",
+        TK_LIT_LBRACKET => "TK_LIT_LBRACKET",
+        TK_LIT_RBRACKET => "TK_LIT_RBRACKET",
+        _ => "Unknown",
+    };
+}
+
+struct Parser {
+    tokens: Array<Token>,
+    pos: i32,
+}
+
+impl Parser {
+    fn new(tokens: Array<Token>) -> Parser {
+        return Parser { tokens, pos: 0 };
+    }
+
+    fn peek(&self) -> &Token {
+        return &self.tokens[self.pos];
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.tokens[self.pos].kind;
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.tokens.len() { return TK_EOF; }
+        return self.tokens[idx].kind;
+    }
+
+    fn advance(&mut self) -> Token {
+        let tok = self.tokens[self.pos];
+        self.pos += 1;
+        return tok;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens[self.pos - 1].span.end;
+    }
+
+    fn expect(&mut self, kind: i32) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind == kind {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        let name = token_kind_name(kind);
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected {name}, got "{tok.text}"`,
+            tok.span,
+            [name],
+        ));
+    }
+
+    fn fail(&self, name: String) -> Result<Token, ParseError> {
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected {name}, got "{tok.text}"`,
+            tok.span,
+            [name],
+        ));
+    }
+
+    fn match_any(&mut self) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind != TK_EOF {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected any token, got "{tok.text}"`,
+            tok.span,
+            ["any token"],
+        ));
+    }
+
+    fn match_not(&mut self, excluded: Array<i32>) -> Result<Token, ParseError> {
+        let k = self.tokens[self.pos].kind;
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                return Result::<Token, ParseError>::Ok(self.advance());
+            }
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `unexpected token "{tok.text}"`,
+            tok.span,
+            ["set complement"],
+        ));
+    }
+}
+
+fn scan_prog(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let mut pos = pos;
+    pos = scan_entry(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && _gale_kind_set_0(tokens[pos].kind) {
+        let sp = pos;
+        pos = scan_entry(tokens, pos, 0);
+        if pos < 0 { pos = sp; break; }
+        if pos == sp { break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_entry(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let start = pos;
+    let mut pos = pos;
+    let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
+    scan_alts: {
+        if alt_kind == TK_LIT_LPAREN {
+            pos = start;
+            try_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LPAREN { break try_0; }
+                pos += 1;
+                pos = scan_typespec(tokens, pos, 0);
+                if pos < 0 { break try_0; }
+                if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RPAREN { break try_0; }
+                pos += 1;
+                break scan_alts;
+            }
+            return -1;
+        } else if alt_kind == TK_LIT_NEW {
+            pos = start;
+            try_1: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_LIT_NEW { break try_1; }
+                pos += 1;
+                pos = scan_typespec(tokens, pos, 0);
+                if pos < 0 { break try_1; }
+                if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break try_1; }
+                pos += 1;
+                if pos >= tokens.len() || tokens[pos].kind != TK_INT { break try_1; }
+                pos += 1;
+                if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break try_1; }
+                pos += 1;
+                break scan_alts;
+            }
+            return -1;
+        } else {
+            return -1;
+        }
+    }
+    return pos;
+}
+
+fn scan_typespec(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let start = pos;
+    let mut pos = pos;
+    let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
+    scan_alts: {
+        if alt_kind == TK_ID {
+            pos = start;
+            try_1: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_ID { break try_1; }
+                pos += 1;
+                if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { break try_1; }
+                pos += 1;
+                if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { break try_1; }
+                pos += 1;
+                break scan_alts;
+            }
+            pos = start;
+            try_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_ID { break try_0; }
+                pos += 1;
+                break scan_alts;
+            }
+            return -1;
+        } else {
+            return -1;
+        }
+    }
+    return pos;
+}
+
+fn parse_prog(p: &mut Parser) -> Result<ProgNode, ParseError> {
+    let start = p.peek().span.start;
+    let mut entry_list: Array<EntryNode> = [];
+    let mut _plus_first = true;
+    loop {
+        if !_plus_first {
+            let mut rep_scan_pos: i32 = -1;
+            rep_scan: {
+                let tokens = &p.tokens;
+                let mut pos: i32 = p.pos;
+                pos = scan_entry(tokens, pos, 0);
+                if pos < 0 { break rep_scan; }
+                if pos <= p.pos { break rep_scan; }
+                rep_scan_pos = pos;
+            }
+            if rep_scan_pos < 0 { break; }
+        }
+        _plus_first = false;
+        let entry = parse_entry(p)?;
+        entry_list.push(entry);
+    }
+    let eof = p.expect(TK_EOF)?;
+    return Result::<ProgNode, ParseError>::Ok(ProgNode {
+        span: Span::new(start, p.last_end()),
+        entry_list,
+        eof,
+    });
+}
+
+fn parse_entry(p: &mut Parser) -> Result<EntryNode, ParseError> {
+    let start = p.peek().span.start;
+    let kind = p.peek_kind();
+    if kind == TK_LIT_LPAREN {
+        let lparen = p.expect(TK_LIT_LPAREN)?;
+        let typespec = parse_typespec(p)?;
+        let rparen = p.expect(TK_LIT_RPAREN)?;
+        return Result::<EntryNode, ParseError>::Ok(EntryNode::Alt0(EntryAlt0 {
+            span: Span::new(start, p.last_end()),
+            lparen,
+            typespec,
+            rparen,
+        }));
+    }
+    if kind == TK_LIT_NEW {
+        let lit_new = p.expect(TK_LIT_NEW)?;
+        let typespec = parse_typespec(p)?;
+        let lbracket = p.expect(TK_LIT_LBRACKET)?;
+        let int = p.expect(TK_INT)?;
+        let rbracket = p.expect(TK_LIT_RBRACKET)?;
+        return Result::<EntryNode, ParseError>::Ok(EntryNode::Alt1(EntryAlt1 {
+            span: Span::new(start, p.last_end()),
+            lit_new,
+            typespec,
+            lbracket,
+            int,
+            rbracket,
+        }));
+    }
+    return Result::<EntryNode, ParseError>::Err(ParseError::new(
+        "expected entry",
+        p.peek().span,
+        ["TK_LIT_LPAREN", "TK_LIT_NEW"],
+    ));
+}
+
+fn parse_typespec_bt_1(p: &mut Parser) -> Result<TypespecNode, ParseError> {
+    let start = p.peek().span.start;
+    let id = p.expect(TK_ID)?;
+    let lbracket = p.expect(TK_LIT_LBRACKET)?;
+    let rbracket = p.expect(TK_LIT_RBRACKET)?;
+    return Result::<TypespecNode, ParseError>::Ok(TypespecNode::Alt1(TypespecAlt1 {
+        span: Span::new(start, p.last_end()),
+        id,
+        lbracket,
+        rbracket,
+    }));
+}
+
+fn parse_typespec_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_ID { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_LBRACKET { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_RBRACKET { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn parse_typespec_bt_0(p: &mut Parser) -> Result<TypespecNode, ParseError> {
+    let start = p.peek().span.start;
+    let id = p.expect(TK_ID)?;
+    return Result::<TypespecNode, ParseError>::Ok(TypespecNode::Alt0(TypespecAlt0 {
+        span: Span::new(start, p.last_end()),
+        id,
+    }));
+}
+
+fn parse_typespec_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_ID { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn parse_typespec(p: &mut Parser) -> Result<TypespecNode, ParseError> {
+    let start = p.peek().span.start;
+    let kind = p.peek_kind();
+    if kind == TK_ID {
+        let _sd_tokens = &p.tokens;
+        let _sd_pos = p.pos;
+        let _sd_p_1 = parse_typespec_scan_1(_sd_tokens, _sd_pos);
+        let _sd_p_0 = parse_typespec_scan_0(_sd_tokens, _sd_pos);
+        let mut _sd_best_i: i32 = -1;
+        let mut _sd_best_p: i32 = -1;
+        if _sd_p_1 > _sd_best_p {
+            _sd_best_p = _sd_p_1;
+            _sd_best_i = 1;
+        }
+        if _sd_p_0 > _sd_best_p {
+            _sd_best_p = _sd_p_0;
+            _sd_best_i = 0;
+        }
+        if _sd_best_i == 1 {
+            return parse_typespec_bt_1(p);
+        }
+        if _sd_best_i == 0 {
+            return parse_typespec_bt_0(p);
+        }
+        return parse_typespec_bt_0(p);
+    }
+    return Result::<TypespecNode, ParseError>::Err(ParseError::new(
+        "expected typespec",
+        p.peek().span,
+        ["TK_ID"],
+    ));
+}
+
+pub fn parse(input: &String) -> Result<ProgNode, ParseError> {
+    let tokens = tokenize(input);
+    let mut parser = Parser::new(tokens);
+    return parse_prog(&mut parser);
+}
+
+pub fn walk_prog<V: Visitor>(v: &mut V, node: &ProgNode) {
+    v.enter_rule(&"prog", &node.span);
+    for let item of &node.entry_list {
+        walk_entry(v, item);
+    }
+    v.visit_token(&node.eof);
+    v.exit_rule(&"prog", &node.span);
+}
+
+pub fn walk_entry<V: Visitor>(v: &mut V, node: &EntryNode) {
+    match node {
+        Alt0(n) => {
+            v.enter_rule(&"entry", &n.span);
+            v.visit_token(&n.lparen);
+            walk_typespec(v, &n.typespec);
+            v.visit_token(&n.rparen);
+            v.exit_rule(&"entry", &n.span);
+        }
+        Alt1(n) => {
+            v.enter_rule(&"entry", &n.span);
+            v.visit_token(&n.lit_new);
+            walk_typespec(v, &n.typespec);
+            v.visit_token(&n.lbracket);
+            v.visit_token(&n.int);
+            v.visit_token(&n.rbracket);
+            v.exit_rule(&"entry", &n.span);
+        }
+    }
+}
+
+pub fn walk_typespec<V: Visitor>(v: &mut V, node: &TypespecNode) {
+    match node {
+        Alt0(n) => {
+            v.enter_rule(&"typespec", &n.span);
+            v.visit_token(&n.id);
+            v.exit_rule(&"typespec", &n.span);
+        }
+        Alt1(n) => {
+            v.enter_rule(&"typespec", &n.span);
+            v.visit_token(&n.id);
+            v.visit_token(&n.lbracket);
+            v.visit_token(&n.rbracket);
+            v.exit_rule(&"typespec", &n.span);
+        }
+    }
+}
+
+pub fn to_tree(node: &ProgNode) -> CstNode {
+    let mut recorder = TreeRecorder::new();
+    walk_prog(&mut recorder, node);
+    return recorder.build();
+}
+
+fn _gale_kind_set_0(k: i32) -> bool {
+    return k matches { TK_LIT_LPAREN | TK_LIT_NEW };
+}
+

--- a/package-gale/tests/generated/calculator/calculator.g4.kiln.json
+++ b/package-gale/tests/generated/calculator/calculator.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7fbe69e34c931e16",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "grammars/calculator.g4",
     "hash": "67431dad6dcc459fea7d4c448fb04944de2c4cf61ecd75d546aeccd93b4564d7"

--- a/package-gale/tests/generated/calculator/calculator.g4.kiln.json
+++ b/package-gale/tests/generated/calculator/calculator.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-7fbe69e34c931e16",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "grammars/calculator.g4",
     "hash": "67431dad6dcc459fea7d4c448fb04944de2c4cf61ecd75d546aeccd93b4564d7"

--- a/package-gale/tests/generated/ci_rule_override/ci_rule_override.g4.kiln.json
+++ b/package-gale/tests/generated/ci_rule_override/ci_rule_override.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-66c270910e5642be",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "grammars/ci_rule_override.g4",
     "hash": "6efdfe55ecb215bf526900a32a11c664a57c9e14d61c6a67758f870adc73d09b"

--- a/package-gale/tests/generated/ci_rule_override/ci_rule_override.g4.kiln.json
+++ b/package-gale/tests/generated/ci_rule_override/ci_rule_override.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-66c270910e5642be",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "grammars/ci_rule_override.g4",
     "hash": "6efdfe55ecb215bf526900a32a11c664a57c9e14d61c6a67758f870adc73d09b"

--- a/package-gale/tests/generated/ci_sql/ci_sql.g4.kiln.json
+++ b/package-gale/tests/generated/ci_sql/ci_sql.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b9bfa38391d7f122",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "grammars/ci_sql.g4",
     "hash": "41b72934417dd2f6fa0359722ce53ca05cd10cccde08fd9f3d0d58018f2137fe"

--- a/package-gale/tests/generated/ci_sql/ci_sql.g4.kiln.json
+++ b/package-gale/tests/generated/ci_sql/ci_sql.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-b9bfa38391d7f122",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "grammars/ci_sql.g4",
     "hash": "41b72934417dd2f6fa0359722ce53ca05cd10cccde08fd9f3d0d58018f2137fe"

--- a/package-gale/tests/generated/css3/css3Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/css3/css3Lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fa4a5fa8cced30ae",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "grammars/css3Lexer.g4",
     "hash": "4733198f782344f0d3dbd2456ee9f6db955f53c688d14334fb403985551c963c"

--- a/package-gale/tests/generated/css3/css3Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/css3/css3Lexer.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-fa4a5fa8cced30ae",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "grammars/css3Lexer.g4",
     "hash": "4733198f782344f0d3dbd2456ee9f6db955f53c688d14334fb403985551c963c"

--- a/package-gale/tests/generated/html/HTMLLexer.g4.kiln.json
+++ b/package-gale/tests/generated/html/HTMLLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c6b3fd168a1b47a8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "grammars/HTMLLexer.g4",
     "hash": "1d3b243228b182ddeca45bf2c7f9ec6512c176bcec126444bce7cbe7a8e93052"

--- a/package-gale/tests/generated/html/HTMLLexer.g4.kiln.json
+++ b/package-gale/tests/generated/html/HTMLLexer.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-c6b3fd168a1b47a8",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "grammars/HTMLLexer.g4",
     "hash": "1d3b243228b182ddeca45bf2c7f9ec6512c176bcec126444bce7cbe7a8e93052"

--- a/package-gale/tests/generated/json/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/json/JSON.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-deb9206518cd2a6f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "grammars/JSON.g4",
     "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"

--- a/package-gale/tests/generated/json/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/json/JSON.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-deb9206518cd2a6f",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "grammars/JSON.g4",
     "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"

--- a/package-gale/tests/generated/json_highlight/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/json_highlight/JSON.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-deb9206518cd2a6f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "grammars/JSON.g4",
     "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"

--- a/package-gale/tests/generated/json_highlight/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/json_highlight/JSON.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-deb9206518cd2a6f",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "grammars/JSON.g4",
     "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"

--- a/package-gale/tests/generated/label_gaps/label_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/label_gaps/label_gaps.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-6e9e12ac993603d7",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "grammars/label_gaps.g4",
     "hash": "8e2049cd7baf82750b8e242018ffdc1f8e684226f8e27fe8068ad7838d6da425"

--- a/package-gale/tests/generated/label_gaps/label_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/label_gaps/label_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6e9e12ac993603d7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "grammars/label_gaps.g4",
     "hash": "8e2049cd7baf82750b8e242018ffdc1f8e684226f8e27fe8068ad7838d6da425"

--- a/package-gale/tests/generated/lexer_command_gaps/lexer_command_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/lexer_command_gaps/lexer_command_gaps.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-c1bc56a77b40e824",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "grammars/lexer_command_gaps.g4",
     "hash": "253a32f9908895a3ffaa23ac8e32eaa12f43998f25d7d2b73637ddf11a3cb3c9"

--- a/package-gale/tests/generated/lexer_command_gaps/lexer_command_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/lexer_command_gaps/lexer_command_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c1bc56a77b40e824",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "grammars/lexer_command_gaps.g4",
     "hash": "253a32f9908895a3ffaa23ac8e32eaa12f43998f25d7d2b73637ddf11a3cb3c9"

--- a/package-gale/tests/generated/mode_gaps/mode_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/mode_gaps/mode_gaps.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-934b67223a7d4708",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "grammars/mode_gaps.g4",
     "hash": "2129310ea345f84328b61531ce102c6306fda62ef4fa71d7c64d1dc4bb9f1d14"

--- a/package-gale/tests/generated/mode_gaps/mode_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/mode_gaps/mode_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-934b67223a7d4708",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "grammars/mode_gaps.g4",
     "hash": "2129310ea345f84328b61531ce102c6306fda62ef4fa71d7c64d1dc4bb9f1d14"

--- a/package-gale/tests/generated/non_greedy_gaps/non_greedy_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/non_greedy_gaps/non_greedy_gaps.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-a7aa34c1db2fca6a",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "grammars/non_greedy_gaps.g4",
     "hash": "b7ebb6e1d962ee295bf43cc5a13f167cbd270ef3d9e15a052d2eb060eefb012c"

--- a/package-gale/tests/generated/non_greedy_gaps/non_greedy_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/non_greedy_gaps/non_greedy_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a7aa34c1db2fca6a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "grammars/non_greedy_gaps.g4",
     "hash": "b7ebb6e1d962ee295bf43cc5a13f167cbd270ef3d9e15a052d2eb060eefb012c"

--- a/package-gale/tests/generated/parser_gaps/parser_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/parser_gaps/parser_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8eb28e22b79ba2bd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "grammars/parser_gaps.g4",
     "hash": "8262a9d7c10805db35e063564eaea6deb43e8de540af19d0969551d042b6d03a"

--- a/package-gale/tests/generated/parser_gaps/parser_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/parser_gaps/parser_gaps.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-8eb28e22b79ba2bd",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "grammars/parser_gaps.g4",
     "hash": "8262a9d7c10805db35e063564eaea6deb43e8de540af19d0969551d042b6d03a"

--- a/package-gale/tests/generated/recursive_lexer/recursive_lexer.g4.kiln.json
+++ b/package-gale/tests/generated/recursive_lexer/recursive_lexer.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-b23078c163edb700",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "grammars/recursive_lexer.g4",
     "hash": "3bba2a980c91c247bfa081040a71e8349ebd29cec177d15cf69feb75f40e705f"

--- a/package-gale/tests/generated/recursive_lexer/recursive_lexer.g4.kiln.json
+++ b/package-gale/tests/generated/recursive_lexer/recursive_lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b23078c163edb700",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "grammars/recursive_lexer.g4",
     "hash": "3bba2a980c91c247bfa081040a71e8349ebd29cec177d15cf69feb75f40e705f"

--- a/package-gale/tests/generated/right_assoc_gaps/right_assoc_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/right_assoc_gaps/right_assoc_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7382226003c5d9e1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "grammars/right_assoc_gaps.g4",
     "hash": "7632fce865fe8aa2c3c460beea14a27a0a020b9ccb2312fb59a2c980f12f639a"

--- a/package-gale/tests/generated/right_assoc_gaps/right_assoc_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/right_assoc_gaps/right_assoc_gaps.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-7382226003c5d9e1",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "grammars/right_assoc_gaps.g4",
     "hash": "7632fce865fe8aa2c3c460beea14a27a0a020b9ccb2312fb59a2c980f12f639a"

--- a/package-gale/tests/generated/rust/RustLexer.g4.kiln.json
+++ b/package-gale/tests/generated/rust/RustLexer.g4.kiln.json
@@ -17,7 +17,7 @@
   "outputs": [
     {
       "path": "tests/generated/rust/rust.wado",
-      "hash": "0979eed585ff5d07ca9c17f82abf957cd5d7f5f781d14b274e61e4fc06aedc6a",
+      "hash": "d39bb8902e44cb2fa29f36710cfb657155cec50989e7f16b41544db59feafa48",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/rust/RustLexer.g4.kiln.json
+++ b/package-gale/tests/generated/rust/RustLexer.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-28566ce8c3b8a5b1",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "grammars/RustLexer.g4",
     "hash": "a9069b6b1a5650b0f5f115897eaa0edaddc42007b262c5096b59eb1de15323d3"

--- a/package-gale/tests/generated/rust/RustLexer.g4.kiln.json
+++ b/package-gale/tests/generated/rust/RustLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-28566ce8c3b8a5b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "grammars/RustLexer.g4",
     "hash": "a9069b6b1a5650b0f5f115897eaa0edaddc42007b262c5096b59eb1de15323d3"

--- a/package-gale/tests/generated/rust/rust.wado
+++ b/package-gale/tests/generated/rust/rust.wado
@@ -22959,18 +22959,28 @@ fn parse_enum_expr_field(p: &mut Parser) -> Result<EnumExprFieldNode, ParseError
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if _gale_kind_set_65(kind) {
-        if p.peek_kind() == TK_NON_KEYWORD_IDENTIFIER {
-            if p.peek_at(1) == TK_COLON {
+        if _gale_kind_set_17(p.peek_kind()) {
+            let _sd_tokens = &p.tokens;
+            let _sd_pos = p.pos;
+            let _sd_p_0 = parse_enum_expr_field_scan_0(_sd_tokens, _sd_pos);
+            let _sd_p_1 = parse_enum_expr_field_scan_1(_sd_tokens, _sd_pos);
+            let mut _sd_best_i: i32 = -1;
+            let mut _sd_best_p: i32 = -1;
+            if _sd_p_0 > _sd_best_p {
+                _sd_best_p = _sd_p_0;
+                _sd_best_i = 0;
+            }
+            if _sd_p_1 > _sd_best_p {
+                _sd_best_p = _sd_p_1;
+                _sd_best_i = 1;
+            }
+            if _sd_best_i == 0 {
+                return parse_enum_expr_field_bt_0(p);
+            }
+            if _sd_best_i == 1 {
                 return parse_enum_expr_field_bt_1(p);
             }
-        } else if p.peek_kind() == TK_RAW_IDENTIFIER {
-            if p.peek_at(1) == TK_COLON {
-                return parse_enum_expr_field_bt_1(p);
-            }
-        } else if p.peek_kind() == TK_KW_MACRORULES {
-            if p.peek_at(1) == TK_COLON {
-                return parse_enum_expr_field_bt_1(p);
-            }
+            return parse_enum_expr_field_bt_1(p);
         } else if p.peek_kind() == TK_INTEGER_LITERAL {
             return parse_enum_expr_field_bt_1(p);
         }

--- a/package-gale/tests/generated/sexpression/sexpression.g4.kiln.json
+++ b/package-gale/tests/generated/sexpression/sexpression.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-1847ef51d5668bfd",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "grammars/sexpression.g4",
     "hash": "74549e6167e186b754886880a5d473ad3361bee8440368f99e1b233e2c1c7bdb"

--- a/package-gale/tests/generated/sexpression/sexpression.g4.kiln.json
+++ b/package-gale/tests/generated/sexpression/sexpression.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1847ef51d5668bfd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "grammars/sexpression.g4",
     "hash": "74549e6167e186b754886880a5d473ad3361bee8440368f99e1b233e2c1c7bdb"

--- a/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-880d9db12a6d7521",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "grammars/SQLite.g4",
     "hash": "72e3fa9877777afa5a4f9e8196d4cb194bb599e719d43b7b29d09eeed3e4c5e0"

--- a/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/sqlite/sqlite.wado",
-      "hash": "813ad4026b0633887076b6e5db16566168db257f63a0dd8cb860b9cfe564594b",
+      "hash": "b54ad1964174727a78606b2e7792e3b42f6f7788f43ca45de7dfb960590d17a6",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-880d9db12a6d7521",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "grammars/SQLite.g4",
     "hash": "72e3fa9877777afa5a4f9e8196d4cb194bb599e719d43b7b29d09eeed3e4c5e0"

--- a/package-gale/tests/generated/sqlite/sqlite.wado
+++ b/package-gale/tests/generated/sqlite/sqlite.wado
@@ -19004,15 +19004,27 @@ fn parse_compound_operator(p: &mut Parser) -> Result<CompoundOperatorNode, Parse
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind == TK_K_UNION {
-        let k_union = p.expect(TK_K_UNION)?;
-        if p.peek_kind() == TK_K_ALL {
-            let k_all = p.expect(TK_K_ALL)?;
-            return Result::<CompoundOperatorNode, ParseError>::Ok(CompoundOperatorNode::Alt1(CompoundOperatorAlt1 {
-                span: Span::new(start, p.last_end()),
-                k_union,
-                k_all,
-            }));
+        let _sd_tokens = &p.tokens;
+        let _sd_pos = p.pos;
+        let _sd_p_1 = parse_compound_operator_scan_1(_sd_tokens, _sd_pos);
+        let _sd_p_0 = parse_compound_operator_scan_0(_sd_tokens, _sd_pos);
+        let mut _sd_best_i: i32 = -1;
+        let mut _sd_best_p: i32 = -1;
+        if _sd_p_1 > _sd_best_p {
+            _sd_best_p = _sd_p_1;
+            _sd_best_i = 1;
         }
+        if _sd_p_0 > _sd_best_p {
+            _sd_best_p = _sd_p_0;
+            _sd_best_i = 0;
+        }
+        if _sd_best_i == 1 {
+            return parse_compound_operator_bt_1(p);
+        }
+        if _sd_best_i == 0 {
+            return parse_compound_operator_bt_0(p);
+        }
+        return parse_compound_operator_bt_0(p);
     }
     if kind == TK_K_INTERSECT {
         let k_intersect = p.expect(TK_K_INTERSECT)?;

--- a/package-gale/tests/generated/sqlite_highlight/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite_highlight/SQLite.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-880d9db12a6d7521",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "grammars/SQLite.g4",
     "hash": "72e3fa9877777afa5a4f9e8196d4cb194bb599e719d43b7b29d09eeed3e4c5e0"

--- a/package-gale/tests/generated/sqlite_highlight/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite_highlight/SQLite.g4.kiln.json
@@ -12,7 +12,7 @@
   "outputs": [
     {
       "path": "tests/generated/sqlite_highlight/sqlite.wado",
-      "hash": "0f68bb64eb900a55437213ed086b057f50698ca07c2baedfcf13500b9c2ed285",
+      "hash": "4461a3525fd67fd57c1df1470e6c63ea42faabef1a3d9472b6edca96bf3b71db",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/sqlite_highlight/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite_highlight/SQLite.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-880d9db12a6d7521",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "grammars/SQLite.g4",
     "hash": "72e3fa9877777afa5a4f9e8196d4cb194bb599e719d43b7b29d09eeed3e4c5e0"

--- a/package-gale/tests/generated/sqlite_highlight/sqlite.wado
+++ b/package-gale/tests/generated/sqlite_highlight/sqlite.wado
@@ -19004,15 +19004,27 @@ fn parse_compound_operator(p: &mut Parser) -> Result<CompoundOperatorNode, Parse
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if kind == TK_K_UNION {
-        let k_union = p.expect(TK_K_UNION)?;
-        if p.peek_kind() == TK_K_ALL {
-            let k_all = p.expect(TK_K_ALL)?;
-            return Result::<CompoundOperatorNode, ParseError>::Ok(CompoundOperatorNode::Alt1(CompoundOperatorAlt1 {
-                span: Span::new(start, p.last_end()),
-                k_union,
-                k_all,
-            }));
+        let _sd_tokens = &p.tokens;
+        let _sd_pos = p.pos;
+        let _sd_p_1 = parse_compound_operator_scan_1(_sd_tokens, _sd_pos);
+        let _sd_p_0 = parse_compound_operator_scan_0(_sd_tokens, _sd_pos);
+        let mut _sd_best_i: i32 = -1;
+        let mut _sd_best_p: i32 = -1;
+        if _sd_p_1 > _sd_best_p {
+            _sd_best_p = _sd_p_1;
+            _sd_best_i = 1;
         }
+        if _sd_p_0 > _sd_best_p {
+            _sd_best_p = _sd_p_0;
+            _sd_best_i = 0;
+        }
+        if _sd_best_i == 1 {
+            return parse_compound_operator_bt_1(p);
+        }
+        if _sd_best_i == 0 {
+            return parse_compound_operator_bt_0(p);
+        }
+        return parse_compound_operator_bt_0(p);
     }
     if kind == TK_K_INTERSECT {
         let k_intersect = p.expect(TK_K_INTERSECT)?;

--- a/package-gale/tests/generated/typescript/TypeScriptLexer.g4.kiln.json
+++ b/package-gale/tests/generated/typescript/TypeScriptLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b6f068637d3275ff",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "grammars/TypeScriptLexer.g4",
     "hash": "f7089740f7e82bbb90a6c4b13c75959b6ceaf3003be0dd0657c52b9eb6a594b7"

--- a/package-gale/tests/generated/typescript/TypeScriptLexer.g4.kiln.json
+++ b/package-gale/tests/generated/typescript/TypeScriptLexer.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-b6f068637d3275ff",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "grammars/TypeScriptLexer.g4",
     "hash": "f7089740f7e82bbb90a6c4b13c75959b6ceaf3003be0dd0657c52b9eb6a594b7"

--- a/package-gale/tests/generated/typescript/TypeScriptLexer.g4.kiln.json
+++ b/package-gale/tests/generated/typescript/TypeScriptLexer.g4.kiln.json
@@ -17,7 +17,7 @@
   "outputs": [
     {
       "path": "tests/generated/typescript/type_script.wado",
-      "hash": "64dac739b8aa386a2a14b1bcf648697fba6782b57ffcde256243a53a3dbcec0a",
+      "hash": "fba0a3d57f9b863c09f42fcaf25966bcf3e6cacf9b880d8e4d123def58f948eb",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/typescript/type_script.wado
+++ b/package-gale/tests/generated/typescript/type_script.wado
@@ -16577,86 +16577,28 @@ fn parse_type_query_expression(p: &mut Parser) -> Result<TypeQueryExpressionNode
     let start = p.peek().span.start;
     let kind = p.peek_kind();
     if _gale_kind_set_16(kind) {
-        if p.peek_kind() == TK_Identifier {
-            if _gale_kind_set_16(p.peek_at(1)) {
+        if _gale_kind_set_2(p.peek_kind()) {
+            let _sd_tokens = &p.tokens;
+            let _sd_pos = p.pos;
+            let _sd_p_0 = parse_type_query_expression_scan_0(_sd_tokens, _sd_pos);
+            let _sd_p_1 = parse_type_query_expression_scan_1(_sd_tokens, _sd_pos);
+            let mut _sd_best_i: i32 = -1;
+            let mut _sd_best_p: i32 = -1;
+            if _sd_p_0 > _sd_best_p {
+                _sd_best_p = _sd_p_0;
+                _sd_best_i = 0;
+            }
+            if _sd_p_1 > _sd_best_p {
+                _sd_best_p = _sd_p_1;
+                _sd_best_i = 1;
+            }
+            if _sd_best_i == 0 {
+                return parse_type_query_expression_bt_0(p);
+            }
+            if _sd_best_i == 1 {
                 return parse_type_query_expression_bt_1(p);
             }
-        } else if p.peek_kind() == TK_Async {
-            if _gale_kind_set_16(p.peek_at(1)) {
-                return parse_type_query_expression_bt_1(p);
-            }
-        } else if p.peek_kind() == TK_As {
-            if _gale_kind_set_16(p.peek_at(1)) {
-                return parse_type_query_expression_bt_1(p);
-            }
-        } else if p.peek_kind() == TK_From {
-            if _gale_kind_set_16(p.peek_at(1)) {
-                return parse_type_query_expression_bt_1(p);
-            }
-        } else if p.peek_kind() == TK_Yield {
-            if _gale_kind_set_16(p.peek_at(1)) {
-                return parse_type_query_expression_bt_1(p);
-            }
-        } else if p.peek_kind() == TK_Of {
-            if _gale_kind_set_16(p.peek_at(1)) {
-                return parse_type_query_expression_bt_1(p);
-            }
-        } else if p.peek_kind() == TK_Any {
-            if _gale_kind_set_16(p.peek_at(1)) {
-                return parse_type_query_expression_bt_1(p);
-            }
-        } else if p.peek_kind() == TK_Number {
-            if _gale_kind_set_16(p.peek_at(1)) {
-                return parse_type_query_expression_bt_1(p);
-            }
-        } else if p.peek_kind() == TK_Boolean {
-            if _gale_kind_set_16(p.peek_at(1)) {
-                return parse_type_query_expression_bt_1(p);
-            }
-        } else if p.peek_kind() == TK_String {
-            if _gale_kind_set_16(p.peek_at(1)) {
-                return parse_type_query_expression_bt_1(p);
-            }
-        } else if p.peek_kind() == TK_Unique {
-            if _gale_kind_set_16(p.peek_at(1)) {
-                return parse_type_query_expression_bt_1(p);
-            }
-        } else if p.peek_kind() == TK_Symbol {
-            if _gale_kind_set_16(p.peek_at(1)) {
-                return parse_type_query_expression_bt_1(p);
-            }
-        } else if p.peek_kind() == TK_Never {
-            if _gale_kind_set_16(p.peek_at(1)) {
-                return parse_type_query_expression_bt_1(p);
-            }
-        } else if p.peek_kind() == TK_Undefined {
-            if _gale_kind_set_16(p.peek_at(1)) {
-                return parse_type_query_expression_bt_1(p);
-            }
-        } else if p.peek_kind() == TK_Object {
-            if _gale_kind_set_16(p.peek_at(1)) {
-                return parse_type_query_expression_bt_1(p);
-            }
-        } else if p.peek_kind() == TK_KeyOf {
-            if _gale_kind_set_16(p.peek_at(1)) {
-                return parse_type_query_expression_bt_1(p);
-            }
-        } else if p.peek_kind() == TK_TypeAlias {
-            if _gale_kind_set_16(p.peek_at(1)) {
-                return parse_type_query_expression_bt_1(p);
-            }
-        } else if p.peek_kind() == TK_Constructor {
-            if _gale_kind_set_16(p.peek_at(1)) {
-                return parse_type_query_expression_bt_1(p);
-            }
-        } else if p.peek_kind() == TK_Namespace {
-            if _gale_kind_set_16(p.peek_at(1)) {
-                return parse_type_query_expression_bt_1(p);
-            }
-        } else if p.peek_kind() == TK_Abstract {
-            if _gale_kind_set_16(p.peek_at(1)) {
-                return parse_type_query_expression_bt_1(p);
-            }
+            return parse_type_query_expression_bt_1(p);
         } else if _gale_kind_set_17(p.peek_kind()) {
             return parse_type_query_expression_bt_1(p);
         }

--- a/package-gale/tests/generated/unicode_props/unicode_props.g4.kiln.json
+++ b/package-gale/tests/generated/unicode_props/unicode_props.g4.kiln.json
@@ -1,7 +1,8 @@
 {
-  "version": 1,
+  "version": 2,
   "invocation": "kiln-f37fa830f2a0df13",
   "generator": "local:src/generator.wado",
+  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
   "primary": {
     "path": "grammars/unicode_props.g4",
     "hash": "7559b99d20b67597cdc99b2e9e0eaeea1ad4b0931d40859c1dbb600e20d1c5c0"

--- a/package-gale/tests/generated/unicode_props/unicode_props.g4.kiln.json
+++ b/package-gale/tests/generated/unicode_props/unicode_props.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f37fa830f2a0df13",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "bee47b2c43412013bed4313d820ae170ceb415934af8a3b92731cd3a3c476545",
+  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
   "primary": {
     "path": "grammars/unicode_props.g4",
     "hash": "7559b99d20b67597cdc99b2e9e0eaeea1ad4b0931d40859c1dbb600e20d1c5c0"

--- a/package-gale/tests/grammars/at_end_alt_gaps.g4
+++ b/package-gale/tests/grammars/at_end_alt_gaps.g4
@@ -1,0 +1,41 @@
+// Regression fixtures for the "at-end alt dropped from dispatch" bug.
+//
+// Pattern: a rule has alts that share a prefix, where one alt extends the
+// shared prefix with optional additional elements:
+//
+//     typespec : ID         // alt 0 — at end after consuming ID
+//              | ID '[' ']' // alt 1 — extends with '[' ']'
+//              ;
+//
+// Before the fix, the predictor built a Dispatch for typespec at depth=1
+// (after consuming ID) with only the LBRACKET branch (alt 1). Alt 0 was
+// silently dropped because its FIRST set at depth=1 is empty (at-end), so
+// the generated code committed to alt 1 whenever the next token was
+// LBRACKET — even when LBRACKET legitimately belonged to the calling
+// context (e.g. `new T[ <expr> ]`).
+//
+// After the fix, this case routes through Backtrack scan-dispatch: the
+// scanner picks the alt whose body actually parses (longest match), so
+// `(T)` picks alt 0 and `(T[])` picks alt 1, while `new T[1]` correctly
+// picks alt 0 because alt 1's body `[ ]` cannot match `[ 1`.
+grammar AtEndAltGaps;
+
+prog : entry+ EOF ;
+
+// Each `entry` exercises one of the three caller contexts:
+//   * `(T)`        — paren caller, typespec must commit to alt 0
+//   * `(T[])`      — paren caller with extension, typespec commits to alt 1
+//   * `new T[1]`   — index caller, typespec must commit to alt 0 even though
+//                     LBRACKET follows ID (alt 1's body would fail at `[1`)
+entry : '(' typespec ')'
+      | 'new' typespec '[' INT ']'
+      ;
+
+typespec
+    : ID
+    | ID '[' ']'
+    ;
+
+ID  : 'A'..'Z' ;
+INT : '0'..'9'+ ;
+WS  : (' ' | '\n') -> skip ;

--- a/wado-cli/src/kiln_driver.rs
+++ b/wado-cli/src/kiln_driver.rs
@@ -333,6 +333,7 @@ pub fn build_metadata(
     invocation: &Invocation,
     run: &InvocationRun,
     options_hash: String,
+    generator_source_hash: String,
 ) -> Metadata {
     let generator = generator_identity(&invocation.module);
     let primary = to_meta_file_hash(&run.primary);
@@ -363,6 +364,7 @@ pub fn build_metadata(
         version: METADATA_VERSION,
         invocation: invocation_name.to_string(),
         generator,
+        generator_source_hash,
         primary,
         inputs,
         options_hash,
@@ -456,11 +458,19 @@ pub async fn cache_matches<H: CompilerHost>(
     invocation: &Invocation,
     manifest_root: &Path,
     host: &H,
+    current_generator_source_hash: &str,
 ) -> CacheCheck {
     if metadata.primary.path != invocation.from.as_str() {
         return CacheCheck::Miss;
     }
     if !matches_file(host, &invocation.from, &metadata.primary.hash).await {
+        return CacheCheck::Miss;
+    }
+    // Generator source closure must match. An empty `current` means the
+    // provider could not compute one (e.g. spec-form generators in v1);
+    // we only treat this as a match against an equally-empty record so
+    // hashed metadata never silently downgrades to "always hit".
+    if metadata.generator_source_hash != current_generator_source_hash {
         return CacheCheck::Miss;
     }
 
@@ -690,6 +700,26 @@ fn validate_rel_output_path(p: &str) -> Result<PathBuf, ExecuteError> {
     Ok(candidate.to_path_buf())
 }
 
+/// Component bytes returned by [`GeneratorProvider::get_component`],
+/// paired with a content-addressed hash of the generator's source
+/// closure. The hash flows into [`Metadata::generator_source_hash`] so
+/// the kiln-output cache invalidates when the generator changes — even
+/// when the consumer's primary `.g4` (or other inputs) is unchanged.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GeneratorComponent {
+    /// Component model `.wasm` bytes ready for `run_generator`.
+    pub bytes: Vec<u8>,
+    /// Hex-encoded SHA-256 of the generator's source closure (entry
+    /// `.wado` plus every transitively imported `.wado`). Empty when
+    /// the provider could not compute one (e.g. the spec-form path on
+    /// providers that have not implemented source-distribution
+    /// hashing). An empty string is recorded verbatim in the metadata
+    /// and matches another empty string only — the driver therefore
+    /// keeps caching consistent for generators that can never produce
+    /// a hash, while still invalidating once one is produced.
+    pub source_hash: String,
+}
+
 /// Resolves a generator's component bytes for execution.
 ///
 /// The runner is deliberately decoupled from how a given module becomes a
@@ -700,12 +730,16 @@ fn validate_rel_output_path(p: &str) -> Result<PathBuf, ExecuteError> {
 ///   when there is a real generator to compile).
 /// - A test provider that returns pre-built bytes.
 pub trait GeneratorProvider {
-    /// Resolve `module` to component bytes. Called at most once per unique
-    /// module in a pipeline run.
+    /// Resolve `module` to component bytes plus a content-addressed
+    /// identity for the generator's source closure. The driver calls
+    /// this once per invocation in the pipeline (so a single module
+    /// shared by N invocations triggers N calls); implementations are
+    /// expected to honor their own internal cache so the steady-state
+    /// hit path is a small filesystem read rather than a recompile.
     fn get_component(
         &self,
         module: &GeneratorModule,
-    ) -> impl std::future::Future<Output = Result<Vec<u8>, ProviderError>> + Send;
+    ) -> impl std::future::Future<Output = Result<GeneratorComponent, ProviderError>> + Send;
 
     /// Resolve `module` to its typed [`OptionsDescriptor`]. Used by the
     /// driver to validate a user-supplied options table before calling the
@@ -891,20 +925,73 @@ where
         let options_hash =
             wado_compiler::kiln::hash_options_canonical(&invocation.options_canonical);
 
+        // Resolve the component once per invocation. The provider is
+        // expected to honor its own internal cache, so on a steady-state
+        // hit this is a small filesystem read of the cached WASM plus
+        // sidecar re-validation. The bytes are needed if we miss; the
+        // `source_hash` is needed even on a hit to detect generator-only
+        // changes.
+        let component_result = provider.get_component(&invocation.module).await;
+
         let (entry, executed) =
             if let Some(prior) = existing.clone().filter(|m| m.options_hash == options_hash) {
-                match cache_matches(&prior, invocation, manifest_root, host).await {
-                    CacheCheck::Hit | CacheCheck::HitButModified => {
-                        outcome.cached.push(invocation_name.clone());
+                match component_result {
+                    Ok(component) => match cache_matches(
+                        &prior,
+                        invocation,
+                        manifest_root,
+                        host,
+                        &component.source_hash,
+                    )
+                    .await
+                    {
+                        CacheCheck::Hit | CacheCheck::HitButModified => {
+                            outcome.cached.push(invocation_name.clone());
+                            (Some(prior), false)
+                        }
+                        CacheCheck::Miss => match run_and_build_metadata(
+                            &invocation_name,
+                            invocation,
+                            manifest_root,
+                            host,
+                            &component,
+                            options_hash.clone(),
+                        )
+                        .await
+                        {
+                            Ok(metadata) => {
+                                outcome.executed.push(invocation_name.clone());
+                                (Some(metadata), true)
+                            }
+                            Err(e) if is_unsupported(&e) => {
+                                emit_stale_warning(host, &invocation_name);
+                                outcome.stale.push(invocation_name.clone());
+                                (Some(prior), false)
+                            }
+                            Err(e) => return Err(e),
+                        },
+                    },
+                    Err(ProviderError::Unsupported { .. }) => {
+                        emit_stale_warning(host, &invocation_name);
+                        outcome.stale.push(invocation_name.clone());
                         (Some(prior), false)
                     }
-                    CacheCheck::Miss => match run_and_build_metadata(
+                    Err(source) => {
+                        return Err(PipelineError::Provider {
+                            invocation: invocation_name.clone(),
+                            source,
+                        });
+                    }
+                }
+            } else {
+                match component_result {
+                    Ok(component) => match run_and_build_metadata(
                         &invocation_name,
                         invocation,
                         manifest_root,
                         host,
-                        provider,
-                        options_hash.clone(),
+                        &component,
+                        options_hash,
                     )
                     .await
                     {
@@ -915,32 +1002,21 @@ where
                         Err(e) if is_unsupported(&e) => {
                             emit_stale_warning(host, &invocation_name);
                             outcome.stale.push(invocation_name.clone());
-                            (Some(prior), false)
+                            (existing, false)
                         }
                         Err(e) => return Err(e),
                     },
-                }
-            } else {
-                match run_and_build_metadata(
-                    &invocation_name,
-                    invocation,
-                    manifest_root,
-                    host,
-                    provider,
-                    options_hash,
-                )
-                .await
-                {
-                    Ok(metadata) => {
-                        outcome.executed.push(invocation_name.clone());
-                        (Some(metadata), true)
-                    }
-                    Err(e) if is_unsupported(&e) => {
+                    Err(ProviderError::Unsupported { .. }) => {
                         emit_stale_warning(host, &invocation_name);
                         outcome.stale.push(invocation_name.clone());
                         (existing, false)
                     }
-                    Err(e) => return Err(e),
+                    Err(source) => {
+                        return Err(PipelineError::Provider {
+                            invocation: invocation_name.clone(),
+                            source,
+                        });
+                    }
                 }
             };
 
@@ -1063,7 +1139,7 @@ where
             })?;
         let run = execute_with_mode(
             invocation,
-            &component,
+            &component.bytes,
             manifest_root,
             host,
             ExecuteMode::DryRun,
@@ -1227,26 +1303,18 @@ async fn typed_encode_options<H, P>(
     }
 }
 
-async fn run_and_build_metadata<H, P>(
+async fn run_and_build_metadata<H>(
     invocation_name: &str,
     invocation: &Invocation,
     manifest_root: &Path,
     host: &H,
-    provider: &P,
+    component: &GeneratorComponent,
     options_hash: String,
 ) -> Result<Metadata, PipelineError>
 where
     H: CompilerHost,
-    P: GeneratorProvider,
 {
-    let component = provider
-        .get_component(&invocation.module)
-        .await
-        .map_err(|source| PipelineError::Provider {
-            invocation: invocation_name.to_string(),
-            source,
-        })?;
-    let run = execute(invocation, &component, manifest_root, host)
+    let run = execute(invocation, &component.bytes, manifest_root, host)
         .await
         .map_err(|source| PipelineError::Execute {
             invocation: invocation_name.to_string(),
@@ -1257,6 +1325,7 @@ where
         invocation,
         &run,
         options_hash,
+        component.source_hash.clone(),
     ))
 }
 
@@ -1635,6 +1704,7 @@ mod tests {
                 &sample_invocation(),
                 &run,
                 "sha256:optdigest".to_string(),
+                String::new(),
             );
 
             assert_eq!(entry.invocation, "proto");
@@ -1677,7 +1747,7 @@ mod tests {
                 response,
                 &[("schema.proto", b"p"), ("dep.proto", b"d")],
             );
-            let entry = build_metadata("proto", &sample_invocation(), &run, "sha256:o".to_string());
+            let entry = build_metadata("proto", &sample_invocation(), &run, "sha256:o".to_string(), String::new());
             assert_eq!(entry.reads.len(), 2);
             assert_eq!(entry.reads[0].path, "a.proto");
             assert_eq!(entry.reads[1].path, "z.proto");
@@ -1699,10 +1769,10 @@ mod tests {
                 response,
                 &[("schema.proto", b"p"), ("dep.proto", b"d")],
             );
-            let entry = build_metadata("proto", &sample_invocation(), &run, "sha256:o".to_string());
+            let entry = build_metadata("proto", &sample_invocation(), &run, "sha256:o".to_string(), String::new());
             let host = HashOnlyHost::new(&[("schema.proto", b"p"), ("dep.proto", b"d")]);
             let hit = runtime().block_on(async {
-                cache_matches(&entry, &sample_invocation(), tmp.path(), &host).await
+                cache_matches(&entry, &sample_invocation(), tmp.path(), &host, "").await
             });
             assert_eq!(hit, CacheCheck::Hit);
         }
@@ -1719,10 +1789,10 @@ mod tests {
                 response,
                 &[("schema.proto", b"p"), ("dep.proto", b"d")],
             );
-            let entry = build_metadata("proto", &sample_invocation(), &run, "sha256:o".to_string());
+            let entry = build_metadata("proto", &sample_invocation(), &run, "sha256:o".to_string(), String::new());
             let host = HashOnlyHost::new(&[("schema.proto", b"different"), ("dep.proto", b"d")]);
             let hit = runtime().block_on(async {
-                cache_matches(&entry, &sample_invocation(), tmp.path(), &host).await
+                cache_matches(&entry, &sample_invocation(), tmp.path(), &host, "").await
             });
             assert_eq!(hit, CacheCheck::Miss);
         }
@@ -1743,11 +1813,11 @@ mod tests {
                 response,
                 &[("schema.proto", b"p"), ("dep.proto", b"d")],
             );
-            let entry = build_metadata("proto", &sample_invocation(), &run, "sha256:o".to_string());
+            let entry = build_metadata("proto", &sample_invocation(), &run, "sha256:o".to_string(), String::new());
             std::fs::remove_file(tmp.path().join("build/kiln/proto/lib.wado")).unwrap();
             let host = HashOnlyHost::new(&[("schema.proto", b"p"), ("dep.proto", b"d")]);
             let hit = runtime().block_on(async {
-                cache_matches(&entry, &sample_invocation(), tmp.path(), &host).await
+                cache_matches(&entry, &sample_invocation(), tmp.path(), &host, "").await
             });
             assert_eq!(hit, CacheCheck::Miss);
         }
@@ -1768,7 +1838,7 @@ mod tests {
                 response,
                 &[("schema.proto", b"p"), ("dep.proto", b"d")],
             );
-            let entry = build_metadata("proto", &sample_invocation(), &run, "sha256:o".to_string());
+            let entry = build_metadata("proto", &sample_invocation(), &run, "sha256:o".to_string(), String::new());
             // Hand-edit the generated file after generation.
             std::fs::write(
                 tmp.path().join("build/kiln/proto/lib.wado"),
@@ -1777,7 +1847,7 @@ mod tests {
             .unwrap();
             let host = HashOnlyHost::new(&[("schema.proto", b"p"), ("dep.proto", b"d")]);
             let hit = runtime().block_on(async {
-                cache_matches(&entry, &sample_invocation(), tmp.path(), &host).await
+                cache_matches(&entry, &sample_invocation(), tmp.path(), &host, "").await
             });
             assert_eq!(hit, CacheCheck::HitButModified);
         }
@@ -1801,14 +1871,14 @@ mod tests {
                 response,
                 &[("schema.proto", b"p"), ("dep.proto", b"d")],
             );
-            let entry = build_metadata("proto", &sample_invocation(), &run, "sha256:o".to_string());
+            let entry = build_metadata("proto", &sample_invocation(), &run, "sha256:o".to_string(), String::new());
             let host = HashOnlyHost::new(&[
                 ("schema.proto", b"p"),
                 ("dep.proto", b"d"),
                 ("imported.proto", b"mutated"),
             ]);
             let hit = runtime().block_on(async {
-                cache_matches(&entry, &sample_invocation(), tmp.path(), &host).await
+                cache_matches(&entry, &sample_invocation(), tmp.path(), &host, "").await
             });
             assert_eq!(hit, CacheCheck::Miss);
         }

--- a/wado-cli/src/kiln_driver.rs
+++ b/wado-cli/src/kiln_driver.rs
@@ -24,6 +24,7 @@
 //! WEP M9 — it does not contain any generator-cache rows.
 
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use wado_compiler::ast::AttrValue;
 use wado_compiler::compiler_host::{
@@ -906,6 +907,13 @@ where
 
     let mut outcome = PipelineOutcome::default();
     let mut kept_by_dir: indexmap::IndexMap<String, Vec<String>> = indexmap::IndexMap::new();
+    // Per-pipeline cache of provider results, keyed by `GeneratorModule`.
+    // Many invocations typically share a single generator module (one
+    // generator package emits parsers for every grammar in a project), so
+    // looking it up once per pipeline keeps the per-invocation hot path to
+    // an in-memory `Arc::clone` instead of a fresh sidecar walk + WASM read.
+    // Linear scan is fine: the unique-module count is O(1) in practice.
+    let mut module_cache: Vec<(GeneratorModule, Arc<GeneratorComponent>)> = Vec::new();
 
     for invocation in &planned.plan.order {
         let invocation_name = invocation_id(invocation);
@@ -925,13 +933,25 @@ where
         let options_hash =
             wado_compiler::kiln::hash_options_canonical(&invocation.options_canonical);
 
-        // Resolve the component once per invocation. The provider is
-        // expected to honor its own internal cache, so on a steady-state
-        // hit this is a small filesystem read of the cached WASM plus
-        // sidecar re-validation. The bytes are needed if we miss; the
-        // `source_hash` is needed even on a hit to detect generator-only
-        // changes.
-        let component_result = provider.get_component(&invocation.module).await;
+        // Resolve the component once per unique module. The provider's
+        // own internal cache makes a first call's hit path cheap; the
+        // pipeline-level cache here ensures we don't repeat that walk
+        // for every invocation that shares the same module.
+        let component_result: Result<Arc<GeneratorComponent>, ProviderError> =
+            match module_cache
+                .iter()
+                .find(|(m, _)| m == &invocation.module)
+            {
+                Some((_, cached)) => Ok(Arc::clone(cached)),
+                None => match provider.get_component(&invocation.module).await {
+                    Ok(c) => {
+                        let arc = Arc::new(c);
+                        module_cache.push((invocation.module.clone(), Arc::clone(&arc)));
+                        Ok(arc)
+                    }
+                    Err(e) => Err(e),
+                },
+            };
 
         let (entry, executed) =
             if let Some(prior) = existing.clone().filter(|m| m.options_hash == options_hash) {
@@ -954,7 +974,7 @@ where
                             invocation,
                             manifest_root,
                             host,
-                            &component,
+                            component.as_ref(),
                             options_hash.clone(),
                         )
                         .await
@@ -990,7 +1010,7 @@ where
                         invocation,
                         manifest_root,
                         host,
-                        &component,
+                        component.as_ref(),
                         options_hash,
                     )
                     .await

--- a/wado-cli/src/kiln_driver.rs
+++ b/wado-cli/src/kiln_driver.rs
@@ -732,11 +732,12 @@ pub struct GeneratorComponent {
 /// - A test provider that returns pre-built bytes.
 pub trait GeneratorProvider {
     /// Resolve `module` to component bytes plus a content-addressed
-    /// identity for the generator's source closure. The driver calls
-    /// this once per invocation in the pipeline (so a single module
-    /// shared by N invocations triggers N calls); implementations are
-    /// expected to honor their own internal cache so the steady-state
-    /// hit path is a small filesystem read rather than a recompile.
+    /// identity for the generator's source closure. The driver caches
+    /// the result by `GeneratorModule` for the duration of one
+    /// `run_pipeline`, so a module shared across N invocations triggers
+    /// at most one call here. Implementations should still honor their
+    /// own internal cache so the steady-state hit on a *cold* pipeline
+    /// is a small filesystem read rather than a recompile.
     fn get_component(
         &self,
         module: &GeneratorModule,

--- a/wado-cli/src/kiln_driver.rs
+++ b/wado-cli/src/kiln_driver.rs
@@ -938,10 +938,7 @@ where
         // pipeline-level cache here ensures we don't repeat that walk
         // for every invocation that shares the same module.
         let component_result: Result<Arc<GeneratorComponent>, ProviderError> =
-            match module_cache
-                .iter()
-                .find(|(m, _)| m == &invocation.module)
-            {
+            match module_cache.iter().find(|(m, _)| m == &invocation.module) {
                 Some((_, cached)) => Ok(Arc::clone(cached)),
                 None => match provider.get_component(&invocation.module).await {
                     Ok(c) => {
@@ -1767,7 +1764,13 @@ mod tests {
                 response,
                 &[("schema.proto", b"p"), ("dep.proto", b"d")],
             );
-            let entry = build_metadata("proto", &sample_invocation(), &run, "sha256:o".to_string(), String::new());
+            let entry = build_metadata(
+                "proto",
+                &sample_invocation(),
+                &run,
+                "sha256:o".to_string(),
+                String::new(),
+            );
             assert_eq!(entry.reads.len(), 2);
             assert_eq!(entry.reads[0].path, "a.proto");
             assert_eq!(entry.reads[1].path, "z.proto");
@@ -1789,7 +1792,13 @@ mod tests {
                 response,
                 &[("schema.proto", b"p"), ("dep.proto", b"d")],
             );
-            let entry = build_metadata("proto", &sample_invocation(), &run, "sha256:o".to_string(), String::new());
+            let entry = build_metadata(
+                "proto",
+                &sample_invocation(),
+                &run,
+                "sha256:o".to_string(),
+                String::new(),
+            );
             let host = HashOnlyHost::new(&[("schema.proto", b"p"), ("dep.proto", b"d")]);
             let hit = runtime().block_on(async {
                 cache_matches(&entry, &sample_invocation(), tmp.path(), &host, "").await
@@ -1809,7 +1818,13 @@ mod tests {
                 response,
                 &[("schema.proto", b"p"), ("dep.proto", b"d")],
             );
-            let entry = build_metadata("proto", &sample_invocation(), &run, "sha256:o".to_string(), String::new());
+            let entry = build_metadata(
+                "proto",
+                &sample_invocation(),
+                &run,
+                "sha256:o".to_string(),
+                String::new(),
+            );
             let host = HashOnlyHost::new(&[("schema.proto", b"different"), ("dep.proto", b"d")]);
             let hit = runtime().block_on(async {
                 cache_matches(&entry, &sample_invocation(), tmp.path(), &host, "").await
@@ -1833,7 +1848,13 @@ mod tests {
                 response,
                 &[("schema.proto", b"p"), ("dep.proto", b"d")],
             );
-            let entry = build_metadata("proto", &sample_invocation(), &run, "sha256:o".to_string(), String::new());
+            let entry = build_metadata(
+                "proto",
+                &sample_invocation(),
+                &run,
+                "sha256:o".to_string(),
+                String::new(),
+            );
             std::fs::remove_file(tmp.path().join("build/kiln/proto/lib.wado")).unwrap();
             let host = HashOnlyHost::new(&[("schema.proto", b"p"), ("dep.proto", b"d")]);
             let hit = runtime().block_on(async {
@@ -1858,7 +1879,13 @@ mod tests {
                 response,
                 &[("schema.proto", b"p"), ("dep.proto", b"d")],
             );
-            let entry = build_metadata("proto", &sample_invocation(), &run, "sha256:o".to_string(), String::new());
+            let entry = build_metadata(
+                "proto",
+                &sample_invocation(),
+                &run,
+                "sha256:o".to_string(),
+                String::new(),
+            );
             // Hand-edit the generated file after generation.
             std::fs::write(
                 tmp.path().join("build/kiln/proto/lib.wado"),
@@ -1891,7 +1918,13 @@ mod tests {
                 response,
                 &[("schema.proto", b"p"), ("dep.proto", b"d")],
             );
-            let entry = build_metadata("proto", &sample_invocation(), &run, "sha256:o".to_string(), String::new());
+            let entry = build_metadata(
+                "proto",
+                &sample_invocation(),
+                &run,
+                "sha256:o".to_string(),
+                String::new(),
+            );
             let host = HashOnlyHost::new(&[
                 ("schema.proto", b"p"),
                 ("dep.proto", b"d"),

--- a/wado-cli/src/kiln_metadata.rs
+++ b/wado-cli/src/kiln_metadata.rs
@@ -21,7 +21,13 @@ use serde::{Deserialize, Serialize};
 /// Schema version of the `<primary>.kiln.json` file. Bumped only on
 /// incompatible changes; older files are silently ignored (treated as a
 /// cache miss) when the version differs.
-pub const METADATA_VERSION: u32 = 1;
+///
+/// v2 (current): added `generator_source_hash` so a change to the
+/// generator's `.wado` source closure invalidates the cache. v1 metadata
+/// has no record of the generator's identity beyond the `generator`
+/// string and silently survived edits to transitive generator imports —
+/// see `cache_matches` for the comparison.
+pub const METADATA_VERSION: u32 = 2;
 
 /// Suffix appended to the primary input's basename to form the metadata
 /// filename. Lives in `<manifest_root>/<output_dir>/`.
@@ -33,6 +39,15 @@ pub struct Metadata {
     pub version: u32,
     pub invocation: String,
     pub generator: String,
+    /// Hex-encoded SHA-256 of the generator's source closure (entry
+    /// `.wado` plus every transitively imported `.wado`). When the
+    /// stored value differs from the provider's current hash the
+    /// cache must miss — see `cache_matches`. An empty string is
+    /// recorded for providers that cannot compute one (currently the
+    /// spec-form path), which means cache validation falls back to
+    /// the file-hash checks alone.
+    #[serde(default)]
+    pub generator_source_hash: String,
     pub primary: FileHash,
     #[serde(default)]
     pub inputs: Vec<FileHash>,
@@ -175,9 +190,10 @@ mod tests {
 
     fn sample() -> Metadata {
         Metadata {
-            version: 1,
+            version: METADATA_VERSION,
             invocation: "kiln-deadbeef".to_string(),
             generator: "local:src/generator.wado".to_string(),
+            generator_source_hash: "sha256:gen".to_string(),
             primary: FileHash {
                 path: "schemas/x.proto".to_string(),
                 hash: "sha256:aa".to_string(),

--- a/wado-cli/src/kiln_provider.rs
+++ b/wado-cli/src/kiln_provider.rs
@@ -310,10 +310,7 @@ impl CliGeneratorProvider {
 /// not descendants of `base` are kept verbatim — they still hash to the
 /// same value and remain stable across runs as long as the toolchain is
 /// stable, so they participate in invalidation correctly.
-fn make_relative_sources(
-    base: &Path,
-    raw: Vec<(String, [u8; 32])>,
-) -> Vec<(String, [u8; 32])> {
+fn make_relative_sources(base: &Path, raw: Vec<(String, [u8; 32])>) -> Vec<(String, [u8; 32])> {
     raw.into_iter()
         .map(|(path, hash)| {
             let p = Path::new(&path);
@@ -390,8 +387,7 @@ impl CompilerHost for SilentHost {
     fn load_source(
         &self,
         path: &str,
-    ) -> impl std::future::Future<Output = Result<Vec<u8>, wado_compiler::SourceError>> + Send
-    {
+    ) -> impl std::future::Future<Output = Result<Vec<u8>, wado_compiler::SourceError>> + Send {
         let path_owned = path.to_string();
         let loaded = self.loaded.clone();
         let inner_fut = self.inner.load_source(path);

--- a/wado-cli/src/kiln_provider.rs
+++ b/wado-cli/src/kiln_provider.rs
@@ -22,15 +22,17 @@
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use wado_compiler::kiln::{GeneratorModule, OptionsDescriptor};
 use wado_compiler::{CompilerHost, CompilerOptions, Diagnostic, LogLevel};
 
 use crate::compiler_host::FilesystemCompilerHost;
-use crate::kiln_driver::{GeneratorProvider, ProviderError};
+use crate::kiln_driver::{GeneratorComponent, GeneratorProvider, ProviderError};
 
 /// Directory under the project root where compiled generator
 /// components are cached: `build/kiln/generators/`. See WEP 2026-04-12
@@ -93,6 +95,45 @@ impl CliGeneratorProvider {
             .join(format!("{stable_id}.descriptor"))
     }
 
+    fn sources_sidecar_path(&self, stable_id: &str) -> PathBuf {
+        self.manifest_root
+            .join(CACHE_DIR)
+            .join(format!("{stable_id}.sources.json"))
+    }
+
+    /// Re-validate the cached generator artefacts at `stable_id` against
+    /// the on-disk sources captured by the previous compile. Returns the
+    /// freshly recomputed `combined_hash` when every listed source file
+    /// still matches its recorded hash; returns `None` when the sidecar
+    /// is missing, malformed, version-mismatched, or any source file has
+    /// drifted (or vanished). Callers must treat `None` as a cache miss
+    /// and recompile.
+    ///
+    /// The combined hash is recomputed from the validated entries rather
+    /// than trusted verbatim from the sidecar, so a hand-edited sidecar
+    /// cannot pin metadata to a value that disagrees with its own
+    /// `sources` list.
+    fn validate_sources_sidecar(&self, stable_id: &str, base: &Path) -> Option<String> {
+        let sidecar_path = self.sources_sidecar_path(stable_id);
+        let bytes = std::fs::read(&sidecar_path).ok()?;
+        let sidecar: GeneratorSourcesSidecar = serde_json::from_slice(&bytes).ok()?;
+        if sidecar.version != SIDECAR_VERSION {
+            return None;
+        }
+        let mut validated: Vec<(String, [u8; 32])> = Vec::with_capacity(sidecar.sources.len());
+        for entry in &sidecar.sources {
+            let abs = base.join(&entry.path);
+            let bytes = std::fs::read(&abs).ok()?;
+            let recorded = hex32_to_array(&entry.hash)?;
+            let actual = sha256_of(&bytes);
+            if actual != recorded {
+                return None;
+            }
+            validated.push((entry.path.clone(), actual));
+        }
+        Some(combined_sources_hash(&validated))
+    }
+
     /// Resolve a `LocalPath` generator source, returning the absolute
     /// path, raw bytes, UTF-8 source string, and stable id. Emits the
     /// same not-found / not-UTF-8 diagnostics for both `get_component`
@@ -148,6 +189,9 @@ impl CliGeneratorProvider {
 
         let base_path = abs.parent().map(Path::to_path_buf).unwrap_or_default();
         let abs_str = abs.to_string_lossy().to_string();
+        let recording_base = base_path.clone();
+        let loaded = Arc::new(Mutex::new(Vec::<(String, [u8; 32])>::new()));
+        let loaded_for_task = loaded.clone();
 
         // `compile_with_options` captures a `Logger<H>` whose internal
         // `Cell<usize>` makes the returned future `!Send`. Run the whole
@@ -158,6 +202,7 @@ impl CliGeneratorProvider {
             tokio::task::spawn_blocking(move || {
                 let host = SilentHost {
                     inner: FilesystemCompilerHost::with_log_level(base_path, LogLevel::Warn),
+                    loaded: loaded_for_task,
                 };
                 let options = CompilerOptions {
                     // `O2` matches the default `wado compile` opt level, so
@@ -187,6 +232,9 @@ impl CliGeneratorProvider {
                     Ok(r) => Ok(CompileArtifacts {
                         wasm: r.wasm,
                         descriptor: r.kiln_options_descriptor,
+                        // Filled in by `compile_local` after the recording
+                        // host's `loaded` queue is drained.
+                        source_hash: String::new(),
                     }),
                     Err(_) => Err(ProviderError::Internal {
                         message: format!(
@@ -200,7 +248,19 @@ impl CliGeneratorProvider {
                 message: format!("kiln: generator compile task panicked or was cancelled: {e}"),
             })?;
 
-        let artifacts = artifacts?;
+        let mut artifacts = artifacts?;
+
+        // Drain the recorded sources, dedup paths (the compiler can request
+        // the same module more than once), and persist the closure sidecar
+        // alongside the cached WASM. The combined hash is what the kiln
+        // driver records in `Metadata::generator_source_hash`.
+        let recorded = loaded
+            .lock()
+            .map(|mut g| std::mem::take(&mut *g))
+            .unwrap_or_default();
+        let sources = dedup_sort_sources(make_relative_sources(&recording_base, recorded));
+        let combined_hash = combined_sources_hash(&sources);
+        artifacts.source_hash = combined_hash.clone();
 
         // Cache writes are best-effort: if the filesystem refuses we
         // still return the fresh bytes. The next invocation just repeats
@@ -212,6 +272,22 @@ impl CliGeneratorProvider {
             let _ = std::fs::create_dir_all(parent);
         }
         let _ = std::fs::write(&wasm_path, &artifacts.wasm);
+
+        let sidecar = GeneratorSourcesSidecar {
+            version: SIDECAR_VERSION,
+            sources: sources
+                .iter()
+                .map(|(path, hash)| SourceEntry {
+                    path: path.clone(),
+                    hash: hex32(hash),
+                })
+                .collect(),
+            combined_hash,
+        };
+        let sidecar_path = self.sources_sidecar_path(&stable_id);
+        if let Ok(bytes) = serde_json::to_vec_pretty(&sidecar) {
+            let _ = std::fs::write(&sidecar_path, &bytes);
+        }
 
         if let Some(ref descriptor) = artifacts.descriptor {
             let desc_path = self.descriptor_cache_path(&stable_id);
@@ -229,19 +305,52 @@ impl CliGeneratorProvider {
     }
 }
 
+/// Convert the absolute paths the recording host captured into project-
+/// relative paths anchored at `base`. Builtins and other paths that are
+/// not descendants of `base` are kept verbatim — they still hash to the
+/// same value and remain stable across runs as long as the toolchain is
+/// stable, so they participate in invalidation correctly.
+fn make_relative_sources(
+    base: &Path,
+    raw: Vec<(String, [u8; 32])>,
+) -> Vec<(String, [u8; 32])> {
+    raw.into_iter()
+        .map(|(path, hash)| {
+            let p = Path::new(&path);
+            let rel = p
+                .strip_prefix(base)
+                .map(|s| s.to_string_lossy().into_owned())
+                .unwrap_or(path);
+            (rel, hash)
+        })
+        .collect()
+}
+
 /// Both artefacts produced by a single invocation of the inner compiler
-/// on a kiln generator package: the component bytes plus the extracted
-/// `Options` descriptor (when extraction succeeded).
+/// on a kiln generator package: the component bytes, the extracted
+/// `Options` descriptor (when extraction succeeded), and the combined
+/// hash of every `.wado` source the compiler loaded along the way.
+/// `source_hash` is filled by `compile_local` after the inner pipeline
+/// returns; it is the hex digest stored in `Metadata::generator_source_hash`.
 struct CompileArtifacts {
     wasm: Vec<u8>,
     descriptor: Option<OptionsDescriptor>,
+    source_hash: String,
 }
 
 /// Compute the stable id for a local generator source file.
 ///
 /// Key inputs (per WEP 2026-04-12 §"`build/kiln/` directory layout"):
 /// - normalized project-relative path
-/// - source tree hash (v1: SHA-256 of the single entry-file content)
+/// - SHA-256 of the entry file's bytes
+///
+/// Note: the stable id intentionally hashes only the entry file. It is
+/// the cache *lookup* key, not the cache *freshness* key — `compile_local`
+/// writes a `<stable_id>.sources.json` sidecar listing every transitively
+/// imported `.wado` (path + hash) and `validate_sources_sidecar` rejects
+/// the cached WASM whenever any of those files drifts on disk. Without
+/// the sidecar, an edit to e.g. `parser_gen.wado` (a dep of the entry
+/// `generator.wado`) would silently reuse stale bytes.
 ///
 /// Returns the first 16 hex chars of the digest, enough to distinguish
 /// typical generator files without bloating `build/kiln/generators/`
@@ -265,16 +374,35 @@ fn stable_id_for_local(path_str: &str, content: &[u8]) -> String {
 /// the host — we want to swallow generator-compile diagnostics so they
 /// don't mix with the consuming project's own compile output. The
 /// provider surfaces a single `ProviderError::Compile` instead.
+///
+/// Also records every `load_source` call into `loaded` (path + content
+/// hash) so the provider can persist the generator's transitive source
+/// closure into a sidecar file and invalidate the WASM cache when any
+/// of those files drifts on disk. The recording is best-effort: a
+/// duplicate `load_source` for the same path appends a duplicate
+/// entry, which the dedup step in `compile_local` collapses.
 struct SilentHost {
     inner: FilesystemCompilerHost,
+    loaded: Arc<Mutex<Vec<(String, [u8; 32])>>>,
 }
 
 impl CompilerHost for SilentHost {
     fn load_source(
         &self,
         path: &str,
-    ) -> impl std::future::Future<Output = Result<Vec<u8>, wado_compiler::SourceError>> + Send {
-        self.inner.load_source(path)
+    ) -> impl std::future::Future<Output = Result<Vec<u8>, wado_compiler::SourceError>> + Send
+    {
+        let path_owned = path.to_string();
+        let loaded = self.loaded.clone();
+        let inner_fut = self.inner.load_source(path);
+        async move {
+            let bytes = inner_fut.await?;
+            let hash = sha256_of(&bytes);
+            if let Ok(mut guard) = loaded.lock() {
+                guard.push((path_owned, hash));
+            }
+            Ok(bytes)
+        }
     }
 
     fn emit_diagnostic(&self, diagnostic: Diagnostic) {
@@ -291,8 +419,94 @@ impl CompilerHost for SilentHost {
     }
 }
 
+fn sha256_of(bytes: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let digest = hasher.finalize();
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&digest);
+    out
+}
+
+/// Sidecar file persisted next to a cached generator WASM, listing every
+/// `.wado` source file the inner compiler loaded while building the
+/// component. Each entry is a project-relative path + the SHA-256 of the
+/// file's bytes when the WASM was produced. The provider re-hashes these
+/// files on the next call and rebuilds the WASM if any drift, so an edit
+/// to a transitive import (e.g. `parser_gen.wado` for a generator entry
+/// at `generator.wado`) correctly invalidates the cache.
+///
+/// `combined_hash` is the SHA-256 of the canonical encoding of `sources`
+/// (sorted lex by path, hex-encoded). It is the value stored in
+/// `Metadata::generator_source_hash` so the kiln-output cache check in
+/// the driver can reuse the same identity.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct GeneratorSourcesSidecar {
+    /// Schema version for forward compatibility. Bump on incompatible
+    /// changes; mismatched versions are treated as cache-miss.
+    version: u32,
+    sources: Vec<SourceEntry>,
+    combined_hash: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SourceEntry {
+    path: String,
+    /// Hex-encoded SHA-256 of the file's bytes at compile time.
+    hash: String,
+}
+
+const SIDECAR_VERSION: u32 = 1;
+
+fn dedup_sort_sources(mut sources: Vec<(String, [u8; 32])>) -> Vec<(String, [u8; 32])> {
+    sources.sort_by(|a, b| a.0.cmp(&b.0));
+    sources.dedup_by(|a, b| a.0 == b.0);
+    sources
+}
+
+fn combined_sources_hash(sources: &[(String, [u8; 32])]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"kiln-generator-sources-v1\n");
+    for (path, hash) in sources {
+        hasher.update(path.as_bytes());
+        hasher.update(b"\n");
+        hasher.update(hash);
+        hasher.update(b"\n");
+    }
+    let digest = hasher.finalize();
+    use std::fmt::Write;
+    let mut out = String::with_capacity(64);
+    for byte in digest {
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
+fn hex32_to_array(hex: &str) -> Option<[u8; 32]> {
+    if hex.len() != 64 {
+        return None;
+    }
+    let mut out = [0u8; 32];
+    for (i, byte) in out.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(&hex[i * 2..i * 2 + 2], 16).ok()?;
+    }
+    Some(out)
+}
+
+fn hex32(bytes: &[u8; 32]) -> String {
+    use std::fmt::Write;
+    let mut out = String::with_capacity(64);
+    for byte in bytes {
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
 impl GeneratorProvider for CliGeneratorProvider {
-    async fn get_component(&self, module: &GeneratorModule) -> Result<Vec<u8>, ProviderError> {
+    async fn get_component(
+        &self,
+        module: &GeneratorModule,
+    ) -> Result<GeneratorComponent, ProviderError> {
         match module {
             GeneratorModule::Spec(spec) => Err(ProviderError::Unsupported {
                 message: format!(
@@ -303,17 +517,30 @@ impl GeneratorProvider for CliGeneratorProvider {
             }),
             GeneratorModule::LocalPath(path) => {
                 let (abs, source, source_str, stable_id) = self.read_local_source(path)?;
+                let base = abs.parent().map(Path::to_path_buf).unwrap_or_default();
                 let cache_path = self.cache_path(&stable_id);
+                // Cache hit only when (a) the WASM blob exists, (b) the
+                // sidecar listing the transitive `.wado` closure exists
+                // and re-validates against the current on-disk bytes.
+                // Without (b) an edit to a transitive import would
+                // silently reuse a stale WASM (the entry-file based
+                // `stable_id` would still match), so the kiln-output
+                // cache further down the pipeline would be checked
+                // against an old generator.
                 if cache_path.is_file()
+                    && let Some(source_hash) = self.validate_sources_sidecar(&stable_id, &base)
                     && let Ok(bytes) = std::fs::read(&cache_path)
                 {
-                    return Ok(bytes);
+                    return Ok(GeneratorComponent { bytes, source_hash });
                 }
                 let artifacts = self
                     .compile_local(path.as_str().to_string(), abs, source_str, stable_id)
                     .await?;
                 let _ = source;
-                Ok(artifacts.wasm)
+                Ok(GeneratorComponent {
+                    bytes: artifacts.wasm,
+                    source_hash: artifacts.source_hash,
+                })
             }
         }
     }
@@ -329,8 +556,13 @@ impl GeneratorProvider for CliGeneratorProvider {
             }),
             GeneratorModule::LocalPath(path) => {
                 let (abs, _source, source_str, stable_id) = self.read_local_source(path)?;
+                let base = abs.parent().map(Path::to_path_buf).unwrap_or_default();
                 let desc_path = self.descriptor_cache_path(&stable_id);
+                // Same validation rule as `get_component`: a cached
+                // descriptor is only honored when the recorded source
+                // closure still matches on disk.
                 if desc_path.is_file()
+                    && self.validate_sources_sidecar(&stable_id, &base).is_some()
                     && let Ok(bytes) = std::fs::read(&desc_path)
                     && let Ok(descriptor) = serde_json::from_slice::<OptionsDescriptor>(&bytes)
                 {
@@ -442,13 +674,20 @@ export fn generate(raw: RawRequest) -> Result<Response, Error> {\n\
 
         assert_eq!(provider.compile_count(), 0);
 
-        let wasm = runtime()
+        let component = runtime()
             .block_on(async { provider.get_component(&module).await })
             .unwrap_or_else(|e| panic!("compile failed: {e:?}"));
-        assert!(!wasm.is_empty(), "component bytes must be non-empty");
         assert!(
-            wasm.starts_with(b"\0asm"),
+            !component.bytes.is_empty(),
+            "component bytes must be non-empty"
+        );
+        assert!(
+            component.bytes.starts_with(b"\0asm"),
             "component must start with wasm magic"
+        );
+        assert!(
+            !component.source_hash.is_empty(),
+            "local generators must produce a non-empty source hash"
         );
         assert_eq!(
             provider.compile_count(),
@@ -462,12 +701,32 @@ export fn generate(raw: RawRequest) -> Result<Response, Error> {\n\
         let entries: Vec<_> = std::fs::read_dir(&cache_dir)
             .map(|it| it.filter_map(Result::ok).collect())
             .unwrap_or_default();
-        assert_eq!(entries.len(), 1, "exactly one cached component expected");
+        let wasm_entries: Vec<_> = entries
+            .iter()
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "wasm"))
+            .collect();
+        assert_eq!(
+            wasm_entries.len(),
+            1,
+            "exactly one cached component .wasm expected"
+        );
+        // The compile-and-write path also persists a sources sidecar
+        // alongside the WASM; assert it landed so the next call's
+        // sidecar-validation path is exercised.
+        let sidecar_entries: Vec<_> = entries
+            .iter()
+            .filter(|e| e.path().to_string_lossy().ends_with(".sources.json"))
+            .collect();
+        assert_eq!(
+            sidecar_entries.len(),
+            1,
+            "exactly one cached sources sidecar expected"
+        );
 
-        let wasm2 = runtime()
+        let component2 = runtime()
             .block_on(async { provider.get_component(&module).await })
             .unwrap();
-        assert_eq!(wasm, wasm2, "cached second call must match first");
+        assert_eq!(component, component2, "cached second call must match first");
         assert_eq!(
             provider.compile_count(),
             1,

--- a/wado-cli/src/kiln_provider.rs
+++ b/wado-cli/src/kiln_provider.rs
@@ -306,10 +306,13 @@ impl CliGeneratorProvider {
 }
 
 /// Convert the absolute paths the recording host captured into project-
-/// relative paths anchored at `base`. Builtins and other paths that are
-/// not descendants of `base` are kept verbatim — they still hash to the
-/// same value and remain stable across runs as long as the toolchain is
-/// stable, so they participate in invalidation correctly.
+/// relative paths anchored at `base`. Stdlib modules (`core:*`, `wasi:*`)
+/// never reach `CompilerHost::load_source`, so the only paths that show
+/// up here are filesystem sources the inner compiler asked for. Anything
+/// outside `base` (e.g. `../shared/foo.wado` if the project layout puts
+/// the generator under a sibling directory, or a remote URL the host
+/// happens to fetch) is kept verbatim — its hash still pins content, so
+/// invalidation stays correct, but the relative-path layout is lost.
 fn make_relative_sources(base: &Path, raw: Vec<(String, [u8; 32])>) -> Vec<(String, [u8; 32])> {
     raw.into_iter()
         .map(|(path, hash)| {
@@ -373,9 +376,12 @@ fn stable_id_for_local(path_str: &str, content: &[u8]) -> String {
 /// provider surfaces a single `ProviderError::Compile` instead.
 ///
 /// Also records every `load_source` call into `loaded` (path + content
-/// hash) so the provider can persist the generator's transitive source
+/// hash) so the provider can persist the generator's transitive load
 /// closure into a sidecar file and invalidate the WASM cache when any
-/// of those files drifts on disk. The recording is best-effort: a
+/// of those files drifts on disk. "Load closure" is the right framing
+/// here: `CompilerHost::load_source` carries both `.wado` modules and
+/// raw assets pulled in via `#include_bytes`, so an edit to either kind
+/// of file drops the WASM cache. The recording is best-effort: a
 /// duplicate `load_source` for the same path appends a duplicate
 /// entry, which the dedup step in `compile_local` collapses.
 struct SilentHost {
@@ -425,12 +431,15 @@ fn sha256_of(bytes: &[u8]) -> [u8; 32] {
 }
 
 /// Sidecar file persisted next to a cached generator WASM, listing every
-/// `.wado` source file the inner compiler loaded while building the
-/// component. Each entry is a project-relative path + the SHA-256 of the
-/// file's bytes when the WASM was produced. The provider re-hashes these
-/// files on the next call and rebuilds the WASM if any drift, so an edit
-/// to a transitive import (e.g. `parser_gen.wado` for a generator entry
-/// at `generator.wado`) correctly invalidates the cache.
+/// file the inner compiler loaded while building the component — both
+/// `.wado` modules and binary assets routed through
+/// `CompilerHost::load_source` (e.g. `#include_bytes` payloads). Stdlib
+/// modules (`core:*`, `wasi:*`) are bypassed by the compiler and never
+/// appear here. Each entry is a project-relative path + the SHA-256 of
+/// the file's bytes when the WASM was produced. The provider re-hashes
+/// these files on the next call and rebuilds the WASM if any drift, so
+/// an edit to a transitive import (e.g. `parser_gen.wado` for a generator
+/// entry at `generator.wado`) correctly invalidates the cache.
 ///
 /// `combined_hash` is the SHA-256 of the canonical encoding of `sources`
 /// (sorted lex by path, hex-encoded). It is the value stored in

--- a/wado-cli/tests/kiln_compile.rs
+++ b/wado-cli/tests/kiln_compile.rs
@@ -110,11 +110,7 @@ fn first_run_compiles_second_run_hits_cache() {
         .iter()
         .filter(|p| p.extension().is_some_and(|ext| ext == "wasm"))
         .collect();
-    assert_eq!(
-        wasm_files.len(),
-        1,
-        "exactly one cached component expected"
-    );
+    assert_eq!(wasm_files.len(), 1, "exactly one cached component expected");
     // The compile path also persists a `.sources.json` sidecar listing
     // the transitive `.wado` closure for cache invalidation.
     let sidecar_files: Vec<&PathBuf> = cache_files
@@ -254,8 +250,8 @@ fn transitive_dep_edit_invalidates_cache() {
     let helper_path = tmp.join("helper.wado");
     std::fs::write(
         &helper_path,
-        r#"pub fn answer() -> i32 { return 42; }
-"#,
+        r"pub fn answer() -> i32 { return 42; }
+",
     )
     .unwrap();
     let entry_src = r#"
@@ -304,8 +300,8 @@ export fn generate(raw: RawRequest) -> Result<Response, Error> {
     // file on disk and the provider falls back to a fresh compile.
     std::fs::write(
         &helper_path,
-        r#"pub fn answer() -> i32 { return 43; }
-"#,
+        r"pub fn answer() -> i32 { return 43; }
+",
     )
     .unwrap();
 

--- a/wado-cli/tests/kiln_compile.rs
+++ b/wado-cli/tests/kiln_compile.rs
@@ -89,10 +89,10 @@ fn first_run_compiles_second_run_hits_cache() {
         .block_on(async { provider.get_component(&module).await })
         .expect("first compile should succeed");
     assert!(
-        first.starts_with(b"\0asm"),
+        first.bytes.starts_with(b"\0asm"),
         "component must start with wasm magic"
     );
-    assert!(first.len() > 100, "component must be non-trivial");
+    assert!(first.bytes.len() > 100, "component must be non-trivial");
     assert_eq!(
         provider.compile_count(),
         1,
@@ -106,10 +106,25 @@ fn first_run_compiles_second_run_hits_cache() {
         .expect("cache dir should exist after first compile")
         .filter_map(|r| r.ok().map(|e| e.path()))
         .collect();
+    let wasm_files: Vec<&PathBuf> = cache_files
+        .iter()
+        .filter(|p| p.extension().is_some_and(|ext| ext == "wasm"))
+        .collect();
     assert_eq!(
-        cache_files.len(),
+        wasm_files.len(),
         1,
         "exactly one cached component expected"
+    );
+    // The compile path also persists a `.sources.json` sidecar listing
+    // the transitive `.wado` closure for cache invalidation.
+    let sidecar_files: Vec<&PathBuf> = cache_files
+        .iter()
+        .filter(|p| p.to_string_lossy().ends_with(".sources.json"))
+        .collect();
+    assert_eq!(
+        sidecar_files.len(),
+        1,
+        "exactly one cached sources sidecar expected"
     );
 
     // Second call: same source, same stable-id → must hit the cache,
@@ -165,7 +180,7 @@ fn source_edit_invalidates_cache() {
     // verify it produced something on second compile, but don't require
     // bytewise divergence.
     assert!(
-        !second.is_empty() && second.starts_with(b"\0asm"),
+        !second.bytes.is_empty() && second.bytes.starts_with(b"\0asm"),
         "second compile should produce valid component bytes"
     );
     let _ = first;
@@ -184,15 +199,15 @@ fn adapter_generator_compiles_like_raw_request_generator() {
     let provider = CliGeneratorProvider::new(tmp.clone());
     let module = GeneratorModule::LocalPath(InvocationPath::normalize("./adapter_generator.wado"));
 
-    let wasm = runtime()
+    let component = runtime()
         .block_on(async { provider.get_component(&module).await })
         .expect("adapter-form generator must compile");
     assert!(
-        wasm.starts_with(b"\0asm"),
+        component.bytes.starts_with(b"\0asm"),
         "adapter generator must produce a valid wasm component"
     );
     assert!(
-        wasm.len() > 100,
+        component.bytes.len() > 100,
         "adapter generator must produce a non-trivial component"
     );
 
@@ -215,6 +230,106 @@ fn missing_local_path_surfaces_internal() {
         }
         _ => panic!("expected ProviderError::Internal, got {err:?}"),
     }
+}
+
+#[test]
+fn transitive_dep_edit_invalidates_cache() {
+    // Regression: the WASM cache key was previously
+    // `sha256(path || entry-file content)`, so an edit to a `.wado`
+    // file imported (transitively) by the generator entry left the
+    // cached bytes untouched. Local generator authors hit this
+    // constantly while iterating on a parser-gen library — the next
+    // `wado test` would happily reuse the previous WASM.
+    //
+    // The fix records every `.wado` file the inner compile loaded
+    // into a `<stable_id>.sources.json` sidecar; cache hits re-hash
+    // those entries and miss when any drift.
+    let tmp = unique_tmp("kiln-compile-transitive");
+    let _ = std::fs::remove_dir_all(&tmp);
+    std::fs::create_dir_all(&tmp).unwrap();
+
+    // Two-file generator: entry imports a sibling helper and uses one
+    // of its functions so the helper is part of the closure (not
+    // dead-import-stripped).
+    let helper_path = tmp.join("helper.wado");
+    std::fs::write(
+        &helper_path,
+        r#"pub fn answer() -> i32 { return 42; }
+"#,
+    )
+    .unwrap();
+    let entry_src = r#"
+use { RawRequest, Response, Error, bind_request } from "core:kiln";
+use { answer } from "./helper.wado";
+
+pub struct Options {
+    pub verbose: bool,
+}
+
+export fn generate(raw: RawRequest) -> Result<Response, Error> {
+    let req = match bind_request::<Options>(raw) {
+        Ok(r) => r,
+        Err(e) => return Result::Err(e),
+    };
+    let _ = req.options.verbose;
+    let _ = answer();
+    return Result::Ok(Response { files: [] });
+}
+"#;
+    let gen_path = tmp.join("entry.wado");
+    std::fs::write(&gen_path, entry_src).unwrap();
+
+    let provider = CliGeneratorProvider::new(tmp.clone());
+    let module = GeneratorModule::LocalPath(InvocationPath::normalize("./entry.wado"));
+
+    let _first = runtime()
+        .block_on(async { provider.get_component(&module).await })
+        .expect("first compile should succeed");
+    assert_eq!(provider.compile_count(), 1);
+
+    // Cache hit on the entry file alone — the entry's SHA-256 is
+    // unchanged, so the v1 stable-id keeps pointing at the same WASM.
+    let _second = runtime()
+        .block_on(async { provider.get_component(&module).await })
+        .expect("second compile should succeed");
+    assert_eq!(
+        provider.compile_count(),
+        1,
+        "cache hit when no source drifted"
+    );
+
+    // Now edit the transitive helper. Without sidecar validation the
+    // cache would hit again (entry SHA-256 unchanged); with the fix the
+    // sidecar's recorded hash for `helper.wado` no longer matches the
+    // file on disk and the provider falls back to a fresh compile.
+    std::fs::write(
+        &helper_path,
+        r#"pub fn answer() -> i32 { return 43; }
+"#,
+    )
+    .unwrap();
+
+    let _third = runtime()
+        .block_on(async { provider.get_component(&module).await })
+        .expect("third compile should succeed");
+    assert_eq!(
+        provider.compile_count(),
+        2,
+        "transitive dep edit must invalidate the WASM cache"
+    );
+
+    // After the rebuild the new sidecar should reflect the latest
+    // helper hash, so a fourth call hits cache cleanly.
+    let _fourth = runtime()
+        .block_on(async { provider.get_component(&module).await })
+        .expect("fourth compile should succeed");
+    assert_eq!(
+        provider.compile_count(),
+        2,
+        "post-rebuild cache hit when no further edit"
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp);
 }
 
 #[test]

--- a/wado-cli/tests/kiln_pipeline.rs
+++ b/wado-cli/tests/kiln_pipeline.rs
@@ -9,7 +9,9 @@ use std::path::Path;
 use std::sync::Mutex;
 
 use indexmap::IndexMap;
-use wado_cli::kiln_driver::{GeneratorProvider, PipelineOutcome, ProviderError, run_pipeline};
+use wado_cli::kiln_driver::{
+    GeneratorComponent, GeneratorProvider, PipelineOutcome, ProviderError, run_pipeline,
+};
 use wado_cli::kiln_metadata;
 use wado_compiler::compiler_host::{
     CompilerHost, Diagnostic, GeneratorOutputFile, GeneratorReadRecord, GeneratorRequest,
@@ -33,9 +35,18 @@ impl StubProvider {
 }
 
 impl GeneratorProvider for StubProvider {
-    async fn get_component(&self, _: &GeneratorModule) -> Result<Vec<u8>, ProviderError> {
+    async fn get_component(
+        &self,
+        _: &GeneratorModule,
+    ) -> Result<GeneratorComponent, ProviderError> {
         *self.calls.lock().unwrap() += 1;
-        Ok(self.bytes.clone())
+        Ok(GeneratorComponent {
+            bytes: self.bytes.clone(),
+            // Tests share a single fixed byte stream across calls; an
+            // empty source hash matches the legacy behaviour where the
+            // metadata's `generator_source_hash` was likewise empty.
+            source_hash: String::new(),
+        })
     }
 }
 
@@ -230,7 +241,18 @@ fn end_to_end_two_generators_execute_cache_and_reuse() {
     let outcome2 = run(&m, tmp.path(), &host2, &provider2, invs);
     assert_eq!(outcome2.cached.len(), 2);
     assert!(outcome2.executed.is_empty());
-    assert_eq!(*provider2.calls.lock().unwrap(), 0);
+    // The driver always queries the provider once per invocation to
+    // pick up the generator's current source hash for cache validation.
+    // For Stub the call is cheap (no inner compile); for Cli the
+    // provider's own cache short-circuits it. The assertion that
+    // matters here is that no `executed` flowed — the inner generator
+    // never ran on the cached path.
+    assert_eq!(
+        *provider2.calls.lock().unwrap(),
+        2,
+        "driver pre-fetches the component once per invocation to validate \
+         the generator's source hash against the recorded metadata"
+    );
 }
 
 #[test]
@@ -320,7 +342,9 @@ fn end_to_end_input_change_invalidates_exactly_that_invocation() {
     let outcome = run(&m, tmp.path(), &host2, &provider2, invs);
     assert_eq!(outcome.executed, vec!["kiln-alpha".to_string()]);
     assert_eq!(outcome.cached, vec!["kiln-beta".to_string()]);
-    assert_eq!(*provider2.calls.lock().unwrap(), 1);
+    // 2 = one provider call per invocation (alpha + beta) for source-hash
+    // pre-fetch; only alpha actually executes the generator.
+    assert_eq!(*provider2.calls.lock().unwrap(), 2);
 }
 
 #[test]

--- a/wado-cli/tests/kiln_pipeline.rs
+++ b/wado-cli/tests/kiln_pipeline.rs
@@ -241,18 +241,14 @@ fn end_to_end_two_generators_execute_cache_and_reuse() {
     let outcome2 = run(&m, tmp.path(), &host2, &provider2, invs);
     assert_eq!(outcome2.cached.len(), 2);
     assert!(outcome2.executed.is_empty());
-    // The driver always queries the provider once per invocation to
-    // pick up the generator's current source hash for cache validation.
-    // For Stub the call is cheap (no inner compile); for Cli the
-    // provider's own cache short-circuits it. The assertion that
-    // matters here is that no `executed` flowed — the inner generator
-    // never ran on the cached path.
-    assert_eq!(
-        *provider2.calls.lock().unwrap(),
-        2,
-        "driver pre-fetches the component once per invocation to validate \
-         the generator's source hash against the recorded metadata"
-    );
+    // alpha and beta declare distinct `GeneratorModule` values, so each
+    // is fetched once through the driver's per-pipeline module cache.
+    // The pre-fetch is what feeds `cache_matches` the current
+    // `source_hash`; the cache itself never had to recompile, hence no
+    // entry in `executed`. (See
+    // `shared_module_across_invocations_calls_provider_once` for the
+    // case where a single module covers both invocations.)
+    assert_eq!(*provider2.calls.lock().unwrap(), 2);
 }
 
 #[test]
@@ -497,5 +493,51 @@ fn inline_invocation_populates_invocation_index_for_redirect() {
     assert!(
         redirect.ends_with("/build/kiln/kiln-deadbeef/sample.wado"),
         "redirect URI must point at the generated entry path, got `{redirect}`"
+    );
+}
+
+#[test]
+fn shared_module_across_invocations_calls_provider_once() {
+    // The pipeline caches the provider's `get_component` result by
+    // `GeneratorModule`. Two invocations targeting the same module
+    // should resolve to a single provider call — the second invocation
+    // reuses the already-fetched component (and its source hash).
+    let tmp = tempfile::tempdir().unwrap();
+    let m = empty_manifest();
+
+    // Two invocations sharing the same `Spec` module. (Spec doesn't
+    // resolve through `CliGeneratorProvider` in v1, but the driver-level
+    // cache is module-keyed and target-agnostic, so the test is valid.)
+    let shared_module = GeneratorModule::Spec("ns:proto@1.0.0".to_string());
+    let inv_a = invocation(
+        "entry.wado",
+        "kiln-a",
+        shared_module.clone(),
+        "./a.proto",
+        "build/kiln/kiln-a",
+    );
+    let inv_b = invocation(
+        "entry.wado",
+        "kiln-b",
+        shared_module,
+        "./b.proto",
+        "build/kiln/kiln-b",
+    );
+
+    let host = StubHost::new(
+        &[("a.proto", b"a-schema"), ("b.proto", b"b-schema")],
+        vec![
+            ("a.proto", simple_response("a.wado")),
+            ("b.proto", simple_response("b.wado")),
+        ],
+    );
+    let provider = StubProvider::new(b"component-bytes".to_vec());
+
+    let outcome = run(&m, tmp.path(), &host, &provider, vec![inv_a, inv_b]);
+    assert_eq!(outcome.executed.len(), 2);
+    assert_eq!(
+        *provider.calls.lock().unwrap(),
+        1,
+        "shared module across invocations must trigger exactly one provider call"
     );
 }


### PR DESCRIPTION
## Summary

Three independent fixes that surfaced during a review of `package-gale/antlr4-compatibility.md`. The doc text was also tightened where the description was inaccurate.

### 1. Gale prediction: at-end alts no longer dropped from Dispatch (b163647)

The SLL prediction tree builder enumerated dispatch branches from a per-token loop and silently dropped any alt whose body was already consumed at the current dispatch depth — its FIRST set was empty. The generated parser committed to whichever branch matched the lookahead and bailed for everything else, even when the at-end alt was the only correct choice.

Concrete repro: `typespec : ID | ID '[' ']'`. After consuming `ID`, only the `LBRACKET → alt 1` branch was emitted; alt 0 vanished. `(T)x` and `new T[1]` then failed because the LBRACKET branch was either taken when it shouldn't have been or absent when alt 0 should have won.

Fix detects at-end configs in `build_sll_node` and routes them through `Backtrack` scan-dispatch (longest-match wins) when explicit branches also exist. A lone at-end alt with no other branches collapses to a `Leaf`. Multiple at-end alts remain ambiguous and fall back to `Backtrack`.

Tests:
- `tests/grammars/at_end_alt_gaps.g4` + `driver_at_end_alt_gaps_test.wado` pin paren / paren-with-extension / `new[index]` shapes.
- `LeftRecursion/JavaExpressions_{7,8,9,12}` drop their `[stage_b_todo]` triage. **Stage B `#[TODO]` count: 10 → 6.**

### 2. Kiln cache: invalidate on local generator source change (603760b, 0422d81)

`stable_id_for_local` keyed the cached generator WASM on the entry-file content alone. An edit to a transitively-imported `.wado` (e.g. a parser library used by the entry generator) left cached bytes untouched, and `cache_matches` had no concept of generator identity at all — so even a fresh recompile followed by a stale `<primary>.kiln.json` would silently reuse outputs from the previous generator. Local generator authors hit this every iteration.

Fix:
- Wrap the inner compiler host with a recording layer that captures every `load_source(path)` call. The set is drained, deduplicated, and sorted after compile.
- Persist `<stable_id>.sources.json` next to the cached `.wasm`, listing every loaded `.wado` with its hash plus a combined SHA-256. `validate_sources_sidecar` re-hashes each listed file on a cache hit and recomputes the combined hash from the validated entries — any drift (or sidecar tampering) misses.
- Extend `GeneratorComponent` with `source_hash`, returned by the provider whether the WASM came from cache or a fresh compile.
- `Metadata` schema bump to v2 with a new `generator_source_hash` field; `cache_matches` compares it. v1 metadata version-mismatches and triggers a full re-run.
- The pipeline driver pre-fetches the component once per invocation so the source hash is available for both the cache check and (on miss) the generator execution. A per-pipeline `Vec<(GeneratorModule, Arc<GeneratorComponent>)>` keeps that pre-fetch O(1) when many invocations share a generator module.

Tests:
- `transitive_dep_edit_invalidates_cache` (kiln_compile.rs) pins the regression.
- `shared_module_across_invocations_calls_provider_once` (kiln_pipeline.rs) pins the pipeline-cache contract.

### 3. Stage A empty-file suppression (2b2f088)

When every descriptor in a category is `[skip]`-triaged (currently only `Listeners`), the extractor was emitting a header-only `<category>_test.wado`. Mirror Stage B's behaviour: skip emission and best-effort unlink any prior copy.

### 4. Doc accuracy (c7e6443)

`antlr4-compatibility.md` Future Work claimed Composite Stage B was a multi-input plumbing problem. A descriptor-by-descriptor scan showed every composite `[output]` is a host-side artefact (`<writeln(...)>` action-body prints, `Token.toString` dumps, or empty). None survive `normalize_output_for_stage_b`, so the bottleneck is Stage C (action-body translation), not multi-input. Doc rewritten accordingly.

## Test plan

- [x] `cargo test -p wado-cli` — 73 lib tests + integration tests pass
- [x] `wado test package-gale` — 1031 passed, 0 failed, 6 TODO
- [x] Gale Stage B descriptor count: 10 `#[TODO]` → 6 `#[TODO]`

https://claude.ai/code/session_01TggatXG7jNRS72M6ePUwzC