### PR TITLE
fix(cm_binding): address #997 follow-up bugs from #996 review

### DIFF
--- a/wado-compiler/src/lower/cm_intrinsics.rs
+++ b/wado-compiler/src/lower/cm_intrinsics.rs
@@ -7,7 +7,7 @@
 //! type, but the call itself remains a generic builtin — it cannot be
 //! lowered to Wasm directly. This module walks the monomorphised TIR,
 //! finds the calls, and replaces each with the equivalent inline lift
-//! code produced by [`synthesize_lift_with_context`], parameterised by
+//! code produced by [`synthesize_lift`], parameterised by
 //! the concrete return type of that call site.
 //!
 //! The pass runs as part of `lower` (after monomorphise, before boxing
@@ -24,7 +24,7 @@ use std::cell::RefCell;
 use crate::ast::{self, Type};
 use crate::component_model::WasiRegistry;
 use crate::name::ModuleSource;
-use crate::synthesis::cm_binding::{LiftContext, synthesize_lift_with_context};
+use crate::synthesis::cm_binding::{LiftContext, synthesize_lift};
 use crate::tir::{
     FunctionRef, ResolvedType, TirBlock, TirExpr, TirExprKind, TirLocal, TirModule, TirStmt,
     TirStmtKind, TypeId, TypeTable,
@@ -113,7 +113,7 @@ impl TirMutVisitor for Rewriter<'_> {
             }
         };
         let mut stmts: Vec<TirStmt> = Vec::new();
-        let lifted = synthesize_lift_with_context(
+        let lifted = synthesize_lift(
             &ast_type,
             addr_expr,
             self.next_local,
@@ -263,8 +263,8 @@ fn type_id_to_ast_type_resolved(
 ///
 /// Used to disambiguate WASI types that share a name across packages —
 /// for example `wasi:cli/ErrorCode` vs `wasi:http/ErrorCode`. Without
-/// a package hint, `synthesize_lift_with_context` falls back to
-/// unscoped lookup and picks an arbitrary match.
+/// a package hint, `synthesize_lift` falls back to unscoped lookup
+/// and picks an arbitrary match.
 fn infer_wasi_package(type_id: TypeId, type_table: &TypeTable) -> Option<String> {
     let resolved = type_table.get(type_id).clone();
     match resolved {

--- a/wado-compiler/src/synthesis/cm_binding.rs
+++ b/wado-compiler/src/synthesis/cm_binding.rs
@@ -744,6 +744,58 @@ mod tests {
         assert_eq!(expr.type_id, TypeTable::I32);
     }
 
+    /// `Array<IpAddress>` lifts must walk the buffer at the variant's
+    /// canonical-ABI stride (1 byte disc + payload), not the 4-byte
+    /// i32-handle fallback. Regression for issue #997 (#1, #2).
+    #[test]
+    fn lift_list_named_variant_uses_registry_stride() {
+        let (registry, _) = WasiRegistry::build_from_stdlib();
+        let elem_ty = named_type("IpAddress");
+        let expected_size = crate::component_model::cm_size_with_registry_scoped(
+            &elem_ty,
+            registry,
+            Some("sockets"),
+        );
+        // Sanity: registry-derived size differs from the 4-byte fallback.
+        assert!(expected_size > 4, "registry size should exceed handle size");
+
+        let mut tt = TypeTable::new();
+        tt.register_comp_feature_variant(
+            crate::wir::COMP_FEATURE_OPTION | crate::wir::COMP_FEATURE_RESULT,
+            ModuleSource::prelude(),
+        );
+        let type_table = std::cell::RefCell::new(tt);
+        let interner = std::cell::RefCell::new(crate::name::ModuleSourceInterner::new());
+        let ctx = LiftContext {
+            wasi_registry: registry,
+            type_table: &type_table,
+            cm_package: "sockets",
+            interner: &interner,
+        };
+        let list_ty = cm_abi::generic_type("Array", vec![elem_ty]);
+        let mut stmts = Vec::new();
+        let mut locals = Vec::new();
+        let mut next_local = 0_u32;
+        let _ = synthesize_lift(
+            &list_ty,
+            i32_const(0),
+            &mut next_local,
+            &mut stmts,
+            &mut locals,
+            &ctx,
+        );
+        // Stride appears at element-addr offset (`i * elem_size`) and in
+        // the realloc free (`count * elem_size`). The registry-aware path
+        // should emit `IntLiteral { value: <expected_size> }` at both sites.
+        let dump = format!("{stmts:?}");
+        let needle = format!("value: {expected_size}");
+        assert!(
+            dump.matches(&needle).count() >= 2,
+            "expected `{needle}` at ≥ 2 sites, got: {}",
+            dump.matches(&needle).count()
+        );
+    }
+
     #[test]
     fn lower_i32() {
         let stmts = synthesize_lower(

--- a/wado-compiler/src/synthesis/cm_binding.rs
+++ b/wado-compiler/src/synthesis/cm_binding.rs
@@ -35,7 +35,7 @@ use export_adapter::{
 };
 pub use import_adapter::binding_func_name;
 use import_adapter::synthesize_adapter;
-pub use lift::{synthesize_lift, synthesize_lift_with_context};
+pub use lift::synthesize_lift;
 pub use lower::synthesize_lower;
 use resource_rewrite::{rewrite_cm_resource_methods, synthesize_record_stream_reads};
 use task_return::{expand_task_returns_in_func, strip_task_returns_in_func};
@@ -505,6 +505,43 @@ mod tests {
         })
     }
 
+    /// Test fixture: empty registry + fresh type table + empty interner.
+    /// Mirrors the production `LiftContext` shape so the lift code paths
+    /// run end-to-end in unit tests.
+    struct LiftCtxFixture {
+        registry: WasiRegistry,
+        type_table: std::cell::RefCell<TypeTable>,
+        interner: std::cell::RefCell<crate::name::ModuleSourceInterner>,
+    }
+
+    impl LiftCtxFixture {
+        fn new() -> Self {
+            // Register the Option/Result comp-features so `make_option` /
+            // `make_result` succeed during unit-test lifts. Production
+            // gets these registered when the stdlib resolver visits
+            // `core:prelude`.
+            let mut tt = TypeTable::new();
+            tt.register_comp_feature_variant(
+                crate::wir::COMP_FEATURE_OPTION | crate::wir::COMP_FEATURE_RESULT,
+                ModuleSource::prelude(),
+            );
+            Self {
+                registry: WasiRegistry::new(),
+                type_table: std::cell::RefCell::new(tt),
+                interner: std::cell::RefCell::new(crate::name::ModuleSourceInterner::new()),
+            }
+        }
+
+        fn ctx(&self) -> LiftContext<'_> {
+            LiftContext {
+                wasi_registry: &self.registry,
+                type_table: &self.type_table,
+                cm_package: "",
+                interner: &self.interner,
+            }
+        }
+    }
+
     #[test]
     fn flatten_param_i32() {
         let reg = WasiRegistry::new();
@@ -579,6 +616,7 @@ mod tests {
 
     #[test]
     fn lift_i32() {
+        let fix = LiftCtxFixture::new();
         let mut stmts = Vec::new();
         let mut locals = Vec::new();
         let expr = synthesize_lift(
@@ -587,6 +625,7 @@ mod tests {
             &mut 0,
             &mut stmts,
             &mut locals,
+            &fix.ctx(),
         );
         assert!(matches!(expr.kind, TirExprKind::Call { .. }));
         assert_eq!(expr.type_id, TypeTable::I32);
@@ -595,6 +634,7 @@ mod tests {
 
     #[test]
     fn lift_bool() {
+        let fix = LiftCtxFixture::new();
         let mut stmts = Vec::new();
         let mut locals = Vec::new();
         let expr = synthesize_lift(
@@ -603,6 +643,7 @@ mod tests {
             &mut 0,
             &mut stmts,
             &mut locals,
+            &fix.ctx(),
         );
         assert!(matches!(expr.kind, TirExprKind::Binary { .. }));
         assert_eq!(expr.type_id, TypeTable::BOOL);
@@ -610,6 +651,7 @@ mod tests {
 
     #[test]
     fn lift_string() {
+        let fix = LiftCtxFixture::new();
         let mut stmts = Vec::new();
         let mut locals = Vec::new();
         let expr = synthesize_lift(
@@ -618,12 +660,14 @@ mod tests {
             &mut 0,
             &mut stmts,
             &mut locals,
+            &fix.ctx(),
         );
         assert!(matches!(expr.kind, TirExprKind::Call { .. }));
     }
 
     #[test]
     fn lift_list_i32() {
+        let fix = LiftCtxFixture::new();
         let mut stmts = Vec::new();
         let mut locals = Vec::new();
         let mut next_local = 0_u32;
@@ -634,6 +678,7 @@ mod tests {
             &mut next_local,
             &mut stmts,
             &mut locals,
+            &fix.ctx(),
         );
         // Should produce setup stmts and return a local ref
         assert!(!stmts.is_empty());
@@ -643,6 +688,7 @@ mod tests {
 
     #[test]
     fn lift_option_i32() {
+        let fix = LiftCtxFixture::new();
         let mut stmts = Vec::new();
         let mut locals = Vec::new();
         let mut next_local = 0_u32;
@@ -653,6 +699,7 @@ mod tests {
             &mut next_local,
             &mut stmts,
             &mut locals,
+            &fix.ctx(),
         );
         assert!(!stmts.is_empty());
         assert!(matches!(expr.kind, TirExprKind::Local { .. }));
@@ -661,6 +708,7 @@ mod tests {
 
     #[test]
     fn lift_result_unit_unit() {
+        let fix = LiftCtxFixture::new();
         let mut stmts = Vec::new();
         let mut locals = Vec::new();
         let mut next_local = 0_u32;
@@ -672,6 +720,7 @@ mod tests {
             &mut next_local,
             &mut stmts,
             &mut locals,
+            &fix.ctx(),
         );
         assert!(!stmts.is_empty());
         assert!(matches!(expr.kind, TirExprKind::Local { .. }));
@@ -679,10 +728,18 @@ mod tests {
 
     #[test]
     fn lift_resource_handle() {
+        let fix = LiftCtxFixture::new();
         let mut stmts = Vec::new();
         let mut locals = Vec::new();
         let own_ty = cm_abi::generic_type("Own", vec![named_type("Fields")]);
-        let expr = synthesize_lift(&own_ty, i32_const(100), &mut 0, &mut stmts, &mut locals);
+        let expr = synthesize_lift(
+            &own_ty,
+            i32_const(100),
+            &mut 0,
+            &mut stmts,
+            &mut locals,
+            &fix.ctx(),
+        );
         assert!(matches!(expr.kind, TirExprKind::Call { .. }));
         assert_eq!(expr.type_id, TypeTable::I32);
     }
@@ -1003,10 +1060,10 @@ mod tests {
 
     #[test]
     fn lift_from_flat_i32() {
+        let fix = LiftCtxFixture::new();
         let mut stmts = Vec::new();
         let mut locals = Vec::new();
         let mut next_local = 1_u32;
-        let type_table = std::cell::RefCell::new(TypeTable::new());
         let tir_modules = IndexMap::default();
         let (expr, consumed) = synthesize_lift_from_flat_params(
             &named_type("i32"),
@@ -1017,8 +1074,8 @@ mod tests {
             &mut stmts,
             &mut locals,
             &tir_modules,
-            &type_table,
-            None,
+            &fix.type_table,
+            fix.ctx(),
         );
         assert_eq!(consumed, 1);
         assert!(matches!(expr.kind, TirExprKind::Local { .. }));
@@ -1027,10 +1084,10 @@ mod tests {
 
     #[test]
     fn lift_from_flat_string() {
+        let fix = LiftCtxFixture::new();
         let mut stmts = Vec::new();
         let mut locals = Vec::new();
         let mut next_local = 2_u32;
-        let type_table = std::cell::RefCell::new(TypeTable::new());
         let tir_modules = IndexMap::default();
         let (expr, consumed) = synthesize_lift_from_flat_params(
             &named_type("String"),
@@ -1041,8 +1098,8 @@ mod tests {
             &mut stmts,
             &mut locals,
             &tir_modules,
-            &type_table,
-            None,
+            &fix.type_table,
+            fix.ctx(),
         );
         assert_eq!(consumed, 2);
         // Should be a call to memory_to_gc_string
@@ -1051,10 +1108,10 @@ mod tests {
 
     #[test]
     fn lift_from_flat_bool() {
+        let fix = LiftCtxFixture::new();
         let mut stmts = Vec::new();
         let mut locals = Vec::new();
         let mut next_local = 1_u32;
-        let type_table = std::cell::RefCell::new(TypeTable::new());
         let tir_modules = IndexMap::default();
         let (expr, consumed) = synthesize_lift_from_flat_params(
             &named_type("bool"),
@@ -1065,8 +1122,8 @@ mod tests {
             &mut stmts,
             &mut locals,
             &tir_modules,
-            &type_table,
-            None,
+            &fix.type_table,
+            fix.ctx(),
         );
         assert_eq!(consumed, 1);
         assert!(matches!(expr.kind, TirExprKind::Binary { .. }));
@@ -1075,10 +1132,10 @@ mod tests {
 
     #[test]
     fn lift_from_flat_unit() {
+        let fix = LiftCtxFixture::new();
         let mut stmts = Vec::new();
         let mut locals = Vec::new();
         let mut next_local = 0_u32;
-        let type_table = std::cell::RefCell::new(TypeTable::new());
         let tir_modules = IndexMap::default();
         let (expr, consumed) = synthesize_lift_from_flat_params(
             &Type::Tuple(vec![]),
@@ -1089,8 +1146,8 @@ mod tests {
             &mut stmts,
             &mut locals,
             &tir_modules,
-            &type_table,
-            None,
+            &fix.type_table,
+            fix.ctx(),
         );
         assert_eq!(consumed, 0);
         assert!(matches!(expr.kind, TirExprKind::Unit));
@@ -1098,10 +1155,10 @@ mod tests {
 
     #[test]
     fn lift_from_flat_resource() {
+        let fix = LiftCtxFixture::new();
         let mut stmts = Vec::new();
         let mut locals = Vec::new();
         let mut next_local = 1_u32;
-        let type_table = std::cell::RefCell::new(TypeTable::new());
         let tir_modules = IndexMap::default();
         let (expr, consumed) = synthesize_lift_from_flat_params(
             &named_type("Request"),
@@ -1112,8 +1169,8 @@ mod tests {
             &mut stmts,
             &mut locals,
             &tir_modules,
-            &type_table,
-            None,
+            &fix.type_table,
+            fix.ctx(),
         );
         assert_eq!(consumed, 1);
         assert!(matches!(expr.kind, TirExprKind::Local { .. }));

--- a/wado-compiler/src/synthesis/cm_binding.rs
+++ b/wado-compiler/src/synthesis/cm_binding.rs
@@ -766,8 +766,7 @@ mod tests {
                     TirExprKind::Binary { left, right, .. } => {
                         n += visit_expr(left, target) + visit_expr(right, target);
                     }
-                    TirExprKind::Call { args, .. }
-                    | TirExprKind::MethodCall { args, .. } => {
+                    TirExprKind::Call { args, .. } | TirExprKind::MethodCall { args, .. } => {
                         for a in args {
                             n += visit_expr(&a.expr, target);
                         }
@@ -798,8 +797,7 @@ mod tests {
                         }
                         n
                     }
-                    TirStmtKind::Loop { body }
-                    | TirStmtKind::LabeledBlock { block: body, .. } => {
+                    TirStmtKind::Loop { body } | TirStmtKind::LabeledBlock { block: body, .. } => {
                         visit_block(body.stmts.as_slice(), target)
                     }
                     _ => 0,

--- a/wado-compiler/src/synthesis/cm_binding.rs
+++ b/wado-compiler/src/synthesis/cm_binding.rs
@@ -749,13 +749,75 @@ mod tests {
     /// i32-handle fallback. Regression for issue #997 (#1, #2).
     #[test]
     fn lift_list_named_variant_uses_registry_stride() {
+        use crate::tir::TirStmt;
+
+        // Visit every TIR sub-expression and count `IntLiteral { value: target }`
+        // occurrences. Walks through the structural recursion sites that
+        // `synthesize_lift_list` emits (Let init, If condition, Loop body,
+        // realloc args). Built as a semantic check so it doesn't depend on
+        // any `Debug` output formatting.
+        fn count_int_literals(stmts: &[TirStmt], target: u64) -> usize {
+            fn visit_expr(e: &TirExpr, target: u64) -> usize {
+                let mut n = match &e.kind {
+                    TirExprKind::IntLiteral { value, .. } if *value == target => 1,
+                    _ => 0,
+                };
+                match &e.kind {
+                    TirExprKind::Binary { left, right, .. } => {
+                        n += visit_expr(left, target) + visit_expr(right, target);
+                    }
+                    TirExprKind::Call { args, .. }
+                    | TirExprKind::MethodCall { args, .. } => {
+                        for a in args {
+                            n += visit_expr(&a.expr, target);
+                        }
+                    }
+                    TirExprKind::Unary { expr: inner, .. }
+                    | TirExprKind::Cast { expr: inner, .. } => n += visit_expr(inner, target),
+                    TirExprKind::Assign { target: t, value } => {
+                        n += visit_expr(t, target) + visit_expr(value, target);
+                    }
+                    _ => {}
+                }
+                n
+            }
+            fn visit_stmt(s: &TirStmt, target: u64) -> usize {
+                match &s.kind {
+                    TirStmtKind::Let { value, .. } | TirStmtKind::Expr(value) => {
+                        visit_expr(value, target)
+                    }
+                    TirStmtKind::If {
+                        condition,
+                        then_block,
+                        else_block,
+                    } => {
+                        let mut n = visit_expr(condition, target)
+                            + visit_block(then_block.stmts.as_slice(), target);
+                        if let Some(b) = else_block {
+                            n += visit_block(b.stmts.as_slice(), target);
+                        }
+                        n
+                    }
+                    TirStmtKind::Loop { body }
+                    | TirStmtKind::LabeledBlock { block: body, .. } => {
+                        visit_block(body.stmts.as_slice(), target)
+                    }
+                    _ => 0,
+                }
+            }
+            fn visit_block(stmts: &[TirStmt], target: u64) -> usize {
+                stmts.iter().map(|s| visit_stmt(s, target)).sum()
+            }
+            visit_block(stmts, target)
+        }
+
         let (registry, _) = WasiRegistry::build_from_stdlib();
         let elem_ty = named_type("IpAddress");
-        let expected_size = crate::component_model::cm_size_with_registry_scoped(
+        let expected_size = u64::from(crate::component_model::cm_size_with_registry_scoped(
             &elem_ty,
             registry,
             Some("sockets"),
-        );
+        ));
         // Sanity: registry-derived size differs from the 4-byte fallback.
         assert!(expected_size > 4, "registry size should exceed handle size");
 
@@ -785,14 +847,11 @@ mod tests {
             &ctx,
         );
         // Stride appears at element-addr offset (`i * elem_size`) and in
-        // the realloc free (`count * elem_size`). The registry-aware path
-        // should emit `IntLiteral { value: <expected_size> }` at both sites.
-        let dump = format!("{stmts:?}");
-        let needle = format!("value: {expected_size}");
+        // the realloc free (`count * elem_size`).
+        let occurrences = count_int_literals(&stmts, expected_size);
         assert!(
-            dump.matches(&needle).count() >= 2,
-            "expected `{needle}` at ≥ 2 sites, got: {}",
-            dump.matches(&needle).count()
+            occurrences >= 2,
+            "expected ≥2 `IntLiteral {{ value: {expected_size} }}` occurrences, got {occurrences}"
         );
     }
 

--- a/wado-compiler/src/synthesis/cm_binding/export_adapter.rs
+++ b/wado-compiler/src/synthesis/cm_binding/export_adapter.rs
@@ -38,7 +38,7 @@ use crate::synthesis::common::{
 };
 
 use super::import_adapter::make_binding_function;
-use super::lift::{synthesize_lift, synthesize_lift_with_context};
+use super::lift::synthesize_lift;
 use super::lower::synthesize_lower_wasi_type_to_memory;
 use super::types::{
     LiftContext, binary_add, binary_ne, cm_val_type_to_type_id, cm_zero,
@@ -512,13 +512,9 @@ fn lower_to_flat_inner(
 ///
 /// Returns the lifted TIR expression and the number of flat params consumed.
 ///
-/// `lift_ctx` is consulted for Array / nested-struct lifts where the
-/// WIR `struct_type_map` lookup needs the full CM resolution stack
-/// (WASI + kiln registries, type-table cell, binding package hint).
-/// When it is `None` the helper falls back to `Array<i32>` placeholders
-/// and non-primitive composites resolve via `find_struct_decl` alone —
-/// callers that exercise real structs (the three export-binding
-/// synthesizers) always pass `Some(ctx)`.
+/// `lift_ctx` carries the full CM resolution stack (WASI + kiln registries,
+/// type-table cell, binding package hint) used for Array / nested-struct
+/// lifts and for the `struct_type_map` lookup in WIR.
 pub(super) fn synthesize_lift_from_flat_params(
     ty: &Type,
     flat_param_locals: &[u32],
@@ -529,7 +525,7 @@ pub(super) fn synthesize_lift_from_flat_params(
     locals: &mut Vec<TirLocal>,
     tir_modules: &IndexMap<ModuleSource, TirModule>,
     type_table_cell: &RefCell<TypeTable>,
-    lift_ctx: Option<LiftContext<'_>>,
+    lift_ctx: LiftContext<'_>,
 ) -> (TirExpr, usize) {
     match ty {
         Type::Named(named) => match named.name.as_str() {
@@ -578,14 +574,10 @@ pub(super) fn synthesize_lift_from_flat_params(
                     // `StructLiteral` WIR pass expects.
                     let (field_ast_tys, struct_type_id) = {
                         let tt = type_table_cell.borrow();
-                        let registry = lift_ctx
-                            .as_ref()
-                            .map(|c| c.wasi_registry)
-                            .expect("lift_ctx required when reconstructing struct field AST types");
                         let field_tys: Vec<Type> = struct_decl
                             .fields
                             .iter()
-                            .map(|f| type_id_to_ast_type(f.type_id, &tt, registry))
+                            .map(|f| type_id_to_ast_type(f.type_id, &tt, lift_ctx.wasi_registry))
                             .collect();
                         // Prefer the already-registered TypeId so the WIR
                         // `struct_type_map` lookup hits — the
@@ -692,30 +684,14 @@ pub(super) fn synthesize_lift_from_flat_params(
                     ],
                     TypeTable::UNIT,
                 )));
-                // Use synthesize_lift to lift from linear memory. When a
-                // `LiftContext` is available (real export binding calls),
-                // route through `synthesize_lift_with_context` so the element
-                // type and its registry (WASI or kiln) resolve correctly —
-                // without it the list lift falls back to `Array<i32>` and
-                // non-primitive element types blow up at monomorphization.
-                let lifted = if let Some(ref ctx) = lift_ctx {
-                    synthesize_lift_with_context(
-                        ty,
-                        local_ref(tmp_ptr_local, "__lift_tmp", TypeTable::I32),
-                        next_local,
-                        stmts,
-                        locals,
-                        ctx,
-                    )
-                } else {
-                    synthesize_lift(
-                        ty,
-                        local_ref(tmp_ptr_local, "__lift_tmp", TypeTable::I32),
-                        next_local,
-                        stmts,
-                        locals,
-                    )
-                };
+                let lifted = synthesize_lift(
+                    ty,
+                    local_ref(tmp_ptr_local, "__lift_tmp", TypeTable::I32),
+                    next_local,
+                    stmts,
+                    locals,
+                    &lift_ctx,
+                );
                 // Free temp memory
                 stmts.push(expr_stmt(builtin_call(
                     "realloc",
@@ -931,7 +907,7 @@ pub(super) fn synthesize_result_export_binding(
                 &mut locals,
                 tir_modules,
                 type_table,
-                Some(lift_ctx),
+                lift_ctx,
             );
             lifted_args.push(lifted);
             flat_offset += consumed;
@@ -1478,7 +1454,7 @@ pub(super) fn synthesize_general_export_binding(
                 &mut locals,
                 tir_modules,
                 type_table,
-                Some(lift_ctx),
+                lift_ctx,
             );
             lifted_args.push(lifted);
             flat_offset += consumed;
@@ -1707,7 +1683,7 @@ pub(super) fn synthesize_async_export_binding(
                 &mut locals,
                 tir_modules,
                 type_table,
-                Some(lift_ctx),
+                lift_ctx,
             );
             lifted_args.push(lifted);
             flat_offset += consumed;

--- a/wado-compiler/src/synthesis/cm_binding/import_adapter.rs
+++ b/wado-compiler/src/synthesis/cm_binding/import_adapter.rs
@@ -583,8 +583,19 @@ pub(super) fn synthesize_adapter(
             // General Array<T> param: lower to (ptr, len) in linear memory
             Type::Generic(g) if g.name == "Array" && g.args.len() == 1 => {
                 let elem_type = &g.args[0];
-                let elem_size = cm_abi::cm_size(elem_type) as i32;
-                let elem_align = cm_abi::cm_align(elem_type) as i32;
+                // Use registry-aware layout so named WASI struct/variant/enum/flags
+                // element types walk at their true CM stride/alignment instead of
+                // the i32-handle fallback in `cm_abi::cm_size`/`cm_align`.
+                let elem_size = crate::component_model::cm_size_with_registry_scoped(
+                    elem_type,
+                    wasi_registry,
+                    Some(&func_info.package),
+                ) as i32;
+                let elem_align = crate::component_model::cm_align_with_registry_scoped(
+                    elem_type,
+                    wasi_registry,
+                    Some(&func_info.package),
+                ) as i32;
 
                 // Resolve proper TypeIds for the element and array types
                 let (elem_type_id, array_type_id) = {

--- a/wado-compiler/src/synthesis/cm_binding/import_adapter.rs
+++ b/wado-compiler/src/synthesis/cm_binding/import_adapter.rs
@@ -32,7 +32,7 @@ use crate::synthesis::common::{
 };
 
 use super::lift::{
-    materialize_if_needed, synthesize_lift_with_context, try_lift_wasi_variant_or_enum,
+    materialize_if_needed, synthesize_lift, try_lift_wasi_variant_or_enum,
 };
 use super::lower::{
     synthesize_flatten_option_to_flat_args, synthesize_flatten_value_to_flat_args,
@@ -1207,7 +1207,7 @@ pub(super) fn synthesize_adapter(
             cm_package: &func_info.package,
             interner,
         };
-        let lifted = synthesize_lift_with_context(
+        let lifted = synthesize_lift(
             &resolved,
             local_ref(outptr_local, "__outptr", TypeTable::I32),
             &mut next_local,

--- a/wado-compiler/src/synthesis/cm_binding/import_adapter.rs
+++ b/wado-compiler/src/synthesis/cm_binding/import_adapter.rs
@@ -56,10 +56,15 @@ const MAX_FLAT_RESULTS: usize = 1;
 ///
 /// For `Result<(), ()>`: disc==0 → Ok, disc==1 → Err (no payloads)
 /// For `Result<(), ErrorCode>`: disc==0 → Ok, disc!=0 → `Err(lift_error)`
+///
+/// `result_type_id` is the resolved `Result<T, E>` `TypeId` shared with
+/// the caller's `result_local`; the emitted `VariantConstruct` exprs use
+/// it directly so no `TypeTable::I32` placeholder leaks downstream.
 fn synthesize_lift_flat_result(
     ty: &Type,
     disc_expr: TirExpr,
     result_local: u32,
+    result_type_id: TypeId,
     next_local: &mut u32,
     stmts: &mut Vec<TirStmt>,
     locals: &mut Vec<TirLocal>,
@@ -80,12 +85,12 @@ fn synthesize_lift_flat_result(
         let ok_construct = if ok_is_unit {
             TirExpr::new(
                 TirExprKind::VariantConstruct {
-                    variant_type: TypeTable::I32,
+                    variant_type: result_type_id,
                     case_index: 0,
                     case_name: "Ok".to_string(),
                     payload: None,
                 },
-                TypeTable::I32,
+                result_type_id,
                 synth_span(),
             )
         } else {
@@ -93,12 +98,12 @@ fn synthesize_lift_flat_result(
             // This shouldn't happen, but handle gracefully
             TirExpr::new(
                 TirExprKind::VariantConstruct {
-                    variant_type: TypeTable::I32,
+                    variant_type: result_type_id,
                     case_index: 0,
                     case_name: "Ok".to_string(),
                     payload: None,
                 },
-                TypeTable::I32,
+                result_type_id,
                 synth_span(),
             )
         };
@@ -106,12 +111,12 @@ fn synthesize_lift_flat_result(
         let err_construct = if err_is_unit {
             TirExpr::new(
                 TirExprKind::VariantConstruct {
-                    variant_type: TypeTable::I32,
+                    variant_type: result_type_id,
                     case_index: 1,
                     case_name: "Err".to_string(),
                     payload: None,
                 },
-                TypeTable::I32,
+                result_type_id,
                 synth_span(),
             )
         } else {
@@ -137,23 +142,23 @@ fn synthesize_lift_flat_result(
             if let Some(lifted) = lifted_variant {
                 TirExpr::new(
                     TirExprKind::VariantConstruct {
-                        variant_type: TypeTable::I32,
+                        variant_type: result_type_id,
                         case_index: 1,
                         case_name: "Err".to_string(),
                         payload: Some(Box::new(lifted)),
                     },
-                    TypeTable::I32,
+                    result_type_id,
                     synth_span(),
                 )
             } else {
                 TirExpr::new(
                     TirExprKind::VariantConstruct {
-                        variant_type: TypeTable::I32,
+                        variant_type: result_type_id,
                         case_index: 1,
                         case_name: "Err".to_string(),
                         payload: None,
                     },
-                    TypeTable::I32,
+                    result_type_id,
                     synth_span(),
                 )
             }
@@ -162,16 +167,16 @@ fn synthesize_lift_flat_result(
         stmts.push(if_stmt(
             binary(TirBinaryOp::Eq, disc_expr, i32_const(0), TypeTable::BOOL),
             block(vec![expr_stmt(assign(
-                local_ref(result_local, "__result_val", TypeTable::I32),
+                local_ref(result_local, "__result_val", result_type_id),
                 ok_construct,
             ))]),
             Some(block(vec![expr_stmt(assign(
-                local_ref(result_local, "__result_val", TypeTable::I32),
+                local_ref(result_local, "__result_val", result_type_id),
                 err_construct,
             ))])),
         ));
 
-        return local_ref(result_local, "__result_val", TypeTable::I32);
+        return local_ref(result_local, "__result_val", result_type_id);
     }
 
     // Fallback: just return the discriminant as-is
@@ -1261,12 +1266,21 @@ pub(super) fn synthesize_adapter(
                 raw_call_expr,
             ));
 
-            let result_local = alloc_local(&mut next_local, &mut locals, TypeTable::I32);
+            // Resolve the concrete `Result<T, E>` TypeId so the binding's
+            // intermediate local and `VariantConstruct` exprs match the
+            // declared return type. Without this, the local was declared as
+            // `TypeTable::I32` and back-patched later by `type_fixup`,
+            // which produced invalid TIR if any consumer ran first.
+            let result_type_id = {
+                let mut tt = type_table.borrow_mut();
+                wasi_type_to_type_id(&resolved, &mut tt, wasi_registry, &func_info.package)
+            };
+            let result_local = alloc_local(&mut next_local, &mut locals, result_type_id);
             body_stmts.push(let_mut_stmt(
                 "__result_val",
                 result_local,
-                TypeTable::I32,
-                null_expr(TypeTable::I32),
+                result_type_id,
+                null_expr(result_type_id),
             ));
 
             let lift_ctx = LiftContext {
@@ -1279,6 +1293,7 @@ pub(super) fn synthesize_adapter(
                 &resolved,
                 local_ref(disc_local, "__disc", TypeTable::I32),
                 result_local,
+                result_type_id,
                 &mut next_local,
                 &mut body_stmts,
                 &mut locals,
@@ -1286,7 +1301,7 @@ pub(super) fn synthesize_adapter(
             );
             let lifted_type_id = lifted.type_id;
             body_stmts.push(return_stmt(Some(lifted)));
-            adapter_return_type = lifted_type_id; // real type, fixed up at call site if needed
+            adapter_return_type = lifted_type_id;
         } else {
             // Truly flat return (primitive): cm_raw_call directly returns the value
             body_stmts.push(return_stmt(Some(raw_call_expr)));

--- a/wado-compiler/src/synthesis/cm_binding/import_adapter.rs
+++ b/wado-compiler/src/synthesis/cm_binding/import_adapter.rs
@@ -31,9 +31,7 @@ use crate::synthesis::common::{
     local_ref, loop_stmt, null_expr, return_stmt, synth_span,
 };
 
-use super::lift::{
-    materialize_if_needed, synthesize_lift, try_lift_wasi_variant_or_enum,
-};
+use super::lift::{materialize_if_needed, synthesize_lift, try_lift_wasi_variant_or_enum};
 use super::lower::{
     synthesize_flatten_option_to_flat_args, synthesize_flatten_value_to_flat_args,
     synthesize_lower, synthesize_lower_option_to_memory, synthesize_lower_tuple,

--- a/wado-compiler/src/synthesis/cm_binding/lift.rs
+++ b/wado-compiler/src/synthesis/cm_binding/lift.rs
@@ -1,11 +1,11 @@
 //! CM ABI lift: load a Wado value from linear memory.
 //!
-//! [`synthesize_lift`] (and the WASI-aware [`synthesize_lift_with_context`])
-//! produces TIR that materialises a Wado value at a given linear-memory
-//! address. Composite types (lists, options, results, tuples, WASI
-//! variants/enums/records) materialise into mutable locals; primitives stay
-//! as plain `*_load` builtins. The list and tuple paths free the underlying
-//! buffers as they read, so callers don't need to clean up after a lift.
+//! [`synthesize_lift`] produces TIR that materialises a Wado value at a given
+//! linear-memory address. Composite types (lists, options, results, tuples,
+//! WASI variants/enums/records) materialise into mutable locals; primitives
+//! stay as plain `*_load` builtins. The list and tuple paths free the
+//! underlying buffers as they read, so callers don't need to clean up after a
+//! lift.
 
 use crate::ast::{NamedType, Type};
 use crate::cm_abi;
@@ -31,22 +31,12 @@ use super::types::{
 ///
 /// For primitives, returns a single expression (no setup statements).
 /// For composites (list, option, result), emits setup statements into `stmts`
-/// and returns a local reference to the lifted value.
+/// and returns a local reference to the lifted value. The CM/WASI registry on
+/// `ctx` is used to resolve named struct/variant/enum/flags types and to
+/// compute their canonical-ABI layout.
 ///
 /// `next_local` / `locals` track local variable allocation.
-/// Callers that don't need composite support may pass empty `&mut vec![]`.
 pub fn synthesize_lift(
-    ty: &Type,
-    addr: TirExpr,
-    next_local: &mut u32,
-    stmts: &mut Vec<TirStmt>,
-    locals: &mut Vec<TirLocal>,
-) -> TirExpr {
-    synthesize_lift_inner(ty, addr, next_local, stmts, locals, None)
-}
-
-/// Lift with WASI context, enabling proper variant/enum construction.
-pub fn synthesize_lift_with_context(
     ty: &Type,
     addr: TirExpr,
     next_local: &mut u32,
@@ -54,7 +44,7 @@ pub fn synthesize_lift_with_context(
     locals: &mut Vec<TirLocal>,
     ctx: &LiftContext<'_>,
 ) -> TirExpr {
-    synthesize_lift_inner(ty, addr, next_local, stmts, locals, Some(ctx))
+    synthesize_lift_inner(ty, addr, next_local, stmts, locals, ctx)
 }
 
 /// Ensure a lifted expression is evaluated before subsequent memory operations.
@@ -99,7 +89,7 @@ fn synthesize_lift_inner(
     next_local: &mut u32,
     stmts: &mut Vec<TirStmt>,
     locals: &mut Vec<TirLocal>,
-    ctx: Option<&LiftContext<'_>>,
+    ctx: &LiftContext<'_>,
 ) -> TirExpr {
     match ty {
         Type::Named(named) => match named.name.as_str() {
@@ -121,11 +111,10 @@ fn synthesize_lift_inner(
                     vec![binary_add(addr, i32_const(4))],
                     TypeTable::I32,
                 );
-                let string_type_id = ctx.map_or(TypeTable::I32, |c| {
-                    c.type_table
-                        .borrow_mut()
-                        .make_struct("String".to_string(), ModuleSource::string())
-                });
+                let string_type_id = ctx
+                    .type_table
+                    .borrow_mut()
+                    .make_struct("String".to_string(), ModuleSource::string());
                 internal_call("memory_to_gc_string", vec![ptr, len], string_type_id)
             }
             _ => {
@@ -135,11 +124,10 @@ fn synthesize_lift_inner(
                 // current binding's WASI package, then to `core:kiln/*` for
                 // generator-world bindings). Non-CM references fall through
                 // to the i32-handle default.
-                if let Some(ctx) = ctx
-                    && let Some(source) = ctx
-                        .wasi_registry
-                        .resolve_cm_source_for(named, Some(ctx.cm_package))
-                        .map(str::to_string)
+                if let Some(source) = ctx
+                    .wasi_registry
+                    .resolve_cm_source_for(named, Some(ctx.cm_package))
+                    .map(str::to_string)
                 {
                     let source = source.as_str();
                     if let Some(lifted) = try_lift_wasi_variant_or_enum(
@@ -251,7 +239,7 @@ pub(super) fn try_lift_wasi_variant_or_enum(
             next_local,
             stmts,
             locals,
-            Some(ctx),
+            ctx,
         ));
     }
     if let Some(case_names) = ctx
@@ -344,7 +332,7 @@ fn try_lift_wasi_struct(
             binary_add(addr.clone(), i32_const(offsets[i] as i32))
         };
         let lifted_field =
-            synthesize_lift_inner(field_ty, field_addr, next_local, stmts, locals, Some(ctx));
+            synthesize_lift_inner(field_ty, field_addr, next_local, stmts, locals, ctx);
         let lifted_field = materialize_if_needed(lifted_field, next_local, stmts, locals);
         let field_name = &wado_fields[i];
         tir_fields.push(TirStructField {
@@ -393,7 +381,7 @@ fn synthesize_lift_wasi_variant(
     next_local: &mut u32,
     stmts: &mut Vec<TirStmt>,
     locals: &mut Vec<TirLocal>,
-    ctx: Option<&LiftContext<'_>>,
+    ctx: &LiftContext<'_>,
 ) -> TirExpr {
     // Load discriminant: 1 byte (u8) for variants with ≤ 256 cases
     let disc_local = alloc_local(next_local, locals, TypeTable::I32);
@@ -414,20 +402,15 @@ fn synthesize_lift_wasi_variant(
     ));
 
     // Compute max payload alignment for payload offset calculation
-    let wasi_package = ctx.map(|c| c.cm_package);
     let max_payload_align = cases
         .iter()
         .filter_map(|case| case.payload.as_ref())
         .map(|ty| {
-            if let Some(c) = ctx {
-                crate::component_model::cm_align_with_registry_scoped(
-                    ty,
-                    c.wasi_registry,
-                    wasi_package,
-                )
-            } else {
-                cm_abi::cm_align(ty)
-            }
+            crate::component_model::cm_align_with_registry_scoped(
+                ty,
+                ctx.wasi_registry,
+                Some(ctx.cm_package),
+            )
         })
         .max()
         .unwrap_or(1);
@@ -588,20 +571,17 @@ fn synthesize_lift_list(
     next_local: &mut u32,
     stmts: &mut Vec<TirStmt>,
     locals: &mut Vec<TirLocal>,
-    ctx: Option<&LiftContext<'_>>,
+    ctx: &LiftContext<'_>,
 ) -> TirExpr {
     let elem_size = cm_abi::cm_size(elem_ty);
 
     // Resolve TypeIds for the element type and Array<ElemType>.
     // These are needed by the monomorphizer to instantiate Array::with_capacity and .push().
-    let (elem_type_id, array_type_id) = if let Some(ctx) = ctx {
+    let (elem_type_id, array_type_id) = {
         let mut tt = ctx.type_table.borrow_mut();
         let elem_tid = wasi_type_to_type_id(elem_ty, &mut tt, ctx.wasi_registry, ctx.cm_package);
         let array_tid = tt.make_array(elem_tid);
         (elem_tid, array_tid)
-    } else {
-        // Fallback: use placeholder types (existing behavior for callers without context)
-        (TypeTable::I32, TypeTable::I32)
     };
 
     let base_local = alloc_local(next_local, locals, TypeTable::I32);
@@ -748,23 +728,22 @@ fn synthesize_lift_option_inner(
     next_local: &mut u32,
     stmts: &mut Vec<TirStmt>,
     locals: &mut Vec<TirLocal>,
-    ctx: Option<&LiftContext<'_>>,
+    ctx: &LiftContext<'_>,
 ) -> TirExpr {
-    let layout = if let Some(c) = ctx {
-        cm_abi::layout_option_with_registry_scoped(inner_ty, c.wasi_registry, Some(c.cm_package))
-    } else {
-        cm_abi::layout_option(inner_ty)
-    };
+    let layout = cm_abi::layout_option_with_registry_scoped(
+        inner_ty,
+        ctx.wasi_registry,
+        Some(ctx.cm_package),
+    );
     let payload_offset = layout.offsets[1];
 
     // Resolve the concrete Option<T> TypeId so the local and null/some exprs
-    // use the correct GC reference type rather than an i32 placeholder.
-    let option_type_id = if let Some(c) = ctx {
-        let mut tt = c.type_table.borrow_mut();
-        let inner_type_id = wasi_type_to_type_id(inner_ty, &mut tt, c.wasi_registry, c.cm_package);
+    // use the correct GC reference type.
+    let option_type_id = {
+        let mut tt = ctx.type_table.borrow_mut();
+        let inner_type_id =
+            wasi_type_to_type_id(inner_ty, &mut tt, ctx.wasi_registry, ctx.cm_package);
         tt.make_option(inner_type_id)
-    } else {
-        TypeTable::I32 // placeholder when no context
     };
 
     let disc_local = alloc_local(next_local, locals, TypeTable::I32);
@@ -824,18 +803,14 @@ fn synthesize_lift_result_inner(
     next_local: &mut u32,
     stmts: &mut Vec<TirStmt>,
     locals: &mut Vec<TirLocal>,
-    ctx: Option<&LiftContext<'_>>,
+    ctx: &LiftContext<'_>,
 ) -> TirExpr {
-    let layout = if let Some(c) = ctx {
-        cm_abi::layout_result_with_registry_scoped(
-            ok_ty,
-            err_ty,
-            c.wasi_registry,
-            Some(c.cm_package),
-        )
-    } else {
-        cm_abi::layout_result(ok_ty, err_ty)
-    };
+    let layout = cm_abi::layout_result_with_registry_scoped(
+        ok_ty,
+        err_ty,
+        ctx.wasi_registry,
+        Some(ctx.cm_package),
+    );
     let payload_offset = layout.offsets[1];
 
     let disc_local = alloc_local(next_local, locals, TypeTable::I32);
@@ -848,16 +823,12 @@ fn synthesize_lift_result_inner(
     ));
 
     // Determine the proper variant TypeId for Result<ok_ty, err_ty> so that the
-    // mutable local is typed as a GC reference (not i32). Using TypeTable::I32 as a
-    // placeholder would cause a wasm validation error: the local would be declared as
-    // i32 but initialized with `ref.null none` (a reference type).
-    let result_type_id = if let Some(ctx) = ctx {
+    // mutable local is typed as a GC reference (not i32).
+    let result_type_id = {
         let mut tt = ctx.type_table.borrow_mut();
         let ok_type_id = wasi_type_to_type_id(ok_ty, &mut tt, ctx.wasi_registry, ctx.cm_package);
         let err_type_id = wasi_type_to_type_id(err_ty, &mut tt, ctx.wasi_registry, ctx.cm_package);
         tt.make_result(ok_type_id, err_type_id)
-    } else {
-        TypeTable::I32 // placeholder when no context
     };
 
     let result_local = alloc_local(next_local, locals, result_type_id);
@@ -951,7 +922,7 @@ fn synthesize_lift_tuple(
     next_local: &mut u32,
     stmts: &mut Vec<TirStmt>,
     locals: &mut Vec<TirLocal>,
-    ctx: Option<&LiftContext<'_>>,
+    ctx: &LiftContext<'_>,
 ) -> TirExpr {
     let layout = cm_abi::layout_tuple(elems);
     let mut elem_exprs = Vec::new();
@@ -963,16 +934,13 @@ fn synthesize_lift_tuple(
         let lifted = materialize_if_needed(lifted, next_local, stmts, locals);
         elem_exprs.push(lifted);
     }
-    // Resolve the tuple TypeId if we have a type table context.
-    let tuple_type_id = if let Some(ctx) = ctx {
+    let tuple_type_id = {
         let mut tt = ctx.type_table.borrow_mut();
         let elem_type_ids: Vec<TypeId> = elems
             .iter()
             .map(|t| wasi_type_to_type_id(t, &mut tt, ctx.wasi_registry, ctx.cm_package))
             .collect();
         tt.make_tuple(elem_type_ids)
-    } else {
-        TypeTable::I32
     };
     TirExpr::new(
         TirExprKind::TupleLiteral {

--- a/wado-compiler/src/synthesis/cm_binding/lift.rs
+++ b/wado-compiler/src/synthesis/cm_binding/lift.rs
@@ -564,7 +564,11 @@ fn synthesize_lift_wasi_enum(
 /// Lift a `list<T>` from linear memory at `addr`.
 ///
 /// Layout: `[base_ptr: i32, count: i32]` at addr.
-/// Elements at `base_ptr + i * cm_size(T)`.
+/// Elements at `base_ptr + i * cm_size(T)`. The element stride and the
+/// alignment passed to `realloc` are computed via the registry so that
+/// named WASI types (records / variants / enums / flags) walk the buffer
+/// at their true canonical-ABI size and align rather than the i32-handle
+/// fallback baked into `cm_abi::cm_size` / `cm_abi::cm_align`.
 fn synthesize_lift_list(
     elem_ty: &Type,
     addr: TirExpr,
@@ -573,7 +577,16 @@ fn synthesize_lift_list(
     locals: &mut Vec<TirLocal>,
     ctx: &LiftContext<'_>,
 ) -> TirExpr {
-    let elem_size = cm_abi::cm_size(elem_ty);
+    let elem_size = crate::component_model::cm_size_with_registry_scoped(
+        elem_ty,
+        ctx.wasi_registry,
+        Some(ctx.cm_package),
+    );
+    let elem_align = crate::component_model::cm_align_with_registry_scoped(
+        elem_ty,
+        ctx.wasi_registry,
+        Some(ctx.cm_package),
+    );
 
     // Resolve TypeIds for the element type and Array<ElemType>.
     // These are needed by the monomorphizer to instantiate Array::with_capacity and .push().
@@ -690,7 +703,7 @@ fn synthesize_lift_list(
 
     stmts.push(loop_stmt(block(loop_stmts)));
 
-    // Free list buffer: realloc(__base, __count * elem_size, 4, 0)
+    // Free list buffer: realloc(__base, __count * elem_size, elem_align, 0)
     stmts.push(if_stmt(
         binary(
             TirBinaryOp::Gt,
@@ -708,7 +721,7 @@ fn synthesize_lift_list(
                     i32_const(elem_size as i32),
                     TypeTable::I32,
                 ),
-                i32_const(4),
+                i32_const(elem_align as i32),
                 i32_const(0),
             ],
             TypeTable::I32,

--- a/wado-compiler/src/synthesis/cm_binding/resource_rewrite.rs
+++ b/wado-compiler/src/synthesis/cm_binding/resource_rewrite.rs
@@ -1007,7 +1007,7 @@ fn is_stream_cm_method(cm_name: &str) -> bool {
 ///
 /// Prefers the canonical CM name registered via `#[cm("…")]` so that
 /// non-mechanical mappings (e.g., `DNSRecord` → `dns-record`) and
-/// preserved acronyms aren't mangled. Falls back to a PascalCase →
+/// preserved acronyms aren't mangled. Falls back to a `PascalCase` →
 /// kebab-case conversion only for receiver element types not in the
 /// registry (user-authored streams).
 fn parameterize_stream_cm_name(
@@ -1054,7 +1054,7 @@ fn registered_cm_name(name: &str, registry: &WasiRegistry) -> Option<String> {
         .map(str::to_string)
 }
 
-/// Mechanical PascalCase → kebab-case fallback for stream element types
+/// Mechanical `PascalCase` → kebab-case fallback for stream element types
 /// not registered with a `#[cm("…")]` name (i.e., user-authored types).
 fn pascal_to_kebab(name: &str) -> String {
     name.chars().fold(String::new(), |mut s, c| {

--- a/wado-compiler/src/synthesis/cm_binding/resource_rewrite.rs
+++ b/wado-compiler/src/synthesis/cm_binding/resource_rewrite.rs
@@ -617,38 +617,54 @@ fn cm_binding_function(cm_name: &str) -> Option<(&'static str, &'static str)> {
 /// Rewrite all #[cm("...")] resource method calls in the project.
 pub(super) fn rewrite_cm_resource_methods(project: &mut Package) {
     let entry_source = project.entry_module_source.clone();
+    let wasi_registry = project.wasi_registry;
     for module in project.tir_modules.values() {
         let type_table = module.type_table.clone();
         for func_rc in &module.functions {
             let mut func = func_rc.borrow_mut();
             if let Some(body) = &mut func.body {
-                rewrite_cm_methods_in_block(body, &type_table.borrow(), &entry_source);
+                rewrite_cm_methods_in_block(
+                    body,
+                    &type_table.borrow(),
+                    &entry_source,
+                    wasi_registry,
+                );
             }
         }
     }
 }
 
-fn rewrite_cm_methods_in_block(block: &mut TirBlock, tt: &TypeTable, entry_source: &ModuleSource) {
+fn rewrite_cm_methods_in_block(
+    block: &mut TirBlock,
+    tt: &TypeTable,
+    entry_source: &ModuleSource,
+    wasi_registry: &WasiRegistry,
+) {
     for stmt in &mut block.stmts {
-        rewrite_cm_methods_in_stmt(stmt, tt, entry_source);
+        rewrite_cm_methods_in_stmt(stmt, tt, entry_source, wasi_registry);
     }
 }
 
-fn rewrite_cm_methods_in_stmt(stmt: &mut TirStmt, tt: &TypeTable, entry_source: &ModuleSource) {
+fn rewrite_cm_methods_in_stmt(
+    stmt: &mut TirStmt,
+    tt: &TypeTable,
+    entry_source: &ModuleSource,
+    wasi_registry: &WasiRegistry,
+) {
     match &mut stmt.kind {
         TirStmtKind::Let { value, type_id, .. } => {
             let old_type = value.type_id;
-            rewrite_cm_methods_in_expr(value, tt, entry_source);
+            rewrite_cm_methods_in_expr(value, tt, entry_source, wasi_registry);
             if value.type_id != old_type {
                 *type_id = value.type_id;
             }
         }
         TirStmtKind::Expr(value) => {
-            rewrite_cm_methods_in_expr(value, tt, entry_source);
+            rewrite_cm_methods_in_expr(value, tt, entry_source, wasi_registry);
         }
         TirStmtKind::Return { value } => {
             if let Some(v) = value {
-                rewrite_cm_methods_in_expr(v, tt, entry_source);
+                rewrite_cm_methods_in_expr(v, tt, entry_source, wasi_registry);
             }
         }
         TirStmtKind::If {
@@ -656,14 +672,14 @@ fn rewrite_cm_methods_in_stmt(stmt: &mut TirStmt, tt: &TypeTable, entry_source: 
             then_block,
             else_block,
         } => {
-            rewrite_cm_methods_in_expr(condition, tt, entry_source);
-            rewrite_cm_methods_in_block(then_block, tt, entry_source);
+            rewrite_cm_methods_in_expr(condition, tt, entry_source, wasi_registry);
+            rewrite_cm_methods_in_block(then_block, tt, entry_source, wasi_registry);
             if let Some(blk) = else_block {
-                rewrite_cm_methods_in_block(blk, tt, entry_source);
+                rewrite_cm_methods_in_block(blk, tt, entry_source, wasi_registry);
             }
         }
         TirStmtKind::Loop { body } | TirStmtKind::LabeledBlock { block: body, .. } => {
-            rewrite_cm_methods_in_block(body, tt, entry_source);
+            rewrite_cm_methods_in_block(body, tt, entry_source, wasi_registry);
         }
         TirStmtKind::IfLet {
             scrutinee,
@@ -671,100 +687,105 @@ fn rewrite_cm_methods_in_stmt(stmt: &mut TirStmt, tt: &TypeTable, entry_source: 
             else_block,
             ..
         } => {
-            rewrite_cm_methods_in_expr(scrutinee, tt, entry_source);
-            rewrite_cm_methods_in_block(then_block, tt, entry_source);
+            rewrite_cm_methods_in_expr(scrutinee, tt, entry_source, wasi_registry);
+            rewrite_cm_methods_in_block(then_block, tt, entry_source, wasi_registry);
             if let Some(blk) = else_block {
-                rewrite_cm_methods_in_block(blk, tt, entry_source);
+                rewrite_cm_methods_in_block(blk, tt, entry_source, wasi_registry);
             }
         }
         TirStmtKind::Break { value, .. } => {
             if let Some(v) = value {
-                rewrite_cm_methods_in_expr(v, tt, entry_source);
+                rewrite_cm_methods_in_expr(v, tt, entry_source, wasi_registry);
             }
         }
         TirStmtKind::LetDestructure { value, .. } => {
-            rewrite_cm_methods_in_expr(value, tt, entry_source);
+            rewrite_cm_methods_in_expr(value, tt, entry_source, wasi_registry);
         }
         TirStmtKind::Continue => {}
         TirStmtKind::TaskReturn { value } => {
-            rewrite_cm_methods_in_expr(value, tt, entry_source);
+            rewrite_cm_methods_in_expr(value, tt, entry_source, wasi_registry);
         }
         TirStmtKind::VariadicForOf { .. } => {}
     }
 }
 
-fn rewrite_cm_methods_in_expr(expr: &mut TirExpr, tt: &TypeTable, entry_source: &ModuleSource) {
+fn rewrite_cm_methods_in_expr(
+    expr: &mut TirExpr,
+    tt: &TypeTable,
+    entry_source: &ModuleSource,
+    wasi_registry: &WasiRegistry,
+) {
     // First, recurse into sub-expressions
     match &mut expr.kind {
         TirExprKind::Call { args, .. } => {
             for arg in args.iter_mut() {
-                rewrite_cm_methods_in_expr(&mut arg.expr, tt, entry_source);
+                rewrite_cm_methods_in_expr(&mut arg.expr, tt, entry_source, wasi_registry);
             }
         }
         TirExprKind::MethodCall { receiver, args, .. } => {
-            rewrite_cm_methods_in_expr(receiver, tt, entry_source);
+            rewrite_cm_methods_in_expr(receiver, tt, entry_source, wasi_registry);
             for arg in args.iter_mut() {
-                rewrite_cm_methods_in_expr(&mut arg.expr, tt, entry_source);
+                rewrite_cm_methods_in_expr(&mut arg.expr, tt, entry_source, wasi_registry);
             }
         }
         TirExprKind::Binary { left, right, .. } => {
-            rewrite_cm_methods_in_expr(left, tt, entry_source);
-            rewrite_cm_methods_in_expr(right, tt, entry_source);
+            rewrite_cm_methods_in_expr(left, tt, entry_source, wasi_registry);
+            rewrite_cm_methods_in_expr(right, tt, entry_source, wasi_registry);
         }
         TirExprKind::Unary { expr: inner, .. } => {
-            rewrite_cm_methods_in_expr(inner, tt, entry_source);
+            rewrite_cm_methods_in_expr(inner, tt, entry_source, wasi_registry);
         }
         TirExprKind::Cast { expr: inner, .. } => {
-            rewrite_cm_methods_in_expr(inner, tt, entry_source);
+            rewrite_cm_methods_in_expr(inner, tt, entry_source, wasi_registry);
         }
         TirExprKind::If {
             condition,
             then_branch,
             else_branch,
         } => {
-            rewrite_cm_methods_in_expr(condition, tt, entry_source);
-            rewrite_cm_methods_in_block(then_branch, tt, entry_source);
+            rewrite_cm_methods_in_expr(condition, tt, entry_source, wasi_registry);
+            rewrite_cm_methods_in_block(then_branch, tt, entry_source, wasi_registry);
             if let Some(blk) = else_branch {
-                rewrite_cm_methods_in_block(blk, tt, entry_source);
+                rewrite_cm_methods_in_block(blk, tt, entry_source, wasi_registry);
             }
         }
         TirExprKind::Match { expr, arms } => {
-            rewrite_cm_methods_in_expr(expr, tt, entry_source);
+            rewrite_cm_methods_in_expr(expr, tt, entry_source, wasi_registry);
             for arm in arms {
-                rewrite_cm_methods_in_expr(&mut arm.body, tt, entry_source);
+                rewrite_cm_methods_in_expr(&mut arm.body, tt, entry_source, wasi_registry);
                 if let Some(guard) = &mut arm.guard {
-                    rewrite_cm_methods_in_expr(guard, tt, entry_source);
+                    rewrite_cm_methods_in_expr(guard, tt, entry_source, wasi_registry);
                 }
             }
         }
         TirExprKind::StructLiteral { fields, .. } => {
             for f in fields {
-                rewrite_cm_methods_in_expr(&mut f.value, tt, entry_source);
+                rewrite_cm_methods_in_expr(&mut f.value, tt, entry_source, wasi_registry);
             }
         }
         TirExprKind::TupleLiteral { elements } => {
             for e in elements {
-                rewrite_cm_methods_in_expr(e, tt, entry_source);
+                rewrite_cm_methods_in_expr(e, tt, entry_source, wasi_registry);
             }
         }
         TirExprKind::FieldAccess { expr, .. } => {
-            rewrite_cm_methods_in_expr(expr, tt, entry_source);
+            rewrite_cm_methods_in_expr(expr, tt, entry_source, wasi_registry);
         }
         TirExprKind::Index { expr, index, .. } => {
-            rewrite_cm_methods_in_expr(expr, tt, entry_source);
-            rewrite_cm_methods_in_expr(index, tt, entry_source);
+            rewrite_cm_methods_in_expr(expr, tt, entry_source, wasi_registry);
+            rewrite_cm_methods_in_expr(index, tt, entry_source, wasi_registry);
         }
         TirExprKind::Assign { target, value } => {
-            rewrite_cm_methods_in_expr(target, tt, entry_source);
-            rewrite_cm_methods_in_expr(value, tt, entry_source);
+            rewrite_cm_methods_in_expr(target, tt, entry_source, wasi_registry);
+            rewrite_cm_methods_in_expr(value, tt, entry_source, wasi_registry);
         }
         TirExprKind::VariantConstruct { payload, .. } => {
             if let Some(p) = payload {
-                rewrite_cm_methods_in_expr(p, tt, entry_source);
+                rewrite_cm_methods_in_expr(p, tt, entry_source, wasi_registry);
             }
         }
         TirExprKind::Block(block) => {
-            rewrite_cm_methods_in_block(block, tt, entry_source);
+            rewrite_cm_methods_in_block(block, tt, entry_source, wasi_registry);
         }
         // CM resource method calls inside `with E => h do { ... }` and
         // its handler binding expressions need the same rewriting as
@@ -775,32 +796,32 @@ fn rewrite_cm_methods_in_expr(expr: &mut TirExpr, tt: &TypeTable, entry_source: 
         // canonical translator no longer handles.
         TirExprKind::WithHandler { bindings, body, .. } => {
             for binding in bindings {
-                rewrite_cm_methods_in_expr(&mut binding.handler, tt, entry_source);
+                rewrite_cm_methods_in_expr(&mut binding.handler, tt, entry_source, wasi_registry);
             }
-            rewrite_cm_methods_in_block(body, tt, entry_source);
+            rewrite_cm_methods_in_block(body, tt, entry_source, wasi_registry);
         }
         TirExprKind::Resume { value } => {
-            rewrite_cm_methods_in_expr(value, tt, entry_source);
+            rewrite_cm_methods_in_expr(value, tt, entry_source, wasi_registry);
         }
         TirExprKind::Closure { body, .. } => {
-            rewrite_cm_methods_in_expr(body, tt, entry_source);
+            rewrite_cm_methods_in_expr(body, tt, entry_source, wasi_registry);
         }
         TirExprKind::IndirectCall { callee, args } => {
-            rewrite_cm_methods_in_expr(callee, tt, entry_source);
+            rewrite_cm_methods_in_expr(callee, tt, entry_source, wasi_registry);
             for arg in args.iter_mut() {
-                rewrite_cm_methods_in_expr(arg, tt, entry_source);
+                rewrite_cm_methods_in_expr(arg, tt, entry_source, wasi_registry);
             }
         }
         TirExprKind::CmRawCall { args, .. } => {
             for arg in args.iter_mut() {
-                rewrite_cm_methods_in_expr(arg, tt, entry_source);
+                rewrite_cm_methods_in_expr(arg, tt, entry_source, wasi_registry);
             }
         }
         TirExprKind::GlobalVarSet { value, .. } => {
-            rewrite_cm_methods_in_expr(value, tt, entry_source);
+            rewrite_cm_methods_in_expr(value, tt, entry_source, wasi_registry);
         }
         TirExprKind::LabeledBlock { block, .. } => {
-            rewrite_cm_methods_in_block(block, tt, entry_source);
+            rewrite_cm_methods_in_block(block, tt, entry_source, wasi_registry);
         }
         TirExprKind::TupleSpread { expr: inner }
         | TirExprKind::TupleZip { expr: inner }
@@ -811,7 +832,7 @@ fn rewrite_cm_methods_in_expr(expr: &mut TirExpr, tt: &TypeTable, entry_source: 
         | TirExprKind::VariantTest { expr: inner, .. }
         | TirExprKind::VariantPayload { expr: inner, .. }
         | TirExprKind::ClosureToCanonical { functor: inner, .. } => {
-            rewrite_cm_methods_in_expr(inner, tt, entry_source);
+            rewrite_cm_methods_in_expr(inner, tt, entry_source, wasi_registry);
         }
         TirExprKind::Switch {
             scrutinee,
@@ -819,16 +840,16 @@ fn rewrite_cm_methods_in_expr(expr: &mut TirExpr, tt: &TypeTable, entry_source: 
             default,
             ..
         } => {
-            rewrite_cm_methods_in_expr(scrutinee, tt, entry_source);
+            rewrite_cm_methods_in_expr(scrutinee, tt, entry_source, wasi_registry);
             for arm in arms.iter_mut() {
-                rewrite_cm_methods_in_block(arm, tt, entry_source);
+                rewrite_cm_methods_in_block(arm, tt, entry_source, wasi_registry);
             }
-            rewrite_cm_methods_in_block(default, tt, entry_source);
+            rewrite_cm_methods_in_block(default, tt, entry_source, wasi_registry);
         }
         TirExprKind::TemplateString { parts } => {
             for part in parts.iter_mut() {
                 if let TirTemplatePart::Interpolation { expr, .. } = part {
-                    rewrite_cm_methods_in_expr(expr, tt, entry_source);
+                    rewrite_cm_methods_in_expr(expr, tt, entry_source, wasi_registry);
                 }
             }
         }
@@ -884,7 +905,7 @@ fn rewrite_cm_methods_in_expr(expr: &mut TirExpr, tt: &TypeTable, entry_source: 
     // For stream operations on non-u8 types, parameterize the canonical name
     // and rewrite as CmRawCall directly (since the name is dynamic).
     if is_stream_cm_method(&cm_name) {
-        let parameterized = parameterize_stream_cm_name(&cm_name, expr, tt);
+        let parameterized = parameterize_stream_cm_name(&cm_name, expr, tt, wasi_registry);
         if parameterized != cm_name {
             rewrite_cm_instance_method(expr, "raw", &parameterized, entry_source);
             return;
@@ -983,7 +1004,18 @@ fn is_stream_cm_method(cm_name: &str) -> bool {
 /// Parameterize a stream CM name based on the receiver type.
 /// For non-u8 streams (e.g., `Stream<DirectoryEntry>`), appends the CM record name
 /// (e.g., "stream-drop-readable:directory-entry").
-fn parameterize_stream_cm_name(cm_name: &str, expr: &TirExpr, tt: &TypeTable) -> String {
+///
+/// Prefers the canonical CM name registered via `#[cm("…")]` so that
+/// non-mechanical mappings (e.g., `DNSRecord` → `dns-record`) and
+/// preserved acronyms aren't mangled. Falls back to a PascalCase →
+/// kebab-case conversion only for receiver element types not in the
+/// registry (user-authored streams).
+fn parameterize_stream_cm_name(
+    cm_name: &str,
+    expr: &TirExpr,
+    tt: &TypeTable,
+    wasi_registry: &WasiRegistry,
+) -> String {
     // Get the receiver's type from the method call
     let receiver_type_id = match &expr.kind {
         TirExprKind::MethodCall { receiver, .. } => receiver.type_id,
@@ -1000,18 +1032,38 @@ fn parameterize_stream_cm_name(cm_name: &str, expr: &TirExpr, tt: &TypeTable) ->
     {
         let elem_name = tt.base_type_name(elem);
         if elem_name != "u8" {
-            // Convert PascalCase to kebab-case for the CM name
-            let cm_elem = elem_name.chars().fold(String::new(), |mut s, c| {
-                if c.is_uppercase() && !s.is_empty() {
-                    s.push('-');
-                }
-                s.push(c.to_ascii_lowercase());
-                s
-            });
+            let cm_elem = registered_cm_name(&elem_name, wasi_registry)
+                .unwrap_or_else(|| pascal_to_kebab(&elem_name));
             return format!("{cm_name}:{cm_elem}");
         }
     }
     cm_name.to_string()
+}
+
+/// Look up the canonical `#[cm("…")]` CM name for a Wado type name across
+/// the registry's stream-eligible categories (struct, resource, variant,
+/// enum, flags). Returns `None` for ambiguous lookups or unregistered
+/// names.
+fn registered_cm_name(name: &str, registry: &WasiRegistry) -> Option<String> {
+    registry
+        .get_struct_cm_name(name)
+        .or_else(|| registry.get_resource_cm_name(name))
+        .or_else(|| registry.get_variant_cm_name(name))
+        .or_else(|| registry.get_enum_cm_name(name))
+        .or_else(|| registry.get_flags_cm_name(name))
+        .map(str::to_string)
+}
+
+/// Mechanical PascalCase → kebab-case fallback for stream element types
+/// not registered with a `#[cm("…")]` name (i.e., user-authored types).
+fn pascal_to_kebab(name: &str) -> String {
+    name.chars().fold(String::new(), |mut s, c| {
+        if c.is_uppercase() && !s.is_empty() {
+            s.push('-');
+        }
+        s.push(c.to_ascii_lowercase());
+        s
+    })
 }
 
 /// Check if a `TypeId` represents `Array<u8>`.

--- a/wado-compiler/src/synthesis/cm_binding/resource_rewrite.rs
+++ b/wado-compiler/src/synthesis/cm_binding/resource_rewrite.rs
@@ -29,7 +29,7 @@ use crate::synthesis::common::{
     if_stmt, internal_call, let_mut_stmt, let_stmt, local_ref, loop_stmt, return_stmt, synth_span,
 };
 
-use super::synthesize_lift_with_context;
+use super::synthesize_lift;
 use super::types::{LiftContext, binary_add};
 
 /// Generate binding functions for Stream<T>.`read()` where T is a non-u8 WASI record type.
@@ -439,7 +439,7 @@ fn synthesize_stream_read_func(
         span: synth_span(),
         source_interface: None,
     });
-    let lifted_elem = synthesize_lift_with_context(
+    let lifted_elem = synthesize_lift(
         &ast_type,
         local_ref(addr_idx, "addr", TypeTable::I32),
         &mut next_local,

--- a/wado-compiler/src/synthesis/cm_binding/task_return.rs
+++ b/wado-compiler/src/synthesis/cm_binding/task_return.rs
@@ -233,7 +233,9 @@ fn expand_task_return_in_stmt(
 /// - Ok arm: flatten T → call task-return(0, ...`flat_ok_values`)
 /// - Err arm: flatten E → call task-return(1, ...`flat_err_values`)
 ///
-/// For other types, generates task-return(0, ...`flat_values`).
+/// For other types, flattens `value` to its CM ABI flat slots and emits
+/// `task-return(...flat_values)`. For unit-returning exports, the value
+/// is evaluated for its side effects and `task-return()` is emitted.
 fn generate_inline_task_return(
     value: TirExpr,
     flat_return_types: &[cm_abi::CmValType],
@@ -431,12 +433,52 @@ fn generate_inline_task_return(
         ));
     } else {
         drop(tt);
-        // Non-Result (or empty flat types): just emit task-return(0)
-        stmts.push(expr_stmt(cm_raw_call(
-            "task-return",
-            vec![i32_const(0)],
-            TypeTable::UNIT,
-        )));
+        // Non-Result task return — flatten the value and forward the flat
+        // slots verbatim. Unit-returning exports (`flat_return_types`
+        // empty) collapse to `task-return()` with the value evaluated for
+        // its side effects.
+        if flat_return_types.is_empty() {
+            // Evaluate `value` for side effects, then signal completion
+            // with no flat payload.
+            stmts.push(expr_stmt(value));
+            stmts.push(expr_stmt(cm_raw_call(
+                "task-return",
+                vec![],
+                TypeTable::UNIT,
+            )));
+        } else {
+            let lowered = synthesize_lower_to_flat(
+                value,
+                value_type_id,
+                next_local,
+                &mut stmts,
+                locals,
+                tir_modules,
+                lift_ctx,
+            );
+            assert_eq!(
+                lowered.len(),
+                flat_return_types.len(),
+                "non-Result task return: flat-lowered slot count {} != world flat-return-type count {}",
+                lowered.len(),
+                flat_return_types.len(),
+            );
+            let mut task_return_args: Vec<TirExpr> = Vec::with_capacity(lowered.len());
+            for (flat_val, &target_vt) in lowered.iter().zip(flat_return_types.iter()) {
+                let target_type = cm_val_type_to_type_id(target_vt);
+                let source_type = cm_val_type_to_type_id(flat_val.cm_type);
+                let mut arg = local_ref(flat_val.index, "__flat", source_type);
+                if flat_val.cm_type != target_vt {
+                    arg = cast(arg, target_type);
+                }
+                task_return_args.push(arg);
+            }
+            stmts.push(expr_stmt(cm_raw_call(
+                "task-return",
+                task_return_args,
+                TypeTable::UNIT,
+            )));
+        }
     }
 
     stmts

--- a/wado-compiler/src/synthesis/cm_binding/types.rs
+++ b/wado-compiler/src/synthesis/cm_binding/types.rs
@@ -46,9 +46,8 @@ pub struct LiftContext<'a> {
     ///
     /// Re-entrancy: the lift call chain may `borrow_mut()` this cell;
     /// callers must not hold a `RefMut` to the same cell across calls
-    /// into `synthesize_lift_with_context` or its helpers. The lift
-    /// path itself only borrows transiently inside
-    /// `module_source_for_cm_interface`.
+    /// into `synthesize_lift` or its helpers. The lift path itself only
+    /// borrows transiently inside `module_source_for_cm_interface`.
     pub interner: &'a RefCell<crate::name::ModuleSourceInterner>,
 }
 

--- a/wado-compiler/tests/fixtures.golden/http-client-advanced.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/http-client-advanced.wir.wado
@@ -1585,7 +1585,7 @@ fn "wado-compiler/tests/fixtures/http-client-advanced.wado/__cm_binding__Fields_
                 };
             };
             if __count_10 > 0 {
-                drop("mem/realloc"(__base_9, __count_10 * 1, 4, 0));
+                drop("mem/realloc"(__base_9, __count_10 * 1, 1, 0));
             }
             "core:prelude/Array<Array<u8>>::push"(__result_6, __result_11);
             __i_7 = __i_7 + 1;

--- a/wado-compiler/tests/fixtures.golden/http-echo-headers.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/http-echo-headers.wir.wado
@@ -876,7 +876,7 @@ fn "wado-compiler/tests/fixtures/http-echo-headers.wado/__cm_binding__Fields_get
                 };
             };
             if __count_10 > 0 {
-                drop("mem/realloc"(__base_9, __count_10 * 1, 4, 0));
+                drop("mem/realloc"(__base_9, __count_10 * 1, 1, 0));
             }
             "core:prelude/Array<Array<u8>>::push"(__result_6, __result_11);
             __i_7 = __i_7 + 1;

--- a/wado-compiler/tests/fixtures.golden/http-fields-copy-all.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/http-fields-copy-all.wir.wado
@@ -1003,7 +1003,7 @@ fn "wado-compiler/tests/fixtures/http-fields-copy-all.wado/__cm_binding__Fields_
                 };
             };
             if __count_9 > 0 {
-                drop("mem/realloc"(__base_8, __count_9 * 1, 4, 0));
+                drop("mem/realloc"(__base_8, __count_9 * 1, 1, 0));
             }
             "core:prelude/Array<Tuple<String,Array<u8>>>::push"(__result_4, struct.new "tuple//[String, Array<u8>]" { 0: __lifted_result_7, 1: __result_10 });
             drop("mem/realloc"(builtin::load_i32(__elem_addr_6 + 0), builtin::load_i32((__elem_addr_6 + 0) + 4), 1, 0));

--- a/wado-compiler/tests/fixtures.golden/http-fields-get-and-delete.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/http-fields-get-and-delete.wir.wado
@@ -1121,7 +1121,7 @@ fn "wado-compiler/tests/fixtures/http-fields-get-and-delete.wado/__cm_binding__F
                     };
                 };
                 if __count_12 > 0 {
-                    drop("mem/realloc"(__base_11, __count_12 * 1, 4, 0));
+                    drop("mem/realloc"(__base_11, __count_12 * 1, 1, 0));
                 }
                 "core:prelude/Array<Array<u8>>::push"(__result_8, __result_13);
                 __i_9 = __i_9 + 1;

--- a/wado-compiler/tests/fixtures.golden/http-fields-immutable-errors.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/http-fields-immutable-errors.wir.wado
@@ -1195,7 +1195,7 @@ fn "wado-compiler/tests/fixtures/http-fields-immutable-errors.wado/__cm_binding_
                 };
             };
             if __count_10 > 0 {
-                drop("mem/realloc"(__base_9, __count_10 * 1, 4, 0));
+                drop("mem/realloc"(__base_9, __count_10 * 1, 1, 0));
             }
             "core:prelude/Array<Array<u8>>::push"(__result_6, __result_11);
             __i_7 = __i_7 + 1;
@@ -1466,7 +1466,7 @@ fn "wado-compiler/tests/fixtures/http-fields-immutable-errors.wado/__cm_binding_
                     };
                 };
                 if __count_12 > 0 {
-                    drop("mem/realloc"(__base_11, __count_12 * 1, 4, 0));
+                    drop("mem/realloc"(__base_11, __count_12 * 1, 1, 0));
                 }
                 "core:prelude/Array<Array<u8>>::push"(__result_8, __result_13);
                 __i_9 = __i_9 + 1;
@@ -1560,7 +1560,7 @@ fn "wado-compiler/tests/fixtures/http-fields-immutable-errors.wado/__cm_binding_
                 };
             };
             if __count_9 > 0 {
-                drop("mem/realloc"(__base_8, __count_9 * 1, 4, 0));
+                drop("mem/realloc"(__base_8, __count_9 * 1, 1, 0));
             }
             "core:prelude/Array<Tuple<String,Array<u8>>>::push"(__result_4, struct.new "tuple//[String, Array<u8>]" { 0: __lifted_result_7, 1: __result_10 });
             drop("mem/realloc"(builtin::load_i32(__elem_addr_6 + 0), builtin::load_i32((__elem_addr_6 + 0) + 4), 1, 0));

--- a/wado-compiler/tests/fixtures.golden/http-fields-set.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/http-fields-set.wir.wado
@@ -1153,7 +1153,7 @@ fn "wado-compiler/tests/fixtures/http-fields-set.wado/__cm_binding__Fields_get"(
                 };
             };
             if __count_10 > 0 {
-                drop("mem/realloc"(__base_9, __count_10 * 1, 4, 0));
+                drop("mem/realloc"(__base_9, __count_10 * 1, 1, 0));
             }
             "core:prelude/Array<Array<u8>>::push"(__result_6, __result_11);
             __i_7 = __i_7 + 1;

--- a/wado-compiler/tests/fixtures.golden/http-request-headers.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/http-request-headers.wir.wado
@@ -955,7 +955,7 @@ fn "wado-compiler/tests/fixtures/http-request-headers.wado/__cm_binding__Fields_
                 };
             };
             if __count_10 > 0 {
-                drop("mem/realloc"(__base_9, __count_10 * 1, 4, 0));
+                drop("mem/realloc"(__base_9, __count_10 * 1, 1, 0));
             }
             "core:prelude/Array<Array<u8>>::push"(__result_6, __result_11);
             __i_7 = __i_7 + 1;

--- a/wado-compiler/tests/fixtures.golden/httpbin-404.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/httpbin-404.wir.wado
@@ -1427,7 +1427,7 @@ fn "wado-compiler/tests/fixtures/httpbin-404.wado/__cm_binding__Fields_copy_all"
                 };
             };
             if __count_9 > 0 {
-                drop("mem/realloc"(__base_8, __count_9 * 1, 4, 0));
+                drop("mem/realloc"(__base_8, __count_9 * 1, 1, 0));
             }
             "core:prelude/Array<Tuple<String,Array<u8>>>::push"(__result_4, struct.new "tuple//[String, Array<u8>]" { 0: __lifted_result_7, 1: __result_10 });
             drop("mem/realloc"(builtin::load_i32(__elem_addr_6 + 0), builtin::load_i32((__elem_addr_6 + 0) + 4), 1, 0));
@@ -1484,7 +1484,7 @@ fn "wado-compiler/tests/fixtures/httpbin-404.wado/__cm_binding__Fields_get"(self
                 };
             };
             if __count_10 > 0 {
-                drop("mem/realloc"(__base_9, __count_10 * 1, 4, 0));
+                drop("mem/realloc"(__base_9, __count_10 * 1, 1, 0));
             }
             "core:prelude/Array<Array<u8>>::push"(__result_6, __result_11);
             __i_7 = __i_7 + 1;

--- a/wado-compiler/tests/fixtures.golden/httpbin-405.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/httpbin-405.wir.wado
@@ -1427,7 +1427,7 @@ fn "wado-compiler/tests/fixtures/httpbin-405.wado/__cm_binding__Fields_copy_all"
                 };
             };
             if __count_9 > 0 {
-                drop("mem/realloc"(__base_8, __count_9 * 1, 4, 0));
+                drop("mem/realloc"(__base_8, __count_9 * 1, 1, 0));
             }
             "core:prelude/Array<Tuple<String,Array<u8>>>::push"(__result_4, struct.new "tuple//[String, Array<u8>]" { 0: __lifted_result_7, 1: __result_10 });
             drop("mem/realloc"(builtin::load_i32(__elem_addr_6 + 0), builtin::load_i32((__elem_addr_6 + 0) + 4), 1, 0));
@@ -1484,7 +1484,7 @@ fn "wado-compiler/tests/fixtures/httpbin-405.wado/__cm_binding__Fields_get"(self
                 };
             };
             if __count_10 > 0 {
-                drop("mem/realloc"(__base_9, __count_10 * 1, 4, 0));
+                drop("mem/realloc"(__base_9, __count_10 * 1, 1, 0));
             }
             "core:prelude/Array<Array<u8>>::push"(__result_6, __result_11);
             __i_7 = __i_7 + 1;

--- a/wado-compiler/tests/fixtures.golden/httpbin-anything.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/httpbin-anything.wir.wado
@@ -1427,7 +1427,7 @@ fn "wado-compiler/tests/fixtures/httpbin-anything.wado/__cm_binding__Fields_copy
                 };
             };
             if __count_9 > 0 {
-                drop("mem/realloc"(__base_8, __count_9 * 1, 4, 0));
+                drop("mem/realloc"(__base_8, __count_9 * 1, 1, 0));
             }
             "core:prelude/Array<Tuple<String,Array<u8>>>::push"(__result_4, struct.new "tuple//[String, Array<u8>]" { 0: __lifted_result_7, 1: __result_10 });
             drop("mem/realloc"(builtin::load_i32(__elem_addr_6 + 0), builtin::load_i32((__elem_addr_6 + 0) + 4), 1, 0));
@@ -1484,7 +1484,7 @@ fn "wado-compiler/tests/fixtures/httpbin-anything.wado/__cm_binding__Fields_get"
                 };
             };
             if __count_10 > 0 {
-                drop("mem/realloc"(__base_9, __count_10 * 1, 4, 0));
+                drop("mem/realloc"(__base_9, __count_10 * 1, 1, 0));
             }
             "core:prelude/Array<Array<u8>>::push"(__result_6, __result_11);
             __i_7 = __i_7 + 1;

--- a/wado-compiler/tests/fixtures.golden/httpbin-get.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/httpbin-get.wir.wado
@@ -1427,7 +1427,7 @@ fn "wado-compiler/tests/fixtures/httpbin-get.wado/__cm_binding__Fields_copy_all"
                 };
             };
             if __count_9 > 0 {
-                drop("mem/realloc"(__base_8, __count_9 * 1, 4, 0));
+                drop("mem/realloc"(__base_8, __count_9 * 1, 1, 0));
             }
             "core:prelude/Array<Tuple<String,Array<u8>>>::push"(__result_4, struct.new "tuple//[String, Array<u8>]" { 0: __lifted_result_7, 1: __result_10 });
             drop("mem/realloc"(builtin::load_i32(__elem_addr_6 + 0), builtin::load_i32((__elem_addr_6 + 0) + 4), 1, 0));
@@ -1484,7 +1484,7 @@ fn "wado-compiler/tests/fixtures/httpbin-get.wado/__cm_binding__Fields_get"(self
                 };
             };
             if __count_10 > 0 {
-                drop("mem/realloc"(__base_9, __count_10 * 1, 4, 0));
+                drop("mem/realloc"(__base_9, __count_10 * 1, 1, 0));
             }
             "core:prelude/Array<Array<u8>>::push"(__result_6, __result_11);
             __i_7 = __i_7 + 1;

--- a/wado-compiler/tests/fixtures.golden/httpbin-headers.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/httpbin-headers.wir.wado
@@ -1427,7 +1427,7 @@ fn "wado-compiler/tests/fixtures/httpbin-headers.wado/__cm_binding__Fields_copy_
                 };
             };
             if __count_9 > 0 {
-                drop("mem/realloc"(__base_8, __count_9 * 1, 4, 0));
+                drop("mem/realloc"(__base_8, __count_9 * 1, 1, 0));
             }
             "core:prelude/Array<Tuple<String,Array<u8>>>::push"(__result_4, struct.new "tuple//[String, Array<u8>]" { 0: __lifted_result_7, 1: __result_10 });
             drop("mem/realloc"(builtin::load_i32(__elem_addr_6 + 0), builtin::load_i32((__elem_addr_6 + 0) + 4), 1, 0));
@@ -1484,7 +1484,7 @@ fn "wado-compiler/tests/fixtures/httpbin-headers.wado/__cm_binding__Fields_get"(
                 };
             };
             if __count_10 > 0 {
-                drop("mem/realloc"(__base_9, __count_10 * 1, 4, 0));
+                drop("mem/realloc"(__base_9, __count_10 * 1, 1, 0));
             }
             "core:prelude/Array<Array<u8>>::push"(__result_6, __result_11);
             __i_7 = __i_7 + 1;

--- a/wado-compiler/tests/fixtures.golden/httpbin-post.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/httpbin-post.wir.wado
@@ -1427,7 +1427,7 @@ fn "wado-compiler/tests/fixtures/httpbin-post.wado/__cm_binding__Fields_copy_all
                 };
             };
             if __count_9 > 0 {
-                drop("mem/realloc"(__base_8, __count_9 * 1, 4, 0));
+                drop("mem/realloc"(__base_8, __count_9 * 1, 1, 0));
             }
             "core:prelude/Array<Tuple<String,Array<u8>>>::push"(__result_4, struct.new "tuple//[String, Array<u8>]" { 0: __lifted_result_7, 1: __result_10 });
             drop("mem/realloc"(builtin::load_i32(__elem_addr_6 + 0), builtin::load_i32((__elem_addr_6 + 0) + 4), 1, 0));
@@ -1484,7 +1484,7 @@ fn "wado-compiler/tests/fixtures/httpbin-post.wado/__cm_binding__Fields_get"(sel
                 };
             };
             if __count_10 > 0 {
-                drop("mem/realloc"(__base_9, __count_10 * 1, 4, 0));
+                drop("mem/realloc"(__base_9, __count_10 * 1, 1, 0));
             }
             "core:prelude/Array<Array<u8>>::push"(__result_6, __result_11);
             __i_7 = __i_7 + 1;

--- a/wado-compiler/tests/fixtures.golden/httpbin-status.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/httpbin-status.wir.wado
@@ -1427,7 +1427,7 @@ fn "wado-compiler/tests/fixtures/httpbin-status.wado/__cm_binding__Fields_copy_a
                 };
             };
             if __count_9 > 0 {
-                drop("mem/realloc"(__base_8, __count_9 * 1, 4, 0));
+                drop("mem/realloc"(__base_8, __count_9 * 1, 1, 0));
             }
             "core:prelude/Array<Tuple<String,Array<u8>>>::push"(__result_4, struct.new "tuple//[String, Array<u8>]" { 0: __lifted_result_7, 1: __result_10 });
             drop("mem/realloc"(builtin::load_i32(__elem_addr_6 + 0), builtin::load_i32((__elem_addr_6 + 0) + 4), 1, 0));
@@ -1484,7 +1484,7 @@ fn "wado-compiler/tests/fixtures/httpbin-status.wado/__cm_binding__Fields_get"(s
                 };
             };
             if __count_10 > 0 {
-                drop("mem/realloc"(__base_9, __count_10 * 1, 4, 0));
+                drop("mem/realloc"(__base_9, __count_10 * 1, 1, 0));
             }
             "core:prelude/Array<Array<u8>>::push"(__result_6, __result_11);
             __i_7 = __i_7 + 1;


### PR DESCRIPTION
## Summary

Addresses all 6 pre-existing concerns surfaced by Copilot during the #996
review and tracked in #997. None of them were introduced by the refactor;
verbatim equivalents existed on `main`. Each is a real bug — most latent
under the current WASI surface — and is fixed independently per the
issue's "splitting fixes per area is fine" suggestion.

| # | Issue | Fix |
|---|---|---|
| 1 | `synthesize_lift_list` stride uses `cm_size` (4-byte handle fallback) | `cm_size_with_registry_scoped` |
| 2 | List buffer freed with hard-coded `align=4` | `cm_align_with_registry_scoped` |
| 3 | Array-parameter lowering uses registry-blind `cm_size`/`cm_align` | `cm_size/align_with_registry_scoped` |
| 4 | `parameterize_stream_cm_name` lowercases instead of consulting registry | `WasiRegistry::get_*_cm_name` first, mechanical fallback for user types |
| 5 | `synthesize_lift_flat_result` uses `TypeTable::I32` placeholder | resolve real `Result<T, E>` `TypeId` up front |
| 6 | Non-`Result` `task return value;` falls through to `task-return(0)` | flatten value via `synthesize_lower_to_flat`, mirror Result-Ok arm |

## Commits (sequential, by area)

| Commit | Phase | Notes |
|---|---|---|
| `refactor(cm_binding/lift)` | A.1 | Drop the test-only `Option<&LiftContext>` codepath. `synthesize_lift` now requires `LiftContext`; `synthesize_lift_with_context` re-export is folded back into `synthesize_lift`. Tests construct a real (empty) context via a shared `LiftCtxFixture`. No production behavior change — all production callers already supplied `Some(ctx)`. |
| `fix(cm_binding): registry-aware Array stride/align` | A.2 | Issues #1, #2, #3. Adds one regression unit test (`lift_list_named_variant_uses_registry_stride`) using `Array<IpAddress>` against the real stdlib registry. |
| `fix(cm_binding/resource_rewrite): registry CM name` | B | Issue #4. Plumbs `WasiRegistry` through `rewrite_cm_methods_in_*`. Falls back to mechanical PascalCase→kebab for user-authored streams. |
| `fix(cm_binding/import_adapter): real Result TypeId` | C | Issue #5. Resolves the `Result<T, E>` `TypeId` at the call site and threads it into `synthesize_lift_flat_result`, removing the `TypeTable::I32` placeholder dependency. |
| `fix(cm_binding/task_return): non-Result flatten` | D | Issue #6. Mirrors the Result-Ok arm: lowers the value to flat slots and forwards to `task-return`. Empty flat-return-types collapses to `task-return()`. Debug-time `assert_eq!` guards against silent slot-count mismatch. |
| `chore: regenerate golden fixtures` | — | Mechanical updates from `mise run on-task-done`. The HTTP golden diffs reflect Phase A.2 — `Array<u8>` element loops now realloc with `align=1` (the true CM align of `u8`) instead of hard-coded `4`. |

## Reproducibility note

None of the 6 bugs is reachable through the current WASI surface as a
straightforward e2e fixture: bugs 1–3 need `Array<NamedRecordOrVariant>`
that the registry can resolve to non-4-byte size (only `resolve_addresses
→ Array<IpAddress>` qualifies, and that needs network); bug 4 needs an
acronym-bearing `Stream<T>` (none registered); bug 5 was masked by the
post-synthesis type-fixup pass; bug 6 needs a non-Result async export
(WASI only has `Result`-returning ones). Per the issue thread, fixing
without an e2e fixture is acceptable; a single registry-stride unit test
provides the regression guard for the alignment cluster.

## Test plan

- [x] `cargo test -p wado-compiler --lib` — 446 / 0 failed (one new test added)
- [x] `cargo test -p wado-compiler --test e2e` (O0 + O2) — 5,700 / 0 failed
- [x] `mise run on-task-done` — clippy / golden / format / Rust tests / `wado test` (main package: 137 passed) all green; only mechanical regenerations committed

https://claude.ai/code/session_019UFKzczus3hwHpp3VHk2rG

---
_Generated by [Claude Code](https://claude.ai/code/session_019UFKzczus3hwHpp3VHk2rG)_