### PR TITLE
refactor(synthesis/traits): extract helpers, unify generic and non-generic paths

### DIFF
--- a/wado-compiler/src/synthesis/traits.rs
+++ b/wado-compiler/src/synthesis/traits.rs
@@ -19,7 +19,7 @@ use crate::package::Package;
 use crate::tir::{
     CallArg, FunctionKind, FunctionRef, InlineHint, MonomorphInfo, ResolvedType, TirBinaryOp,
     TirBlock, TirExpr, TirExprKind, TirFunction, TirLocal, TirModule, TirParam, TirStmt,
-    TirStmtKind, TirTypeParam, TirUnaryOp, TypeId, TypeTable,
+    TirStmtKind, TirTypeParam, TypeId, TypeTable,
 };
 use crate::token::Span;
 
@@ -27,6 +27,190 @@ use super::common::{
     deref_expr, make_synthetic_method, param_local, ref_expr, synth_span, trait_method_call,
     write_str_stmt,
 };
+
+/// One half of an auto-derived trait pair: the `Display`/`DisplayAlt`/`InspectAlt`
+/// fallback machinery is parameterised over which trait to emit and which trait
+/// to delegate to.
+struct TraitPair {
+    /// e.g. `"Display"` or `"DisplayAlt"`.
+    target_trait: &'static str,
+    /// e.g. `"fmt"` or `"fmt_alt"`.
+    target_method: &'static str,
+    /// Trait the fallback delegates to (`"Inspect"` or `"InspectAlt"`).
+    delegate_trait: &'static str,
+    /// Method on the delegate trait (`"inspect"` or `"inspect_alt"`).
+    delegate_method: &'static str,
+}
+
+const DISPLAY_PAIR: TraitPair = TraitPair {
+    target_trait: "Display",
+    target_method: "fmt",
+    delegate_trait: "Inspect",
+    delegate_method: "inspect",
+};
+
+const DISPLAY_ALT_PAIR: TraitPair = TraitPair {
+    target_trait: "DisplayAlt",
+    target_method: "fmt_alt",
+    delegate_trait: "InspectAlt",
+    delegate_method: "inspect_alt",
+};
+
+/// Shorthand for `LocalMethodName::new(struct.into(), Some(trait.into()), method.into())`.
+fn trait_method_info(struct_name: &str, trait_name: &str, method: &str) -> LocalMethodName {
+    LocalMethodName::new(
+        struct_name.to_string(),
+        Some(trait_name.to_string()),
+        method.to_string(),
+    )
+}
+
+/// Build a local-variable reference expression.
+fn local_expr(index: u32, name: &str, type_id: TypeId, span: Span) -> TirExpr {
+    TirExpr::new(
+        TirExprKind::Local {
+            index,
+            name: name.to_string(),
+        },
+        type_id,
+        span,
+    )
+}
+
+/// Build `*<local>` where the local has reference type `ref_type` and dereferences to `inner_type`.
+fn deref_local(
+    index: u32,
+    name: &str,
+    ref_type: TypeId,
+    inner_type: TypeId,
+    span: Span,
+) -> TirExpr {
+    deref_expr(local_expr(index, name, ref_type, span), inner_type, span)
+}
+
+/// Standard `(self, other)` parameter list for `Eq`/`Ord`-style methods.
+fn binary_method_params(ref_type: TypeId, span: Span) -> Vec<TirParam> {
+    vec![
+        TirParam {
+            name: "self".to_string(),
+            type_id: ref_type,
+            local_index: 0,
+            is_mut: false,
+            span,
+            default_expr: None,
+        },
+        TirParam {
+            name: "other".to_string(),
+            type_id: ref_type,
+            local_index: 1,
+            is_mut: false,
+            span,
+            default_expr: None,
+        },
+    ]
+}
+
+/// Locals slice matching `binary_method_params`.
+fn binary_method_locals(ref_type: TypeId) -> Vec<TirLocal> {
+    vec![
+        param_local("self", ref_type, false),
+        param_local("other", ref_type, false),
+    ]
+}
+
+/// Standard `(&self, &mut Formatter)` parameter list for `Inspect`/`Display`-style methods.
+fn inspect_params(ref_type: TypeId, fmt_type: TypeId, span: Span) -> Vec<TirParam> {
+    vec![
+        TirParam {
+            name: "self".to_string(),
+            type_id: ref_type,
+            local_index: 0,
+            is_mut: false,
+            span,
+            default_expr: None,
+        },
+        TirParam {
+            name: "f".to_string(),
+            type_id: fmt_type,
+            local_index: 1,
+            is_mut: false,
+            span,
+            default_expr: None,
+        },
+    ]
+}
+
+/// Locals slice matching `inspect_params`.
+fn inspect_locals(ref_type: TypeId, fmt_type: TypeId) -> Vec<TirLocal> {
+    vec![
+        param_local("self", ref_type, false),
+        param_local("f", fmt_type, false),
+    ]
+}
+
+/// Build an `Ordering::<case>` enum-construct expression.
+fn ordering_construct(
+    ordering_type: TypeId,
+    case_index: u32,
+    case_name: &str,
+    span: Span,
+) -> TirExpr {
+    TirExpr::new(
+        TirExprKind::EnumConstruct {
+            enum_type: ordering_type,
+            case_index,
+            case_name: case_name.to_string(),
+        },
+        ordering_type,
+        span,
+    )
+}
+
+/// Like `make_synthetic_method`, but lets the caller attach `impl_type_params`
+/// so generic auto-derived methods participate in monomorphisation.
+fn make_trait_method(
+    name: String,
+    method_info: LocalMethodName,
+    impl_type_params: Vec<TirTypeParam>,
+    params: Vec<TirParam>,
+    return_type: TypeId,
+    body: TirBlock,
+    locals: Vec<TirLocal>,
+    span: Span,
+) -> TirFunction {
+    let local_count = locals.len() as u32;
+    TirFunction {
+        module_source: ModuleSource::default(),
+        name,
+        is_pub: true,
+        is_export: false,
+        is_async: false,
+        type_params: Vec::new(),
+        impl_type_params,
+        monomorph_info: None,
+        method_info: Some(method_info),
+        params,
+        return_type,
+        task_return_type: None,
+        effects: Vec::new(),
+        stores: vec![],
+        body: Some(body),
+        span,
+        local_count,
+        locals,
+        address_taken_locals: IndexSet::default(),
+        stores_aliased_locals: IndexSet::default(),
+        is_cm_binding: false,
+        is_dispatch_wrapper: false,
+        is_cm_export: false,
+        is_ambient: false,
+        inline_hint: InlineHint::Auto,
+        comp_features: 0,
+        export_name: None,
+        allocator_tag: None,
+        kind: FunctionKind::Regular,
+    }
+}
 
 /// Run trait synthesis on the entire project.
 ///
@@ -285,7 +469,6 @@ fn generate_struct_eq_ord_impls(module: &mut TirModule) {
     let mut tt = module.type_table.borrow_mut();
 
     let struct_infos = collect_struct_fields(module);
-
     for (name, fields, span) in &struct_infos {
         let struct_type = tt.make_struct(name.clone(), module_source.clone());
         let ref_struct_type = tt.make_ref(struct_type);
@@ -293,6 +476,7 @@ fn generate_struct_eq_ord_impls(module: &mut TirModule) {
         if !has_existing_impl(&existing, name, "Eq", "eq") {
             let func = generate_struct_eq_fn(
                 name,
+                &[],
                 fields,
                 ref_struct_type,
                 &module_source,
@@ -306,6 +490,7 @@ fn generate_struct_eq_ord_impls(module: &mut TirModule) {
             let ordering_type = tt.make_enum("Ordering".to_string(), ModuleSource::traits());
             let func = generate_struct_ord_fn(
                 name,
+                &[],
                 fields,
                 ref_struct_type,
                 ordering_type,
@@ -318,7 +503,6 @@ fn generate_struct_eq_ord_impls(module: &mut TirModule) {
     }
 
     let generic_struct_infos = collect_generic_struct_fields(module);
-
     for (name, type_params, fields, span) in &generic_struct_infos {
         let type_param_ids = make_type_param_ids(type_params, &mut tt);
         let struct_type =
@@ -326,7 +510,7 @@ fn generate_struct_eq_ord_impls(module: &mut TirModule) {
         let ref_struct_type = tt.make_ref(struct_type);
 
         if !has_existing_impl(&existing, name, "Eq", "eq") {
-            let func = generate_generic_struct_eq_fn(
+            let func = generate_struct_eq_fn(
                 name,
                 type_params,
                 fields,
@@ -340,7 +524,7 @@ fn generate_struct_eq_ord_impls(module: &mut TirModule) {
 
         if !has_existing_impl(&existing, name, "Ord", "cmp") {
             let ordering_type = tt.make_enum("Ordering".to_string(), ModuleSource::traits());
-            let func = generate_generic_struct_ord_fn(
+            let func = generate_struct_ord_fn(
                 name,
                 type_params,
                 fields,
@@ -424,11 +608,7 @@ fn generate_struct_default_fn(
     struct_type: TypeId,
     span: Span,
 ) -> TirFunction {
-    let method_info = LocalMethodName::new(
-        struct_name.to_string(),
-        Some("Default".to_string()),
-        "default".to_string(),
-    );
+    let method_info = trait_method_info(struct_name, "Default", "default");
     let qualified_name = method_info.to_mangled_name();
 
     let struct_fields = fields
@@ -487,9 +667,7 @@ fn generate_variant_eq_impls(module: &mut TirModule) {
 
     let mut tt = module.type_table.borrow_mut();
 
-    // Non-generic variants
     let variant_infos = collect_variant_cases(module);
-
     for (name, cases, span) in &variant_infos {
         if has_existing_impl(&existing, name, "Eq", "eq") {
             continue;
@@ -498,6 +676,7 @@ fn generate_variant_eq_impls(module: &mut TirModule) {
         let ref_variant_type = tt.make_ref(variant_type);
         let func = generate_variant_eq_fn(
             name,
+            &[],
             cases,
             variant_type,
             ref_variant_type,
@@ -508,9 +687,7 @@ fn generate_variant_eq_impls(module: &mut TirModule) {
         generated.push(Rc::new(RefCell::new(func)));
     }
 
-    // Generic variants
     let generic_variant_infos = collect_generic_variant_cases(module);
-
     for (name, type_params, cases, span) in &generic_variant_infos {
         if has_existing_impl(&existing, name, "Eq", "eq") {
             continue;
@@ -519,7 +696,7 @@ fn generate_variant_eq_impls(module: &mut TirModule) {
         let variant_type =
             tt.make_generic_instance(name.clone(), module_source.clone(), type_param_ids);
         let ref_variant_type = tt.make_ref(variant_type);
-        let func = generate_generic_variant_eq_fn(
+        let func = generate_variant_eq_fn(
             name,
             type_params,
             cases,
@@ -535,8 +712,6 @@ fn generate_variant_eq_impls(module: &mut TirModule) {
     drop(tt);
     module.functions.extend(generated);
 }
-
-// ─── Inspect synthesis ───
 
 /// Generate auto-derived `Inspect` trait implementations for all types in a module.
 ///
@@ -596,6 +771,7 @@ fn generate_inspect_impls(module: &mut TirModule) {
         let ref_type = tt.make_ref(struct_type);
         generated.push(Rc::new(RefCell::new(generate_struct_inspect_fn(
             name,
+            &[],
             fields,
             *has_hidden,
             ref_type,
@@ -607,9 +783,7 @@ fn generate_inspect_impls(module: &mut TirModule) {
         ))));
     }
 
-    // Generic structs
     let generic_struct_infos = collect_generic_struct_visible_fields(module);
-
     for (name, type_params, fields, has_hidden, sspan) in &generic_struct_infos {
         if has_existing_impl(&existing, name, "Inspect", "inspect") {
             continue;
@@ -618,7 +792,7 @@ fn generate_inspect_impls(module: &mut TirModule) {
         let struct_type =
             tt.make_generic_instance(name.clone(), module_source.clone(), type_param_ids);
         let ref_type = tt.make_ref(struct_type);
-        generated.push(Rc::new(RefCell::new(generate_generic_struct_inspect_fn(
+        generated.push(Rc::new(RefCell::new(generate_struct_inspect_fn(
             name,
             type_params,
             fields,
@@ -632,9 +806,7 @@ fn generate_inspect_impls(module: &mut TirModule) {
         ))));
     }
 
-    // Non-generic variants
     let variant_infos = collect_variant_cases(module);
-
     for (name, cases, vspan) in &variant_infos {
         if has_existing_impl(&existing, name, "Inspect", "inspect") {
             continue;
@@ -643,6 +815,7 @@ fn generate_inspect_impls(module: &mut TirModule) {
         let ref_type = tt.make_ref(variant_type);
         generated.push(Rc::new(RefCell::new(generate_variant_inspect_fn(
             name,
+            &[],
             cases,
             variant_type,
             ref_type,
@@ -654,9 +827,7 @@ fn generate_inspect_impls(module: &mut TirModule) {
         ))));
     }
 
-    // Generic variants (e.g., Option<T>, Result<T, E>)
     let generic_variant_infos = collect_generic_variant_cases(module);
-
     for (name, type_params, cases, vspan) in &generic_variant_infos {
         if has_existing_impl(&existing, name, "Inspect", "inspect") {
             continue;
@@ -665,7 +836,7 @@ fn generate_inspect_impls(module: &mut TirModule) {
         let variant_type =
             tt.make_generic_instance(name.clone(), module_source.clone(), type_param_ids);
         let ref_type = tt.make_ref(variant_type);
-        generated.push(Rc::new(RefCell::new(generate_generic_variant_inspect_fn(
+        generated.push(Rc::new(RefCell::new(generate_variant_inspect_fn(
             name,
             type_params,
             cases,
@@ -808,66 +979,21 @@ fn generate_enum_inspect_fn(
     string_type: TypeId,
     span: Span,
 ) -> TirFunction {
-    let method_info = LocalMethodName::new(
-        enum_name.to_string(),
-        Some("Inspect".to_string()),
-        "inspect".to_string(),
-    );
+    let method_info = trait_method_info(enum_name, "Inspect", "inspect");
     let qualified_name = method_info.to_mangled_name();
 
-    let params = vec![
-        TirParam {
-            name: "self".to_string(),
-            type_id: ref_enum_type,
-            local_index: 0,
-            is_mut: false,
-            span,
-            default_expr: None,
-        },
-        TirParam {
-            name: "f".to_string(),
-            type_id: fmt_type,
-            local_index: 1,
-            is_mut: false,
-            span,
-            default_expr: None,
-        },
-    ];
-
-    // Build if-else chain from bottom up
-    let deref_self = || {
-        TirExpr::new(
-            TirExprKind::Unary {
-                op: TirUnaryOp::Deref,
-                expr: Box::new(TirExpr::new(
-                    TirExprKind::Local {
-                        index: 0,
-                        name: "self".to_string(),
-                    },
-                    ref_enum_type,
-                    span,
-                )),
-            },
-            enum_type,
-            span,
-        )
-    };
-    let fmt_local = || {
-        TirExpr::new(
-            TirExprKind::Local {
-                index: 1,
-                name: "f".to_string(),
-            },
-            fmt_type,
-            span,
-        )
-    };
+    let deref_self = || deref_local(0, "self", ref_enum_type, enum_type, span);
+    let fmt = || local_expr(1, "f", fmt_type, span);
 
     let mut chain: Option<TirExpr> = None;
     for (case_name, case_index) in cases.iter().rev() {
-        let text = format!("{enum_name}::{case_name}");
         let then_block = TirBlock::new(
-            vec![write_str_stmt(text, fmt_local(), string_type, span)],
+            vec![write_str_stmt(
+                format!("{enum_name}::{case_name}"),
+                fmt(),
+                string_type,
+                span,
+            )],
             span,
         );
         let cond = TirExpr::new(
@@ -905,17 +1031,14 @@ fn generate_enum_inspect_fn(
     make_synthetic_method(
         qualified_name,
         method_info,
-        params,
+        inspect_params(ref_enum_type, fmt_type, span),
         TypeTable::UNIT,
         body,
-        vec![
-            param_local("self", ref_enum_type, false),
-            param_local("f", fmt_type, false),
-        ],
+        inspect_locals(ref_enum_type, fmt_type),
     )
 }
 
-/// Generate `StructName^Inspect::inspect(&self, &mut Formatter)` for non-generic structs.
+/// Generate `StructName^Inspect::inspect(&self, &mut Formatter)`.
 ///
 /// Body:
 /// ```text
@@ -924,8 +1047,11 @@ fn generate_enum_inspect_fn(
 /// f.write_str(", field2: "); self.field2.inspect(f);
 /// f.write_str(" }");
 /// ```
+///
+/// Pass an empty `impl_type_params` slice for non-generic structs.
 fn generate_struct_inspect_fn(
     struct_name: &str,
+    impl_type_params: &[TirTypeParam],
     fields: &[(String, TypeId, u32)],
     has_hidden: bool,
     ref_struct_type: TypeId,
@@ -935,150 +1061,38 @@ fn generate_struct_inspect_fn(
     tt: &mut TypeTable,
     span: Span,
 ) -> TirFunction {
-    let method_info = LocalMethodName::new(
-        struct_name.to_string(),
-        Some("Inspect".to_string()),
-        "inspect".to_string(),
-    );
+    let method_info = trait_method_info(struct_name, "Inspect", "inspect");
     let qualified_name = method_info.to_mangled_name();
 
-    let params = vec![
-        TirParam {
-            name: "self".to_string(),
-            type_id: ref_struct_type,
-            local_index: 0,
-            is_mut: false,
-            span,
-            default_expr: None,
-        },
-        TirParam {
-            name: "f".to_string(),
-            type_id: fmt_type,
-            local_index: 1,
-            is_mut: false,
-            span,
-            default_expr: None,
-        },
-    ];
-
-    let self_ref = || {
-        TirExpr::new(
-            TirExprKind::Local {
-                index: 0,
-                name: "self".to_string(),
-            },
-            ref_struct_type,
-            span,
-        )
-    };
-    let fmt_local = || {
-        TirExpr::new(
-            TirExprKind::Local {
-                index: 1,
-                name: "f".to_string(),
-            },
-            fmt_type,
-            span,
-        )
-    };
-
-    let mut stmts = Vec::new();
-
-    if fields.is_empty() {
-        if has_hidden {
-            stmts.push(write_str_stmt(
-                format!("{struct_name} {{ .. }}"),
-                fmt_local(),
-                string_type,
-                span,
-            ));
-        } else {
-            stmts.push(write_str_stmt(
-                format!("{struct_name} {{}}"),
-                fmt_local(),
-                string_type,
-                span,
-            ));
-        }
-    } else {
-        stmts.push(write_str_stmt(
-            format!("{struct_name} {{ "),
-            fmt_local(),
-            string_type,
-            span,
-        ));
-        for (i, (field_name, field_type, field_index)) in fields.iter().enumerate() {
-            if i > 0 {
-                stmts.push(write_str_stmt(
-                    ", ".to_string(),
-                    fmt_local(),
-                    string_type,
-                    span,
-                ));
-            }
-            stmts.push(write_str_stmt(
-                format!("{field_name}: "),
-                fmt_local(),
-                string_type,
-                span,
-            ));
-            // self.field_name — FieldAccess through &self gives the field value
-            let field_access = TirExpr::new(
-                TirExprKind::FieldAccess {
-                    expr: Box::new(self_ref()),
-                    field_index: *field_index,
-                    field_name: field_name.clone(),
-                },
-                *field_type,
-                span,
-            );
-            stmts.push(inspect_call(
-                field_access,
-                *field_type,
-                fmt_local(),
-                module_source,
-                tt,
-                span,
-            ));
-        }
-        if has_hidden {
-            stmts.push(write_str_stmt(
-                ", ..".to_string(),
-                fmt_local(),
-                string_type,
-                span,
-            ));
-        }
-        stmts.push(write_str_stmt(
-            " }".to_string(),
-            fmt_local(),
-            string_type,
-            span,
-        ));
-    }
-
+    let stmts = build_struct_inspect_body(
+        struct_name,
+        fields,
+        has_hidden,
+        ref_struct_type,
+        fmt_type,
+        string_type,
+        module_source,
+        tt,
+        span,
+    );
     let body = TirBlock::new(stmts, span);
 
-    make_synthetic_method(
+    make_trait_method(
         qualified_name,
         method_info,
-        params,
+        impl_type_params.to_vec(),
+        inspect_params(ref_struct_type, fmt_type, span),
         TypeTable::UNIT,
         body,
-        vec![
-            param_local("self", ref_struct_type, false),
-            param_local("f", fmt_type, false),
-        ],
+        inspect_locals(ref_struct_type, fmt_type),
+        span,
     )
 }
 
-/// Generate `StructName^Inspect::inspect(&self, &mut Formatter)` for generic structs.
-///
-/// Sets `impl_type_params` with Inspect bounds so the monomorphizer can
-/// specialize field inspect calls for concrete types.
-fn generate_generic_struct_inspect_fn(
+/// Build the body statements for a struct `Inspect::inspect`: writes the type name,
+/// each visible field via `inspect`, plus a trailing `, ..` when hidden fields are present.
+fn build_struct_inspect_body(
     struct_name: &str,
-    type_params: &[TirTypeParam],
     fields: &[(String, TypeId, u32)],
     has_hidden: bool,
     ref_struct_type: TypeId,
@@ -1087,172 +1101,49 @@ fn generate_generic_struct_inspect_fn(
     module_source: &ModuleSource,
     tt: &mut TypeTable,
     span: Span,
-) -> TirFunction {
-    let method_info = LocalMethodName::new(
-        struct_name.to_string(),
-        Some("Inspect".to_string()),
-        "inspect".to_string(),
-    );
-    let qualified_name = method_info.to_mangled_name();
-
-    let params = vec![
-        TirParam {
-            name: "self".to_string(),
-            type_id: ref_struct_type,
-            local_index: 0,
-            is_mut: false,
-            span,
-            default_expr: None,
-        },
-        TirParam {
-            name: "f".to_string(),
-            type_id: fmt_type,
-            local_index: 1,
-            is_mut: false,
-            span,
-            default_expr: None,
-        },
-    ];
-
-    let self_ref = || {
-        TirExpr::new(
-            TirExprKind::Local {
-                index: 0,
-                name: "self".to_string(),
-            },
-            ref_struct_type,
-            span,
-        )
-    };
-    let fmt_local = || {
-        TirExpr::new(
-            TirExprKind::Local {
-                index: 1,
-                name: "f".to_string(),
-            },
-            fmt_type,
-            span,
-        )
-    };
-
+) -> Vec<TirStmt> {
+    let fmt = || local_expr(1, "f", fmt_type, span);
+    let write = |s: String| write_str_stmt(s, fmt(), string_type, span);
     let mut stmts = Vec::new();
 
     if fields.is_empty() {
-        if has_hidden {
-            stmts.push(write_str_stmt(
-                format!("{struct_name} {{ .. }}"),
-                fmt_local(),
-                string_type,
-                span,
-            ));
-        } else {
-            stmts.push(write_str_stmt(
-                format!("{struct_name} {{}}"),
-                fmt_local(),
-                string_type,
-                span,
-            ));
+        let suffix = if has_hidden { " { .. }" } else { " {}" };
+        stmts.push(write(format!("{struct_name}{suffix}")));
+        return stmts;
+    }
+
+    stmts.push(write(format!("{struct_name} {{ ")));
+    for (i, (field_name, field_type, field_index)) in fields.iter().enumerate() {
+        if i > 0 {
+            stmts.push(write(", ".to_string()));
         }
-    } else {
-        stmts.push(write_str_stmt(
-            format!("{struct_name} {{ "),
-            fmt_local(),
-            string_type,
+        stmts.push(write(format!("{field_name}: ")));
+        let field_access = field_access_local(
+            0,
+            "self",
+            ref_struct_type,
+            *field_index,
+            field_name,
+            *field_type,
             span,
-        ));
-        for (i, (field_name, field_type, field_index)) in fields.iter().enumerate() {
-            if i > 0 {
-                stmts.push(write_str_stmt(
-                    ", ".to_string(),
-                    fmt_local(),
-                    string_type,
-                    span,
-                ));
-            }
-            stmts.push(write_str_stmt(
-                format!("{field_name}: "),
-                fmt_local(),
-                string_type,
-                span,
-            ));
-            let field_access = TirExpr::new(
-                TirExprKind::FieldAccess {
-                    expr: Box::new(self_ref()),
-                    field_index: *field_index,
-                    field_name: field_name.clone(),
-                },
-                *field_type,
-                span,
-            );
-            stmts.push(inspect_call(
-                field_access,
-                *field_type,
-                fmt_local(),
-                module_source,
-                tt,
-                span,
-            ));
-        }
-        if has_hidden {
-            stmts.push(write_str_stmt(
-                ", ..".to_string(),
-                fmt_local(),
-                string_type,
-                span,
-            ));
-        }
-        stmts.push(write_str_stmt(
-            " }".to_string(),
-            fmt_local(),
-            string_type,
+        );
+        stmts.push(inspect_call(
+            field_access,
+            *field_type,
+            fmt(),
+            module_source,
+            tt,
             span,
         ));
     }
-
-    let body = TirBlock::new(stmts, span);
-
-    // impl_type_params: same as the struct's type_params
-    // The monomorphizer uses these to specialize the function
-    let impl_type_params: Vec<TirTypeParam> = type_params.to_vec();
-
-    let local_count = 2;
-    TirFunction {
-        module_source: ModuleSource::default(),
-        name: qualified_name,
-        is_pub: true,
-        is_export: false,
-        is_async: false,
-        type_params: Vec::new(),
-        impl_type_params,
-        monomorph_info: None,
-        method_info: Some(method_info),
-        params,
-        return_type: TypeTable::UNIT,
-        task_return_type: None,
-        effects: Vec::new(),
-        stores: vec![],
-        body: Some(body),
-        span,
-        local_count,
-        locals: vec![
-            param_local("self", ref_struct_type, false),
-            param_local("f", fmt_type, false),
-        ],
-        address_taken_locals: IndexSet::default(),
-        stores_aliased_locals: IndexSet::default(),
-        is_cm_binding: false,
-        is_dispatch_wrapper: false,
-        is_cm_export: false,
-        is_ambient: false,
-        inline_hint: InlineHint::Auto,
-        comp_features: 0,
-        export_name: None,
-        allocator_tag: None,
-        kind: FunctionKind::Regular,
+    if has_hidden {
+        stmts.push(write(", ..".to_string()));
     }
+    stmts.push(write(" }".to_string()));
+    stmts
 }
 
-/// Generate `VariantName^Inspect::inspect(&self, &mut Formatter)` for non-generic variants.
+/// Generate `VariantName^Inspect::inspect(&self, &mut Formatter)`.
 ///
 /// Body: `VariantTest` dispatch with type-qualified case names.
 /// ```text
@@ -1260,8 +1151,11 @@ fn generate_generic_struct_inspect_fn(
 /// else if variant_test(self, 1) { f.write_str("Shape::Point"); }
 /// ...
 /// ```
+///
+/// Pass an empty `impl_type_params` slice for non-generic variants.
 fn generate_variant_inspect_fn(
     variant_name: &str,
+    impl_type_params: &[TirTypeParam],
     cases: &[(String, u32, TypeId)],
     variant_type: TypeId,
     ref_variant_type: TypeId,
@@ -1271,149 +1165,38 @@ fn generate_variant_inspect_fn(
     tt: &mut TypeTable,
     span: Span,
 ) -> TirFunction {
-    let method_info = LocalMethodName::new(
-        variant_name.to_string(),
-        Some("Inspect".to_string()),
-        "inspect".to_string(),
-    );
+    let method_info = trait_method_info(variant_name, "Inspect", "inspect");
     let qualified_name = method_info.to_mangled_name();
 
-    let params = vec![
-        TirParam {
-            name: "self".to_string(),
-            type_id: ref_variant_type,
-            local_index: 0,
-            is_mut: false,
-            span,
-            default_expr: None,
-        },
-        TirParam {
-            name: "f".to_string(),
-            type_id: fmt_type,
-            local_index: 1,
-            is_mut: false,
-            span,
-            default_expr: None,
-        },
-    ];
-
-    let deref_self = || {
-        TirExpr::new(
-            TirExprKind::Unary {
-                op: TirUnaryOp::Deref,
-                expr: Box::new(TirExpr::new(
-                    TirExprKind::Local {
-                        index: 0,
-                        name: "self".to_string(),
-                    },
-                    ref_variant_type,
-                    span,
-                )),
-            },
-            variant_type,
-            span,
-        )
-    };
-    let fmt_local = || {
-        TirExpr::new(
-            TirExprKind::Local {
-                index: 1,
-                name: "f".to_string(),
-            },
-            fmt_type,
-            span,
-        )
-    };
-
-    let mut chain: Option<TirExpr> = None;
-    for (case_name, case_index, payload_type) in cases.iter().rev() {
-        let is_unit = *payload_type == TypeTable::UNIT;
-        let mut then_stmts = Vec::new();
-
-        if is_unit {
-            then_stmts.push(write_str_stmt(
-                format!("{variant_name}::{case_name}"),
-                fmt_local(),
-                string_type,
-                span,
-            ));
-        } else {
-            then_stmts.push(write_str_stmt(
-                format!("{variant_name}::{case_name}("),
-                fmt_local(),
-                string_type,
-                span,
-            ));
-            let payload = TirExpr::new(
-                TirExprKind::VariantPayload {
-                    expr: Box::new(deref_self()),
-                    case_index: *case_index,
-                    payload_type: *payload_type,
-                },
-                *payload_type,
-                span,
-            );
-            then_stmts.push(inspect_call(
-                payload,
-                *payload_type,
-                fmt_local(),
-                module_source,
-                tt,
-                span,
-            ));
-            then_stmts.push(write_str_stmt(
-                ")".to_string(),
-                fmt_local(),
-                string_type,
-                span,
-            ));
-        }
-
-        let cond = TirExpr::new(
-            TirExprKind::VariantTest {
-                expr: Box::new(deref_self()),
-                case_index: *case_index,
-                case_name: case_name.clone(),
-            },
-            TypeTable::BOOL,
-            span,
-        );
-        let if_expr = TirExpr::new(
-            TirExprKind::If {
-                condition: Box::new(cond),
-                then_branch: TirBlock::new(then_stmts, span),
-                else_branch: chain
-                    .map(|e| TirBlock::new(vec![TirStmt::new(TirStmtKind::Expr(e), span)], span)),
-            },
-            TypeTable::UNIT,
-            span,
-        );
-        chain = Some(if_expr);
-    }
-
-    let stmts = chain.map_or_else(Vec::new, |e| vec![TirStmt::new(TirStmtKind::Expr(e), span)]);
+    let stmts = build_variant_inspect_body(
+        variant_name,
+        cases,
+        variant_type,
+        ref_variant_type,
+        fmt_type,
+        string_type,
+        module_source,
+        tt,
+        span,
+    );
     let body = TirBlock::new(stmts, span);
 
-    make_synthetic_method(
+    make_trait_method(
         qualified_name,
         method_info,
-        params,
+        impl_type_params.to_vec(),
+        inspect_params(ref_variant_type, fmt_type, span),
         TypeTable::UNIT,
         body,
-        vec![
-            param_local("self", ref_variant_type, false),
-            param_local("f", fmt_type, false),
-        ],
+        inspect_locals(ref_variant_type, fmt_type),
+        span,
     )
 }
 
-/// Generate `VariantName^Inspect::inspect(&self, &mut Formatter)` for generic variants.
-///
-/// Same structure as `generate_variant_inspect_fn` but with `impl_type_params` set so the
-/// monomorphizer can specialize it for each concrete instantiation (e.g. `Option<i32>`).
-fn generate_generic_variant_inspect_fn(
+/// Build the body for variant `Inspect::inspect`: an if-else chain of `VariantTest` checks
+/// that writes either `VariantName::Case` (unit cases) or `VariantName::Case(<payload>)`.
+fn build_variant_inspect_body(
     variant_name: &str,
-    type_params: &[TirTypeParam],
     cases: &[(String, u32, TypeId)],
     variant_type: TypeId,
     ref_variant_type: TypeId,
@@ -1422,80 +1205,18 @@ fn generate_generic_variant_inspect_fn(
     module_source: &ModuleSource,
     tt: &mut TypeTable,
     span: Span,
-) -> TirFunction {
-    let method_info = LocalMethodName::new(
-        variant_name.to_string(),
-        Some("Inspect".to_string()),
-        "inspect".to_string(),
-    );
-    let qualified_name = method_info.to_mangled_name();
-
-    let params = vec![
-        TirParam {
-            name: "self".to_string(),
-            type_id: ref_variant_type,
-            local_index: 0,
-            is_mut: false,
-            span,
-            default_expr: None,
-        },
-        TirParam {
-            name: "f".to_string(),
-            type_id: fmt_type,
-            local_index: 1,
-            is_mut: false,
-            span,
-            default_expr: None,
-        },
-    ];
-
-    let deref_self = || {
-        TirExpr::new(
-            TirExprKind::Unary {
-                op: TirUnaryOp::Deref,
-                expr: Box::new(TirExpr::new(
-                    TirExprKind::Local {
-                        index: 0,
-                        name: "self".to_string(),
-                    },
-                    ref_variant_type,
-                    span,
-                )),
-            },
-            variant_type,
-            span,
-        )
-    };
-    let fmt_local = || {
-        TirExpr::new(
-            TirExprKind::Local {
-                index: 1,
-                name: "f".to_string(),
-            },
-            fmt_type,
-            span,
-        )
-    };
+) -> Vec<TirStmt> {
+    let deref_self = || deref_local(0, "self", ref_variant_type, variant_type, span);
+    let fmt = || local_expr(1, "f", fmt_type, span);
+    let write = |s: String| write_str_stmt(s, fmt(), string_type, span);
 
     let mut chain: Option<TirExpr> = None;
     for (case_name, case_index, payload_type) in cases.iter().rev() {
-        let is_unit = *payload_type == TypeTable::UNIT;
         let mut then_stmts = Vec::new();
-
-        if is_unit {
-            then_stmts.push(write_str_stmt(
-                format!("{variant_name}::{case_name}"),
-                fmt_local(),
-                string_type,
-                span,
-            ));
+        if *payload_type == TypeTable::UNIT {
+            then_stmts.push(write(format!("{variant_name}::{case_name}")));
         } else {
-            then_stmts.push(write_str_stmt(
-                format!("{variant_name}::{case_name}("),
-                fmt_local(),
-                string_type,
-                span,
-            ));
+            then_stmts.push(write(format!("{variant_name}::{case_name}(")));
             let payload = TirExpr::new(
                 TirExprKind::VariantPayload {
                     expr: Box::new(deref_self()),
@@ -1508,17 +1229,12 @@ fn generate_generic_variant_inspect_fn(
             then_stmts.push(inspect_call(
                 payload,
                 *payload_type,
-                fmt_local(),
+                fmt(),
                 module_source,
                 tt,
                 span,
             ));
-            then_stmts.push(write_str_stmt(
-                ")".to_string(),
-                fmt_local(),
-                string_type,
-                span,
-            ));
+            then_stmts.push(write(")".to_string()));
         }
 
         let cond = TirExpr::new(
@@ -1543,43 +1259,7 @@ fn generate_generic_variant_inspect_fn(
         chain = Some(if_expr);
     }
 
-    let stmts = chain.map_or_else(Vec::new, |e| vec![TirStmt::new(TirStmtKind::Expr(e), span)]);
-    let body = TirBlock::new(stmts, span);
-
-    TirFunction {
-        module_source: ModuleSource::default(),
-        name: qualified_name,
-        is_pub: true,
-        is_export: false,
-        is_async: false,
-        type_params: Vec::new(),
-        impl_type_params: type_params.to_vec(),
-        monomorph_info: None,
-        method_info: Some(method_info),
-        params,
-        return_type: TypeTable::UNIT,
-        task_return_type: None,
-        effects: Vec::new(),
-        stores: vec![],
-        body: Some(body),
-        span,
-        local_count: 2,
-        locals: vec![
-            param_local("self", ref_variant_type, false),
-            param_local("f", fmt_type, false),
-        ],
-        address_taken_locals: IndexSet::default(),
-        stores_aliased_locals: IndexSet::default(),
-        is_cm_binding: false,
-        is_dispatch_wrapper: false,
-        is_cm_export: false,
-        is_ambient: false,
-        inline_hint: InlineHint::Auto,
-        comp_features: 0,
-        export_name: None,
-        allocator_tag: None,
-        kind: FunctionKind::Regular,
-    }
+    chain.map_or_else(Vec::new, |e| vec![TirStmt::new(TirStmtKind::Expr(e), span)])
 }
 
 /// Generate `NewtypeName^Inspect::inspect(&self, &mut Formatter)` for a newtype.
@@ -1597,65 +1277,25 @@ fn generate_newtype_inspect_fn(
     tt: &mut TypeTable,
     span: Span,
 ) -> TirFunction {
-    let method_info = LocalMethodName::new(
-        newtype_name.to_string(),
-        Some("Inspect".to_string()),
-        "inspect".to_string(),
-    );
+    let method_info = trait_method_info(newtype_name, "Inspect", "inspect");
     let qualified_name = method_info.to_mangled_name();
 
-    let deref_self = || {
-        deref_expr(
-            TirExpr::new(
-                TirExprKind::Local {
-                    index: 0,
-                    name: "self".to_string(),
-                },
-                ref_newtype_type,
-                span,
-            ),
-            newtype_type,
-            span,
-        )
-    };
-    let fmt_local = || {
-        TirExpr::new(
-            TirExprKind::Local {
-                index: 1,
-                name: "f".to_string(),
-            },
-            fmt_type,
-            span,
-        )
-    };
+    let deref_self = deref_local(0, "self", ref_newtype_type, newtype_type, span);
+    let fmt = || local_expr(1, "f", fmt_type, span);
 
-    // Cast to base type
     let cast_to_base = TirExpr::new(
         TirExprKind::Cast {
-            expr: Box::new(deref_self()),
+            expr: Box::new(deref_self),
             target_type: base_type,
         },
         base_type,
         span,
     );
 
-    let mut stmts = Vec::new();
-    // Inspect the base value
-    stmts.push(inspect_call(
-        cast_to_base,
-        base_type,
-        fmt_local(),
-        module_source,
-        tt,
-        span,
-    ));
-    // Write " as NewtypeName"
-    stmts.push(write_str_stmt(
-        format!(" as {newtype_name}"),
-        fmt_local(),
-        string_type,
-        span,
-    ));
+    let stmts = vec![
+        inspect_call(cast_to_base, base_type, fmt(), module_source, tt, span),
+        write_str_stmt(format!(" as {newtype_name}"), fmt(), string_type, span),
+    ];
 
     make_synthetic_method(
         qualified_name,
@@ -1663,10 +1303,7 @@ fn generate_newtype_inspect_fn(
         inspect_params(ref_newtype_type, fmt_type, span),
         TypeTable::UNIT,
         TirBlock::new(stmts, span),
-        vec![
-            param_local("self", ref_newtype_type, false),
-            param_local("f", fmt_type, false),
-        ],
+        inspect_locals(ref_newtype_type, fmt_type),
     )
 }
 
@@ -1683,51 +1320,21 @@ fn generate_flags_inspect_fn(
     string_type: TypeId,
     span: &Span,
 ) -> TirFunction {
-    let method_info = LocalMethodName::new(
-        flags_name.to_string(),
-        Some("Inspect".to_string()),
-        "inspect".to_string(),
-    );
+    let method_info = trait_method_info(flags_name, "Inspect", "inspect");
     let qualified_name = method_info.to_mangled_name();
 
-    let deref_self = || {
-        TirExpr::new(
-            TirExprKind::Unary {
-                op: TirUnaryOp::Deref,
-                expr: Box::new(TirExpr::new(
-                    TirExprKind::Local {
-                        index: 0,
-                        name: "self".to_string(),
-                    },
-                    ref_flags_type,
-                    *span,
-                )),
-            },
-            flags_type,
-            *span,
-        )
-    };
-    // Cast deref'd flags value to u32 for bit operations
+    // Cast deref'd flags value to u32 for bit operations.
     let self_as_u32 = || {
         TirExpr::new(
             TirExprKind::Cast {
-                expr: Box::new(deref_self()),
+                expr: Box::new(deref_local(0, "self", ref_flags_type, flags_type, *span)),
                 target_type: TypeTable::U32,
             },
             TypeTable::U32,
             *span,
         )
     };
-    let fmt_local = || {
-        TirExpr::new(
-            TirExprKind::Local {
-                index: 1,
-                name: "f".to_string(),
-            },
-            fmt_type,
-            *span,
-        )
-    };
+    let fmt_local = || local_expr(1, "f", fmt_type, *span);
 
     let mut stmts = Vec::new();
 
@@ -1881,10 +1488,7 @@ fn generate_flags_inspect_fn(
         inspect_params(ref_flags_type, fmt_type, *span),
         TypeTable::UNIT,
         body,
-        vec![
-            param_local("self", ref_flags_type, false),
-            param_local("f", fmt_type, false),
-        ],
+        inspect_locals(ref_flags_type, fmt_type),
     )
 }
 
@@ -1902,21 +1506,16 @@ fn generate_fn_inspect_fn(
     tt: &mut TypeTable,
     span: Span,
 ) -> TirFunction {
-    let method_info = LocalMethodName::new(
-        "Fn".to_string(),
-        Some("Inspect".to_string()),
-        "inspect".to_string(),
-    )
-    .with_struct_type_args(type_arg_names);
+    let method_info =
+        trait_method_info("Fn", "Inspect", "inspect").with_struct_type_args(type_arg_names);
     let qualified_name = method_info.to_mangled_name();
 
-    // Build the signature string at compile time: "|i32, String| -> bool"
     let param_names: Vec<String> = param_types.iter().map(|t| tt.type_name(*t)).collect();
     let ret_name = tt.type_name(return_type);
     let sig = format!("|{}| -> {}", param_names.join(", "), ret_name);
 
-    let fmt = || local_expr(1, "f", fmt_type, span);
-    let body = TirBlock::new(vec![write_str_stmt(sig, fmt(), string_type, span)], span);
+    let fmt = local_expr(1, "f", fmt_type, span);
+    let body = TirBlock::new(vec![write_str_stmt(sig, fmt, string_type, span)], span);
 
     make_synthetic_method(
         qualified_name,
@@ -1924,10 +1523,7 @@ fn generate_fn_inspect_fn(
         inspect_params(ref_fn_type, fmt_type, span),
         TypeTable::UNIT,
         body,
-        vec![
-            param_local("self", ref_fn_type, false),
-            param_local("f", fmt_type, false),
-        ],
+        inspect_locals(ref_fn_type, fmt_type),
     )
 }
 
@@ -1943,19 +1539,15 @@ fn generate_opaque_inspect_fn(
     string_type: TypeId,
     span: Span,
 ) -> TirFunction {
-    let method_info = LocalMethodName::new(
-        base_name.to_string(),
-        Some("Inspect".to_string()),
-        "inspect".to_string(),
-    )
-    .with_struct_type_args(type_arg_names);
+    let method_info =
+        trait_method_info(base_name, "Inspect", "inspect").with_struct_type_args(type_arg_names);
     let qualified_name = method_info.to_mangled_name();
 
-    let fmt = || local_expr(1, "f", fmt_type, span);
+    let fmt = local_expr(1, "f", fmt_type, span);
     let body = TirBlock::new(
         vec![write_str_stmt(
             type_name.to_string(),
-            fmt(),
+            fmt,
             string_type,
             span,
         )],
@@ -1968,48 +1560,9 @@ fn generate_opaque_inspect_fn(
         inspect_params(ref_type, fmt_type, span),
         TypeTable::UNIT,
         body,
-        vec![
-            param_local("self", ref_type, false),
-            param_local("f", fmt_type, false),
-        ],
+        inspect_locals(ref_type, fmt_type),
     )
 }
-
-/// Standard parameters for `Inspect::inspect` and `Display::fmt`.
-fn inspect_params(ref_type: TypeId, fmt_type: TypeId, span: Span) -> Vec<TirParam> {
-    vec![
-        TirParam {
-            name: "self".to_string(),
-            type_id: ref_type,
-            local_index: 0,
-            is_mut: false,
-            span,
-            default_expr: None,
-        },
-        TirParam {
-            name: "f".to_string(),
-            type_id: fmt_type,
-            local_index: 1,
-            is_mut: false,
-            span,
-            default_expr: None,
-        },
-    ]
-}
-
-/// Create a local variable reference expression.
-fn local_expr(index: u32, name: &str, type_id: TypeId, span: Span) -> TirExpr {
-    TirExpr::new(
-        TirExprKind::Local {
-            index,
-            name: name.to_string(),
-        },
-        type_id,
-        span,
-    )
-}
-
-// ─── InspectAlt synthesis ───
 
 /// Generate auto-derived `InspectAlt` trait implementations for all types in a module.
 ///
@@ -2052,15 +1605,9 @@ fn generate_inspect_alt_impls(module: &mut TirModule) {
         }
         let enum_type = tt.make_enum(name.clone(), module_source.clone());
         let ref_type = tt.make_ref(enum_type);
-        let di = LocalMethodName::new(
-            name.clone(),
-            Some("InspectAlt".to_string()),
-            "inspect_alt".to_string(),
-        );
-        let ii = LocalMethodName::new(name, Some("Inspect".to_string()), "inspect".to_string());
         generated.push(Rc::new(RefCell::new(generate_display_fallback(
-            di,
-            ii,
+            trait_method_info(&name, "InspectAlt", "inspect_alt"),
+            trait_method_info(&name, "Inspect", "inspect"),
             ref_type,
             fmt_type,
             &module_source,
@@ -2083,6 +1630,7 @@ fn generate_inspect_alt_impls(module: &mut TirModule) {
         let ref_type = tt.make_ref(struct_type);
         generated.push(Rc::new(RefCell::new(generate_struct_inspect_alt_fn(
             name,
+            &[],
             fields,
             *has_hidden,
             ref_type,
@@ -2094,9 +1642,7 @@ fn generate_inspect_alt_impls(module: &mut TirModule) {
         ))));
     }
 
-    // Generic structs — pretty-print with impl_type_params
     let generic_struct_infos = collect_generic_struct_visible_fields(module);
-
     for (name, type_params, fields, has_hidden, sspan) in &generic_struct_infos {
         if has_existing_impl(&existing, name, "InspectAlt", "inspect_alt") {
             continue;
@@ -2105,25 +1651,21 @@ fn generate_inspect_alt_impls(module: &mut TirModule) {
         let struct_type =
             tt.make_generic_instance(name.clone(), module_source.clone(), type_param_ids);
         let ref_type = tt.make_ref(struct_type);
-        generated.push(Rc::new(RefCell::new(
-            generate_generic_struct_inspect_alt_fn(
-                name,
-                type_params,
-                fields,
-                *has_hidden,
-                ref_type,
-                fmt_type,
-                string_type,
-                &module_source,
-                &mut tt,
-                *sspan,
-            ),
-        )));
+        generated.push(Rc::new(RefCell::new(generate_struct_inspect_alt_fn(
+            name,
+            type_params,
+            fields,
+            *has_hidden,
+            ref_type,
+            fmt_type,
+            string_type,
+            &module_source,
+            &mut tt,
+            *sspan,
+        ))));
     }
 
-    // Non-generic variants — pretty-print
     let variant_infos = collect_variant_cases(module);
-
     for (name, cases, vspan) in &variant_infos {
         if has_existing_impl(&existing, name, "InspectAlt", "inspect_alt") {
             continue;
@@ -2132,6 +1674,7 @@ fn generate_inspect_alt_impls(module: &mut TirModule) {
         let ref_type = tt.make_ref(variant_type);
         generated.push(Rc::new(RefCell::new(generate_variant_inspect_alt_fn(
             name,
+            &[],
             cases,
             variant_type,
             ref_type,
@@ -2143,9 +1686,7 @@ fn generate_inspect_alt_impls(module: &mut TirModule) {
         ))));
     }
 
-    // Generic variants — pretty-print
     let generic_variant_infos = collect_generic_variant_cases(module);
-
     for (name, type_params, cases, vspan) in &generic_variant_infos {
         if has_existing_impl(&existing, name, "InspectAlt", "inspect_alt") {
             continue;
@@ -2154,20 +1695,18 @@ fn generate_inspect_alt_impls(module: &mut TirModule) {
         let variant_type =
             tt.make_generic_instance(name.clone(), module_source.clone(), type_param_ids);
         let ref_type = tt.make_ref(variant_type);
-        generated.push(Rc::new(RefCell::new(
-            generate_generic_variant_inspect_alt_fn(
-                name,
-                type_params,
-                cases,
-                variant_type,
-                ref_type,
-                fmt_type,
-                string_type,
-                &module_source,
-                &mut tt,
-                *vspan,
-            ),
-        )));
+        generated.push(Rc::new(RefCell::new(generate_variant_inspect_alt_fn(
+            name,
+            type_params,
+            cases,
+            variant_type,
+            ref_type,
+            fmt_type,
+            string_type,
+            &module_source,
+            &mut tt,
+            *vspan,
+        ))));
     }
 
     // Flags — delegate to Inspect (bit flags don't need pretty print)
@@ -2184,19 +1723,9 @@ fn generate_inspect_alt_impls(module: &mut TirModule) {
             continue;
         }
         let ref_type = tt.make_ref(*flags_type_id);
-        let di = LocalMethodName::new(
-            name.clone(),
-            Some("InspectAlt".to_string()),
-            "inspect_alt".to_string(),
-        );
-        let ii = LocalMethodName::new(
-            name.clone(),
-            Some("Inspect".to_string()),
-            "inspect".to_string(),
-        );
         generated.push(Rc::new(RefCell::new(generate_display_fallback(
-            di,
-            ii,
+            trait_method_info(name, "InspectAlt", "inspect_alt"),
+            trait_method_info(name, "Inspect", "inspect"),
             ref_type,
             fmt_type,
             &module_source,
@@ -2205,7 +1734,6 @@ fn generate_inspect_alt_impls(module: &mut TirModule) {
         ))));
     }
 
-    // Newtypes — delegate to Inspect
     for nt in &module.newtypes {
         if module.flags.iter().any(|f| f.type_id == nt.type_id) {
             continue;
@@ -2220,19 +1748,9 @@ fn generate_inspect_alt_impls(module: &mut TirModule) {
             continue;
         }
         let ref_type = tt.make_ref(nt.type_id);
-        let di = LocalMethodName::new(
-            nt.name.clone(),
-            Some("InspectAlt".to_string()),
-            "inspect_alt".to_string(),
-        );
-        let ii = LocalMethodName::new(
-            nt.name.clone(),
-            Some("Inspect".to_string()),
-            "inspect".to_string(),
-        );
         generated.push(Rc::new(RefCell::new(generate_display_fallback(
-            di,
-            ii,
+            trait_method_info(&nt.name, "InspectAlt", "inspect_alt"),
+            trait_method_info(&nt.name, "Inspect", "inspect"),
             ref_type,
             fmt_type,
             &module_source,
@@ -2241,7 +1759,9 @@ fn generate_inspect_alt_impls(module: &mut TirModule) {
         ))));
     }
 
-    // Parameterized types (tuples, function types)
+    // Tuples are skipped — their `InspectAlt` is provided by the variadic impl
+    // in `core:prelude/tuple.wado`. Function types and opaque types delegate
+    // to their `Inspect` counterpart.
     for (type_id, base_name, type_arg_names) in collect_parameterized_types(&tt) {
         let mangled = format_parameterized_name(&base_name, &type_arg_names);
         let alt_key = format!("{mangled}^InspectAlt::inspect_alt");
@@ -2249,35 +1769,23 @@ fn generate_inspect_alt_impls(module: &mut TirModule) {
         if existing.contains(&alt_key) || !has_inspect(&inspect_key) {
             continue;
         }
-        let ref_type = tt.make_ref(type_id);
         let resolved = tt.get(type_id).clone();
         if matches!(resolved, ResolvedType::GenericInstance { ref name, ref module_source, .. } if TypeTable::is_tuple_type(name, module_source))
         {
-            // Tuple InspectAlt is provided by variadic impl in core:prelude/tuple.wado
-        } else {
-            // Function types, opaque types: delegate to Inspect
-            let di = LocalMethodName::new(
-                base_name.clone(),
-                Some("InspectAlt".to_string()),
-                "inspect_alt".to_string(),
-            )
-            .with_struct_type_args(&type_arg_names);
-            let ii = LocalMethodName::new(
-                base_name,
-                Some("Inspect".to_string()),
-                "inspect".to_string(),
-            )
-            .with_struct_type_args(&type_arg_names);
-            generated.push(Rc::new(RefCell::new(generate_display_fallback(
-                di,
-                ii,
-                ref_type,
-                fmt_type,
-                &module_source,
-                vec![],
-                span,
-            ))));
+            continue;
         }
+        let ref_type = tt.make_ref(type_id);
+        generated.push(Rc::new(RefCell::new(generate_display_fallback(
+            trait_method_info(&base_name, "InspectAlt", "inspect_alt")
+                .with_struct_type_args(&type_arg_names),
+            trait_method_info(&base_name, "Inspect", "inspect")
+                .with_struct_type_args(&type_arg_names),
+            ref_type,
+            fmt_type,
+            &module_source,
+            vec![],
+            span,
+        ))));
     }
 
     drop(tt);
@@ -2293,8 +1801,10 @@ fn generate_inspect_alt_impls(module: &mut TirModule) {
 /// f.write_indent(); f.write_str("field2: "); self.field2.inspect_alt(f); f.write_str(",\n");
 /// f.end_block("}");
 /// ```
+/// Pass an empty `impl_type_params` slice for non-generic structs.
 fn generate_struct_inspect_alt_fn(
     struct_name: &str,
+    impl_type_params: &[TirTypeParam],
     fields: &[(String, TypeId, u32)],
     has_hidden: bool,
     ref_struct_type: TypeId,
@@ -2304,211 +1814,117 @@ fn generate_struct_inspect_alt_fn(
     tt: &mut TypeTable,
     span: Span,
 ) -> TirFunction {
-    let method_info = LocalMethodName::new(
-        struct_name.to_string(),
-        Some("InspectAlt".to_string()),
-        "inspect_alt".to_string(),
-    );
+    let method_info = trait_method_info(struct_name, "InspectAlt", "inspect_alt");
     let qualified_name = method_info.to_mangled_name();
-
-    let self_ref = || local_expr(0, "self", ref_struct_type, span);
-    let fmt_local = || local_expr(1, "f", fmt_type, span);
 
     let stmts = build_struct_inspect_alt_body(
         struct_name,
         fields,
         has_hidden,
-        self_ref,
-        fmt_local,
+        ref_struct_type,
+        fmt_type,
         string_type,
         module_source,
         tt,
         span,
     );
-
     let body = TirBlock::new(stmts, span);
-    make_synthetic_method(
+
+    make_trait_method(
         qualified_name,
         method_info,
+        impl_type_params.to_vec(),
         inspect_params(ref_struct_type, fmt_type, span),
         TypeTable::UNIT,
         body,
-        vec![
-            param_local("self", ref_struct_type, false),
-            param_local("f", fmt_type, false),
-        ],
+        inspect_locals(ref_struct_type, fmt_type),
+        span,
     )
 }
 
-/// Generate `StructName^InspectAlt::inspect_alt` for generic structs (pretty-print).
-fn generate_generic_struct_inspect_alt_fn(
-    struct_name: &str,
-    type_params: &[TirTypeParam],
-    fields: &[(String, TypeId, u32)],
-    has_hidden: bool,
-    ref_struct_type: TypeId,
-    fmt_type: TypeId,
-    string_type: TypeId,
-    module_source: &ModuleSource,
-    tt: &mut TypeTable,
-    span: Span,
-) -> TirFunction {
-    let method_info = LocalMethodName::new(
-        struct_name.to_string(),
-        Some("InspectAlt".to_string()),
-        "inspect_alt".to_string(),
-    );
-    let qualified_name = method_info.to_mangled_name();
-
-    let self_ref = || local_expr(0, "self", ref_struct_type, span);
-    let fmt_local = || local_expr(1, "f", fmt_type, span);
-
-    let stmts = build_struct_inspect_alt_body(
-        struct_name,
-        fields,
-        has_hidden,
-        self_ref,
-        fmt_local,
-        string_type,
-        module_source,
-        tt,
-        span,
-    );
-
-    let body = TirBlock::new(stmts, span);
-    let impl_type_params: Vec<TirTypeParam> = type_params.to_vec();
-
-    TirFunction {
-        module_source: ModuleSource::default(),
-        name: qualified_name,
-        is_pub: true,
-        is_export: false,
-        is_async: false,
-        type_params: Vec::new(),
-        impl_type_params,
-        monomorph_info: None,
-        method_info: Some(method_info),
-        params: inspect_params(ref_struct_type, fmt_type, span),
-        return_type: TypeTable::UNIT,
-        task_return_type: None,
-        effects: Vec::new(),
-        stores: vec![],
-        body: Some(body),
-        span,
-        local_count: 2,
-        locals: vec![
-            param_local("self", ref_struct_type, false),
-            param_local("f", fmt_type, false),
-        ],
-        address_taken_locals: IndexSet::default(),
-        stores_aliased_locals: IndexSet::default(),
-        is_cm_binding: false,
-        is_dispatch_wrapper: false,
-        is_cm_export: false,
-        is_ambient: false,
-        inline_hint: InlineHint::Auto,
-        comp_features: 0,
-        export_name: None,
-        allocator_tag: None,
-        kind: FunctionKind::Regular,
-    }
-}
-
-/// Build the body statements for struct `InspectAlt` (shared between generic and non-generic).
+/// Build the body statements for struct `InspectAlt`: pretty-printed multi-line output
+/// using `Formatter::open_brace`/`close_brace`/`write_newline_indent`.
 fn build_struct_inspect_alt_body(
     struct_name: &str,
     fields: &[(String, TypeId, u32)],
     has_hidden: bool,
-    self_ref: impl Fn() -> TirExpr,
-    fmt_local: impl Fn() -> TirExpr,
+    ref_struct_type: TypeId,
+    fmt_type: TypeId,
     string_type: TypeId,
     module_source: &ModuleSource,
     tt: &mut TypeTable,
     span: Span,
 ) -> Vec<TirStmt> {
+    let fmt = || local_expr(1, "f", fmt_type, span);
+    let write = |s: &str| write_str_stmt(s.to_string(), fmt(), string_type, span);
+    let newline_indent =
+        || formatter_call("write_newline_indent", fmt(), None::<(&str, TypeId)>, span);
+
     let mut stmts = Vec::new();
 
     if fields.is_empty() {
-        if has_hidden {
-            stmts.push(write_str_stmt(
-                format!("{struct_name} {{ .. }}"),
-                fmt_local(),
-                string_type,
-                span,
-            ));
-        } else {
-            stmts.push(write_str_stmt(
-                format!("{struct_name} {{}}"),
-                fmt_local(),
-                string_type,
-                span,
-            ));
-        }
-    } else {
-        // f.begin_block("StructName {")
-        stmts.push(formatter_call(
-            "open_brace",
-            fmt_local(),
-            Some((format!("{struct_name} {{"), string_type)),
+        let suffix = if has_hidden { " { .. }" } else { " {}" };
+        stmts.push(write_str_stmt(
+            format!("{struct_name}{suffix}"),
+            fmt(),
+            string_type,
             span,
         ));
-        for (field_name, field_type, field_index) in fields {
-            // f.write_newline_indent()
-            stmts.push(formatter_call(
-                "write_newline_indent",
-                fmt_local(),
-                None::<(&str, TypeId)>,
-                span,
-            ));
-            stmts.push(write_str_stmt(
-                format!("{field_name}: "),
-                fmt_local(),
-                string_type,
-                span,
-            ));
-            let field_access = TirExpr::new(
-                TirExprKind::FieldAccess {
-                    expr: Box::new(self_ref()),
-                    field_index: *field_index,
-                    field_name: field_name.clone(),
-                },
-                *field_type,
-                span,
-            );
-            stmts.push(inspect_alt_call(
-                field_access,
-                *field_type,
-                fmt_local(),
-                module_source,
-                tt,
-                span,
-            ));
-            stmts.push(write_str_stmt(",", fmt_local(), string_type, span));
-        }
-        if has_hidden {
-            stmts.push(formatter_call(
-                "write_newline_indent",
-                fmt_local(),
-                None::<(&str, TypeId)>,
-                span,
-            ));
-            stmts.push(write_str_stmt("..", fmt_local(), string_type, span));
-        }
-        // f.end_block("}")
-        stmts.push(formatter_call(
-            "close_brace",
-            fmt_local(),
-            Some(("}", string_type)),
-            span,
-        ));
+        return stmts;
     }
 
+    stmts.push(formatter_call(
+        "open_brace",
+        fmt(),
+        Some((format!("{struct_name} {{"), string_type)),
+        span,
+    ));
+    for (field_name, field_type, field_index) in fields {
+        stmts.push(newline_indent());
+        stmts.push(write_str_stmt(
+            format!("{field_name}: "),
+            fmt(),
+            string_type,
+            span,
+        ));
+        let field_access = field_access_local(
+            0,
+            "self",
+            ref_struct_type,
+            *field_index,
+            field_name,
+            *field_type,
+            span,
+        );
+        stmts.push(inspect_alt_call(
+            field_access,
+            *field_type,
+            fmt(),
+            module_source,
+            tt,
+            span,
+        ));
+        stmts.push(write(","));
+    }
+    if has_hidden {
+        stmts.push(newline_indent());
+        stmts.push(write(".."));
+    }
+    stmts.push(formatter_call(
+        "close_brace",
+        fmt(),
+        Some(("}", string_type)),
+        span,
+    ));
     stmts
 }
 
-/// Generate `VariantName^InspectAlt::inspect_alt` for non-generic variants (pretty-print).
+/// Generate `VariantName^InspectAlt::inspect_alt`.
+///
+/// Pass an empty `impl_type_params` slice for non-generic variants.
 fn generate_variant_inspect_alt_fn(
     variant_name: &str,
+    impl_type_params: &[TirTypeParam],
     cases: &[(String, u32, TypeId)],
     variant_type: TypeId,
     ref_variant_type: TypeId,
@@ -2518,11 +1934,7 @@ fn generate_variant_inspect_alt_fn(
     tt: &mut TypeTable,
     span: Span,
 ) -> TirFunction {
-    let method_info = LocalMethodName::new(
-        variant_name.to_string(),
-        Some("InspectAlt".to_string()),
-        "inspect_alt".to_string(),
-    );
+    let method_info = trait_method_info(variant_name, "InspectAlt", "inspect_alt");
     let qualified_name = method_info.to_mangled_name();
 
     let stmts = build_variant_inspect_alt_body(
@@ -2536,88 +1948,18 @@ fn generate_variant_inspect_alt_fn(
         tt,
         span,
     );
-
     let body = TirBlock::new(stmts, span);
-    make_synthetic_method(
+
+    make_trait_method(
         qualified_name,
         method_info,
+        impl_type_params.to_vec(),
         inspect_params(ref_variant_type, fmt_type, span),
         TypeTable::UNIT,
         body,
-        vec![
-            param_local("self", ref_variant_type, false),
-            param_local("f", fmt_type, false),
-        ],
+        inspect_locals(ref_variant_type, fmt_type),
+        span,
     )
-}
-
-/// Generate `VariantName^InspectAlt::inspect_alt` for generic variants (pretty-print).
-fn generate_generic_variant_inspect_alt_fn(
-    variant_name: &str,
-    type_params: &[TirTypeParam],
-    cases: &[(String, u32, TypeId)],
-    variant_type: TypeId,
-    ref_variant_type: TypeId,
-    fmt_type: TypeId,
-    string_type: TypeId,
-    module_source: &ModuleSource,
-    tt: &mut TypeTable,
-    span: Span,
-) -> TirFunction {
-    let method_info = LocalMethodName::new(
-        variant_name.to_string(),
-        Some("InspectAlt".to_string()),
-        "inspect_alt".to_string(),
-    );
-    let qualified_name = method_info.to_mangled_name();
-
-    let stmts = build_variant_inspect_alt_body(
-        variant_name,
-        cases,
-        variant_type,
-        ref_variant_type,
-        fmt_type,
-        string_type,
-        module_source,
-        tt,
-        span,
-    );
-
-    let body = TirBlock::new(stmts, span);
-    TirFunction {
-        module_source: ModuleSource::default(),
-        name: qualified_name,
-        is_pub: true,
-        is_export: false,
-        is_async: false,
-        type_params: Vec::new(),
-        impl_type_params: type_params.to_vec(),
-        monomorph_info: None,
-        method_info: Some(method_info),
-        params: inspect_params(ref_variant_type, fmt_type, span),
-        return_type: TypeTable::UNIT,
-        task_return_type: None,
-        effects: Vec::new(),
-        stores: vec![],
-        body: Some(body),
-        span,
-        local_count: 2,
-        locals: vec![
-            param_local("self", ref_variant_type, false),
-            param_local("f", fmt_type, false),
-        ],
-        address_taken_locals: IndexSet::default(),
-        stores_aliased_locals: IndexSet::default(),
-        is_cm_binding: false,
-        is_dispatch_wrapper: false,
-        is_cm_export: false,
-        is_ambient: false,
-        inline_hint: InlineHint::Auto,
-        comp_features: 0,
-        export_name: None,
-        allocator_tag: None,
-        kind: FunctionKind::Regular,
-    }
 }
 
 /// Build the body for variant `InspectAlt` (shared between generic and non-generic).
@@ -2781,323 +2123,14 @@ fn formatter_call(
     TirStmt::new(TirStmtKind::Expr(call), span)
 }
 
-// ─── Display fallback synthesis ───
-
-/// Generate `Display::fmt` fallback implementations for types without a user-provided Display impl.
+/// Generate `Display::fmt` fallback implementations for types without a user-provided
+/// Display impl. The fallback delegates to `Inspect::inspect`:
 ///
-/// The fallback simply delegates to `Inspect::inspect`:
 /// ```text
 /// fn fmt(&self, f: &mut Formatter) { self.inspect(f); }
 /// ```
 fn generate_display_fallback_impls(module: &mut TirModule) {
-    let module_source = module.module_source.clone();
-    let existing = collect_existing_trait_methods(module);
-    let all_fn_names: IndexSet<String> = module
-        .functions
-        .iter()
-        .filter_map(|f| f.try_borrow().ok().map(|func| func.name.clone()))
-        .collect();
-    let mut generated = Vec::new();
-
-    let span = synth_span();
-    let mut tt = module.type_table.borrow_mut();
-    let formatter_type = tt.make_struct("Formatter".to_string(), ModuleSource::format());
-    let fmt_type = tt.make_mut_ref(formatter_type);
-
-    // Helper: make Display/Inspect LocalMethodName pairs for a simple type
-    let simple_pair = |name: &str| -> (LocalMethodName, LocalMethodName) {
-        (
-            LocalMethodName::new(
-                name.to_string(),
-                Some("Display".to_string()),
-                "fmt".to_string(),
-            ),
-            LocalMethodName::new(
-                name.to_string(),
-                Some("Inspect".to_string()),
-                "inspect".to_string(),
-            ),
-        )
-    };
-
-    // Enums
-    for name in module
-        .enums
-        .iter()
-        .map(|e| e.name.clone())
-        .collect::<Vec<_>>()
-    {
-        if !should_generate_fallback(
-            &existing,
-            &all_fn_names,
-            &name,
-            "Display",
-            "fmt",
-            "Inspect",
-            "inspect",
-        ) {
-            continue;
-        }
-        let enum_type = tt.make_enum(name.clone(), module_source.clone());
-        let ref_type = tt.make_ref(enum_type);
-        let (di, ii) = simple_pair(&name);
-        generated.push(Rc::new(RefCell::new(generate_display_fallback(
-            di,
-            ii,
-            ref_type,
-            fmt_type,
-            &module_source,
-            vec![],
-            span,
-        ))));
-    }
-
-    // Non-generic structs
-    for name in module
-        .structs
-        .iter()
-        .filter(|s| s.type_params.is_empty() && s.monomorph_info.is_none())
-        .map(|s| s.name.clone())
-        .collect::<Vec<_>>()
-    {
-        if name == "String" || name == "Formatter" {
-            continue;
-        }
-        if !should_generate_fallback(
-            &existing,
-            &all_fn_names,
-            &name,
-            "Display",
-            "fmt",
-            "Inspect",
-            "inspect",
-        ) {
-            continue;
-        }
-        let struct_type = tt.make_struct(name.clone(), module_source.clone());
-        let ref_type = tt.make_ref(struct_type);
-        let (di, ii) = simple_pair(&name);
-        generated.push(Rc::new(RefCell::new(generate_display_fallback(
-            di,
-            ii,
-            ref_type,
-            fmt_type,
-            &module_source,
-            vec![],
-            span,
-        ))));
-    }
-
-    // Generic structs
-    for (name, type_params) in module
-        .structs
-        .iter()
-        .filter(|s| !s.type_params.is_empty() && s.monomorph_info.is_none())
-        .map(|s| (s.name.clone(), s.type_params.clone()))
-        .collect::<Vec<_>>()
-    {
-        if name == "Array" {
-            continue;
-        }
-        if !should_generate_fallback(
-            &existing,
-            &all_fn_names,
-            &name,
-            "Display",
-            "fmt",
-            "Inspect",
-            "inspect",
-        ) {
-            continue;
-        }
-        let type_param_ids = make_type_param_ids(&type_params, &mut tt);
-        let struct_type =
-            tt.make_generic_instance(name.clone(), module_source.clone(), type_param_ids);
-        let ref_type = tt.make_ref(struct_type);
-        let (di, ii) = simple_pair(&name);
-        generated.push(Rc::new(RefCell::new(generate_display_fallback(
-            di,
-            ii,
-            ref_type,
-            fmt_type,
-            &module_source,
-            type_params,
-            span,
-        ))));
-    }
-
-    // Non-generic variants
-    for name in module
-        .variants
-        .iter()
-        .filter(|v| v.type_params.is_empty())
-        .map(|v| v.name.clone())
-        .collect::<Vec<_>>()
-    {
-        if !should_generate_fallback(
-            &existing,
-            &all_fn_names,
-            &name,
-            "Display",
-            "fmt",
-            "Inspect",
-            "inspect",
-        ) {
-            continue;
-        }
-        let variant_type = tt.make_variant(name.clone(), module_source.clone());
-        let ref_type = tt.make_ref(variant_type);
-        let (di, ii) = simple_pair(&name);
-        generated.push(Rc::new(RefCell::new(generate_display_fallback(
-            di,
-            ii,
-            ref_type,
-            fmt_type,
-            &module_source,
-            vec![],
-            span,
-        ))));
-    }
-
-    // Generic variants (e.g., Option<T>, Result<T, E>)
-    for (name, type_params) in module
-        .variants
-        .iter()
-        .filter(|v| !v.type_params.is_empty())
-        .map(|v| (v.name.clone(), v.type_params.clone()))
-        .collect::<Vec<_>>()
-    {
-        if !should_generate_fallback(
-            &existing,
-            &all_fn_names,
-            &name,
-            "Display",
-            "fmt",
-            "Inspect",
-            "inspect",
-        ) {
-            continue;
-        }
-        let type_param_ids = make_type_param_ids(&type_params, &mut tt);
-        let variant_type =
-            tt.make_generic_instance(name.clone(), module_source.clone(), type_param_ids);
-        let ref_type = tt.make_ref(variant_type);
-        let (di, ii) = simple_pair(&name);
-        generated.push(Rc::new(RefCell::new(generate_display_fallback(
-            di,
-            ii,
-            ref_type,
-            fmt_type,
-            &module_source,
-            type_params,
-            span,
-        ))));
-    }
-
-    // Flags types
-    for (name, flags_type_id) in module
-        .flags
-        .iter()
-        .map(|f| (f.name.clone(), f.type_id))
-        .collect::<Vec<_>>()
-    {
-        if !should_generate_fallback(
-            &existing,
-            &all_fn_names,
-            &name,
-            "Display",
-            "fmt",
-            "Inspect",
-            "inspect",
-        ) {
-            continue;
-        }
-        let ref_type = tt.make_ref(flags_type_id);
-        let (di, ii) = simple_pair(&name);
-        generated.push(Rc::new(RefCell::new(generate_display_fallback(
-            di,
-            ii,
-            ref_type,
-            fmt_type,
-            &module_source,
-            vec![],
-            span,
-        ))));
-    }
-
-    // Newtypes
-    for nt in &module.newtypes {
-        if module.flags.iter().any(|f| f.type_id == nt.type_id) {
-            continue;
-        }
-        if !should_generate_fallback(
-            &existing,
-            &all_fn_names,
-            &nt.name,
-            "Display",
-            "fmt",
-            "Inspect",
-            "inspect",
-        ) {
-            continue;
-        }
-        let ref_type = tt.make_ref(nt.type_id);
-        let (di, ii) = simple_pair(&nt.name);
-        generated.push(Rc::new(RefCell::new(generate_display_fallback(
-            di,
-            ii,
-            ref_type,
-            fmt_type,
-            &module_source,
-            vec![],
-            span,
-        ))));
-    }
-
-    // Parameterized types (function types, opaque types) — Display fallback
-    // Tuples: Display is provided by variadic impl in core:prelude/tuple.wado
-    for (type_id, base_name, type_arg_names) in collect_parameterized_types(&tt) {
-        // TODO: collect_parameterized_types returns only base_name without module_source,
-        // so we cannot use TypeTable::is_tuple_type here. This is safe because
-        // collect_parameterized_types only returns TUPLE_TYPE_NAME for actual tuple types.
-        if base_name == TypeTable::TUPLE_TYPE_NAME {
-            continue;
-        }
-        let mangled = format_parameterized_name(&base_name, &type_arg_names);
-        let display_key = format!("{mangled}^Display::fmt");
-        if existing.contains(&display_key) {
-            continue;
-        }
-        let inspect_key = format!("{mangled}^Inspect::inspect");
-        if !existing.contains(&inspect_key) && !all_fn_names.contains(&inspect_key) {
-            continue;
-        }
-        let ref_type = tt.make_ref(type_id);
-        let di = LocalMethodName::new(
-            base_name.clone(),
-            Some("Display".to_string()),
-            "fmt".to_string(),
-        )
-        .with_struct_type_args(&type_arg_names);
-        let ii = LocalMethodName::new(
-            base_name,
-            Some("Inspect".to_string()),
-            "inspect".to_string(),
-        )
-        .with_struct_type_args(&type_arg_names);
-        generated.push(Rc::new(RefCell::new(generate_display_fallback(
-            di,
-            ii,
-            ref_type,
-            fmt_type,
-            &module_source,
-            vec![],
-            span,
-        ))));
-    }
-
-    drop(tt);
-    module.functions.extend(generated);
+    generate_fallback_impls(module, &DISPLAY_PAIR);
 }
 
 /// Generate a `Display::fmt` function that delegates to `self.inspect(f)`.
@@ -3199,12 +2232,15 @@ fn generate_display_fallback(
     }
 }
 
-// ─── DisplayAlt fallback synthesis ───
-
 /// Generate `DisplayAlt::fmt_alt` fallback implementations that delegate to `InspectAlt::inspect_alt`.
-///
-/// Mirrors `generate_display_fallback_impls` but for the Alt trait pair.
 fn generate_display_alt_fallback_impls(module: &mut TirModule) {
+    generate_fallback_impls(module, &DISPLAY_ALT_PAIR);
+}
+
+/// Walk every type kind in a module and emit a delegating fallback method
+/// for the configured `TraitPair`. Skips any type where the target trait is
+/// already implemented or the delegate trait is missing.
+fn generate_fallback_impls(module: &mut TirModule, pair: &TraitPair) {
     let module_source = module.module_source.clone();
     let existing = collect_existing_trait_methods(module);
     let all_fn_names: IndexSet<String> = module
@@ -3219,282 +2255,170 @@ fn generate_display_alt_fallback_impls(module: &mut TirModule) {
     let formatter_type = tt.make_struct("Formatter".to_string(), ModuleSource::format());
     let fmt_type = tt.make_mut_ref(formatter_type);
 
-    let simple_pair = |name: &str| -> (LocalMethodName, LocalMethodName) {
-        (
-            LocalMethodName::new(
-                name.to_string(),
-                Some("DisplayAlt".to_string()),
-                "fmt_alt".to_string(),
-            ),
-            LocalMethodName::new(
-                name.to_string(),
-                Some("InspectAlt".to_string()),
-                "inspect_alt".to_string(),
-            ),
+    let needs_fallback = |name: &str| {
+        should_generate_fallback(
+            &existing,
+            &all_fn_names,
+            name,
+            pair.target_trait,
+            pair.target_method,
+            pair.delegate_trait,
+            pair.delegate_method,
         )
     };
 
-    // Enums
-    for name in module
-        .enums
-        .iter()
-        .map(|e| e.name.clone())
-        .collect::<Vec<_>>()
-    {
-        if !should_generate_fallback(
-            &existing,
-            &all_fn_names,
-            &name,
-            "DisplayAlt",
-            "fmt_alt",
-            "InspectAlt",
-            "inspect_alt",
-        ) {
+    let push_fallback = |generated: &mut Vec<Rc<RefCell<TirFunction>>>,
+                         name: &str,
+                         ref_type: TypeId,
+                         impl_type_params: Vec<TirTypeParam>| {
+        let target_info = trait_method_info(name, pair.target_trait, pair.target_method);
+        let delegate_info = trait_method_info(name, pair.delegate_trait, pair.delegate_method);
+        generated.push(Rc::new(RefCell::new(generate_display_fallback(
+            target_info,
+            delegate_info,
+            ref_type,
+            fmt_type,
+            &module_source,
+            impl_type_params,
+            span,
+        ))));
+    };
+
+    let enum_names: Vec<_> = module.enums.iter().map(|e| e.name.clone()).collect();
+    for name in &enum_names {
+        if !needs_fallback(name) {
             continue;
         }
         let enum_type = tt.make_enum(name.clone(), module_source.clone());
         let ref_type = tt.make_ref(enum_type);
-        let (di, ii) = simple_pair(&name);
-        generated.push(Rc::new(RefCell::new(generate_display_fallback(
-            di,
-            ii,
-            ref_type,
-            fmt_type,
-            &module_source,
-            vec![],
-            span,
-        ))));
+        push_fallback(&mut generated, name, ref_type, vec![]);
     }
 
-    // Non-generic structs
-    for name in module
+    let struct_names: Vec<_> = module
         .structs
         .iter()
         .filter(|s| s.type_params.is_empty() && s.monomorph_info.is_none())
         .map(|s| s.name.clone())
-        .collect::<Vec<_>>()
-    {
+        .collect();
+    for name in &struct_names {
         if name == "String" || name == "Formatter" {
             continue;
         }
-        if !should_generate_fallback(
-            &existing,
-            &all_fn_names,
-            &name,
-            "DisplayAlt",
-            "fmt_alt",
-            "InspectAlt",
-            "inspect_alt",
-        ) {
+        if !needs_fallback(name) {
             continue;
         }
         let struct_type = tt.make_struct(name.clone(), module_source.clone());
         let ref_type = tt.make_ref(struct_type);
-        let (di, ii) = simple_pair(&name);
-        generated.push(Rc::new(RefCell::new(generate_display_fallback(
-            di,
-            ii,
-            ref_type,
-            fmt_type,
-            &module_source,
-            vec![],
-            span,
-        ))));
+        push_fallback(&mut generated, name, ref_type, vec![]);
     }
 
-    // Generic structs
-    for (name, type_params) in module
+    let generic_struct_infos: Vec<_> = module
         .structs
         .iter()
         .filter(|s| !s.type_params.is_empty() && s.monomorph_info.is_none())
         .map(|s| (s.name.clone(), s.type_params.clone()))
-        .collect::<Vec<_>>()
-    {
+        .collect();
+    for (name, type_params) in &generic_struct_infos {
         if name == "Array" {
             continue;
         }
-        if !should_generate_fallback(
-            &existing,
-            &all_fn_names,
-            &name,
-            "DisplayAlt",
-            "fmt_alt",
-            "InspectAlt",
-            "inspect_alt",
-        ) {
+        if !needs_fallback(name) {
             continue;
         }
-        let type_param_ids = make_type_param_ids(&type_params, &mut tt);
+        let type_param_ids = make_type_param_ids(type_params, &mut tt);
         let struct_type =
             tt.make_generic_instance(name.clone(), module_source.clone(), type_param_ids);
         let ref_type = tt.make_ref(struct_type);
-        let (di, ii) = simple_pair(&name);
-        generated.push(Rc::new(RefCell::new(generate_display_fallback(
-            di,
-            ii,
-            ref_type,
-            fmt_type,
-            &module_source,
-            type_params,
-            span,
-        ))));
+        push_fallback(&mut generated, name, ref_type, type_params.clone());
     }
 
-    // Non-generic variants
-    for name in module
+    let variant_names: Vec<_> = module
         .variants
         .iter()
         .filter(|v| v.type_params.is_empty())
         .map(|v| v.name.clone())
-        .collect::<Vec<_>>()
-    {
-        if !should_generate_fallback(
-            &existing,
-            &all_fn_names,
-            &name,
-            "DisplayAlt",
-            "fmt_alt",
-            "InspectAlt",
-            "inspect_alt",
-        ) {
+        .collect();
+    for name in &variant_names {
+        if !needs_fallback(name) {
             continue;
         }
         let variant_type = tt.make_variant(name.clone(), module_source.clone());
         let ref_type = tt.make_ref(variant_type);
-        let (di, ii) = simple_pair(&name);
-        generated.push(Rc::new(RefCell::new(generate_display_fallback(
-            di,
-            ii,
-            ref_type,
-            fmt_type,
-            &module_source,
-            vec![],
-            span,
-        ))));
+        push_fallback(&mut generated, name, ref_type, vec![]);
     }
 
-    // Generic variants
-    for (name, type_params) in module
+    let generic_variant_infos: Vec<_> = module
         .variants
         .iter()
         .filter(|v| !v.type_params.is_empty())
         .map(|v| (v.name.clone(), v.type_params.clone()))
-        .collect::<Vec<_>>()
-    {
-        if !should_generate_fallback(
-            &existing,
-            &all_fn_names,
-            &name,
-            "DisplayAlt",
-            "fmt_alt",
-            "InspectAlt",
-            "inspect_alt",
-        ) {
+        .collect();
+    for (name, type_params) in &generic_variant_infos {
+        if !needs_fallback(name) {
             continue;
         }
-        let type_param_ids = make_type_param_ids(&type_params, &mut tt);
+        let type_param_ids = make_type_param_ids(type_params, &mut tt);
         let variant_type =
             tt.make_generic_instance(name.clone(), module_source.clone(), type_param_ids);
         let ref_type = tt.make_ref(variant_type);
-        let (di, ii) = simple_pair(&name);
-        generated.push(Rc::new(RefCell::new(generate_display_fallback(
-            di,
-            ii,
-            ref_type,
-            fmt_type,
-            &module_source,
-            type_params,
-            span,
-        ))));
+        push_fallback(&mut generated, name, ref_type, type_params.clone());
     }
 
-    // Flags
-    for (name, flags_type_id) in module
+    let flags_infos: Vec<_> = module
         .flags
         .iter()
         .map(|f| (f.name.clone(), f.type_id))
-        .collect::<Vec<_>>()
-    {
-        if !should_generate_fallback(
-            &existing,
-            &all_fn_names,
-            &name,
-            "DisplayAlt",
-            "fmt_alt",
-            "InspectAlt",
-            "inspect_alt",
-        ) {
+        .collect();
+    for (name, flags_type_id) in &flags_infos {
+        if !needs_fallback(name) {
             continue;
         }
-        let ref_type = tt.make_ref(flags_type_id);
-        let (di, ii) = simple_pair(&name);
-        generated.push(Rc::new(RefCell::new(generate_display_fallback(
-            di,
-            ii,
-            ref_type,
-            fmt_type,
-            &module_source,
-            vec![],
-            span,
-        ))));
+        let ref_type = tt.make_ref(*flags_type_id);
+        push_fallback(&mut generated, name, ref_type, vec![]);
     }
 
-    // Newtypes
     for nt in &module.newtypes {
         if module.flags.iter().any(|f| f.type_id == nt.type_id) {
             continue;
         }
-        if !should_generate_fallback(
-            &existing,
-            &all_fn_names,
-            &nt.name,
-            "DisplayAlt",
-            "fmt_alt",
-            "InspectAlt",
-            "inspect_alt",
-        ) {
+        if !needs_fallback(&nt.name) {
             continue;
         }
         let ref_type = tt.make_ref(nt.type_id);
-        let (di, ii) = simple_pair(&nt.name);
-        generated.push(Rc::new(RefCell::new(generate_display_fallback(
-            di,
-            ii,
-            ref_type,
-            fmt_type,
-            &module_source,
-            vec![],
-            span,
-        ))));
+        push_fallback(&mut generated, &nt.name, ref_type, vec![]);
     }
 
-    // Parameterized types
+    // Parameterized types (function types, opaque types). Tuples are skipped
+    // because their fallback is provided by a variadic impl in `core:prelude/tuple.wado`.
     for (type_id, base_name, type_arg_names) in collect_parameterized_types(&tt) {
-        let mangled = format_parameterized_name(&base_name, &type_arg_names);
-        let da_key = format!("{mangled}^DisplayAlt::fmt_alt");
-        if existing.contains(&da_key) {
+        // `collect_parameterized_types` returns only the base name without a
+        // module source, so `TypeTable::is_tuple_type` is unavailable here. The
+        // `TUPLE_TYPE_NAME` check is sound because `collect_parameterized_types`
+        // only emits that name for actual tuple types.
+        if base_name == TypeTable::TUPLE_TYPE_NAME {
             continue;
         }
-        let ia_key = format!("{mangled}^InspectAlt::inspect_alt");
-        if !existing.contains(&ia_key) && !all_fn_names.contains(&ia_key) {
+        let mangled = format_parameterized_name(&base_name, &type_arg_names);
+        let target_key = format!("{mangled}^{}::{}", pair.target_trait, pair.target_method);
+        if existing.contains(&target_key) {
+            continue;
+        }
+        let delegate_key = format!(
+            "{mangled}^{}::{}",
+            pair.delegate_trait, pair.delegate_method
+        );
+        if !existing.contains(&delegate_key) && !all_fn_names.contains(&delegate_key) {
             continue;
         }
         let ref_type = tt.make_ref(type_id);
-        let di = LocalMethodName::new(
-            base_name.clone(),
-            Some("DisplayAlt".to_string()),
-            "fmt_alt".to_string(),
-        )
-        .with_struct_type_args(&type_arg_names);
-        let ii = LocalMethodName::new(
-            base_name,
-            Some("InspectAlt".to_string()),
-            "inspect_alt".to_string(),
-        )
-        .with_struct_type_args(&type_arg_names);
+        let target_info = trait_method_info(&base_name, pair.target_trait, pair.target_method)
+            .with_struct_type_args(&type_arg_names);
+        let delegate_info =
+            trait_method_info(&base_name, pair.delegate_trait, pair.delegate_method)
+                .with_struct_type_args(&type_arg_names);
         generated.push(Rc::new(RefCell::new(generate_display_fallback(
-            di,
-            ii,
+            target_info,
+            delegate_info,
             ref_type,
             fmt_type,
             &module_source,
@@ -3684,8 +2608,6 @@ fn format_parameterized_name(base_name: &str, type_arg_names: &[String]) -> Stri
     }
 }
 
-// ─── Eq/Ord generators (existing) ───
-
 /// Generate `EnumName^Eq::eq(&self, &Self) -> bool`
 ///
 /// Body: `return *self == *other;` (i32 comparison via enum discriminant)
@@ -3695,67 +2617,14 @@ fn generate_enum_eq_fn(
     ref_enum_type: TypeId,
     span: Span,
 ) -> TirFunction {
-    let method_info = LocalMethodName::new(
-        enum_name.to_string(),
-        Some("Eq".to_string()),
-        "eq".to_string(),
-    );
+    let method_info = trait_method_info(enum_name, "Eq", "eq");
     let qualified_name = method_info.to_mangled_name();
 
-    let params = vec![
-        TirParam {
-            name: "self".to_string(),
-            type_id: ref_enum_type,
-            local_index: 0,
-            is_mut: false,
-            span,
-            default_expr: None,
-        },
-        TirParam {
-            name: "other".to_string(),
-            type_id: ref_enum_type,
-            local_index: 1,
-            is_mut: false,
-            span,
-            default_expr: None,
-        },
-    ];
-
-    let deref_self = TirExpr::new(
-        TirExprKind::Unary {
-            op: TirUnaryOp::Deref,
-            expr: Box::new(TirExpr::new(
-                TirExprKind::Local {
-                    index: 0,
-                    name: "self".to_string(),
-                },
-                ref_enum_type,
-                span,
-            )),
-        },
-        enum_type,
-        span,
-    );
-    let deref_other = TirExpr::new(
-        TirExprKind::Unary {
-            op: TirUnaryOp::Deref,
-            expr: Box::new(TirExpr::new(
-                TirExprKind::Local {
-                    index: 1,
-                    name: "other".to_string(),
-                },
-                ref_enum_type,
-                span,
-            )),
-        },
-        enum_type,
-        span,
-    );
     let comparison = TirExpr::new(
         TirExprKind::Binary {
-            left: Box::new(deref_self),
+            left: Box::new(deref_local(0, "self", ref_enum_type, enum_type, span)),
             op: TirBinaryOp::Eq,
-            right: Box::new(deref_other),
+            right: Box::new(deref_local(1, "other", ref_enum_type, enum_type, span)),
         },
         TypeTable::BOOL,
         span,
@@ -3773,13 +2642,10 @@ fn generate_enum_eq_fn(
     make_synthetic_method(
         qualified_name,
         method_info,
-        params,
+        binary_method_params(ref_enum_type, span),
         TypeTable::BOOL,
         body,
-        vec![
-            param_local("self", ref_enum_type, false),
-            param_local("other", ref_enum_type, false),
-        ],
+        binary_method_locals(ref_enum_type),
     )
 }
 
@@ -3800,216 +2666,95 @@ fn generate_enum_ord_fn(
     ordering_type: TypeId,
     span: Span,
 ) -> TirFunction {
-    let method_info = LocalMethodName::new(
-        enum_name.to_string(),
-        Some("Ord".to_string()),
-        "cmp".to_string(),
-    );
+    let method_info = trait_method_info(enum_name, "Ord", "cmp");
     let qualified_name = method_info.to_mangled_name();
 
-    let params = vec![
-        TirParam {
-            name: "self".to_string(),
-            type_id: ref_enum_type,
-            local_index: 0,
-            is_mut: false,
-            span,
-            default_expr: None,
-        },
-        TirParam {
-            name: "other".to_string(),
-            type_id: ref_enum_type,
-            local_index: 1,
-            is_mut: false,
-            span,
-            default_expr: None,
-        },
-    ];
+    let local_a = || local_expr(2, "a", enum_type, span);
+    let local_b = || local_expr(3, "b", enum_type, span);
 
-    let deref_self = TirExpr::new(
-        TirExprKind::Unary {
-            op: TirUnaryOp::Deref,
-            expr: Box::new(TirExpr::new(
-                TirExprKind::Local {
-                    index: 0,
-                    name: "self".to_string(),
-                },
-                ref_enum_type,
-                span,
-            )),
-        },
-        enum_type,
-        span,
-    );
-    let deref_other = TirExpr::new(
-        TirExprKind::Unary {
-            op: TirUnaryOp::Deref,
-            expr: Box::new(TirExpr::new(
-                TirExprKind::Local {
-                    index: 1,
-                    name: "other".to_string(),
-                },
-                ref_enum_type,
-                span,
-            )),
-        },
-        enum_type,
-        span,
-    );
-
-    let local_a = |span: Span| {
-        TirExpr::new(
-            TirExprKind::Local {
-                index: 2,
-                name: "a".to_string(),
+    let cmp_branch = |op, ordering_case_index, ordering_case_name| {
+        let cond = TirExpr::new(
+            TirExprKind::Binary {
+                left: Box::new(local_a()),
+                op,
+                right: Box::new(local_b()),
             },
-            enum_type,
+            TypeTable::BOOL,
             span,
-        )
-    };
-    let local_b = |span: Span| {
-        TirExpr::new(
-            TirExprKind::Local {
-                index: 3,
-                name: "b".to_string(),
+        );
+        TirStmt::new(
+            TirStmtKind::If {
+                condition: cond,
+                then_block: TirBlock::new(
+                    vec![TirStmt::new(
+                        TirStmtKind::Return {
+                            value: Some(ordering_construct(
+                                ordering_type,
+                                ordering_case_index,
+                                ordering_case_name,
+                                span,
+                            )),
+                        },
+                        span,
+                    )],
+                    span,
+                ),
+                else_block: None,
             },
-            enum_type,
             span,
         )
     };
 
-    let ordering_less = TirExpr::new(
-        TirExprKind::EnumConstruct {
-            enum_type: ordering_type,
-            case_index: 0,
-            case_name: "Less".to_string(),
-        },
-        ordering_type,
-        span,
-    );
-    let ordering_greater = TirExpr::new(
-        TirExprKind::EnumConstruct {
-            enum_type: ordering_type,
-            case_index: 2,
-            case_name: "Greater".to_string(),
-        },
-        ordering_type,
-        span,
-    );
-    let ordering_equal = TirExpr::new(
-        TirExprKind::EnumConstruct {
-            enum_type: ordering_type,
-            case_index: 1,
-            case_name: "Equal".to_string(),
-        },
-        ordering_type,
-        span,
-    );
-
-    let cond_lt = TirExpr::new(
-        TirExprKind::Binary {
-            left: Box::new(local_a(span)),
-            op: TirBinaryOp::Lt,
-            right: Box::new(local_b(span)),
-        },
-        TypeTable::BOOL,
-        span,
-    );
-    let if_lt = TirStmt::new(
-        TirStmtKind::If {
-            condition: cond_lt,
-            then_block: TirBlock::new(
-                vec![TirStmt::new(
-                    TirStmtKind::Return {
-                        value: Some(ordering_less),
-                    },
-                    span,
-                )],
-                span,
-            ),
-            else_block: None,
-        },
-        span,
-    );
-
-    let cond_gt = TirExpr::new(
-        TirExprKind::Binary {
-            left: Box::new(local_a(span)),
-            op: TirBinaryOp::Gt,
-            right: Box::new(local_b(span)),
-        },
-        TypeTable::BOOL,
-        span,
-    );
-    let if_gt = TirStmt::new(
-        TirStmtKind::If {
-            condition: cond_gt,
-            then_block: TirBlock::new(
-                vec![TirStmt::new(
-                    TirStmtKind::Return {
-                        value: Some(ordering_greater),
-                    },
-                    span,
-                )],
-                span,
-            ),
-            else_block: None,
-        },
-        span,
-    );
-
-    let return_equal = TirStmt::new(
-        TirStmtKind::Return {
-            value: Some(ordering_equal),
-        },
-        span,
-    );
+    let let_local = |name, local_index, value| {
+        TirStmt::new(
+            TirStmtKind::Let {
+                name: String::from(name),
+                local_index,
+                is_mut: false,
+                is_reactive: false,
+                type_id: enum_type,
+                value,
+                skip_value_copy: false,
+            },
+            span,
+        )
+    };
 
     let body = TirBlock::new(
         vec![
+            let_local(
+                "a",
+                2,
+                deref_local(0, "self", ref_enum_type, enum_type, span),
+            ),
+            let_local(
+                "b",
+                3,
+                deref_local(1, "other", ref_enum_type, enum_type, span),
+            ),
+            cmp_branch(TirBinaryOp::Lt, 0, "Less"),
+            cmp_branch(TirBinaryOp::Gt, 2, "Greater"),
             TirStmt::new(
-                TirStmtKind::Let {
-                    name: "a".to_string(),
-                    local_index: 2,
-                    is_mut: false,
-                    is_reactive: false,
-                    type_id: enum_type,
-                    value: deref_self,
-                    skip_value_copy: false,
+                TirStmtKind::Return {
+                    value: Some(ordering_construct(ordering_type, 1, "Equal", span)),
                 },
                 span,
             ),
-            TirStmt::new(
-                TirStmtKind::Let {
-                    name: "b".to_string(),
-                    local_index: 3,
-                    is_mut: false,
-                    is_reactive: false,
-                    type_id: enum_type,
-                    value: deref_other,
-                    skip_value_copy: false,
-                },
-                span,
-            ),
-            if_lt,
-            if_gt,
-            return_equal,
         ],
         span,
     );
+
+    let mut locals = binary_method_locals(ref_enum_type);
+    locals.push(TirLocal::synth(2, enum_type, false));
+    locals.push(TirLocal::synth(3, enum_type, false));
 
     make_synthetic_method(
         qualified_name,
         method_info,
-        params,
+        binary_method_params(ref_enum_type, span),
         ordering_type,
         body,
-        vec![
-            param_local("self", ref_enum_type, false),
-            param_local("other", ref_enum_type, false),
-            TirLocal::synth(2, enum_type, false),
-            TirLocal::synth(3, enum_type, false),
-        ],
+        locals,
     )
 }
 
@@ -4037,11 +2782,7 @@ fn trait_call_on_type(
     let (base_name, is_type_param, type_arg_names) =
         decompose_type_for_method_name(&resolved, value_type, tt);
 
-    let mut info = LocalMethodName::new(
-        base_name,
-        Some(trait_name.to_string()),
-        method_name.to_string(),
-    );
+    let mut info = trait_method_info(&base_name, trait_name, method_name);
     if !type_arg_names.is_empty() {
         info = info.with_struct_type_args(&type_arg_names);
     }
@@ -4056,11 +2797,7 @@ fn trait_call_on_type(
     let monomorph_info = if needs_ref_monomorph {
         match &resolved {
             ResolvedType::Ref(inner_id) | ResolvedType::MutRef(inner_id) => {
-                let base_info = LocalMethodName::new(
-                    info.base_struct_name.clone(),
-                    Some(trait_name.to_string()),
-                    method_name.to_string(),
-                );
+                let base_info = trait_method_info(&info.base_struct_name, trait_name, method_name);
                 Some(MonomorphInfo {
                     generic_name: base_info.to_mangled_name(),
                     impl_type_args: vec![*inner_id],
@@ -4162,133 +2899,17 @@ fn eq_impl_module(type_id: TypeId, tt: &TypeTable, default: &ModuleSource) -> Mo
 /// Empty structs: `return true;`
 fn generate_struct_eq_fn(
     struct_name: &str,
+    impl_type_params: &[TirTypeParam],
     fields: &[(String, TypeId, u32)],
     ref_struct_type: TypeId,
     module_source: &ModuleSource,
     tt: &mut TypeTable,
     span: Span,
 ) -> TirFunction {
-    let method_info = LocalMethodName::new(
-        struct_name.to_string(),
-        Some("Eq".to_string()),
-        "eq".to_string(),
-    );
+    let method_info = trait_method_info(struct_name, "Eq", "eq");
     let qualified_name = method_info.to_mangled_name();
 
-    let params = vec![
-        TirParam {
-            name: "self".to_string(),
-            type_id: ref_struct_type,
-            local_index: 0,
-            is_mut: false,
-            span,
-            default_expr: None,
-        },
-        TirParam {
-            name: "other".to_string(),
-            type_id: ref_struct_type,
-            local_index: 1,
-            is_mut: false,
-            span,
-            default_expr: None,
-        },
-    ];
-
-    let self_ref = |span: Span| {
-        TirExpr::new(
-            TirExprKind::Local {
-                index: 0,
-                name: "self".to_string(),
-            },
-            ref_struct_type,
-            span,
-        )
-    };
-    let other_ref = |span: Span| {
-        TirExpr::new(
-            TirExprKind::Local {
-                index: 1,
-                name: "other".to_string(),
-            },
-            ref_struct_type,
-            span,
-        )
-    };
-
-    let result = if fields.is_empty() {
-        // Empty struct: always equal
-        TirExpr::new(TirExprKind::BoolLiteral(true), TypeTable::BOOL, span)
-    } else {
-        // Build: self.f0.eq(&other.f0) && self.f1.eq(&other.f1) && ...
-        let mut iter = fields.iter();
-        let (first_name, first_type, first_index) = iter.next().unwrap();
-        let self_field = TirExpr::new(
-            TirExprKind::FieldAccess {
-                expr: Box::new(self_ref(span)),
-                field_index: *first_index,
-                field_name: first_name.clone(),
-            },
-            *first_type,
-            span,
-        );
-        let other_field = TirExpr::new(
-            TirExprKind::FieldAccess {
-                expr: Box::new(other_ref(span)),
-                field_index: *first_index,
-                field_name: first_name.clone(),
-            },
-            *first_type,
-            span,
-        );
-        let mut result = eq_call_expr(
-            self_field,
-            other_field,
-            *first_type,
-            module_source,
-            tt,
-            span,
-        );
-
-        for (field_name, field_type, field_index) in iter {
-            let self_field = TirExpr::new(
-                TirExprKind::FieldAccess {
-                    expr: Box::new(self_ref(span)),
-                    field_index: *field_index,
-                    field_name: field_name.clone(),
-                },
-                *field_type,
-                span,
-            );
-            let other_field = TirExpr::new(
-                TirExprKind::FieldAccess {
-                    expr: Box::new(other_ref(span)),
-                    field_index: *field_index,
-                    field_name: field_name.clone(),
-                },
-                *field_type,
-                span,
-            );
-            let cmp = eq_call_expr(
-                self_field,
-                other_field,
-                *field_type,
-                module_source,
-                tt,
-                span,
-            );
-            result = TirExpr::new(
-                TirExprKind::Binary {
-                    op: TirBinaryOp::And,
-                    left: Box::new(result),
-                    right: Box::new(cmp),
-                },
-                TypeTable::BOOL,
-                span,
-            );
-        }
-        result
-    };
-
+    let result = build_struct_eq_chain(fields, ref_struct_type, module_source, tt, span);
     let body = TirBlock::new(
         vec![TirStmt::new(
             TirStmtKind::Return {
@@ -4299,16 +2920,89 @@ fn generate_struct_eq_fn(
         span,
     );
 
-    make_synthetic_method(
+    make_trait_method(
         qualified_name,
         method_info,
-        params,
+        impl_type_params.to_vec(),
+        binary_method_params(ref_struct_type, span),
         TypeTable::BOOL,
         body,
-        vec![
-            param_local("self", ref_struct_type, false),
-            param_local("other", ref_struct_type, false),
-        ],
+        binary_method_locals(ref_struct_type),
+        span,
+    )
+}
+
+/// Build the AND-chain `self.f0.eq(&other.f0) && self.f1.eq(&other.f1) && ...`
+/// for a struct's `Eq::eq` body. Returns `true` for an empty field list.
+fn build_struct_eq_chain(
+    fields: &[(String, TypeId, u32)],
+    ref_struct_type: TypeId,
+    module_source: &ModuleSource,
+    tt: &mut TypeTable,
+    span: Span,
+) -> TirExpr {
+    if fields.is_empty() {
+        return TirExpr::new(TirExprKind::BoolLiteral(true), TypeTable::BOOL, span);
+    }
+
+    let field_eq = |name: &str, field_type: TypeId, field_index: u32, tt: &mut TypeTable| {
+        let self_field = field_access_local(
+            0,
+            "self",
+            ref_struct_type,
+            field_index,
+            name,
+            field_type,
+            span,
+        );
+        let other_field = field_access_local(
+            1,
+            "other",
+            ref_struct_type,
+            field_index,
+            name,
+            field_type,
+            span,
+        );
+        eq_call_expr(self_field, other_field, field_type, module_source, tt, span)
+    };
+
+    let mut iter = fields.iter();
+    let (first_name, first_type, first_index) = iter.next().unwrap();
+    let mut result = field_eq(first_name, *first_type, *first_index, tt);
+    for (field_name, field_type, field_index) in iter {
+        let cmp = field_eq(field_name, *field_type, *field_index, tt);
+        result = TirExpr::new(
+            TirExprKind::Binary {
+                op: TirBinaryOp::And,
+                left: Box::new(result),
+                right: Box::new(cmp),
+            },
+            TypeTable::BOOL,
+            span,
+        );
+    }
+    result
+}
+
+/// Build `<local>.<field>` where `<local>` is a local of reference type.
+fn field_access_local(
+    local_index: u32,
+    local_name: &str,
+    local_ref_type: TypeId,
+    field_index: u32,
+    field_name: &str,
+    field_type: TypeId,
+    span: Span,
+) -> TirExpr {
+    TirExpr::new(
+        TirExprKind::FieldAccess {
+            expr: Box::new(local_expr(local_index, local_name, local_ref_type, span)),
+            field_index,
+            field_name: field_name.to_string(),
+        },
+        field_type,
+        span,
     )
 }
 
@@ -4325,6 +3019,7 @@ fn generate_struct_eq_fn(
 /// ```
 fn generate_struct_ord_fn(
     struct_name: &str,
+    impl_type_params: &[TirTypeParam],
     fields: &[(String, TypeId, u32)],
     ref_struct_type: TypeId,
     ordering_type: TypeId,
@@ -4332,86 +3027,65 @@ fn generate_struct_ord_fn(
     tt: &mut TypeTable,
     span: Span,
 ) -> TirFunction {
-    let method_info = LocalMethodName::new(
-        struct_name.to_string(),
-        Some("Ord".to_string()),
-        "cmp".to_string(),
-    );
+    let method_info = trait_method_info(struct_name, "Ord", "cmp");
     let qualified_name = method_info.to_mangled_name();
 
-    let params = vec![
-        TirParam {
-            name: "self".to_string(),
-            type_id: ref_struct_type,
-            local_index: 0,
-            is_mut: false,
-            span,
-            default_expr: None,
-        },
-        TirParam {
-            name: "other".to_string(),
-            type_id: ref_struct_type,
-            local_index: 1,
-            is_mut: false,
-            span,
-            default_expr: None,
-        },
-    ];
-
-    let self_ref = |span: Span| {
-        TirExpr::new(
-            TirExprKind::Local {
-                index: 0,
-                name: "self".to_string(),
-            },
-            ref_struct_type,
-            span,
-        )
-    };
-    let other_ref = |span: Span| {
-        TirExpr::new(
-            TirExprKind::Local {
-                index: 1,
-                name: "other".to_string(),
-            },
-            ref_struct_type,
-            span,
-        )
-    };
-
-    let ordering_equal = TirExpr::new(
-        TirExprKind::EnumConstruct {
-            enum_type: ordering_type,
-            case_index: 1,
-            case_name: "Equal".to_string(),
-        },
+    let (stmts, locals) = build_struct_ord_body(
+        fields,
+        ref_struct_type,
         ordering_type,
+        module_source,
+        tt,
         span,
     );
+    let body = TirBlock::new(stmts, span);
 
+    make_trait_method(
+        qualified_name,
+        method_info,
+        impl_type_params.to_vec(),
+        binary_method_params(ref_struct_type, span),
+        ordering_type,
+        body,
+        locals,
+        span,
+    )
+}
+
+/// Build the lexicographic compare statements for a struct `Ord::cmp` body.
+///
+/// Each field gets a `let c_i = self.fi.cmp(&other.fi);` followed by
+/// `if c_i != Ordering::Equal { return c_i; }`, terminated by
+/// `return Ordering::Equal;`. Returns the statement list and the locals
+/// table (which includes the `c_i` slots for each field, starting at
+/// local index 2).
+fn build_struct_ord_body(
+    fields: &[(String, TypeId, u32)],
+    ref_struct_type: TypeId,
+    ordering_type: TypeId,
+    module_source: &ModuleSource,
+    tt: &mut TypeTable,
+    span: Span,
+) -> (Vec<TirStmt>, Vec<TirLocal>) {
     let mut stmts = Vec::new();
-    let mut locals = vec![
-        param_local("self", ref_struct_type, false),
-        param_local("other", ref_struct_type, false),
-    ];
+    let mut locals = binary_method_locals(ref_struct_type);
 
-    // Local indices start at 2 (0 = self, 1 = other).
     for (local_idx, (field_name, field_type, field_index)) in (2_u32..).zip(fields.iter()) {
-        let self_field = TirExpr::new(
-            TirExprKind::FieldAccess {
-                expr: Box::new(self_ref(span)),
-                field_index: *field_index,
-                field_name: field_name.clone(),
-            },
+        let self_field = field_access_local(
+            0,
+            "self",
+            ref_struct_type,
+            *field_index,
+            field_name,
             *field_type,
             span,
         );
-        let other_field = TirExpr::new(
-            TirExprKind::FieldAccess {
-                expr: Box::new(other_ref(span)),
-                field_index: *field_index,
-                field_name: field_name.clone(),
-            },
+        let other_field = field_access_local(
+            1,
+            "other",
+            ref_struct_type,
+            *field_index,
+            field_name,
             *field_type,
             span,
         );
@@ -4431,7 +3105,6 @@ fn generate_struct_ord_fn(
             is_mut: false,
         });
 
-        // let c = self.field.cmp(&other.field);
         stmts.push(TirStmt::new(
             TirStmtKind::Let {
                 name: "c".to_string(),
@@ -4445,20 +3118,12 @@ fn generate_struct_ord_fn(
             span,
         ));
 
-        // if c != Ordering::Equal { return c; }
-        let local_c = TirExpr::new(
-            TirExprKind::Local {
-                index: local_idx,
-                name: "c".to_string(),
-            },
-            ordering_type,
-            span,
-        );
+        let local_c = local_expr(local_idx, "c", ordering_type, span);
         let cond = TirExpr::new(
             TirExprKind::Binary {
                 op: TirBinaryOp::NotEq,
                 left: Box::new(local_c.clone()),
-                right: Box::new(ordering_equal.clone()),
+                right: Box::new(ordering_construct(ordering_type, 1, "Equal", span)),
             },
             TypeTable::BOOL,
             span,
@@ -4481,211 +3146,23 @@ fn generate_struct_ord_fn(
         ));
     }
 
-    // return Ordering::Equal;
     stmts.push(TirStmt::new(
         TirStmtKind::Return {
-            value: Some(ordering_equal),
+            value: Some(ordering_construct(ordering_type, 1, "Equal", span)),
         },
         span,
     ));
 
-    let body = TirBlock::new(stmts, span);
-
-    make_synthetic_method(
-        qualified_name,
-        method_info,
-        params,
-        ordering_type,
-        body,
-        locals,
-    )
+    (stmts, locals)
 }
 
-/// Generate `StructName^Eq::eq(&self, &Self) -> bool` for generic structs.
-///
-/// Sets `impl_type_params` with Eq bounds so the monomorphizer can
-/// specialize field eq calls for concrete types.
-fn generate_generic_struct_eq_fn(
-    struct_name: &str,
-    type_params: &[TirTypeParam],
-    fields: &[(String, TypeId, u32)],
-    ref_struct_type: TypeId,
-    module_source: &ModuleSource,
-    tt: &mut TypeTable,
-    span: Span,
-) -> TirFunction {
-    let method_info = LocalMethodName::new(
-        struct_name.to_string(),
-        Some("Eq".to_string()),
-        "eq".to_string(),
-    );
-    let qualified_name = method_info.to_mangled_name();
-
-    let params = vec![
-        TirParam {
-            name: "self".to_string(),
-            type_id: ref_struct_type,
-            local_index: 0,
-            is_mut: false,
-            span,
-            default_expr: None,
-        },
-        TirParam {
-            name: "other".to_string(),
-            type_id: ref_struct_type,
-            local_index: 1,
-            is_mut: false,
-            span,
-            default_expr: None,
-        },
-    ];
-
-    let self_ref = |span: Span| {
-        TirExpr::new(
-            TirExprKind::Local {
-                index: 0,
-                name: "self".to_string(),
-            },
-            ref_struct_type,
-            span,
-        )
-    };
-    let other_ref = |span: Span| {
-        TirExpr::new(
-            TirExprKind::Local {
-                index: 1,
-                name: "other".to_string(),
-            },
-            ref_struct_type,
-            span,
-        )
-    };
-
-    let result = if fields.is_empty() {
-        TirExpr::new(TirExprKind::BoolLiteral(true), TypeTable::BOOL, span)
-    } else {
-        let mut iter = fields.iter();
-        let (first_name, first_type, first_index) = iter.next().unwrap();
-        let self_field = TirExpr::new(
-            TirExprKind::FieldAccess {
-                expr: Box::new(self_ref(span)),
-                field_index: *first_index,
-                field_name: first_name.clone(),
-            },
-            *first_type,
-            span,
-        );
-        let other_field = TirExpr::new(
-            TirExprKind::FieldAccess {
-                expr: Box::new(other_ref(span)),
-                field_index: *first_index,
-                field_name: first_name.clone(),
-            },
-            *first_type,
-            span,
-        );
-        let mut result = eq_call_expr(
-            self_field,
-            other_field,
-            *first_type,
-            module_source,
-            tt,
-            span,
-        );
-
-        for (field_name, field_type, field_index) in iter {
-            let self_field = TirExpr::new(
-                TirExprKind::FieldAccess {
-                    expr: Box::new(self_ref(span)),
-                    field_index: *field_index,
-                    field_name: field_name.clone(),
-                },
-                *field_type,
-                span,
-            );
-            let other_field = TirExpr::new(
-                TirExprKind::FieldAccess {
-                    expr: Box::new(other_ref(span)),
-                    field_index: *field_index,
-                    field_name: field_name.clone(),
-                },
-                *field_type,
-                span,
-            );
-            let cmp = eq_call_expr(
-                self_field,
-                other_field,
-                *field_type,
-                module_source,
-                tt,
-                span,
-            );
-            result = TirExpr::new(
-                TirExprKind::Binary {
-                    op: TirBinaryOp::And,
-                    left: Box::new(result),
-                    right: Box::new(cmp),
-                },
-                TypeTable::BOOL,
-                span,
-            );
-        }
-        result
-    };
-
-    let body = TirBlock::new(
-        vec![TirStmt::new(
-            TirStmtKind::Return {
-                value: Some(result),
-            },
-            span,
-        )],
-        span,
-    );
-
-    let impl_type_params: Vec<TirTypeParam> = type_params.to_vec();
-
-    TirFunction {
-        module_source: ModuleSource::default(),
-        name: qualified_name,
-        is_pub: true,
-        is_export: false,
-        is_async: false,
-        type_params: Vec::new(),
-        impl_type_params,
-        monomorph_info: None,
-        method_info: Some(method_info),
-        params,
-        return_type: TypeTable::BOOL,
-        task_return_type: None,
-        effects: Vec::new(),
-        stores: vec![],
-        body: Some(body),
-        span,
-        local_count: 2,
-        locals: vec![
-            param_local("self", ref_struct_type, false),
-            param_local("other", ref_struct_type, false),
-        ],
-        address_taken_locals: IndexSet::default(),
-        stores_aliased_locals: IndexSet::default(),
-        is_cm_binding: false,
-        is_dispatch_wrapper: false,
-        is_cm_export: false,
-        is_ambient: false,
-        inline_hint: InlineHint::Auto,
-        comp_features: 0,
-        export_name: None,
-        allocator_tag: None,
-        kind: FunctionKind::Regular,
-    }
-}
-
-/// Generate `VariantName^Eq::eq(&self, &Self) -> bool` for non-generic variants.
+/// Generate `VariantName^Eq::eq(&self, &Self) -> bool`.
 ///
 /// Body: if-else chain testing each case with `VariantTest`, comparing payloads via `eq_call_expr`.
+/// Pass an empty `impl_type_params` slice for non-generic variants.
 fn generate_variant_eq_fn(
     variant_name: &str,
+    impl_type_params: &[TirTypeParam],
     cases: &[(String, u32, TypeId)],
     variant_type: TypeId,
     ref_variant_type: TypeId,
@@ -4693,185 +3170,25 @@ fn generate_variant_eq_fn(
     tt: &mut TypeTable,
     span: Span,
 ) -> TirFunction {
-    let method_info = LocalMethodName::new(
-        variant_name.to_string(),
-        Some("Eq".to_string()),
-        "eq".to_string(),
-    );
+    let method_info = trait_method_info(variant_name, "Eq", "eq");
     let qualified_name = method_info.to_mangled_name();
 
-    let params = vec![
-        TirParam {
-            name: "self".to_string(),
-            type_id: ref_variant_type,
-            local_index: 0,
-            is_mut: false,
-            span,
-            default_expr: None,
-        },
-        TirParam {
-            name: "other".to_string(),
-            type_id: ref_variant_type,
-            local_index: 1,
-            is_mut: false,
-            span,
-            default_expr: None,
-        },
-    ];
-
-    let deref_self = || {
-        deref_expr(
-            TirExpr::new(
-                TirExprKind::Local {
-                    index: 0,
-                    name: "self".to_string(),
-                },
-                ref_variant_type,
-                span,
-            ),
-            variant_type,
-            span,
-        )
-    };
-    let deref_other = || {
-        deref_expr(
-            TirExpr::new(
-                TirExprKind::Local {
-                    index: 1,
-                    name: "other".to_string(),
-                },
-                ref_variant_type,
-                span,
-            ),
-            variant_type,
-            span,
-        )
-    };
+    let deref_self = || deref_local(0, "self", ref_variant_type, variant_type, span);
+    let deref_other = || deref_local(1, "other", ref_variant_type, variant_type, span);
 
     let body_stmts = variant_eq_body(cases, &deref_self, &deref_other, module_source, tt, span);
     let body = TirBlock::new(body_stmts, span);
 
-    make_synthetic_method(
+    make_trait_method(
         qualified_name,
         method_info,
-        params,
+        impl_type_params.to_vec(),
+        binary_method_params(ref_variant_type, span),
         TypeTable::BOOL,
         body,
-        vec![
-            param_local("self", ref_variant_type, false),
-            param_local("other", ref_variant_type, false),
-        ],
-    )
-}
-
-/// Generate `VariantName^Eq::eq(&self, &Self) -> bool` for generic variants.
-///
-/// Same structure as `generate_variant_eq_fn` but with `impl_type_params` set so the
-/// monomorphizer can specialize payload comparisons for each concrete instantiation.
-fn generate_generic_variant_eq_fn(
-    variant_name: &str,
-    type_params: &[TirTypeParam],
-    cases: &[(String, u32, TypeId)],
-    variant_type: TypeId,
-    ref_variant_type: TypeId,
-    module_source: &ModuleSource,
-    tt: &mut TypeTable,
-    span: Span,
-) -> TirFunction {
-    let method_info = LocalMethodName::new(
-        variant_name.to_string(),
-        Some("Eq".to_string()),
-        "eq".to_string(),
-    );
-    let qualified_name = method_info.to_mangled_name();
-
-    let params = vec![
-        TirParam {
-            name: "self".to_string(),
-            type_id: ref_variant_type,
-            local_index: 0,
-            is_mut: false,
-            span,
-            default_expr: None,
-        },
-        TirParam {
-            name: "other".to_string(),
-            type_id: ref_variant_type,
-            local_index: 1,
-            is_mut: false,
-            span,
-            default_expr: None,
-        },
-    ];
-
-    let deref_self = || {
-        deref_expr(
-            TirExpr::new(
-                TirExprKind::Local {
-                    index: 0,
-                    name: "self".to_string(),
-                },
-                ref_variant_type,
-                span,
-            ),
-            variant_type,
-            span,
-        )
-    };
-    let deref_other = || {
-        deref_expr(
-            TirExpr::new(
-                TirExprKind::Local {
-                    index: 1,
-                    name: "other".to_string(),
-                },
-                ref_variant_type,
-                span,
-            ),
-            variant_type,
-            span,
-        )
-    };
-
-    let body_stmts = variant_eq_body(cases, &deref_self, &deref_other, module_source, tt, span);
-    let body = TirBlock::new(body_stmts, span);
-
-    let impl_type_params: Vec<TirTypeParam> = type_params.to_vec();
-
-    TirFunction {
-        module_source: ModuleSource::default(),
-        name: qualified_name,
-        is_pub: true,
-        is_export: false,
-        is_async: false,
-        type_params: Vec::new(),
-        impl_type_params,
-        monomorph_info: None,
-        method_info: Some(method_info),
-        params,
-        return_type: TypeTable::BOOL,
-        task_return_type: None,
-        effects: Vec::new(),
-        stores: vec![],
-        body: Some(body),
+        binary_method_locals(ref_variant_type),
         span,
-        local_count: 2,
-        locals: vec![
-            param_local("self", ref_variant_type, false),
-            param_local("other", ref_variant_type, false),
-        ],
-        address_taken_locals: IndexSet::default(),
-        stores_aliased_locals: IndexSet::default(),
-        is_cm_binding: false,
-        is_dispatch_wrapper: false,
-        is_cm_export: false,
-        is_ambient: false,
-        inline_hint: InlineHint::Auto,
-        comp_features: 0,
-        export_name: None,
-        allocator_tag: None,
-        kind: FunctionKind::Regular,
-    }
+    )
 }
 
 /// Build the body statements for variant Eq: a chain of if-else testing each case.
@@ -5019,209 +3336,4 @@ fn variant_eq_body(
     ));
 
     stmts
-}
-
-/// Generate `StructName^Ord::cmp(&self, &Self) -> Ordering` for generic structs.
-///
-/// Sets `impl_type_params` with Ord bounds so the monomorphizer can
-/// specialize field cmp calls for concrete types.
-fn generate_generic_struct_ord_fn(
-    struct_name: &str,
-    type_params: &[TirTypeParam],
-    fields: &[(String, TypeId, u32)],
-    ref_struct_type: TypeId,
-    ordering_type: TypeId,
-    module_source: &ModuleSource,
-    tt: &mut TypeTable,
-    span: Span,
-) -> TirFunction {
-    let method_info = LocalMethodName::new(
-        struct_name.to_string(),
-        Some("Ord".to_string()),
-        "cmp".to_string(),
-    );
-    let qualified_name = method_info.to_mangled_name();
-
-    let params = vec![
-        TirParam {
-            name: "self".to_string(),
-            type_id: ref_struct_type,
-            local_index: 0,
-            is_mut: false,
-            span,
-            default_expr: None,
-        },
-        TirParam {
-            name: "other".to_string(),
-            type_id: ref_struct_type,
-            local_index: 1,
-            is_mut: false,
-            span,
-            default_expr: None,
-        },
-    ];
-
-    let self_ref = |span: Span| {
-        TirExpr::new(
-            TirExprKind::Local {
-                index: 0,
-                name: "self".to_string(),
-            },
-            ref_struct_type,
-            span,
-        )
-    };
-    let other_ref = |span: Span| {
-        TirExpr::new(
-            TirExprKind::Local {
-                index: 1,
-                name: "other".to_string(),
-            },
-            ref_struct_type,
-            span,
-        )
-    };
-
-    let ordering_equal = TirExpr::new(
-        TirExprKind::EnumConstruct {
-            enum_type: ordering_type,
-            case_index: 1,
-            case_name: "Equal".to_string(),
-        },
-        ordering_type,
-        span,
-    );
-
-    let mut stmts = Vec::new();
-    let mut locals = vec![
-        param_local("self", ref_struct_type, false),
-        param_local("other", ref_struct_type, false),
-    ];
-
-    // Local indices start at 2 (0 = self, 1 = other).
-    for (local_idx, (field_name, field_type, field_index)) in (2_u32..).zip(fields.iter()) {
-        let self_field = TirExpr::new(
-            TirExprKind::FieldAccess {
-                expr: Box::new(self_ref(span)),
-                field_index: *field_index,
-                field_name: field_name.clone(),
-            },
-            *field_type,
-            span,
-        );
-        let other_field = TirExpr::new(
-            TirExprKind::FieldAccess {
-                expr: Box::new(other_ref(span)),
-                field_index: *field_index,
-                field_name: field_name.clone(),
-            },
-            *field_type,
-            span,
-        );
-        let cmp_result = cmp_call_expr(
-            self_field,
-            other_field,
-            *field_type,
-            ordering_type,
-            module_source,
-            tt,
-            span,
-        );
-
-        locals.push(TirLocal {
-            name: "c".to_string(),
-            type_id: ordering_type,
-            is_mut: false,
-        });
-
-        stmts.push(TirStmt::new(
-            TirStmtKind::Let {
-                name: "c".to_string(),
-                local_index: local_idx,
-                is_mut: false,
-                is_reactive: false,
-                type_id: ordering_type,
-                value: cmp_result,
-                skip_value_copy: false,
-            },
-            span,
-        ));
-
-        let local_c = TirExpr::new(
-            TirExprKind::Local {
-                index: local_idx,
-                name: "c".to_string(),
-            },
-            ordering_type,
-            span,
-        );
-        let cond = TirExpr::new(
-            TirExprKind::Binary {
-                op: TirBinaryOp::NotEq,
-                left: Box::new(local_c.clone()),
-                right: Box::new(ordering_equal.clone()),
-            },
-            TypeTable::BOOL,
-            span,
-        );
-        stmts.push(TirStmt::new(
-            TirStmtKind::If {
-                condition: cond,
-                then_block: TirBlock::new(
-                    vec![TirStmt::new(
-                        TirStmtKind::Return {
-                            value: Some(local_c),
-                        },
-                        span,
-                    )],
-                    span,
-                ),
-                else_block: None,
-            },
-            span,
-        ));
-    }
-
-    stmts.push(TirStmt::new(
-        TirStmtKind::Return {
-            value: Some(ordering_equal),
-        },
-        span,
-    ));
-
-    let body = TirBlock::new(stmts, span);
-
-    let impl_type_params: Vec<TirTypeParam> = type_params.to_vec();
-
-    TirFunction {
-        module_source: ModuleSource::default(),
-        name: qualified_name,
-        is_pub: true,
-        is_export: false,
-        is_async: false,
-        type_params: Vec::new(),
-        impl_type_params,
-        monomorph_info: None,
-        method_info: Some(method_info),
-        params,
-        return_type: ordering_type,
-        task_return_type: None,
-        effects: Vec::new(),
-        stores: vec![],
-        body: Some(body),
-        span,
-        local_count: locals.len() as u32,
-        locals,
-        address_taken_locals: IndexSet::default(),
-        stores_aliased_locals: IndexSet::default(),
-        is_cm_binding: false,
-        is_dispatch_wrapper: false,
-        is_cm_export: false,
-        is_ambient: false,
-        inline_hint: InlineHint::Auto,
-        comp_features: 0,
-        export_name: None,
-        allocator_tag: None,
-        kind: FunctionKind::Regular,
-    }
 }


### PR DESCRIPTION
## Summary

Reduces `wado-compiler/src/synthesis/traits.rs` from **5227 → 3339 lines (~36%)** by removing duplication between Eq/Ord/Inspect/InspectAlt/Display generators and consolidating their helpers.

### Helper extraction
- `trait_method_info`, `local_expr`, `deref_local`, `field_access_local`, `ordering_construct` — replace the inline `LocalMethodName::new`, `TirExprKind::Local{...}`, `TirExprKind::Unary{Deref,...}`, `TirExprKind::FieldAccess{...}`, and `TirExprKind::EnumConstruct{ordering,...}` patterns that were repeated dozens of times.
- `binary_method_params/locals` and `inspect_params/locals` — shared `(self, other)` and `(self, f)` parameter / locals slices.
- `make_trait_method` — `make_synthetic_method` variant that takes `impl_type_params`, so generic auto-derived methods don't need the inline `TirFunction { ... }` literal.

### Generic / non-generic merge
Each `generate_*_fn` and `generate_generic_*_fn` pair is now a single function that takes `impl_type_params: &[TirTypeParam]` (empty slice for non-generic):

| Removed                                     | Replacement                       |
| ------------------------------------------- | --------------------------------- |
| `generate_generic_struct_eq_fn`             | `generate_struct_eq_fn`           |
| `generate_generic_struct_ord_fn`            | `generate_struct_ord_fn`          |
| `generate_generic_variant_eq_fn`            | `generate_variant_eq_fn`          |
| `generate_generic_struct_inspect_fn`        | `generate_struct_inspect_fn`      |
| `generate_generic_variant_inspect_fn`       | `generate_variant_inspect_fn`     |
| `generate_generic_struct_inspect_alt_fn`    | `generate_struct_inspect_alt_fn`  |
| `generate_generic_variant_inspect_alt_fn`   | `generate_variant_inspect_alt_fn` |

Body construction is shared via `build_struct_eq_chain`, `build_struct_ord_body`, `build_struct_inspect_body`, `build_variant_inspect_body`.

### Display / DisplayAlt fallback unified
`generate_display_fallback_impls` and `generate_display_alt_fallback_impls` were nearly identical. Both now defer to `generate_fallback_impls(module, &TraitPair)`, parameterised over the target/delegate trait+method pair (`DISPLAY_PAIR` and `DISPLAY_ALT_PAIR` consts).

### Misc
- Dropped `// ─── ... ───` section divider comments per project rule "Do not use any comment sections to separate or organize code."

## Test plan

- [x] `cargo check -p wado-compiler` — clean
- [x] `mise run on-task-done` — exit 0 (build / clippy-fix / golden update / format / `cargo test --test-threads=2` (5700 e2e + ~1000 unit/integration) / `wado test`)

https://claude.ai/code/session_01AqBHNN5YTaX2s3sPZVW3bQ