### PR TITLE
gale: complete bt → scan-dispatch migration (docs + dead-code + renames)

### DIFF
--- a/package-gale/AGENTS.md
+++ b/package-gale/AGENTS.md
@@ -188,7 +188,24 @@ pointer.
 
 ## Generated Parser Rules
 
-- **No backtracking in new code.** Use static k-token lookahead prediction to disambiguate alternatives. If prediction cannot resolve within depth 5, file an issue rather than adding backtracking. Existing backtracking sites are being migrated to prediction; do not add new ones. The migration is complete for all committed grammars — `bt_try` count is 0 across `sqlite`, `sqlite_highlight`, `rust`, `type_script`, and `antlrv4`. Stage C dispatch sites use scan-side first-success-wins on `sort_group_by_element_count` order, with `gen_scan_multi_alt` partitioning atom alts by their depth-0 first token so longest-first sort behaves like longest-match within each partition.
+- **No backtracking in new code.** Use static k-token lookahead prediction
+  to disambiguate alternatives. If prediction cannot resolve within depth 5,
+  file an issue rather than adding backtracking. The codegen has no
+  speculative-parse fallback any more — an alt whose suffix is unscannable
+  at a tournament site is a codegen-time `panic!`, not a `bt_try` block.
+
+### Migration status (2026-04)
+
+The bt → scan-dispatch migration is complete. `bt_try` and `opt_bt` count
+is 0 across every committed grammar (`sqlite`, `sqlite_highlight`, `rust`,
+`type_script`, `antlrv4`, plus the smaller fixture grammars). Stage C
+dispatch sites use scan-side first-success-wins on
+`sort_group_by_element_count` (longest-first) order, and
+`gen_scan_multi_alt` partitions atom alts by their depth-0 first token
+before applying first-success-wins inside each partition — that
+combination is correctness-equivalent to the longest-match tournament for
+the cases that actually arise (e.g. `expr`'s `column_ref` IDENT vs
+`function_call` IDENT '(' … ')').
 
 ## Failed Approaches (Do Not Repeat)
 

--- a/package-gale/AGENTS.md
+++ b/package-gale/AGENTS.md
@@ -213,4 +213,3 @@ pointer.
 - Tokens from inside expanded sub-rules cannot be used for prediction at the decision point level
 - To use expansion correctly, the prediction must map expanded tokens back to the decision point's lookahead depth (essentially an ATN simulator)
 - `sll_dedup_by_alt` is too aggressive for expanded configs — alternatives sharing sub-rules get merged
-

--- a/package-gale/AGENTS.md
+++ b/package-gale/AGENTS.md
@@ -188,7 +188,7 @@ pointer.
 
 ## Generated Parser Rules
 
-- **No backtracking in new code.** Use static k-token lookahead prediction to disambiguate alternatives. If prediction cannot resolve within depth 5, file an issue rather than adding backtracking. Existing backtracking sites are being migrated to prediction; do not add new ones.
+- **No backtracking in new code.** Use static k-token lookahead prediction to disambiguate alternatives. If prediction cannot resolve within depth 5, file an issue rather than adding backtracking. Existing backtracking sites are being migrated to prediction; do not add new ones. The migration is complete for all committed grammars — `bt_try` count is 0 across `sqlite`, `sqlite_highlight`, `rust`, `type_script`, and `antlrv4`. Stage C dispatch sites use scan-side first-success-wins on `sort_group_by_element_count` order, with `gen_scan_multi_alt` partitioning atom alts by their depth-0 first token so longest-first sort behaves like longest-match within each partition.
 
 ## Failed Approaches (Do Not Repeat)
 
@@ -214,25 +214,3 @@ pointer.
 - To use expansion correctly, the prediction must map expanded tokens back to the decision point's lookahead depth (essentially an ATN simulator)
 - `sll_dedup_by_alt` is too aggressive for expanded configs — alternatives sharing sub-rules get merged
 
-### Removing the LR Gate in `is_rule_scannable` without Smarter Stage C (2026-04)
-
-**Goal:** Drop the "has-left-recursive-alt" guard at `gen_context.wado:is_rule_scannable` so Stage C group-level dispatch can activate for `sql_stmt`'s statement-type alternation (nine shared-first-token alts that all transitively reference the LR rule `expr`). Expected: eliminate the last nine `bt_try` blocks in `sqlite.wado`.
-
-**What was tried:** Generated faithful scan-side twins of the parser's precedence-climbing infrastructure (`scan_X_atom` / `scan_X_prec` / `scan_X_lr_N`), mirroring `parse_X_prec` with token-kind dispatch, `peek_at(1)` overlap dispatch, and precedence guards. Then removed the LR gate in `is_rule_scannable`.
-
-**Why it failed:**
-
-- `bt_try` count on `sqlite.wado` dropped 54 → 38 as expected, but `sqlite_parse` regressed **14,379 → 136,947 µs/iter (10×)**.
-- Root cause: Stage C uses a **tournament dispatch** (scan every candidate alt to completion, then pick the longest match). For `sql_stmt`'s nine statement-type alts that all share first tokens on `{WITH, SELECT, DELETE, INSERT, REPLACE, UPDATE, VALUES}`, the tournament runs nine full LR scans per statement. Each scan is a deep precedence-climbing traversal over every suffix operator, so the total cost is `O(statement_length × 9)` — no matter which alt actually matches.
-- `bt_try` wins here by being **first-success-wins**: when alt 1 parses cleanly, alts 2..9 are never touched. The scan-based tournament has no such short-circuit.
-
-**Second attempt (also reverted, 2026-04):** Switched the four Stage C dispatch sites (`gen_group_scan_dispatch`, `gen_general_group_scan_dispatch`, `gen_rule_ref_group_scan_dispatch`, and rule-level `emit_scan_partition_body`) to first-success-wins on `sort_group_by_element_count` order, then dropped the gate. `bt_try` went to 0 across `sqlite.wado` / `sqlite_highlight.wado` / `rust.wado` / `type_script.wado` / `antlrv4.wado`, and gale's own driver tests stayed green — but the larger `benchmark/sqlite_parse/queries.sql` corpus failed with `Parse error: expected Eof, got "("`. The divergence is not in the `gen_rule_ref_group_scan_dispatch` site (where alts are heterogeneous statement rules and the longer one happens to come first under the element-count sort), but in `emit_scan_partition_body` for `expr`'s atom: `column_ref` matches a single `IDENTIFIER` while `function_call` matches `IDENTIFIER '(' ... ')'`. With first-success-wins on element-count sort, `column_ref` (2 elements) commits before `function_call` (4 elements) is even tried, and the trailing `(...)` becomes an unattached suffix that surfaces only when the outer parser checks for `Eof`. The element-count sort is a poor proxy for "longest token consumption" once an alt's prefix overlap is shorter than its full match. Reverted; the longest-match tournament stays in all four sites.
-
-**What remains:** The faithful `scan_X_atom` / `scan_X_prec` / `scan_X_lr_N` generators are correct and committed — they fix a real divergence bug where the old naive scan could commit to the wrong LR alt on shared-first-token suffixes (e.g. `K_NOT K_IN` vs `K_NOT K_LIKE` vs `K_NOT K_BETWEEN` under `expr`). The LR gate in `is_rule_scannable` is kept, with a docstring explaining the cost tradeoff. Net win: `sqlite_parse` 14,883 → 11,826 µs (−21%) from other scan improvements, not from LR unlock.
-
-**Lessons:**
-
-- `bt_try` is not strictly worse than scan-dispatch: ordered-lazy first-success-wins beats exhaustive tournament whenever alts are not mutually-exclusive-by-first-token and the cost of the wrong scan is large.
-- Faithful scan semantics (correctness) and cheap Stage C dispatch (performance) are **independent concerns**. Solving one does not unlock the other.
-- First-success-wins on `sort_group_by_element_count` is **not** a drop-in replacement for longest-match: it agrees with longest-match only when the first-tried alt also consumes the most tokens, which holds for the heterogeneous RuleRef alts of `sql_stmt`'s WITH partition but breaks for the `expr` atom alts where `column_ref` is a strict prefix of `function_call`.
-- Before removing the LR gate, Stage C needs one of: (a) k=2/3 lookahead partitioning to shrink the candidate set before the tournament, (b) per-site first-success-wins guarded by a static "alts are mutually disjoint after k tokens" check, or (c) ATN-style adaptive prediction. See `TODO.md` for the plan.

--- a/package-gale/AGENTS.md
+++ b/package-gale/AGENTS.md
@@ -196,7 +196,7 @@ pointer.
 
 **Goal:** Expand multi-token RuleRefs during SLL prediction to reduce backtracking.
 
-**What was tried:** Added `return_stack` to `SllConfig` to track continuation points when entering a referenced rule. `sll_expand_rule_ref` pushed return frames and advanced inside sub-rules. `try_expand_opaque` called expansion when `build_sll_node` would otherwise produce `Backtrack`.
+**What was tried:** Added `return_stack` to `SllConfig` to track continuation points when entering a referenced rule. `sll_expand_rule_ref` pushed return frames and advanced inside sub-rules. `try_expand_opaque` called expansion when `build_sll_node` would otherwise produce `Ambiguous` (then named `Backtrack`).
 
 **Why it failed (3 distinct bugs):**
 

--- a/package-gale/AGENTS.md
+++ b/package-gale/AGENTS.md
@@ -190,9 +190,13 @@ pointer.
 
 - **No backtracking in new code.** Use static k-token lookahead prediction
   to disambiguate alternatives. If prediction cannot resolve within depth 5,
-  file an issue rather than adding backtracking. The codegen has no
-  speculative-parse fallback any more — an alt whose suffix is unscannable
-  at a tournament site is a codegen-time `panic!`, not a `bt_try` block.
+  file an issue rather than adding backtracking. The Stage C codegen no
+  longer emits `bt_try` or `opt_bt` blocks — an alt whose suffix is
+  unscannable at a tournament site is a codegen-time `panic!`. (The
+  rule-level LR-atom path in `gen_prediction_code_inner` retains a
+  save-and-rewind pattern as a structural fallback when scan helpers are
+  unavailable; no committed grammar exercises it, but the code is kept
+  for malformed-grammar diagnostics.)
 
 ### Migration status (2026-04)
 

--- a/package-gale/TODO.md
+++ b/package-gale/TODO.md
@@ -10,60 +10,6 @@ exception). The remaining work is mostly about **propagating** parsed
 information into the IR and **using** it in the code generator so that
 generated parsers are semantically correct, not just syntactically accepted.
 
-## Performance: sqlite-parse Benchmark
-
-### Next Up: Remove the LR Gate in `is_rule_scannable`
-
-See `AGENTS.md` "Failed Approaches: Removing the LR Gate ... 2026-04"
-for the two attempts that did not land. The remaining `bt_try` blocks
-in `sqlite.wado` (`parse_sql_stmt` — WITH/SELECT/DELETE/... and CREATE
-groups) and their mirrors in `sqlite_highlight.wado` all sit under
-Stage C's LR bail-out. Closing this requires one of the three
-approaches below, in increasing order of implementation cost:
-
-1. **Per-site ordered-lazy mode for `gen_rule_ref_group_scan_dispatch`.**
-   The `sql_stmt` WITH partition is RuleRef-only and its sorted alts are
-   mutually disjoint after a 1–2 token prefix, so first-success-wins on
-   `sort_group_by_element_count` is correctness-preserving there. The
-   2026-04 attempt got this right; what blocked it was applying the same
-   change to `emit_scan_partition_body` and the two general-group
-   dispatch sites, where alts include strict-prefix shapes like
-   `column_ref` vs `function_call` that need true longest-match. The
-   minimal fix is to flip first-success-wins on **only** in
-   `gen_rule_ref_group_scan_dispatch` (statement-rule RuleRef alts), and
-   keep longest-match everywhere else. This unlocks the LR gate without
-   regressing `expr`-atom dispatch.
-   - Note: the gate is still tripped by the LR check in
-     `is_rule_scannable`. Either drop the gate just for the
-     RuleRef-only path, or detect "all alts of this rule are scannable
-     in the RuleRef-only sense" at the call site.
-
-2. **k-lookahead candidate pruning before the tournament.** Use the
-   existing `alt_position_first_sets(alt, max_k)` to partition group
-   alts by their depth-0..k fingerprints. Scan only the subset whose
-   fingerprint matches the upcoming k tokens. For `sql_stmt`: the alts
-   diverge by k=2 or k=3 (e.g. `WITH`-prefixed vs bare `SELECT` vs
-   `SELECT`-after-CTE vs `DELETE FROM` vs `INSERT INTO`/`REPLACE INTO`
-   vs `UPDATE`/`UPDATE OR`). This shrinks the tournament from 9 to
-   typically 1–2 candidates before any full LR scan runs.
-
-3. **ATN-style adaptive prediction (ALL(\*)).** The textbook answer.
-   Out of scope for the short term; listed for completeness.
-
-**Verification gates** (must hold throughout):
-
-- All Wado tests green, including `mise run test-wado` (the CI gate
-  that broke on the 2026-04 second attempt — `benchmark/sqlite_parse`
-  exercises COALESCE/COUNT/SUM-style `function_call` shapes that the
-  small driver tests in `package-gale/tests/` do not).
-- `driver_sqlite_test`, `driver_sqlite_create_table_test`,
-  `driver_sqlite_minimal_test`, `driver_sqlite_highlight_test`,
-  `sqlite_regression_test`, `sqlite_case_when_test`.
-- `sqlite_parse` per-iteration ≤ today's 11,826 µs on the dev machine.
-- `typescript.wado` / `rust.wado` `bt_try` counts must not increase
-  (they are semantic-predicate-gated, not LR-gated, and out of scope
-  per WEP-2026-03-02).
-
 ## Generated Parser Bugs
 
 (none currently)

--- a/package-gale/src/parser_gen.wado
+++ b/package-gale/src/parser_gen.wado
@@ -71,7 +71,7 @@ variant PredictionNode {
     Leaf(i32),
     Dispatch(PredictionDispatch),
     Consume(ConsumeNode),
-    Backtrack(Array<i32>),
+    Ambiguous(Array<i32>),
 }
 
 struct ConsumeNode {
@@ -116,18 +116,18 @@ fn build_prediction(alt_indices: &Array<i32>, first_sets: &Array<Array<String>>,
     return strip_dead_consume(tree);
 }
 
-/// Strip Consume nodes whose child contains any Backtrack — fall back to
-/// Backtrack from the original position rather than consuming then failing.
-/// This handles both direct Consume → Backtrack and indirect cases like
-/// Consume → Dispatch → (Branch → Backtrack).
+/// Strip Consume nodes whose child contains any Ambiguous — fall back to
+/// Ambiguous from the original position rather than consuming then failing.
+/// This handles both direct Consume → Ambiguous and indirect cases like
+/// Consume → Dispatch → (Branch → Ambiguous).
 fn strip_dead_consume(node: PredictionNode) -> PredictionNode {
     return match node {
         Consume(c) => {
             let child = strip_dead_consume(c.child);
-            if prediction_contains_backtrack(&child) {
+            if prediction_contains_ambiguous(&child) {
                 let mut indices: Array<i32> = [];
                 prediction_collect_all_indices(&child, &mut indices);
-                PredictionNode::Backtrack(indices);
+                PredictionNode::Ambiguous(indices);
             } else {
                 PredictionNode::Consume(ConsumeNode { element: c.element, child });
             }
@@ -146,13 +146,13 @@ fn strip_dead_consume(node: PredictionNode) -> PredictionNode {
     };
 }
 
-fn prediction_contains_backtrack(node: &PredictionNode) -> bool {
+fn prediction_contains_ambiguous(node: &PredictionNode) -> bool {
     return match *node {
-        Backtrack(_) => true,
-        Consume(c) => prediction_contains_backtrack(&c.child),
+        Ambiguous(_) => true,
+        Consume(c) => prediction_contains_ambiguous(&c.child),
         Dispatch(d) => {
             for let b of &d.branches {
-                if prediction_contains_backtrack(&b.child) {
+                if prediction_contains_ambiguous(&b.child) {
                     return true;
                 }
             }
@@ -164,7 +164,7 @@ fn prediction_contains_backtrack(node: &PredictionNode) -> bool {
 
 fn prediction_collect_all_indices(node: &PredictionNode, out: &mut Array<i32>) {
     match *node {
-        Backtrack(indices) => {
+        Ambiguous(indices) => {
             for let i of &indices {
                 if !out.iter().any(|x: i32| x == *i) {
                     out.push(*i);
@@ -563,10 +563,10 @@ fn sll_dedup_by_alt(configs: &Array<SllConfig>) -> Array<SllConfig> {
 fn build_sll_node(configs: &Array<SllConfig>, depth: i32, max_depth: i32, ctx: &mut GenContext) -> PredictionNode {
     let closed = sll_closure(configs);
 
-    // Guard: if too many configs, fall back to backtracking to avoid explosion.
+    // Guard: if too many configs, fall back to Ambiguous (codegen scan-dispatches) to avoid explosion.
     if closed.len() > 200 {
         let alts = sll_unique_alts(&closed);
-        return PredictionNode::Backtrack(alts);
+        return PredictionNode::Ambiguous(alts);
     }
 
     // Check unique alternatives.
@@ -575,7 +575,7 @@ fn build_sll_node(configs: &Array<SllConfig>, depth: i32, max_depth: i32, ctx: &
         return PredictionNode::Leaf(alts[0]);
     }
     if alts.len() == 0 || depth >= max_depth {
-        return PredictionNode::Backtrack(alts);
+        return PredictionNode::Ambiguous(alts);
     }
 
     // Check for common prefix: if all configs are at a terminal element
@@ -661,7 +661,7 @@ fn build_sll_node(configs: &Array<SllConfig>, depth: i32, max_depth: i32, ctx: &
             if let Some(node) = expanded {
                 node;
             } else {
-                PredictionNode::Backtrack(next_alts);
+                PredictionNode::Ambiguous(next_alts);
             }
         } else {
             // Still ambiguous: recurse with deeper lookahead.
@@ -688,9 +688,9 @@ fn build_sll_node(configs: &Array<SllConfig>, depth: i32, max_depth: i32, ctx: &
     //    branch can fail at parse time (e.g. typespec `ID '[' ']'` matches
     //    the lookahead `[` but the body `[ ]` won't match `[ <e> ]`),
     //    leaving the at-end alt as the only correct choice. Fall back to
-    //    Backtrack so the codegen's longest-match scan dispatch picks the
+    //    Ambiguous so the codegen's longest-match scan dispatch picks the
     //    alt whose body actually parses (cf. ANTLR4's adaptive prediction).
-    //  * Multiple at-end alts → true ambiguity → Backtrack.
+    //  * Multiple at-end alts → true ambiguity → Ambiguous.
     let mut at_end_alts: Array<i32> = [];
     for let c of &closed {
         if config_is_at_end(c) && !array_contains_i32(&at_end_alts, c.alt_index) {
@@ -699,14 +699,14 @@ fn build_sll_node(configs: &Array<SllConfig>, depth: i32, max_depth: i32, ctx: &
     }
 
     if at_end_alts.len() >= 1 && branches.len() >= 1 {
-        return PredictionNode::Backtrack(alts);
+        return PredictionNode::Ambiguous(alts);
     }
 
     if branches.len() == 0 {
         if at_end_alts.len() == 1 {
             return PredictionNode::Leaf(at_end_alts[0]);
         }
-        return PredictionNode::Backtrack(alts);
+        return PredictionNode::Ambiguous(alts);
     }
     return PredictionNode::Dispatch(PredictionDispatch { depth, branches });
 }
@@ -818,7 +818,7 @@ fn try_expand_opaque(original_configs: &Array<SllConfig>, token: &String, non_op
             has_improvement = true;
             PredictionNode::Leaf(token_alts[0]);
         } else {
-            PredictionNode::Backtrack(token_alts.sorted());
+            PredictionNode::Ambiguous(token_alts.sorted());
         };
         let idx = find_merge_branch(&branches, &child);
         if idx >= 0 {
@@ -830,11 +830,11 @@ fn try_expand_opaque(original_configs: &Array<SllConfig>, token: &String, non_op
     if !has_improvement || branches.is_empty() {
         return null;
     }
-    // Only use if ALL branches are Leaf — any Backtrack branch means expansion
+    // Only use if ALL branches are Leaf — any Ambiguous branch means expansion
     // didn't fully resolve, and the code generator's Dispatch has no fallback
     // for unmatched tokens, which would silently drop valid inputs.
     for let b of branches {
-        if let Backtrack(_) = b.child {
+        if let Ambiguous(_) = b.child {
             return null;
         }
     }
@@ -978,7 +978,7 @@ fn first_of_elements(elements: &Array<Element>, ctx: &mut GenContext, visiting: 
 fn prediction_node_eq(a: &PredictionNode, b: &PredictionNode) -> bool {
     return match [*a, *b] {
         [Leaf(ai), Leaf(bi)] => ai == bi,
-        [Backtrack(aa), Backtrack(ba)] => {
+        [Ambiguous(aa), Ambiguous(ba)] => {
             if aa.len() != ba.len() {
                 return false;
             }
@@ -1039,36 +1039,6 @@ fn array_contains_i32(arr: &Array<i32>, val: i32) -> bool {
         }
     }
     return false;
-}
-
-fn count_backtrack_nodes(node: &PredictionNode) -> i32 {
-    return match *node {
-        Backtrack(_) => 1,
-        Dispatch(d) => {
-            let mut count = 0;
-            for let b of &d.branches {
-                count += count_backtrack_nodes(&b.child);
-            }
-            count;
-        },
-        Consume(c) => count_backtrack_nodes(&c.child),
-        Leaf(_) => 0,
-    };
-}
-
-fn count_leaf_nodes(node: &PredictionNode) -> i32 {
-    return match *node {
-        Leaf(_) => 1,
-        Dispatch(d) => {
-            let mut count = 0;
-            for let b of &d.branches {
-                count += count_leaf_nodes(&b.child);
-            }
-            count;
-        },
-        Consume(c) => count_leaf_nodes(&c.child),
-        Backtrack(_) => 0,
-    };
 }
 
 pub fn gen_parser(w: &mut CodeWriter, grammar: &Grammar, ctx: &mut GenContext) {
@@ -1236,7 +1206,7 @@ fn gen_parser_struct(w: &mut CodeWriter) {
 }
 
 // --- Alternative Scan Helpers ---
-// For each alternative in a Backtrack group that has a scannable prefix,
+// For each alternative in an Ambiguous group that has a scannable prefix,
 // generate a scan_<rule>_bt_<N> function. This function scans only the
 // scannable prefix of the alternative, which is enough to distinguish it
 // from other alternatives without full speculative parsing.
@@ -1255,8 +1225,9 @@ fn scannable_prefix_len(elements: &Array<Element>, ctx: &mut GenContext) -> i32 
     return count;
 }
 
-/// Generate a scan function for a backtracking alternative if it has at least
-/// one scannable leading element. The scan covers the scannable prefix only.
+/// Generate a scan function for a tournament alternative (`parse_X_bt_N` —
+/// the `_bt_` infix is historical) if it has at least one scannable leading
+/// element. The scan covers the scannable prefix only.
 fn gen_bt_scan_if_possible(w: &mut CodeWriter, alt: &Alternative, fn_name: &String, alt_idx: i32, ctx: &mut GenContext) {
     let prefix_len = scannable_prefix_len(&alt.elements, ctx);
     if prefix_len == 0 {
@@ -1299,7 +1270,7 @@ fn alt_scan_is_full(elements: &Array<Element>, ctx: &mut GenContext) -> bool {
 // --- Scan Function Generation ---
 // Scan functions recognize parser rules by walking token kinds without building
 // CST nodes or constructing error messages. They return the token position after
-// successful recognition, or -1 on failure. Used to disambiguate Backtrack
+// successful recognition, or -1 on failure. Used to disambiguate Ambiguous
 // alternatives without expensive speculative parsing.
 
 fn gen_scan_functions(w: &mut CodeWriter, grammar: &Grammar, ctx: &mut GenContext) {
@@ -2213,7 +2184,8 @@ fn gen_scan_element(w: &mut CodeWriter, elem: &Element, ctx: &mut GenContext, fa
 }
 
 /// Emit scan code for an element that assigns to `pos` (may set -1 on failure).
-/// Used inside optional/repetition blocks where failure means backtrack, not abort.
+/// Used inside optional/repetition blocks where failure means "skip this
+/// iteration / branch", not abort.
 fn gen_scan_element_assign(w: &mut CodeWriter, elem: &Element, ctx: &mut GenContext) {
     if let Label(lab) = elem {
         gen_scan_element_assign(w, &lab.element, ctx);
@@ -2475,9 +2447,9 @@ fn gen_parse_fn(w: &mut CodeWriter, rule: &ParserRule, ctx: &mut GenContext) {
         first_sets.push(ctx.first_of_alt(&rule.alternatives[idx], &mut visiting));
     }
     let mut groups = compute_overlap_groups(&first_sets);
-    let needs_bt = has_multi_alt_groups(&groups);
+    let has_overlaps = has_multi_alt_groups(&groups);
 
-    if needs_bt {
+    if has_overlaps {
         for let mut g = 0; g < groups.len(); g += 1 {
             if groups[g].len() > 1 {
                 sort_group_by_specificity(&mut groups[g], &first_sets);
@@ -2499,7 +2471,7 @@ fn gen_parse_fn(w: &mut CodeWriter, rule: &ParserRule, ctx: &mut GenContext) {
         }
     }
 
-    if needs_bt {
+    if has_overlaps {
         for let group of groups {
             if group.len() > 1 {
                 for let gi of group {
@@ -2552,7 +2524,7 @@ fn gen_parse_fn(w: &mut CodeWriter, rule: &ParserRule, ctx: &mut GenContext) {
         f.set_return_type(`Result<{type_name}, ParseError>`);
         f.emit_begin(w);
         w.line("let start = p.peek().span.start;");
-        if needs_bt {
+        if has_overlaps {
             gen_multi_alt_body_bt(w, rule, &type_name, ctx, &groups, &first_sets, &non_lr_indices);
         } else {
             gen_multi_alt_body(w, rule, &type_name, ctx, &non_lr_indices);
@@ -2585,7 +2557,7 @@ fn gen_parse_fn(w: &mut CodeWriter, rule: &ParserRule, ctx: &mut GenContext) {
         f.set_return_type(`Result<{type_name}, ParseError>`);
         f.emit_begin(w);
         w.line("let start = p.peek().span.start;");
-        if needs_bt {
+        if has_overlaps {
             gen_multi_alt_body_bt(w, rule, &type_name, ctx, &groups, &first_sets, &non_lr_indices);
         } else {
             gen_multi_alt_body(w, rule, &type_name, ctx, &non_lr_indices);
@@ -3077,7 +3049,7 @@ fn gen_repeat(w: &mut CodeWriter, rep: &RepeatElement, ctx: &mut GenContext, nam
         }
 
         if let Optional = rep.kind {
-            gen_optional_with_backtrack(w, inner, ctx, name_counts);
+            gen_optional_with_scan_guard(w, inner, ctx, name_counts);
         }
     }
 }
@@ -3285,7 +3257,7 @@ fn gen_repeat_with_follow(w: &mut CodeWriter, rep: &RepeatElement, ctx: &mut Gen
         w.line("null");
         w.end_with(";");
     } else {
-        gen_optional_with_backtrack(w, inner, ctx, name_counts);
+        gen_optional_with_scan_guard(w, inner, ctx, name_counts);
     }
 }
 
@@ -3559,7 +3531,7 @@ fn emit_scan_guard_with_prefix(w: &mut CodeWriter, inner: &Element, ctx: &mut Ge
     return scan_pos_var;
 }
 
-fn gen_optional_with_backtrack(w: &mut CodeWriter, inner: &Element, ctx: &mut GenContext, name_counts: &mut Array<[String, i32]>) {
+fn gen_optional_with_scan_guard(w: &mut CodeWriter, inner: &Element, ctx: &mut GenContext, name_counts: &mut Array<[String, i32]>) {
     if has_nested_optionals(inner) {
         if let Group(g) = inner {
             gen_optional_with_lookahead(w, &g.alternatives[0].elements, ctx, name_counts);
@@ -3601,7 +3573,7 @@ fn gen_optional_with_backtrack(w: &mut CodeWriter, inner: &Element, ctx: &mut Ge
     // codegen-time error.
     let mut visiting: Array<String> = [];
     if !ctx.is_element_scannable(inner, &mut visiting) {
-        panic("gen_optional_with_backtrack: inner element is not scannable; backtracking has been removed (see AGENTS.md 'Generated Parser Rules')");
+        panic("gen_optional_with_scan_guard: inner element is not scannable; backtracking has been removed (see AGENTS.md 'Generated Parser Rules')");
     }
     let scan_pos_var = emit_opt_scan_guard(w, inner, ctx, name_counts);
     w.begin(`if {scan_pos_var} >= 0`);
@@ -3657,7 +3629,7 @@ fn gen_storable_optional(w: &mut CodeWriter, inner: &Element, ctx: &mut GenConte
         gen_storable_optional_with_lookahead(w, inner, ctx, name_counts, type_str, opt_name, field_name);
     } else {
         // Inline scan-guard: scan first, parse on success.
-        gen_storable_optional_with_backtrack(w, inner, ctx, name_counts, type_str, opt_name, field_name);
+        gen_storable_optional_with_scan_guard(w, inner, ctx, name_counts, type_str, opt_name, field_name);
     }
 }
 
@@ -3770,29 +3742,20 @@ fn gen_absent_optional_field(w: &mut CodeWriter, elem: &Element, name_counts: &m
     }
 }
 
-/// Generate a storable optional with backtracking for struct capture.
+/// Generate a storable optional with a scan-guard for struct capture.
 ///
 /// Produces code like:
-///   let opt: Option<Type> = if first_check {
-///       let saved = p.pos;
-///       let mut result: Option<Type> = null;
-///       bt: {
-///           let r1 = parse_foo(p);
-///           if let Err(_) = r1 { p.pos = saved; break bt; }
-///           let foo = r1.unwrap();
-///           let r2 = p.expect(TK_DOT);
-///           if let Err(_) = r2 { p.pos = saved; break bt; }
-///           let dot = r2.unwrap();
-///           result = Option::<Type>::Some(Type { foo, dot });
-///       }
-///       result
+///   let opt: Option<Type> = if scan_pos >= 0 {
+///       let foo = parse_foo(p);
+///       let dot = p.expect(TK_DOT);
+///       Option::<Type>::Some(Type { foo, dot })
 ///   } else { null };
-fn gen_storable_optional_with_backtrack(w: &mut CodeWriter, inner: &Element, ctx: &mut GenContext, name_counts: &mut Array<[String, i32]>, type_str: &String, opt_name: &String, field_name: &String) {
+fn gen_storable_optional_with_scan_guard(w: &mut CodeWriter, inner: &Element, ctx: &mut GenContext, name_counts: &mut Array<[String, i32]>, type_str: &String, opt_name: &String, field_name: &String) {
     // Scan-based guard: the inner must be fully scannable. Backtracking has
     // been removed; an unscannable inner is a codegen-time error.
     let mut visiting: Array<String> = [];
     if !ctx.is_element_scannable(inner, &mut visiting) {
-        panic("gen_storable_optional_with_backtrack: inner element is not scannable; backtracking has been removed (see AGENTS.md 'Generated Parser Rules')");
+        panic("gen_storable_optional_with_scan_guard: inner element is not scannable; backtracking has been removed (see AGENTS.md 'Generated Parser Rules')");
     }
     let scan_pos_var = emit_opt_scan_guard(w, inner, ctx, name_counts);
     w.begin(`let {opt_name}: Option<{type_str}> = if {scan_pos_var} >= 0`);
@@ -4170,7 +4133,7 @@ fn gen_consume_group(w: &mut CodeWriter, alts: &Array<Alternative>, ctx: &mut Ge
             let mut sorted_group = group.sorted();
             sort_group_by_element_count(&mut sorted_group, alts);
             let mut nc: Array<[String, i32]> = [];
-            gen_backtracking_body(w, &sorted_group, alts, ctx, &mut nc);
+            gen_prediction_body(w, &sorted_group, alts, ctx, &mut nc);
         }
     }
     w.end();
@@ -4211,7 +4174,7 @@ fn gen_consume_group_store(w: &mut CodeWriter, alts: &Array<Alternative>, ctx: &
         }
         w.end_with(";");
     } else {
-        // Complex case: overlapping FIRST sets, use Option + backtracking
+        // Complex case: overlapping FIRST sets, use Option + scan dispatch
         let opt_var = dedup_name(&`{var_name}_opt`, name_counts);
         w.line(`let mut {opt_var}: Option<{type_name}> = null;`);
 
@@ -4530,7 +4493,7 @@ fn gen_general_group_store(w: &mut CodeWriter, alts: &Array<Alternative>, ctx: &
         w.end_with(";");
         ctx.group_counter = gc_max;
     } else {
-        // Overlapping FIRST sets — use Option + backtracking
+        // Overlapping FIRST sets — use Option + scan dispatch
         let opt_var = dedup_name(&`{var_name}_opt`, name_counts);
         w.line(`let mut {opt_var}: Option<{type_name}> = null;`);
 
@@ -4651,7 +4614,7 @@ fn general_group_all_scannable(sorted_group: &Array<i32>, alts: &Array<Alternati
 
 /// Returns true iff every alt's remaining suffix `[skip..]` is fully
 /// scannable. Used as the precondition for the prediction-tree
-/// `Backtrack` branch to fall through to scan dispatch.
+/// `Ambiguous` branch to fall through to scan dispatch.
 fn backtrack_node_all_scannable(sorted: &Array<i32>, alts: &Array<Alternative>, ctx: &mut GenContext, skip: i32) -> bool {
     if sorted.len() < 2 {
         return false;
@@ -4732,7 +4695,7 @@ fn gen_general_group_scan_dispatch(w: &mut CodeWriter, alts: &Array<Alternative>
     w.end();
 }
 
-fn gen_backtracking_body(w: &mut CodeWriter, group: &Array<i32>, alts: &Array<Alternative>, ctx: &mut GenContext, name_counts: &mut Array<[String, i32]>) {
+fn gen_prediction_body(w: &mut CodeWriter, group: &Array<i32>, alts: &Array<Alternative>, ctx: &mut GenContext, name_counts: &mut Array<[String, i32]>) {
     // Build prediction tree for the group alternatives.
     let mut pred_indices: Array<i32> = [];
     let mut pred_firsts: Array<Array<String>> = [];
@@ -4774,14 +4737,14 @@ fn gen_group_prediction_code_skip(w: &mut CodeWriter, node: &PredictionNode, alt
         gen_group_prediction_code_skip(w, &c.child, alts, ctx, name_counts, skip + 1);
         return;
     }
-    if let Backtrack(indices) = node {
+    if let Ambiguous(indices) = node {
         let mut sorted = indices.sorted();
         sort_group_by_element_count(&mut sorted, alts);
 
         // Every alt's remaining elements must be fully scannable. Backtracking
         // has been removed; an unscannable suffix is a codegen-time error.
         if !backtrack_node_all_scannable(&sorted, alts, ctx, skip) {
-            panic("prediction Backtrack node has unscannable alt; backtracking has been removed (see AGENTS.md 'Generated Parser Rules')");
+            panic("prediction Ambiguous node has unscannable alt; backtracking has been removed (see AGENTS.md 'Generated Parser Rules')");
         }
         gen_group_scan_dispatch(w, &sorted, alts, ctx, name_counts, skip);
         return;
@@ -4807,7 +4770,7 @@ fn gen_group_prediction_code_skip(w: &mut CodeWriter, node: &PredictionNode, alt
 /// whose scan advances furthest is parsed; ties go to the first in sorted
 /// order. If all scans fail, the last alt is parsed to surface a real error.
 /// First-success-wins scan dispatch for `gen_group_prediction_code`'s
-/// `Backtrack` node. The `sorted` parameter has already been ordered by
+/// `Ambiguous` node. The `sorted` parameter has already been ordered by
 /// `sort_group_by_element_count` (longest-first), so scanning candidates
 /// in that order and committing on first success matches what the
 /// longest-match tournament would have picked while skipping the remaining
@@ -5442,7 +5405,7 @@ fn gen_prediction_code_inner(w: &mut CodeWriter, node: &PredictionNode, fn_name:
         // If it doesn't (e.g. a RuleRef at position skip was expanded via Dispatch
         // and the Consume is actually for a later element), the skip count would be
         // wrong and the Leaf would generate incorrect code. In that case, don't
-        // increment skip — the Leaf will fall back to the backtracking helper.
+        // increment skip — the Leaf will fall back to the scan-tournament helper.
         let elem_matches = elements_match(&c.element, &alts[0].elements[skip]);
         if elem_matches {
             gen_element(w, &c.element, ctx, name_counts);
@@ -5454,15 +5417,15 @@ fn gen_prediction_code_inner(w: &mut CodeWriter, node: &PredictionNode, fn_name:
         }
         return;
     }
-    if let Backtrack(indices) = node {
+    if let Ambiguous(indices) = node {
         // Sort by element count for proper ordering (single RuleRef first, etc.)
         let mut sorted_indices = indices.sorted();
         sort_group_by_element_count(&mut sorted_indices, alts);
         if skip == 0 {
             // Check if any alternatives have scan functions available.
-            // If ALL non-last alternatives have scans, we can eliminate
-            // backtracking entirely: scan each, parse the winner.
-            // If some have scans and some don't, use a hybrid approach.
+            // If ALL non-last alternatives have scans, we run a longest-match
+            // scan tournament: scan each, parse the winner. If some have
+            // scans and some don't, use a hybrid approach.
             let mut all_have_scans = true;
             for let mut i = 0; i < sorted_indices.len() - 1; i += 1 {
                 let idx = sorted_indices[i];
@@ -5546,7 +5509,7 @@ fn gen_prediction_code_inner(w: &mut CodeWriter, node: &PredictionNode, fn_name:
                                 w.end();
                                 w.end();
                             } else {
-                                // No scan: full backtracking.
+                                // No scan: save-and-rewind speculative parse.
                                 w.line(`let r_{idx} = {*fn_name}_bt_{idx}(p);`);
                                 w.begin(`if let Err(_) = r_{idx}`);
                                 w.line("p.pos = saved;");
@@ -5558,7 +5521,7 @@ fn gen_prediction_code_inner(w: &mut CodeWriter, node: &PredictionNode, fn_name:
                     }
                 }
             } else {
-                // Fallback: original backtracking pattern.
+                // Fallback: save-and-rewind speculative parse pattern.
                 w.line("let saved = p.pos;");
                 for let mut i = 0; i < sorted_indices.len(); i += 1 {
                     let idx = sorted_indices[i];
@@ -5577,8 +5540,8 @@ fn gen_prediction_code_inner(w: &mut CodeWriter, node: &PredictionNode, fn_name:
             }
         } else {
             // Prefix already consumed — should not happen.
-            // Consume nodes that lead to Backtrack are stripped at build time.
-            panic("unreachable: Consume leading to Backtrack should have been stripped");
+            // Consume nodes that lead to Ambiguous are stripped at build time.
+            panic("unreachable: Consume leading to Ambiguous should have been stripped");
         }
         return;
     }
@@ -5678,8 +5641,6 @@ fn gen_multi_alt_body_bt(w: &mut CodeWriter, rule: &ParserRule, type_name: &Stri
                 pred_elements.push(rule.alternatives[real_idx].elements);
             }
             let tree = build_prediction(&pred_indices, &pred_firsts, &pred_elements, 0, 5, ctx);
-            let bt_count = count_backtrack_nodes(&tree);
-
             gen_prediction_code(w, &tree, &fn_name, &rule.alternatives, type_name, ctx);
         }
 

--- a/package-gale/src/parser_gen.wado
+++ b/package-gale/src/parser_gen.wado
@@ -4614,14 +4614,19 @@ fn general_group_all_scannable(sorted_group: &Array<i32>, alts: &Array<Alternati
 
 /// Returns true iff every alt's remaining suffix `[skip..]` is fully
 /// scannable. Used as the precondition for the prediction-tree
-/// `Ambiguous` branch to fall through to scan dispatch.
-fn backtrack_node_all_scannable(sorted: &Array<i32>, alts: &Array<Alternative>, ctx: &mut GenContext, skip: i32) -> bool {
+/// `Ambiguous` branch to fall through to scan dispatch. An empty suffix
+/// (`skip == alt.elements.len()`, i.e. an at-end alt produced by
+/// `build_sll_node`'s `at_end_alts` path) is treated as scannable: its
+/// scan trivially succeeds at the current position, and `sort_group_by_
+/// element_count` sorts it last so it acts as the unconditional
+/// fallback in `gen_group_scan_dispatch`.
+fn ambiguous_node_all_scannable(sorted: &Array<i32>, alts: &Array<Alternative>, ctx: &mut GenContext, skip: i32) -> bool {
     if sorted.len() < 2 {
         return false;
     }
     for let mut k = 0; k < sorted.len(); k += 1 {
         let alt = &alts[sorted[k]];
-        if skip >= alt.elements.len() {
+        if skip > alt.elements.len() {
             return false;
         }
         for let mut i = skip; i < alt.elements.len(); i += 1 {
@@ -4743,7 +4748,7 @@ fn gen_group_prediction_code_skip(w: &mut CodeWriter, node: &PredictionNode, alt
 
         // Every alt's remaining elements must be fully scannable. Backtracking
         // has been removed; an unscannable suffix is a codegen-time error.
-        if !backtrack_node_all_scannable(&sorted, alts, ctx, skip) {
+        if !ambiguous_node_all_scannable(&sorted, alts, ctx, skip) {
             panic("prediction Ambiguous node has unscannable alt; backtracking has been removed (see AGENTS.md 'Generated Parser Rules')");
         }
         gen_group_scan_dispatch(w, &sorted, alts, ctx, name_counts, skip);

--- a/package-gale/src/parser_gen.wado
+++ b/package-gale/src/parser_gen.wado
@@ -1809,12 +1809,12 @@ fn gen_scan_multi_alt(w: &mut CodeWriter, alts: &Array<Alternative>, ctx: &mut G
         }
     }
 
-    // Sort each partition (and the unguarded alts) longest-first using the
-    // same sort that parse-side `bt_try` uses (`sort_group_by_element_count`).
-    // First-success-wins in `emit_scan_partition_body` relies on this order:
-    // the most specific (highest-priority, then most-elements) candidate is
-    // scanned first, so committing on first success is correctness-equivalent
-    // to a longest-match tournament when alts may share prefixes (e.g.
+    // Sort each partition (and the unguarded alts) longest-first via
+    // `sort_group_by_element_count`. First-success-wins in
+    // `emit_scan_partition_body` relies on this order: the most specific
+    // (highest-priority, then most-elements) candidate is scanned first,
+    // so committing on first success is correctness-equivalent to a
+    // longest-match tournament when alts may share prefixes (e.g.
     // `expr`'s `column_ref` IDENT vs `function_call` IDENT '(' ... ')' ).
     for let mut g = 0; g < groups_alts.len(); g += 1 {
         sort_group_by_element_count(&mut groups_alts[g], alts);
@@ -3596,108 +3596,28 @@ fn gen_optional_with_backtrack(w: &mut CodeWriter, inner: &Element, ctx: &mut Ge
         return;
     }
 
-    // Scan-based guard: when the inner is fully scannable (no LR rule refs),
-    // predict with an inline scan and commit-parse unconditionally.
+    // Scan-based guard: the inner must be fully scannable (no unresolved
+    // RuleRefs). Backtracking has been removed; an unscannable inner is a
+    // codegen-time error.
     let mut visiting: Array<String> = [];
-    if ctx.is_element_scannable(inner, &mut visiting) {
-        let scan_pos_var = emit_opt_scan_guard(w, inner, ctx, name_counts);
-        w.begin(`if {scan_pos_var} >= 0`);
-        let mut nc: Array<[String, i32]> = [];
-        if let Group(g) = inner {
-            if g.alternatives.len() == 1 {
-                for let elem of g.alternatives[0].elements {
-                    gen_element(w, &elem, ctx, &mut nc);
-                }
-            } else {
-                gen_element(w, inner, ctx, &mut nc);
+    if !ctx.is_element_scannable(inner, &mut visiting) {
+        panic("gen_optional_with_backtrack: inner element is not scannable; backtracking has been removed (see AGENTS.md 'Generated Parser Rules')");
+    }
+    let scan_pos_var = emit_opt_scan_guard(w, inner, ctx, name_counts);
+    w.begin(`if {scan_pos_var} >= 0`);
+    let mut nc: Array<[String, i32]> = [];
+    if let Group(g) = inner {
+        if g.alternatives.len() == 1 {
+            for let elem of g.alternatives[0].elements {
+                gen_element(w, &elem, ctx, &mut nc);
             }
         } else {
             gen_element(w, inner, ctx, &mut nc);
         }
-        w.end();
-        return;
-    }
-
-    w.begin(`if {ctx.first_check_str(first)}`);
-
-    let saved = dedup_name(&"opt_saved", name_counts);
-    let label = dedup_name(&"opt_bt", name_counts);
-    w.line(`let {saved} = p.pos;`);
-    w.begin(`{label}:`);
-
-    let mut bt_nc: Array<[String, i32]> = [];
-    if let Group(g) = inner {
-        if g.alternatives.len() == 1 {
-            for let elem of g.alternatives[0].elements {
-                gen_element_failable(w, &elem, ctx, &saved, &label, &mut bt_nc);
-            }
-        } else {
-            gen_element(w, inner, ctx, &mut bt_nc);
-        }
     } else {
-        gen_element_failable(w, inner, ctx, &saved, &label, &mut bt_nc);
+        gen_element(w, inner, ctx, &mut nc);
     }
-
-    w.end();  // label
-    w.end();  // if
-}
-
-fn gen_element_failable(w: &mut CodeWriter, elem: &Element, ctx: &mut GenContext, saved_var: &String, label: &String, name_counts: &mut Array<[String, i32]>) {
-    if let TokenRef(t) = elem {
-        let const_name = `TK_{t.name}`;
-        let r_var = dedup_name(&"opt_r", name_counts);
-        w.line(`let {r_var} = p.expect({const_name});`);
-        w.line(`if let Err(_) = {r_var} \{ p.pos = {saved_var}; break {label}; \}`);
-        return;
-    }
-    if let Literal(l) = elem {
-        let const_name = literal_const_name(&l.text);
-        let display = `'{l.text}'`;
-        let r_var = dedup_name(&"opt_r", name_counts);
-        w.line(`let {r_var} = p.expect({const_name});`);
-        w.line(`if let Err(_) = {r_var} \{ p.pos = {saved_var}; break {label}; \}`);
-        return;
-    }
-    if let RuleRef(r) = elem {
-        let fn_name = `parse_{r.snake_name}`;
-        let r_var = dedup_name(&"opt_r", name_counts);
-        w.line(`let {r_var} = {fn_name}(p);`);
-        w.line(`if let Err(_) = {r_var} \{ p.pos = {saved_var}; break {label}; \}`);
-        return;
-    }
-    if let Wildcard(_) = elem {
-        let r_var = dedup_name(&"opt_r", name_counts);
-        w.line(`let {r_var} = p.match_any();`);
-        w.line(`if let Err(_) = {r_var} \{ p.pos = {saved_var}; break {label}; \}`);
-        return;
-    }
-    if let Not(ne) = elem {
-        let r_var = dedup_name(&"opt_r", name_counts);
-        let call = not_match_call(&ne.element);
-        w.line(`let {r_var} = {call};`);
-        w.line(`if let Err(_) = {r_var} \{ p.pos = {saved_var}; break {label}; \}`);
-        return;
-    }
-    if let Repeat(rep) = elem {
-        gen_repeat(w, rep, ctx, name_counts, &([] as Array<String>));
-        return;
-    }
-    if let Group(g) = elem {
-        if g.alternatives.len() == 1 {
-            for let inner_elem of g.alternatives[0].elements {
-                gen_element_failable(w, &inner_elem, ctx, saved_var, label, name_counts);
-            }
-        } else if is_general_group(&g.alternatives) {
-            gen_general_group_store_optional(w, &g.alternatives, ctx, name_counts);
-        } else {
-            gen_consume_group(w, &g.alternatives, ctx, name_counts);
-        }
-        return;
-    }
-    if let Label(lab) = elem {
-        gen_element_failable(w, &lab.element, ctx, saved_var, label, name_counts);
-        return;
-    }
+    w.end();
 }
 
 /// Generate a storable optional group with proper backtracking.
@@ -3866,66 +3786,23 @@ fn gen_absent_optional_field(w: &mut CodeWriter, elem: &Element, name_counts: &m
 ///       result
 ///   } else { null };
 fn gen_storable_optional_with_backtrack(w: &mut CodeWriter, inner: &Element, ctx: &mut GenContext, first: &Array<String>, name_counts: &mut Array<[String, i32]>, type_str: &String, opt_name: &String, field_name: &String) {
-    // Scan-based guard: when the inner is fully scannable, predict with an
-    // inline scan and commit-parse without any backtracking machinery.
+    // Scan-based guard: the inner must be fully scannable. Backtracking has
+    // been removed; an unscannable inner is a codegen-time error.
     let mut visiting: Array<String> = [];
-    if ctx.is_element_scannable(inner, &mut visiting) {
-        let scan_pos_var = emit_opt_scan_guard(w, inner, ctx, name_counts);
-        w.begin(`let {opt_name}: Option<{type_str}> = if {scan_pos_var} >= 0`);
-
-        if let Group(g) = inner {
-            if is_single_alt_group(&g.alternatives) {
-                let alt = &g.alternatives[0];
-                let mut elem_nc: Array<[String, i32]> = [];
-                let gc_start = ctx.group_counter;
-                for let elem of &alt.elements {
-                    gen_element(w, elem, ctx, &mut elem_nc);
-                }
-                let struct_type_name = single_alt_group_type_name(alt);
-                let struct_field_name = single_alt_group_field_name(alt);
-                w.line(`let {struct_field_name} = {struct_type_name} \{`);
-                w.indent();
-                ctx.group_counter = gc_start;
-                let mut assign_nc: Array<[String, i32]> = [];
-                for let elem of &alt.elements {
-                    gen_field_assignment(w, elem, &mut assign_nc, ctx);
-                }
-                w.dedent();
-                w.line("};");
-                w.line(`Option::<{type_str}>::Some({field_name})`);
-            } else {
-                let mut nc: Array<[String, i32]> = [];
-                gen_group_store_any(w, inner, ctx, &mut nc, &([] as Array<String>));
-                w.line(`Option::<{type_str}>::Some({field_name})`);
-            }
-        }
-
-        w.else_begin("else");
-        w.line("null");
-        w.end_with(";");
-        return;
+    if !ctx.is_element_scannable(inner, &mut visiting) {
+        panic("gen_storable_optional_with_backtrack: inner element is not scannable; backtracking has been removed (see AGENTS.md 'Generated Parser Rules')");
     }
-
-    w.begin(`let {opt_name}: Option<{type_str}> = if {ctx.first_check_str(first)}`);
-
-    let saved = dedup_name(&"opt_saved", name_counts);
-    let label = dedup_name(&"opt_bt", name_counts);
-    let result_var = dedup_name(&"opt_result", name_counts);
-
-    w.line(`let {saved} = p.pos;`);
-    w.line(`let mut {result_var}: Option<{type_str}> = null;`);
-    w.begin(`{label}:`);
+    let scan_pos_var = emit_opt_scan_guard(w, inner, ctx, name_counts);
+    w.begin(`let {opt_name}: Option<{type_str}> = if {scan_pos_var} >= 0`);
 
     if let Group(g) = inner {
         if is_single_alt_group(&g.alternatives) {
             let alt = &g.alternatives[0];
-            // Use fresh name counters so element names match field assignments
             let mut elem_nc: Array<[String, i32]> = [];
             let gc_start = ctx.group_counter;
             for let elem of &alt.elements {
-                gen_element_failable_named(w, elem, ctx, &saved, &label, &mut elem_nc);
+                gen_element(w, elem, ctx, &mut elem_nc);
             }
-            // Construct the struct
             let struct_type_name = single_alt_group_type_name(alt);
             let struct_field_name = single_alt_group_field_name(alt);
             w.line(`let {struct_field_name} = {struct_type_name} \{`);
@@ -3937,96 +3814,17 @@ fn gen_storable_optional_with_backtrack(w: &mut CodeWriter, inner: &Element, ctx
             }
             w.dedent();
             w.line("};");
-            w.line(`{result_var} = Option::<{type_str}>::Some({field_name});`);
+            w.line(`Option::<{type_str}>::Some({field_name})`);
         } else {
-            // For other storable patterns (simple_cst_group, token_only_group),
-            // they should be safe without backtracking. Generate normally.
             let mut nc: Array<[String, i32]> = [];
             gen_group_store_any(w, inner, ctx, &mut nc, &([] as Array<String>));
-            w.line(`{result_var} = Option::<{type_str}>::Some({field_name});`);
+            w.line(`Option::<{type_str}>::Some({field_name})`);
         }
     }
 
-    w.end();  // label
-    w.line(result_var);
     w.else_begin("else");
     w.line("null");
     w.end_with(";");
-}
-
-/// Generate a failable element that uses proper variable names for struct
-/// construction, instead of the anonymous `opt_r` variables.
-///
-/// For TokenRef/Literal: generates `let r = p.expect(TK); if Err, break; let name = r.unwrap();`
-/// For RuleRef: generates `let r = parse_foo(p); if Err, break; let foo = r.unwrap();`
-fn gen_element_failable_named(w: &mut CodeWriter, elem: &Element, ctx: &mut GenContext, saved_var: &String, label: &String, name_counts: &mut Array<[String, i32]>) {
-    if let TokenRef(tr) = elem {
-        let const_name = `TK_{tr.name}`;
-        let field_name = dedup_name(&tr.field_name, name_counts);
-        let r_var = dedup_name(&"_bt_r", name_counts);
-        w.line(`let {r_var} = p.expect({const_name});`);
-        w.line(`if let Err(_) = {r_var} \{ p.pos = {saved_var}; break {label}; \}`);
-        w.line(`let {field_name} = {r_var}.unwrap();`);
-        return;
-    }
-    if let Literal(lit) = elem {
-        let const_name = literal_const_name(&lit.text);
-        let display = `'{lit.text}'`;
-        let field_name = dedup_name(&literal_field_name(&lit.text), name_counts);
-        let r_var = dedup_name(&"_bt_r", name_counts);
-        w.line(`let {r_var} = p.expect({const_name});`);
-        w.line(`if let Err(_) = {r_var} \{ p.pos = {saved_var}; break {label}; \}`);
-        w.line(`let {field_name} = {r_var}.unwrap();`);
-        return;
-    }
-    if let RuleRef(rr) = elem {
-        let fn_name = `parse_{rr.snake_name}`;
-        let field_name = dedup_name(&rr.field_name, name_counts);
-        let r_var = dedup_name(&"_bt_r", name_counts);
-        w.line(`let {r_var} = {fn_name}(p);`);
-        w.line(`if let Err(_) = {r_var} \{ p.pos = {saved_var}; break {label}; \}`);
-        w.line(`let {field_name} = {r_var}.unwrap();`);
-        return;
-    }
-    if let Wildcard(_) = elem {
-        let field_name = dedup_name(&"wildcard", name_counts);
-        let r_var = dedup_name(&"_bt_r", name_counts);
-        w.line(`let {r_var} = p.match_any();`);
-        w.line(`if let Err(_) = {r_var} \{ p.pos = {saved_var}; break {label}; \}`);
-        w.line(`let {field_name} = {r_var}.unwrap();`);
-        return;
-    }
-    if let Not(ne) = elem {
-        let field_name = dedup_name(&not_element_field_name(&ne.element), name_counts);
-        let r_var = dedup_name(&"_bt_r", name_counts);
-        let call = not_match_call(&ne.element);
-        w.line(`let {r_var} = {call};`);
-        w.line(`if let Err(_) = {r_var} \{ p.pos = {saved_var}; break {label}; \}`);
-        w.line(`let {field_name} = {r_var}.unwrap();`);
-        return;
-    }
-    if let Repeat(rep) = elem {
-        gen_repeat(w, rep, ctx, name_counts, &([] as Array<String>));
-        return;
-    }
-    if let Group(g) = elem {
-        if is_simple_cst_group(&g.alternatives) {
-            gen_consume_group_store_optional(w, &g.alternatives, ctx, name_counts);
-        } else if is_token_only_group(&g.alternatives) {
-            gen_consume_token_group(w, &g.alternatives, ctx, name_counts);
-        } else if is_single_alt_group(&g.alternatives) {
-            gen_consume_single_alt_group(w, &g.alternatives[0], ctx, name_counts, &([] as Array<String>));
-        } else if is_general_group(&g.alternatives) {
-            gen_general_group_store_optional(w, &g.alternatives, ctx, name_counts);
-        } else {
-            gen_consume_group(w, &g.alternatives, ctx, name_counts);
-        }
-        return;
-    }
-    if let Label(lab) = elem {
-        gen_element_failable_named(w, &lab.element, ctx, saved_var, label, name_counts);
-        return;
-    }
 }
 
 /// Emit the Parser call expression for `~ X` (set complement). Returns a
@@ -4446,11 +4244,10 @@ fn gen_consume_group_store(w: &mut CodeWriter, alts: &Array<Alternative>, ctx: &
                 let mut sorted_group = group.sorted();
                 sort_group_by_element_count(&mut sorted_group, alts);
 
-                if rule_ref_group_all_scannable(&sorted_group, alts, ctx) {
-                    gen_rule_ref_group_scan_dispatch(w, &sorted_group, alts, &opt_var, type_name, ctx, name_counts);
-                } else {
-                    gen_rule_ref_group_backtrack(w, &sorted_group, alts, &opt_var, type_name, ctx, name_counts);
+                if !rule_ref_group_all_scannable(&sorted_group, alts, ctx) {
+                    panic("rule-ref group has unscannable alt; backtracking has been removed (see AGENTS.md 'Generated Parser Rules')");
                 }
+                gen_rule_ref_group_scan_dispatch(w, &sorted_group, alts, &opt_var, type_name, ctx, name_counts);
             }
         }
         w.end();  // if/else if chain
@@ -4536,44 +4333,6 @@ fn gen_rule_ref_group_scan_dispatch(w: &mut CodeWriter, sorted_group: &Array<i32
     w.end();
 }
 
-/// Speculative-parse fallback for RuleRef-only groups when scan is unavailable.
-fn gen_rule_ref_group_backtrack(w: &mut CodeWriter, sorted_group: &Array<i32>, alts: &Array<Alternative>, opt_var: &String, type_name: &String, ctx: &mut GenContext, name_counts: &mut Array<[String, i32]>) {
-    let saved = dedup_name(&"saved_pos", name_counts);
-    let done = dedup_name(&"bt_done", name_counts);
-    w.line(`let {saved} = p.pos;`);
-    w.line(`let mut {done} = false;`);
-
-    for let mut k = 0; k < sorted_group.len(); k += 1 {
-        let alt_idx = sorted_group[k];
-        let is_last = k == sorted_group.len() - 1;
-        if let RuleRef(r) = &alts[alt_idx].elements[0] {
-            let fn_name = `parse_{r.snake_name}`;
-            let case_name = group_case_name(&alts[alt_idx]);
-
-            if is_last {
-                w.begin(`if !{done}`);
-                let local_var = r.snake_name;
-                w.line(`let {local_var} = {fn_name}(p)?;`);
-                w.line(`{*opt_var} = Option::<{type_name}>::Some({type_name}::{case_name}({local_var}));`);
-                w.end();
-            } else {
-                let bt_label = dedup_name(&"bt_try", name_counts);
-                w.begin(`if !{done}`);
-                w.begin(`{bt_label}:`);
-                let r_var = dedup_name(&"opt_r", name_counts);
-                w.line(`let {r_var} = {fn_name}(p);`);
-                w.line(`if let Err(_) = {r_var} \{ p.pos = {saved}; break {bt_label}; \}`);
-                w.line(
-                    `{*opt_var} = Option::<{type_name}>::Some({type_name}::{case_name}({r_var}.unwrap()));`,
-                );
-                w.line(`{done} = true;`);
-                w.end();  // label
-                w.end();  // if !done
-            }
-        }
-    }
-}
-
 fn gen_consume_group_store_optional(w: &mut CodeWriter, alts: &Array<Alternative>, ctx: &mut GenContext, name_counts: &mut Array<[String, i32]>) {
     let var_name = dedup_name(&group_field_base_name(alts), name_counts);
     let type_name = group_variant_type_name(alts);
@@ -4622,11 +4381,10 @@ fn gen_consume_group_store_optional(w: &mut CodeWriter, alts: &Array<Alternative
             let mut sorted_group = group.sorted();
             sort_group_by_element_count(&mut sorted_group, alts);
 
-            if rule_ref_group_all_scannable(&sorted_group, alts, ctx) {
-                gen_rule_ref_group_scan_dispatch(w, &sorted_group, alts, &inner_var, type_name, ctx, name_counts);
-            } else {
-                gen_rule_ref_group_backtrack(w, &sorted_group, alts, &inner_var, type_name, ctx, name_counts);
+            if !rule_ref_group_all_scannable(&sorted_group, alts, ctx) {
+                panic("rule-ref group has unscannable alt; backtracking has been removed (see AGENTS.md 'Generated Parser Rules')");
             }
+            gen_rule_ref_group_scan_dispatch(w, &sorted_group, alts, &inner_var, type_name, ctx, name_counts);
         }
     }
     w.end();  // if/else if chain
@@ -4720,7 +4478,7 @@ fn gen_general_group_store_optional(w: &mut CodeWriter, alts: &Array<Alternative
         } else {
             let mut sorted_group = group.sorted();
             sort_group_by_element_count(&mut sorted_group, alts);
-            gen_general_group_backtrack(w, alts, &sorted_group, &type_name, &inner_var, ctx, name_counts, group_index);
+            gen_general_group_dispatch(w, alts, &sorted_group, &type_name, &inner_var, ctx, name_counts, group_index);
         }
         if ctx.group_counter > gc_max {
             gc_max = ctx.group_counter;
@@ -4800,7 +4558,7 @@ fn gen_general_group_store(w: &mut CodeWriter, alts: &Array<Alternative>, ctx: &
             } else {
                 let mut sorted_group = group.sorted();
                 sort_group_by_element_count(&mut sorted_group, alts);
-                gen_general_group_backtrack(w, alts, &sorted_group, &type_name, &opt_var, ctx, name_counts, group_index);
+                gen_general_group_dispatch(w, alts, &sorted_group, &type_name, &opt_var, ctx, name_counts, group_index);
             }
             if ctx.group_counter > gc_max {
                 gc_max = ctx.group_counter;
@@ -4856,88 +4614,59 @@ fn gen_general_alt_construct(w: &mut CodeWriter, alts: &Array<Alternative>, alt_
     w.line("})");
 }
 
-/// Backtracking for overlapping alts in a general group — try each, store on success.
-fn gen_general_group_backtrack(w: &mut CodeWriter, alts: &Array<Alternative>, sorted_group: &Array<i32>, type_name: &String, inner_var: &String, ctx: &mut GenContext, name_counts: &mut Array<[String, i32]>, group_index: i32) {
-    // Stage C/2: longest-match scan dispatch when every alt is fully
-    // scannable. Replaces speculative parse + bt_try with non-allocating
-    // scan, then parses only the winner.
-    let mut all_scannable = sorted_group.len() >= 2;
-    if all_scannable {
-        for let mut k = 0; k < sorted_group.len(); k += 1 {
-            let alt = &alts[sorted_group[k]];
-            if alt.elements.len() == 0 {
-                all_scannable = false;
-                break;
-            }
-            for let elem of &alt.elements {
-                let mut visiting: Array<String> = [];
-                if !ctx.is_element_scannable(elem, &mut visiting) {
-                    all_scannable = false;
-                    break;
-                }
-            }
-            if !all_scannable {
-                break;
-            }
-        }
+/// First-success-wins scan dispatch wrapper for overlapping general-group
+/// alts. Asserts that every alt is fully scannable, then delegates to
+/// `gen_general_group_scan_dispatch`. Backtracking has been removed; an
+/// unscannable alt is a codegen-time error.
+fn gen_general_group_dispatch(w: &mut CodeWriter, alts: &Array<Alternative>, sorted_group: &Array<i32>, type_name: &String, inner_var: &String, ctx: &mut GenContext, name_counts: &mut Array<[String, i32]>, group_index: i32) {
+    if !general_group_all_scannable(sorted_group, alts, ctx) {
+        panic("general group has unscannable alt; backtracking has been removed (see AGENTS.md 'Generated Parser Rules')");
     }
+    gen_general_group_scan_dispatch(w, alts, sorted_group, type_name, inner_var, ctx, name_counts, group_index);
+}
 
-    if all_scannable {
-        gen_general_group_scan_dispatch(w, alts, sorted_group, type_name, inner_var, ctx, name_counts, group_index);
-        return;
+/// Returns true iff every alt in `sorted_group` has at least one element
+/// and all its elements are scannable. Used as the precondition for
+/// `gen_general_group_dispatch` (non-RuleRef-only overlapping groups).
+fn general_group_all_scannable(sorted_group: &Array<i32>, alts: &Array<Alternative>, ctx: &mut GenContext) -> bool {
+    if sorted_group.len() < 2 {
+        return false;
     }
-
-    let saved = dedup_name(&"saved_pos", name_counts);
-    let done = dedup_name(&"bt_done", name_counts);
-    w.line(`let {saved} = p.pos;`);
-    w.line(`let mut {done} = false;`);
-
-    let gc_entry = ctx.group_counter;
     for let mut k = 0; k < sorted_group.len(); k += 1 {
-        let alt_idx = sorted_group[k];
-        let is_last = k == sorted_group.len() - 1;
-        let alt = &alts[alt_idx];
-        let struct_name = general_group_alt_struct_name(&ctx.current_rule_name, group_index, alt_idx);
-
-        ctx.group_counter = gc_entry;
-        if is_last {
-            w.begin(`if !{done}`);
-            let mut nc: Array<[String, i32]> = [];
-            let gc_last = ctx.group_counter;
-            gen_elements_with_non_greedy(w, &alt.elements, ctx, &mut nc, &([] as Array<String>));
-            w.line(`{inner_var} = Option::<{type_name}>::Some({type_name}::Alt{alt_idx}({struct_name} \{`);
-            w.indent();
-            ctx.group_counter = gc_last;
-            let mut assign_nc: Array<[String, i32]> = [];
-            for let elem of &alt.elements {
-                gen_field_assignment(w, elem, &mut assign_nc, ctx);
+        let alt = &alts[sorted_group[k]];
+        if alt.elements.len() == 0 {
+            return false;
+        }
+        for let elem of &alt.elements {
+            let mut visiting: Array<String> = [];
+            if !ctx.is_element_scannable(elem, &mut visiting) {
+                return false;
             }
-            w.dedent();
-            w.line("}));");
-            w.end();
-        } else {
-            let bt_label = dedup_name(&"bt_try", name_counts);
-            w.begin(`if !{done}`);
-            w.begin(`{bt_label}:`);
-            let mut nc: Array<[String, i32]> = [];
-            let gc_bt = ctx.group_counter;
-            for let elem of &alt.elements {
-                gen_element_failable_named(w, elem, ctx, &saved, &bt_label, &mut nc);
-            }
-            w.line(`{inner_var} = Option::<{type_name}>::Some({type_name}::Alt{alt_idx}({struct_name} \{`);
-            w.indent();
-            ctx.group_counter = gc_bt;
-            let mut assign_nc: Array<[String, i32]> = [];
-            for let elem of &alt.elements {
-                gen_field_assignment(w, elem, &mut assign_nc, ctx);
-            }
-            w.dedent();
-            w.line("}));");
-            w.line(`{done} = true;`);
-            w.end();  // label
-            w.end();  // if !done
         }
     }
+    return true;
+}
+
+/// Returns true iff every alt's remaining suffix `[skip..]` is fully
+/// scannable. Used as the precondition for the prediction-tree
+/// `Backtrack` branch to fall through to scan dispatch.
+fn backtrack_node_all_scannable(sorted: &Array<i32>, alts: &Array<Alternative>, ctx: &mut GenContext, skip: i32) -> bool {
+    if sorted.len() < 2 {
+        return false;
+    }
+    for let mut k = 0; k < sorted.len(); k += 1 {
+        let alt = &alts[sorted[k]];
+        if skip >= alt.elements.len() {
+            return false;
+        }
+        for let mut i = skip; i < alt.elements.len(); i += 1 {
+            let mut visiting: Array<String> = [];
+            if !ctx.is_element_scannable(&alt.elements[i], &mut visiting) {
+                return false;
+            }
+        }
+    }
+    return true;
 }
 
 /// First-success-wins scan dispatch for general groups (overlapping alts).
@@ -5047,64 +4776,12 @@ fn gen_group_prediction_code_skip(w: &mut CodeWriter, node: &PredictionNode, alt
         let mut sorted = indices.sorted();
         sort_group_by_element_count(&mut sorted, alts);
 
-        // Stage C/2: if every alt's remaining elements are fully scannable,
-        // use longest-match first-win scan dispatch instead of speculative
-        // parse with bt_try labels. This eliminates per-alt ParseError
-        // construction and token-array rewind.
-        let mut all_scannable = sorted.len() >= 2;
-        if all_scannable {
-            for let mut k = 0; k < sorted.len(); k += 1 {
-                let alt = &alts[sorted[k]];
-                if skip >= alt.elements.len() {
-                    all_scannable = false;
-                    break;
-                }
-                for let mut i = skip; i < alt.elements.len(); i += 1 {
-                    let mut visiting: Array<String> = [];
-                    if !ctx.is_element_scannable(&alt.elements[i], &mut visiting) {
-                        all_scannable = false;
-                        break;
-                    }
-                }
-                if !all_scannable {
-                    break;
-                }
-            }
+        // Every alt's remaining elements must be fully scannable. Backtracking
+        // has been removed; an unscannable suffix is a codegen-time error.
+        if !backtrack_node_all_scannable(&sorted, alts, ctx, skip) {
+            panic("prediction Backtrack node has unscannable alt; backtracking has been removed (see AGENTS.md 'Generated Parser Rules')");
         }
-
-        if all_scannable {
-            gen_group_scan_dispatch(w, &sorted, alts, ctx, name_counts, skip);
-            return;
-        }
-
-        let saved_var = dedup_name(&"saved_pos", name_counts);
-        let done_var = dedup_name(&"bt_done", name_counts);
-        w.line(`let {saved_var} = p.pos;`);
-        w.line(`let mut {done_var} = false;`);
-        for let mut k = 0; k < sorted.len(); k += 1 {
-            let alt_idx = sorted[k];
-            let is_last = k == sorted.len() - 1;
-            let alt = &alts[alt_idx];
-            if is_last {
-                w.begin(`if !{done_var}`);
-                let mut nc: Array<[String, i32]> = [];
-                for let mut i = skip; i < alt.elements.len(); i += 1 {
-                    gen_element(w, &alt.elements[i], ctx, &mut nc);
-                }
-                w.end();
-            } else {
-                let bt_label = dedup_name(&"bt_try", name_counts);
-                w.begin(`if !{done_var}`);
-                w.begin(`{bt_label}:`);
-                let mut nc: Array<[String, i32]> = [];
-                for let mut i = skip; i < alt.elements.len(); i += 1 {
-                    gen_element_failable(w, &alt.elements[i], ctx, &saved_var, &bt_label, &mut nc);
-                }
-                w.line(`{done_var} = true;`);
-                w.end();  // label
-                w.end();
-            }
-        }
+        gen_group_scan_dispatch(w, &sorted, alts, ctx, name_counts, skip);
         return;
     }
     if let Dispatch(d) = node {

--- a/package-gale/src/parser_gen.wado
+++ b/package-gale/src/parser_gen.wado
@@ -4770,14 +4770,10 @@ fn gen_group_prediction_code_skip(w: &mut CodeWriter, node: &PredictionNode, alt
     }
 }
 
-/// Emit longest-match first-win scan dispatch for group-level alternatives.
-/// Each alt's remaining elements (from `skip`) are scanned inline. The alt
-/// whose scan advances furthest is parsed; ties go to the first in sorted
-/// order. If all scans fail, the last alt is parsed to surface a real error.
 /// First-success-wins scan dispatch for `gen_group_prediction_code`'s
 /// `Ambiguous` node. The `sorted` parameter has already been ordered by
 /// `sort_group_by_element_count` (longest-first), so scanning candidates
-/// in that order and committing on first success matches what the
+/// in that order and committing on first success matches what a
 /// longest-match tournament would have picked while skipping the remaining
 /// scans. Critical for performance when any alt's scan recurses through
 /// an LR rule (`AGENTS.md` "Failed Approaches: Removing the LR Gate
@@ -4787,7 +4783,8 @@ fn gen_group_prediction_code_skip(w: &mut CodeWriter, node: &PredictionNode, alt
 /// matching alt index is recorded in `gd_winner` and the winner is parsed
 /// once via the trailing `if/else if/else` chain. The last alt is the
 /// unconditional fallback so a real parse error surfaces when no scan
-/// matched.
+/// matched (or so an at-end empty-suffix alt acts as the epsilon
+/// fallback — its scan trivially succeeds with zero tokens consumed).
 fn gen_group_scan_dispatch(w: &mut CodeWriter, sorted: &Array<i32>, alts: &Array<Alternative>, ctx: &mut GenContext, name_counts: &mut Array<[String, i32]>, skip: i32) {
     let winner_var = dedup_name(&"gd_winner", name_counts);
     let dispatch_label = dedup_name(&"gd_dispatch", name_counts);

--- a/package-gale/src/parser_gen.wado
+++ b/package-gale/src/parser_gen.wado
@@ -3027,7 +3027,7 @@ fn gen_repeat(w: &mut CodeWriter, rep: &RepeatElement, ctx: &mut GenContext, nam
             let opt_name = dedup_name(&field_info.0, name_counts);
             if is_group_store {
                 ctx.group_counter = gc_before;
-                gen_storable_optional(w, inner, ctx, &first, name_counts, &type_str, &opt_name, &field_info.0);
+                gen_storable_optional(w, inner, ctx, name_counts, &type_str, &opt_name, &field_info.0);
             } else {
                 w.begin(`let {opt_name}: Option<{type_str}> = if {ctx.first_check_str(&first)}`);
                 let mut nc: Array<[String, i32]> = [];
@@ -3077,7 +3077,7 @@ fn gen_repeat(w: &mut CodeWriter, rep: &RepeatElement, ctx: &mut GenContext, nam
         }
 
         if let Optional = rep.kind {
-            gen_optional_with_backtrack(w, inner, ctx, &first, name_counts);
+            gen_optional_with_backtrack(w, inner, ctx, name_counts);
         }
     }
 }
@@ -3285,7 +3285,7 @@ fn gen_repeat_with_follow(w: &mut CodeWriter, rep: &RepeatElement, ctx: &mut Gen
         w.line("null");
         w.end_with(";");
     } else {
-        gen_optional_with_backtrack(w, inner, ctx, &first, name_counts);
+        gen_optional_with_backtrack(w, inner, ctx, name_counts);
     }
 }
 
@@ -3559,7 +3559,7 @@ fn emit_scan_guard_with_prefix(w: &mut CodeWriter, inner: &Element, ctx: &mut Ge
     return scan_pos_var;
 }
 
-fn gen_optional_with_backtrack(w: &mut CodeWriter, inner: &Element, ctx: &mut GenContext, first: &Array<String>, name_counts: &mut Array<[String, i32]>) {
+fn gen_optional_with_backtrack(w: &mut CodeWriter, inner: &Element, ctx: &mut GenContext, name_counts: &mut Array<[String, i32]>) {
     if has_nested_optionals(inner) {
         if let Group(g) = inner {
             gen_optional_with_lookahead(w, &g.alternatives[0].elements, ctx, name_counts);
@@ -3620,13 +3620,15 @@ fn gen_optional_with_backtrack(w: &mut CodeWriter, inner: &Element, ctx: &mut Ge
     w.end();
 }
 
-/// Generate a storable optional group with proper backtracking.
+/// Generate a storable optional group, picking the best available
+/// disambiguation strategy:
 ///
-/// For groups where leading fixed tokens provide sufficient lookahead
-/// (e.g. `(K_IF K_NOT K_EXISTS)?`), uses multi-token lookahead condition.
-/// For groups starting with rule refs (e.g. `(database_name '.')?`), uses
-/// backtracking to restore position on failure while still capturing fields.
-fn gen_storable_optional(w: &mut CodeWriter, inner: &Element, ctx: &mut GenContext, first: &Array<String>, name_counts: &mut Array<[String, i32]>, type_str: &String, opt_name: &String, field_name: &String) {
+/// - Multi-token lookahead when leading fixed tokens uniquely identify
+///   the optional (e.g. `(K_IF K_NOT K_EXISTS)?`).
+/// - Shape-based lookahead when nested optionals require it.
+/// - Inline scan-guard otherwise (e.g. `(database_name '.')?`); the
+///   inner must be fully scannable, since backtracking has been removed.
+fn gen_storable_optional(w: &mut CodeWriter, inner: &Element, ctx: &mut GenContext, name_counts: &mut Array<[String, i32]>, type_str: &String, opt_name: &String, field_name: &String) {
     let la_depth = optional_lookahead_depth(inner);
     if la_depth >= 1 {
         // Multi-token lookahead: safe to use ? since tokens are confirmed
@@ -3654,8 +3656,8 @@ fn gen_storable_optional(w: &mut CodeWriter, inner: &Element, ctx: &mut GenConte
         // Nested optionals: use shape-based lookahead dispatch with struct capture
         gen_storable_optional_with_lookahead(w, inner, ctx, name_counts, type_str, opt_name, field_name);
     } else {
-        // Backtracking: save position and restore on mid-sequence failure
-        gen_storable_optional_with_backtrack(w, inner, ctx, first, name_counts, type_str, opt_name, field_name);
+        // Inline scan-guard: scan first, parse on success.
+        gen_storable_optional_with_backtrack(w, inner, ctx, name_counts, type_str, opt_name, field_name);
     }
 }
 
@@ -3785,7 +3787,7 @@ fn gen_absent_optional_field(w: &mut CodeWriter, elem: &Element, name_counts: &m
 ///       }
 ///       result
 ///   } else { null };
-fn gen_storable_optional_with_backtrack(w: &mut CodeWriter, inner: &Element, ctx: &mut GenContext, first: &Array<String>, name_counts: &mut Array<[String, i32]>, type_str: &String, opt_name: &String, field_name: &String) {
+fn gen_storable_optional_with_backtrack(w: &mut CodeWriter, inner: &Element, ctx: &mut GenContext, name_counts: &mut Array<[String, i32]>, type_str: &String, opt_name: &String, field_name: &String) {
     // Scan-based guard: the inner must be fully scannable. Backtracking has
     // been removed; an unscannable inner is a codegen-time error.
     let mut visiting: Array<String> = [];

--- a/package-gale/tests/generated/antlr4/ANTLRv4Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4/ANTLRv4Lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6fd58782d32cfb10",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "grammars/ANTLRv4Lexer.g4",
     "hash": "30bd52b58a5916a63041f501c2d45358431c5c379f1ed3e8a3fbbb311f3572bd"

--- a/package-gale/tests/generated/antlr4/ANTLRv4Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4/ANTLRv4Lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6fd58782d32cfb10",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "grammars/ANTLRv4Lexer.g4",
     "hash": "30bd52b58a5916a63041f501c2d45358431c5c379f1ed3e8a3fbbb311f3572bd"

--- a/package-gale/tests/generated/antlr4/ANTLRv4Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4/ANTLRv4Lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6fd58782d32cfb10",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "grammars/ANTLRv4Lexer.g4",
     "hash": "30bd52b58a5916a63041f501c2d45358431c5c379f1ed3e8a3fbbb311f3572bd"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a6ec2b8f2ddde283",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_1.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a6ec2b8f2ddde283",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_1.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a6ec2b8f2ddde283",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_1.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-61c5e70fcdb6da1f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_10.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-61c5e70fcdb6da1f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_10.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-61c5e70fcdb6da1f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_10.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-699ecb3a8f815e27",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_2.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-699ecb3a8f815e27",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_2.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-699ecb3a8f815e27",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_2.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-262e54587e9044c3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_3.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-262e54587e9044c3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_3.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-262e54587e9044c3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_3.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a998eaa06c653a5b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_4.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a998eaa06c653a5b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_4.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a998eaa06c653a5b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_4.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fc22b0fc36d36630",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_5.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fc22b0fc36d36630",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_5.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fc22b0fc36d36630",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_5.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2852af861801de26",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_6.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2852af861801de26",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_6.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2852af861801de26",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_6.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-320d631a0baf5c0b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_7.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-320d631a0baf5c0b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_7.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-320d631a0baf5c0b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_7.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3bd4c5ea00e5572f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_8.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3bd4c5ea00e5572f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_8.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3bd4c5ea00e5572f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_8.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-49d484703a919155",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_9.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-49d484703a919155",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_9.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-49d484703a919155",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_9.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-713ef5230fbaf9f1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_1.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-713ef5230fbaf9f1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_1.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-713ef5230fbaf9f1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_1.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-558b311b80c4da10",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_2.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-558b311b80c4da10",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_2.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-558b311b80c4da10",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_2.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c369756dc031bf12",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_3.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c369756dc031bf12",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_3.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c369756dc031bf12",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_3.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-abed1c70b5e6c53f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_1.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-abed1c70b5e6c53f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_1.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-abed1c70b5e6c53f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_1.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a1b502206053bf7a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_2.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a1b502206053bf7a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_2.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a1b502206053bf7a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_2.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-68045ae831d55159",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_3.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-68045ae831d55159",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_3.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-68045ae831d55159",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_3.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-678c469712c8fc23",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_4.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-678c469712c8fc23",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_4.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-678c469712c8fc23",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_4.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-16bc5e2c231c2ba8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_5.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-16bc5e2c231c2ba8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_5.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-16bc5e2c231c2ba8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_5.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c116bb1cfe62a2a8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_6.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c116bb1cfe62a2a8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_6.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c116bb1cfe62a2a8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_6.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0484794f535b91f2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_7.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0484794f535b91f2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_7.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0484794f535b91f2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_7.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fe2840241e9172a0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_1.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fe2840241e9172a0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_1.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fe2840241e9172a0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_1.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-235cd53ca8f4663a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_10.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-235cd53ca8f4663a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_10.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-235cd53ca8f4663a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_10.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ed84013859c673b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_11.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ed84013859c673b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_11.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ed84013859c673b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_11.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-739357c31b4c8ca4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_12.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-739357c31b4c8ca4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_12.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-739357c31b4c8ca4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_12.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-70a21a8410fad983",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_2.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-70a21a8410fad983",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_2.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-70a21a8410fad983",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_2.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-99bcc333174e8ead",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_5.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-99bcc333174e8ead",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_5.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-99bcc333174e8ead",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_5.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2f290cf17eba13e0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_6.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2f290cf17eba13e0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_6.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2f290cf17eba13e0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_6.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bd943cd5ec077b75",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_7.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bd943cd5ec077b75",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_7.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bd943cd5ec077b75",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_7.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6ad535192ef3e12f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_8.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6ad535192ef3e12f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_8.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6ad535192ef3e12f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_8.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-43dcc5eba0df7ec4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_9.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-43dcc5eba0df7ec4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_9.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-43dcc5eba0df7ec4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_9.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-112c4a21992a04ed",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_1.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-112c4a21992a04ed",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_1.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-112c4a21992a04ed",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_1.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-459d0b754845c21f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_2.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-459d0b754845c21f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_2.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-459d0b754845c21f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_2.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1181507cda20d45b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_3.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1181507cda20d45b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_3.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1181507cda20d45b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_3.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4b506a26b7b7c7b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_1.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4b506a26b7b7c7b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_1.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4b506a26b7b7c7b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_1.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-34e6293e9d4c3e83",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_2.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-34e6293e9d4c3e83",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_2.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-34e6293e9d4c3e83",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_2.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b2467e37954af95c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_3.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b2467e37954af95c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_3.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b2467e37954af95c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_3.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-be8254158e713214",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_1.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-be8254158e713214",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_1.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-be8254158e713214",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_1.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4fc8261d73da648f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_2.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4fc8261d73da648f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_2.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4fc8261d73da648f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_2.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-93334f393b16d8e0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_3.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-93334f393b16d8e0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_3.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-93334f393b16d8e0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_3.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e522638eb5f62a2f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrecedenceFilterConsidersContext.g4",
     "hash": "c92df3158f9ed1c1b43de581aedaf3b0918fa525ff0258f855022b78585b860b"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e522638eb5f62a2f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrecedenceFilterConsidersContext.g4",
     "hash": "c92df3158f9ed1c1b43de581aedaf3b0918fa525ff0258f855022b78585b860b"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e522638eb5f62a2f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrecedenceFilterConsidersContext.g4",
     "hash": "c92df3158f9ed1c1b43de581aedaf3b0918fa525ff0258f855022b78585b860b"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-709c12dbc0d22c0c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrefixAndOtherAlt_1.g4",
     "hash": "f946ec43c09928b2aae968a817d4ff315478257d5700925eab82fd22d94714d8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-709c12dbc0d22c0c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrefixAndOtherAlt_1.g4",
     "hash": "f946ec43c09928b2aae968a817d4ff315478257d5700925eab82fd22d94714d8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-709c12dbc0d22c0c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrefixAndOtherAlt_1.g4",
     "hash": "f946ec43c09928b2aae968a817d4ff315478257d5700925eab82fd22d94714d8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1f6f1364b2571756",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrefixAndOtherAlt_2.g4",
     "hash": "f946ec43c09928b2aae968a817d4ff315478257d5700925eab82fd22d94714d8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1f6f1364b2571756",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrefixAndOtherAlt_2.g4",
     "hash": "f946ec43c09928b2aae968a817d4ff315478257d5700925eab82fd22d94714d8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1f6f1364b2571756",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrefixAndOtherAlt_2.g4",
     "hash": "f946ec43c09928b2aae968a817d4ff315478257d5700925eab82fd22d94714d8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPred/SemPred.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPred/SemPred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-960ef5ffa9d45556",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/SemPred.g4",
     "hash": "a19c17fc308f32463fe399a657b189a837ad4fa52afc1206ab0d1d8a38dcbe04"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPred/SemPred.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPred/SemPred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-960ef5ffa9d45556",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/SemPred.g4",
     "hash": "a19c17fc308f32463fe399a657b189a837ad4fa52afc1206ab0d1d8a38dcbe04"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPred/SemPred.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPred/SemPred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-960ef5ffa9d45556",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/SemPred.g4",
     "hash": "a19c17fc308f32463fe399a657b189a837ad4fa52afc1206ab0d1d8a38dcbe04"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPredFailOption/SemPredFailOption.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPredFailOption/SemPredFailOption.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a26551c8d0a65a59",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/SemPredFailOption.g4",
     "hash": "baacd97f45a8e197f2d9363c57506eebffd7f8862b34984e659ed317ac48a7d5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPredFailOption/SemPredFailOption.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPredFailOption/SemPredFailOption.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a26551c8d0a65a59",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/SemPredFailOption.g4",
     "hash": "baacd97f45a8e197f2d9363c57506eebffd7f8862b34984e659ed317ac48a7d5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPredFailOption/SemPredFailOption.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPredFailOption/SemPredFailOption.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a26551c8d0a65a59",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/SemPredFailOption.g4",
     "hash": "baacd97f45a8e197f2d9363c57506eebffd7f8862b34984e659ed317ac48a7d5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5d3495c986bff9bd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_1.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5d3495c986bff9bd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_1.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5d3495c986bff9bd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_1.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-33ccce79b79bf5e2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_2.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-33ccce79b79bf5e2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_2.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-33ccce79b79bf5e2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_2.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6dcbc071fc2f601e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_3.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6dcbc071fc2f601e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_3.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6dcbc071fc2f601e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_3.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-741313c066ff2cd5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_1.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-741313c066ff2cd5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_1.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-741313c066ff2cd5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_1.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-381677e2c28357d8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_2.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-381677e2c28357d8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_2.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-381677e2c28357d8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_2.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4d665f3c7d50cbb6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_3.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4d665f3c7d50cbb6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_3.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4d665f3c7d50cbb6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_3.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-18d85335cd7b6ba7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_4.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-18d85335cd7b6ba7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_4.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-18d85335cd7b6ba7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_4.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6c0e1c831530f504",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_5.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6c0e1c831530f504",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_5.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6c0e1c831530f504",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_5.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d5dda292b3d95344",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_6.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d5dda292b3d95344",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_6.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d5dda292b3d95344",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_6.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bc586f7b630f85cb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_7.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bc586f7b630f85cb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_7.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bc586f7b630f85cb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_7.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b8fe4abc43e4380d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_8.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b8fe4abc43e4380d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_8.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b8fe4abc43e4380d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_8.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ddd4f8db5f21632f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_9.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ddd4f8db5f21632f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_9.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ddd4f8db5f21632f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_9.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1a2ad3adca9a2a07",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_1.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1a2ad3adca9a2a07",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_1.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1a2ad3adca9a2a07",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_1.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-eed4df03ca7a51f5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_2.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-eed4df03ca7a51f5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_2.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-eed4df03ca7a51f5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_2.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bfcc2ec63de46569",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_3.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bfcc2ec63de46569",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_3.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bfcc2ec63de46569",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_3.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-20cd1bcceb40fb33",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_4.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-20cd1bcceb40fb33",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_4.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-20cd1bcceb40fb33",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_4.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-cfe1fc1849a20141",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_5.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-cfe1fc1849a20141",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_5.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-cfe1fc1849a20141",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_5.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-88482992acd5509f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_6.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-88482992acd5509f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_6.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-88482992acd5509f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_6.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-78bbab6b273081fa",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_7.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-78bbab6b273081fa",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_7.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-78bbab6b273081fa",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_7.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-03918ec747b14ad6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_8.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-03918ec747b14ad6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_8.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-03918ec747b14ad6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_8.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a66253165de20181",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_9.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a66253165de20181",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_9.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a66253165de20181",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_9.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1d1b100d63f04166",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/ParserExec/BuildParseTree_TRUE.g4",
     "hash": "2a131cc48cdbfa4950f7c16ef0fcb51f4679926cabf71d403883a9fc01e9cb99"

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1d1b100d63f04166",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/ParserExec/BuildParseTree_TRUE.g4",
     "hash": "2a131cc48cdbfa4950f7c16ef0fcb51f4679926cabf71d403883a9fc01e9cb99"

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1d1b100d63f04166",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/ParserExec/BuildParseTree_TRUE.g4",
     "hash": "2a131cc48cdbfa4950f7c16ef0fcb51f4679926cabf71d403883a9fc01e9cb99"

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-94c0b5df15a69680",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/ParserExec/PredictionIssue334.g4",
     "hash": "05f509013c98f1d1ef907d23c43aa328f3c9ee0ad9166b21ac03dbc715ee8542"

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-94c0b5df15a69680",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/ParserExec/PredictionIssue334.g4",
     "hash": "05f509013c98f1d1ef907d23c43aa328f3c9ee0ad9166b21ac03dbc715ee8542"

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-94c0b5df15a69680",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/ParserExec/PredictionIssue334.g4",
     "hash": "05f509013c98f1d1ef907d23c43aa328f3c9ee0ad9166b21ac03dbc715ee8542"

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3ebf8faf7a4261df",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/ParserExec/PredictionMode_LL.g4",
     "hash": "8542495134a20f622112aa07fc5cd71fcc1b8e3669f41ff329126b355c4df7f4"

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3ebf8faf7a4261df",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/ParserExec/PredictionMode_LL.g4",
     "hash": "8542495134a20f622112aa07fc5cd71fcc1b8e3669f41ff329126b355c4df7f4"

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3ebf8faf7a4261df",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/ParserExec/PredictionMode_LL.g4",
     "hash": "8542495134a20f622112aa07fc5cd71fcc1b8e3669f41ff329126b355c4df7f4"

--- a/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_1/PredFromAltTestedInLoopBack_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_1/PredFromAltTestedInLoopBack_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3c84aa606fbeb863",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/PredFromAltTestedInLoopBack_1.g4",
     "hash": "b6144b334167648d1e1560be8a7590525c8b34cbba2e27d040c41026fa7c9323"

--- a/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_1/PredFromAltTestedInLoopBack_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_1/PredFromAltTestedInLoopBack_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3c84aa606fbeb863",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/PredFromAltTestedInLoopBack_1.g4",
     "hash": "b6144b334167648d1e1560be8a7590525c8b34cbba2e27d040c41026fa7c9323"

--- a/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_1/PredFromAltTestedInLoopBack_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_1/PredFromAltTestedInLoopBack_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3c84aa606fbeb863",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/PredFromAltTestedInLoopBack_1.g4",
     "hash": "b6144b334167648d1e1560be8a7590525c8b34cbba2e27d040c41026fa7c9323"

--- a/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7f162199fbfa5a4d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/PredFromAltTestedInLoopBack_2.g4",
     "hash": "b6144b334167648d1e1560be8a7590525c8b34cbba2e27d040c41026fa7c9323"

--- a/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7f162199fbfa5a4d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/PredFromAltTestedInLoopBack_2.g4",
     "hash": "b6144b334167648d1e1560be8a7590525c8b34cbba2e27d040c41026fa7c9323"

--- a/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7f162199fbfa5a4d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/PredFromAltTestedInLoopBack_2.g4",
     "hash": "b6144b334167648d1e1560be8a7590525c8b34cbba2e27d040c41026fa7c9323"

--- a/package-gale/tests/generated/at_end_alt_gaps/at_end_alt_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/at_end_alt_gaps/at_end_alt_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-105bcd36568c5dd8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "grammars/at_end_alt_gaps.g4",
     "hash": "9cd47ca80f5762b4107f87ae05f1bce472bbfb8aca3c06ef0bdbf501ac519f82"

--- a/package-gale/tests/generated/at_end_alt_gaps/at_end_alt_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/at_end_alt_gaps/at_end_alt_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-105bcd36568c5dd8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "grammars/at_end_alt_gaps.g4",
     "hash": "9cd47ca80f5762b4107f87ae05f1bce472bbfb8aca3c06ef0bdbf501ac519f82"

--- a/package-gale/tests/generated/at_end_alt_gaps/at_end_alt_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/at_end_alt_gaps/at_end_alt_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-105bcd36568c5dd8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "grammars/at_end_alt_gaps.g4",
     "hash": "9cd47ca80f5762b4107f87ae05f1bce472bbfb8aca3c06ef0bdbf501ac519f82"

--- a/package-gale/tests/generated/calculator/calculator.g4.kiln.json
+++ b/package-gale/tests/generated/calculator/calculator.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7fbe69e34c931e16",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "grammars/calculator.g4",
     "hash": "67431dad6dcc459fea7d4c448fb04944de2c4cf61ecd75d546aeccd93b4564d7"

--- a/package-gale/tests/generated/calculator/calculator.g4.kiln.json
+++ b/package-gale/tests/generated/calculator/calculator.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7fbe69e34c931e16",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "grammars/calculator.g4",
     "hash": "67431dad6dcc459fea7d4c448fb04944de2c4cf61ecd75d546aeccd93b4564d7"

--- a/package-gale/tests/generated/calculator/calculator.g4.kiln.json
+++ b/package-gale/tests/generated/calculator/calculator.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7fbe69e34c931e16",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "grammars/calculator.g4",
     "hash": "67431dad6dcc459fea7d4c448fb04944de2c4cf61ecd75d546aeccd93b4564d7"

--- a/package-gale/tests/generated/ci_rule_override/ci_rule_override.g4.kiln.json
+++ b/package-gale/tests/generated/ci_rule_override/ci_rule_override.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-66c270910e5642be",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "grammars/ci_rule_override.g4",
     "hash": "6efdfe55ecb215bf526900a32a11c664a57c9e14d61c6a67758f870adc73d09b"

--- a/package-gale/tests/generated/ci_rule_override/ci_rule_override.g4.kiln.json
+++ b/package-gale/tests/generated/ci_rule_override/ci_rule_override.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-66c270910e5642be",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "grammars/ci_rule_override.g4",
     "hash": "6efdfe55ecb215bf526900a32a11c664a57c9e14d61c6a67758f870adc73d09b"

--- a/package-gale/tests/generated/ci_rule_override/ci_rule_override.g4.kiln.json
+++ b/package-gale/tests/generated/ci_rule_override/ci_rule_override.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-66c270910e5642be",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "grammars/ci_rule_override.g4",
     "hash": "6efdfe55ecb215bf526900a32a11c664a57c9e14d61c6a67758f870adc73d09b"

--- a/package-gale/tests/generated/ci_sql/ci_sql.g4.kiln.json
+++ b/package-gale/tests/generated/ci_sql/ci_sql.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b9bfa38391d7f122",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "grammars/ci_sql.g4",
     "hash": "41b72934417dd2f6fa0359722ce53ca05cd10cccde08fd9f3d0d58018f2137fe"

--- a/package-gale/tests/generated/ci_sql/ci_sql.g4.kiln.json
+++ b/package-gale/tests/generated/ci_sql/ci_sql.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b9bfa38391d7f122",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "grammars/ci_sql.g4",
     "hash": "41b72934417dd2f6fa0359722ce53ca05cd10cccde08fd9f3d0d58018f2137fe"

--- a/package-gale/tests/generated/ci_sql/ci_sql.g4.kiln.json
+++ b/package-gale/tests/generated/ci_sql/ci_sql.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b9bfa38391d7f122",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "grammars/ci_sql.g4",
     "hash": "41b72934417dd2f6fa0359722ce53ca05cd10cccde08fd9f3d0d58018f2137fe"

--- a/package-gale/tests/generated/css3/css3Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/css3/css3Lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fa4a5fa8cced30ae",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "grammars/css3Lexer.g4",
     "hash": "4733198f782344f0d3dbd2456ee9f6db955f53c688d14334fb403985551c963c"

--- a/package-gale/tests/generated/css3/css3Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/css3/css3Lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fa4a5fa8cced30ae",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "grammars/css3Lexer.g4",
     "hash": "4733198f782344f0d3dbd2456ee9f6db955f53c688d14334fb403985551c963c"

--- a/package-gale/tests/generated/css3/css3Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/css3/css3Lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fa4a5fa8cced30ae",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "grammars/css3Lexer.g4",
     "hash": "4733198f782344f0d3dbd2456ee9f6db955f53c688d14334fb403985551c963c"

--- a/package-gale/tests/generated/html/HTMLLexer.g4.kiln.json
+++ b/package-gale/tests/generated/html/HTMLLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c6b3fd168a1b47a8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "grammars/HTMLLexer.g4",
     "hash": "1d3b243228b182ddeca45bf2c7f9ec6512c176bcec126444bce7cbe7a8e93052"

--- a/package-gale/tests/generated/html/HTMLLexer.g4.kiln.json
+++ b/package-gale/tests/generated/html/HTMLLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c6b3fd168a1b47a8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "grammars/HTMLLexer.g4",
     "hash": "1d3b243228b182ddeca45bf2c7f9ec6512c176bcec126444bce7cbe7a8e93052"

--- a/package-gale/tests/generated/html/HTMLLexer.g4.kiln.json
+++ b/package-gale/tests/generated/html/HTMLLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c6b3fd168a1b47a8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "grammars/HTMLLexer.g4",
     "hash": "1d3b243228b182ddeca45bf2c7f9ec6512c176bcec126444bce7cbe7a8e93052"

--- a/package-gale/tests/generated/json/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/json/JSON.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-deb9206518cd2a6f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "grammars/JSON.g4",
     "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"

--- a/package-gale/tests/generated/json/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/json/JSON.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-deb9206518cd2a6f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "grammars/JSON.g4",
     "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"

--- a/package-gale/tests/generated/json/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/json/JSON.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-deb9206518cd2a6f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "grammars/JSON.g4",
     "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"

--- a/package-gale/tests/generated/json_highlight/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/json_highlight/JSON.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-deb9206518cd2a6f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "grammars/JSON.g4",
     "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"

--- a/package-gale/tests/generated/json_highlight/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/json_highlight/JSON.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-deb9206518cd2a6f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "grammars/JSON.g4",
     "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"

--- a/package-gale/tests/generated/json_highlight/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/json_highlight/JSON.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-deb9206518cd2a6f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "grammars/JSON.g4",
     "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"

--- a/package-gale/tests/generated/label_gaps/label_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/label_gaps/label_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6e9e12ac993603d7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "grammars/label_gaps.g4",
     "hash": "8e2049cd7baf82750b8e242018ffdc1f8e684226f8e27fe8068ad7838d6da425"

--- a/package-gale/tests/generated/label_gaps/label_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/label_gaps/label_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6e9e12ac993603d7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "grammars/label_gaps.g4",
     "hash": "8e2049cd7baf82750b8e242018ffdc1f8e684226f8e27fe8068ad7838d6da425"

--- a/package-gale/tests/generated/label_gaps/label_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/label_gaps/label_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6e9e12ac993603d7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "grammars/label_gaps.g4",
     "hash": "8e2049cd7baf82750b8e242018ffdc1f8e684226f8e27fe8068ad7838d6da425"

--- a/package-gale/tests/generated/lexer_command_gaps/lexer_command_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/lexer_command_gaps/lexer_command_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c1bc56a77b40e824",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "grammars/lexer_command_gaps.g4",
     "hash": "253a32f9908895a3ffaa23ac8e32eaa12f43998f25d7d2b73637ddf11a3cb3c9"

--- a/package-gale/tests/generated/lexer_command_gaps/lexer_command_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/lexer_command_gaps/lexer_command_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c1bc56a77b40e824",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "grammars/lexer_command_gaps.g4",
     "hash": "253a32f9908895a3ffaa23ac8e32eaa12f43998f25d7d2b73637ddf11a3cb3c9"

--- a/package-gale/tests/generated/lexer_command_gaps/lexer_command_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/lexer_command_gaps/lexer_command_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c1bc56a77b40e824",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "grammars/lexer_command_gaps.g4",
     "hash": "253a32f9908895a3ffaa23ac8e32eaa12f43998f25d7d2b73637ddf11a3cb3c9"

--- a/package-gale/tests/generated/mode_gaps/mode_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/mode_gaps/mode_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-934b67223a7d4708",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "grammars/mode_gaps.g4",
     "hash": "2129310ea345f84328b61531ce102c6306fda62ef4fa71d7c64d1dc4bb9f1d14"

--- a/package-gale/tests/generated/mode_gaps/mode_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/mode_gaps/mode_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-934b67223a7d4708",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "grammars/mode_gaps.g4",
     "hash": "2129310ea345f84328b61531ce102c6306fda62ef4fa71d7c64d1dc4bb9f1d14"

--- a/package-gale/tests/generated/mode_gaps/mode_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/mode_gaps/mode_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-934b67223a7d4708",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "grammars/mode_gaps.g4",
     "hash": "2129310ea345f84328b61531ce102c6306fda62ef4fa71d7c64d1dc4bb9f1d14"

--- a/package-gale/tests/generated/non_greedy_gaps/non_greedy_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/non_greedy_gaps/non_greedy_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a7aa34c1db2fca6a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "grammars/non_greedy_gaps.g4",
     "hash": "b7ebb6e1d962ee295bf43cc5a13f167cbd270ef3d9e15a052d2eb060eefb012c"

--- a/package-gale/tests/generated/non_greedy_gaps/non_greedy_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/non_greedy_gaps/non_greedy_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a7aa34c1db2fca6a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "grammars/non_greedy_gaps.g4",
     "hash": "b7ebb6e1d962ee295bf43cc5a13f167cbd270ef3d9e15a052d2eb060eefb012c"

--- a/package-gale/tests/generated/non_greedy_gaps/non_greedy_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/non_greedy_gaps/non_greedy_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a7aa34c1db2fca6a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "grammars/non_greedy_gaps.g4",
     "hash": "b7ebb6e1d962ee295bf43cc5a13f167cbd270ef3d9e15a052d2eb060eefb012c"

--- a/package-gale/tests/generated/parser_gaps/parser_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/parser_gaps/parser_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8eb28e22b79ba2bd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "grammars/parser_gaps.g4",
     "hash": "8262a9d7c10805db35e063564eaea6deb43e8de540af19d0969551d042b6d03a"

--- a/package-gale/tests/generated/parser_gaps/parser_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/parser_gaps/parser_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8eb28e22b79ba2bd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "grammars/parser_gaps.g4",
     "hash": "8262a9d7c10805db35e063564eaea6deb43e8de540af19d0969551d042b6d03a"

--- a/package-gale/tests/generated/parser_gaps/parser_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/parser_gaps/parser_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8eb28e22b79ba2bd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "grammars/parser_gaps.g4",
     "hash": "8262a9d7c10805db35e063564eaea6deb43e8de540af19d0969551d042b6d03a"

--- a/package-gale/tests/generated/recursive_lexer/recursive_lexer.g4.kiln.json
+++ b/package-gale/tests/generated/recursive_lexer/recursive_lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b23078c163edb700",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "grammars/recursive_lexer.g4",
     "hash": "3bba2a980c91c247bfa081040a71e8349ebd29cec177d15cf69feb75f40e705f"

--- a/package-gale/tests/generated/recursive_lexer/recursive_lexer.g4.kiln.json
+++ b/package-gale/tests/generated/recursive_lexer/recursive_lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b23078c163edb700",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "grammars/recursive_lexer.g4",
     "hash": "3bba2a980c91c247bfa081040a71e8349ebd29cec177d15cf69feb75f40e705f"

--- a/package-gale/tests/generated/recursive_lexer/recursive_lexer.g4.kiln.json
+++ b/package-gale/tests/generated/recursive_lexer/recursive_lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b23078c163edb700",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "grammars/recursive_lexer.g4",
     "hash": "3bba2a980c91c247bfa081040a71e8349ebd29cec177d15cf69feb75f40e705f"

--- a/package-gale/tests/generated/right_assoc_gaps/right_assoc_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/right_assoc_gaps/right_assoc_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7382226003c5d9e1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "grammars/right_assoc_gaps.g4",
     "hash": "7632fce865fe8aa2c3c460beea14a27a0a020b9ccb2312fb59a2c980f12f639a"

--- a/package-gale/tests/generated/right_assoc_gaps/right_assoc_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/right_assoc_gaps/right_assoc_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7382226003c5d9e1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "grammars/right_assoc_gaps.g4",
     "hash": "7632fce865fe8aa2c3c460beea14a27a0a020b9ccb2312fb59a2c980f12f639a"

--- a/package-gale/tests/generated/right_assoc_gaps/right_assoc_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/right_assoc_gaps/right_assoc_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7382226003c5d9e1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "grammars/right_assoc_gaps.g4",
     "hash": "7632fce865fe8aa2c3c460beea14a27a0a020b9ccb2312fb59a2c980f12f639a"

--- a/package-gale/tests/generated/rust/RustLexer.g4.kiln.json
+++ b/package-gale/tests/generated/rust/RustLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-28566ce8c3b8a5b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "grammars/RustLexer.g4",
     "hash": "a9069b6b1a5650b0f5f115897eaa0edaddc42007b262c5096b59eb1de15323d3"

--- a/package-gale/tests/generated/rust/RustLexer.g4.kiln.json
+++ b/package-gale/tests/generated/rust/RustLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-28566ce8c3b8a5b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "grammars/RustLexer.g4",
     "hash": "a9069b6b1a5650b0f5f115897eaa0edaddc42007b262c5096b59eb1de15323d3"

--- a/package-gale/tests/generated/rust/RustLexer.g4.kiln.json
+++ b/package-gale/tests/generated/rust/RustLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-28566ce8c3b8a5b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "grammars/RustLexer.g4",
     "hash": "a9069b6b1a5650b0f5f115897eaa0edaddc42007b262c5096b59eb1de15323d3"

--- a/package-gale/tests/generated/sexpression/sexpression.g4.kiln.json
+++ b/package-gale/tests/generated/sexpression/sexpression.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1847ef51d5668bfd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "grammars/sexpression.g4",
     "hash": "74549e6167e186b754886880a5d473ad3361bee8440368f99e1b233e2c1c7bdb"

--- a/package-gale/tests/generated/sexpression/sexpression.g4.kiln.json
+++ b/package-gale/tests/generated/sexpression/sexpression.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1847ef51d5668bfd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "grammars/sexpression.g4",
     "hash": "74549e6167e186b754886880a5d473ad3361bee8440368f99e1b233e2c1c7bdb"

--- a/package-gale/tests/generated/sexpression/sexpression.g4.kiln.json
+++ b/package-gale/tests/generated/sexpression/sexpression.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1847ef51d5668bfd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "grammars/sexpression.g4",
     "hash": "74549e6167e186b754886880a5d473ad3361bee8440368f99e1b233e2c1c7bdb"

--- a/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-880d9db12a6d7521",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "13e6559d1fe192e454f48a64814e0e900caff805ca45c2a8b195f15efd8142a7",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "grammars/SQLite.g4",
     "hash": "72e3fa9877777afa5a4f9e8196d4cb194bb599e719d43b7b29d09eeed3e4c5e0"

--- a/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-880d9db12a6d7521",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "grammars/SQLite.g4",
     "hash": "72e3fa9877777afa5a4f9e8196d4cb194bb599e719d43b7b29d09eeed3e4c5e0"

--- a/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-880d9db12a6d7521",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "grammars/SQLite.g4",
     "hash": "72e3fa9877777afa5a4f9e8196d4cb194bb599e719d43b7b29d09eeed3e4c5e0"

--- a/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-880d9db12a6d7521",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "13e6559d1fe192e454f48a64814e0e900caff805ca45c2a8b195f15efd8142a7",
   "primary": {
     "path": "grammars/SQLite.g4",
     "hash": "72e3fa9877777afa5a4f9e8196d4cb194bb599e719d43b7b29d09eeed3e4c5e0"

--- a/package-gale/tests/generated/sqlite_highlight/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite_highlight/SQLite.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-880d9db12a6d7521",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "13e6559d1fe192e454f48a64814e0e900caff805ca45c2a8b195f15efd8142a7",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "grammars/SQLite.g4",
     "hash": "72e3fa9877777afa5a4f9e8196d4cb194bb599e719d43b7b29d09eeed3e4c5e0"

--- a/package-gale/tests/generated/sqlite_highlight/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite_highlight/SQLite.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-880d9db12a6d7521",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "grammars/SQLite.g4",
     "hash": "72e3fa9877777afa5a4f9e8196d4cb194bb599e719d43b7b29d09eeed3e4c5e0"

--- a/package-gale/tests/generated/sqlite_highlight/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite_highlight/SQLite.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-880d9db12a6d7521",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "grammars/SQLite.g4",
     "hash": "72e3fa9877777afa5a4f9e8196d4cb194bb599e719d43b7b29d09eeed3e4c5e0"

--- a/package-gale/tests/generated/sqlite_highlight/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite_highlight/SQLite.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-880d9db12a6d7521",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "13e6559d1fe192e454f48a64814e0e900caff805ca45c2a8b195f15efd8142a7",
   "primary": {
     "path": "grammars/SQLite.g4",
     "hash": "72e3fa9877777afa5a4f9e8196d4cb194bb599e719d43b7b29d09eeed3e4c5e0"

--- a/package-gale/tests/generated/typescript/TypeScriptLexer.g4.kiln.json
+++ b/package-gale/tests/generated/typescript/TypeScriptLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b6f068637d3275ff",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "grammars/TypeScriptLexer.g4",
     "hash": "f7089740f7e82bbb90a6c4b13c75959b6ceaf3003be0dd0657c52b9eb6a594b7"

--- a/package-gale/tests/generated/typescript/TypeScriptLexer.g4.kiln.json
+++ b/package-gale/tests/generated/typescript/TypeScriptLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b6f068637d3275ff",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "grammars/TypeScriptLexer.g4",
     "hash": "f7089740f7e82bbb90a6c4b13c75959b6ceaf3003be0dd0657c52b9eb6a594b7"

--- a/package-gale/tests/generated/typescript/TypeScriptLexer.g4.kiln.json
+++ b/package-gale/tests/generated/typescript/TypeScriptLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b6f068637d3275ff",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "grammars/TypeScriptLexer.g4",
     "hash": "f7089740f7e82bbb90a6c4b13c75959b6ceaf3003be0dd0657c52b9eb6a594b7"

--- a/package-gale/tests/generated/unicode_props/unicode_props.g4.kiln.json
+++ b/package-gale/tests/generated/unicode_props/unicode_props.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f37fa830f2a0df13",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "e7ea3d8efe9de01d380da011dfea005821cbbab5a616515ddfe1f2a7fdea3c53",
+  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
   "primary": {
     "path": "grammars/unicode_props.g4",
     "hash": "7559b99d20b67597cdc99b2e9e0eaeea1ad4b0931d40859c1dbb600e20d1c5c0"

--- a/package-gale/tests/generated/unicode_props/unicode_props.g4.kiln.json
+++ b/package-gale/tests/generated/unicode_props/unicode_props.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f37fa830f2a0df13",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "188ed1cae782a3cffb70b7643b9d0eb21491e6fad0e136cc4587bfa2df71f887",
+  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
   "primary": {
     "path": "grammars/unicode_props.g4",
     "hash": "7559b99d20b67597cdc99b2e9e0eaeea1ad4b0931d40859c1dbb600e20d1c5c0"

--- a/package-gale/tests/generated/unicode_props/unicode_props.g4.kiln.json
+++ b/package-gale/tests/generated/unicode_props/unicode_props.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f37fa830f2a0df13",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "decfdb49abc581b81f2e1e65823a0cf6dd14393f57e7142e188165dd0e9bf068",
+  "generator_source_hash": "1271e0ae8cd5179fa2111464f9ebddd10b8d2d0c539cc15f32e7b5b28f27f592",
   "primary": {
     "path": "grammars/unicode_props.g4",
     "hash": "7559b99d20b67597cdc99b2e9e0eaeea1ad4b0931d40859c1dbb600e20d1c5c0"


### PR DESCRIPTION
## Summary

Closes the long-standing "Remove the LR Gate in `is_rule_scannable`" TODO in `package-gale/`. The gate had already been removed in a prior commit (Stage C dispatch sites use scan-side first-success-wins on `sort_group_by_element_count` longest-first order, with `gen_scan_multi_alt` partitioning by depth-0 first token), and `bt_try` / `opt_bt` count is 0 across every committed grammar. This PR brings the docs, dead code, and naming in line with that shipped reality.

Four commits, each independently reviewable:

1. **`docs(gale): retire LR-gate TODO and "Failed Approaches" entry`** — drop the obsolete `## Performance: sqlite-parse Benchmark` section from `package-gale/TODO.md`, replace the "Removing the LR Gate" subsection in `AGENTS.md` "Failed Approaches" with a one-line bullet under "Generated Parser Rules" stating that the migration is complete.

2. **`refactor(gale): remove dead bt_try / opt_bt fallbacks`** — replace every `bt_try` / `opt_bt` emission path (in `gen_optional_with_backtrack`, `gen_storable_optional_with_backtrack`, `gen_rule_ref_group_backtrack`, `gen_general_group_backtrack`, and the prediction-tree `Backtrack` branch) with a `panic!` at the scannable-check site. Delete `gen_rule_ref_group_backtrack`, `gen_element_failable`, and `gen_element_failable_named` (no remaining callers). Add `general_group_all_scannable` / `backtrack_node_all_scannable` helpers as preconditions for the surviving scan dispatchers.

3. **`refactor(gale): drop unused first from optional-emit helpers`** — `first: &Array<String>` is no longer referenced by `gen_optional_with_backtrack`, `gen_storable_optional_with_backtrack`, or `gen_storable_optional` after the bt body deletion. Drop the parameter from all three signatures and update the two call sites in `gen_repeat` / `gen_repeat_with_follow`.

4. **`refactor(gale): rename bt/Backtrack misnomers after migration`** — `PredictionNode::Backtrack` → `Ambiguous` (semantic name: "k=5 LL prediction couldn't pick a single alt; codegen scan-dispatches"), `prediction_contains_backtrack` → `prediction_contains_ambiguous`, `gen_optional_with_backtrack` → `gen_optional_with_scan_guard`, `gen_storable_optional_with_backtrack` → `gen_storable_optional_with_scan_guard`, `gen_backtracking_body` → `gen_prediction_body`, `needs_bt` → `has_overlaps`. Delete two now-unused helpers (`count_ambiguous_nodes`, `count_leaf_nodes`). Touch up stale comments that referenced "backtracking" as the live mechanism.

**Out of scope (left for a follow-up PR):**
- `parse_X_bt_N` (in generated parsers) and `gen_bt_scan_*` / `gen_multi_alt_body_bt` (in the generator). The `_bt_` infix is historical — these helpers used to run from a backtracking fallback and now run from the longest-match scan tournament. Renaming would touch generated function names across all 90+ golden parsers and is best done as a focused PR.
- `panic("...; backtracking has been removed (see AGENTS.md ...)")` messages — intentionally retained as historical hints to anyone hitting them on a malformed grammar.

## Test plan

- [x] `mise run test-wado` — compile 336 ok / 0 failed, test 1751 passed / 0 failed, todo 7 pending. Each commit was test-validated incrementally.
- [x] `bt_try` / `opt_bt` count = 0 across every regenerated parser (`sqlite`, `sqlite_highlight`, `rust`, `type_script`, `antlrv4`, plus the 80+ smaller fixture grammars).
- [x] `driver_sqlite_test`, `driver_sqlite_create_table_test`, `driver_sqlite_minimal_test`, `driver_sqlite_highlight_test`, `sqlite_regression_test`, `sqlite_case_when_test` all green.
- [ ] `benchmark/sqlite_parse` per-iteration ≤ today's 11,826 µs on the dev machine (not re-measured on this branch since no perf-relevant codegen path changed — the panics are codegen-time only and never reached for any committed grammar).

https://claude.ai/code/session_01PDTSwLGqQArhUuaEfbASxo

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDTSwLGqQArhUuaEfbASxo)_