### PR TITLE
fix(gale): close 3 ANTLR4 stage_b compatibility gaps

### DIFF
--- a/package-gale/TODO.md
+++ b/package-gale/TODO.md
@@ -25,6 +25,59 @@ recognition rule. The remaining work splits into:
 
 (none currently)
 
+## Correctness: full-context LL(\*) prediction (next focus)
+
+Gale's prediction is essentially SLL — it picks an alt by inspecting
+the current and (for some sites) one or two lookahead tokens, then
+commits. ANTLR4's prediction is LL(\*): when SLL is ambiguous it
+considers the full call-stack context, including what the caller
+expects to follow. Real-world `.g4` files rely on this in subtle
+places, and grammars that hit those cases tokenize the same input but
+choose a different alt than ANTLR4 would.
+
+This is **the next planned correctness focus** — Stage C
+(action/predicate execution) sits behind it because the harder LL
+cases in real grammars depend on predicates as a tiebreaker, so the
+prediction story has to be settled first.
+
+The minimal reproducer lives at
+`tests/antlr4-compat/grammars/ParserExec/PredictionMode_LL.g4`:
+
+```antlr
+r : (a b | a) EOF ;
+a : X Y? ;
+b : Y ;
+```
+
+For input `X Y` ANTLR4 (with `predictionMode=LL`) picks alt 1
+(`a b`) so that `a` matches just `X` and `b` consumes `Y`. Gale picks
+alt 2 (`a` only) because its scan for `a` is greedy on `Y?` and has
+no way to learn that `Y` belongs to the follow set (`b` then EOF).
+Result: `(r (a X Y))` instead of `(r (a X) (b Y))`.
+
+Fixing this requires routing follow-set information into rule scans
+so that an optional whose first token is in follow stops being
+greedy at the call site. The cleanest design is to generate a
+follow-aware variant of each affected scan (or pass an explicit
+`follow_mask` parameter), invoked from the alt's scan rather than
+the generic global scan.
+
+Sketch:
+
+- At each call site, compute the static follow set FOLLOW(rule_call)
+  from the surrounding alt elements.
+- For each rule whose body contains a tail-position optional whose
+  first token can appear in some caller's FOLLOW, generate a
+  per-call-site scan variant (or a `follow_mask: u64` parameter on
+  the global scan) so the optional's "should I consume?" decision
+  becomes context-aware.
+- Update the alt-dispatch and LR-loop predictors to use the new
+  follow-aware scan in place of the greedy global one. The existing
+  scan remains the fallback when no caller cares about the follow.
+
+Tracked descriptor: `ParserExec/PredictionMode_LL` (`stage_b_todo`
+in `tests/antlr4-compat/status.toml`).
+
 ## Correctness: full ANTLR4 compatibility (action / predicate execution)
 
 Gale currently **recognizes** but **silently discards** the contents of

--- a/package-gale/antlr4-compatibility.md
+++ b/package-gale/antlr4-compatibility.md
@@ -295,15 +295,13 @@ invocation), runs the generated parser on `[input]`, and compares
 
 Current numbers (run `wado test package-gale/tests/antlr4-compat`):
 
-- **70 Stage B tests emitted** — 57 pass, 13 `#[TODO]` (known
+- **74 Stage B tests emitted** — 70 pass, 4 `#[TODO]` (known
   divergences tracked in `[stage_b_todo]` of `status.toml`).
-- **4 `[stage_b_skip]`** — list-label LR alts
-  (`LeftRecursion/ReturnValueAndActionsList[12]_*`) where
-  `b+=expr ',' b+=expr` produces two distinct `Array<ExprNode>`
-  fields (`b` and `b_2`) instead of appending both to one list, and
-  the LR helper passes `left: ExprNode` into the array-typed field —
-  ANTLR4 `+=` semantic gap rather than a descriptor bug.
-- **185 auto-skip** — descriptor's `[output]` is not a parse tree at
+- **0 `[stage_b_skip]`** — the historical four
+  (`LeftRecursion/ReturnValueAndActionsList[12]_[13]`) were unblocked
+  by the LR-helper list-label fix described under
+  [Recently closed gaps](#recently-closed-gaps) below.
+- **~185 auto-skip** — descriptor's `[output]` is not a parse tree at
   all (lexer token-type names, Token.toString dumps, ATN decision
   traces, action-block prints) or its `[output]` starts with a
   rule other than `[start]` (the descriptor's `@after` action prints
@@ -328,25 +326,55 @@ Three independent pieces make up the wiring:
    `output_dir`, avoiding cross-grammar name collisions in
    generated code.
 
-The 13 `#[TODO]` entries are the natural Stage B backlog. They
-break down into three buckets:
+The 4 `#[TODO]` entries are the natural Stage B backlog. They split
+into two buckets:
 
-- **LR rewriting tree-shape divergence** —
-  `LeftRecursion/{Expressions_7, PrefixAndOtherAlt_1,
-  PrefixAndOtherAlt_2}` plus `LeftRecursion/SemPredFailOption`
-  (where the failing predicate guard is silently dropped because
-  action bodies are skipped — Stage C territory).
-- **Parse failures on left-recursion edge cases** —
-  `LeftRecursion/JavaExpressions_{7,8,9,12}` and
+- **Full-context LL(\*) prediction (next focus)** —
+  `ParserExec/PredictionMode_LL`, where `(a b | a) EOF` with a
+  greedy `a : X Y?` makes Gale's first-token dispatch pick `a` only
+  while ANTLR4's LL prediction picks `a b` based on the follow set.
+  Sketch and design notes in [`TODO.md`](./TODO.md). This is the
+  planned next compatibility track because the harder cases in the
+  Stage C bucket below depend on predicates as a prediction
+  tiebreaker, so prediction has to be sound first.
+- **Action / predicate execution (Stage C territory)** —
+  `LeftRecursion/SemPredFailOption` (the failing predicate guard is
+  silently dropped because action bodies are skipped),
+  `SemPredEvalParser/PredFromAltTestedInLoopBack_{1,2}` (semantic
+  predicate enforcement).
+
+### Recently closed gaps
+
+The following Stage B blockers are now fixed and the descriptors are
+emitted plain (no `#[TODO]` / `[stage_b_skip]`):
+
+- **Lexer keyword classification was unreachable when no carrier rule
+  existed.** Single-literal lexer rules (`A : 'A' ;`) were collected
+  as keyword candidates even when no longer non-keyword rule could
+  match their first character — the tokenize loop's
+  `if best_end > start { classify_keyword(...) }` gate could never
+  fire, so `A` and friends were never produced. `collect_keyword_rules`
+  now demotes such candidates back to the regular dispatch path.
+  Closed `ParserExec/BuildParseTree_TRUE`.
+- **LR continuation prediction failed the whole scan when a suffix's
+  first token matched but the suffix did not complete.**
+  `gen_scan_lr_call_with_prec` returned `-1` from the entire scan on
+  suffix failure; the enclosing `statement*` driver therefore matched
+  zero statements and reported `expected EOF, got "a"` at position 0.
+  The scan side now saves `pos` and restores+breaks on failure; the
+  parse side consults the scan twin first and only commits when the
+  scan confirms the suffix would succeed. Closed
   `LeftRecursion/PrecedenceFilterConsidersContext`.
-- **Predicates and full-context LL** —
-  `ParserExec/{BuildParseTree_TRUE, PredictionMode_LL}`,
-  `SemPredEvalParser/PredFromAltTestedInLoopBack_{1,2}`. All fall
-  under Stage C (action-body translation) for a full fix.
+- **List-label LR alts (`b+=expr`) generated invalid Wado.** When the
+  LR-rewritten recursive position carries a `+=` label (or any other
+  `+=` label appears later in the suffix), the IR field is
+  `Array<T>` but the helper assigned a single `T` value. The helper
+  now wraps both the inherited `left` and each per-iteration value in
+  `[...] as Array<T>`. Closed all four
+  `LeftRecursion/ReturnValueAndActionsList[12]_[13]` skips.
 
-Two recent fixes that closed earlier `[stage_b_skip]` entries are
-worth noting because they each unblocked ~10 % of the bucket and
-the underlying compiler / codegen bugs were both real:
+Earlier closed gaps worth noting (each unblocked ~10 % of the
+historical Stage B bucket and exposed real compiler / codegen bugs):
 
 - **Wado compiler ICE on struct-field rebind in `export fn`** — the
   `sroa_multi_value_returns` WIR pass scalarised the function

--- a/package-gale/src/codegen_test.wado
+++ b/package-gale/src/codegen_test.wado
@@ -733,6 +733,103 @@ fn parse_grammar(input: String, path: String) -> Grammar {
     return g;
 }
 
+test "LR scan loop saves pos and backs off on a suffix failure" {
+    // statement: letterA | statement letterA 'b' ;
+    // Both alts start with TK_LIT_A (letterA = 'a'), so the LR suffix's
+    // first-token check alone cannot decide whether the suffix will complete.
+    // When `scan_statement_lr_1` returns -1 (e.g. the trailing 'b' is missing),
+    // the LR loop must restore `pos` to the prior atom-end and `break` —
+    // never propagate `-1` as the whole scan failing, which would prevent
+    // the enclosing `statement*` repetition from matching anything (ANTLR4
+    // stops after the longest valid prefix).
+    let input = "grammar Test;
+prog : statement* EOF ;
+statement : letterA | statement letterA 'b' ;
+letterA : 'a' ;
+";
+    let mut grammar = parse_grammar(input, "test.g4");
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let scan_body = extract_fn_body(&output, &"fn scan_statement(");
+    // The LR loop must save `pos` before the suffix call and restore it on
+    // failure. Look for the save+restore pair around `scan_statement_lr_1(`.
+    assert str_contains(&scan_body, "let lr_saved_pos = pos;"),
+        `scan_statement must save pos before the LR suffix call:\n{scan_body}`;
+    assert str_contains(&scan_body, "pos = lr_saved_pos; break;"),
+        `scan_statement must restore pos and break on LR suffix failure:\n{scan_body}`;
+}
+
+test "LR helper wraps left into an array when the recursive-position label uses +=" {
+    // `b+=expr ',' b+=expr` declares `b` as a list-label (`+=`). After LR
+    // rewriting the recursive `b+=expr` is consumed into the helper's `left`
+    // parameter, but the generated struct field `b` keeps its
+    // `Array<ExprNode>` type (the `+=` semantics) — the helper must build
+    // `[left]` instead of bare `left`, otherwise the struct literal mismatches
+    // the field type and the generated parser fails to compile.
+    let input = "grammar Test;
+s : expr EOF ;
+expr : b+=expr ',' b+=expr #Comma | ID #JustId ;
+ID : 'a' ;
+WS : [ \\t\\n]+ -> skip ;
+";
+    let mut grammar = parse_grammar(input, "test.g4");
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let helper = extract_fn_body(&output, &"fn parse_expr_lr_");
+    assert str_contains(&helper, "b: [left] as Array<ExprNode>,"),
+        `LR helper must wrap a list-label \`left\` in an Array<T>-typed array literal:\n{helper}`;
+}
+
+test "LR parse loop predicts via scan when suffix's first token is shared with the atom" {
+    // Same grammar as the scan-side test. On the parse side the suffix call
+    // mutates `p.pos`, so the LR loop must consult the scan twin first to
+    // decide whether to commit. Without that check, `parse_statement_lr_1`
+    // would consume `letterA` then fail on `'b'`, leaving `p.pos` mid-suffix
+    // and corrupting the surrounding `statement*` driver.
+    let input = "grammar Test;
+prog : statement* EOF ;
+statement : letterA | statement letterA 'b' ;
+letterA : 'a' ;
+";
+    let mut grammar = parse_grammar(input, "test.g4");
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let parse_body = extract_fn_body(&output, &"fn parse_statement(");
+    assert str_contains(&parse_body, "scan_statement_lr_1(") || str_contains(&parse_body, "scan_statement_lr_1 ("),
+        `parse_statement must consult scan_statement_lr_1 before parsing the LR suffix:\n{parse_body}`;
+}
+
+fn extract_fn_body(output: &String, header: &String) -> String {
+    let start = find_substr(output, header);
+    if start < 0 { return ""; }
+    // Find the next "\nfn " (start of the next top-level fn) or end of file.
+    let after = start + header.len();
+    let next = find_substr_from(output, &"\nfn ", after);
+    let end = if next < 0 { output.len() } else { next };
+    return output.substr_bytes(start, end);
+}
+
+fn find_substr(haystack: &String, needle: &String) -> i32 {
+    return find_substr_from(haystack, needle, 0);
+}
+
+fn find_substr_from(haystack: &String, needle: &String, from: i32) -> i32 {
+    let h_len = haystack.len();
+    let n_len = needle.len();
+    if n_len > h_len {
+        return -1;
+    }
+    let limit = h_len - n_len;
+    for let mut i = from; i <= limit; i += 1 {
+        let mut ok = true;
+        for let mut j = 0; j < n_len; j += 1 {
+            if haystack.get_byte(i + j) != needle.get_byte(j) {
+                ok = false;
+                break;
+            }
+        }
+        if ok { return i; }
+    }
+    return -1;
+}
+
 test "caseInsensitive grammar option makes literal match CI" {
     let input = "lexer grammar Test;
 options { caseInsensitive = true; }
@@ -763,12 +860,12 @@ STRICT options { caseInsensitive = false; } : 'x' ;
 WS : [ \\t]+ -> skip ;";
     let mut grammar = parse_grammar(input, "test.g4");
     let output = generate(&mut grammar, &DEFAULT_OPTIONS);
-    // IF still CI.
+    // IF still CI: the literal 'i' must use the branchless CI helper.
     assert str_contains(&output, "!chars[pos].eq_ignore_ascii_case(&'i')"), `IF must remain CI (grammar-level):\n{output}`;
-    // STRICT must emit plain equality for 'x' (no CI fold). The keyword
-    // classifier uses `start + i` indexing.
-    assert str_contains(&output, "chars[start + 0] == 'x'"), `STRICT must not fold 'x':\n{output}`;
-    assert !str_contains(&output, "chars[start + 0].eq_ignore_ascii_case(&'x')"), `STRICT must not fold 'x' to [xX]:\n{output}`;
+    // STRICT: rule-level caseInsensitive=false means 'x' must NOT be folded,
+    // regardless of which match path the optimisation chose for the rule
+    // (keyword classifier, regular dispatch, or shared literal).
+    assert !str_contains(&output, "eq_ignore_ascii_case(&'x')"), `STRICT must not fold 'x' to [xX]:\n{output}`;
 }
 
 test "lexer rule caseInsensitive=true enables CI when grammar-level absent" {
@@ -967,6 +1064,43 @@ test "visibility comment emitted on non-default lexer rule" {
     };
     let output = generate(&mut grammar, &DEFAULT_OPTIONS);
     assert str_contains(&output, "// rule visibility: protected (ignored by codegen, matches ANTLR4)"), `expected visibility comment for Protected lexer rule:\n{output}`;
+}
+
+test "single-char literal lexer rule without an identifier carrier emits its own try_ matcher" {
+    // `A : 'A' ;` and `B : 'B' ;` look like keyword candidates (single-letter
+    // literal rules). But the keyword classifier only fires after a longer
+    // non-keyword rule has already matched the same characters — and this
+    // grammar has no such carrier (only WS, which matches whitespace). Without
+    // demotion the literals would be unreachable: the tokenize loop would not
+    // dispatch on 'A'/'B', and `classify_keyword` would never run on them.
+    let input = "grammar Test;
+r : A B ;
+A : 'A' ;
+B : 'B' ;
+WS : [ \\t\\n\\r]+ -> skip ;
+";
+    let mut grammar = parse_grammar(input, "test.g4");
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    assert str_contains(&output, "fn try_a("), `try_a should be generated when no keyword carrier exists:\n{output}`;
+    assert str_contains(&output, "fn try_b("), `try_b should be generated when no keyword carrier exists:\n{output}`;
+    assert str_contains(&output, "first_char == 'A'"), `tokenize dispatch must include 'A':\n{output}`;
+    assert str_contains(&output, "first_char == 'B'"), `tokenize dispatch must include 'B':\n{output}`;
+}
+
+test "single-char literal with an ID carrier stays a keyword (no try_ matcher)" {
+    // `A : 'A'` is a keyword candidate, and `ID : [a-zA-Z]+` covers 'A' as a
+    // first character. The classify_keyword path is therefore reachable, so
+    // `A` must keep its keyword classification — no try_a is emitted.
+    let input = "grammar Test;
+r : A ID ;
+A : 'A' ;
+ID : [a-zA-Z]+ ;
+WS : [ \\t\\n\\r]+ -> skip ;
+";
+    let mut grammar = parse_grammar(input, "test.g4");
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    assert !str_contains(&output, "fn try_a("), `try_a must not be generated when an ID carrier exists:\n{output}`;
+    assert str_contains(&output, "classify_keyword"), `keyword classifier must still be emitted:\n{output}`;
 }
 
 fn str_contains(haystack: &String, needle: &String) -> bool {

--- a/package-gale/src/lexer_gen.wado
+++ b/package-gale/src/lexer_gen.wado
@@ -647,18 +647,70 @@ fn try_extract_keyword_info(rule: &LexerRule, all_rules: &Array<LexerRule>, gram
 }
 
 /// Collects all keyword rules from the grammar.
+///
+/// The keyword path is an optimisation: instead of dispatching keyword-shaped
+/// rules through their own first-character branch, the tokenize loop runs
+/// `classify_keyword` after a longer non-keyword rule has already matched the
+/// same characters (the gate is `best_end > start`). The optimisation is
+/// only sound when some non-keyword rule could match the keyword's first
+/// character — otherwise the classifier never runs and the rule is
+/// unreachable. ANTLR4 has no such precondition (every lexer rule is its own
+/// dispatch path); to stay compatible Gale must not classify a rule as a
+/// keyword unless that precondition holds. Candidates that fail the check
+/// fall back to the regular dispatch path (`gen_lexer_match_fn`).
 pub fn collect_keyword_rules(lexer_rules: &Array<LexerRule>, grammar_opts: &Array<GrammarOption>) -> Array<KeywordInfo> {
-    let mut result: Array<KeywordInfo> = [];
+    let mut candidates: Array<KeywordInfo> = [];
     for let rule of lexer_rules {
         if rule.is_fragment || rule.is_virtual {
             continue;
         }
         let info = try_extract_keyword_info(rule, lexer_rules, grammar_opts);
         if let Some(kw) = info {
-            result.push(kw);
+            candidates.push(kw);
+        }
+    }
+    let mut result: Array<KeywordInfo> = [];
+    for let kw of &candidates {
+        if keyword_has_carrier(kw, &candidates, lexer_rules, grammar_opts) {
+            result.push(*kw);
         }
     }
     return result;
+}
+
+/// Returns true if some non-candidate non-fragment non-virtual lexer rule has
+/// a first-character set that covers `kw`'s first character (folded to either
+/// case when `kw`'s first character is case-insensitive).
+fn keyword_has_carrier(
+    kw: &KeywordInfo,
+    candidates: &Array<KeywordInfo>,
+    lexer_rules: &Array<LexerRule>,
+    grammar_opts: &Array<GrammarOption>,
+) -> bool {
+    let first_char = kw.lowercase_text.chars().next().unwrap();
+    let first_ci = kw.char_ci[0];
+    for let rule of lexer_rules {
+        if rule.is_fragment || rule.is_virtual {
+            continue;
+        }
+        if is_keyword_rule_name(&rule.name, candidates) {
+            continue;
+        }
+        let try_call = compute_first_chars(rule, lexer_rules, false, false, false, false, grammar_opts);
+        if try_call.is_wildcard {
+            return true;
+        }
+        if char_matches_ranges(first_char, &try_call.first_chars) {
+            return true;
+        }
+        if first_ci {
+            let upper = first_char.to_ascii_uppercase();
+            if upper != first_char && char_matches_ranges(upper, &try_call.first_chars) {
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 fn is_keyword_rule_name(name: &String, keywords: &Array<KeywordInfo>) -> bool {

--- a/package-gale/src/lexer_gen.wado
+++ b/package-gale/src/lexer_gen.wado
@@ -669,45 +669,49 @@ pub fn collect_keyword_rules(lexer_rules: &Array<LexerRule>, grammar_opts: &Arra
             candidates.push(kw);
         }
     }
+    // Precompute the first-char set of each potential carrier rule once, so
+    // the per-candidate filter below is O(carriers + candidates) rather than
+    // O(carriers × candidates) `compute_first_chars` calls. A single
+    // wildcard carrier (e.g. `UNEXPECTED : .;`) covers every candidate, so
+    // we short-circuit and skip the filter entirely.
+    let mut carrier_first_chars: Array<Array<[char, char]>> = [];
+    let mut any_wildcard_carrier = false;
+    for let rule of lexer_rules {
+        if rule.is_fragment || rule.is_virtual {
+            continue;
+        }
+        if is_keyword_rule_name(&rule.name, &candidates) {
+            continue;
+        }
+        let try_call = compute_first_chars(rule, lexer_rules, false, false, false, false, grammar_opts);
+        if try_call.is_wildcard {
+            any_wildcard_carrier = true;
+            break;
+        }
+        carrier_first_chars.push(try_call.first_chars);
+    }
     let mut result: Array<KeywordInfo> = [];
     for let kw of &candidates {
-        if keyword_has_carrier(kw, &candidates, lexer_rules, grammar_opts) {
+        if any_wildcard_carrier || keyword_has_carrier(kw, &carrier_first_chars) {
             result.push(*kw);
         }
     }
     return result;
 }
 
-/// Returns true if some non-candidate non-fragment non-virtual lexer rule has
-/// a first-character set that covers `kw`'s first character (folded to either
-/// case when `kw`'s first character is case-insensitive).
-fn keyword_has_carrier(
-    kw: &KeywordInfo,
-    candidates: &Array<KeywordInfo>,
-    lexer_rules: &Array<LexerRule>,
-    grammar_opts: &Array<GrammarOption>,
-) -> bool {
+/// Returns true if some precomputed carrier first-char set covers `kw`'s
+/// first character (folded to either case when `kw`'s first character is
+/// case-insensitive).
+fn keyword_has_carrier(kw: &KeywordInfo, carrier_first_chars: &Array<Array<[char, char]>>) -> bool {
     let first_char = kw.lowercase_text.chars().next().unwrap();
     let first_ci = kw.char_ci[0];
-    for let rule of lexer_rules {
-        if rule.is_fragment || rule.is_virtual {
-            continue;
-        }
-        if is_keyword_rule_name(&rule.name, candidates) {
-            continue;
-        }
-        let try_call = compute_first_chars(rule, lexer_rules, false, false, false, false, grammar_opts);
-        if try_call.is_wildcard {
+    let upper = if first_ci { first_char.to_ascii_uppercase() } else { first_char };
+    for let ranges of carrier_first_chars {
+        if char_matches_ranges(first_char, ranges) {
             return true;
         }
-        if char_matches_ranges(first_char, &try_call.first_chars) {
+        if first_ci && upper != first_char && char_matches_ranges(upper, ranges) {
             return true;
-        }
-        if first_ci {
-            let upper = first_char.to_ascii_uppercase();
-            if upper != first_char && char_matches_ranges(upper, &try_call.first_chars) {
-                return true;
-            }
         }
     }
     return false;

--- a/package-gale/src/parser_gen.wado
+++ b/package-gale/src/parser_gen.wado
@@ -1567,9 +1567,18 @@ fn gen_scan_lr_suffix_dispatch(w: &mut CodeWriter, rule: &ParserRule, lr_indices
 }
 
 fn gen_scan_lr_call_with_prec(w: &mut CodeWriter, suffix_fn: &String, prec: i32) {
+    // The LR loop must always commit to the longest valid prefix it can
+    // build. If the suffix scan fails (e.g. the suffix's first token matches
+    // but a deeper element does not, as in `statement letterA 'b'` consuming
+    // the trailing `letterA` then failing on `'b'`), we restore `pos` to the
+    // last successful position and break out of the loop — never propagate
+    // the failure as the whole scan failing. ANTLR4's LL(*) prediction
+    // achieves the same result at decision time; Gale's first-token dispatch
+    // makes the same decision lazily after attempting the suffix.
     w.begin(`if {prec} >= min_prec`);
+    w.line(`let lr_saved_pos = pos;`);
     w.line(`pos = {*suffix_fn}(tokens, pos);`);
-    w.line("if pos < 0 { return -1; }");
+    w.line("if pos < 0 { pos = lr_saved_pos; break; }");
     w.else_begin("else");
     w.line("break;");
     w.end();
@@ -4997,10 +5006,18 @@ fn gen_lr_suffix_helpers(w: &mut CodeWriter, rule: &ParserRule, type_name: &Stri
         // Reserve the binding the bt-side parse function uses for the
         // self-reference (the label name for `a=e`, the rule's own
         // field_name for the bare `e` form) so subsequent dedup matches.
+        // `first_is_list_label` is true for ANTLR4's `+=` form, where the
+        // resulting struct field has type `Array<T>` rather than `T` —
+        // the helper must build `[left]` so the literal matches the field.
         let first_binding = if let Label(lab) = &alt.elements[0] {
             lab.field_name
         } else {
             rule.field_name
+        };
+        let first_is_list_label = if let Label(lab) = &alt.elements[0] {
+            lab.list
+        } else {
+            false
         };
         dedup_name(&first_binding, &mut name_counts);
 
@@ -5030,6 +5047,8 @@ fn gen_lr_suffix_helpers(w: &mut CodeWriter, rule: &ParserRule, type_name: &Stri
             } else if let Label(lab) = elem {
                 // Labeled self-recursive call: use precedence the same way
                 // as the bare-RuleRef arm above, then re-bind to the label.
+                // List labels (`+=`) declare an `Array<T>` field; wrap the
+                // single per-iteration value to match the field type.
                 if let RuleRef(rr) = &lab.element {
                     if rr.name == rule.name {
                         let lab_name = dedup_name(&lab.field_name, &mut name_counts);
@@ -5042,7 +5061,13 @@ fn gen_lr_suffix_helpers(w: &mut CodeWriter, rule: &ParserRule, type_name: &Stri
                             &lr_suffix_first_tokens,
                         );
                         w.line(`let {inner_name} = {fn_name}(p, {prec})?;`);
-                        w.line(`let {lab_name} = {inner_name};`);
+                        if lab.list {
+                            // Type-annotate the local so `[inner]` parses as
+                            // `Array<T>` rather than a 1-tuple `[T]`.
+                            w.line(`let {lab_name}: Array<{type_name}> = [{inner_name}];`);
+                        } else {
+                            w.line(`let {lab_name} = {inner_name};`);
+                        }
                         continue;
                     }
                 }
@@ -5068,7 +5093,13 @@ fn gen_lr_suffix_helpers(w: &mut CodeWriter, rule: &ParserRule, type_name: &Stri
         w.line(`return Result::<{type_name}, ParseError>::Ok({type_name}::{case_names[lr_idx]}({sname} \{`);
         w.indent();
         w.line("span: Span::new(start, p.last_end()),");
-        w.line(`{first_field}: left,`);
+        if first_is_list_label {
+            // Cast so `[left]` matches the `Array<T>` field type rather
+            // than the inferred 1-tuple `[T]`.
+            w.line(`{first_field}: [left] as Array<{type_name}>,`);
+        } else {
+            w.line(`{first_field}: left,`);
+        }
         ctx.group_counter = gc_lr;
         let mut field_counts: Array<[String, i32]> = [];
         // Reserve the field that `left` occupies so a repeat occurrence
@@ -5135,15 +5166,45 @@ fn compute_lr_second_token(shared_token: &String, elements: &Array<Element>, ctx
 }
 
 fn gen_lr_call_with_prec(w: &mut CodeWriter, suffix_fn: &String, prec: i32, use_prec: bool) {
+    // First-token dispatch alone can mis-predict an LR continuation when the
+    // suffix's first token is shared with the atom (e.g.
+    // `statement: letterA | statement letterA 'b'`). In that case the suffix
+    // can begin to match and then fail on a later element, leaving `p.pos`
+    // mid-suffix and corrupting any enclosing repetition driver. Consult the
+    // scan twin first — it has no side effects — and only commit to the
+    // (mutating) parse when the scan confirms the suffix would succeed.
+    let scan_fn = `scan_{strip_parse_prefix(suffix_fn)}`;
     if use_prec {
         w.begin(`if {prec} >= min_prec`);
+        w.begin(`if {scan_fn}(&p.tokens, p.pos) < 0`);
+        w.line("break;");
+        w.end();
         w.line(`result = {*suffix_fn}(p, result, start)?;`);
         w.else_begin("else");
         w.line("break;");
         w.end();
     } else {
+        w.begin(`if {scan_fn}(&p.tokens, p.pos) < 0`);
+        w.line("break;");
+        w.end();
         w.line(`result = {*suffix_fn}(p, result, start)?;`);
     }
+}
+
+fn strip_parse_prefix(parse_fn: &String) -> String {
+    // `suffix_fn` is generated as `parse_<rule>_lr_<idx>`; the scan twin is
+    // `scan_<rule>_lr_<idx>`. Drop the leading `parse_` so the caller can
+    // prepend `scan_`.
+    let prefix = "parse_";
+    if parse_fn.len() < prefix.len() {
+        panic("strip_parse_prefix: input does not start with `parse_`");
+    }
+    for let mut i = 0; i < prefix.len(); i += 1 {
+        if parse_fn.get_byte(i) != prefix.get_byte(i) {
+            panic("strip_parse_prefix: input does not start with `parse_`");
+        }
+    }
+    return parse_fn.substr_bytes(prefix.len(), parse_fn.len());
 }
 
 fn gen_lr_overlap_dispatch(w: &mut CodeWriter, fn_name: &String, rule: &ParserRule, group: &Array<i32>, valid_lr_indices: &Array<i32>, lr_precs: &Array<i32>, suffix_first_sets: &Array<Array<String>>, ctx: &mut GenContext, use_prec: bool) {
@@ -5336,15 +5397,7 @@ fn gen_lr_suffix_dispatch(w: &mut CodeWriter, rule: &ParserRule, type_name: &Str
             let lr_idx = d.valid_lr_indices[group[0]];
             let prec = d.lr_precs[group[0]];
             let suffix_fn = `{fn_name}_lr_{lr_idx}`;
-            if use_prec {
-                w.begin(`if {prec} >= min_prec`);
-                w.line(`result = {suffix_fn}(p, result, start)?;`);
-                w.else_begin("else");
-                w.line("break;");
-                w.end();
-            } else {
-                w.line(`result = {suffix_fn}(p, result, start)?;`);
-            }
+            gen_lr_call_with_prec(w, &suffix_fn, prec, use_prec);
         } else {
             gen_lr_overlap_dispatch(
                 w,

--- a/package-gale/tests/antlr4-compat/stage_b/LeftRecursion/PrecedenceFilterConsidersContext_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b/LeftRecursion/PrecedenceFilterConsidersContext_test.wado
@@ -14,8 +14,6 @@ use t from "../../grammars/LeftRecursion/PrecedenceFilterConsidersContext.g4"
     };
 use { normalize_tree } from "../../grammars/LeftRecursion/PrecedenceFilterConsidersContext.g4";
 
-#[TODO]
-// triage: Stage B test parse fails with Result::Err — precedence filter behaviour gap
 test "stage_b: LeftRecursion/PrecedenceFilterConsidersContext" {
     let input = "aa";
     let expected = "(prog (statement (letterA a)) (statement (letterA a)))";

--- a/package-gale/tests/antlr4-compat/stage_b/LeftRecursion/ReturnValueAndActionsList1_1_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b/LeftRecursion/ReturnValueAndActionsList1_1_test.wado
@@ -1,0 +1,24 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: LeftRecursion/ReturnValueAndActionsList1_1 (ANTLR4 runtime-testsuite).
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_b_*]).
+
+use t from "../../grammars/LeftRecursion/ReturnValueAndActionsList1_1.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            options: { highlight: false },
+            output_dir: "tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList1_1",
+        },
+    };
+use { normalize_tree } from "../../grammars/LeftRecursion/ReturnValueAndActionsList1_1.g4";
+
+test "stage_b: LeftRecursion/ReturnValueAndActionsList1_1" {
+    let input = "a*b";
+    let expected = "(s (expr (expr a) * (expr b)))";
+    let root = t::parse(&input).unwrap();
+    let actual = t::to_tree(&root).to_string_tree();
+    let norm = normalize_tree(&expected);
+    assert actual == norm, `actual:   {actual}\nexpected: {norm}`;
+}

--- a/package-gale/tests/antlr4-compat/stage_b/LeftRecursion/ReturnValueAndActionsList1_3_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b/LeftRecursion/ReturnValueAndActionsList1_3_test.wado
@@ -1,0 +1,24 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: LeftRecursion/ReturnValueAndActionsList1_3 (ANTLR4 runtime-testsuite).
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_b_*]).
+
+use t from "../../grammars/LeftRecursion/ReturnValueAndActionsList1_3.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            options: { highlight: false },
+            output_dir: "tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList1_3",
+        },
+    };
+use { normalize_tree } from "../../grammars/LeftRecursion/ReturnValueAndActionsList1_3.g4";
+
+test "stage_b: LeftRecursion/ReturnValueAndActionsList1_3" {
+    let input = "x";
+    let expected = "(s (expr x))";
+    let root = t::parse(&input).unwrap();
+    let actual = t::to_tree(&root).to_string_tree();
+    let norm = normalize_tree(&expected);
+    assert actual == norm, `actual:   {actual}\nexpected: {norm}`;
+}

--- a/package-gale/tests/antlr4-compat/stage_b/LeftRecursion/ReturnValueAndActionsList2_1_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b/LeftRecursion/ReturnValueAndActionsList2_1_test.wado
@@ -1,0 +1,24 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: LeftRecursion/ReturnValueAndActionsList2_1 (ANTLR4 runtime-testsuite).
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_b_*]).
+
+use t from "../../grammars/LeftRecursion/ReturnValueAndActionsList2_1.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            options: { highlight: false },
+            output_dir: "tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList2_1",
+        },
+    };
+use { normalize_tree } from "../../grammars/LeftRecursion/ReturnValueAndActionsList2_1.g4";
+
+test "stage_b: LeftRecursion/ReturnValueAndActionsList2_1" {
+    let input = "a*b";
+    let expected = "(s (expr (expr a) * (expr b)))";
+    let root = t::parse(&input).unwrap();
+    let actual = t::to_tree(&root).to_string_tree();
+    let norm = normalize_tree(&expected);
+    assert actual == norm, `actual:   {actual}\nexpected: {norm}`;
+}

--- a/package-gale/tests/antlr4-compat/stage_b/LeftRecursion/ReturnValueAndActionsList2_3_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b/LeftRecursion/ReturnValueAndActionsList2_3_test.wado
@@ -1,0 +1,24 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: LeftRecursion/ReturnValueAndActionsList2_3 (ANTLR4 runtime-testsuite).
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_b_*]).
+
+use t from "../../grammars/LeftRecursion/ReturnValueAndActionsList2_3.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            options: { highlight: false },
+            output_dir: "tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList2_3",
+        },
+    };
+use { normalize_tree } from "../../grammars/LeftRecursion/ReturnValueAndActionsList2_3.g4";
+
+test "stage_b: LeftRecursion/ReturnValueAndActionsList2_3" {
+    let input = "x";
+    let expected = "(s (expr x))";
+    let root = t::parse(&input).unwrap();
+    let actual = t::to_tree(&root).to_string_tree();
+    let norm = normalize_tree(&expected);
+    assert actual == norm, `actual:   {actual}\nexpected: {norm}`;
+}

--- a/package-gale/tests/antlr4-compat/stage_b/ParserExec/BuildParseTree_TRUE_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b/ParserExec/BuildParseTree_TRUE_test.wado
@@ -14,8 +14,6 @@ use t from "../../grammars/ParserExec/BuildParseTree_TRUE.g4"
     };
 use { normalize_tree } from "../../grammars/ParserExec/BuildParseTree_TRUE.g4";
 
-#[TODO]
-// triage: Stage B test parse fails or tree shape diverges — investigation pending
 test "stage_b: ParserExec/BuildParseTree_TRUE" {
     let input = "A B";
     let expected = "(r (a A) (b B))";

--- a/package-gale/tests/antlr4-compat/status.toml
+++ b/package-gale/tests/antlr4-compat/status.toml
@@ -43,21 +43,9 @@
 "ParserErrors/SingleTokenDeletionConsumption" = "trailing <! ... !> StringTemplate comment outside any rule — testsuite descriptor artifact, not a self-contained .g4"
 
 [stage_b_todo]
-"LeftRecursion/PrecedenceFilterConsidersContext" = "Stage B test parse fails with Result::Err — precedence filter behaviour gap"
 "LeftRecursion/SemPredFailOption" = "Stage B parse-tree shape diverges because action bodies are skipped (the predicate guard is dropped) — Stage C territory"
-"ParserExec/BuildParseTree_TRUE" = "Stage B test parse fails or tree shape diverges — investigation pending"
 "ParserExec/PredictionMode_LL" = "Stage B test parse fails with Result::Err — full-context LL prediction not yet enabled in generated parsers"
 "SemPredEvalParser/PredFromAltTestedInLoopBack_1" = "Stage B test parse fails with Result::Err — semantic predicate enforcement is Stage C"
 "SemPredEvalParser/PredFromAltTestedInLoopBack_2" = "Stage B test parse fails with Result::Err — semantic predicate enforcement is Stage C"
 
 [stage_b_skip]
-# All four LeftRecursion/ReturnValueAndActionsList* entries below share
-# one root cause: list-label LR alts (`b+=expr ',' b+=expr`) compile each
-# `+=` occurrence into its own Array<ExprNode> field (`b` and `b_2`)
-# instead of appending both to a single list, and the LR helper then
-# passes `left: ExprNode` into the Array<ExprNode> field — type mismatch
-# at codegen. Fixing this needs ANTLR4 `+=` semantics in the IR.
-"LeftRecursion/ReturnValueAndActionsList1_1" = "list-label LR alt: see [stage_b_skip] header"
-"LeftRecursion/ReturnValueAndActionsList1_3" = "list-label LR alt: see [stage_b_skip] header"
-"LeftRecursion/ReturnValueAndActionsList2_1" = "list-label LR alt: see [stage_b_skip] header"
-"LeftRecursion/ReturnValueAndActionsList2_3" = "list-label LR alt: see [stage_b_skip] header"

--- a/package-gale/tests/generated/antlr4/ANTLRv4Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4/ANTLRv4Lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6fd58782d32cfb10",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "grammars/ANTLRv4Lexer.g4",
     "hash": "30bd52b58a5916a63041f501c2d45358431c5c379f1ed3e8a3fbbb311f3572bd"

--- a/package-gale/tests/generated/antlr4/ANTLRv4Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4/ANTLRv4Lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6fd58782d32cfb10",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "grammars/ANTLRv4Lexer.g4",
     "hash": "30bd52b58a5916a63041f501c2d45358431c5c379f1ed3e8a3fbbb311f3572bd"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a6ec2b8f2ddde283",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_1.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a6ec2b8f2ddde283",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_1.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_1/t.wado",
-      "hash": "6689b5ed70f461b75cca864ccb9f7fef092f0238a4d8ef1d38d84ecbb309482a",
+      "hash": "65965570057ef253bfc7ff040e7334dec3f6bb8cd71a51141abc768c2f299685",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_1/t.wado
@@ -908,15 +908,17 @@ fn scan_declarator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if second_kind == TK_INT {
                     if 3 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_declarator_lr_0(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 2 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_declarator_lr_1(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -924,8 +926,9 @@ fn scan_declarator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_declarator_lr_2(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -1035,12 +1038,18 @@ fn parse_declarator(p: &mut Parser, min_prec: i32 = 0) -> Result<DeclaratorNode,
             if suffix_kind == TK_LIT_LBRACKET {
                 if p.peek_at(1) == TK_INT {
                     if 3 >= min_prec {
+                        if scan_declarator_lr_0(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_declarator_lr_0(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 2 >= min_prec {
+                        if scan_declarator_lr_1(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_declarator_lr_1(p, result, start)?;
                     } else {
                         break;
@@ -1049,6 +1058,9 @@ fn parse_declarator(p: &mut Parser, min_prec: i32 = 0) -> Result<DeclaratorNode,
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 1 >= min_prec {
+                if scan_declarator_lr_2(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_declarator_lr_2(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-61c5e70fcdb6da1f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_10.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_10/t.wado",
-      "hash": "5b66de4b1ff872cf2aa51148ada665b6db8c6082927825c2ce0dd7e0301d41b8",
+      "hash": "24e6cd7f9d6c2ba52a6b1e9a265da95aaa475d4988498a0dcd45e0a30c1aca2c",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-61c5e70fcdb6da1f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_10.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_10/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_10/t.wado
@@ -908,15 +908,17 @@ fn scan_declarator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if second_kind == TK_INT {
                     if 3 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_declarator_lr_0(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 2 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_declarator_lr_1(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -924,8 +926,9 @@ fn scan_declarator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_declarator_lr_2(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -1035,12 +1038,18 @@ fn parse_declarator(p: &mut Parser, min_prec: i32 = 0) -> Result<DeclaratorNode,
             if suffix_kind == TK_LIT_LBRACKET {
                 if p.peek_at(1) == TK_INT {
                     if 3 >= min_prec {
+                        if scan_declarator_lr_0(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_declarator_lr_0(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 2 >= min_prec {
+                        if scan_declarator_lr_1(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_declarator_lr_1(p, result, start)?;
                     } else {
                         break;
@@ -1049,6 +1058,9 @@ fn parse_declarator(p: &mut Parser, min_prec: i32 = 0) -> Result<DeclaratorNode,
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 1 >= min_prec {
+                if scan_declarator_lr_2(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_declarator_lr_2(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-699ecb3a8f815e27",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_2.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_2/t.wado",
-      "hash": "5d8067a7c1b5ea3c41c11df3c3e096224325099b228641196e588f0f914fbe18",
+      "hash": "983ddde5b6e52bd97eef4aff58f6489034ffcbc674df8df420de9cad86d00807",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-699ecb3a8f815e27",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_2.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_2/t.wado
@@ -908,15 +908,17 @@ fn scan_declarator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if second_kind == TK_INT {
                     if 3 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_declarator_lr_0(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 2 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_declarator_lr_1(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -924,8 +926,9 @@ fn scan_declarator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_declarator_lr_2(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -1035,12 +1038,18 @@ fn parse_declarator(p: &mut Parser, min_prec: i32 = 0) -> Result<DeclaratorNode,
             if suffix_kind == TK_LIT_LBRACKET {
                 if p.peek_at(1) == TK_INT {
                     if 3 >= min_prec {
+                        if scan_declarator_lr_0(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_declarator_lr_0(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 2 >= min_prec {
+                        if scan_declarator_lr_1(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_declarator_lr_1(p, result, start)?;
                     } else {
                         break;
@@ -1049,6 +1058,9 @@ fn parse_declarator(p: &mut Parser, min_prec: i32 = 0) -> Result<DeclaratorNode,
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 1 >= min_prec {
+                if scan_declarator_lr_2(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_declarator_lr_2(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-262e54587e9044c3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_3.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_3/t.wado",
-      "hash": "f8aec618cdd5558e0eb036d559e17623c1a4422cf769efc815f6d42410281027",
+      "hash": "d62ebcc092f18271392c138f7e60662c32cdaac179d2b15480868e719850eeb1",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-262e54587e9044c3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_3.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_3/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_3/t.wado
@@ -908,15 +908,17 @@ fn scan_declarator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if second_kind == TK_INT {
                     if 3 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_declarator_lr_0(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 2 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_declarator_lr_1(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -924,8 +926,9 @@ fn scan_declarator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_declarator_lr_2(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -1035,12 +1038,18 @@ fn parse_declarator(p: &mut Parser, min_prec: i32 = 0) -> Result<DeclaratorNode,
             if suffix_kind == TK_LIT_LBRACKET {
                 if p.peek_at(1) == TK_INT {
                     if 3 >= min_prec {
+                        if scan_declarator_lr_0(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_declarator_lr_0(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 2 >= min_prec {
+                        if scan_declarator_lr_1(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_declarator_lr_1(p, result, start)?;
                     } else {
                         break;
@@ -1049,6 +1058,9 @@ fn parse_declarator(p: &mut Parser, min_prec: i32 = 0) -> Result<DeclaratorNode,
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 1 >= min_prec {
+                if scan_declarator_lr_2(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_declarator_lr_2(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a998eaa06c653a5b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_4.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_4/t.wado",
-      "hash": "ef016e81737c1c42423f10f3c203b4a56a940d202e4fd4fd5dbd9eb77cade10d",
+      "hash": "2201419a417a506a8cfa3f527c835f9aa1412de289142908a52c2c593c7b3a88",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a998eaa06c653a5b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_4.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_4/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_4/t.wado
@@ -908,15 +908,17 @@ fn scan_declarator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if second_kind == TK_INT {
                     if 3 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_declarator_lr_0(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 2 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_declarator_lr_1(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -924,8 +926,9 @@ fn scan_declarator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_declarator_lr_2(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -1035,12 +1038,18 @@ fn parse_declarator(p: &mut Parser, min_prec: i32 = 0) -> Result<DeclaratorNode,
             if suffix_kind == TK_LIT_LBRACKET {
                 if p.peek_at(1) == TK_INT {
                     if 3 >= min_prec {
+                        if scan_declarator_lr_0(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_declarator_lr_0(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 2 >= min_prec {
+                        if scan_declarator_lr_1(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_declarator_lr_1(p, result, start)?;
                     } else {
                         break;
@@ -1049,6 +1058,9 @@ fn parse_declarator(p: &mut Parser, min_prec: i32 = 0) -> Result<DeclaratorNode,
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 1 >= min_prec {
+                if scan_declarator_lr_2(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_declarator_lr_2(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fc22b0fc36d36630",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_5.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fc22b0fc36d36630",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_5.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_5/t.wado",
-      "hash": "ad707af2a5df1d2bacf3c9470a3bd7f6f8d70fa5c04c5c553bafaec344e4b174",
+      "hash": "a55991daf7d7aacb9f4178c4cd98abae50678b624d430a85b7881375dda33766",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_5/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_5/t.wado
@@ -908,15 +908,17 @@ fn scan_declarator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if second_kind == TK_INT {
                     if 3 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_declarator_lr_0(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 2 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_declarator_lr_1(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -924,8 +926,9 @@ fn scan_declarator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_declarator_lr_2(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -1035,12 +1038,18 @@ fn parse_declarator(p: &mut Parser, min_prec: i32 = 0) -> Result<DeclaratorNode,
             if suffix_kind == TK_LIT_LBRACKET {
                 if p.peek_at(1) == TK_INT {
                     if 3 >= min_prec {
+                        if scan_declarator_lr_0(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_declarator_lr_0(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 2 >= min_prec {
+                        if scan_declarator_lr_1(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_declarator_lr_1(p, result, start)?;
                     } else {
                         break;
@@ -1049,6 +1058,9 @@ fn parse_declarator(p: &mut Parser, min_prec: i32 = 0) -> Result<DeclaratorNode,
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 1 >= min_prec {
+                if scan_declarator_lr_2(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_declarator_lr_2(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2852af861801de26",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_6.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_6/t.wado",
-      "hash": "df9131b975f356e64b69ed54c958e2a9de8e909eeb49e03aa7469b48cc61101c",
+      "hash": "00901731f78464cb955a36dfd59a84057de9043310559eae8ffc8742c13a18ae",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2852af861801de26",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_6.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_6/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_6/t.wado
@@ -908,15 +908,17 @@ fn scan_declarator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if second_kind == TK_INT {
                     if 3 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_declarator_lr_0(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 2 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_declarator_lr_1(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -924,8 +926,9 @@ fn scan_declarator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_declarator_lr_2(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -1035,12 +1038,18 @@ fn parse_declarator(p: &mut Parser, min_prec: i32 = 0) -> Result<DeclaratorNode,
             if suffix_kind == TK_LIT_LBRACKET {
                 if p.peek_at(1) == TK_INT {
                     if 3 >= min_prec {
+                        if scan_declarator_lr_0(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_declarator_lr_0(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 2 >= min_prec {
+                        if scan_declarator_lr_1(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_declarator_lr_1(p, result, start)?;
                     } else {
                         break;
@@ -1049,6 +1058,9 @@ fn parse_declarator(p: &mut Parser, min_prec: i32 = 0) -> Result<DeclaratorNode,
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 1 >= min_prec {
+                if scan_declarator_lr_2(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_declarator_lr_2(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-320d631a0baf5c0b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_7.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-320d631a0baf5c0b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_7.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_7/t.wado",
-      "hash": "0791548decb331def050be92f7d04da03aa570258b9cd8efea0249b0a5f4708a",
+      "hash": "0c4cffe37a16b7b16fd80e68e3e519235d280e78907b540d9e80b4e5e7db4569",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_7/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_7/t.wado
@@ -908,15 +908,17 @@ fn scan_declarator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if second_kind == TK_INT {
                     if 3 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_declarator_lr_0(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 2 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_declarator_lr_1(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -924,8 +926,9 @@ fn scan_declarator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_declarator_lr_2(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -1035,12 +1038,18 @@ fn parse_declarator(p: &mut Parser, min_prec: i32 = 0) -> Result<DeclaratorNode,
             if suffix_kind == TK_LIT_LBRACKET {
                 if p.peek_at(1) == TK_INT {
                     if 3 >= min_prec {
+                        if scan_declarator_lr_0(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_declarator_lr_0(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 2 >= min_prec {
+                        if scan_declarator_lr_1(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_declarator_lr_1(p, result, start)?;
                     } else {
                         break;
@@ -1049,6 +1058,9 @@ fn parse_declarator(p: &mut Parser, min_prec: i32 = 0) -> Result<DeclaratorNode,
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 1 >= min_prec {
+                if scan_declarator_lr_2(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_declarator_lr_2(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3bd4c5ea00e5572f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_8.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_8/t.wado",
-      "hash": "9276d1799e21d8b320b7a3cd6de56532449519797b6cb79597dc0e8b1e34bf46",
+      "hash": "ace3d4446266ce3f8083e42cf0795d022193f02520e729ef2c3e8a624c1854a0",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3bd4c5ea00e5572f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_8.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_8/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_8/t.wado
@@ -908,15 +908,17 @@ fn scan_declarator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if second_kind == TK_INT {
                     if 3 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_declarator_lr_0(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 2 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_declarator_lr_1(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -924,8 +926,9 @@ fn scan_declarator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_declarator_lr_2(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -1035,12 +1038,18 @@ fn parse_declarator(p: &mut Parser, min_prec: i32 = 0) -> Result<DeclaratorNode,
             if suffix_kind == TK_LIT_LBRACKET {
                 if p.peek_at(1) == TK_INT {
                     if 3 >= min_prec {
+                        if scan_declarator_lr_0(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_declarator_lr_0(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 2 >= min_prec {
+                        if scan_declarator_lr_1(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_declarator_lr_1(p, result, start)?;
                     } else {
                         break;
@@ -1049,6 +1058,9 @@ fn parse_declarator(p: &mut Parser, min_prec: i32 = 0) -> Result<DeclaratorNode,
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 1 >= min_prec {
+                if scan_declarator_lr_2(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_declarator_lr_2(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-49d484703a919155",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_9.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-49d484703a919155",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_9.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Declarations_9/t.wado",
-      "hash": "d48a232e849ef8b48cf60b2acdc5ae161524cd24477a010fbecdd23c140d11d4",
+      "hash": "704554c1c432c1e3c27c421609b2159986c43e96e651b11007b1e80d8e85efa0",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_9/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_9/t.wado
@@ -908,15 +908,17 @@ fn scan_declarator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if second_kind == TK_INT {
                     if 3 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_declarator_lr_0(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 2 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_declarator_lr_1(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -924,8 +926,9 @@ fn scan_declarator(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_declarator_lr_2(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -1035,12 +1038,18 @@ fn parse_declarator(p: &mut Parser, min_prec: i32 = 0) -> Result<DeclaratorNode,
             if suffix_kind == TK_LIT_LBRACKET {
                 if p.peek_at(1) == TK_INT {
                     if 3 >= min_prec {
+                        if scan_declarator_lr_0(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_declarator_lr_0(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 2 >= min_prec {
+                        if scan_declarator_lr_1(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_declarator_lr_1(p, result, start)?;
                     } else {
                         break;
@@ -1049,6 +1058,9 @@ fn parse_declarator(p: &mut Parser, min_prec: i32 = 0) -> Result<DeclaratorNode,
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 1 >= min_prec {
+                if scan_declarator_lr_2(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_declarator_lr_2(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-713ef5230fbaf9f1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_1.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-713ef5230fbaf9f1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_1.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_1/t.wado",
-      "hash": "cc33e07380a5cc7d01b3fac13a4cf991a0eeb234639cf1586b78bd1eb8adbedf",
+      "hash": "7377fe5b37075aa32c329e8d86f31e905fc4f588228308ae11b77cd5c7701c86",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_1/t.wado
@@ -720,8 +720,9 @@ fn scan_a(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if suffix_kind == TK_ID {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_a_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -765,6 +766,9 @@ fn parse_a(p: &mut Parser, min_prec: i32 = 0) -> Result<ANode, ParseError> {
         let suffix_kind = p.peek_kind();
         if suffix_kind == TK_ID {
             if 1 >= min_prec {
+                if scan_a_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_a_lr_0(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-558b311b80c4da10",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_2.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-558b311b80c4da10",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_2.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_2/t.wado",
-      "hash": "359323bfea6646fefad6d3d93d534cc09b1ceb76be29c05d7ee794f6ba00b155",
+      "hash": "6b15a5567c6c173724339b3922bfc3a1a12f4f10b670ad6f8c0488157d091bde",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_2/t.wado
@@ -720,8 +720,9 @@ fn scan_a(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if suffix_kind == TK_ID {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_a_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -765,6 +766,9 @@ fn parse_a(p: &mut Parser, min_prec: i32 = 0) -> Result<ANode, ParseError> {
         let suffix_kind = p.peek_kind();
         if suffix_kind == TK_ID {
             if 1 >= min_prec {
+                if scan_a_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_a_lr_0(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c369756dc031bf12",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_3.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c369756dc031bf12",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_3.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_3/t.wado",
-      "hash": "cbd57c724d871ee71dddecaff2574f598ba7c5b9d346f5dc09ce1cf175fb82da",
+      "hash": "b803e6f8758c85bcd4daeec68187d06f3f86f9b8ddcffda2f84cb8e77a87c996",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_3/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_3/t.wado
@@ -720,8 +720,9 @@ fn scan_a(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if suffix_kind == TK_ID {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_a_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -765,6 +766,9 @@ fn parse_a(p: &mut Parser, min_prec: i32 = 0) -> Result<ANode, ParseError> {
         let suffix_kind = p.peek_kind();
         if suffix_kind == TK_ID {
             if 1 >= min_prec {
+                if scan_a_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_a_lr_0(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-abed1c70b5e6c53f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_1.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Expressions_1/t.wado",
-      "hash": "cf7f2043feeaf69b8b15d0de7915b48eb41c7928f1f303ace55d660c86306486",
+      "hash": "f5de22f0ac47789b6a272a48d5a079cd17533430ba986a81ce54ec903d5978eb",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-abed1c70b5e6c53f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_1.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_1/t.wado
@@ -931,15 +931,17 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if second_kind == TK_ID {
                     if 4 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_0(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 3 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_1(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -947,15 +949,17 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
             }
         } else if suffix_kind == TK_LIT_STAR {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_3(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_0(suffix_kind) {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_4(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -1063,12 +1067,18 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             if suffix_kind == TK_LIT_DOT {
                 if p.peek_at(1) == TK_ID {
                     if 4 >= min_prec {
+                        if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_0(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 3 >= min_prec {
+                        if scan_e_lr_1(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_1(p, result, start)?;
                     } else {
                         break;
@@ -1077,12 +1087,18 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             }
         } else if suffix_kind == TK_LIT_STAR {
             if 2 >= min_prec {
+                if scan_e_lr_3(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_3(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_0(suffix_kind) {
             if 1 >= min_prec {
+                if scan_e_lr_4(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_4(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a1b502206053bf7a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_2.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Expressions_2/t.wado",
-      "hash": "eca481d4e3ea764ace1b6c27ba27fcfe64100f18021c7449e7b4fa40f5fb48e3",
+      "hash": "257e17ea79c705136465636a3110d03269e893b252ac018c9565b02ed02c52c9",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a1b502206053bf7a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_2.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_2/t.wado
@@ -931,15 +931,17 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if second_kind == TK_ID {
                     if 4 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_0(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 3 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_1(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -947,15 +949,17 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
             }
         } else if suffix_kind == TK_LIT_STAR {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_3(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_0(suffix_kind) {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_4(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -1063,12 +1067,18 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             if suffix_kind == TK_LIT_DOT {
                 if p.peek_at(1) == TK_ID {
                     if 4 >= min_prec {
+                        if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_0(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 3 >= min_prec {
+                        if scan_e_lr_1(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_1(p, result, start)?;
                     } else {
                         break;
@@ -1077,12 +1087,18 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             }
         } else if suffix_kind == TK_LIT_STAR {
             if 2 >= min_prec {
+                if scan_e_lr_3(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_3(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_0(suffix_kind) {
             if 1 >= min_prec {
+                if scan_e_lr_4(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_4(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-68045ae831d55159",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_3.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-68045ae831d55159",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_3.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Expressions_3/t.wado",
-      "hash": "cc7a3ad48626273e0a3c7ec9abca25f3185d20d1b2b4aac5a0835f379bb15e1e",
+      "hash": "81dbc51e5d08e508526d8eaa1466bcb272f571bbde5c07a6a278b0abd02405f7",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_3/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_3/t.wado
@@ -931,15 +931,17 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if second_kind == TK_ID {
                     if 4 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_0(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 3 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_1(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -947,15 +949,17 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
             }
         } else if suffix_kind == TK_LIT_STAR {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_3(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_0(suffix_kind) {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_4(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -1063,12 +1067,18 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             if suffix_kind == TK_LIT_DOT {
                 if p.peek_at(1) == TK_ID {
                     if 4 >= min_prec {
+                        if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_0(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 3 >= min_prec {
+                        if scan_e_lr_1(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_1(p, result, start)?;
                     } else {
                         break;
@@ -1077,12 +1087,18 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             }
         } else if suffix_kind == TK_LIT_STAR {
             if 2 >= min_prec {
+                if scan_e_lr_3(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_3(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_0(suffix_kind) {
             if 1 >= min_prec {
+                if scan_e_lr_4(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_4(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-678c469712c8fc23",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_4.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-678c469712c8fc23",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_4.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Expressions_4/t.wado",
-      "hash": "bd10e14aa390c59186ad4a1d223fa98d3a072b9d25d417470ea0f2ab4cb383b3",
+      "hash": "ef75682a42c62d52f77546fefd11464d744f0f3c00f5ee1e3eaa3cf2deef4b69",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_4/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_4/t.wado
@@ -931,15 +931,17 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if second_kind == TK_ID {
                     if 4 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_0(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 3 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_1(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -947,15 +949,17 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
             }
         } else if suffix_kind == TK_LIT_STAR {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_3(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_0(suffix_kind) {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_4(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -1063,12 +1067,18 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             if suffix_kind == TK_LIT_DOT {
                 if p.peek_at(1) == TK_ID {
                     if 4 >= min_prec {
+                        if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_0(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 3 >= min_prec {
+                        if scan_e_lr_1(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_1(p, result, start)?;
                     } else {
                         break;
@@ -1077,12 +1087,18 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             }
         } else if suffix_kind == TK_LIT_STAR {
             if 2 >= min_prec {
+                if scan_e_lr_3(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_3(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_0(suffix_kind) {
             if 1 >= min_prec {
+                if scan_e_lr_4(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_4(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-16bc5e2c231c2ba8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_5.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-16bc5e2c231c2ba8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_5.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Expressions_5/t.wado",
-      "hash": "743c084232c27a716086a47ecb7ce1b32f29d35da8b1a27832b63f1087472c86",
+      "hash": "9181af18d9e1895807c56d7b4acc81d3b77186713b833ab87e3c7838b991fe49",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_5/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_5/t.wado
@@ -931,15 +931,17 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if second_kind == TK_ID {
                     if 4 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_0(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 3 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_1(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -947,15 +949,17 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
             }
         } else if suffix_kind == TK_LIT_STAR {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_3(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_0(suffix_kind) {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_4(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -1063,12 +1067,18 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             if suffix_kind == TK_LIT_DOT {
                 if p.peek_at(1) == TK_ID {
                     if 4 >= min_prec {
+                        if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_0(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 3 >= min_prec {
+                        if scan_e_lr_1(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_1(p, result, start)?;
                     } else {
                         break;
@@ -1077,12 +1087,18 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             }
         } else if suffix_kind == TK_LIT_STAR {
             if 2 >= min_prec {
+                if scan_e_lr_3(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_3(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_0(suffix_kind) {
             if 1 >= min_prec {
+                if scan_e_lr_4(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_4(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c116bb1cfe62a2a8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_6.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c116bb1cfe62a2a8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_6.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Expressions_6/t.wado",
-      "hash": "13c3ab50024c69f89e830bdcb9fea636a2cc3ba09f116f07bad47d366d0119bf",
+      "hash": "d54589f8b6cb3920085c2c123047ff5f406cde8b1c31d0236001d6ad62b0a763",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_6/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_6/t.wado
@@ -931,15 +931,17 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if second_kind == TK_ID {
                     if 4 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_0(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 3 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_1(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -947,15 +949,17 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
             }
         } else if suffix_kind == TK_LIT_STAR {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_3(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_0(suffix_kind) {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_4(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -1063,12 +1067,18 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             if suffix_kind == TK_LIT_DOT {
                 if p.peek_at(1) == TK_ID {
                     if 4 >= min_prec {
+                        if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_0(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 3 >= min_prec {
+                        if scan_e_lr_1(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_1(p, result, start)?;
                     } else {
                         break;
@@ -1077,12 +1087,18 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             }
         } else if suffix_kind == TK_LIT_STAR {
             if 2 >= min_prec {
+                if scan_e_lr_3(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_3(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_0(suffix_kind) {
             if 1 >= min_prec {
+                if scan_e_lr_4(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_4(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0484794f535b91f2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_7.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Expressions_7/t.wado",
-      "hash": "53f7442b7c35dcc5d5eca41647b831ee280b0dca0ebab2a08e09dd87a93e1e18",
+      "hash": "168d065e2ca2042012b1ea1110901a8a2d898338c15c97b38f22ba9a6e29d330",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0484794f535b91f2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_7.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_7/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_7/t.wado
@@ -931,15 +931,17 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if second_kind == TK_ID {
                     if 4 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_0(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 3 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_1(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -947,15 +949,17 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
             }
         } else if suffix_kind == TK_LIT_STAR {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_3(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_0(suffix_kind) {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_4(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -1063,12 +1067,18 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             if suffix_kind == TK_LIT_DOT {
                 if p.peek_at(1) == TK_ID {
                     if 4 >= min_prec {
+                        if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_0(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 3 >= min_prec {
+                        if scan_e_lr_1(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_1(p, result, start)?;
                     } else {
                         break;
@@ -1077,12 +1087,18 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             }
         } else if suffix_kind == TK_LIT_STAR {
             if 2 >= min_prec {
+                if scan_e_lr_3(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_3(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_0(suffix_kind) {
             if 1 >= min_prec {
+                if scan_e_lr_4(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_4(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fe2840241e9172a0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_1.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fe2840241e9172a0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_1.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/t.wado",
-      "hash": "46995ee431d72ad209ee60fe7cf69cf36a8d89fa603918be1d7ac6f9baacabcf",
+      "hash": "4e40262d8e6159159e6d72ef9f62cbc492ada389bc7388b267cf80e3adfdd358",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/t.wado
@@ -2290,29 +2290,33 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if second_kind == TK_ID {
                     if 20 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_6(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else if second_kind == TK_LIT_THIS {
                     if 19 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_7(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else if second_kind == TK_LIT_SUPER {
                     if 18 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_8(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 17 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_9(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -2320,113 +2324,129 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
             }
         } else if suffix_kind == TK_LIT_LBRACKET {
             if 16 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_11(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_4(suffix_kind) {
             if 15 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_13(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 14 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_14(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_5(suffix_kind) {
             if 13 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_17(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_6(suffix_kind) {
             if 12 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_18(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_7(suffix_kind) {
             if 11 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_19(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_8(suffix_kind) {
             if 10 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_20(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_INSTANCEOF {
             if 9 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_21(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_9(suffix_kind) {
             if 8 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_22(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMP {
             if 7 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_23(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_CARET {
             if 6 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_24(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPE {
             if 5 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_25(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMPAMP {
             if 4 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_26(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPEPIPE {
             if 3 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_27(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_28(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_10(suffix_kind) {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_29(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -3045,24 +3065,36 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             if suffix_kind == TK_LIT_DOT {
                 if p.peek_at(1) == TK_ID {
                     if 20 >= min_prec {
+                        if scan_e_lr_6(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_6(p, result, start)?;
                     } else {
                         break;
                     }
                 } else if p.peek_at(1) == TK_LIT_THIS {
                     if 19 >= min_prec {
+                        if scan_e_lr_7(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_7(p, result, start)?;
                     } else {
                         break;
                     }
                 } else if p.peek_at(1) == TK_LIT_SUPER {
                     if 18 >= min_prec {
+                        if scan_e_lr_8(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_8(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 17 >= min_prec {
+                        if scan_e_lr_9(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_9(p, result, start)?;
                     } else {
                         break;
@@ -3071,96 +3103,144 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             }
         } else if suffix_kind == TK_LIT_LBRACKET {
             if 16 >= min_prec {
+                if scan_e_lr_11(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_11(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_4(suffix_kind) {
             if 15 >= min_prec {
+                if scan_e_lr_13(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_13(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 14 >= min_prec {
+                if scan_e_lr_14(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_14(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_5(suffix_kind) {
             if 13 >= min_prec {
+                if scan_e_lr_17(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_17(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_6(suffix_kind) {
             if 12 >= min_prec {
+                if scan_e_lr_18(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_18(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_7(suffix_kind) {
             if 11 >= min_prec {
+                if scan_e_lr_19(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_19(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_8(suffix_kind) {
             if 10 >= min_prec {
+                if scan_e_lr_20(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_20(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_INSTANCEOF {
             if 9 >= min_prec {
+                if scan_e_lr_21(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_21(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_9(suffix_kind) {
             if 8 >= min_prec {
+                if scan_e_lr_22(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_22(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMP {
             if 7 >= min_prec {
+                if scan_e_lr_23(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_23(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_CARET {
             if 6 >= min_prec {
+                if scan_e_lr_24(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_24(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPE {
             if 5 >= min_prec {
+                if scan_e_lr_25(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_25(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMPAMP {
             if 4 >= min_prec {
+                if scan_e_lr_26(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_26(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPEPIPE {
             if 3 >= min_prec {
+                if scan_e_lr_27(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_27(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                if scan_e_lr_28(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_28(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_10(suffix_kind) {
             if 1 >= min_prec {
+                if scan_e_lr_29(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_29(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-235cd53ca8f4663a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_10.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/t.wado",
-      "hash": "283c4587281d2f45f05d0e39dd826a16fc3893b886a193bd0755b9b69a962f70",
+      "hash": "1fbf302bc170578293d29de5480c5d48c1baf8d50f7ba61817ec83560dd6dae0",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-235cd53ca8f4663a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_10.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/t.wado
@@ -2290,29 +2290,33 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if second_kind == TK_ID {
                     if 20 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_6(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else if second_kind == TK_LIT_THIS {
                     if 19 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_7(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else if second_kind == TK_LIT_SUPER {
                     if 18 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_8(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 17 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_9(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -2320,113 +2324,129 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
             }
         } else if suffix_kind == TK_LIT_LBRACKET {
             if 16 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_11(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_4(suffix_kind) {
             if 15 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_13(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 14 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_14(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_5(suffix_kind) {
             if 13 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_17(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_6(suffix_kind) {
             if 12 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_18(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_7(suffix_kind) {
             if 11 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_19(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_8(suffix_kind) {
             if 10 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_20(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_INSTANCEOF {
             if 9 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_21(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_9(suffix_kind) {
             if 8 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_22(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMP {
             if 7 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_23(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_CARET {
             if 6 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_24(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPE {
             if 5 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_25(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMPAMP {
             if 4 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_26(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPEPIPE {
             if 3 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_27(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_28(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_10(suffix_kind) {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_29(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -3045,24 +3065,36 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             if suffix_kind == TK_LIT_DOT {
                 if p.peek_at(1) == TK_ID {
                     if 20 >= min_prec {
+                        if scan_e_lr_6(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_6(p, result, start)?;
                     } else {
                         break;
                     }
                 } else if p.peek_at(1) == TK_LIT_THIS {
                     if 19 >= min_prec {
+                        if scan_e_lr_7(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_7(p, result, start)?;
                     } else {
                         break;
                     }
                 } else if p.peek_at(1) == TK_LIT_SUPER {
                     if 18 >= min_prec {
+                        if scan_e_lr_8(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_8(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 17 >= min_prec {
+                        if scan_e_lr_9(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_9(p, result, start)?;
                     } else {
                         break;
@@ -3071,96 +3103,144 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             }
         } else if suffix_kind == TK_LIT_LBRACKET {
             if 16 >= min_prec {
+                if scan_e_lr_11(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_11(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_4(suffix_kind) {
             if 15 >= min_prec {
+                if scan_e_lr_13(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_13(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 14 >= min_prec {
+                if scan_e_lr_14(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_14(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_5(suffix_kind) {
             if 13 >= min_prec {
+                if scan_e_lr_17(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_17(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_6(suffix_kind) {
             if 12 >= min_prec {
+                if scan_e_lr_18(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_18(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_7(suffix_kind) {
             if 11 >= min_prec {
+                if scan_e_lr_19(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_19(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_8(suffix_kind) {
             if 10 >= min_prec {
+                if scan_e_lr_20(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_20(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_INSTANCEOF {
             if 9 >= min_prec {
+                if scan_e_lr_21(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_21(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_9(suffix_kind) {
             if 8 >= min_prec {
+                if scan_e_lr_22(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_22(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMP {
             if 7 >= min_prec {
+                if scan_e_lr_23(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_23(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_CARET {
             if 6 >= min_prec {
+                if scan_e_lr_24(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_24(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPE {
             if 5 >= min_prec {
+                if scan_e_lr_25(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_25(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMPAMP {
             if 4 >= min_prec {
+                if scan_e_lr_26(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_26(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPEPIPE {
             if 3 >= min_prec {
+                if scan_e_lr_27(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_27(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                if scan_e_lr_28(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_28(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_10(suffix_kind) {
             if 1 >= min_prec {
+                if scan_e_lr_29(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_29(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ed84013859c673b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_11.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/t.wado",
-      "hash": "fce09b30bc615ae92af70e1059253d8a6058bdcda42a056964411a21ed9c9392",
+      "hash": "89111214268927d04761154591330a967dde7401471637fa736aa6d773554d47",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ed84013859c673b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_11.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/t.wado
@@ -2290,29 +2290,33 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if second_kind == TK_ID {
                     if 20 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_6(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else if second_kind == TK_LIT_THIS {
                     if 19 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_7(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else if second_kind == TK_LIT_SUPER {
                     if 18 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_8(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 17 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_9(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -2320,113 +2324,129 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
             }
         } else if suffix_kind == TK_LIT_LBRACKET {
             if 16 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_11(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_4(suffix_kind) {
             if 15 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_13(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 14 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_14(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_5(suffix_kind) {
             if 13 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_17(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_6(suffix_kind) {
             if 12 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_18(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_7(suffix_kind) {
             if 11 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_19(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_8(suffix_kind) {
             if 10 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_20(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_INSTANCEOF {
             if 9 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_21(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_9(suffix_kind) {
             if 8 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_22(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMP {
             if 7 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_23(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_CARET {
             if 6 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_24(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPE {
             if 5 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_25(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMPAMP {
             if 4 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_26(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPEPIPE {
             if 3 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_27(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_28(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_10(suffix_kind) {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_29(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -3045,24 +3065,36 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             if suffix_kind == TK_LIT_DOT {
                 if p.peek_at(1) == TK_ID {
                     if 20 >= min_prec {
+                        if scan_e_lr_6(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_6(p, result, start)?;
                     } else {
                         break;
                     }
                 } else if p.peek_at(1) == TK_LIT_THIS {
                     if 19 >= min_prec {
+                        if scan_e_lr_7(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_7(p, result, start)?;
                     } else {
                         break;
                     }
                 } else if p.peek_at(1) == TK_LIT_SUPER {
                     if 18 >= min_prec {
+                        if scan_e_lr_8(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_8(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 17 >= min_prec {
+                        if scan_e_lr_9(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_9(p, result, start)?;
                     } else {
                         break;
@@ -3071,96 +3103,144 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             }
         } else if suffix_kind == TK_LIT_LBRACKET {
             if 16 >= min_prec {
+                if scan_e_lr_11(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_11(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_4(suffix_kind) {
             if 15 >= min_prec {
+                if scan_e_lr_13(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_13(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 14 >= min_prec {
+                if scan_e_lr_14(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_14(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_5(suffix_kind) {
             if 13 >= min_prec {
+                if scan_e_lr_17(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_17(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_6(suffix_kind) {
             if 12 >= min_prec {
+                if scan_e_lr_18(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_18(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_7(suffix_kind) {
             if 11 >= min_prec {
+                if scan_e_lr_19(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_19(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_8(suffix_kind) {
             if 10 >= min_prec {
+                if scan_e_lr_20(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_20(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_INSTANCEOF {
             if 9 >= min_prec {
+                if scan_e_lr_21(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_21(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_9(suffix_kind) {
             if 8 >= min_prec {
+                if scan_e_lr_22(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_22(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMP {
             if 7 >= min_prec {
+                if scan_e_lr_23(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_23(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_CARET {
             if 6 >= min_prec {
+                if scan_e_lr_24(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_24(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPE {
             if 5 >= min_prec {
+                if scan_e_lr_25(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_25(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMPAMP {
             if 4 >= min_prec {
+                if scan_e_lr_26(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_26(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPEPIPE {
             if 3 >= min_prec {
+                if scan_e_lr_27(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_27(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                if scan_e_lr_28(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_28(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_10(suffix_kind) {
             if 1 >= min_prec {
+                if scan_e_lr_29(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_29(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-739357c31b4c8ca4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_12.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-739357c31b4c8ca4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_12.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/t.wado",
-      "hash": "32f5b98675941cd9064c799a058da6a8b2819688a2802445d774381c8a0852c7",
+      "hash": "d3f024ac890820c116d90b295d7fb79c56f3b100f128ccadbc8195f4d4a1f65d",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/t.wado
@@ -2290,29 +2290,33 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if second_kind == TK_ID {
                     if 20 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_6(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else if second_kind == TK_LIT_THIS {
                     if 19 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_7(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else if second_kind == TK_LIT_SUPER {
                     if 18 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_8(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 17 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_9(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -2320,113 +2324,129 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
             }
         } else if suffix_kind == TK_LIT_LBRACKET {
             if 16 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_11(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_4(suffix_kind) {
             if 15 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_13(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 14 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_14(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_5(suffix_kind) {
             if 13 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_17(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_6(suffix_kind) {
             if 12 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_18(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_7(suffix_kind) {
             if 11 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_19(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_8(suffix_kind) {
             if 10 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_20(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_INSTANCEOF {
             if 9 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_21(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_9(suffix_kind) {
             if 8 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_22(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMP {
             if 7 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_23(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_CARET {
             if 6 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_24(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPE {
             if 5 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_25(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMPAMP {
             if 4 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_26(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPEPIPE {
             if 3 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_27(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_28(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_10(suffix_kind) {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_29(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -3045,24 +3065,36 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             if suffix_kind == TK_LIT_DOT {
                 if p.peek_at(1) == TK_ID {
                     if 20 >= min_prec {
+                        if scan_e_lr_6(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_6(p, result, start)?;
                     } else {
                         break;
                     }
                 } else if p.peek_at(1) == TK_LIT_THIS {
                     if 19 >= min_prec {
+                        if scan_e_lr_7(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_7(p, result, start)?;
                     } else {
                         break;
                     }
                 } else if p.peek_at(1) == TK_LIT_SUPER {
                     if 18 >= min_prec {
+                        if scan_e_lr_8(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_8(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 17 >= min_prec {
+                        if scan_e_lr_9(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_9(p, result, start)?;
                     } else {
                         break;
@@ -3071,96 +3103,144 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             }
         } else if suffix_kind == TK_LIT_LBRACKET {
             if 16 >= min_prec {
+                if scan_e_lr_11(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_11(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_4(suffix_kind) {
             if 15 >= min_prec {
+                if scan_e_lr_13(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_13(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 14 >= min_prec {
+                if scan_e_lr_14(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_14(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_5(suffix_kind) {
             if 13 >= min_prec {
+                if scan_e_lr_17(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_17(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_6(suffix_kind) {
             if 12 >= min_prec {
+                if scan_e_lr_18(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_18(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_7(suffix_kind) {
             if 11 >= min_prec {
+                if scan_e_lr_19(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_19(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_8(suffix_kind) {
             if 10 >= min_prec {
+                if scan_e_lr_20(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_20(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_INSTANCEOF {
             if 9 >= min_prec {
+                if scan_e_lr_21(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_21(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_9(suffix_kind) {
             if 8 >= min_prec {
+                if scan_e_lr_22(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_22(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMP {
             if 7 >= min_prec {
+                if scan_e_lr_23(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_23(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_CARET {
             if 6 >= min_prec {
+                if scan_e_lr_24(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_24(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPE {
             if 5 >= min_prec {
+                if scan_e_lr_25(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_25(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMPAMP {
             if 4 >= min_prec {
+                if scan_e_lr_26(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_26(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPEPIPE {
             if 3 >= min_prec {
+                if scan_e_lr_27(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_27(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                if scan_e_lr_28(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_28(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_10(suffix_kind) {
             if 1 >= min_prec {
+                if scan_e_lr_29(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_29(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-70a21a8410fad983",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_2.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/t.wado",
-      "hash": "189466b4c794e6e52f6c062f4a133841db8d61e25ed95423d7243b8327e7ad78",
+      "hash": "e6fae3af3753e91d5be2b276a9b34b8f8e36ff0723ae4cfe0ca5ae53dfc2afdc",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-70a21a8410fad983",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_2.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/t.wado
@@ -2290,29 +2290,33 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if second_kind == TK_ID {
                     if 20 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_6(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else if second_kind == TK_LIT_THIS {
                     if 19 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_7(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else if second_kind == TK_LIT_SUPER {
                     if 18 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_8(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 17 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_9(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -2320,113 +2324,129 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
             }
         } else if suffix_kind == TK_LIT_LBRACKET {
             if 16 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_11(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_4(suffix_kind) {
             if 15 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_13(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 14 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_14(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_5(suffix_kind) {
             if 13 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_17(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_6(suffix_kind) {
             if 12 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_18(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_7(suffix_kind) {
             if 11 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_19(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_8(suffix_kind) {
             if 10 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_20(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_INSTANCEOF {
             if 9 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_21(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_9(suffix_kind) {
             if 8 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_22(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMP {
             if 7 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_23(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_CARET {
             if 6 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_24(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPE {
             if 5 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_25(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMPAMP {
             if 4 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_26(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPEPIPE {
             if 3 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_27(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_28(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_10(suffix_kind) {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_29(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -3045,24 +3065,36 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             if suffix_kind == TK_LIT_DOT {
                 if p.peek_at(1) == TK_ID {
                     if 20 >= min_prec {
+                        if scan_e_lr_6(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_6(p, result, start)?;
                     } else {
                         break;
                     }
                 } else if p.peek_at(1) == TK_LIT_THIS {
                     if 19 >= min_prec {
+                        if scan_e_lr_7(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_7(p, result, start)?;
                     } else {
                         break;
                     }
                 } else if p.peek_at(1) == TK_LIT_SUPER {
                     if 18 >= min_prec {
+                        if scan_e_lr_8(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_8(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 17 >= min_prec {
+                        if scan_e_lr_9(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_9(p, result, start)?;
                     } else {
                         break;
@@ -3071,96 +3103,144 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             }
         } else if suffix_kind == TK_LIT_LBRACKET {
             if 16 >= min_prec {
+                if scan_e_lr_11(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_11(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_4(suffix_kind) {
             if 15 >= min_prec {
+                if scan_e_lr_13(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_13(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 14 >= min_prec {
+                if scan_e_lr_14(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_14(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_5(suffix_kind) {
             if 13 >= min_prec {
+                if scan_e_lr_17(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_17(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_6(suffix_kind) {
             if 12 >= min_prec {
+                if scan_e_lr_18(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_18(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_7(suffix_kind) {
             if 11 >= min_prec {
+                if scan_e_lr_19(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_19(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_8(suffix_kind) {
             if 10 >= min_prec {
+                if scan_e_lr_20(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_20(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_INSTANCEOF {
             if 9 >= min_prec {
+                if scan_e_lr_21(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_21(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_9(suffix_kind) {
             if 8 >= min_prec {
+                if scan_e_lr_22(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_22(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMP {
             if 7 >= min_prec {
+                if scan_e_lr_23(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_23(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_CARET {
             if 6 >= min_prec {
+                if scan_e_lr_24(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_24(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPE {
             if 5 >= min_prec {
+                if scan_e_lr_25(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_25(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMPAMP {
             if 4 >= min_prec {
+                if scan_e_lr_26(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_26(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPEPIPE {
             if 3 >= min_prec {
+                if scan_e_lr_27(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_27(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                if scan_e_lr_28(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_28(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_10(suffix_kind) {
             if 1 >= min_prec {
+                if scan_e_lr_29(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_29(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-99bcc333174e8ead",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_5.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/t.wado",
-      "hash": "e4f44872d3c1e86b58723385ab9cf60380164b81e1b207cf78a669a4e7a7bfbc",
+      "hash": "ef85e6b516e051078f2a762cc6e01973774b850948f6496bd1f0e0cbf455f260",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-99bcc333174e8ead",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_5.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/t.wado
@@ -2290,29 +2290,33 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if second_kind == TK_ID {
                     if 20 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_6(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else if second_kind == TK_LIT_THIS {
                     if 19 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_7(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else if second_kind == TK_LIT_SUPER {
                     if 18 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_8(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 17 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_9(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -2320,113 +2324,129 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
             }
         } else if suffix_kind == TK_LIT_LBRACKET {
             if 16 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_11(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_4(suffix_kind) {
             if 15 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_13(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 14 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_14(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_5(suffix_kind) {
             if 13 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_17(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_6(suffix_kind) {
             if 12 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_18(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_7(suffix_kind) {
             if 11 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_19(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_8(suffix_kind) {
             if 10 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_20(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_INSTANCEOF {
             if 9 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_21(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_9(suffix_kind) {
             if 8 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_22(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMP {
             if 7 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_23(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_CARET {
             if 6 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_24(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPE {
             if 5 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_25(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMPAMP {
             if 4 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_26(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPEPIPE {
             if 3 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_27(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_28(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_10(suffix_kind) {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_29(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -3045,24 +3065,36 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             if suffix_kind == TK_LIT_DOT {
                 if p.peek_at(1) == TK_ID {
                     if 20 >= min_prec {
+                        if scan_e_lr_6(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_6(p, result, start)?;
                     } else {
                         break;
                     }
                 } else if p.peek_at(1) == TK_LIT_THIS {
                     if 19 >= min_prec {
+                        if scan_e_lr_7(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_7(p, result, start)?;
                     } else {
                         break;
                     }
                 } else if p.peek_at(1) == TK_LIT_SUPER {
                     if 18 >= min_prec {
+                        if scan_e_lr_8(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_8(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 17 >= min_prec {
+                        if scan_e_lr_9(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_9(p, result, start)?;
                     } else {
                         break;
@@ -3071,96 +3103,144 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             }
         } else if suffix_kind == TK_LIT_LBRACKET {
             if 16 >= min_prec {
+                if scan_e_lr_11(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_11(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_4(suffix_kind) {
             if 15 >= min_prec {
+                if scan_e_lr_13(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_13(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 14 >= min_prec {
+                if scan_e_lr_14(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_14(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_5(suffix_kind) {
             if 13 >= min_prec {
+                if scan_e_lr_17(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_17(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_6(suffix_kind) {
             if 12 >= min_prec {
+                if scan_e_lr_18(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_18(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_7(suffix_kind) {
             if 11 >= min_prec {
+                if scan_e_lr_19(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_19(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_8(suffix_kind) {
             if 10 >= min_prec {
+                if scan_e_lr_20(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_20(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_INSTANCEOF {
             if 9 >= min_prec {
+                if scan_e_lr_21(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_21(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_9(suffix_kind) {
             if 8 >= min_prec {
+                if scan_e_lr_22(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_22(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMP {
             if 7 >= min_prec {
+                if scan_e_lr_23(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_23(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_CARET {
             if 6 >= min_prec {
+                if scan_e_lr_24(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_24(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPE {
             if 5 >= min_prec {
+                if scan_e_lr_25(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_25(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMPAMP {
             if 4 >= min_prec {
+                if scan_e_lr_26(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_26(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPEPIPE {
             if 3 >= min_prec {
+                if scan_e_lr_27(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_27(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                if scan_e_lr_28(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_28(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_10(suffix_kind) {
             if 1 >= min_prec {
+                if scan_e_lr_29(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_29(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2f290cf17eba13e0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_6.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/t.wado",
-      "hash": "5065cb4314f3324027591bbf93094dc85d03c3568247548b0ad522698d42397e",
+      "hash": "123a8410dd2d02098afd836ea01f8acc0754af24796d3960a51d1977959ef0b2",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2f290cf17eba13e0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_6.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/t.wado
@@ -2290,29 +2290,33 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if second_kind == TK_ID {
                     if 20 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_6(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else if second_kind == TK_LIT_THIS {
                     if 19 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_7(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else if second_kind == TK_LIT_SUPER {
                     if 18 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_8(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 17 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_9(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -2320,113 +2324,129 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
             }
         } else if suffix_kind == TK_LIT_LBRACKET {
             if 16 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_11(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_4(suffix_kind) {
             if 15 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_13(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 14 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_14(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_5(suffix_kind) {
             if 13 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_17(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_6(suffix_kind) {
             if 12 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_18(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_7(suffix_kind) {
             if 11 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_19(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_8(suffix_kind) {
             if 10 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_20(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_INSTANCEOF {
             if 9 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_21(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_9(suffix_kind) {
             if 8 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_22(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMP {
             if 7 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_23(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_CARET {
             if 6 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_24(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPE {
             if 5 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_25(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMPAMP {
             if 4 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_26(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPEPIPE {
             if 3 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_27(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_28(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_10(suffix_kind) {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_29(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -3045,24 +3065,36 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             if suffix_kind == TK_LIT_DOT {
                 if p.peek_at(1) == TK_ID {
                     if 20 >= min_prec {
+                        if scan_e_lr_6(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_6(p, result, start)?;
                     } else {
                         break;
                     }
                 } else if p.peek_at(1) == TK_LIT_THIS {
                     if 19 >= min_prec {
+                        if scan_e_lr_7(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_7(p, result, start)?;
                     } else {
                         break;
                     }
                 } else if p.peek_at(1) == TK_LIT_SUPER {
                     if 18 >= min_prec {
+                        if scan_e_lr_8(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_8(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 17 >= min_prec {
+                        if scan_e_lr_9(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_9(p, result, start)?;
                     } else {
                         break;
@@ -3071,96 +3103,144 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             }
         } else if suffix_kind == TK_LIT_LBRACKET {
             if 16 >= min_prec {
+                if scan_e_lr_11(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_11(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_4(suffix_kind) {
             if 15 >= min_prec {
+                if scan_e_lr_13(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_13(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 14 >= min_prec {
+                if scan_e_lr_14(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_14(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_5(suffix_kind) {
             if 13 >= min_prec {
+                if scan_e_lr_17(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_17(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_6(suffix_kind) {
             if 12 >= min_prec {
+                if scan_e_lr_18(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_18(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_7(suffix_kind) {
             if 11 >= min_prec {
+                if scan_e_lr_19(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_19(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_8(suffix_kind) {
             if 10 >= min_prec {
+                if scan_e_lr_20(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_20(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_INSTANCEOF {
             if 9 >= min_prec {
+                if scan_e_lr_21(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_21(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_9(suffix_kind) {
             if 8 >= min_prec {
+                if scan_e_lr_22(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_22(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMP {
             if 7 >= min_prec {
+                if scan_e_lr_23(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_23(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_CARET {
             if 6 >= min_prec {
+                if scan_e_lr_24(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_24(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPE {
             if 5 >= min_prec {
+                if scan_e_lr_25(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_25(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMPAMP {
             if 4 >= min_prec {
+                if scan_e_lr_26(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_26(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPEPIPE {
             if 3 >= min_prec {
+                if scan_e_lr_27(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_27(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                if scan_e_lr_28(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_28(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_10(suffix_kind) {
             if 1 >= min_prec {
+                if scan_e_lr_29(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_29(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bd943cd5ec077b75",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_7.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/t.wado",
-      "hash": "0f5e521e243ac617a1390712cf209595ac140aabe0483b2123ccaa07d4aae834",
+      "hash": "621b5c9882af22998f413892903f1bd8f716ef731c2508a7bb604c2e5b51d674",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bd943cd5ec077b75",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_7.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/t.wado
@@ -2290,29 +2290,33 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if second_kind == TK_ID {
                     if 20 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_6(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else if second_kind == TK_LIT_THIS {
                     if 19 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_7(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else if second_kind == TK_LIT_SUPER {
                     if 18 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_8(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 17 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_9(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -2320,113 +2324,129 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
             }
         } else if suffix_kind == TK_LIT_LBRACKET {
             if 16 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_11(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_4(suffix_kind) {
             if 15 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_13(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 14 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_14(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_5(suffix_kind) {
             if 13 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_17(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_6(suffix_kind) {
             if 12 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_18(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_7(suffix_kind) {
             if 11 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_19(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_8(suffix_kind) {
             if 10 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_20(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_INSTANCEOF {
             if 9 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_21(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_9(suffix_kind) {
             if 8 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_22(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMP {
             if 7 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_23(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_CARET {
             if 6 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_24(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPE {
             if 5 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_25(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMPAMP {
             if 4 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_26(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPEPIPE {
             if 3 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_27(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_28(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_10(suffix_kind) {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_29(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -3045,24 +3065,36 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             if suffix_kind == TK_LIT_DOT {
                 if p.peek_at(1) == TK_ID {
                     if 20 >= min_prec {
+                        if scan_e_lr_6(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_6(p, result, start)?;
                     } else {
                         break;
                     }
                 } else if p.peek_at(1) == TK_LIT_THIS {
                     if 19 >= min_prec {
+                        if scan_e_lr_7(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_7(p, result, start)?;
                     } else {
                         break;
                     }
                 } else if p.peek_at(1) == TK_LIT_SUPER {
                     if 18 >= min_prec {
+                        if scan_e_lr_8(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_8(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 17 >= min_prec {
+                        if scan_e_lr_9(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_9(p, result, start)?;
                     } else {
                         break;
@@ -3071,96 +3103,144 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             }
         } else if suffix_kind == TK_LIT_LBRACKET {
             if 16 >= min_prec {
+                if scan_e_lr_11(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_11(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_4(suffix_kind) {
             if 15 >= min_prec {
+                if scan_e_lr_13(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_13(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 14 >= min_prec {
+                if scan_e_lr_14(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_14(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_5(suffix_kind) {
             if 13 >= min_prec {
+                if scan_e_lr_17(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_17(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_6(suffix_kind) {
             if 12 >= min_prec {
+                if scan_e_lr_18(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_18(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_7(suffix_kind) {
             if 11 >= min_prec {
+                if scan_e_lr_19(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_19(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_8(suffix_kind) {
             if 10 >= min_prec {
+                if scan_e_lr_20(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_20(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_INSTANCEOF {
             if 9 >= min_prec {
+                if scan_e_lr_21(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_21(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_9(suffix_kind) {
             if 8 >= min_prec {
+                if scan_e_lr_22(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_22(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMP {
             if 7 >= min_prec {
+                if scan_e_lr_23(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_23(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_CARET {
             if 6 >= min_prec {
+                if scan_e_lr_24(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_24(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPE {
             if 5 >= min_prec {
+                if scan_e_lr_25(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_25(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMPAMP {
             if 4 >= min_prec {
+                if scan_e_lr_26(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_26(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPEPIPE {
             if 3 >= min_prec {
+                if scan_e_lr_27(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_27(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                if scan_e_lr_28(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_28(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_10(suffix_kind) {
             if 1 >= min_prec {
+                if scan_e_lr_29(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_29(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6ad535192ef3e12f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_8.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/t.wado",
-      "hash": "1820358b8341b2ca193aa9b6694528d50672552f2f152761fc3d0ef3e52ee50f",
+      "hash": "89dbbd88a80af75519cf3cbfa826c61e57f229628b3aa2eef0e4a0392acfa040",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6ad535192ef3e12f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_8.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/t.wado
@@ -2290,29 +2290,33 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if second_kind == TK_ID {
                     if 20 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_6(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else if second_kind == TK_LIT_THIS {
                     if 19 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_7(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else if second_kind == TK_LIT_SUPER {
                     if 18 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_8(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 17 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_9(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -2320,113 +2324,129 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
             }
         } else if suffix_kind == TK_LIT_LBRACKET {
             if 16 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_11(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_4(suffix_kind) {
             if 15 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_13(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 14 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_14(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_5(suffix_kind) {
             if 13 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_17(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_6(suffix_kind) {
             if 12 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_18(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_7(suffix_kind) {
             if 11 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_19(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_8(suffix_kind) {
             if 10 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_20(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_INSTANCEOF {
             if 9 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_21(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_9(suffix_kind) {
             if 8 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_22(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMP {
             if 7 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_23(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_CARET {
             if 6 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_24(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPE {
             if 5 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_25(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMPAMP {
             if 4 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_26(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPEPIPE {
             if 3 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_27(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_28(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_10(suffix_kind) {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_29(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -3045,24 +3065,36 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             if suffix_kind == TK_LIT_DOT {
                 if p.peek_at(1) == TK_ID {
                     if 20 >= min_prec {
+                        if scan_e_lr_6(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_6(p, result, start)?;
                     } else {
                         break;
                     }
                 } else if p.peek_at(1) == TK_LIT_THIS {
                     if 19 >= min_prec {
+                        if scan_e_lr_7(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_7(p, result, start)?;
                     } else {
                         break;
                     }
                 } else if p.peek_at(1) == TK_LIT_SUPER {
                     if 18 >= min_prec {
+                        if scan_e_lr_8(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_8(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 17 >= min_prec {
+                        if scan_e_lr_9(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_9(p, result, start)?;
                     } else {
                         break;
@@ -3071,96 +3103,144 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             }
         } else if suffix_kind == TK_LIT_LBRACKET {
             if 16 >= min_prec {
+                if scan_e_lr_11(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_11(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_4(suffix_kind) {
             if 15 >= min_prec {
+                if scan_e_lr_13(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_13(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 14 >= min_prec {
+                if scan_e_lr_14(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_14(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_5(suffix_kind) {
             if 13 >= min_prec {
+                if scan_e_lr_17(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_17(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_6(suffix_kind) {
             if 12 >= min_prec {
+                if scan_e_lr_18(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_18(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_7(suffix_kind) {
             if 11 >= min_prec {
+                if scan_e_lr_19(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_19(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_8(suffix_kind) {
             if 10 >= min_prec {
+                if scan_e_lr_20(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_20(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_INSTANCEOF {
             if 9 >= min_prec {
+                if scan_e_lr_21(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_21(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_9(suffix_kind) {
             if 8 >= min_prec {
+                if scan_e_lr_22(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_22(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMP {
             if 7 >= min_prec {
+                if scan_e_lr_23(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_23(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_CARET {
             if 6 >= min_prec {
+                if scan_e_lr_24(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_24(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPE {
             if 5 >= min_prec {
+                if scan_e_lr_25(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_25(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMPAMP {
             if 4 >= min_prec {
+                if scan_e_lr_26(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_26(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPEPIPE {
             if 3 >= min_prec {
+                if scan_e_lr_27(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_27(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                if scan_e_lr_28(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_28(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_10(suffix_kind) {
             if 1 >= min_prec {
+                if scan_e_lr_29(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_29(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-43dcc5eba0df7ec4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_9.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/t.wado",
-      "hash": "df3cd2069816c988d5e11d77edb845edf7b373c57b05a821b3bd7afee892bc5a",
+      "hash": "7efa2f5b2c4fd4b48dd927db5b09248c62f132cf0fbacde7e6d4d56c4f6ad1b0",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-43dcc5eba0df7ec4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_9.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/t.wado
@@ -2290,29 +2290,33 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if second_kind == TK_ID {
                     if 20 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_6(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else if second_kind == TK_LIT_THIS {
                     if 19 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_7(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else if second_kind == TK_LIT_SUPER {
                     if 18 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_8(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 17 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_e_lr_9(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -2320,113 +2324,129 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
             }
         } else if suffix_kind == TK_LIT_LBRACKET {
             if 16 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_11(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_4(suffix_kind) {
             if 15 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_13(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 14 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_14(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_5(suffix_kind) {
             if 13 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_17(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_6(suffix_kind) {
             if 12 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_18(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_7(suffix_kind) {
             if 11 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_19(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_8(suffix_kind) {
             if 10 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_20(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_INSTANCEOF {
             if 9 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_21(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_9(suffix_kind) {
             if 8 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_22(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMP {
             if 7 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_23(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_CARET {
             if 6 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_24(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPE {
             if 5 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_25(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMPAMP {
             if 4 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_26(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPEPIPE {
             if 3 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_27(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_28(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_10(suffix_kind) {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_29(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -3045,24 +3065,36 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             if suffix_kind == TK_LIT_DOT {
                 if p.peek_at(1) == TK_ID {
                     if 20 >= min_prec {
+                        if scan_e_lr_6(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_6(p, result, start)?;
                     } else {
                         break;
                     }
                 } else if p.peek_at(1) == TK_LIT_THIS {
                     if 19 >= min_prec {
+                        if scan_e_lr_7(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_7(p, result, start)?;
                     } else {
                         break;
                     }
                 } else if p.peek_at(1) == TK_LIT_SUPER {
                     if 18 >= min_prec {
+                        if scan_e_lr_8(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_8(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 17 >= min_prec {
+                        if scan_e_lr_9(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_e_lr_9(p, result, start)?;
                     } else {
                         break;
@@ -3071,96 +3103,144 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
             }
         } else if suffix_kind == TK_LIT_LBRACKET {
             if 16 >= min_prec {
+                if scan_e_lr_11(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_11(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_4(suffix_kind) {
             if 15 >= min_prec {
+                if scan_e_lr_13(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_13(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 14 >= min_prec {
+                if scan_e_lr_14(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_14(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_5(suffix_kind) {
             if 13 >= min_prec {
+                if scan_e_lr_17(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_17(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_6(suffix_kind) {
             if 12 >= min_prec {
+                if scan_e_lr_18(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_18(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_7(suffix_kind) {
             if 11 >= min_prec {
+                if scan_e_lr_19(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_19(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_8(suffix_kind) {
             if 10 >= min_prec {
+                if scan_e_lr_20(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_20(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_INSTANCEOF {
             if 9 >= min_prec {
+                if scan_e_lr_21(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_21(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_9(suffix_kind) {
             if 8 >= min_prec {
+                if scan_e_lr_22(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_22(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMP {
             if 7 >= min_prec {
+                if scan_e_lr_23(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_23(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_CARET {
             if 6 >= min_prec {
+                if scan_e_lr_24(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_24(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPE {
             if 5 >= min_prec {
+                if scan_e_lr_25(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_25(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMPAMP {
             if 4 >= min_prec {
+                if scan_e_lr_26(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_26(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPEPIPE {
             if 3 >= min_prec {
+                if scan_e_lr_27(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_27(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                if scan_e_lr_28(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_28(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_10(suffix_kind) {
             if 1 >= min_prec {
+                if scan_e_lr_29(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_29(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-112c4a21992a04ed",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_1.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_1/t.wado",
-      "hash": "014b27ad7b1d5c992f5bed9ba11d58e6ba2d4aa35892de11621c565d6b65b6f5",
+      "hash": "366a3560fecc8364c152502f819f7efc6d09c38bb76917011810c8d385a483e1",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-112c4a21992a04ed",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_1.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_1/t.wado
@@ -822,8 +822,9 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if _gale_kind_set_0(suffix_kind) {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -892,6 +893,9 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
         let suffix_kind = p.peek_kind();
         if _gale_kind_set_0(suffix_kind) {
             if 1 >= min_prec {
+                if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_0(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-459d0b754845c21f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_2.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-459d0b754845c21f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_2.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_2/t.wado",
-      "hash": "ad323a32d83b2826972b2028c2be9d64e315c8a5d52b34eb552683970f804c74",
+      "hash": "67f270f146afc7ce199a82f3dc426139031002c0b72957e9ee1a178c903545ec",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_2/t.wado
@@ -822,8 +822,9 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if _gale_kind_set_0(suffix_kind) {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -892,6 +893,9 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
         let suffix_kind = p.peek_kind();
         if _gale_kind_set_0(suffix_kind) {
             if 1 >= min_prec {
+                if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_0(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1181507cda20d45b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_3.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_3/t.wado",
-      "hash": "c9e49d14271d64dd723e48b5e88b828011dc216d251d6035ee33b2cffd855ce2",
+      "hash": "7c8f7b88729b182643a4f8d6199766172e019dfe17e100d1d156cec1db8d0d41",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1181507cda20d45b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_3.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_3/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_3/t.wado
@@ -822,8 +822,9 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if _gale_kind_set_0(suffix_kind) {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -892,6 +893,9 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
         let suffix_kind = p.peek_kind();
         if _gale_kind_set_0(suffix_kind) {
             if 1 >= min_prec {
+                if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_0(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4b506a26b7b7c7b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_1.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_1/t.wado",
-      "hash": "3f67432f213b88b8700fcfd96ae7ab7a5df27c7e97847cf3c15f957593bb430e",
+      "hash": "543a214e24c83acb4654a3d71f380270b0e8bdc662fa7d24ee375ab4b110fb34",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4b506a26b7b7c7b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_1.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_1/t.wado
@@ -873,15 +873,17 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if _gale_kind_set_0(suffix_kind) {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_1(suffix_kind) {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_1(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -963,12 +965,18 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
         let suffix_kind = p.peek_kind();
         if _gale_kind_set_0(suffix_kind) {
             if 2 >= min_prec {
+                if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_0(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_1(suffix_kind) {
             if 1 >= min_prec {
+                if scan_e_lr_1(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_1(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-34e6293e9d4c3e83",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_2.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_2/t.wado",
-      "hash": "8a53b5551be9693a5d20c07e35660c5ac1cb15ecff2f40924aa77c4811d558a7",
+      "hash": "69e99a5b50c269b744b6609646550c84cb11a1c1c2604db5fa748dcd3043a9b8",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-34e6293e9d4c3e83",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_2.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_2/t.wado
@@ -873,15 +873,17 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if _gale_kind_set_0(suffix_kind) {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_1(suffix_kind) {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_1(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -963,12 +965,18 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
         let suffix_kind = p.peek_kind();
         if _gale_kind_set_0(suffix_kind) {
             if 2 >= min_prec {
+                if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_0(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_1(suffix_kind) {
             if 1 >= min_prec {
+                if scan_e_lr_1(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_1(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b2467e37954af95c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_3.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b2467e37954af95c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_3.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_3/t.wado",
-      "hash": "4ac555e66b81599fbc34fb87882c216ec872252155ccb1c50cef2ebfde8bdc82",
+      "hash": "06d7d18d06b44d296df033d97c8bff51493bde42edd818f2e97f65ca3c56459a",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_3/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_3/t.wado
@@ -873,15 +873,17 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if _gale_kind_set_0(suffix_kind) {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_1(suffix_kind) {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_1(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -963,12 +965,18 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
         let suffix_kind = p.peek_kind();
         if _gale_kind_set_0(suffix_kind) {
             if 2 >= min_prec {
+                if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_0(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_1(suffix_kind) {
             if 1 >= min_prec {
+                if scan_e_lr_1(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_1(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-be8254158e713214",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_1.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/MultipleActions_1/t.wado",
-      "hash": "daaf017c9fcca3166038013af1cee137ad019d50bdafb649bbdc9d9fdb08cac0",
+      "hash": "941e8f641b790c5911a5cd13100daa54d4aff9a8bd5f279ea54848ab9f08fec6",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-be8254158e713214",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_1.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_1/t.wado
@@ -822,8 +822,9 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if _gale_kind_set_0(suffix_kind) {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -892,6 +893,9 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
         let suffix_kind = p.peek_kind();
         if _gale_kind_set_0(suffix_kind) {
             if 1 >= min_prec {
+                if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_0(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4fc8261d73da648f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_2.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/MultipleActions_2/t.wado",
-      "hash": "5a6e7a26668e683cd9019911e4e75661fbd38c14edd7254bb0bb47c4facacb36",
+      "hash": "7af860e432bd1b3401fcf48d82b3f1995149b9b21ea907b4a18821ca189acfb5",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4fc8261d73da648f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_2.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_2/t.wado
@@ -822,8 +822,9 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if _gale_kind_set_0(suffix_kind) {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -892,6 +893,9 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
         let suffix_kind = p.peek_kind();
         if _gale_kind_set_0(suffix_kind) {
             if 1 >= min_prec {
+                if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_0(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-93334f393b16d8e0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_3.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/MultipleActions_3/t.wado",
-      "hash": "354aa097d55d2b560f9a15b663d548558c620d4c270437bc2d18129b4b5d1d73",
+      "hash": "eb16d0f29d29897b7cf320548027d67ccc7d9c0230ee148f10f73e6f5b02afe7",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-93334f393b16d8e0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_3.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_3/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_3/t.wado
@@ -822,8 +822,9 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if _gale_kind_set_0(suffix_kind) {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -892,6 +893,9 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
         let suffix_kind = p.peek_kind();
         if _gale_kind_set_0(suffix_kind) {
             if 1 >= min_prec {
+                if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_0(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e522638eb5f62a2f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrecedenceFilterConsidersContext.g4",
     "hash": "c92df3158f9ed1c1b43de581aedaf3b0918fa525ff0258f855022b78585b860b"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e522638eb5f62a2f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrecedenceFilterConsidersContext.g4",
     "hash": "c92df3158f9ed1c1b43de581aedaf3b0918fa525ff0258f855022b78585b860b"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/PrecedenceFilterConsidersContext/t.wado",
-      "hash": "2aea3659836291a7f46a51c686c027862bc7fa39efc0b8697319d514af0edbaf",
+      "hash": "8714db2d3fd65720da680c6928547c305f60702aaed05c01b9696a6f1728e641",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrecedenceFilterConsidersContext/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrecedenceFilterConsidersContext/t.wado
@@ -713,8 +713,9 @@ fn scan_statement(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if suffix_kind == TK_LIT_A {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_statement_lr_1(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -792,6 +793,9 @@ fn parse_statement(p: &mut Parser, min_prec: i32 = 0) -> Result<StatementNode, P
         let suffix_kind = p.peek_kind();
         if suffix_kind == TK_LIT_A {
             if 1 >= min_prec {
+                if scan_statement_lr_1(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_statement_lr_1(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-709c12dbc0d22c0c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrefixAndOtherAlt_1.g4",
     "hash": "f946ec43c09928b2aae968a817d4ff315478257d5700925eab82fd22d94714d8"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/t.wado",
-      "hash": "08186153a3b4448f1300fdd5534fbc6a2c820a39004954bab7df393e77594d55",
+      "hash": "f5bcd5e645e3d56ae29bb1fd837a224a94c669d99567d04e49e8d02d067323f1",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-709c12dbc0d22c0c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrefixAndOtherAlt_1.g4",
     "hash": "f946ec43c09928b2aae968a817d4ff315478257d5700925eab82fd22d94714d8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/t.wado
@@ -827,8 +827,9 @@ fn scan_expr(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if _gale_kind_set_0(suffix_kind) {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expr_lr_2(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -962,6 +963,9 @@ fn parse_expr(p: &mut Parser, min_prec: i32 = 0) -> Result<ExprNode, ParseError>
         let suffix_kind = p.peek_kind();
         if _gale_kind_set_0(suffix_kind) {
             if 1 >= min_prec {
+                if scan_expr_lr_2(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expr_lr_2(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1f6f1364b2571756",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrefixAndOtherAlt_2.g4",
     "hash": "f946ec43c09928b2aae968a817d4ff315478257d5700925eab82fd22d94714d8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1f6f1364b2571756",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrefixAndOtherAlt_2.g4",
     "hash": "f946ec43c09928b2aae968a817d4ff315478257d5700925eab82fd22d94714d8"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/t.wado",
-      "hash": "f7f2a41604c502f243c828bef0f5a485ee2ab03c355d1cb16cee0c42af7a034e",
+      "hash": "3e24744f2cc8ef3097832649fecfb6b229b030fe204cbc75ea1f81f5c7865659",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/t.wado
@@ -827,8 +827,9 @@ fn scan_expr(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if _gale_kind_set_0(suffix_kind) {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expr_lr_2(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -962,6 +963,9 @@ fn parse_expr(p: &mut Parser, min_prec: i32 = 0) -> Result<ExprNode, ParseError>
         let suffix_kind = p.peek_kind();
         if _gale_kind_set_0(suffix_kind) {
             if 1 >= min_prec {
+                if scan_expr_lr_2(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expr_lr_2(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList1_1/ReturnValueAndActionsList1_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList1_1/ReturnValueAndActionsList1_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-98215ef7f217d444",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList1_1.g4",
     "hash": "97ed3cba25571f64d3b3f1ada1225af38693f6353aa699ec825c47886f968b1e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList1_1/ReturnValueAndActionsList1_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList1_1/ReturnValueAndActionsList1_1.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-98215ef7f217d444",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList1_1.g4",
+    "hash": "97ed3cba25571f64d3b3f1ada1225af38693f6353aa699ec825c47886f968b1e"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList1_1/t.wado",
+      "hash": "02604009612227c9747f154c6135eebbb67eabfebc7a7f174b56f0c64e4167df",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList1_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList1_1/t.wado
@@ -1,0 +1,1050 @@
+#![generated(by = "local:src/generator.wado", sources = ["../../grammars/LeftRecursion/ReturnValueAndActionsList1_1.g4"])]
+#![generated(by = "gale", sources = ["T.g4"])]
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &Array<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &Array<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &Array<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: Array<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// ParseError represents a parse failure with location and expected tokens.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: Array<String>,
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: Array<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+}
+
+/// CstChild is either a terminal token or a non-terminal sub-tree.
+pub variant CstChild {
+    Token(Token),
+    Node(CstNode),
+}
+
+/// CstNode is a generic (untyped) concrete syntax tree node.
+pub struct CstNode {
+    pub name: String,
+    pub span: Span,
+    pub children: Array<CstChild>,
+}
+
+impl CstNode {
+    /// Produce an ANTLR4-style S-expression representation of this tree.
+    /// Rule nodes become `(name child1 child2 ...)`, tokens become their text.
+    /// Tokens with empty text (e.g. EOF) are omitted.
+    pub fn to_string_tree(&self) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(out: &mut String, node: &CstNode) {
+    out.push_str(`({node.name}`);
+    for let child of &node.children {
+        if let Token(t) = *child {
+            if !t.text.is_empty() {
+                out.push_str(` {t.text}`);
+            }
+        } else if let Node(n) = *child {
+            out.push_str(" ");
+            cst_to_string_tree_impl(out, n);
+        }
+    }
+    out.push_str(")");
+}
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Highlight override: when inside a specific rule, override the capture for a token kind.
+pub struct HighlightOverride {
+    pub rule_name: String,
+    pub token_kind: i32,
+    pub capture: String,
+}
+
+/// Highlight mapping: defaults by token kind + context-aware overrides.
+pub struct HighlightMapping {
+    pub defaults: Array<String>,
+    pub overrides: Array<HighlightOverride>,
+}
+
+/// A single highlight capture: a named range in the source text.
+pub struct HighlightCapture {
+    pub capture: String,
+    pub start: i32,
+    pub end: i32,
+}
+
+/// HighlightVisitor collects highlight captures during a CST walk.
+pub struct HighlightVisitor {
+    mapping: HighlightMapping,
+    rule_stack: Array<String>,
+    pub captures: Array<HighlightCapture>,
+}
+
+impl HighlightVisitor {
+    pub fn new(mapping: HighlightMapping) -> HighlightVisitor {
+        return HighlightVisitor { mapping, rule_stack: [], captures: [] };
+    }
+
+    fn classify(&self, kind: i32) -> String {
+        for let ov of &self.mapping.overrides {
+            if ov.token_kind == kind {
+                for let rule of &self.rule_stack {
+                    if *rule == ov.rule_name {
+                        return ov.capture;
+                    }
+                }
+            }
+        }
+        if kind >= 0 && kind < self.mapping.defaults.len() {
+            return self.mapping.defaults[kind];
+        }
+        return "";
+    }
+}
+
+impl Visitor for HighlightVisitor {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+        self.rule_stack.push(*name);
+    }
+
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+        if !self.rule_stack.is_empty() {
+            let last = self.rule_stack.len() - 1;
+            let mut new_stack: Array<String> = [];
+            for let mut i = 0; i < last; i += 1 {
+                new_stack.push(self.rule_stack[i]);
+            }
+            self.rule_stack = new_stack;
+        }
+    }
+
+    fn visit_token(&mut self, token: &Token) {
+        for let trivia of &token.leading_trivia {
+            let cap = self.classify(trivia.kind);
+            if !cap.is_empty() {
+                self.captures.push(HighlightCapture { capture: cap, start: trivia.span.start, end: trivia.span.end });
+            }
+        }
+        if token.text.is_empty() {
+            return;
+        }
+        let cap = self.classify(token.kind);
+        if !cap.is_empty() {
+            self.captures.push(HighlightCapture { capture: cap, start: token.span.start, end: token.span.end });
+        }
+    }
+}
+
+fn escape_html(out: &mut String, text: &String) {
+    for let c of text.chars() {
+        if c == '&' {
+            out.push_str("&amp;");
+        } else if c == '<' {
+            out.push_str("&lt;");
+        } else if c == '>' {
+            out.push_str("&gt;");
+        } else if c == '"' {
+            out.push_str("&quot;");
+        } else {
+            out.push(c);
+        }
+    }
+}
+
+fn escape_html_char(out: &mut String, c: char) {
+    if c == '&' {
+        out.push_str("&amp;");
+    } else if c == '<' {
+        out.push_str("&lt;");
+    } else if c == '>' {
+        out.push_str("&gt;");
+    } else if c == '"' {
+        out.push_str("&quot;");
+    } else {
+        out.push(c);
+    }
+}
+
+fn push_class(out: &mut String, capture: &String) {
+    for let c of capture.chars() {
+        if c == '.' {
+            out.push(' ');
+        } else {
+            out.push(c);
+        }
+    }
+}
+
+/// Produce a highlighted HTML fragment from source text and captures.
+/// Captures must be sorted by start position (as produced by HighlightVisitor).
+pub fn highlight_html(source: &String, captures: &Array<HighlightCapture>) -> String {
+    let mut out = String::with_capacity(source.len() * 5);
+    let mut pos = 0;
+    let mut iter = source.chars();
+    for let cap of captures {
+        while pos < cap.start {
+            if let Some(c) = iter.next() {
+                escape_html_char(&mut out, c);
+            }
+            pos += 1;
+        }
+        out.push_str("<span class=\"");
+        push_class(&mut out, &cap.capture);
+        out.push_str("\">");
+        let end = cap.end;
+        while pos < end {
+            if let Some(c) = iter.next() {
+                escape_html_char(&mut out, c);
+            }
+            pos += 1;
+        }
+        out.push_str("</span>");
+    }
+    while let Some(c) = iter.next() {
+        escape_html_char(&mut out, c);
+    }
+    return out;
+}
+
+fn substr(chars: &Array<char>, start: i32, end: i32) -> String {
+    let mut out = String::with_capacity(end - start);
+    let mut i = start;
+    while i < end && i < chars.len() {
+        out.push(chars[i]);
+        i += 1;
+    }
+    return out;
+}
+
+/// Visitor trait for walking typed CST nodes.
+/// Default methods are no-ops; override to add behavior.
+pub trait Visitor {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+    }
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+    }
+    fn visit_token(&mut self, token: &Token) {
+    }
+}
+
+/// TreeRecorder is a Visitor that records events for building a CstNode tree.
+pub struct TreeRecorder {
+    events: Array<TreeEvent>,
+}
+
+variant TreeEvent {
+    Enter(TreeEnterInfo),
+    Exit,
+    VisitToken(Token),
+}
+
+struct TreeEnterInfo {
+    name: String,
+    span: Span,
+}
+
+impl TreeRecorder {
+    pub fn new() -> TreeRecorder {
+        return TreeRecorder { events: [] };
+    }
+
+    pub fn build(&self) -> CstNode {
+        let mut pos = 0;
+        return tree_build_node(&self.events, &mut pos);
+    }
+}
+
+impl Visitor for TreeRecorder {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+        self.events.push(TreeEvent::Enter(TreeEnterInfo { name: *name, span: *span }));
+    }
+
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+        self.events.push(TreeEvent::Exit);
+    }
+
+    fn visit_token(&mut self, token: &Token) {
+        self.events.push(TreeEvent::VisitToken(*token));
+    }
+}
+
+fn tree_build_node(events: &Array<TreeEvent>, pos: &mut i32) -> CstNode {
+    if let Enter(info) = events[*pos] {
+        *pos += 1;
+        let mut children: Array<CstChild> = [];
+        loop {
+            if *pos >= events.len() {
+                break;
+            }
+            let ev = events[*pos];
+            if let Exit = ev {
+                *pos += 1;
+                break;
+            }
+            if let Enter(_) = ev {
+                children.push(CstChild::Node(tree_build_node(events, pos)));
+            } else if let VisitToken(t) = ev {
+                children.push(CstChild::Token(t));
+                *pos += 1;
+            }
+        }
+        return CstNode { name: info.name, span: info.span, children };
+    }
+    panic("TreeRecorder: expected Enter event");
+    return CstNode { name: "", span: Span::new(0, 0), children: [] };
+}
+
+pub enum TokenKind {
+    ID,
+    WS,
+    Eof,
+    Error,
+}
+
+pub struct SNode {
+    pub span: Span,
+    pub expr: ExprNode,
+    pub eof: Token,
+}
+
+pub variant ExprNode {
+    Factor(ExprFactor),
+    Send(ExprSend),
+    JustId(ExprJustId),
+}
+
+pub struct ExprFactor {
+    pub span: Span,
+    pub a: ExprNode,
+    pub star: Token,
+    pub a_2: ExprNode,
+}
+
+pub struct CommaBItem {
+    pub comma: Token,
+    pub b: Array<ExprNode>,
+}
+
+pub struct ExprSend {
+    pub span: Span,
+    pub b: Array<ExprNode>,
+    pub comma_b_list: Array<CommaBItem>,
+    pub lit_gtgt: Token,
+    pub c: ExprNode,
+}
+
+pub struct ExprJustId {
+    pub span: Span,
+    pub id: Token,
+}
+
+global TK_ID: i32 = 0;
+global TK_WS: i32 = 1;
+global TK_EOF: i32 = 2;
+global TK_ERROR: i32 = 3;
+global TK_LIT_STAR: i32 = 4;
+global TK_LIT_COMMA: i32 = 5;
+global TK_LIT_GTGT: i32 = 6;
+
+struct Lexer {
+    chars: Array<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.chars().collect(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_id(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    let alts_saved_0 = pos;
+    let mut alts_ok_0 = false;
+    alts_0_0: {
+        pos = alts_saved_0;
+        if pos >= chars.len() || !('a' <= chars[pos] <= 'z') { break alts_0_0; }
+        pos += 1;
+        alts_ok_0 = true;
+    }
+    if !alts_ok_0 {
+        alts_0_1: {
+            pos = alts_saved_0;
+            if pos >= chars.len() || !('A' <= chars[pos] <= 'Z') { break alts_0_1; }
+            pos += 1;
+            alts_ok_0 = true;
+        }
+        if !alts_ok_0 {
+            alts_0_2: {
+                pos = alts_saved_0;
+                if pos >= chars.len() || chars[pos] != '_' { break alts_0_2; }
+                pos += 1;
+                alts_ok_0 = true;
+            }
+        }
+    }
+    if !alts_ok_0 { return -1; }
+    loop {
+        let rep_saved_1 = pos;
+        rep_1: {
+            let alts_saved_2 = pos;
+            let mut alts_ok_2 = false;
+            alts_2_0: {
+                pos = alts_saved_2;
+                if pos >= chars.len() || !('a' <= chars[pos] <= 'z') { break alts_2_0; }
+                pos += 1;
+                alts_ok_2 = true;
+            }
+            if !alts_ok_2 {
+                alts_2_1: {
+                    pos = alts_saved_2;
+                    if pos >= chars.len() || !('A' <= chars[pos] <= 'Z') { break alts_2_1; }
+                    pos += 1;
+                    alts_ok_2 = true;
+                }
+                if !alts_ok_2 {
+                    alts_2_2: {
+                        pos = alts_saved_2;
+                        if pos >= chars.len() || !('0' <= chars[pos] <= '9') { break alts_2_2; }
+                        pos += 1;
+                        alts_ok_2 = true;
+                    }
+                    if !alts_ok_2 {
+                        alts_2_3: {
+                            pos = alts_saved_2;
+                            if pos >= chars.len() || chars[pos] != '_' { break alts_2_3; }
+                            pos += 1;
+                            alts_ok_2 = true;
+                        }
+                    }
+                }
+            }
+            if !alts_ok_2 { break rep_1; }
+            continue;
+        }
+        pos = rep_saved_1;
+        break;
+    }
+    return pos;
+}
+
+fn try_ws(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !(false || chars[pos] == ' ' || chars[pos] == '\t' || chars[pos] == '\n') { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_3 = pos;
+        rep_3: {
+            if pos >= chars.len() { break rep_3; }
+            if !(false || chars[pos] == ' ' || chars[pos] == '\t' || chars[pos] == '\n') { break rep_3; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_3;
+        break;
+    }
+    return pos;
+}
+
+fn try_lit_star(chars: &Array<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '*' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_comma(chars: &Array<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != ',' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_gtgt(chars: &Array<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '>' { return -1; }
+    if pos + 1 >= chars.len() || chars[pos + 1] != '>' { return -1; }
+    return pos + 2;
+}
+
+pub fn tokenize(input: &String) -> Array<Token> {
+    let mut lexer = Lexer::new(input);
+    let mut tokens: Array<Token> = [];
+    let mut trivia: Array<Token> = [];
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == '\t' || first_char == '\n' || first_char == ' ' {
+            end = try_ws(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if first_char == '*' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_STAR; }
+        } else if first_char == ',' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_COMMA; }
+        } else if first_char == '>' {
+            end = try_lit_gtgt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_GTGT; }
+        } else if first_char == '_' {
+            end = try_id(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else if 'a' <= first_char <= 'z' {
+            end = try_id(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else if 'A' <= first_char <= 'Z' {
+            end = try_id(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else {
+            end = try_id(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        }
+        if best_end <= start {
+            let tok = Token::with_trivia(TK_ERROR, lexer.slice(start, start + 1), Span::new(start, start + 1), trivia);
+            tokens.push(tok);
+            trivia = [];
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                trivia.push(Token::new(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end)));
+            } else {
+                let tok = Token::with_trivia(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), trivia);
+                tokens.push(tok);
+                trivia = [];
+            }
+            lexer.pos = best_end;
+        }
+    }
+    tokens.push(Token::with_trivia(TK_EOF, LexerSlice::empty(&lexer.chars), Span::new(lexer.pos, lexer.pos), trivia));
+    return tokens;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_ID => "ID",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        TK_LIT_STAR => "TK_LIT_STAR",
+        TK_LIT_COMMA => "TK_LIT_COMMA",
+        TK_LIT_GTGT => "TK_LIT_GTGT",
+        _ => "Unknown",
+    };
+}
+
+struct Parser {
+    tokens: Array<Token>,
+    pos: i32,
+}
+
+impl Parser {
+    fn new(tokens: Array<Token>) -> Parser {
+        return Parser { tokens, pos: 0 };
+    }
+
+    fn peek(&self) -> &Token {
+        return &self.tokens[self.pos];
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.tokens[self.pos].kind;
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.tokens.len() { return TK_EOF; }
+        return self.tokens[idx].kind;
+    }
+
+    fn advance(&mut self) -> Token {
+        let tok = self.tokens[self.pos];
+        self.pos += 1;
+        return tok;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens[self.pos - 1].span.end;
+    }
+
+    fn expect(&mut self, kind: i32) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind == kind {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        let name = token_kind_name(kind);
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected {name}, got "{tok.text}"`,
+            tok.span,
+            [name],
+        ));
+    }
+
+    fn fail(&self, name: String) -> Result<Token, ParseError> {
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected {name}, got "{tok.text}"`,
+            tok.span,
+            [name],
+        ));
+    }
+
+    fn match_any(&mut self) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind != TK_EOF {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected any token, got "{tok.text}"`,
+            tok.span,
+            ["any token"],
+        ));
+    }
+
+    fn match_not(&mut self, excluded: Array<i32>) -> Result<Token, ParseError> {
+        let k = self.tokens[self.pos].kind;
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                return Result::<Token, ParseError>::Ok(self.advance());
+            }
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `unexpected token "{tok.text}"`,
+            tok.span,
+            ["set complement"],
+        ));
+    }
+}
+
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let mut pos = pos;
+    pos = scan_expr(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_ID { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_expr_lr_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_STAR { return -1; }
+    pos += 1;
+    pos = scan_expr(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_expr_lr_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
+        let sp = pos;
+        sg_0_done: {
+            sg_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_0; }
+                pos += 1;
+                pos = scan_expr(tokens, pos, 0);
+                if pos < 0 { break sg_0; }
+                break sg_0_done;
+            }
+            pos = -1;
+        }
+        if pos < 0 { pos = sp; break; }
+        if pos == sp { break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_GTGT { return -1; }
+    pos += 1;
+    pos = scan_expr(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_expr(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let mut pos = scan_expr_atom(tokens, pos);
+    if pos < 0 { return -1; }
+    loop {
+        let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
+        if suffix_kind == TK_LIT_STAR {
+            if 2 >= min_prec {
+                let lr_saved_pos = pos;
+                pos = scan_expr_lr_0(tokens, pos);
+                if pos < 0 { pos = lr_saved_pos; break; }
+            } else {
+                break;
+            }
+        } else if _gale_kind_set_0(suffix_kind) {
+            if 1 >= min_prec {
+                let lr_saved_pos = pos;
+                pos = scan_expr_lr_1(tokens, pos);
+                if pos < 0 { pos = lr_saved_pos; break; }
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    return pos;
+}
+
+fn parse_s(p: &mut Parser) -> Result<SNode, ParseError> {
+    let start = p.peek().span.start;
+    let expr = parse_expr(p)?;
+    let eof = p.expect(TK_EOF)?;
+    return Result::<SNode, ParseError>::Ok(SNode {
+        span: Span::new(start, p.last_end()),
+        expr,
+        eof,
+    });
+}
+
+fn parse_expr_atom(p: &mut Parser) -> Result<ExprNode, ParseError> {
+    let start = p.peek().span.start;
+    let kind = p.peek_kind();
+    if kind == TK_ID {
+        let id = p.expect(TK_ID)?;
+        return Result::<ExprNode, ParseError>::Ok(ExprNode::JustId(ExprJustId {
+            span: Span::new(start, p.last_end()),
+            id,
+        }));
+    }
+    return Result::<ExprNode, ParseError>::Err(ParseError::new(
+        "expected expr",
+        p.peek().span,
+        ["TK_ID"],
+    ));
+}
+
+fn parse_expr_lr_0(p: &mut Parser, left: ExprNode, start: i32) -> Result<ExprNode, ParseError> {
+    let star = p.expect(TK_LIT_STAR)?;
+    let expr = parse_expr(p, 3)?;
+    let a_2 = expr;
+    return Result::<ExprNode, ParseError>::Ok(ExprNode::Factor(ExprFactor {
+        span: Span::new(start, p.last_end()),
+        a: left,
+        star,
+        a_2,
+    }));
+}
+
+fn parse_expr_lr_1(p: &mut Parser, left: ExprNode, start: i32) -> Result<ExprNode, ParseError> {
+    let mut comma_b_list: Array<CommaBItem> = [];
+    loop {
+        let mut rep_scan_pos: i32 = -1;
+        rep_scan: {
+            let tokens = &p.tokens;
+            let mut pos: i32 = p.pos;
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
+            pos += 1;
+            pos = scan_expr(tokens, pos, 0);
+            if pos < 0 { break rep_scan; }
+            if pos <= p.pos { break rep_scan; }
+            rep_scan_pos = pos;
+        }
+        if rep_scan_pos < 0 { break; }
+        let comma = p.expect(TK_LIT_COMMA)?;
+        let mut b: Array<ExprNode> = [];
+        let expr = parse_expr(p)?;
+        b.push(expr);
+        let comma_b = CommaBItem {
+            comma,
+            b,
+        };
+        comma_b_list.push(comma_b);
+    }
+    let lit_gtgt = p.expect(TK_LIT_GTGT)?;
+    let expr = parse_expr(p, 2)?;
+    let c = expr;
+    return Result::<ExprNode, ParseError>::Ok(ExprNode::Send(ExprSend {
+        span: Span::new(start, p.last_end()),
+        b: [left] as Array<ExprNode>,
+        comma_b_list,
+        lit_gtgt,
+        c,
+    }));
+}
+
+fn parse_expr(p: &mut Parser, min_prec: i32 = 0) -> Result<ExprNode, ParseError> {
+    let start = p.peek().span.start;
+    let mut result = parse_expr_atom(p)?;
+    loop {
+        let suffix_kind = p.peek_kind();
+        if suffix_kind == TK_LIT_STAR {
+            if 2 >= min_prec {
+                if scan_expr_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
+                result = parse_expr_lr_0(p, result, start)?;
+            } else {
+                break;
+            }
+        } else if _gale_kind_set_0(suffix_kind) {
+            if 1 >= min_prec {
+                if scan_expr_lr_1(&p.tokens, p.pos) < 0 {
+                    break;
+                }
+                result = parse_expr_lr_1(p, result, start)?;
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    return Result::<ExprNode, ParseError>::Ok(result);
+}
+
+pub fn parse(input: &String) -> Result<SNode, ParseError> {
+    let tokens = tokenize(input);
+    let mut parser = Parser::new(tokens);
+    return parse_s(&mut parser);
+}
+
+pub fn walk_s<V: Visitor>(v: &mut V, node: &SNode) {
+    v.enter_rule(&"s", &node.span);
+    walk_expr(v, &node.expr);
+    v.visit_token(&node.eof);
+    v.exit_rule(&"s", &node.span);
+}
+
+pub fn walk_expr<V: Visitor>(v: &mut V, node: &ExprNode) {
+    match node {
+        Factor(n) => {
+            v.enter_rule(&"expr", &n.span);
+            walk_expr(v, &n.a);
+            v.visit_token(&n.star);
+            walk_expr(v, &n.a_2);
+            v.exit_rule(&"expr", &n.span);
+        }
+        Send(n) => {
+            v.enter_rule(&"expr", &n.span);
+            for let item of &n.b {
+                walk_expr(v, item);
+            }
+            for let item of &n.comma_b_list {
+                v.visit_token(&item.comma);
+                for let item of &item.b {
+                    walk_expr(v, item);
+                }
+            }
+            v.visit_token(&n.lit_gtgt);
+            walk_expr(v, &n.c);
+            v.exit_rule(&"expr", &n.span);
+        }
+        JustId(n) => {
+            v.enter_rule(&"expr", &n.span);
+            v.visit_token(&n.id);
+            v.exit_rule(&"expr", &n.span);
+        }
+    }
+}
+
+pub fn to_tree(node: &SNode) -> CstNode {
+    let mut recorder = TreeRecorder::new();
+    walk_s(&mut recorder, node);
+    return recorder.build();
+}
+
+fn _gale_kind_set_0(k: i32) -> bool {
+    return k matches { TK_LIT_COMMA | TK_LIT_GTGT };
+}
+

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList1_3/ReturnValueAndActionsList1_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList1_3/ReturnValueAndActionsList1_3.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-d3f80bba204a6230",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList1_3.g4",
+    "hash": "97ed3cba25571f64d3b3f1ada1225af38693f6353aa699ec825c47886f968b1e"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList1_3/t.wado",
+      "hash": "9c418841e7846429ae73e4517182d9d4e13a7dc996387881ce86135df293833c",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList1_3/ReturnValueAndActionsList1_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList1_3/ReturnValueAndActionsList1_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d3f80bba204a6230",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList1_3.g4",
     "hash": "97ed3cba25571f64d3b3f1ada1225af38693f6353aa699ec825c47886f968b1e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList1_3/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList1_3/t.wado
@@ -1,0 +1,1050 @@
+#![generated(by = "local:src/generator.wado", sources = ["../../grammars/LeftRecursion/ReturnValueAndActionsList1_3.g4"])]
+#![generated(by = "gale", sources = ["T.g4"])]
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &Array<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &Array<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &Array<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: Array<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// ParseError represents a parse failure with location and expected tokens.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: Array<String>,
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: Array<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+}
+
+/// CstChild is either a terminal token or a non-terminal sub-tree.
+pub variant CstChild {
+    Token(Token),
+    Node(CstNode),
+}
+
+/// CstNode is a generic (untyped) concrete syntax tree node.
+pub struct CstNode {
+    pub name: String,
+    pub span: Span,
+    pub children: Array<CstChild>,
+}
+
+impl CstNode {
+    /// Produce an ANTLR4-style S-expression representation of this tree.
+    /// Rule nodes become `(name child1 child2 ...)`, tokens become their text.
+    /// Tokens with empty text (e.g. EOF) are omitted.
+    pub fn to_string_tree(&self) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(out: &mut String, node: &CstNode) {
+    out.push_str(`({node.name}`);
+    for let child of &node.children {
+        if let Token(t) = *child {
+            if !t.text.is_empty() {
+                out.push_str(` {t.text}`);
+            }
+        } else if let Node(n) = *child {
+            out.push_str(" ");
+            cst_to_string_tree_impl(out, n);
+        }
+    }
+    out.push_str(")");
+}
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Highlight override: when inside a specific rule, override the capture for a token kind.
+pub struct HighlightOverride {
+    pub rule_name: String,
+    pub token_kind: i32,
+    pub capture: String,
+}
+
+/// Highlight mapping: defaults by token kind + context-aware overrides.
+pub struct HighlightMapping {
+    pub defaults: Array<String>,
+    pub overrides: Array<HighlightOverride>,
+}
+
+/// A single highlight capture: a named range in the source text.
+pub struct HighlightCapture {
+    pub capture: String,
+    pub start: i32,
+    pub end: i32,
+}
+
+/// HighlightVisitor collects highlight captures during a CST walk.
+pub struct HighlightVisitor {
+    mapping: HighlightMapping,
+    rule_stack: Array<String>,
+    pub captures: Array<HighlightCapture>,
+}
+
+impl HighlightVisitor {
+    pub fn new(mapping: HighlightMapping) -> HighlightVisitor {
+        return HighlightVisitor { mapping, rule_stack: [], captures: [] };
+    }
+
+    fn classify(&self, kind: i32) -> String {
+        for let ov of &self.mapping.overrides {
+            if ov.token_kind == kind {
+                for let rule of &self.rule_stack {
+                    if *rule == ov.rule_name {
+                        return ov.capture;
+                    }
+                }
+            }
+        }
+        if kind >= 0 && kind < self.mapping.defaults.len() {
+            return self.mapping.defaults[kind];
+        }
+        return "";
+    }
+}
+
+impl Visitor for HighlightVisitor {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+        self.rule_stack.push(*name);
+    }
+
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+        if !self.rule_stack.is_empty() {
+            let last = self.rule_stack.len() - 1;
+            let mut new_stack: Array<String> = [];
+            for let mut i = 0; i < last; i += 1 {
+                new_stack.push(self.rule_stack[i]);
+            }
+            self.rule_stack = new_stack;
+        }
+    }
+
+    fn visit_token(&mut self, token: &Token) {
+        for let trivia of &token.leading_trivia {
+            let cap = self.classify(trivia.kind);
+            if !cap.is_empty() {
+                self.captures.push(HighlightCapture { capture: cap, start: trivia.span.start, end: trivia.span.end });
+            }
+        }
+        if token.text.is_empty() {
+            return;
+        }
+        let cap = self.classify(token.kind);
+        if !cap.is_empty() {
+            self.captures.push(HighlightCapture { capture: cap, start: token.span.start, end: token.span.end });
+        }
+    }
+}
+
+fn escape_html(out: &mut String, text: &String) {
+    for let c of text.chars() {
+        if c == '&' {
+            out.push_str("&amp;");
+        } else if c == '<' {
+            out.push_str("&lt;");
+        } else if c == '>' {
+            out.push_str("&gt;");
+        } else if c == '"' {
+            out.push_str("&quot;");
+        } else {
+            out.push(c);
+        }
+    }
+}
+
+fn escape_html_char(out: &mut String, c: char) {
+    if c == '&' {
+        out.push_str("&amp;");
+    } else if c == '<' {
+        out.push_str("&lt;");
+    } else if c == '>' {
+        out.push_str("&gt;");
+    } else if c == '"' {
+        out.push_str("&quot;");
+    } else {
+        out.push(c);
+    }
+}
+
+fn push_class(out: &mut String, capture: &String) {
+    for let c of capture.chars() {
+        if c == '.' {
+            out.push(' ');
+        } else {
+            out.push(c);
+        }
+    }
+}
+
+/// Produce a highlighted HTML fragment from source text and captures.
+/// Captures must be sorted by start position (as produced by HighlightVisitor).
+pub fn highlight_html(source: &String, captures: &Array<HighlightCapture>) -> String {
+    let mut out = String::with_capacity(source.len() * 5);
+    let mut pos = 0;
+    let mut iter = source.chars();
+    for let cap of captures {
+        while pos < cap.start {
+            if let Some(c) = iter.next() {
+                escape_html_char(&mut out, c);
+            }
+            pos += 1;
+        }
+        out.push_str("<span class=\"");
+        push_class(&mut out, &cap.capture);
+        out.push_str("\">");
+        let end = cap.end;
+        while pos < end {
+            if let Some(c) = iter.next() {
+                escape_html_char(&mut out, c);
+            }
+            pos += 1;
+        }
+        out.push_str("</span>");
+    }
+    while let Some(c) = iter.next() {
+        escape_html_char(&mut out, c);
+    }
+    return out;
+}
+
+fn substr(chars: &Array<char>, start: i32, end: i32) -> String {
+    let mut out = String::with_capacity(end - start);
+    let mut i = start;
+    while i < end && i < chars.len() {
+        out.push(chars[i]);
+        i += 1;
+    }
+    return out;
+}
+
+/// Visitor trait for walking typed CST nodes.
+/// Default methods are no-ops; override to add behavior.
+pub trait Visitor {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+    }
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+    }
+    fn visit_token(&mut self, token: &Token) {
+    }
+}
+
+/// TreeRecorder is a Visitor that records events for building a CstNode tree.
+pub struct TreeRecorder {
+    events: Array<TreeEvent>,
+}
+
+variant TreeEvent {
+    Enter(TreeEnterInfo),
+    Exit,
+    VisitToken(Token),
+}
+
+struct TreeEnterInfo {
+    name: String,
+    span: Span,
+}
+
+impl TreeRecorder {
+    pub fn new() -> TreeRecorder {
+        return TreeRecorder { events: [] };
+    }
+
+    pub fn build(&self) -> CstNode {
+        let mut pos = 0;
+        return tree_build_node(&self.events, &mut pos);
+    }
+}
+
+impl Visitor for TreeRecorder {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+        self.events.push(TreeEvent::Enter(TreeEnterInfo { name: *name, span: *span }));
+    }
+
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+        self.events.push(TreeEvent::Exit);
+    }
+
+    fn visit_token(&mut self, token: &Token) {
+        self.events.push(TreeEvent::VisitToken(*token));
+    }
+}
+
+fn tree_build_node(events: &Array<TreeEvent>, pos: &mut i32) -> CstNode {
+    if let Enter(info) = events[*pos] {
+        *pos += 1;
+        let mut children: Array<CstChild> = [];
+        loop {
+            if *pos >= events.len() {
+                break;
+            }
+            let ev = events[*pos];
+            if let Exit = ev {
+                *pos += 1;
+                break;
+            }
+            if let Enter(_) = ev {
+                children.push(CstChild::Node(tree_build_node(events, pos)));
+            } else if let VisitToken(t) = ev {
+                children.push(CstChild::Token(t));
+                *pos += 1;
+            }
+        }
+        return CstNode { name: info.name, span: info.span, children };
+    }
+    panic("TreeRecorder: expected Enter event");
+    return CstNode { name: "", span: Span::new(0, 0), children: [] };
+}
+
+pub enum TokenKind {
+    ID,
+    WS,
+    Eof,
+    Error,
+}
+
+pub struct SNode {
+    pub span: Span,
+    pub expr: ExprNode,
+    pub eof: Token,
+}
+
+pub variant ExprNode {
+    Factor(ExprFactor),
+    Send(ExprSend),
+    JustId(ExprJustId),
+}
+
+pub struct ExprFactor {
+    pub span: Span,
+    pub a: ExprNode,
+    pub star: Token,
+    pub a_2: ExprNode,
+}
+
+pub struct CommaBItem {
+    pub comma: Token,
+    pub b: Array<ExprNode>,
+}
+
+pub struct ExprSend {
+    pub span: Span,
+    pub b: Array<ExprNode>,
+    pub comma_b_list: Array<CommaBItem>,
+    pub lit_gtgt: Token,
+    pub c: ExprNode,
+}
+
+pub struct ExprJustId {
+    pub span: Span,
+    pub id: Token,
+}
+
+global TK_ID: i32 = 0;
+global TK_WS: i32 = 1;
+global TK_EOF: i32 = 2;
+global TK_ERROR: i32 = 3;
+global TK_LIT_STAR: i32 = 4;
+global TK_LIT_COMMA: i32 = 5;
+global TK_LIT_GTGT: i32 = 6;
+
+struct Lexer {
+    chars: Array<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.chars().collect(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_id(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    let alts_saved_0 = pos;
+    let mut alts_ok_0 = false;
+    alts_0_0: {
+        pos = alts_saved_0;
+        if pos >= chars.len() || !('a' <= chars[pos] <= 'z') { break alts_0_0; }
+        pos += 1;
+        alts_ok_0 = true;
+    }
+    if !alts_ok_0 {
+        alts_0_1: {
+            pos = alts_saved_0;
+            if pos >= chars.len() || !('A' <= chars[pos] <= 'Z') { break alts_0_1; }
+            pos += 1;
+            alts_ok_0 = true;
+        }
+        if !alts_ok_0 {
+            alts_0_2: {
+                pos = alts_saved_0;
+                if pos >= chars.len() || chars[pos] != '_' { break alts_0_2; }
+                pos += 1;
+                alts_ok_0 = true;
+            }
+        }
+    }
+    if !alts_ok_0 { return -1; }
+    loop {
+        let rep_saved_1 = pos;
+        rep_1: {
+            let alts_saved_2 = pos;
+            let mut alts_ok_2 = false;
+            alts_2_0: {
+                pos = alts_saved_2;
+                if pos >= chars.len() || !('a' <= chars[pos] <= 'z') { break alts_2_0; }
+                pos += 1;
+                alts_ok_2 = true;
+            }
+            if !alts_ok_2 {
+                alts_2_1: {
+                    pos = alts_saved_2;
+                    if pos >= chars.len() || !('A' <= chars[pos] <= 'Z') { break alts_2_1; }
+                    pos += 1;
+                    alts_ok_2 = true;
+                }
+                if !alts_ok_2 {
+                    alts_2_2: {
+                        pos = alts_saved_2;
+                        if pos >= chars.len() || !('0' <= chars[pos] <= '9') { break alts_2_2; }
+                        pos += 1;
+                        alts_ok_2 = true;
+                    }
+                    if !alts_ok_2 {
+                        alts_2_3: {
+                            pos = alts_saved_2;
+                            if pos >= chars.len() || chars[pos] != '_' { break alts_2_3; }
+                            pos += 1;
+                            alts_ok_2 = true;
+                        }
+                    }
+                }
+            }
+            if !alts_ok_2 { break rep_1; }
+            continue;
+        }
+        pos = rep_saved_1;
+        break;
+    }
+    return pos;
+}
+
+fn try_ws(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !(false || chars[pos] == ' ' || chars[pos] == '\t' || chars[pos] == '\n') { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_3 = pos;
+        rep_3: {
+            if pos >= chars.len() { break rep_3; }
+            if !(false || chars[pos] == ' ' || chars[pos] == '\t' || chars[pos] == '\n') { break rep_3; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_3;
+        break;
+    }
+    return pos;
+}
+
+fn try_lit_star(chars: &Array<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '*' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_comma(chars: &Array<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != ',' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_gtgt(chars: &Array<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '>' { return -1; }
+    if pos + 1 >= chars.len() || chars[pos + 1] != '>' { return -1; }
+    return pos + 2;
+}
+
+pub fn tokenize(input: &String) -> Array<Token> {
+    let mut lexer = Lexer::new(input);
+    let mut tokens: Array<Token> = [];
+    let mut trivia: Array<Token> = [];
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == '\t' || first_char == '\n' || first_char == ' ' {
+            end = try_ws(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if first_char == '*' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_STAR; }
+        } else if first_char == ',' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_COMMA; }
+        } else if first_char == '>' {
+            end = try_lit_gtgt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_GTGT; }
+        } else if first_char == '_' {
+            end = try_id(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else if 'a' <= first_char <= 'z' {
+            end = try_id(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else if 'A' <= first_char <= 'Z' {
+            end = try_id(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else {
+            end = try_id(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        }
+        if best_end <= start {
+            let tok = Token::with_trivia(TK_ERROR, lexer.slice(start, start + 1), Span::new(start, start + 1), trivia);
+            tokens.push(tok);
+            trivia = [];
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                trivia.push(Token::new(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end)));
+            } else {
+                let tok = Token::with_trivia(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), trivia);
+                tokens.push(tok);
+                trivia = [];
+            }
+            lexer.pos = best_end;
+        }
+    }
+    tokens.push(Token::with_trivia(TK_EOF, LexerSlice::empty(&lexer.chars), Span::new(lexer.pos, lexer.pos), trivia));
+    return tokens;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_ID => "ID",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        TK_LIT_STAR => "TK_LIT_STAR",
+        TK_LIT_COMMA => "TK_LIT_COMMA",
+        TK_LIT_GTGT => "TK_LIT_GTGT",
+        _ => "Unknown",
+    };
+}
+
+struct Parser {
+    tokens: Array<Token>,
+    pos: i32,
+}
+
+impl Parser {
+    fn new(tokens: Array<Token>) -> Parser {
+        return Parser { tokens, pos: 0 };
+    }
+
+    fn peek(&self) -> &Token {
+        return &self.tokens[self.pos];
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.tokens[self.pos].kind;
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.tokens.len() { return TK_EOF; }
+        return self.tokens[idx].kind;
+    }
+
+    fn advance(&mut self) -> Token {
+        let tok = self.tokens[self.pos];
+        self.pos += 1;
+        return tok;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens[self.pos - 1].span.end;
+    }
+
+    fn expect(&mut self, kind: i32) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind == kind {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        let name = token_kind_name(kind);
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected {name}, got "{tok.text}"`,
+            tok.span,
+            [name],
+        ));
+    }
+
+    fn fail(&self, name: String) -> Result<Token, ParseError> {
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected {name}, got "{tok.text}"`,
+            tok.span,
+            [name],
+        ));
+    }
+
+    fn match_any(&mut self) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind != TK_EOF {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected any token, got "{tok.text}"`,
+            tok.span,
+            ["any token"],
+        ));
+    }
+
+    fn match_not(&mut self, excluded: Array<i32>) -> Result<Token, ParseError> {
+        let k = self.tokens[self.pos].kind;
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                return Result::<Token, ParseError>::Ok(self.advance());
+            }
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `unexpected token "{tok.text}"`,
+            tok.span,
+            ["set complement"],
+        ));
+    }
+}
+
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let mut pos = pos;
+    pos = scan_expr(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_ID { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_expr_lr_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_STAR { return -1; }
+    pos += 1;
+    pos = scan_expr(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_expr_lr_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    while pos < tokens.len() && tokens[pos].kind == TK_LIT_COMMA {
+        let sp = pos;
+        sg_0_done: {
+            sg_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break sg_0; }
+                pos += 1;
+                pos = scan_expr(tokens, pos, 0);
+                if pos < 0 { break sg_0; }
+                break sg_0_done;
+            }
+            pos = -1;
+        }
+        if pos < 0 { pos = sp; break; }
+        if pos == sp { break; }
+    }
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_GTGT { return -1; }
+    pos += 1;
+    pos = scan_expr(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_expr(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let mut pos = scan_expr_atom(tokens, pos);
+    if pos < 0 { return -1; }
+    loop {
+        let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
+        if suffix_kind == TK_LIT_STAR {
+            if 2 >= min_prec {
+                let lr_saved_pos = pos;
+                pos = scan_expr_lr_0(tokens, pos);
+                if pos < 0 { pos = lr_saved_pos; break; }
+            } else {
+                break;
+            }
+        } else if _gale_kind_set_0(suffix_kind) {
+            if 1 >= min_prec {
+                let lr_saved_pos = pos;
+                pos = scan_expr_lr_1(tokens, pos);
+                if pos < 0 { pos = lr_saved_pos; break; }
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    return pos;
+}
+
+fn parse_s(p: &mut Parser) -> Result<SNode, ParseError> {
+    let start = p.peek().span.start;
+    let expr = parse_expr(p)?;
+    let eof = p.expect(TK_EOF)?;
+    return Result::<SNode, ParseError>::Ok(SNode {
+        span: Span::new(start, p.last_end()),
+        expr,
+        eof,
+    });
+}
+
+fn parse_expr_atom(p: &mut Parser) -> Result<ExprNode, ParseError> {
+    let start = p.peek().span.start;
+    let kind = p.peek_kind();
+    if kind == TK_ID {
+        let id = p.expect(TK_ID)?;
+        return Result::<ExprNode, ParseError>::Ok(ExprNode::JustId(ExprJustId {
+            span: Span::new(start, p.last_end()),
+            id,
+        }));
+    }
+    return Result::<ExprNode, ParseError>::Err(ParseError::new(
+        "expected expr",
+        p.peek().span,
+        ["TK_ID"],
+    ));
+}
+
+fn parse_expr_lr_0(p: &mut Parser, left: ExprNode, start: i32) -> Result<ExprNode, ParseError> {
+    let star = p.expect(TK_LIT_STAR)?;
+    let expr = parse_expr(p, 3)?;
+    let a_2 = expr;
+    return Result::<ExprNode, ParseError>::Ok(ExprNode::Factor(ExprFactor {
+        span: Span::new(start, p.last_end()),
+        a: left,
+        star,
+        a_2,
+    }));
+}
+
+fn parse_expr_lr_1(p: &mut Parser, left: ExprNode, start: i32) -> Result<ExprNode, ParseError> {
+    let mut comma_b_list: Array<CommaBItem> = [];
+    loop {
+        let mut rep_scan_pos: i32 = -1;
+        rep_scan: {
+            let tokens = &p.tokens;
+            let mut pos: i32 = p.pos;
+            if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { break rep_scan; }
+            pos += 1;
+            pos = scan_expr(tokens, pos, 0);
+            if pos < 0 { break rep_scan; }
+            if pos <= p.pos { break rep_scan; }
+            rep_scan_pos = pos;
+        }
+        if rep_scan_pos < 0 { break; }
+        let comma = p.expect(TK_LIT_COMMA)?;
+        let mut b: Array<ExprNode> = [];
+        let expr = parse_expr(p)?;
+        b.push(expr);
+        let comma_b = CommaBItem {
+            comma,
+            b,
+        };
+        comma_b_list.push(comma_b);
+    }
+    let lit_gtgt = p.expect(TK_LIT_GTGT)?;
+    let expr = parse_expr(p, 2)?;
+    let c = expr;
+    return Result::<ExprNode, ParseError>::Ok(ExprNode::Send(ExprSend {
+        span: Span::new(start, p.last_end()),
+        b: [left] as Array<ExprNode>,
+        comma_b_list,
+        lit_gtgt,
+        c,
+    }));
+}
+
+fn parse_expr(p: &mut Parser, min_prec: i32 = 0) -> Result<ExprNode, ParseError> {
+    let start = p.peek().span.start;
+    let mut result = parse_expr_atom(p)?;
+    loop {
+        let suffix_kind = p.peek_kind();
+        if suffix_kind == TK_LIT_STAR {
+            if 2 >= min_prec {
+                if scan_expr_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
+                result = parse_expr_lr_0(p, result, start)?;
+            } else {
+                break;
+            }
+        } else if _gale_kind_set_0(suffix_kind) {
+            if 1 >= min_prec {
+                if scan_expr_lr_1(&p.tokens, p.pos) < 0 {
+                    break;
+                }
+                result = parse_expr_lr_1(p, result, start)?;
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    return Result::<ExprNode, ParseError>::Ok(result);
+}
+
+pub fn parse(input: &String) -> Result<SNode, ParseError> {
+    let tokens = tokenize(input);
+    let mut parser = Parser::new(tokens);
+    return parse_s(&mut parser);
+}
+
+pub fn walk_s<V: Visitor>(v: &mut V, node: &SNode) {
+    v.enter_rule(&"s", &node.span);
+    walk_expr(v, &node.expr);
+    v.visit_token(&node.eof);
+    v.exit_rule(&"s", &node.span);
+}
+
+pub fn walk_expr<V: Visitor>(v: &mut V, node: &ExprNode) {
+    match node {
+        Factor(n) => {
+            v.enter_rule(&"expr", &n.span);
+            walk_expr(v, &n.a);
+            v.visit_token(&n.star);
+            walk_expr(v, &n.a_2);
+            v.exit_rule(&"expr", &n.span);
+        }
+        Send(n) => {
+            v.enter_rule(&"expr", &n.span);
+            for let item of &n.b {
+                walk_expr(v, item);
+            }
+            for let item of &n.comma_b_list {
+                v.visit_token(&item.comma);
+                for let item of &item.b {
+                    walk_expr(v, item);
+                }
+            }
+            v.visit_token(&n.lit_gtgt);
+            walk_expr(v, &n.c);
+            v.exit_rule(&"expr", &n.span);
+        }
+        JustId(n) => {
+            v.enter_rule(&"expr", &n.span);
+            v.visit_token(&n.id);
+            v.exit_rule(&"expr", &n.span);
+        }
+    }
+}
+
+pub fn to_tree(node: &SNode) -> CstNode {
+    let mut recorder = TreeRecorder::new();
+    walk_s(&mut recorder, node);
+    return recorder.build();
+}
+
+fn _gale_kind_set_0(k: i32) -> bool {
+    return k matches { TK_LIT_COMMA | TK_LIT_GTGT };
+}
+

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList2_1/ReturnValueAndActionsList2_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList2_1/ReturnValueAndActionsList2_1.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-fe2931b7e3ce7624",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList2_1.g4",
+    "hash": "d020b96fea143032cbc0f3f58b543f99e6ee62a9921e2c0c402a721dfeb8e67c"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList2_1/t.wado",
+      "hash": "ab2ebbefe57b196cfca981d6ca198139351d3abd738ca79dbfe76bb3fed944a8",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList2_1/ReturnValueAndActionsList2_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList2_1/ReturnValueAndActionsList2_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fe2931b7e3ce7624",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList2_1.g4",
     "hash": "d020b96fea143032cbc0f3f58b543f99e6ee62a9921e2c0c402a721dfeb8e67c"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList2_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList2_1/t.wado
@@ -1,0 +1,1051 @@
+#![generated(by = "local:src/generator.wado", sources = ["../../grammars/LeftRecursion/ReturnValueAndActionsList2_1.g4"])]
+#![generated(by = "gale", sources = ["T.g4"])]
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &Array<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &Array<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &Array<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: Array<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// ParseError represents a parse failure with location and expected tokens.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: Array<String>,
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: Array<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+}
+
+/// CstChild is either a terminal token or a non-terminal sub-tree.
+pub variant CstChild {
+    Token(Token),
+    Node(CstNode),
+}
+
+/// CstNode is a generic (untyped) concrete syntax tree node.
+pub struct CstNode {
+    pub name: String,
+    pub span: Span,
+    pub children: Array<CstChild>,
+}
+
+impl CstNode {
+    /// Produce an ANTLR4-style S-expression representation of this tree.
+    /// Rule nodes become `(name child1 child2 ...)`, tokens become their text.
+    /// Tokens with empty text (e.g. EOF) are omitted.
+    pub fn to_string_tree(&self) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(out: &mut String, node: &CstNode) {
+    out.push_str(`({node.name}`);
+    for let child of &node.children {
+        if let Token(t) = *child {
+            if !t.text.is_empty() {
+                out.push_str(` {t.text}`);
+            }
+        } else if let Node(n) = *child {
+            out.push_str(" ");
+            cst_to_string_tree_impl(out, n);
+        }
+    }
+    out.push_str(")");
+}
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Highlight override: when inside a specific rule, override the capture for a token kind.
+pub struct HighlightOverride {
+    pub rule_name: String,
+    pub token_kind: i32,
+    pub capture: String,
+}
+
+/// Highlight mapping: defaults by token kind + context-aware overrides.
+pub struct HighlightMapping {
+    pub defaults: Array<String>,
+    pub overrides: Array<HighlightOverride>,
+}
+
+/// A single highlight capture: a named range in the source text.
+pub struct HighlightCapture {
+    pub capture: String,
+    pub start: i32,
+    pub end: i32,
+}
+
+/// HighlightVisitor collects highlight captures during a CST walk.
+pub struct HighlightVisitor {
+    mapping: HighlightMapping,
+    rule_stack: Array<String>,
+    pub captures: Array<HighlightCapture>,
+}
+
+impl HighlightVisitor {
+    pub fn new(mapping: HighlightMapping) -> HighlightVisitor {
+        return HighlightVisitor { mapping, rule_stack: [], captures: [] };
+    }
+
+    fn classify(&self, kind: i32) -> String {
+        for let ov of &self.mapping.overrides {
+            if ov.token_kind == kind {
+                for let rule of &self.rule_stack {
+                    if *rule == ov.rule_name {
+                        return ov.capture;
+                    }
+                }
+            }
+        }
+        if kind >= 0 && kind < self.mapping.defaults.len() {
+            return self.mapping.defaults[kind];
+        }
+        return "";
+    }
+}
+
+impl Visitor for HighlightVisitor {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+        self.rule_stack.push(*name);
+    }
+
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+        if !self.rule_stack.is_empty() {
+            let last = self.rule_stack.len() - 1;
+            let mut new_stack: Array<String> = [];
+            for let mut i = 0; i < last; i += 1 {
+                new_stack.push(self.rule_stack[i]);
+            }
+            self.rule_stack = new_stack;
+        }
+    }
+
+    fn visit_token(&mut self, token: &Token) {
+        for let trivia of &token.leading_trivia {
+            let cap = self.classify(trivia.kind);
+            if !cap.is_empty() {
+                self.captures.push(HighlightCapture { capture: cap, start: trivia.span.start, end: trivia.span.end });
+            }
+        }
+        if token.text.is_empty() {
+            return;
+        }
+        let cap = self.classify(token.kind);
+        if !cap.is_empty() {
+            self.captures.push(HighlightCapture { capture: cap, start: token.span.start, end: token.span.end });
+        }
+    }
+}
+
+fn escape_html(out: &mut String, text: &String) {
+    for let c of text.chars() {
+        if c == '&' {
+            out.push_str("&amp;");
+        } else if c == '<' {
+            out.push_str("&lt;");
+        } else if c == '>' {
+            out.push_str("&gt;");
+        } else if c == '"' {
+            out.push_str("&quot;");
+        } else {
+            out.push(c);
+        }
+    }
+}
+
+fn escape_html_char(out: &mut String, c: char) {
+    if c == '&' {
+        out.push_str("&amp;");
+    } else if c == '<' {
+        out.push_str("&lt;");
+    } else if c == '>' {
+        out.push_str("&gt;");
+    } else if c == '"' {
+        out.push_str("&quot;");
+    } else {
+        out.push(c);
+    }
+}
+
+fn push_class(out: &mut String, capture: &String) {
+    for let c of capture.chars() {
+        if c == '.' {
+            out.push(' ');
+        } else {
+            out.push(c);
+        }
+    }
+}
+
+/// Produce a highlighted HTML fragment from source text and captures.
+/// Captures must be sorted by start position (as produced by HighlightVisitor).
+pub fn highlight_html(source: &String, captures: &Array<HighlightCapture>) -> String {
+    let mut out = String::with_capacity(source.len() * 5);
+    let mut pos = 0;
+    let mut iter = source.chars();
+    for let cap of captures {
+        while pos < cap.start {
+            if let Some(c) = iter.next() {
+                escape_html_char(&mut out, c);
+            }
+            pos += 1;
+        }
+        out.push_str("<span class=\"");
+        push_class(&mut out, &cap.capture);
+        out.push_str("\">");
+        let end = cap.end;
+        while pos < end {
+            if let Some(c) = iter.next() {
+                escape_html_char(&mut out, c);
+            }
+            pos += 1;
+        }
+        out.push_str("</span>");
+    }
+    while let Some(c) = iter.next() {
+        escape_html_char(&mut out, c);
+    }
+    return out;
+}
+
+fn substr(chars: &Array<char>, start: i32, end: i32) -> String {
+    let mut out = String::with_capacity(end - start);
+    let mut i = start;
+    while i < end && i < chars.len() {
+        out.push(chars[i]);
+        i += 1;
+    }
+    return out;
+}
+
+/// Visitor trait for walking typed CST nodes.
+/// Default methods are no-ops; override to add behavior.
+pub trait Visitor {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+    }
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+    }
+    fn visit_token(&mut self, token: &Token) {
+    }
+}
+
+/// TreeRecorder is a Visitor that records events for building a CstNode tree.
+pub struct TreeRecorder {
+    events: Array<TreeEvent>,
+}
+
+variant TreeEvent {
+    Enter(TreeEnterInfo),
+    Exit,
+    VisitToken(Token),
+}
+
+struct TreeEnterInfo {
+    name: String,
+    span: Span,
+}
+
+impl TreeRecorder {
+    pub fn new() -> TreeRecorder {
+        return TreeRecorder { events: [] };
+    }
+
+    pub fn build(&self) -> CstNode {
+        let mut pos = 0;
+        return tree_build_node(&self.events, &mut pos);
+    }
+}
+
+impl Visitor for TreeRecorder {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+        self.events.push(TreeEvent::Enter(TreeEnterInfo { name: *name, span: *span }));
+    }
+
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+        self.events.push(TreeEvent::Exit);
+    }
+
+    fn visit_token(&mut self, token: &Token) {
+        self.events.push(TreeEvent::VisitToken(*token));
+    }
+}
+
+fn tree_build_node(events: &Array<TreeEvent>, pos: &mut i32) -> CstNode {
+    if let Enter(info) = events[*pos] {
+        *pos += 1;
+        let mut children: Array<CstChild> = [];
+        loop {
+            if *pos >= events.len() {
+                break;
+            }
+            let ev = events[*pos];
+            if let Exit = ev {
+                *pos += 1;
+                break;
+            }
+            if let Enter(_) = ev {
+                children.push(CstChild::Node(tree_build_node(events, pos)));
+            } else if let VisitToken(t) = ev {
+                children.push(CstChild::Token(t));
+                *pos += 1;
+            }
+        }
+        return CstNode { name: info.name, span: info.span, children };
+    }
+    panic("TreeRecorder: expected Enter event");
+    return CstNode { name: "", span: Span::new(0, 0), children: [] };
+}
+
+pub enum TokenKind {
+    ID,
+    WS,
+    Eof,
+    Error,
+}
+
+pub struct SNode {
+    pub span: Span,
+    pub expr: ExprNode,
+    pub eof: Token,
+}
+
+pub variant ExprNode {
+    Factor(ExprFactor),
+    Comma(ExprComma),
+    Send(ExprSend),
+    JustId(ExprJustId),
+}
+
+pub struct ExprFactor {
+    pub span: Span,
+    pub a: ExprNode,
+    pub star: Token,
+    pub a_2: ExprNode,
+}
+
+pub struct ExprComma {
+    pub span: Span,
+    pub b: Array<ExprNode>,
+    pub comma: Token,
+    pub b_2: Array<ExprNode>,
+}
+
+pub struct ExprSend {
+    pub span: Span,
+    pub b: Array<ExprNode>,
+    pub lit_gtgt: Token,
+    pub c: ExprNode,
+}
+
+pub struct ExprJustId {
+    pub span: Span,
+    pub id: Token,
+}
+
+global TK_ID: i32 = 0;
+global TK_WS: i32 = 1;
+global TK_EOF: i32 = 2;
+global TK_ERROR: i32 = 3;
+global TK_LIT_STAR: i32 = 4;
+global TK_LIT_COMMA: i32 = 5;
+global TK_LIT_GTGT: i32 = 6;
+
+struct Lexer {
+    chars: Array<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.chars().collect(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_id(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    let alts_saved_0 = pos;
+    let mut alts_ok_0 = false;
+    alts_0_0: {
+        pos = alts_saved_0;
+        if pos >= chars.len() || !('a' <= chars[pos] <= 'z') { break alts_0_0; }
+        pos += 1;
+        alts_ok_0 = true;
+    }
+    if !alts_ok_0 {
+        alts_0_1: {
+            pos = alts_saved_0;
+            if pos >= chars.len() || !('A' <= chars[pos] <= 'Z') { break alts_0_1; }
+            pos += 1;
+            alts_ok_0 = true;
+        }
+        if !alts_ok_0 {
+            alts_0_2: {
+                pos = alts_saved_0;
+                if pos >= chars.len() || chars[pos] != '_' { break alts_0_2; }
+                pos += 1;
+                alts_ok_0 = true;
+            }
+        }
+    }
+    if !alts_ok_0 { return -1; }
+    loop {
+        let rep_saved_1 = pos;
+        rep_1: {
+            let alts_saved_2 = pos;
+            let mut alts_ok_2 = false;
+            alts_2_0: {
+                pos = alts_saved_2;
+                if pos >= chars.len() || !('a' <= chars[pos] <= 'z') { break alts_2_0; }
+                pos += 1;
+                alts_ok_2 = true;
+            }
+            if !alts_ok_2 {
+                alts_2_1: {
+                    pos = alts_saved_2;
+                    if pos >= chars.len() || !('A' <= chars[pos] <= 'Z') { break alts_2_1; }
+                    pos += 1;
+                    alts_ok_2 = true;
+                }
+                if !alts_ok_2 {
+                    alts_2_2: {
+                        pos = alts_saved_2;
+                        if pos >= chars.len() || !('0' <= chars[pos] <= '9') { break alts_2_2; }
+                        pos += 1;
+                        alts_ok_2 = true;
+                    }
+                    if !alts_ok_2 {
+                        alts_2_3: {
+                            pos = alts_saved_2;
+                            if pos >= chars.len() || chars[pos] != '_' { break alts_2_3; }
+                            pos += 1;
+                            alts_ok_2 = true;
+                        }
+                    }
+                }
+            }
+            if !alts_ok_2 { break rep_1; }
+            continue;
+        }
+        pos = rep_saved_1;
+        break;
+    }
+    return pos;
+}
+
+fn try_ws(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !(false || chars[pos] == ' ' || chars[pos] == '\t' || chars[pos] == '\n') { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_3 = pos;
+        rep_3: {
+            if pos >= chars.len() { break rep_3; }
+            if !(false || chars[pos] == ' ' || chars[pos] == '\t' || chars[pos] == '\n') { break rep_3; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_3;
+        break;
+    }
+    return pos;
+}
+
+fn try_lit_star(chars: &Array<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '*' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_comma(chars: &Array<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != ',' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_gtgt(chars: &Array<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '>' { return -1; }
+    if pos + 1 >= chars.len() || chars[pos + 1] != '>' { return -1; }
+    return pos + 2;
+}
+
+pub fn tokenize(input: &String) -> Array<Token> {
+    let mut lexer = Lexer::new(input);
+    let mut tokens: Array<Token> = [];
+    let mut trivia: Array<Token> = [];
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == '\t' || first_char == '\n' || first_char == ' ' {
+            end = try_ws(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if first_char == '*' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_STAR; }
+        } else if first_char == ',' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_COMMA; }
+        } else if first_char == '>' {
+            end = try_lit_gtgt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_GTGT; }
+        } else if first_char == '_' {
+            end = try_id(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else if 'a' <= first_char <= 'z' {
+            end = try_id(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else if 'A' <= first_char <= 'Z' {
+            end = try_id(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else {
+            end = try_id(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        }
+        if best_end <= start {
+            let tok = Token::with_trivia(TK_ERROR, lexer.slice(start, start + 1), Span::new(start, start + 1), trivia);
+            tokens.push(tok);
+            trivia = [];
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                trivia.push(Token::new(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end)));
+            } else {
+                let tok = Token::with_trivia(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), trivia);
+                tokens.push(tok);
+                trivia = [];
+            }
+            lexer.pos = best_end;
+        }
+    }
+    tokens.push(Token::with_trivia(TK_EOF, LexerSlice::empty(&lexer.chars), Span::new(lexer.pos, lexer.pos), trivia));
+    return tokens;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_ID => "ID",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        TK_LIT_STAR => "TK_LIT_STAR",
+        TK_LIT_COMMA => "TK_LIT_COMMA",
+        TK_LIT_GTGT => "TK_LIT_GTGT",
+        _ => "Unknown",
+    };
+}
+
+struct Parser {
+    tokens: Array<Token>,
+    pos: i32,
+}
+
+impl Parser {
+    fn new(tokens: Array<Token>) -> Parser {
+        return Parser { tokens, pos: 0 };
+    }
+
+    fn peek(&self) -> &Token {
+        return &self.tokens[self.pos];
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.tokens[self.pos].kind;
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.tokens.len() { return TK_EOF; }
+        return self.tokens[idx].kind;
+    }
+
+    fn advance(&mut self) -> Token {
+        let tok = self.tokens[self.pos];
+        self.pos += 1;
+        return tok;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens[self.pos - 1].span.end;
+    }
+
+    fn expect(&mut self, kind: i32) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind == kind {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        let name = token_kind_name(kind);
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected {name}, got "{tok.text}"`,
+            tok.span,
+            [name],
+        ));
+    }
+
+    fn fail(&self, name: String) -> Result<Token, ParseError> {
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected {name}, got "{tok.text}"`,
+            tok.span,
+            [name],
+        ));
+    }
+
+    fn match_any(&mut self) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind != TK_EOF {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected any token, got "{tok.text}"`,
+            tok.span,
+            ["any token"],
+        ));
+    }
+
+    fn match_not(&mut self, excluded: Array<i32>) -> Result<Token, ParseError> {
+        let k = self.tokens[self.pos].kind;
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                return Result::<Token, ParseError>::Ok(self.advance());
+            }
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `unexpected token "{tok.text}"`,
+            tok.span,
+            ["set complement"],
+        ));
+    }
+}
+
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let mut pos = pos;
+    pos = scan_expr(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_ID { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_expr_lr_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_STAR { return -1; }
+    pos += 1;
+    pos = scan_expr(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_expr_lr_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { return -1; }
+    pos += 1;
+    pos = scan_expr(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_expr_lr_2(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_GTGT { return -1; }
+    pos += 1;
+    pos = scan_expr(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_expr(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let mut pos = scan_expr_atom(tokens, pos);
+    if pos < 0 { return -1; }
+    loop {
+        let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
+        if suffix_kind == TK_LIT_STAR {
+            if 3 >= min_prec {
+                let lr_saved_pos = pos;
+                pos = scan_expr_lr_0(tokens, pos);
+                if pos < 0 { pos = lr_saved_pos; break; }
+            } else {
+                break;
+            }
+        } else if suffix_kind == TK_LIT_COMMA {
+            if 2 >= min_prec {
+                let lr_saved_pos = pos;
+                pos = scan_expr_lr_1(tokens, pos);
+                if pos < 0 { pos = lr_saved_pos; break; }
+            } else {
+                break;
+            }
+        } else if suffix_kind == TK_LIT_GTGT {
+            if 1 >= min_prec {
+                let lr_saved_pos = pos;
+                pos = scan_expr_lr_2(tokens, pos);
+                if pos < 0 { pos = lr_saved_pos; break; }
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    return pos;
+}
+
+fn parse_s(p: &mut Parser) -> Result<SNode, ParseError> {
+    let start = p.peek().span.start;
+    let expr = parse_expr(p)?;
+    let eof = p.expect(TK_EOF)?;
+    return Result::<SNode, ParseError>::Ok(SNode {
+        span: Span::new(start, p.last_end()),
+        expr,
+        eof,
+    });
+}
+
+fn parse_expr_atom(p: &mut Parser) -> Result<ExprNode, ParseError> {
+    let start = p.peek().span.start;
+    let kind = p.peek_kind();
+    if kind == TK_ID {
+        let id = p.expect(TK_ID)?;
+        return Result::<ExprNode, ParseError>::Ok(ExprNode::JustId(ExprJustId {
+            span: Span::new(start, p.last_end()),
+            id,
+        }));
+    }
+    return Result::<ExprNode, ParseError>::Err(ParseError::new(
+        "expected expr",
+        p.peek().span,
+        ["TK_ID"],
+    ));
+}
+
+fn parse_expr_lr_0(p: &mut Parser, left: ExprNode, start: i32) -> Result<ExprNode, ParseError> {
+    let star = p.expect(TK_LIT_STAR)?;
+    let expr = parse_expr(p, 4)?;
+    let a_2 = expr;
+    return Result::<ExprNode, ParseError>::Ok(ExprNode::Factor(ExprFactor {
+        span: Span::new(start, p.last_end()),
+        a: left,
+        star,
+        a_2,
+    }));
+}
+
+fn parse_expr_lr_1(p: &mut Parser, left: ExprNode, start: i32) -> Result<ExprNode, ParseError> {
+    let comma = p.expect(TK_LIT_COMMA)?;
+    let expr = parse_expr(p, 3)?;
+    let b_2: Array<ExprNode> = [expr];
+    return Result::<ExprNode, ParseError>::Ok(ExprNode::Comma(ExprComma {
+        span: Span::new(start, p.last_end()),
+        b: [left] as Array<ExprNode>,
+        comma,
+        b_2,
+    }));
+}
+
+fn parse_expr_lr_2(p: &mut Parser, left: ExprNode, start: i32) -> Result<ExprNode, ParseError> {
+    let lit_gtgt = p.expect(TK_LIT_GTGT)?;
+    let expr = parse_expr(p, 2)?;
+    let c = expr;
+    return Result::<ExprNode, ParseError>::Ok(ExprNode::Send(ExprSend {
+        span: Span::new(start, p.last_end()),
+        b: [left] as Array<ExprNode>,
+        lit_gtgt,
+        c,
+    }));
+}
+
+fn parse_expr(p: &mut Parser, min_prec: i32 = 0) -> Result<ExprNode, ParseError> {
+    let start = p.peek().span.start;
+    let mut result = parse_expr_atom(p)?;
+    loop {
+        let suffix_kind = p.peek_kind();
+        if suffix_kind == TK_LIT_STAR {
+            if 3 >= min_prec {
+                if scan_expr_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
+                result = parse_expr_lr_0(p, result, start)?;
+            } else {
+                break;
+            }
+        } else if suffix_kind == TK_LIT_COMMA {
+            if 2 >= min_prec {
+                if scan_expr_lr_1(&p.tokens, p.pos) < 0 {
+                    break;
+                }
+                result = parse_expr_lr_1(p, result, start)?;
+            } else {
+                break;
+            }
+        } else if suffix_kind == TK_LIT_GTGT {
+            if 1 >= min_prec {
+                if scan_expr_lr_2(&p.tokens, p.pos) < 0 {
+                    break;
+                }
+                result = parse_expr_lr_2(p, result, start)?;
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    return Result::<ExprNode, ParseError>::Ok(result);
+}
+
+pub fn parse(input: &String) -> Result<SNode, ParseError> {
+    let tokens = tokenize(input);
+    let mut parser = Parser::new(tokens);
+    return parse_s(&mut parser);
+}
+
+pub fn walk_s<V: Visitor>(v: &mut V, node: &SNode) {
+    v.enter_rule(&"s", &node.span);
+    walk_expr(v, &node.expr);
+    v.visit_token(&node.eof);
+    v.exit_rule(&"s", &node.span);
+}
+
+pub fn walk_expr<V: Visitor>(v: &mut V, node: &ExprNode) {
+    match node {
+        Factor(n) => {
+            v.enter_rule(&"expr", &n.span);
+            walk_expr(v, &n.a);
+            v.visit_token(&n.star);
+            walk_expr(v, &n.a_2);
+            v.exit_rule(&"expr", &n.span);
+        }
+        Comma(n) => {
+            v.enter_rule(&"expr", &n.span);
+            for let item of &n.b {
+                walk_expr(v, item);
+            }
+            v.visit_token(&n.comma);
+            for let item of &n.b_2 {
+                walk_expr(v, item);
+            }
+            v.exit_rule(&"expr", &n.span);
+        }
+        Send(n) => {
+            v.enter_rule(&"expr", &n.span);
+            for let item of &n.b {
+                walk_expr(v, item);
+            }
+            v.visit_token(&n.lit_gtgt);
+            walk_expr(v, &n.c);
+            v.exit_rule(&"expr", &n.span);
+        }
+        JustId(n) => {
+            v.enter_rule(&"expr", &n.span);
+            v.visit_token(&n.id);
+            v.exit_rule(&"expr", &n.span);
+        }
+    }
+}
+
+pub fn to_tree(node: &SNode) -> CstNode {
+    let mut recorder = TreeRecorder::new();
+    walk_s(&mut recorder, node);
+    return recorder.build();
+}
+

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList2_3/ReturnValueAndActionsList2_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList2_3/ReturnValueAndActionsList2_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-292efe417a055f21",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList2_3.g4",
     "hash": "d020b96fea143032cbc0f3f58b543f99e6ee62a9921e2c0c402a721dfeb8e67c"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList2_3/ReturnValueAndActionsList2_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList2_3/ReturnValueAndActionsList2_3.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-292efe417a055f21",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "primary": {
+    "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList2_3.g4",
+    "hash": "d020b96fea143032cbc0f3f58b543f99e6ee62a9921e2c0c402a721dfeb8e67c"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList2_3/t.wado",
+      "hash": "266984b920ab4dfeb88d90f09d0872f572af0f078004a832cf7029c2e95a44f3",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList2_3/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList2_3/t.wado
@@ -1,0 +1,1051 @@
+#![generated(by = "local:src/generator.wado", sources = ["../../grammars/LeftRecursion/ReturnValueAndActionsList2_3.g4"])]
+#![generated(by = "gale", sources = ["T.g4"])]
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &Array<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &Array<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &Array<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: Array<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// ParseError represents a parse failure with location and expected tokens.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: Array<String>,
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: Array<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+}
+
+/// CstChild is either a terminal token or a non-terminal sub-tree.
+pub variant CstChild {
+    Token(Token),
+    Node(CstNode),
+}
+
+/// CstNode is a generic (untyped) concrete syntax tree node.
+pub struct CstNode {
+    pub name: String,
+    pub span: Span,
+    pub children: Array<CstChild>,
+}
+
+impl CstNode {
+    /// Produce an ANTLR4-style S-expression representation of this tree.
+    /// Rule nodes become `(name child1 child2 ...)`, tokens become their text.
+    /// Tokens with empty text (e.g. EOF) are omitted.
+    pub fn to_string_tree(&self) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(out: &mut String, node: &CstNode) {
+    out.push_str(`({node.name}`);
+    for let child of &node.children {
+        if let Token(t) = *child {
+            if !t.text.is_empty() {
+                out.push_str(` {t.text}`);
+            }
+        } else if let Node(n) = *child {
+            out.push_str(" ");
+            cst_to_string_tree_impl(out, n);
+        }
+    }
+    out.push_str(")");
+}
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Highlight override: when inside a specific rule, override the capture for a token kind.
+pub struct HighlightOverride {
+    pub rule_name: String,
+    pub token_kind: i32,
+    pub capture: String,
+}
+
+/// Highlight mapping: defaults by token kind + context-aware overrides.
+pub struct HighlightMapping {
+    pub defaults: Array<String>,
+    pub overrides: Array<HighlightOverride>,
+}
+
+/// A single highlight capture: a named range in the source text.
+pub struct HighlightCapture {
+    pub capture: String,
+    pub start: i32,
+    pub end: i32,
+}
+
+/// HighlightVisitor collects highlight captures during a CST walk.
+pub struct HighlightVisitor {
+    mapping: HighlightMapping,
+    rule_stack: Array<String>,
+    pub captures: Array<HighlightCapture>,
+}
+
+impl HighlightVisitor {
+    pub fn new(mapping: HighlightMapping) -> HighlightVisitor {
+        return HighlightVisitor { mapping, rule_stack: [], captures: [] };
+    }
+
+    fn classify(&self, kind: i32) -> String {
+        for let ov of &self.mapping.overrides {
+            if ov.token_kind == kind {
+                for let rule of &self.rule_stack {
+                    if *rule == ov.rule_name {
+                        return ov.capture;
+                    }
+                }
+            }
+        }
+        if kind >= 0 && kind < self.mapping.defaults.len() {
+            return self.mapping.defaults[kind];
+        }
+        return "";
+    }
+}
+
+impl Visitor for HighlightVisitor {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+        self.rule_stack.push(*name);
+    }
+
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+        if !self.rule_stack.is_empty() {
+            let last = self.rule_stack.len() - 1;
+            let mut new_stack: Array<String> = [];
+            for let mut i = 0; i < last; i += 1 {
+                new_stack.push(self.rule_stack[i]);
+            }
+            self.rule_stack = new_stack;
+        }
+    }
+
+    fn visit_token(&mut self, token: &Token) {
+        for let trivia of &token.leading_trivia {
+            let cap = self.classify(trivia.kind);
+            if !cap.is_empty() {
+                self.captures.push(HighlightCapture { capture: cap, start: trivia.span.start, end: trivia.span.end });
+            }
+        }
+        if token.text.is_empty() {
+            return;
+        }
+        let cap = self.classify(token.kind);
+        if !cap.is_empty() {
+            self.captures.push(HighlightCapture { capture: cap, start: token.span.start, end: token.span.end });
+        }
+    }
+}
+
+fn escape_html(out: &mut String, text: &String) {
+    for let c of text.chars() {
+        if c == '&' {
+            out.push_str("&amp;");
+        } else if c == '<' {
+            out.push_str("&lt;");
+        } else if c == '>' {
+            out.push_str("&gt;");
+        } else if c == '"' {
+            out.push_str("&quot;");
+        } else {
+            out.push(c);
+        }
+    }
+}
+
+fn escape_html_char(out: &mut String, c: char) {
+    if c == '&' {
+        out.push_str("&amp;");
+    } else if c == '<' {
+        out.push_str("&lt;");
+    } else if c == '>' {
+        out.push_str("&gt;");
+    } else if c == '"' {
+        out.push_str("&quot;");
+    } else {
+        out.push(c);
+    }
+}
+
+fn push_class(out: &mut String, capture: &String) {
+    for let c of capture.chars() {
+        if c == '.' {
+            out.push(' ');
+        } else {
+            out.push(c);
+        }
+    }
+}
+
+/// Produce a highlighted HTML fragment from source text and captures.
+/// Captures must be sorted by start position (as produced by HighlightVisitor).
+pub fn highlight_html(source: &String, captures: &Array<HighlightCapture>) -> String {
+    let mut out = String::with_capacity(source.len() * 5);
+    let mut pos = 0;
+    let mut iter = source.chars();
+    for let cap of captures {
+        while pos < cap.start {
+            if let Some(c) = iter.next() {
+                escape_html_char(&mut out, c);
+            }
+            pos += 1;
+        }
+        out.push_str("<span class=\"");
+        push_class(&mut out, &cap.capture);
+        out.push_str("\">");
+        let end = cap.end;
+        while pos < end {
+            if let Some(c) = iter.next() {
+                escape_html_char(&mut out, c);
+            }
+            pos += 1;
+        }
+        out.push_str("</span>");
+    }
+    while let Some(c) = iter.next() {
+        escape_html_char(&mut out, c);
+    }
+    return out;
+}
+
+fn substr(chars: &Array<char>, start: i32, end: i32) -> String {
+    let mut out = String::with_capacity(end - start);
+    let mut i = start;
+    while i < end && i < chars.len() {
+        out.push(chars[i]);
+        i += 1;
+    }
+    return out;
+}
+
+/// Visitor trait for walking typed CST nodes.
+/// Default methods are no-ops; override to add behavior.
+pub trait Visitor {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+    }
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+    }
+    fn visit_token(&mut self, token: &Token) {
+    }
+}
+
+/// TreeRecorder is a Visitor that records events for building a CstNode tree.
+pub struct TreeRecorder {
+    events: Array<TreeEvent>,
+}
+
+variant TreeEvent {
+    Enter(TreeEnterInfo),
+    Exit,
+    VisitToken(Token),
+}
+
+struct TreeEnterInfo {
+    name: String,
+    span: Span,
+}
+
+impl TreeRecorder {
+    pub fn new() -> TreeRecorder {
+        return TreeRecorder { events: [] };
+    }
+
+    pub fn build(&self) -> CstNode {
+        let mut pos = 0;
+        return tree_build_node(&self.events, &mut pos);
+    }
+}
+
+impl Visitor for TreeRecorder {
+    fn enter_rule(&mut self, name: &String, span: &Span) {
+        self.events.push(TreeEvent::Enter(TreeEnterInfo { name: *name, span: *span }));
+    }
+
+    fn exit_rule(&mut self, name: &String, span: &Span) {
+        self.events.push(TreeEvent::Exit);
+    }
+
+    fn visit_token(&mut self, token: &Token) {
+        self.events.push(TreeEvent::VisitToken(*token));
+    }
+}
+
+fn tree_build_node(events: &Array<TreeEvent>, pos: &mut i32) -> CstNode {
+    if let Enter(info) = events[*pos] {
+        *pos += 1;
+        let mut children: Array<CstChild> = [];
+        loop {
+            if *pos >= events.len() {
+                break;
+            }
+            let ev = events[*pos];
+            if let Exit = ev {
+                *pos += 1;
+                break;
+            }
+            if let Enter(_) = ev {
+                children.push(CstChild::Node(tree_build_node(events, pos)));
+            } else if let VisitToken(t) = ev {
+                children.push(CstChild::Token(t));
+                *pos += 1;
+            }
+        }
+        return CstNode { name: info.name, span: info.span, children };
+    }
+    panic("TreeRecorder: expected Enter event");
+    return CstNode { name: "", span: Span::new(0, 0), children: [] };
+}
+
+pub enum TokenKind {
+    ID,
+    WS,
+    Eof,
+    Error,
+}
+
+pub struct SNode {
+    pub span: Span,
+    pub expr: ExprNode,
+    pub eof: Token,
+}
+
+pub variant ExprNode {
+    Factor(ExprFactor),
+    Comma(ExprComma),
+    Send(ExprSend),
+    JustId(ExprJustId),
+}
+
+pub struct ExprFactor {
+    pub span: Span,
+    pub a: ExprNode,
+    pub star: Token,
+    pub a_2: ExprNode,
+}
+
+pub struct ExprComma {
+    pub span: Span,
+    pub b: Array<ExprNode>,
+    pub comma: Token,
+    pub b_2: Array<ExprNode>,
+}
+
+pub struct ExprSend {
+    pub span: Span,
+    pub b: Array<ExprNode>,
+    pub lit_gtgt: Token,
+    pub c: ExprNode,
+}
+
+pub struct ExprJustId {
+    pub span: Span,
+    pub id: Token,
+}
+
+global TK_ID: i32 = 0;
+global TK_WS: i32 = 1;
+global TK_EOF: i32 = 2;
+global TK_ERROR: i32 = 3;
+global TK_LIT_STAR: i32 = 4;
+global TK_LIT_COMMA: i32 = 5;
+global TK_LIT_GTGT: i32 = 6;
+
+struct Lexer {
+    chars: Array<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.chars().collect(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_id(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    let alts_saved_0 = pos;
+    let mut alts_ok_0 = false;
+    alts_0_0: {
+        pos = alts_saved_0;
+        if pos >= chars.len() || !('a' <= chars[pos] <= 'z') { break alts_0_0; }
+        pos += 1;
+        alts_ok_0 = true;
+    }
+    if !alts_ok_0 {
+        alts_0_1: {
+            pos = alts_saved_0;
+            if pos >= chars.len() || !('A' <= chars[pos] <= 'Z') { break alts_0_1; }
+            pos += 1;
+            alts_ok_0 = true;
+        }
+        if !alts_ok_0 {
+            alts_0_2: {
+                pos = alts_saved_0;
+                if pos >= chars.len() || chars[pos] != '_' { break alts_0_2; }
+                pos += 1;
+                alts_ok_0 = true;
+            }
+        }
+    }
+    if !alts_ok_0 { return -1; }
+    loop {
+        let rep_saved_1 = pos;
+        rep_1: {
+            let alts_saved_2 = pos;
+            let mut alts_ok_2 = false;
+            alts_2_0: {
+                pos = alts_saved_2;
+                if pos >= chars.len() || !('a' <= chars[pos] <= 'z') { break alts_2_0; }
+                pos += 1;
+                alts_ok_2 = true;
+            }
+            if !alts_ok_2 {
+                alts_2_1: {
+                    pos = alts_saved_2;
+                    if pos >= chars.len() || !('A' <= chars[pos] <= 'Z') { break alts_2_1; }
+                    pos += 1;
+                    alts_ok_2 = true;
+                }
+                if !alts_ok_2 {
+                    alts_2_2: {
+                        pos = alts_saved_2;
+                        if pos >= chars.len() || !('0' <= chars[pos] <= '9') { break alts_2_2; }
+                        pos += 1;
+                        alts_ok_2 = true;
+                    }
+                    if !alts_ok_2 {
+                        alts_2_3: {
+                            pos = alts_saved_2;
+                            if pos >= chars.len() || chars[pos] != '_' { break alts_2_3; }
+                            pos += 1;
+                            alts_ok_2 = true;
+                        }
+                    }
+                }
+            }
+            if !alts_ok_2 { break rep_1; }
+            continue;
+        }
+        pos = rep_saved_1;
+        break;
+    }
+    return pos;
+}
+
+fn try_ws(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !(false || chars[pos] == ' ' || chars[pos] == '\t' || chars[pos] == '\n') { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_3 = pos;
+        rep_3: {
+            if pos >= chars.len() { break rep_3; }
+            if !(false || chars[pos] == ' ' || chars[pos] == '\t' || chars[pos] == '\n') { break rep_3; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_3;
+        break;
+    }
+    return pos;
+}
+
+fn try_lit_star(chars: &Array<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '*' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_comma(chars: &Array<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != ',' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_gtgt(chars: &Array<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '>' { return -1; }
+    if pos + 1 >= chars.len() || chars[pos + 1] != '>' { return -1; }
+    return pos + 2;
+}
+
+pub fn tokenize(input: &String) -> Array<Token> {
+    let mut lexer = Lexer::new(input);
+    let mut tokens: Array<Token> = [];
+    let mut trivia: Array<Token> = [];
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == '\t' || first_char == '\n' || first_char == ' ' {
+            end = try_ws(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if first_char == '*' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_STAR; }
+        } else if first_char == ',' {
+            if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_COMMA; }
+        } else if first_char == '>' {
+            end = try_lit_gtgt(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_GTGT; }
+        } else if first_char == '_' {
+            end = try_id(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else if 'a' <= first_char <= 'z' {
+            end = try_id(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else if 'A' <= first_char <= 'Z' {
+            end = try_id(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else {
+            end = try_id(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        }
+        if best_end <= start {
+            let tok = Token::with_trivia(TK_ERROR, lexer.slice(start, start + 1), Span::new(start, start + 1), trivia);
+            tokens.push(tok);
+            trivia = [];
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                trivia.push(Token::new(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end)));
+            } else {
+                let tok = Token::with_trivia(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), trivia);
+                tokens.push(tok);
+                trivia = [];
+            }
+            lexer.pos = best_end;
+        }
+    }
+    tokens.push(Token::with_trivia(TK_EOF, LexerSlice::empty(&lexer.chars), Span::new(lexer.pos, lexer.pos), trivia));
+    return tokens;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_ID => "ID",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        TK_LIT_STAR => "TK_LIT_STAR",
+        TK_LIT_COMMA => "TK_LIT_COMMA",
+        TK_LIT_GTGT => "TK_LIT_GTGT",
+        _ => "Unknown",
+    };
+}
+
+struct Parser {
+    tokens: Array<Token>,
+    pos: i32,
+}
+
+impl Parser {
+    fn new(tokens: Array<Token>) -> Parser {
+        return Parser { tokens, pos: 0 };
+    }
+
+    fn peek(&self) -> &Token {
+        return &self.tokens[self.pos];
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.tokens[self.pos].kind;
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.tokens.len() { return TK_EOF; }
+        return self.tokens[idx].kind;
+    }
+
+    fn advance(&mut self) -> Token {
+        let tok = self.tokens[self.pos];
+        self.pos += 1;
+        return tok;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens[self.pos - 1].span.end;
+    }
+
+    fn expect(&mut self, kind: i32) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind == kind {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        let name = token_kind_name(kind);
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected {name}, got "{tok.text}"`,
+            tok.span,
+            [name],
+        ));
+    }
+
+    fn fail(&self, name: String) -> Result<Token, ParseError> {
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected {name}, got "{tok.text}"`,
+            tok.span,
+            [name],
+        ));
+    }
+
+    fn match_any(&mut self) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind != TK_EOF {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `expected any token, got "{tok.text}"`,
+            tok.span,
+            ["any token"],
+        ));
+    }
+
+    fn match_not(&mut self, excluded: Array<i32>) -> Result<Token, ParseError> {
+        let k = self.tokens[self.pos].kind;
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                return Result::<Token, ParseError>::Ok(self.advance());
+            }
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(ParseError::new(
+            `unexpected token "{tok.text}"`,
+            tok.span,
+            ["set complement"],
+        ));
+    }
+}
+
+fn scan_s(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let mut pos = pos;
+    pos = scan_expr(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos].kind != TK_EOF { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_expr_atom(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_ID { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_expr_lr_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_STAR { return -1; }
+    pos += 1;
+    pos = scan_expr(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_expr_lr_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_COMMA { return -1; }
+    pos += 1;
+    pos = scan_expr(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_expr_lr_2(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_LIT_GTGT { return -1; }
+    pos += 1;
+    pos = scan_expr(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_expr(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let mut pos = scan_expr_atom(tokens, pos);
+    if pos < 0 { return -1; }
+    loop {
+        let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
+        if suffix_kind == TK_LIT_STAR {
+            if 3 >= min_prec {
+                let lr_saved_pos = pos;
+                pos = scan_expr_lr_0(tokens, pos);
+                if pos < 0 { pos = lr_saved_pos; break; }
+            } else {
+                break;
+            }
+        } else if suffix_kind == TK_LIT_COMMA {
+            if 2 >= min_prec {
+                let lr_saved_pos = pos;
+                pos = scan_expr_lr_1(tokens, pos);
+                if pos < 0 { pos = lr_saved_pos; break; }
+            } else {
+                break;
+            }
+        } else if suffix_kind == TK_LIT_GTGT {
+            if 1 >= min_prec {
+                let lr_saved_pos = pos;
+                pos = scan_expr_lr_2(tokens, pos);
+                if pos < 0 { pos = lr_saved_pos; break; }
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    return pos;
+}
+
+fn parse_s(p: &mut Parser) -> Result<SNode, ParseError> {
+    let start = p.peek().span.start;
+    let expr = parse_expr(p)?;
+    let eof = p.expect(TK_EOF)?;
+    return Result::<SNode, ParseError>::Ok(SNode {
+        span: Span::new(start, p.last_end()),
+        expr,
+        eof,
+    });
+}
+
+fn parse_expr_atom(p: &mut Parser) -> Result<ExprNode, ParseError> {
+    let start = p.peek().span.start;
+    let kind = p.peek_kind();
+    if kind == TK_ID {
+        let id = p.expect(TK_ID)?;
+        return Result::<ExprNode, ParseError>::Ok(ExprNode::JustId(ExprJustId {
+            span: Span::new(start, p.last_end()),
+            id,
+        }));
+    }
+    return Result::<ExprNode, ParseError>::Err(ParseError::new(
+        "expected expr",
+        p.peek().span,
+        ["TK_ID"],
+    ));
+}
+
+fn parse_expr_lr_0(p: &mut Parser, left: ExprNode, start: i32) -> Result<ExprNode, ParseError> {
+    let star = p.expect(TK_LIT_STAR)?;
+    let expr = parse_expr(p, 4)?;
+    let a_2 = expr;
+    return Result::<ExprNode, ParseError>::Ok(ExprNode::Factor(ExprFactor {
+        span: Span::new(start, p.last_end()),
+        a: left,
+        star,
+        a_2,
+    }));
+}
+
+fn parse_expr_lr_1(p: &mut Parser, left: ExprNode, start: i32) -> Result<ExprNode, ParseError> {
+    let comma = p.expect(TK_LIT_COMMA)?;
+    let expr = parse_expr(p, 3)?;
+    let b_2: Array<ExprNode> = [expr];
+    return Result::<ExprNode, ParseError>::Ok(ExprNode::Comma(ExprComma {
+        span: Span::new(start, p.last_end()),
+        b: [left] as Array<ExprNode>,
+        comma,
+        b_2,
+    }));
+}
+
+fn parse_expr_lr_2(p: &mut Parser, left: ExprNode, start: i32) -> Result<ExprNode, ParseError> {
+    let lit_gtgt = p.expect(TK_LIT_GTGT)?;
+    let expr = parse_expr(p, 2)?;
+    let c = expr;
+    return Result::<ExprNode, ParseError>::Ok(ExprNode::Send(ExprSend {
+        span: Span::new(start, p.last_end()),
+        b: [left] as Array<ExprNode>,
+        lit_gtgt,
+        c,
+    }));
+}
+
+fn parse_expr(p: &mut Parser, min_prec: i32 = 0) -> Result<ExprNode, ParseError> {
+    let start = p.peek().span.start;
+    let mut result = parse_expr_atom(p)?;
+    loop {
+        let suffix_kind = p.peek_kind();
+        if suffix_kind == TK_LIT_STAR {
+            if 3 >= min_prec {
+                if scan_expr_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
+                result = parse_expr_lr_0(p, result, start)?;
+            } else {
+                break;
+            }
+        } else if suffix_kind == TK_LIT_COMMA {
+            if 2 >= min_prec {
+                if scan_expr_lr_1(&p.tokens, p.pos) < 0 {
+                    break;
+                }
+                result = parse_expr_lr_1(p, result, start)?;
+            } else {
+                break;
+            }
+        } else if suffix_kind == TK_LIT_GTGT {
+            if 1 >= min_prec {
+                if scan_expr_lr_2(&p.tokens, p.pos) < 0 {
+                    break;
+                }
+                result = parse_expr_lr_2(p, result, start)?;
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    return Result::<ExprNode, ParseError>::Ok(result);
+}
+
+pub fn parse(input: &String) -> Result<SNode, ParseError> {
+    let tokens = tokenize(input);
+    let mut parser = Parser::new(tokens);
+    return parse_s(&mut parser);
+}
+
+pub fn walk_s<V: Visitor>(v: &mut V, node: &SNode) {
+    v.enter_rule(&"s", &node.span);
+    walk_expr(v, &node.expr);
+    v.visit_token(&node.eof);
+    v.exit_rule(&"s", &node.span);
+}
+
+pub fn walk_expr<V: Visitor>(v: &mut V, node: &ExprNode) {
+    match node {
+        Factor(n) => {
+            v.enter_rule(&"expr", &n.span);
+            walk_expr(v, &n.a);
+            v.visit_token(&n.star);
+            walk_expr(v, &n.a_2);
+            v.exit_rule(&"expr", &n.span);
+        }
+        Comma(n) => {
+            v.enter_rule(&"expr", &n.span);
+            for let item of &n.b {
+                walk_expr(v, item);
+            }
+            v.visit_token(&n.comma);
+            for let item of &n.b_2 {
+                walk_expr(v, item);
+            }
+            v.exit_rule(&"expr", &n.span);
+        }
+        Send(n) => {
+            v.enter_rule(&"expr", &n.span);
+            for let item of &n.b {
+                walk_expr(v, item);
+            }
+            v.visit_token(&n.lit_gtgt);
+            walk_expr(v, &n.c);
+            v.exit_rule(&"expr", &n.span);
+        }
+        JustId(n) => {
+            v.enter_rule(&"expr", &n.span);
+            v.visit_token(&n.id);
+            v.exit_rule(&"expr", &n.span);
+        }
+    }
+}
+
+pub fn to_tree(node: &SNode) -> CstNode {
+    let mut recorder = TreeRecorder::new();
+    walk_s(&mut recorder, node);
+    return recorder.build();
+}
+

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPred/SemPred.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPred/SemPred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-960ef5ffa9d45556",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/SemPred.g4",
     "hash": "a19c17fc308f32463fe399a657b189a837ad4fa52afc1206ab0d1d8a38dcbe04"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/SemPred/t.wado",
-      "hash": "3178d7ce72c81e3c18423e4a318d30059a393b62dff2212fd5e8a952a751cdb1",
+      "hash": "b0c610e5acf350dc116004c2c10b679caa016d7778048736d2d39fd47adb02e6",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPred/SemPred.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPred/SemPred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-960ef5ffa9d45556",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/SemPred.g4",
     "hash": "a19c17fc308f32463fe399a657b189a837ad4fa52afc1206ab0d1d8a38dcbe04"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPred/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPred/t.wado
@@ -732,8 +732,9 @@ fn scan_a(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if suffix_kind == TK_ID {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_a_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -786,6 +787,9 @@ fn parse_a(p: &mut Parser, min_prec: i32 = 0) -> Result<ANode, ParseError> {
         let suffix_kind = p.peek_kind();
         if suffix_kind == TK_ID {
             if 1 >= min_prec {
+                if scan_a_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_a_lr_0(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPredFailOption/SemPredFailOption.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPredFailOption/SemPredFailOption.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a26551c8d0a65a59",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/SemPredFailOption.g4",
     "hash": "baacd97f45a8e197f2d9363c57506eebffd7f8862b34984e659ed317ac48a7d5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPredFailOption/SemPredFailOption.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPredFailOption/SemPredFailOption.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a26551c8d0a65a59",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/SemPredFailOption.g4",
     "hash": "baacd97f45a8e197f2d9363c57506eebffd7f8862b34984e659ed317ac48a7d5"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/SemPredFailOption/t.wado",
-      "hash": "e5da379b8ac01eed17e2dbb676605ad5b2aff20515d7b19d8c7a3e60362bac13",
+      "hash": "7c614b95907171a8e59e654cecd0b004d0577d122dadad67678d330d6e65f000",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPredFailOption/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPredFailOption/t.wado
@@ -732,8 +732,9 @@ fn scan_a(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if suffix_kind == TK_ID {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_a_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -786,6 +787,9 @@ fn parse_a(p: &mut Parser, min_prec: i32 = 0) -> Result<ANode, ParseError> {
         let suffix_kind = p.peek_kind();
         if suffix_kind == TK_ID {
             if 1 >= min_prec {
+                if scan_a_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_a_lr_0(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5d3495c986bff9bd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_1.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Simple_1/t.wado",
-      "hash": "6cd920a30d072ec76ac15fb5074b8672c55d26653ab5460e92df6d1694e41b5b",
+      "hash": "1898a5cc65f030a6d6f2c41939bc7c66dd4e4655a06f0ac9ea60e9ab9bedb368",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5d3495c986bff9bd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_1.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_1/t.wado
@@ -732,8 +732,9 @@ fn scan_a(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if suffix_kind == TK_ID {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_a_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -786,6 +787,9 @@ fn parse_a(p: &mut Parser, min_prec: i32 = 0) -> Result<ANode, ParseError> {
         let suffix_kind = p.peek_kind();
         if suffix_kind == TK_ID {
             if 1 >= min_prec {
+                if scan_a_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_a_lr_0(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-33ccce79b79bf5e2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_2.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-33ccce79b79bf5e2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_2.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Simple_2/t.wado",
-      "hash": "15e43a6f6fec31173026866d7d9a67a0dad0da29d1f1f26a71da6509e77fcfa1",
+      "hash": "ac1302085653d146440cd3d0fabe42934f97078870d363e0a1e66e0bd302f461",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_2/t.wado
@@ -732,8 +732,9 @@ fn scan_a(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if suffix_kind == TK_ID {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_a_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -786,6 +787,9 @@ fn parse_a(p: &mut Parser, min_prec: i32 = 0) -> Result<ANode, ParseError> {
         let suffix_kind = p.peek_kind();
         if suffix_kind == TK_ID {
             if 1 >= min_prec {
+                if scan_a_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_a_lr_0(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6dcbc071fc2f601e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_3.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/Simple_3/t.wado",
-      "hash": "2e1f9b64c7569d5857fe3137184a7ad2eaf9eb050fe2be9f48ca780f3c4a23d6",
+      "hash": "30f9b9f0fcddda4fb1651d02d04f414b322be35840572120926b94a5e09c021f",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6dcbc071fc2f601e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_3.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_3/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_3/t.wado
@@ -732,8 +732,9 @@ fn scan_a(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if suffix_kind == TK_ID {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_a_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -786,6 +787,9 @@ fn parse_a(p: &mut Parser, min_prec: i32 = 0) -> Result<ANode, ParseError> {
         let suffix_kind = p.peek_kind();
         if suffix_kind == TK_ID {
             if 1 >= min_prec {
+                if scan_a_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_a_lr_0(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-741313c066ff2cd5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_1.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_1/t.wado",
-      "hash": "8f9ec1b08b8b4621ca351426ac38ad441d7c7b9472519f2fdb66af8612b7bf31",
+      "hash": "a234b0b179bfe9e71c34e2d6fa5c2f7a46769eca59aa221c65bf5f5092e47ef3",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-741313c066ff2cd5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_1.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_1/t.wado
@@ -845,29 +845,33 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_1(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_2(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_3(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -961,24 +965,36 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
         let suffix_kind = p.peek_kind();
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_0(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                if scan_e_lr_1(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_1(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                if scan_e_lr_2(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_2(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                if scan_e_lr_3(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_3(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-381677e2c28357d8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_2.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-381677e2c28357d8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_2.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_2/t.wado",
-      "hash": "e3463fbe825dee70da9c87f35837099e83d479429890f83af360ba2a700d17e4",
+      "hash": "d6358b4e1306e3315e9f99470c014147bb8d89a5318ee65c158b20f5f4b4bfa0",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_2/t.wado
@@ -845,29 +845,33 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_1(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_2(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_3(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -961,24 +965,36 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
         let suffix_kind = p.peek_kind();
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_0(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                if scan_e_lr_1(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_1(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                if scan_e_lr_2(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_2(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                if scan_e_lr_3(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_3(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4d665f3c7d50cbb6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_3.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4d665f3c7d50cbb6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_3.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_3/t.wado",
-      "hash": "0a7bb6c9761eee622b731a266ac3e67ac5cbed1680e9990272ab7786f25a852d",
+      "hash": "f0c72003791324aa3149164815e7c5db9764ad2c7190fbc00ef4e5e1bb50659d",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_3/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_3/t.wado
@@ -845,29 +845,33 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_1(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_2(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_3(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -961,24 +965,36 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
         let suffix_kind = p.peek_kind();
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_0(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                if scan_e_lr_1(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_1(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                if scan_e_lr_2(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_2(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                if scan_e_lr_3(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_3(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-18d85335cd7b6ba7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_4.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-18d85335cd7b6ba7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_4.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_4/t.wado",
-      "hash": "dd550d01630fc0d944c589bf993021a279419ca304c9e75948fc6b5bf86597e0",
+      "hash": "1b32bead34aa0ee9b4b5850a6e1815c2a4e4270fa92b4f81d4721a0bce23c801",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_4/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_4/t.wado
@@ -845,29 +845,33 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_1(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_2(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_3(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -961,24 +965,36 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
         let suffix_kind = p.peek_kind();
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_0(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                if scan_e_lr_1(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_1(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                if scan_e_lr_2(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_2(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                if scan_e_lr_3(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_3(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6c0e1c831530f504",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_5.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6c0e1c831530f504",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_5.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_5/t.wado",
-      "hash": "43038506f6bce7be8f79d30a61048a75d204fb1b8de6517a606053d1c9d21583",
+      "hash": "000fca805d96f65214270fbffa591a0be338752e37c39bac8981ed45a2b66c7d",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_5/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_5/t.wado
@@ -845,29 +845,33 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_1(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_2(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_3(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -961,24 +965,36 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
         let suffix_kind = p.peek_kind();
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_0(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                if scan_e_lr_1(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_1(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                if scan_e_lr_2(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_2(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                if scan_e_lr_3(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_3(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d5dda292b3d95344",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_6.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d5dda292b3d95344",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_6.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_6/t.wado",
-      "hash": "7d85dfedbf579b59c62b3aad5a6bc72d85fa70e8372b4f5e678559047481625b",
+      "hash": "ac49d73acc314ffd1e6c7430dc5d76891b1b6eb5b6240e7ea8ac4e2630df8430",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_6/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_6/t.wado
@@ -845,29 +845,33 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_1(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_2(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_3(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -961,24 +965,36 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
         let suffix_kind = p.peek_kind();
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_0(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                if scan_e_lr_1(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_1(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                if scan_e_lr_2(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_2(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                if scan_e_lr_3(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_3(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bc586f7b630f85cb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_7.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bc586f7b630f85cb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_7.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_7/t.wado",
-      "hash": "c25dbdde491808187d2ecba03f0807b13c04f02cfb54f5922a677ac10c806559",
+      "hash": "99f0a9facc8f44f6325f1ea076f83f9ecbf1b199054325ccb456c8374073ab89",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_7/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_7/t.wado
@@ -845,29 +845,33 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_1(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_2(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_3(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -961,24 +965,36 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
         let suffix_kind = p.peek_kind();
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_0(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                if scan_e_lr_1(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_1(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                if scan_e_lr_2(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_2(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                if scan_e_lr_3(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_3(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b8fe4abc43e4380d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_8.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b8fe4abc43e4380d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_8.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_8/t.wado",
-      "hash": "852ddcac6423d347b1b6198138808b0cf303bb3712d22621ef18a275a45a7d5d",
+      "hash": "4044685b65f5f707536cd2f8be47ef9023796809febad211df1f0e2ace31a961",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_8/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_8/t.wado
@@ -845,29 +845,33 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_1(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_2(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_3(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -961,24 +965,36 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
         let suffix_kind = p.peek_kind();
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_0(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                if scan_e_lr_1(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_1(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                if scan_e_lr_2(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_2(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                if scan_e_lr_3(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_3(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ddd4f8db5f21632f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_9.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ddd4f8db5f21632f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_9.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_9/t.wado",
-      "hash": "e4cdc1e70df863b17aed4e9147e180e2801e85482c3c593230f924805db5d5df",
+      "hash": "e10d744f6b53e31c27b1635a6e25cf99229e469091125ce6989163ecfff0199e",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_9/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_9/t.wado
@@ -845,29 +845,33 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_1(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_2(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_3(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -961,24 +965,36 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
         let suffix_kind = p.peek_kind();
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_0(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                if scan_e_lr_1(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_1(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                if scan_e_lr_2(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_2(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                if scan_e_lr_3(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_3(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1a2ad3adca9a2a07",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_1.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_1/t.wado",
-      "hash": "63cfddde936c5fc020eb096cabf95b3de2e7000a3ce9f94fc4223a71c0e87f7a",
+      "hash": "9bccbb47a1bc3faed9321b6dd5e296bf2a6b399557a33c78fd37d4b49661a258",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1a2ad3adca9a2a07",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_1.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_1/t.wado
@@ -845,29 +845,33 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_1(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_2(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_3(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -961,24 +965,36 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
         let suffix_kind = p.peek_kind();
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_0(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                if scan_e_lr_1(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_1(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                if scan_e_lr_2(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_2(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                if scan_e_lr_3(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_3(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-eed4df03ca7a51f5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_2.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_2/t.wado",
-      "hash": "7e32519ca78eb72f23e5024afc0c9686da78aed13750b9c7b12aacb9134b32ce",
+      "hash": "d32ca4da309a2fa8f74919df8cc5167140f81aa94e708fecd050543dd4138a29",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-eed4df03ca7a51f5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_2.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_2/t.wado
@@ -845,29 +845,33 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_1(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_2(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_3(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -961,24 +965,36 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
         let suffix_kind = p.peek_kind();
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_0(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                if scan_e_lr_1(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_1(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                if scan_e_lr_2(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_2(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                if scan_e_lr_3(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_3(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bfcc2ec63de46569",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_3.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bfcc2ec63de46569",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_3.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_3/t.wado",
-      "hash": "3f0b8c65b4388f40caac3ffd97878f07ff2d6b30a16969e91b57f51a9f151c72",
+      "hash": "8cb3d81f17726057da6ea6193453a17b3f790953e00c3d2d524527b4e9dd3ae9",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_3/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_3/t.wado
@@ -845,29 +845,33 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_1(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_2(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_3(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -961,24 +965,36 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
         let suffix_kind = p.peek_kind();
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_0(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                if scan_e_lr_1(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_1(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                if scan_e_lr_2(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_2(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                if scan_e_lr_3(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_3(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-20cd1bcceb40fb33",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_4.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_4/t.wado",
-      "hash": "740688ed275e59b6e8a85aa3eb73c6860f81780c92a7c0f1c16b63164f70fcb1",
+      "hash": "4b0eb083b4b3c89f64f6566770ff529e0b835fbdbb53931b98e1aca99d1c2278",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-20cd1bcceb40fb33",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_4.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_4/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_4/t.wado
@@ -845,29 +845,33 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_1(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_2(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_3(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -961,24 +965,36 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
         let suffix_kind = p.peek_kind();
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_0(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                if scan_e_lr_1(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_1(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                if scan_e_lr_2(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_2(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                if scan_e_lr_3(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_3(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-cfe1fc1849a20141",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_5.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-cfe1fc1849a20141",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_5.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_5/t.wado",
-      "hash": "57ad67440ec648f42a68104776f8798f4c31ec2764a5dc00f1bbb21030a088a1",
+      "hash": "0ef07cd51e48e801002f832204aec108e52b122972dbeb29fa25122a5e5b640c",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_5/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_5/t.wado
@@ -845,29 +845,33 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_1(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_2(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_3(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -961,24 +965,36 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
         let suffix_kind = p.peek_kind();
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_0(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                if scan_e_lr_1(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_1(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                if scan_e_lr_2(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_2(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                if scan_e_lr_3(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_3(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-88482992acd5509f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_6.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-88482992acd5509f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_6.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_6/t.wado",
-      "hash": "52344531e09b549b438ae222718da63d83000d28b2ba5eaf366e278735fdff75",
+      "hash": "accef44c284f4e3c6762918c2d9b7fac5ef0b9617cc91060915320ee582280a2",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_6/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_6/t.wado
@@ -845,29 +845,33 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_1(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_2(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_3(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -961,24 +965,36 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
         let suffix_kind = p.peek_kind();
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_0(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                if scan_e_lr_1(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_1(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                if scan_e_lr_2(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_2(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                if scan_e_lr_3(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_3(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-78bbab6b273081fa",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_7.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_7/t.wado",
-      "hash": "3e0dd40a14baf855386c203be7fb0fcbcb229d6ff119e3a16f9373b83d263797",
+      "hash": "2a4eecbe80b15ff63b66417d5b740ea085e654a19a5ce669582d59036ad9b7d2",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-78bbab6b273081fa",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_7.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_7/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_7/t.wado
@@ -845,29 +845,33 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_1(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_2(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_3(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -961,24 +965,36 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
         let suffix_kind = p.peek_kind();
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_0(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                if scan_e_lr_1(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_1(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                if scan_e_lr_2(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_2(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                if scan_e_lr_3(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_3(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-03918ec747b14ad6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_8.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-03918ec747b14ad6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_8.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_8/t.wado",
-      "hash": "cece6b2866f6ddaf748cbf4bd45744f6a542ade234818f26b9941ad5d1c219e9",
+      "hash": "0a454c8fd2e1145a904303e9acf0f4cc74a55f71cf7a366a68af4aa995242e43",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_8/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_8/t.wado
@@ -845,29 +845,33 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_1(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_2(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_3(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -961,24 +965,36 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
         let suffix_kind = p.peek_kind();
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_0(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                if scan_e_lr_1(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_1(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                if scan_e_lr_2(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_2(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                if scan_e_lr_3(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_3(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a66253165de20181",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_9.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_9/t.wado",
-      "hash": "e2393ae7b2aee08ec1c37b44e237f292829d103d534f751e0e74f701d9ab8f31",
+      "hash": "4807cc6e245524a248775d5d8d32bee450a706effd9bfcfad9ce2f775240a428",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a66253165de20181",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_9.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_9/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_9/t.wado
@@ -845,29 +845,33 @@ fn scan_e(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_1(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_2(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_e_lr_3(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -961,24 +965,36 @@ fn parse_e(p: &mut Parser, min_prec: i32 = 0) -> Result<ENode, ParseError> {
         let suffix_kind = p.peek_kind();
         if suffix_kind == TK_LIT_STAR {
             if 4 >= min_prec {
+                if scan_e_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_0(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 3 >= min_prec {
+                if scan_e_lr_1(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_1(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTION {
             if 2 >= min_prec {
+                if scan_e_lr_2(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_2(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 1 >= min_prec {
+                if scan_e_lr_3(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_e_lr_3(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1d1b100d63f04166",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/ParserExec/BuildParseTree_TRUE.g4",
     "hash": "2a131cc48cdbfa4950f7c16ef0fcb51f4679926cabf71d403883a9fc01e9cb99"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/ParserExec/BuildParseTree_TRUE/t.wado",
-      "hash": "34a7ff94b11efd92640d6884ffb70029450b867f27f8d14222d03a4fa82535d1",
+      "hash": "0313fefae3a38553e9b5e7ad2e549a2d9f1278a7d3b40a3312218e34a892b439",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1d1b100d63f04166",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/ParserExec/BuildParseTree_TRUE.g4",
     "hash": "2a131cc48cdbfa4950f7c16ef0fcb51f4679926cabf71d403883a9fc01e9cb99"

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/BuildParseTree_TRUE/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/BuildParseTree_TRUE/t.wado
@@ -518,6 +518,20 @@ impl Lexer {
     }
 }
 
+fn try_a(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != 'A' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_b(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != 'B' { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn try_ws(chars: &Array<char>, start: i32) -> i32 {
     let mut pos = start;
     if pos >= chars.len() { return -1; }
@@ -537,18 +551,6 @@ fn try_ws(chars: &Array<char>, start: i32) -> i32 {
     return pos;
 }
 
-fn classify_keyword(chars: &Array<char>, start: i32, end: i32) -> i32 {
-    let len = end - start;
-    if len == 1 {
-        if chars[start].eq_ignore_ascii_case(&'a') {
-            if chars[start + 0] == 'a' { return TK_A; }
-        } else if chars[start].eq_ignore_ascii_case(&'b') {
-            if chars[start + 0] == 'b' { return TK_B; }
-        }
-    }
-    return -1;
-}
-
 pub fn tokenize(input: &String) -> Array<Token> {
     let mut lexer = Lexer::new(input);
     let mut tokens: Array<Token> = [];
@@ -562,10 +564,12 @@ pub fn tokenize(input: &String) -> Array<Token> {
         if first_char == '\t' || first_char == '\n' || first_char == '\r' || first_char == ' ' {
             end = try_ws(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_WS; }
-        }
-        if best_end > start {
-            let kw_kind = classify_keyword(&lexer.chars, start, best_end);
-            if kw_kind >= 0 { best_kind = kw_kind; }
+        } else if first_char == 'A' {
+            end = try_a(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_A; }
+        } else if first_char == 'B' {
+            end = try_b(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_B; }
         }
         if best_end <= start {
             let tok = Token::with_trivia(TK_ERROR, lexer.slice(start, start + 1), Span::new(start, start + 1), trivia);

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-94c0b5df15a69680",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/ParserExec/PredictionIssue334.g4",
     "hash": "05f509013c98f1d1ef907d23c43aa328f3c9ee0ad9166b21ac03dbc715ee8542"

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-94c0b5df15a69680",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/ParserExec/PredictionIssue334.g4",
     "hash": "05f509013c98f1d1ef907d23c43aa328f3c9ee0ad9166b21ac03dbc715ee8542"

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3ebf8faf7a4261df",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/ParserExec/PredictionMode_LL.g4",
     "hash": "8542495134a20f622112aa07fc5cd71fcc1b8e3669f41ff329126b355c4df7f4"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/ParserExec/PredictionMode_LL/t.wado",
-      "hash": "d9bb3aa77685901c2c56cd8c66c527cad00d5c506bde2847d8cde4b674ecd7d0",
+      "hash": "15ed144c8c3e692950b3e56a1a7deb81375ce0ca0cc937c0f21928c464254ee1",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3ebf8faf7a4261df",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/ParserExec/PredictionMode_LL.g4",
     "hash": "8542495134a20f622112aa07fc5cd71fcc1b8e3669f41ff329126b355c4df7f4"

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionMode_LL/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionMode_LL/t.wado
@@ -533,6 +533,20 @@ impl Lexer {
     }
 }
 
+fn try_x(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != 'X' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_y(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != 'Y' { return -1; }
+    pos += 1;
+    return pos;
+}
+
 fn try_ws(chars: &Array<char>, start: i32) -> i32 {
     let mut pos = start;
     if pos >= chars.len() { return -1; }
@@ -552,18 +566,6 @@ fn try_ws(chars: &Array<char>, start: i32) -> i32 {
     return pos;
 }
 
-fn classify_keyword(chars: &Array<char>, start: i32, end: i32) -> i32 {
-    let len = end - start;
-    if len == 1 {
-        if chars[start].eq_ignore_ascii_case(&'x') {
-            if chars[start + 0] == 'x' { return TK_X; }
-        } else if chars[start].eq_ignore_ascii_case(&'y') {
-            if chars[start + 0] == 'y' { return TK_Y; }
-        }
-    }
-    return -1;
-}
-
 pub fn tokenize(input: &String) -> Array<Token> {
     let mut lexer = Lexer::new(input);
     let mut tokens: Array<Token> = [];
@@ -577,10 +579,12 @@ pub fn tokenize(input: &String) -> Array<Token> {
         if first_char == '\t' || first_char == '\n' || first_char == '\r' || first_char == ' ' {
             end = try_ws(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_WS; }
-        }
-        if best_end > start {
-            let kw_kind = classify_keyword(&lexer.chars, start, best_end);
-            if kw_kind >= 0 { best_kind = kw_kind; }
+        } else if first_char == 'X' {
+            end = try_x(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_X; }
+        } else if first_char == 'Y' {
+            end = try_y(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_Y; }
         }
         if best_end <= start {
             let tok = Token::with_trivia(TK_ERROR, lexer.slice(start, start + 1), Span::new(start, start + 1), trivia);

--- a/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_1/PredFromAltTestedInLoopBack_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_1/PredFromAltTestedInLoopBack_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3c84aa606fbeb863",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/PredFromAltTestedInLoopBack_1.g4",
     "hash": "b6144b334167648d1e1560be8a7590525c8b34cbba2e27d040c41026fa7c9323"

--- a/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_1/PredFromAltTestedInLoopBack_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_1/PredFromAltTestedInLoopBack_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3c84aa606fbeb863",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/PredFromAltTestedInLoopBack_1.g4",
     "hash": "b6144b334167648d1e1560be8a7590525c8b34cbba2e27d040c41026fa7c9323"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_1/t.wado",
-      "hash": "b711e9443e4106f88f4cc548a3e784fcf5ac8bfd585a74899a758be927fd901c",
+      "hash": "848440638801512a64d1a1a9ccdb2a75837fd2de186bde67eab6f9d8bc6c30a1",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_1/t.wado
@@ -545,14 +545,6 @@ fn try_lit_x(chars: &Array<char>, start: i32) -> i32 {
     return pos + 1;
 }
 
-fn classify_keyword(chars: &Array<char>, start: i32, end: i32) -> i32 {
-    let len = end - start;
-    if len == 1 {
-        if chars[start + 0] == 'x' { return TK_X; }
-    }
-    return -1;
-}
-
 pub fn tokenize(input: &String) -> Array<Token> {
     let mut lexer = Lexer::new(input);
     let mut tokens: Array<Token> = [];
@@ -570,10 +562,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_S; }
         } else if first_char == 'x' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_X; }
-        }
-        if best_end > start {
-            let kw_kind = classify_keyword(&lexer.chars, start, best_end);
-            if kw_kind >= 0 { best_kind = kw_kind; }
         }
         if best_end <= start {
             let tok = Token::with_trivia(TK_ERROR, lexer.slice(start, start + 1), Span::new(start, start + 1), trivia);

--- a/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7f162199fbfa5a4d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/PredFromAltTestedInLoopBack_2.g4",
     "hash": "b6144b334167648d1e1560be8a7590525c8b34cbba2e27d040c41026fa7c9323"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_2/t.wado",
-      "hash": "c50a30245fba68525b763c537d4c7774264c9e3e4e5a659aa5f834a72d76ee43",
+      "hash": "b7c69145abd4211dd39d7260457b26f643678a86d6454fde88e325a463b456f9",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7f162199fbfa5a4d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/PredFromAltTestedInLoopBack_2.g4",
     "hash": "b6144b334167648d1e1560be8a7590525c8b34cbba2e27d040c41026fa7c9323"

--- a/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_2/t.wado
@@ -545,14 +545,6 @@ fn try_lit_x(chars: &Array<char>, start: i32) -> i32 {
     return pos + 1;
 }
 
-fn classify_keyword(chars: &Array<char>, start: i32, end: i32) -> i32 {
-    let len = end - start;
-    if len == 1 {
-        if chars[start + 0] == 'x' { return TK_X; }
-    }
-    return -1;
-}
-
 pub fn tokenize(input: &String) -> Array<Token> {
     let mut lexer = Lexer::new(input);
     let mut tokens: Array<Token> = [];
@@ -570,10 +562,6 @@ pub fn tokenize(input: &String) -> Array<Token> {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_S; }
         } else if first_char == 'x' {
             if start + 1 > best_end { best_end = start + 1; best_kind = TK_LIT_X; }
-        }
-        if best_end > start {
-            let kw_kind = classify_keyword(&lexer.chars, start, best_end);
-            if kw_kind >= 0 { best_kind = kw_kind; }
         }
         if best_end <= start {
             let tok = Token::with_trivia(TK_ERROR, lexer.slice(start, start + 1), Span::new(start, start + 1), trivia);

--- a/package-gale/tests/generated/at_end_alt_gaps/at_end_alt_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/at_end_alt_gaps/at_end_alt_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-105bcd36568c5dd8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "grammars/at_end_alt_gaps.g4",
     "hash": "9cd47ca80f5762b4107f87ae05f1bce472bbfb8aca3c06ef0bdbf501ac519f82"

--- a/package-gale/tests/generated/at_end_alt_gaps/at_end_alt_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/at_end_alt_gaps/at_end_alt_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-105bcd36568c5dd8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "grammars/at_end_alt_gaps.g4",
     "hash": "9cd47ca80f5762b4107f87ae05f1bce472bbfb8aca3c06ef0bdbf501ac519f82"

--- a/package-gale/tests/generated/calculator/calculator.g4.kiln.json
+++ b/package-gale/tests/generated/calculator/calculator.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7fbe69e34c931e16",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "grammars/calculator.g4",
     "hash": "67431dad6dcc459fea7d4c448fb04944de2c4cf61ecd75d546aeccd93b4564d7"

--- a/package-gale/tests/generated/calculator/calculator.g4.kiln.json
+++ b/package-gale/tests/generated/calculator/calculator.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7fbe69e34c931e16",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "grammars/calculator.g4",
     "hash": "67431dad6dcc459fea7d4c448fb04944de2c4cf61ecd75d546aeccd93b4564d7"

--- a/package-gale/tests/generated/ci_rule_override/ci_rule_override.g4.kiln.json
+++ b/package-gale/tests/generated/ci_rule_override/ci_rule_override.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-66c270910e5642be",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "grammars/ci_rule_override.g4",
     "hash": "6efdfe55ecb215bf526900a32a11c664a57c9e14d61c6a67758f870adc73d09b"

--- a/package-gale/tests/generated/ci_rule_override/ci_rule_override.g4.kiln.json
+++ b/package-gale/tests/generated/ci_rule_override/ci_rule_override.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-66c270910e5642be",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "grammars/ci_rule_override.g4",
     "hash": "6efdfe55ecb215bf526900a32a11c664a57c9e14d61c6a67758f870adc73d09b"

--- a/package-gale/tests/generated/ci_sql/ci_sql.g4.kiln.json
+++ b/package-gale/tests/generated/ci_sql/ci_sql.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b9bfa38391d7f122",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "grammars/ci_sql.g4",
     "hash": "41b72934417dd2f6fa0359722ce53ca05cd10cccde08fd9f3d0d58018f2137fe"

--- a/package-gale/tests/generated/ci_sql/ci_sql.g4.kiln.json
+++ b/package-gale/tests/generated/ci_sql/ci_sql.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b9bfa38391d7f122",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "grammars/ci_sql.g4",
     "hash": "41b72934417dd2f6fa0359722ce53ca05cd10cccde08fd9f3d0d58018f2137fe"

--- a/package-gale/tests/generated/css3/css3Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/css3/css3Lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fa4a5fa8cced30ae",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "grammars/css3Lexer.g4",
     "hash": "4733198f782344f0d3dbd2456ee9f6db955f53c688d14334fb403985551c963c"

--- a/package-gale/tests/generated/css3/css3Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/css3/css3Lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fa4a5fa8cced30ae",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "grammars/css3Lexer.g4",
     "hash": "4733198f782344f0d3dbd2456ee9f6db955f53c688d14334fb403985551c963c"

--- a/package-gale/tests/generated/html/HTMLLexer.g4.kiln.json
+++ b/package-gale/tests/generated/html/HTMLLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c6b3fd168a1b47a8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "grammars/HTMLLexer.g4",
     "hash": "1d3b243228b182ddeca45bf2c7f9ec6512c176bcec126444bce7cbe7a8e93052"

--- a/package-gale/tests/generated/html/HTMLLexer.g4.kiln.json
+++ b/package-gale/tests/generated/html/HTMLLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c6b3fd168a1b47a8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "grammars/HTMLLexer.g4",
     "hash": "1d3b243228b182ddeca45bf2c7f9ec6512c176bcec126444bce7cbe7a8e93052"

--- a/package-gale/tests/generated/json/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/json/JSON.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-deb9206518cd2a6f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "grammars/JSON.g4",
     "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"

--- a/package-gale/tests/generated/json/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/json/JSON.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-deb9206518cd2a6f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "grammars/JSON.g4",
     "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"

--- a/package-gale/tests/generated/json_highlight/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/json_highlight/JSON.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-deb9206518cd2a6f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "grammars/JSON.g4",
     "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"

--- a/package-gale/tests/generated/json_highlight/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/json_highlight/JSON.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-deb9206518cd2a6f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "grammars/JSON.g4",
     "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"

--- a/package-gale/tests/generated/label_gaps/label_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/label_gaps/label_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6e9e12ac993603d7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "grammars/label_gaps.g4",
     "hash": "8e2049cd7baf82750b8e242018ffdc1f8e684226f8e27fe8068ad7838d6da425"

--- a/package-gale/tests/generated/label_gaps/label_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/label_gaps/label_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6e9e12ac993603d7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "grammars/label_gaps.g4",
     "hash": "8e2049cd7baf82750b8e242018ffdc1f8e684226f8e27fe8068ad7838d6da425"

--- a/package-gale/tests/generated/lexer_command_gaps/lexer_command_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/lexer_command_gaps/lexer_command_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c1bc56a77b40e824",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "grammars/lexer_command_gaps.g4",
     "hash": "253a32f9908895a3ffaa23ac8e32eaa12f43998f25d7d2b73637ddf11a3cb3c9"

--- a/package-gale/tests/generated/lexer_command_gaps/lexer_command_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/lexer_command_gaps/lexer_command_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c1bc56a77b40e824",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "grammars/lexer_command_gaps.g4",
     "hash": "253a32f9908895a3ffaa23ac8e32eaa12f43998f25d7d2b73637ddf11a3cb3c9"

--- a/package-gale/tests/generated/mode_gaps/mode_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/mode_gaps/mode_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-934b67223a7d4708",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "grammars/mode_gaps.g4",
     "hash": "2129310ea345f84328b61531ce102c6306fda62ef4fa71d7c64d1dc4bb9f1d14"

--- a/package-gale/tests/generated/mode_gaps/mode_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/mode_gaps/mode_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-934b67223a7d4708",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "grammars/mode_gaps.g4",
     "hash": "2129310ea345f84328b61531ce102c6306fda62ef4fa71d7c64d1dc4bb9f1d14"

--- a/package-gale/tests/generated/non_greedy_gaps/non_greedy_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/non_greedy_gaps/non_greedy_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a7aa34c1db2fca6a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "grammars/non_greedy_gaps.g4",
     "hash": "b7ebb6e1d962ee295bf43cc5a13f167cbd270ef3d9e15a052d2eb060eefb012c"

--- a/package-gale/tests/generated/non_greedy_gaps/non_greedy_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/non_greedy_gaps/non_greedy_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a7aa34c1db2fca6a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "grammars/non_greedy_gaps.g4",
     "hash": "b7ebb6e1d962ee295bf43cc5a13f167cbd270ef3d9e15a052d2eb060eefb012c"

--- a/package-gale/tests/generated/parser_gaps/parser_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/parser_gaps/parser_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8eb28e22b79ba2bd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "grammars/parser_gaps.g4",
     "hash": "8262a9d7c10805db35e063564eaea6deb43e8de540af19d0969551d042b6d03a"

--- a/package-gale/tests/generated/parser_gaps/parser_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/parser_gaps/parser_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8eb28e22b79ba2bd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "grammars/parser_gaps.g4",
     "hash": "8262a9d7c10805db35e063564eaea6deb43e8de540af19d0969551d042b6d03a"

--- a/package-gale/tests/generated/recursive_lexer/recursive_lexer.g4.kiln.json
+++ b/package-gale/tests/generated/recursive_lexer/recursive_lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b23078c163edb700",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "grammars/recursive_lexer.g4",
     "hash": "3bba2a980c91c247bfa081040a71e8349ebd29cec177d15cf69feb75f40e705f"

--- a/package-gale/tests/generated/recursive_lexer/recursive_lexer.g4.kiln.json
+++ b/package-gale/tests/generated/recursive_lexer/recursive_lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b23078c163edb700",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "grammars/recursive_lexer.g4",
     "hash": "3bba2a980c91c247bfa081040a71e8349ebd29cec177d15cf69feb75f40e705f"

--- a/package-gale/tests/generated/right_assoc_gaps/right_assoc_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/right_assoc_gaps/right_assoc_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7382226003c5d9e1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "grammars/right_assoc_gaps.g4",
     "hash": "7632fce865fe8aa2c3c460beea14a27a0a020b9ccb2312fb59a2c980f12f639a"

--- a/package-gale/tests/generated/right_assoc_gaps/right_assoc_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/right_assoc_gaps/right_assoc_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7382226003c5d9e1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "grammars/right_assoc_gaps.g4",
     "hash": "7632fce865fe8aa2c3c460beea14a27a0a020b9ccb2312fb59a2c980f12f639a"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/right_assoc_gaps/right_assoc_gaps.wado",
-      "hash": "d53161e2efe8f44a82af00de79e4a64671033a827a320fb5c0c0b9155835510d",
+      "hash": "4c41095fe0b3e066c59740c4ef96b4ad7ed1bcc66feea85b3c2378fbfc3f2a5e",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/right_assoc_gaps/right_assoc_gaps.wado
+++ b/package-gale/tests/generated/right_assoc_gaps/right_assoc_gaps.wado
@@ -759,15 +759,17 @@ fn scan_expr(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if suffix_kind == TK_LIT_CARET {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expr_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expr_lr_1(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -824,12 +826,18 @@ fn parse_expr(p: &mut Parser, min_prec: i32 = 0) -> Result<ExprNode, ParseError>
         let suffix_kind = p.peek_kind();
         if suffix_kind == TK_LIT_CARET {
             if 2 >= min_prec {
+                if scan_expr_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expr_lr_0(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUS {
             if 1 >= min_prec {
+                if scan_expr_lr_1(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expr_lr_1(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/rust/RustLexer.g4.kiln.json
+++ b/package-gale/tests/generated/rust/RustLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-28566ce8c3b8a5b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "grammars/RustLexer.g4",
     "hash": "a9069b6b1a5650b0f5f115897eaa0edaddc42007b262c5096b59eb1de15323d3"

--- a/package-gale/tests/generated/rust/RustLexer.g4.kiln.json
+++ b/package-gale/tests/generated/rust/RustLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-28566ce8c3b8a5b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "grammars/RustLexer.g4",
     "hash": "a9069b6b1a5650b0f5f115897eaa0edaddc42007b262c5096b59eb1de15323d3"
@@ -18,7 +18,7 @@
   "outputs": [
     {
       "path": "tests/generated/rust/rust.wado",
-      "hash": "d39bb8902e44cb2fa29f36710cfb657155cec50989e7f16b41544db59feafa48",
+      "hash": "c71ca0e309f6e59d6ff140e6281f3a1fe039e451e175d882ed95e3f378bdf401",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/rust/rust.wado
+++ b/package-gale/tests/generated/rust/rust.wado
@@ -12408,29 +12408,33 @@ fn scan_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if _gale_kind_set_55(second_kind) {
                     if 21 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_expression_lr_3(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else if _gale_kind_set_17(second_kind) {
                     if 20 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_expression_lr_4(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else if second_kind == TK_INTEGER_LITERAL {
                     if 19 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_expression_lr_5(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 18 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_expression_lr_6(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -12438,72 +12442,82 @@ fn scan_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
             }
         } else if suffix_kind == TK_LPAREN {
             if 17 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expression_lr_7(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LSQUAREBRACKET {
             if 16 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expression_lr_8(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_QUESTION {
             if 15 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expression_lr_9(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_KW_AS {
             if 14 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expression_lr_13(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_56(suffix_kind) {
             if 13 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expression_lr_14(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_57(suffix_kind) {
             if 12 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expression_lr_15(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_58(suffix_kind) {
             if suffix_kind == TK_EQEQ {
                 if 7 >= min_prec {
+                    let lr_saved_pos = pos;
                     pos = scan_expression_lr_20(tokens, pos);
-                    if pos < 0 { return -1; }
+                    if pos < 0 { pos = lr_saved_pos; break; }
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_NE {
                 if 7 >= min_prec {
+                    let lr_saved_pos = pos;
                     pos = scan_expression_lr_20(tokens, pos);
-                    if pos < 0 { return -1; }
+                    if pos < 0 { pos = lr_saved_pos; break; }
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_GE {
                 if 7 >= min_prec {
+                    let lr_saved_pos = pos;
                     pos = scan_expression_lr_20(tokens, pos);
-                    if pos < 0 { return -1; }
+                    if pos < 0 { pos = lr_saved_pos; break; }
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_LE {
                 if 7 >= min_prec {
+                    let lr_saved_pos = pos;
                     pos = scan_expression_lr_20(tokens, pos);
-                    if pos < 0 { return -1; }
+                    if pos < 0 { pos = lr_saved_pos; break; }
                 } else {
                     break;
                 }
@@ -12511,15 +12525,17 @@ fn scan_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if _gale_kind_set_51(second_kind) {
                     if 11 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_expression_lr_16(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 7 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_expression_lr_20(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -12528,15 +12544,17 @@ fn scan_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if _gale_kind_set_51(second_kind) {
                     if 11 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_expression_lr_16(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 7 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_expression_lr_20(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -12544,64 +12562,73 @@ fn scan_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
             }
         } else if suffix_kind == TK_AND {
             if 10 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expression_lr_17(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_CARET {
             if 9 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expression_lr_18(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_OR {
             if 8 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expression_lr_19(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_ANDAND {
             if 6 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expression_lr_21(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_OROR {
             if 5 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expression_lr_22(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_DOTDOT {
             if 4 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expression_lr_23(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_DOTDOTEQ {
             if 3 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expression_lr_26(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_EQ {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expression_lr_27(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_59(suffix_kind) {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expression_lr_28(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -21439,24 +21466,36 @@ fn parse_expression(p: &mut Parser, min_prec: i32 = 0) -> Result<ExpressionNode,
             if suffix_kind == TK_DOT {
                 if _gale_kind_set_55(p.peek_at(1)) {
                     if 21 >= min_prec {
+                        if scan_expression_lr_3(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_expression_lr_3(p, result, start)?;
                     } else {
                         break;
                     }
                 } else if _gale_kind_set_17(p.peek_at(1)) {
                     if 20 >= min_prec {
+                        if scan_expression_lr_4(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_expression_lr_4(p, result, start)?;
                     } else {
                         break;
                     }
                 } else if p.peek_at(1) == TK_INTEGER_LITERAL {
                     if 19 >= min_prec {
+                        if scan_expression_lr_5(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_expression_lr_5(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 18 >= min_prec {
+                        if scan_expression_lr_6(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_expression_lr_6(p, result, start)?;
                     } else {
                         break;
@@ -21465,36 +21504,54 @@ fn parse_expression(p: &mut Parser, min_prec: i32 = 0) -> Result<ExpressionNode,
             }
         } else if suffix_kind == TK_LPAREN {
             if 17 >= min_prec {
+                if scan_expression_lr_7(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expression_lr_7(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LSQUAREBRACKET {
             if 16 >= min_prec {
+                if scan_expression_lr_8(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expression_lr_8(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_QUESTION {
             if 15 >= min_prec {
+                if scan_expression_lr_9(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expression_lr_9(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_KW_AS {
             if 14 >= min_prec {
+                if scan_expression_lr_13(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expression_lr_13(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_56(suffix_kind) {
             if 13 >= min_prec {
+                if scan_expression_lr_14(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expression_lr_14(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_57(suffix_kind) {
             if 12 >= min_prec {
+                if scan_expression_lr_15(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expression_lr_15(p, result, start)?;
             } else {
                 break;
@@ -21502,24 +21559,36 @@ fn parse_expression(p: &mut Parser, min_prec: i32 = 0) -> Result<ExpressionNode,
         } else if _gale_kind_set_58(suffix_kind) {
             if suffix_kind == TK_EQEQ {
                 if 7 >= min_prec {
+                    if scan_expression_lr_20(&p.tokens, p.pos) < 0 {
+                        break;
+                    }
                     result = parse_expression_lr_20(p, result, start)?;
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_NE {
                 if 7 >= min_prec {
+                    if scan_expression_lr_20(&p.tokens, p.pos) < 0 {
+                        break;
+                    }
                     result = parse_expression_lr_20(p, result, start)?;
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_GE {
                 if 7 >= min_prec {
+                    if scan_expression_lr_20(&p.tokens, p.pos) < 0 {
+                        break;
+                    }
                     result = parse_expression_lr_20(p, result, start)?;
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_LE {
                 if 7 >= min_prec {
+                    if scan_expression_lr_20(&p.tokens, p.pos) < 0 {
+                        break;
+                    }
                     result = parse_expression_lr_20(p, result, start)?;
                 } else {
                     break;
@@ -21527,12 +21596,18 @@ fn parse_expression(p: &mut Parser, min_prec: i32 = 0) -> Result<ExpressionNode,
             } else if suffix_kind == TK_LT {
                 if _gale_kind_set_51(p.peek_at(1)) {
                     if 11 >= min_prec {
+                        if scan_expression_lr_16(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_expression_lr_16(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 7 >= min_prec {
+                        if scan_expression_lr_20(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_expression_lr_20(p, result, start)?;
                     } else {
                         break;
@@ -21541,12 +21616,18 @@ fn parse_expression(p: &mut Parser, min_prec: i32 = 0) -> Result<ExpressionNode,
             } else if suffix_kind == TK_GT {
                 if _gale_kind_set_51(p.peek_at(1)) {
                     if 11 >= min_prec {
+                        if scan_expression_lr_16(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_expression_lr_16(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 7 >= min_prec {
+                        if scan_expression_lr_20(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_expression_lr_20(p, result, start)?;
                     } else {
                         break;
@@ -21555,54 +21636,81 @@ fn parse_expression(p: &mut Parser, min_prec: i32 = 0) -> Result<ExpressionNode,
             }
         } else if suffix_kind == TK_AND {
             if 10 >= min_prec {
+                if scan_expression_lr_17(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expression_lr_17(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_CARET {
             if 9 >= min_prec {
+                if scan_expression_lr_18(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expression_lr_18(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_OR {
             if 8 >= min_prec {
+                if scan_expression_lr_19(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expression_lr_19(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_ANDAND {
             if 6 >= min_prec {
+                if scan_expression_lr_21(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expression_lr_21(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_OROR {
             if 5 >= min_prec {
+                if scan_expression_lr_22(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expression_lr_22(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_DOTDOT {
             if 4 >= min_prec {
+                if scan_expression_lr_23(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expression_lr_23(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_DOTDOTEQ {
             if 3 >= min_prec {
+                if scan_expression_lr_26(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expression_lr_26(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_EQ {
             if 2 >= min_prec {
+                if scan_expression_lr_27(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expression_lr_27(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_59(suffix_kind) {
             if 1 >= min_prec {
+                if scan_expression_lr_28(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expression_lr_28(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/sexpression/sexpression.g4.kiln.json
+++ b/package-gale/tests/generated/sexpression/sexpression.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1847ef51d5668bfd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "grammars/sexpression.g4",
     "hash": "74549e6167e186b754886880a5d473ad3361bee8440368f99e1b233e2c1c7bdb"

--- a/package-gale/tests/generated/sexpression/sexpression.g4.kiln.json
+++ b/package-gale/tests/generated/sexpression/sexpression.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1847ef51d5668bfd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "grammars/sexpression.g4",
     "hash": "74549e6167e186b754886880a5d473ad3361bee8440368f99e1b233e2c1c7bdb"

--- a/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-880d9db12a6d7521",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "grammars/SQLite.g4",
     "hash": "72e3fa9877777afa5a4f9e8196d4cb194bb599e719d43b7b29d09eeed3e4c5e0"

--- a/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-880d9db12a6d7521",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "grammars/SQLite.g4",
     "hash": "72e3fa9877777afa5a4f9e8196d4cb194bb599e719d43b7b29d09eeed3e4c5e0"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/sqlite/sqlite.wado",
-      "hash": "b54ad1964174727a78606b2e7792e3b42f6f7788f43ca45de7dfb960590d17a6",
+      "hash": "a2bf00a7a684a2388923354d1fe8914c11339dfcd4d44878af30f9f5926b77a6",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/sqlite/sqlite.wado
+++ b/package-gale/tests/generated/sqlite/sqlite.wado
@@ -9178,100 +9178,114 @@ fn scan_expr(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if suffix_kind == TK_LIT_PIPEPIPE {
             if 14 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expr_lr_4(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_31(suffix_kind) {
             if 13 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expr_lr_5(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_32(suffix_kind) {
             if 12 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expr_lr_6(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_33(suffix_kind) {
             if 11 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expr_lr_7(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_34(suffix_kind) {
             if 10 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expr_lr_8(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_35(suffix_kind) {
             if 9 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expr_lr_9(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_36(suffix_kind) {
             if suffix_kind == TK_K_IN {
                 if 8 >= min_prec {
+                    let lr_saved_pos = pos;
                     pos = scan_expr_lr_10(tokens, pos);
-                    if pos < 0 { return -1; }
+                    if pos < 0 { pos = lr_saved_pos; break; }
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_K_LIKE {
                 if 4 >= min_prec {
+                    let lr_saved_pos = pos;
                     pos = scan_expr_lr_17(tokens, pos);
-                    if pos < 0 { return -1; }
+                    if pos < 0 { pos = lr_saved_pos; break; }
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_K_GLOB {
                 if 4 >= min_prec {
+                    let lr_saved_pos = pos;
                     pos = scan_expr_lr_17(tokens, pos);
-                    if pos < 0 { return -1; }
+                    if pos < 0 { pos = lr_saved_pos; break; }
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_K_REGEXP {
                 if 4 >= min_prec {
+                    let lr_saved_pos = pos;
                     pos = scan_expr_lr_17(tokens, pos);
-                    if pos < 0 { return -1; }
+                    if pos < 0 { pos = lr_saved_pos; break; }
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_K_MATCH {
                 if 4 >= min_prec {
+                    let lr_saved_pos = pos;
                     pos = scan_expr_lr_17(tokens, pos);
-                    if pos < 0 { return -1; }
+                    if pos < 0 { pos = lr_saved_pos; break; }
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_K_ISNULL {
                 if 3 >= min_prec {
+                    let lr_saved_pos = pos;
                     pos = scan_expr_lr_18(tokens, pos);
-                    if pos < 0 { return -1; }
+                    if pos < 0 { pos = lr_saved_pos; break; }
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_K_NOTNULL {
                 if 3 >= min_prec {
+                    let lr_saved_pos = pos;
                     pos = scan_expr_lr_18(tokens, pos);
-                    if pos < 0 { return -1; }
+                    if pos < 0 { pos = lr_saved_pos; break; }
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_K_BETWEEN {
                 if 1 >= min_prec {
+                    let lr_saved_pos = pos;
                     pos = scan_expr_lr_20(tokens, pos);
-                    if pos < 0 { return -1; }
+                    if pos < 0 { pos = lr_saved_pos; break; }
                 } else {
                     break;
                 }
@@ -9279,29 +9293,33 @@ fn scan_expr(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if second_kind == TK_K_IN {
                     if 8 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_expr_lr_10(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else if _gale_kind_set_37(second_kind) {
                     if 4 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_expr_lr_17(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else if second_kind == TK_K_NULL {
                     if 3 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_expr_lr_18(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 1 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_expr_lr_20(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -9309,29 +9327,33 @@ fn scan_expr(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
             }
         } else if suffix_kind == TK_K_AND {
             if 7 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expr_lr_11(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_K_OR {
             if 6 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expr_lr_12(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_K_COLLATE {
             if 5 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expr_lr_16(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_K_IS {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expr_lr_19(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -16676,36 +16698,54 @@ fn parse_expr(p: &mut Parser, min_prec: i32 = 0) -> Result<ExprNode, ParseError>
         let suffix_kind = p.peek_kind();
         if suffix_kind == TK_LIT_PIPEPIPE {
             if 14 >= min_prec {
+                if scan_expr_lr_4(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expr_lr_4(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_31(suffix_kind) {
             if 13 >= min_prec {
+                if scan_expr_lr_5(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expr_lr_5(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_32(suffix_kind) {
             if 12 >= min_prec {
+                if scan_expr_lr_6(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expr_lr_6(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_33(suffix_kind) {
             if 11 >= min_prec {
+                if scan_expr_lr_7(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expr_lr_7(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_34(suffix_kind) {
             if 10 >= min_prec {
+                if scan_expr_lr_8(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expr_lr_8(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_35(suffix_kind) {
             if 9 >= min_prec {
+                if scan_expr_lr_9(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expr_lr_9(p, result, start)?;
             } else {
                 break;
@@ -16713,48 +16753,72 @@ fn parse_expr(p: &mut Parser, min_prec: i32 = 0) -> Result<ExprNode, ParseError>
         } else if _gale_kind_set_36(suffix_kind) {
             if suffix_kind == TK_K_IN {
                 if 8 >= min_prec {
+                    if scan_expr_lr_10(&p.tokens, p.pos) < 0 {
+                        break;
+                    }
                     result = parse_expr_lr_10(p, result, start)?;
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_K_LIKE {
                 if 4 >= min_prec {
+                    if scan_expr_lr_17(&p.tokens, p.pos) < 0 {
+                        break;
+                    }
                     result = parse_expr_lr_17(p, result, start)?;
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_K_GLOB {
                 if 4 >= min_prec {
+                    if scan_expr_lr_17(&p.tokens, p.pos) < 0 {
+                        break;
+                    }
                     result = parse_expr_lr_17(p, result, start)?;
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_K_REGEXP {
                 if 4 >= min_prec {
+                    if scan_expr_lr_17(&p.tokens, p.pos) < 0 {
+                        break;
+                    }
                     result = parse_expr_lr_17(p, result, start)?;
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_K_MATCH {
                 if 4 >= min_prec {
+                    if scan_expr_lr_17(&p.tokens, p.pos) < 0 {
+                        break;
+                    }
                     result = parse_expr_lr_17(p, result, start)?;
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_K_ISNULL {
                 if 3 >= min_prec {
+                    if scan_expr_lr_18(&p.tokens, p.pos) < 0 {
+                        break;
+                    }
                     result = parse_expr_lr_18(p, result, start)?;
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_K_NOTNULL {
                 if 3 >= min_prec {
+                    if scan_expr_lr_18(&p.tokens, p.pos) < 0 {
+                        break;
+                    }
                     result = parse_expr_lr_18(p, result, start)?;
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_K_BETWEEN {
                 if 1 >= min_prec {
+                    if scan_expr_lr_20(&p.tokens, p.pos) < 0 {
+                        break;
+                    }
                     result = parse_expr_lr_20(p, result, start)?;
                 } else {
                     break;
@@ -16762,24 +16826,36 @@ fn parse_expr(p: &mut Parser, min_prec: i32 = 0) -> Result<ExprNode, ParseError>
             } else if suffix_kind == TK_K_NOT {
                 if p.peek_at(1) == TK_K_IN {
                     if 8 >= min_prec {
+                        if scan_expr_lr_10(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_expr_lr_10(p, result, start)?;
                     } else {
                         break;
                     }
                 } else if _gale_kind_set_37(p.peek_at(1)) {
                     if 4 >= min_prec {
+                        if scan_expr_lr_17(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_expr_lr_17(p, result, start)?;
                     } else {
                         break;
                     }
                 } else if p.peek_at(1) == TK_K_NULL {
                     if 3 >= min_prec {
+                        if scan_expr_lr_18(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_expr_lr_18(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 1 >= min_prec {
+                        if scan_expr_lr_20(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_expr_lr_20(p, result, start)?;
                     } else {
                         break;
@@ -16788,24 +16864,36 @@ fn parse_expr(p: &mut Parser, min_prec: i32 = 0) -> Result<ExprNode, ParseError>
             }
         } else if suffix_kind == TK_K_AND {
             if 7 >= min_prec {
+                if scan_expr_lr_11(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expr_lr_11(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_K_OR {
             if 6 >= min_prec {
+                if scan_expr_lr_12(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expr_lr_12(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_K_COLLATE {
             if 5 >= min_prec {
+                if scan_expr_lr_16(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expr_lr_16(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_K_IS {
             if 2 >= min_prec {
+                if scan_expr_lr_19(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expr_lr_19(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/sqlite_highlight/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite_highlight/SQLite.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-880d9db12a6d7521",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "grammars/SQLite.g4",
     "hash": "72e3fa9877777afa5a4f9e8196d4cb194bb599e719d43b7b29d09eeed3e4c5e0"

--- a/package-gale/tests/generated/sqlite_highlight/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite_highlight/SQLite.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-880d9db12a6d7521",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "grammars/SQLite.g4",
     "hash": "72e3fa9877777afa5a4f9e8196d4cb194bb599e719d43b7b29d09eeed3e4c5e0"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/sqlite_highlight/sqlite.wado",
-      "hash": "4461a3525fd67fd57c1df1470e6c63ea42faabef1a3d9472b6edca96bf3b71db",
+      "hash": "e5a8f180825f7a8cbc362cca2227f4acdf845be97da14507c2f4fb91a66932d3",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/sqlite_highlight/sqlite.wado
+++ b/package-gale/tests/generated/sqlite_highlight/sqlite.wado
@@ -9178,100 +9178,114 @@ fn scan_expr(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if suffix_kind == TK_LIT_PIPEPIPE {
             if 14 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expr_lr_4(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_31(suffix_kind) {
             if 13 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expr_lr_5(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_32(suffix_kind) {
             if 12 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expr_lr_6(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_33(suffix_kind) {
             if 11 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expr_lr_7(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_34(suffix_kind) {
             if 10 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expr_lr_8(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_35(suffix_kind) {
             if 9 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expr_lr_9(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_36(suffix_kind) {
             if suffix_kind == TK_K_IN {
                 if 8 >= min_prec {
+                    let lr_saved_pos = pos;
                     pos = scan_expr_lr_10(tokens, pos);
-                    if pos < 0 { return -1; }
+                    if pos < 0 { pos = lr_saved_pos; break; }
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_K_LIKE {
                 if 4 >= min_prec {
+                    let lr_saved_pos = pos;
                     pos = scan_expr_lr_17(tokens, pos);
-                    if pos < 0 { return -1; }
+                    if pos < 0 { pos = lr_saved_pos; break; }
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_K_GLOB {
                 if 4 >= min_prec {
+                    let lr_saved_pos = pos;
                     pos = scan_expr_lr_17(tokens, pos);
-                    if pos < 0 { return -1; }
+                    if pos < 0 { pos = lr_saved_pos; break; }
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_K_REGEXP {
                 if 4 >= min_prec {
+                    let lr_saved_pos = pos;
                     pos = scan_expr_lr_17(tokens, pos);
-                    if pos < 0 { return -1; }
+                    if pos < 0 { pos = lr_saved_pos; break; }
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_K_MATCH {
                 if 4 >= min_prec {
+                    let lr_saved_pos = pos;
                     pos = scan_expr_lr_17(tokens, pos);
-                    if pos < 0 { return -1; }
+                    if pos < 0 { pos = lr_saved_pos; break; }
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_K_ISNULL {
                 if 3 >= min_prec {
+                    let lr_saved_pos = pos;
                     pos = scan_expr_lr_18(tokens, pos);
-                    if pos < 0 { return -1; }
+                    if pos < 0 { pos = lr_saved_pos; break; }
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_K_NOTNULL {
                 if 3 >= min_prec {
+                    let lr_saved_pos = pos;
                     pos = scan_expr_lr_18(tokens, pos);
-                    if pos < 0 { return -1; }
+                    if pos < 0 { pos = lr_saved_pos; break; }
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_K_BETWEEN {
                 if 1 >= min_prec {
+                    let lr_saved_pos = pos;
                     pos = scan_expr_lr_20(tokens, pos);
-                    if pos < 0 { return -1; }
+                    if pos < 0 { pos = lr_saved_pos; break; }
                 } else {
                     break;
                 }
@@ -9279,29 +9293,33 @@ fn scan_expr(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if second_kind == TK_K_IN {
                     if 8 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_expr_lr_10(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else if _gale_kind_set_37(second_kind) {
                     if 4 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_expr_lr_17(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else if second_kind == TK_K_NULL {
                     if 3 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_expr_lr_18(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 1 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_expr_lr_20(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -9309,29 +9327,33 @@ fn scan_expr(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
             }
         } else if suffix_kind == TK_K_AND {
             if 7 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expr_lr_11(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_K_OR {
             if 6 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expr_lr_12(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_K_COLLATE {
             if 5 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expr_lr_16(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_K_IS {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_expr_lr_19(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -16676,36 +16698,54 @@ fn parse_expr(p: &mut Parser, min_prec: i32 = 0) -> Result<ExprNode, ParseError>
         let suffix_kind = p.peek_kind();
         if suffix_kind == TK_LIT_PIPEPIPE {
             if 14 >= min_prec {
+                if scan_expr_lr_4(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expr_lr_4(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_31(suffix_kind) {
             if 13 >= min_prec {
+                if scan_expr_lr_5(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expr_lr_5(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_32(suffix_kind) {
             if 12 >= min_prec {
+                if scan_expr_lr_6(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expr_lr_6(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_33(suffix_kind) {
             if 11 >= min_prec {
+                if scan_expr_lr_7(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expr_lr_7(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_34(suffix_kind) {
             if 10 >= min_prec {
+                if scan_expr_lr_8(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expr_lr_8(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_35(suffix_kind) {
             if 9 >= min_prec {
+                if scan_expr_lr_9(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expr_lr_9(p, result, start)?;
             } else {
                 break;
@@ -16713,48 +16753,72 @@ fn parse_expr(p: &mut Parser, min_prec: i32 = 0) -> Result<ExprNode, ParseError>
         } else if _gale_kind_set_36(suffix_kind) {
             if suffix_kind == TK_K_IN {
                 if 8 >= min_prec {
+                    if scan_expr_lr_10(&p.tokens, p.pos) < 0 {
+                        break;
+                    }
                     result = parse_expr_lr_10(p, result, start)?;
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_K_LIKE {
                 if 4 >= min_prec {
+                    if scan_expr_lr_17(&p.tokens, p.pos) < 0 {
+                        break;
+                    }
                     result = parse_expr_lr_17(p, result, start)?;
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_K_GLOB {
                 if 4 >= min_prec {
+                    if scan_expr_lr_17(&p.tokens, p.pos) < 0 {
+                        break;
+                    }
                     result = parse_expr_lr_17(p, result, start)?;
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_K_REGEXP {
                 if 4 >= min_prec {
+                    if scan_expr_lr_17(&p.tokens, p.pos) < 0 {
+                        break;
+                    }
                     result = parse_expr_lr_17(p, result, start)?;
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_K_MATCH {
                 if 4 >= min_prec {
+                    if scan_expr_lr_17(&p.tokens, p.pos) < 0 {
+                        break;
+                    }
                     result = parse_expr_lr_17(p, result, start)?;
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_K_ISNULL {
                 if 3 >= min_prec {
+                    if scan_expr_lr_18(&p.tokens, p.pos) < 0 {
+                        break;
+                    }
                     result = parse_expr_lr_18(p, result, start)?;
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_K_NOTNULL {
                 if 3 >= min_prec {
+                    if scan_expr_lr_18(&p.tokens, p.pos) < 0 {
+                        break;
+                    }
                     result = parse_expr_lr_18(p, result, start)?;
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_K_BETWEEN {
                 if 1 >= min_prec {
+                    if scan_expr_lr_20(&p.tokens, p.pos) < 0 {
+                        break;
+                    }
                     result = parse_expr_lr_20(p, result, start)?;
                 } else {
                     break;
@@ -16762,24 +16826,36 @@ fn parse_expr(p: &mut Parser, min_prec: i32 = 0) -> Result<ExprNode, ParseError>
             } else if suffix_kind == TK_K_NOT {
                 if p.peek_at(1) == TK_K_IN {
                     if 8 >= min_prec {
+                        if scan_expr_lr_10(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_expr_lr_10(p, result, start)?;
                     } else {
                         break;
                     }
                 } else if _gale_kind_set_37(p.peek_at(1)) {
                     if 4 >= min_prec {
+                        if scan_expr_lr_17(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_expr_lr_17(p, result, start)?;
                     } else {
                         break;
                     }
                 } else if p.peek_at(1) == TK_K_NULL {
                     if 3 >= min_prec {
+                        if scan_expr_lr_18(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_expr_lr_18(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 1 >= min_prec {
+                        if scan_expr_lr_20(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_expr_lr_20(p, result, start)?;
                     } else {
                         break;
@@ -16788,24 +16864,36 @@ fn parse_expr(p: &mut Parser, min_prec: i32 = 0) -> Result<ExprNode, ParseError>
             }
         } else if suffix_kind == TK_K_AND {
             if 7 >= min_prec {
+                if scan_expr_lr_11(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expr_lr_11(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_K_OR {
             if 6 >= min_prec {
+                if scan_expr_lr_12(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expr_lr_12(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_K_COLLATE {
             if 5 >= min_prec {
+                if scan_expr_lr_16(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expr_lr_16(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_K_IS {
             if 2 >= min_prec {
+                if scan_expr_lr_19(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_expr_lr_19(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/typescript/TypeScriptLexer.g4.kiln.json
+++ b/package-gale/tests/generated/typescript/TypeScriptLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b6f068637d3275ff",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "grammars/TypeScriptLexer.g4",
     "hash": "f7089740f7e82bbb90a6c4b13c75959b6ceaf3003be0dd0657c52b9eb6a594b7"
@@ -18,7 +18,7 @@
   "outputs": [
     {
       "path": "tests/generated/typescript/type_script.wado",
-      "hash": "fba0a3d57f9b863c09f42fcaf25966bcf3e6cacf9b880d8e4d123def58f948eb",
+      "hash": "7e82198e0c448aca31570adcf42d6c4bc2f6258d03c024635dd10f4ba96b2ae6",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/typescript/TypeScriptLexer.g4.kiln.json
+++ b/package-gale/tests/generated/typescript/TypeScriptLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b6f068637d3275ff",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "grammars/TypeScriptLexer.g4",
     "hash": "f7089740f7e82bbb90a6c4b13c75959b6ceaf3003be0dd0657c52b9eb6a594b7"

--- a/package-gale/tests/generated/typescript/type_script.wado
+++ b/package-gale/tests/generated/typescript/type_script.wado
@@ -8242,15 +8242,17 @@ fn scan_union_or_intersection_or_primary_type(tokens: &Array<Token>, pos: i32, m
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if suffix_kind == TK_LIT_PIPE {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_union_or_intersection_or_primary_type_lr_0(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMP {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_union_or_intersection_or_primary_type_lr_1(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -8418,8 +8420,9 @@ fn scan_primary_type(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if suffix_kind == TK_LIT_LBRACKET {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_primary_type_lr_4(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -9699,8 +9702,9 @@ fn scan_decorator_member_expression(tokens: &Array<Token>, pos: i32, min_prec: i
         let suffix_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
         if suffix_kind == TK_LIT_DOT {
             if 1 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_decorator_member_expression_lr_1(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -14187,8 +14191,9 @@ fn scan_single_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) ->
         if _gale_kind_set_60(suffix_kind) {
             if suffix_kind == TK_LIT_LBRACKET {
                 if 27 >= min_prec {
+                    let lr_saved_pos = pos;
                     pos = scan_single_expression_lr_2(tokens, pos);
-                    if pos < 0 { return -1; }
+                    if pos < 0 { pos = lr_saved_pos; break; }
                 } else {
                     break;
                 }
@@ -14196,15 +14201,17 @@ fn scan_single_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) ->
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if second_kind == TK_LIT_LBRACKET {
                     if 27 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_single_expression_lr_2(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 26 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_single_expression_lr_3(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -14215,15 +14222,17 @@ fn scan_single_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) ->
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if second_kind == TK_LIT_DOT {
                     if 25 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_single_expression_lr_4(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 1 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_single_expression_lr_52(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -14232,15 +14241,17 @@ fn scan_single_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) ->
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if _gale_kind_set_62(second_kind) {
                     if 25 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_single_expression_lr_4(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 24 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_single_expression_lr_5(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -14249,15 +14260,17 @@ fn scan_single_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) ->
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if second_kind == TK_LIT_DOT {
                     if 24 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_single_expression_lr_5(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 6 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_single_expression_lr_35(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -14265,79 +14278,90 @@ fn scan_single_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) ->
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 23 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_single_expression_lr_8(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUSPLUS {
             if 22 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_single_expression_lr_9(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_MINUSMINUS {
             if 21 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_single_expression_lr_10(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_STARSTAR {
             if 20 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_single_expression_lr_21(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_63(suffix_kind) {
             if 19 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_single_expression_lr_22(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_64(suffix_kind) {
             if 18 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_single_expression_lr_23(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTIONQUESTION {
             if 17 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_single_expression_lr_24(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_65(suffix_kind) {
             if suffix_kind == TK_LIT_LTLT {
                 if 16 >= min_prec {
+                    let lr_saved_pos = pos;
                     pos = scan_single_expression_lr_25(tokens, pos);
-                    if pos < 0 { return -1; }
+                    if pos < 0 { pos = lr_saved_pos; break; }
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_LIT_LT {
                 if 15 >= min_prec {
+                    let lr_saved_pos = pos;
                     pos = scan_single_expression_lr_26(tokens, pos);
-                    if pos < 0 { return -1; }
+                    if pos < 0 { pos = lr_saved_pos; break; }
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_LIT_LTEQ {
                 if 15 >= min_prec {
+                    let lr_saved_pos = pos;
                     pos = scan_single_expression_lr_26(tokens, pos);
-                    if pos < 0 { return -1; }
+                    if pos < 0 { pos = lr_saved_pos; break; }
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_LIT_GTEQ {
                 if 15 >= min_prec {
+                    let lr_saved_pos = pos;
                     pos = scan_single_expression_lr_26(tokens, pos);
-                    if pos < 0 { return -1; }
+                    if pos < 0 { pos = lr_saved_pos; break; }
                 } else {
                     break;
                 }
@@ -14345,15 +14369,17 @@ fn scan_single_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) ->
                 let second_kind = if pos + 1 < tokens.len() { tokens[pos + 1].kind } else { TK_EOF };
                 if second_kind == TK_LIT_GT {
                     if 16 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_single_expression_lr_25(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
                 } else {
                     if 15 >= min_prec {
+                        let lr_saved_pos = pos;
                         pos = scan_single_expression_lr_26(tokens, pos);
-                        if pos < 0 { return -1; }
+                        if pos < 0 { pos = lr_saved_pos; break; }
                     } else {
                         break;
                     }
@@ -14361,85 +14387,97 @@ fn scan_single_expression(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) ->
             }
         } else if suffix_kind == TK_Instanceof {
             if 14 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_single_expression_lr_27(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_In {
             if 13 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_single_expression_lr_28(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_66(suffix_kind) {
             if 12 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_single_expression_lr_29(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMP {
             if 11 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_single_expression_lr_30(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_CARET {
             if 10 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_single_expression_lr_31(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPE {
             if 9 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_single_expression_lr_32(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMPAMP {
             if 8 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_single_expression_lr_33(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPEPIPE {
             if 7 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_single_expression_lr_34(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 5 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_single_expression_lr_36(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if _gale_kind_set_67(suffix_kind) {
             if 4 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_single_expression_lr_37(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_BackTick {
             if 3 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_single_expression_lr_38(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
         } else if suffix_kind == TK_As {
             if 2 >= min_prec {
+                let lr_saved_pos = pos;
                 pos = scan_single_expression_lr_51(tokens, pos);
-                if pos < 0 { return -1; }
+                if pos < 0 { pos = lr_saved_pos; break; }
             } else {
                 break;
             }
@@ -15618,12 +15656,18 @@ fn parse_union_or_intersection_or_primary_type(p: &mut Parser, min_prec: i32 = 0
         let suffix_kind = p.peek_kind();
         if suffix_kind == TK_LIT_PIPE {
             if 2 >= min_prec {
+                if scan_union_or_intersection_or_primary_type_lr_0(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_union_or_intersection_or_primary_type_lr_0(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMP {
             if 1 >= min_prec {
+                if scan_union_or_intersection_or_primary_type_lr_1(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_union_or_intersection_or_primary_type_lr_1(p, result, start)?;
             } else {
                 break;
@@ -15876,6 +15920,9 @@ fn parse_primary_type(p: &mut Parser, min_prec: i32 = 0) -> Result<PrimaryTypeNo
         let suffix_kind = p.peek_kind();
         if suffix_kind == TK_LIT_LBRACKET {
             if 1 >= min_prec {
+                if scan_primary_type_lr_4(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_primary_type_lr_4(p, result, start)?;
             } else {
                 break;
@@ -17593,6 +17640,9 @@ fn parse_decorator_member_expression(p: &mut Parser, min_prec: i32 = 0) -> Resul
         let suffix_kind = p.peek_kind();
         if suffix_kind == TK_LIT_DOT {
             if 1 >= min_prec {
+                if scan_decorator_member_expression_lr_1(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_decorator_member_expression_lr_1(p, result, start)?;
             } else {
                 break;
@@ -24312,6 +24362,9 @@ fn parse_single_expression(p: &mut Parser, min_prec: i32 = 0) -> Result<SingleEx
         if _gale_kind_set_60(suffix_kind) {
             if suffix_kind == TK_LIT_LBRACKET {
                 if 27 >= min_prec {
+                    if scan_single_expression_lr_2(&p.tokens, p.pos) < 0 {
+                        break;
+                    }
                     result = parse_single_expression_lr_2(p, result, start)?;
                 } else {
                     break;
@@ -24319,12 +24372,18 @@ fn parse_single_expression(p: &mut Parser, min_prec: i32 = 0) -> Result<SingleEx
             } else if suffix_kind == TK_LIT_QUESTIONDOT {
                 if p.peek_at(1) == TK_LIT_LBRACKET {
                     if 27 >= min_prec {
+                        if scan_single_expression_lr_2(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_single_expression_lr_2(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 26 >= min_prec {
+                        if scan_single_expression_lr_3(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_single_expression_lr_3(p, result, start)?;
                     } else {
                         break;
@@ -24335,12 +24394,18 @@ fn parse_single_expression(p: &mut Parser, min_prec: i32 = 0) -> Result<SingleEx
             if suffix_kind == TK_LIT_BANG {
                 if p.peek_at(1) == TK_LIT_DOT {
                     if 25 >= min_prec {
+                        if scan_single_expression_lr_4(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_single_expression_lr_4(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 1 >= min_prec {
+                        if scan_single_expression_lr_52(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_single_expression_lr_52(p, result, start)?;
                     } else {
                         break;
@@ -24349,12 +24414,18 @@ fn parse_single_expression(p: &mut Parser, min_prec: i32 = 0) -> Result<SingleEx
             } else if suffix_kind == TK_LIT_DOT {
                 if _gale_kind_set_62(p.peek_at(1)) {
                     if 25 >= min_prec {
+                        if scan_single_expression_lr_4(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_single_expression_lr_4(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 24 >= min_prec {
+                        if scan_single_expression_lr_5(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_single_expression_lr_5(p, result, start)?;
                     } else {
                         break;
@@ -24363,12 +24434,18 @@ fn parse_single_expression(p: &mut Parser, min_prec: i32 = 0) -> Result<SingleEx
             } else if suffix_kind == TK_LIT_QUESTION {
                 if p.peek_at(1) == TK_LIT_DOT {
                     if 24 >= min_prec {
+                        if scan_single_expression_lr_5(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_single_expression_lr_5(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 6 >= min_prec {
+                        if scan_single_expression_lr_35(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_single_expression_lr_35(p, result, start)?;
                     } else {
                         break;
@@ -24377,42 +24454,63 @@ fn parse_single_expression(p: &mut Parser, min_prec: i32 = 0) -> Result<SingleEx
             }
         } else if suffix_kind == TK_LIT_LPAREN {
             if 23 >= min_prec {
+                if scan_single_expression_lr_8(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_single_expression_lr_8(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PLUSPLUS {
             if 22 >= min_prec {
+                if scan_single_expression_lr_9(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_single_expression_lr_9(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_MINUSMINUS {
             if 21 >= min_prec {
+                if scan_single_expression_lr_10(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_single_expression_lr_10(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_STARSTAR {
             if 20 >= min_prec {
+                if scan_single_expression_lr_21(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_single_expression_lr_21(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_63(suffix_kind) {
             if 19 >= min_prec {
+                if scan_single_expression_lr_22(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_single_expression_lr_22(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_64(suffix_kind) {
             if 18 >= min_prec {
+                if scan_single_expression_lr_23(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_single_expression_lr_23(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_QUESTIONQUESTION {
             if 17 >= min_prec {
+                if scan_single_expression_lr_24(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_single_expression_lr_24(p, result, start)?;
             } else {
                 break;
@@ -24420,24 +24518,36 @@ fn parse_single_expression(p: &mut Parser, min_prec: i32 = 0) -> Result<SingleEx
         } else if _gale_kind_set_65(suffix_kind) {
             if suffix_kind == TK_LIT_LTLT {
                 if 16 >= min_prec {
+                    if scan_single_expression_lr_25(&p.tokens, p.pos) < 0 {
+                        break;
+                    }
                     result = parse_single_expression_lr_25(p, result, start)?;
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_LIT_LT {
                 if 15 >= min_prec {
+                    if scan_single_expression_lr_26(&p.tokens, p.pos) < 0 {
+                        break;
+                    }
                     result = parse_single_expression_lr_26(p, result, start)?;
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_LIT_LTEQ {
                 if 15 >= min_prec {
+                    if scan_single_expression_lr_26(&p.tokens, p.pos) < 0 {
+                        break;
+                    }
                     result = parse_single_expression_lr_26(p, result, start)?;
                 } else {
                     break;
                 }
             } else if suffix_kind == TK_LIT_GTEQ {
                 if 15 >= min_prec {
+                    if scan_single_expression_lr_26(&p.tokens, p.pos) < 0 {
+                        break;
+                    }
                     result = parse_single_expression_lr_26(p, result, start)?;
                 } else {
                     break;
@@ -24445,12 +24555,18 @@ fn parse_single_expression(p: &mut Parser, min_prec: i32 = 0) -> Result<SingleEx
             } else if suffix_kind == TK_LIT_GT {
                 if p.peek_at(1) == TK_LIT_GT {
                     if 16 >= min_prec {
+                        if scan_single_expression_lr_25(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_single_expression_lr_25(p, result, start)?;
                     } else {
                         break;
                     }
                 } else {
                     if 15 >= min_prec {
+                        if scan_single_expression_lr_26(&p.tokens, p.pos) < 0 {
+                            break;
+                        }
                         result = parse_single_expression_lr_26(p, result, start)?;
                     } else {
                         break;
@@ -24459,72 +24575,108 @@ fn parse_single_expression(p: &mut Parser, min_prec: i32 = 0) -> Result<SingleEx
             }
         } else if suffix_kind == TK_Instanceof {
             if 14 >= min_prec {
+                if scan_single_expression_lr_27(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_single_expression_lr_27(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_In {
             if 13 >= min_prec {
+                if scan_single_expression_lr_28(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_single_expression_lr_28(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_66(suffix_kind) {
             if 12 >= min_prec {
+                if scan_single_expression_lr_29(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_single_expression_lr_29(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMP {
             if 11 >= min_prec {
+                if scan_single_expression_lr_30(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_single_expression_lr_30(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_CARET {
             if 10 >= min_prec {
+                if scan_single_expression_lr_31(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_single_expression_lr_31(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPE {
             if 9 >= min_prec {
+                if scan_single_expression_lr_32(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_single_expression_lr_32(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_AMPAMP {
             if 8 >= min_prec {
+                if scan_single_expression_lr_33(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_single_expression_lr_33(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_PIPEPIPE {
             if 7 >= min_prec {
+                if scan_single_expression_lr_34(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_single_expression_lr_34(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_LIT_EQ {
             if 5 >= min_prec {
+                if scan_single_expression_lr_36(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_single_expression_lr_36(p, result, start)?;
             } else {
                 break;
             }
         } else if _gale_kind_set_67(suffix_kind) {
             if 4 >= min_prec {
+                if scan_single_expression_lr_37(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_single_expression_lr_37(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_BackTick {
             if 3 >= min_prec {
+                if scan_single_expression_lr_38(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_single_expression_lr_38(p, result, start)?;
             } else {
                 break;
             }
         } else if suffix_kind == TK_As {
             if 2 >= min_prec {
+                if scan_single_expression_lr_51(&p.tokens, p.pos) < 0 {
+                    break;
+                }
                 result = parse_single_expression_lr_51(p, result, start)?;
             } else {
                 break;

--- a/package-gale/tests/generated/unicode_props/unicode_props.g4.kiln.json
+++ b/package-gale/tests/generated/unicode_props/unicode_props.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f37fa830f2a0df13",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1f31da89fa61c21d45db7b7015dc848fa1fe72841bd92749ece698b41f878835",
+  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
   "primary": {
     "path": "grammars/unicode_props.g4",
     "hash": "7559b99d20b67597cdc99b2e9e0eaeea1ad4b0931d40859c1dbb600e20d1c5c0"

--- a/package-gale/tests/generated/unicode_props/unicode_props.g4.kiln.json
+++ b/package-gale/tests/generated/unicode_props/unicode_props.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f37fa830f2a0df13",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "fd7758a72ea36dccc1aa31950af995a8ccb6c16b9ee41334d9fd5ad5a9c153b2",
+  "generator_source_hash": "7544a0ef9c47eaecaf04778fb5bfb4551c2972fda8dbbe88d446c8f0372b1091",
   "primary": {
     "path": "grammars/unicode_props.g4",
     "hash": "7559b99d20b67597cdc99b2e9e0eaeea1ad4b0931d40859c1dbb600e20d1c5c0"


### PR DESCRIPTION
## Summary

Close three ANTLR4 Stage B compatibility gaps surfaced by
`tests/antlr4-compat/`. Each fix is grounded in a sound design rather
than a minimal patch:

- **Keyword classification carrier check** (`lexer_gen.wado`).
  `collect_keyword_rules` now demotes single-literal candidates to
  the regular `try_*` matcher path when no non-keyword rule covers
  their first character — without a carrier, the
  `if best_end > start { classify_keyword(...) }` gate never fires
  and the rule is unreachable. Fixes
  `ParserExec/BuildParseTree_TRUE` (was a `[stage_b_todo]`
  "investigation pending").
- **LR loop suffix back-off + scan-predicted parse**
  (`parser_gen.wado`). When the suffix's first token is shared with
  the atom (e.g. `statement: letterA | statement letterA 'b'`),
  first-token dispatch alone can mis-predict. The scan side now
  saves `pos` and restores+breaks on suffix failure instead of
  failing the whole scan with `-1`; the parse side consults the
  scan twin first and only commits to the (mutating) parse when
  the scan confirms the suffix would succeed. Refactored the
  inline copy in `gen_lr_suffix_dispatch` to call the shared
  `gen_lr_call_with_prec` helper so the change applies to overlap
  dispatch too. Fixes
  `LeftRecursion/PrecedenceFilterConsidersContext`.
- **List-label `+=` Array<T> wrapping** (`parser_gen.wado`). When an
  LR helper's recursive position carries a `+=` label (or a later
  `+=` label appears in the suffix), the IR field type is
  `Array<T>` but the helper was assigning a single `T`. The helper
  now wraps the inherited `left` and each per-iteration value in
  `[...] as Array<T>` so the struct literal matches. Unblocks all
  four `LeftRecursion/ReturnValueAndActionsList[12]_[13]`
  `[stage_b_skip]` entries.

Plus docs: a new "next focus" section in `TODO.md` for full-context
LL(\*) prediction (the remaining `ParserExec/PredictionMode_LL`
descriptor), and refreshed Stage B counters / "Recently closed gaps"
in `antlr4-compatibility.md`.

## Stage B status after this branch

| Counter           | Before | After |
| ----------------- | -----: | ----: |
| Stage B emitted   |     70 |    74 |
| pass              |     57 |    70 |
| `#[TODO]`         |     13 |     4 |
| `[stage_b_skip]`  |      4 |     0 |

(The "before" `#[TODO]=13` is the documented historical figure; the
live `status.toml` was at 6 going in.)

Remaining `#[TODO]`s split into two buckets:

- **LL(\*) prediction (next focus)** — `ParserExec/PredictionMode_LL`
- **Stage C action / predicate execution** —
  `LeftRecursion/SemPredFailOption`,
  `SemPredEvalParser/PredFromAltTestedInLoopBack_{1,2}`

## Test plan

- [x] `wado test package-gale/src/codegen_test.wado` — 37 pass
      (3 new TDD tests for the structural changes + an existing
      assertion sharpened to its semantic intent)
- [x] `wado test package-gale/tests/antlr4-compat` — 415 pass / 0
      fail / 4 todo
- [x] `wado test package-gale` (full suite) — 1042 pass / 0 fail /
      4 todo
- [x] `package-gale/scripts/extract-antlr4-descriptors.sh
      LeftRecursion ParserExec` regenerates the per-descriptor
      `stage_b/...` test files cleanly; no `#[TODO]` decoration on
      the resolved entries

https://claude.ai/code/session_01XGe8EtPXLnX7WhhLxp8imo

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGe8EtPXLnX7WhhLxp8imo)_