### PR TITLE
example: fast HTTP router benchmark + WEP for core:router

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -107,3 +107,4 @@ It may include TODOs on WIP.
 - [Resource Inheritance and Downcast (`resource extends`)](./wep-2026-04-28-resource-inheritance.md)
 - [Test Discovery](./wep-2026-05-02-test-discovery.md)
 - [WIT Interoperability](./wep-2026-05-02-wit-interoperability.md)
+- [HTTP Path Router (`core:router`)](./wep-2026-05-06-core-router.md)

--- a/docs/wep-2026-05-06-core-router.md
+++ b/docs/wep-2026-05-06-core-router.md
@@ -2,84 +2,65 @@
 
 ## Context
 
-Wado programs that handle HTTP requests via `wasi:http/service` need to dispatch incoming requests to handlers based on `(method, path)`. Today every author rolls their own — a `match` ladder, a hand-written `if`/`else if` chain, or an inline trie — and gets to choose between unacceptably slow linear scans and writing several hundred lines of routing infrastructure. A standard router lets every Wado HTTP service ship with a fast, correct, parameterized matcher out of the box.
-
-### Design Goals
-
-1. **Wasm/WASI native**: zero non-Wado dependencies, no I/O, no FFI; pure computation usable in any world
-2. **Fast match path**: per-lookup cost competitive with mainstream native HTTP routers (`httprouter`, `matchit`, `axum`); no per-segment allocations on the hot path
-3. **Path-parameter capture by name**: results expose params as `TreeMap<String, String>` so handlers read `params["id"]` rather than tracking positional indices
-4. **Generic over handler type**: route to whatever the user wants — handler ids, function references, structs — via a `Router<H>` parameter
-5. **Algorithm-neutral surface**: the public API does not commit to a specific data structure, so future implementation swaps (precompiled DFAs, hybrid hash + DFA, etc.) ship without breaking source compatibility
-6. **`wasi:http` ergonomics**: provide a one-call helper that takes a `Request` and returns the match result, hiding path-vs-query splitting
+Wado programs that handle HTTP requests via `wasi:http/service` need to dispatch incoming requests to handlers based on `(method, path)`. Today every author rolls their own — a `match` ladder, a hand-written `if`/`else if` chain, or an inline trie. A standard router lets every Wado HTTP service ship with a fast, correct, parameterized matcher out of the box.
 
 ### Scope
 
-#### In Scope
+In:
 
-- Static segment matching (`/api/v1/health`)
+- Static segments (`/api/v1/health`)
 - Single-segment parameters (`/users/:id`)
-- Trailing wildcard / catch-all (`/static/*path`)
-- HTTP method dispatch (multiple methods per path with different handlers)
-- 404 and 405 distinction (`allowed_methods(path)` returns the methods registered for a matching path)
-- `Eq`-based duplicate-route handling: last write wins
+- Trailing wildcard (`/static/*path`)
+- HTTP method dispatch with 404 vs. 405 distinction
 - `wasi:http::Request` adapter
 
-#### Out of Scope (for v1)
+Out (deferred until a real Wado service hits the limit):
 
 - Constrained / typed parameters (`:id<\d+>`, `:slug<[a-z0-9-]+>`)
-- Regex routes
 - Subdomain / hostname routing
 - Mid-segment splits (`/users-:id`)
 - Streaming / partial match
-- Route precedence configuration knobs (the engine fixes literal > param > wildcard)
-
-These are deferred until a real Wado service hits the limit; the structure of the v1 API leaves room to add them.
 
 ### Prior Art
 
-| Router                 | Algorithm                      | Param style | Notes                                        |
-| ---------------------- | ------------------------------ | ----------- | -------------------------------------------- |
-| Go `httprouter`, `gin` | Radix tree                     | `:name`     | Industry baseline, byte-level prefix tree    |
-| Rust `matchit`         | Radix tree                     | `{name}`    | Faster `httprouter` clone, used by axum      |
-| Rust `actix-web`       | Compiled state machine + regex | `{name}`    | Slower than radix in practice, more flexible |
-| Node `find-my-way`     | Radix tree                     | `:name`     | Used by Fastify                              |
-| Rails `journey`        | Code-generated NFA             | `:name`     | Fast lookup, slow build, generates Ruby code |
-| Express.js             | Linear scan                    | `:name`     | Simple, slow at scale                        |
+| Router                 | Algorithm                      | Param style |
+| ---------------------- | ------------------------------ | ----------- |
+| Go `httprouter`, `gin` | Radix tree                     | `:name`     |
+| Rust `matchit` (axum)  | Radix tree                     | `{name}`    |
+| Rust `actix-web`       | Compiled state machine + regex | `{name}`    |
+| Node `find-my-way`     | Radix tree                     | `:name`     |
 
-Wado follows the same pattern syntax convention as `httprouter` / `matchit` / `find-my-way` (`:name`, `*name`) so users coming from these ecosystems do not need to relearn anything.
+Wado follows the `httprouter` / `matchit` syntax (`:name`, `*name`).
 
 ### Experimental Validation
 
-The choice of algorithm in `core:router` is informed by a benchmark living under `example/router-*.wado`. Three engines — Linear scan / Radix tree / segment-level tagged DFA — were implemented against an identical 100-route fixture (70 static, 25 parametric, 5 wildcard, clustered under `/api/v1/...`) and run through a 10-element access pattern (9 hits + 1 miss).
+The algorithm choice is informed by `example/router-*.wado`, which implements three engines (Linear / Radix tree / segment-level tagged DFA) against an identical 100-route fixture (70 static, 25 parametric, 5 wildcard, clustered under `/api/v1/...`) and runs them through a 10-element access pattern (9 hits + 1 miss).
 
-Final numbers (debug `wasmtime`, Wado `-O2`, 5000 outer iterations × 10 lookups = 50000 lookups):
+Final numbers (debug `wasmtime`, Wado `-O2`, 50000 lookups):
 
-| Engine                   | Total time     | Per-lookup | vs Linear  |
-| ------------------------ | -------------- | ---------- | ---------- |
-| Linear (mixed)           | 34027 ms       | 681 µs     | 1×         |
-| Linear (best, 1st route) | 571 ms / 50K   | 11 µs      | 60× faster |
-| Linear (worst, miss)     | 48649 ms / 50K | 973 µs     | 0.7×       |
-| **Radix tree**           | **2376 ms**    | **48 µs**  | **14×**    |
-| **Segment DFA**          | **2293 ms**    | **46 µs**  | **15×**    |
+| Engine                   | Total time     | Per-lookup |
+| ------------------------ | -------------- | ---------- |
+| Linear (mixed)           | 34027 ms       | 681 µs     |
+| Linear (best, 1st route) | 571 ms / 50K   | 11 µs      |
+| Linear (worst, miss)     | 48649 ms / 50K | 973 µs     |
+| **Radix tree**           | **2376 ms**    | **48 µs**  |
+| **Segment DFA**          | **2293 ms**    | **46 µs**  |
 
-Radix and DFA are within measurement noise of each other after both received their respective hot-path optimizations (radix: removing a defensive `params.keys()` snapshot; DFA: replacing per-state `TreeMap<String, i32>` with a sorted `Array<Edge>` plus a byte-range binary-search comparator that avoids `substr_bytes` allocation).
+Radix and DFA are within measurement noise of each other.
 
-### Why Segment DFA Wins (Capability View, Not Speed)
+### Why Segment DFA
 
-Given speed parity, the choice is driven by capability and maintenance characteristics:
+Given speed parity, the choice is driven by capability and maintenance:
 
-| Aspect                           | Radix tree                         | Segment DFA                     |
-| -------------------------------- | ---------------------------------- | ------------------------------- |
-| Build cost (100 routes, debug)   | 77 ms                              | 21 ms (~3.5× faster)            |
-| Code size                        | ~180 lines                         | ~150 lines                      |
-| Hot-path branches                | recursive, with backtracking       | iterative loop, no backtracking |
-| State-graph readability          | byte-level edges, hard to dump     | segment-level, dump-friendly    |
-| Mid-segment prefix sharing       | yes (`/list` / `/listed` collapse) | no (separate edges)             |
-| Future `:id<\d+>` constraints    | easy                               | easy                            |
-| Future per-state instrumentation | awkward (edges may span segments)  | natural (segment = transition)  |
+| Aspect                           | Radix tree                        | Segment DFA                     |
+| -------------------------------- | --------------------------------- | ------------------------------- |
+| Build cost (100 routes, debug)   | 77 ms                             | 21 ms (~3.5× faster)            |
+| Code size                        | ~180 lines                        | ~150 lines                      |
+| Hot-path branches                | recursive, with backtracking      | iterative loop, no backtracking |
+| State-graph readability          | byte-level edges, hard to dump    | segment-level, dump-friendly    |
+| Future per-state instrumentation | awkward (edges may span segments) | natural (segment = transition)  |
 
-The segment-level model matches "how authors think about routes" (segment → segment → handler) and is therefore the easier shape to extend in upcoming features (typed params, debug introspection, code-gen DFA). Mid-segment prefix sharing — the one strict win of byte-level radix — does not occur in real HTTP route sets often enough to justify the additional complexity.
+The segment-level model matches "how authors think about routes" (segment → segment → handler) and is the easier shape to extend (typed params, debug introspection, code-gen DFA).
 
 Radix tree is still recommended as a separate `core:collections::PrefixTree<V>` for general byte-prefix indexing, where its byte-level granularity is genuinely useful.
 
@@ -89,7 +70,7 @@ Radix tree is still recommended as a separate `core:collections::PrefixTree<V>` 
 
 ```wado
 use { Router, RouteMatch } from "core:router";
-use { Method } from "wasi:http";   // re-exported convenience: also available as core:router::Method
+use { Method } from "wasi:http";   // also re-exported as core:router::Method
 ```
 
 The router is generic over the handler type `H`. Typical choices:
@@ -106,14 +87,15 @@ The router is generic over the handler type `H`. Typical choices:
 "/api/v1/users/:id"              parameter
 "/api/v1/users/:id/posts/:pid"   multiple parameters (each captures one segment)
 "/static/*path"                  trailing wildcard (must be last)
+"/"                              the root / home route
 ```
 
 Rules:
 
-- A leading `/` is required.
+- A leading `/` is required. Patterns without one panic at registration.
 - A `:` segment must contain a non-empty parameter name.
 - A `*` segment must contain a non-empty parameter name and be the last segment.
-- Path matching is strict on trailing slashes: `/users` and `/users/` are different routes.
+- Path matching is strict on trailing slashes: `/users` and `/users/` are different routes. `/` is the canonical root and matches the empty-segment pattern `"/"`.
 
 ### Types
 
@@ -128,12 +110,6 @@ pub struct RouteMatch<H> {
 
 /// Generic HTTP path router.
 pub struct Router<H> { /* private */ }
-```
-
-`Method` is re-exported from `wasi:http` so the typical service does not need a second `use`:
-
-```wado
-pub use { Method } from "wasi:http";
 ```
 
 ### `Router<H>` Methods
@@ -160,29 +136,12 @@ impl<H> Router<H> {
     /// `Allow:` header on a 405 response. Returns an empty array on a
     /// genuine 404.
     pub fn allowed_methods(&self, path: &String) -> Array<Method>
-}
-```
 
-### `wasi:http` Adapter
-
-```wado
-use { Request } from "wasi:http";
-
-impl<H> Router<H> {
     /// Matches against a `wasi:http` `Request`, splitting the path from the
-    /// query string internally. Equivalent to:
-    ///
-    ///   let pq = request.get_path_with_query().unwrap_or("/");
-    ///   let path = match pq.find("?") {
-    ///       Some(i) => pq.substr_bytes(0, i),
-    ///       None => pq,
-    ///   };
-    ///   self.match_path(request.get_method(), &path)
+    /// query string internally. Recommended entry point for HTTP services.
     pub fn match_request(&self, request: &Request) -> Option<RouteMatch<H>>
 }
 ```
-
-This adapter is the recommended entry point for `wasi:http/service` programs.
 
 ### Usage Examples
 
@@ -228,20 +187,16 @@ export async fn handle(request: Request) -> Result<Response, ErrorCode> {
 #### Closure-handler style
 
 ```wado
-type Handler = fn(&Request, &TreeMap<String, String>) -> Response with EffectsHere;
+type Handler = fn(&Request, &TreeMap<String, String>) -> Response with Stdout;
 
 let mut r = Router::<Handler>::new();
-r.route(Method::Get, "/health", |_req, _params| Response::ok("ok"));
-r.route(Method::Get, "/users/:id", |_req, params| {
-    Response::ok(`user {params["id"]}`)
-});
+r.route(Method::Get, "/health",   |_req, _params| Response::ok("ok"));
+r.route(Method::Get, "/users/:id", |_req, params| Response::ok(`user {params["id"]}`));
 ```
 
 (For the CM-async case, the same shape works with `async fn(...) -> ...` once Wado closures support async — orthogonal to this WEP.)
 
-### Behavior Specification
-
-#### Lookup precedence
+### Lookup Precedence
 
 At each state during traversal, transitions are tried in this fixed order; there is no backtracking:
 
@@ -251,24 +206,15 @@ At each state during traversal, transitions are tried in this fixed order; there
 
 This means that `/users/list` registered alongside `/users/:id` will route exactly `/users/list` to the literal handler and any other single-segment value to the param handler. A path like `/users/list/extra` is **not** automatically re-tried against the param branch; it is a 404 unless `/users/:id/extra` is also registered.
 
-This is the same rule used by `httprouter`, `gin`, `echo`, and `matchit`. The alternative — backtracking from a literal dead-end into the param branch — is rejected because it produces surprising matches (a literal that "wins" at one level but later fails redirects to a `:id` capture that swallows the literal name as the id).
+This is the same rule used by `httprouter`, `gin`, `echo`, and `matchit`. The alternative — backtracking from a literal dead-end into the param branch — produces surprising matches where a literal "wins" at one level but later fails and silently falls into a `:id` capture that swallows the literal name as the id.
 
-#### Method handling
+### Method Handling
 
 Each terminal stores a small list of `(Method, H)` entries. Registering `(Get, "/users", h1)` and `(Post, "/users", h2)` produces two entries at the same terminal; `match_path(Get, ...)` returns `h1`, `match_path(Post, ...)` returns `h2`, and `match_path(Put, ...)` returns `None` while `allowed_methods("/users")` returns `[Get, Post]`.
 
-#### Trait Implementations
-
-```wado
-impl<H: Inspect> Inspect for Router<H>          // for `{router:?}`
-impl<H: Inspect> Inspect for RouteMatch<H>      // for `{m:?}`
-```
-
-`Router<H>` is not `Eq` (route order during build can produce structurally distinct DFAs that match identically; defining equality is more confusing than helpful).
-
 ### Implementation Notes
 
-The implementation lives in `wado-compiler/lib/core/router.wado` and is ported almost verbatim from `example/router-dfa.wado`, with the following changes:
+The implementation lives in `wado-compiler/lib/core/router.wado` and is ported from `example/router-dfa.wado`, with the following changes:
 
 - `RouteMatch` is generic over `H`; the example uses a concrete `i32 handler_id`.
 - A `handlers: Array<H>` arena is added to `Router<H>`; terminal states reference handlers by `i32` index. This keeps `DfaState` non-generic, which avoids the monomorphization blow-up of including `H` inside every state.
@@ -282,26 +228,18 @@ wado-compiler/lib/core/router_test.wado   Unit tests (re-uses cases from the exa
 example/router-*.wado                     Retained as a competing-algorithm benchmark
 ```
 
-### Migration & Out-of-Tree Impact
-
-- `example/http-server.wado` and any future `wasi:http/service` example can use `core:router` instead of inline `match path` ladders.
-- No language changes are required.
-- No breaking changes to `core:url`, `wasi:http`, or other modules.
-
 ## Consequences
 
 ### Pros
 
 - A single canonical, fast HTTP router ships with the language.
 - Uniform pattern syntax across the Wado ecosystem (no third-party divergence on `:name` vs `{name}`).
-- The DFA structure is amenable to a future `wado-from-routes` build-time codegen: a constant set of routes can be lowered into a generated `match` cascade with zero runtime construction. The runtime API stays the same.
+- The DFA structure is amenable to a future build-time codegen: a constant set of routes can be lowered into a generated `match` cascade with zero runtime construction. The runtime API stays the same.
 - Shared between `wasi:http` (server side) and HTTP client SPAs (e.g., reactive routers built on `core:url` + `core:router`).
 
-### Cons / Trade-offs
+### Cons
 
-- Generic `Router<H>` adds one more monomorphization axis. Cost is bounded — most services have at most one or two `H` types — and `H` is held in `Array<H>`, not in every state, so the bulk of the DFA is not re-monomorphized per `H`.
-- Routes are not validated at compile time. A typo in a pattern string only surfaces at `Router::new` time. A future macro / `#routes!` form could lift this to compile time.
-- Introducing `Router<H>` discourages users from writing their own routers; if the v1 API is too narrow (e.g., no constraint syntax), users either fall back to manual matching or wait for v2.
+- Routes are not validated at compile time. A typo in a pattern string only surfaces at `Router::new` time. A future `#routes!` form could lift this to compile time.
 
 ### Future Work
 
@@ -309,7 +247,6 @@ example/router-*.wado                     Retained as a competing-algorithm benc
 - [ ] Build-time route compilation: `#![generated]` DFA tables produced from a TOML/Wado route manifest
 - [ ] `core:collections::PrefixTree<V>` for the byte-level radix algorithm, separated from HTTP routing
 - [ ] OpenAPI / Swagger introspection: dump the route table as JSON for documentation tooling
-- [ ] Route precedence customization (priority hints) — only if a real use case appears
 
 ## See Also
 

--- a/docs/wep-2026-05-06-core-router.md
+++ b/docs/wep-2026-05-06-core-router.md
@@ -1,0 +1,318 @@
+# WEP: HTTP Path Router (`core:router`)
+
+## Context
+
+Wado programs that handle HTTP requests via `wasi:http/service` need to dispatch incoming requests to handlers based on `(method, path)`. Today every author rolls their own — a `match` ladder, a hand-written `if`/`else if` chain, or an inline trie — and gets to choose between unacceptably slow linear scans and writing several hundred lines of routing infrastructure. A standard router lets every Wado HTTP service ship with a fast, correct, parameterized matcher out of the box.
+
+### Design Goals
+
+1. **Wasm/WASI native**: zero non-Wado dependencies, no I/O, no FFI; pure computation usable in any world
+2. **Fast match path**: per-lookup cost competitive with mainstream native HTTP routers (`httprouter`, `matchit`, `axum`); no per-segment allocations on the hot path
+3. **Path-parameter capture by name**: results expose params as `TreeMap<String, String>` so handlers read `params["id"]` rather than tracking positional indices
+4. **Generic over handler type**: route to whatever the user wants — handler ids, function references, structs — via a `Router<H>` parameter
+5. **Algorithm-neutral surface**: the public API does not commit to a specific data structure, so future implementation swaps (precompiled DFAs, hybrid hash + DFA, etc.) ship without breaking source compatibility
+6. **`wasi:http` ergonomics**: provide a one-call helper that takes a `Request` and returns the match result, hiding path-vs-query splitting
+
+### Scope
+
+#### In Scope
+
+- Static segment matching (`/api/v1/health`)
+- Single-segment parameters (`/users/:id`)
+- Trailing wildcard / catch-all (`/static/*path`)
+- HTTP method dispatch (multiple methods per path with different handlers)
+- 404 and 405 distinction (`allowed_methods(path)` returns the methods registered for a matching path)
+- `Eq`-based duplicate-route handling: last write wins
+- `wasi:http::Request` adapter
+
+#### Out of Scope (for v1)
+
+- Constrained / typed parameters (`:id<\d+>`, `:slug<[a-z0-9-]+>`)
+- Regex routes
+- Subdomain / hostname routing
+- Mid-segment splits (`/users-:id`)
+- Streaming / partial match
+- Route precedence configuration knobs (the engine fixes literal > param > wildcard)
+
+These are deferred until a real Wado service hits the limit; the structure of the v1 API leaves room to add them.
+
+### Prior Art
+
+| Router                 | Algorithm                      | Param style | Notes                                        |
+| ---------------------- | ------------------------------ | ----------- | -------------------------------------------- |
+| Go `httprouter`, `gin` | Radix tree                     | `:name`     | Industry baseline, byte-level prefix tree    |
+| Rust `matchit`         | Radix tree                     | `{name}`    | Faster `httprouter` clone, used by axum      |
+| Rust `actix-web`       | Compiled state machine + regex | `{name}`    | Slower than radix in practice, more flexible |
+| Node `find-my-way`     | Radix tree                     | `:name`     | Used by Fastify                              |
+| Rails `journey`        | Code-generated NFA             | `:name`     | Fast lookup, slow build, generates Ruby code |
+| Express.js             | Linear scan                    | `:name`     | Simple, slow at scale                        |
+
+Wado follows the same pattern syntax convention as `httprouter` / `matchit` / `find-my-way` (`:name`, `*name`) so users coming from these ecosystems do not need to relearn anything.
+
+### Experimental Validation
+
+The choice of algorithm in `core:router` is informed by a benchmark living under `example/router-*.wado`. Three engines — Linear scan / Radix tree / segment-level tagged DFA — were implemented against an identical 100-route fixture (70 static, 25 parametric, 5 wildcard, clustered under `/api/v1/...`) and run through a 10-element access pattern (9 hits + 1 miss).
+
+Final numbers (debug `wasmtime`, Wado `-O2`, 5000 outer iterations × 10 lookups = 50000 lookups):
+
+| Engine                   | Total time     | Per-lookup | vs Linear  |
+| ------------------------ | -------------- | ---------- | ---------- |
+| Linear (mixed)           | 34027 ms       | 681 µs     | 1×         |
+| Linear (best, 1st route) | 571 ms / 50K   | 11 µs      | 60× faster |
+| Linear (worst, miss)     | 48649 ms / 50K | 973 µs     | 0.7×       |
+| **Radix tree**           | **2376 ms**    | **48 µs**  | **14×**    |
+| **Segment DFA**          | **2293 ms**    | **46 µs**  | **15×**    |
+
+Radix and DFA are within measurement noise of each other after both received their respective hot-path optimizations (radix: removing a defensive `params.keys()` snapshot; DFA: replacing per-state `TreeMap<String, i32>` with a sorted `Array<Edge>` plus a byte-range binary-search comparator that avoids `substr_bytes` allocation).
+
+### Why Segment DFA Wins (Capability View, Not Speed)
+
+Given speed parity, the choice is driven by capability and maintenance characteristics:
+
+| Aspect                           | Radix tree                         | Segment DFA                     |
+| -------------------------------- | ---------------------------------- | ------------------------------- |
+| Build cost (100 routes, debug)   | 77 ms                              | 21 ms (~3.5× faster)            |
+| Code size                        | ~180 lines                         | ~150 lines                      |
+| Hot-path branches                | recursive, with backtracking       | iterative loop, no backtracking |
+| State-graph readability          | byte-level edges, hard to dump     | segment-level, dump-friendly    |
+| Mid-segment prefix sharing       | yes (`/list` / `/listed` collapse) | no (separate edges)             |
+| Future `:id<\d+>` constraints    | easy                               | easy                            |
+| Future per-state instrumentation | awkward (edges may span segments)  | natural (segment = transition)  |
+
+The segment-level model matches "how authors think about routes" (segment → segment → handler) and is therefore the easier shape to extend in upcoming features (typed params, debug introspection, code-gen DFA). Mid-segment prefix sharing — the one strict win of byte-level radix — does not occur in real HTTP route sets often enough to justify the additional complexity.
+
+Radix tree is still recommended as a separate `core:collections::PrefixTree<V>` for general byte-prefix indexing, where its byte-level granularity is genuinely useful.
+
+## Decision
+
+### Module: `core:router`
+
+```wado
+use { Router, RouteMatch } from "core:router";
+use { Method } from "wasi:http";   // re-exported convenience: also available as core:router::Method
+```
+
+The router is generic over the handler type `H`. Typical choices:
+
+- `i32` (handler id, user-managed dispatch table)
+- `fn(Request) -> Result<Response, ErrorCode>` (synchronous handler)
+- `async fn(Request) -> Result<Response, ErrorCode>` (CM-async handler)
+- A user-defined struct or variant
+
+### Pattern Syntax
+
+```
+"/api/v1/users"                  static
+"/api/v1/users/:id"              parameter
+"/api/v1/users/:id/posts/:pid"   multiple parameters (each captures one segment)
+"/static/*path"                  trailing wildcard (must be last)
+```
+
+Rules:
+
+- A leading `/` is required.
+- A `:` segment must contain a non-empty parameter name.
+- A `*` segment must contain a non-empty parameter name and be the last segment.
+- Path matching is strict on trailing slashes: `/users` and `/users/` are different routes.
+
+### Types
+
+```wado
+/// Result of a successful match. `params` is the captured parameter values
+/// keyed by parameter name; for a wildcard route the captured tail is
+/// stored under the wildcard name.
+pub struct RouteMatch<H> {
+    pub handler: H,
+    pub params: TreeMap<String, String>,
+}
+
+/// Generic HTTP path router.
+pub struct Router<H> { /* private */ }
+```
+
+`Method` is re-exported from `wasi:http` so the typical service does not need a second `use`:
+
+```wado
+pub use { Method } from "wasi:http";
+```
+
+### `Router<H>` Methods
+
+```wado
+impl<H> Router<H> {
+    /// Constructs an empty router.
+    pub fn new() -> Router<H>
+
+    /// Registers a handler for the given (method, pattern).
+    /// Last-write-wins: re-registering the same (method, pattern) replaces
+    /// the previous handler. Panics on a malformed pattern (empty,
+    /// missing leading `/`, trailing-wildcard not last, empty param/wildcard
+    /// name).
+    pub fn route(&mut self, method: Method, pattern: String, handler: H) with stores[handler]
+
+    /// Matches a method/path pair. Returns `Some(RouteMatch)` on a hit and
+    /// `None` on a miss. The path argument must be the URL path only (no
+    /// query string, no fragment).
+    pub fn match_path(&self, method: Method, path: &String) -> Option<RouteMatch<H>>
+
+    /// If `path` matches a registered route under any method, returns the
+    /// list of methods registered for that path. Useful for emitting the
+    /// `Allow:` header on a 405 response. Returns an empty array on a
+    /// genuine 404.
+    pub fn allowed_methods(&self, path: &String) -> Array<Method>
+}
+```
+
+### `wasi:http` Adapter
+
+```wado
+use { Request } from "wasi:http";
+
+impl<H> Router<H> {
+    /// Matches against a `wasi:http` `Request`, splitting the path from the
+    /// query string internally. Equivalent to:
+    ///
+    ///   let pq = request.get_path_with_query().unwrap_or("/");
+    ///   let path = match pq.find("?") {
+    ///       Some(i) => pq.substr_bytes(0, i),
+    ///       None => pq,
+    ///   };
+    ///   self.match_path(request.get_method(), &path)
+    pub fn match_request(&self, request: &Request) -> Option<RouteMatch<H>>
+}
+```
+
+This adapter is the recommended entry point for `wasi:http/service` programs.
+
+### Usage Examples
+
+#### Handler-id style
+
+```wado
+use { Router } from "core:router";
+use { Method, Request, Response, ErrorCode } from "wasi:http";
+
+global ROUTER: Router<i32> = build_router();
+
+fn build_router() -> Router<i32> {
+    let mut r = Router::<i32>::new();
+    r.route(Method::Get,    "/health",                 0);
+    r.route(Method::Get,    "/api/v1/users",           1);
+    r.route(Method::Post,   "/api/v1/users",           2);
+    r.route(Method::Get,    "/api/v1/users/:id",       3);
+    r.route(Method::Delete, "/api/v1/users/:id",       4);
+    r.route(Method::Get,    "/static/*path",           5);
+    return r;
+}
+
+export async fn handle(request: Request) -> Result<Response, ErrorCode> {
+    if let Some(m) = ROUTER.match_request(&request) {
+        return match m.handler {
+            0 => respond_health(),
+            1 => respond_users_list(),
+            2 => respond_user_create(&request),
+            3 => respond_user_get(m.params["id"]),
+            4 => respond_user_delete(m.params["id"]),
+            5 => respond_static(m.params["path"]),
+            _ => unreachable(),
+        };
+    }
+    let allowed = ROUTER.allowed_methods(&request.get_path_with_query().unwrap_or("/"));
+    if !allowed.is_empty() {
+        return Result::Ok(method_not_allowed(allowed));   // 405 with Allow:
+    }
+    return Result::Ok(not_found());                       // 404
+}
+```
+
+#### Closure-handler style
+
+```wado
+type Handler = fn(&Request, &TreeMap<String, String>) -> Response with EffectsHere;
+
+let mut r = Router::<Handler>::new();
+r.route(Method::Get, "/health", |_req, _params| Response::ok("ok"));
+r.route(Method::Get, "/users/:id", |_req, params| {
+    Response::ok(`user {params["id"]}`)
+});
+```
+
+(For the CM-async case, the same shape works with `async fn(...) -> ...` once Wado closures support async — orthogonal to this WEP.)
+
+### Behavior Specification
+
+#### Lookup precedence
+
+At each state during traversal, transitions are tried in this fixed order; there is no backtracking:
+
+1. Literal — the segment exactly equals one of the registered literal edges
+2. Parameter — there is a `:name` child; the current segment is captured and traversal descends
+3. Wildcard — there is a `*name` child; the entire remainder of the path is captured
+
+This means that `/users/list` registered alongside `/users/:id` will route exactly `/users/list` to the literal handler and any other single-segment value to the param handler. A path like `/users/list/extra` is **not** automatically re-tried against the param branch; it is a 404 unless `/users/:id/extra` is also registered.
+
+This is the same rule used by `httprouter`, `gin`, `echo`, and `matchit`. The alternative — backtracking from a literal dead-end into the param branch — is rejected because it produces surprising matches (a literal that "wins" at one level but later fails redirects to a `:id` capture that swallows the literal name as the id).
+
+#### Method handling
+
+Each terminal stores a small list of `(Method, H)` entries. Registering `(Get, "/users", h1)` and `(Post, "/users", h2)` produces two entries at the same terminal; `match_path(Get, ...)` returns `h1`, `match_path(Post, ...)` returns `h2`, and `match_path(Put, ...)` returns `None` while `allowed_methods("/users")` returns `[Get, Post]`.
+
+#### Trait Implementations
+
+```wado
+impl<H: Inspect> Inspect for Router<H>          // for `{router:?}`
+impl<H: Inspect> Inspect for RouteMatch<H>      // for `{m:?}`
+```
+
+`Router<H>` is not `Eq` (route order during build can produce structurally distinct DFAs that match identically; defining equality is more confusing than helpful).
+
+### Implementation Notes
+
+The implementation lives in `wado-compiler/lib/core/router.wado` and is ported almost verbatim from `example/router-dfa.wado`, with the following changes:
+
+- `RouteMatch` is generic over `H`; the example uses a concrete `i32 handler_id`.
+- A `handlers: Array<H>` arena is added to `Router<H>`; terminal states reference handlers by `i32` index. This keeps `DfaState` non-generic, which avoids the monomorphization blow-up of including `H` inside every state.
+- `route()` validates patterns and panics on malformed input.
+- Method dispatch supports multiple methods per terminal via a sorted `Array<MethodEntry>` per terminal, binary-searched on lookup. (The example assumes one method per terminal.)
+- A `match_request` adapter handles path/query split.
+
+```
+wado-compiler/lib/core/router.wado        Implementation (~250 lines)
+wado-compiler/lib/core/router_test.wado   Unit tests (re-uses cases from the example)
+example/router-*.wado                     Retained as a competing-algorithm benchmark
+```
+
+### Migration & Out-of-Tree Impact
+
+- `example/http-server.wado` and any future `wasi:http/service` example can use `core:router` instead of inline `match path` ladders.
+- No language changes are required.
+- No breaking changes to `core:url`, `wasi:http`, or other modules.
+
+## Consequences
+
+### Pros
+
+- A single canonical, fast HTTP router ships with the language.
+- Uniform pattern syntax across the Wado ecosystem (no third-party divergence on `:name` vs `{name}`).
+- The DFA structure is amenable to a future `wado-from-routes` build-time codegen: a constant set of routes can be lowered into a generated `match` cascade with zero runtime construction. The runtime API stays the same.
+- Shared between `wasi:http` (server side) and HTTP client SPAs (e.g., reactive routers built on `core:url` + `core:router`).
+
+### Cons / Trade-offs
+
+- Generic `Router<H>` adds one more monomorphization axis. Cost is bounded — most services have at most one or two `H` types — and `H` is held in `Array<H>`, not in every state, so the bulk of the DFA is not re-monomorphized per `H`.
+- Routes are not validated at compile time. A typo in a pattern string only surfaces at `Router::new` time. A future macro / `#routes!` form could lift this to compile time.
+- Introducing `Router<H>` discourages users from writing their own routers; if the v1 API is too narrow (e.g., no constraint syntax), users either fall back to manual matching or wait for v2.
+
+### Future Work
+
+- [ ] Constrained parameters: `:id<\d+>`, `:slug<[a-z0-9-]+>`
+- [ ] Build-time route compilation: `#![generated]` DFA tables produced from a TOML/Wado route manifest
+- [ ] `core:collections::PrefixTree<V>` for the byte-level radix algorithm, separated from HTTP routing
+- [ ] OpenAPI / Swagger introspection: dump the route table as JSON for documentation tooling
+- [ ] Route precedence customization (priority hints) — only if a real use case appears
+
+## See Also
+
+- [WEP: URL Standard Library (`core:url`)](./wep-2026-04-10-url-stdlib.md)
+- [WEP: WASI HTTP Integration](./wep-2026-02-21-wasi-http.md)
+- `example/router-*.wado` — competing-algorithm benchmark

--- a/example/router-bench.wado
+++ b/example/router-bench.wado
@@ -19,6 +19,7 @@
 use { println, Stdout } from "core:cli";
 use { MonotonicClock } from "wasi:clocks";
 use { Benchmark } from "core:benchmark";
+use { TreeMap } from "core:collections";
 use {
     AccessRequest, Method, RoutePattern,
     build_routes, build_access_pattern,
@@ -77,9 +78,29 @@ fn run_linear_one(router: &LinearRouter, method: Method, path: &String, repeats:
     return acc;
 }
 
-/// Sanity check: all three engines must return identical results for
-/// every entry in the access pattern. Run before timing so a regression
-/// in one engine doesn't masquerade as a speedup.
+/// Returns true when both maps contain the same key/value pairs. Order
+/// independent because TreeMap.get is O(log n) lookup.
+fn maps_equal(a: &TreeMap<String, String>, b: &TreeMap<String, String>) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    for let [k, v] of a.entries() {
+        match b.get(k) {
+            Some(bv) => {
+                if bv != v {
+                    return false;
+                }
+            },
+            None => { return false; },
+        }
+    }
+    return true;
+}
+
+/// Sanity check: all three engines must return identical handler ids
+/// *and* identical params for every entry in the access pattern. Run
+/// before timing so a regression in one engine doesn't masquerade as a
+/// speedup.
 fn verify_engines_agree(
     linear: &LinearRouter,
     radix: &RadixRouter,
@@ -94,6 +115,11 @@ fn verify_engines_agree(
         let expected = req.expected_handler_id;
         if l.handler_id != expected || r.handler_id != expected || d.handler_id != expected {
             println(`MISMATCH on {req.path}: expected={expected} linear={l.handler_id} radix={r.handler_id} dfa={d.handler_id}`);
+            all_ok = false;
+            continue;
+        }
+        if !maps_equal(&l.params, &r.params) || !maps_equal(&l.params, &d.params) {
+            println(`PARAMS MISMATCH on {req.path}: linear={l.params:?} radix={r.params:?} dfa={d.params:?}`);
             all_ok = false;
         }
     }

--- a/example/router-bench.wado
+++ b/example/router-bench.wado
@@ -1,0 +1,143 @@
+//! HTTP router benchmark driver.
+//!
+//! Builds the same 100 routes (see router-common.wado) into three engines
+//! — Linear / Radix tree / segment-level tagged DFA — and times them on
+//! a balanced 10-element access pattern (9 hits + 1 miss).
+//!
+//! Linear is reported twice to expose the spread between best and worst
+//! cases: `linear (best)` always matches the very first route in the
+//! array, while `linear (worst)` repeatedly hits a path that does not
+//! exist (full N-route walk + match-fail). The other two engines are
+//! given the realistic mixed pattern.
+//!
+//! Run:
+//!   cargo run --bin wado -- run example/router-bench.wado
+//!
+//! Each result line shows `total ms` for `iterations` repetitions of the
+//! given inner loop and `ms/iter` for one inner loop. Smaller is faster.
+
+use { println, Stdout } from "core:cli";
+use { MonotonicClock } from "wasi:clocks";
+use { Benchmark } from "core:benchmark";
+use {
+    AccessRequest, Method, RoutePattern,
+    build_routes, build_access_pattern,
+} from "./router-common.wado";
+use { LinearRouter } from "./router-linear.wado";
+use { RadixRouter } from "./router-radix.wado";
+use { DfaRouter } from "./router-dfa.wado";
+
+/// Each outer benchmark iteration runs the entire 10-element access
+/// pattern through the engine. Adjust to shift signal-to-noise.
+global OUTER_ITERATIONS: i32 = 5_000;
+
+/// Linear best/worst use a single-path inner loop because their behavior
+/// is uniform within a category. Larger inner count → noise floor sinks.
+global LINEAR_REPEAT: i32 = 50_000;
+
+fn run_mixed_linear(router: &LinearRouter, pattern: &Array<AccessRequest>) -> i32 {
+    let mut acc: i32 = 0;
+    for let mut k = 0; k < OUTER_ITERATIONS; k += 1 {
+        for let req of pattern {
+            let m = router.match_path(req.method, &req.path);
+            acc += m.handler_id;
+        }
+    }
+    return acc;
+}
+
+fn run_mixed_radix(router: &RadixRouter, pattern: &Array<AccessRequest>) -> i32 {
+    let mut acc: i32 = 0;
+    for let mut k = 0; k < OUTER_ITERATIONS; k += 1 {
+        for let req of pattern {
+            let m = router.match_path(req.method, &req.path);
+            acc += m.handler_id;
+        }
+    }
+    return acc;
+}
+
+fn run_mixed_dfa(router: &DfaRouter, pattern: &Array<AccessRequest>) -> i32 {
+    let mut acc: i32 = 0;
+    for let mut k = 0; k < OUTER_ITERATIONS; k += 1 {
+        for let req of pattern {
+            let m = router.match_path(req.method, &req.path);
+            acc += m.handler_id;
+        }
+    }
+    return acc;
+}
+
+fn run_linear_one(router: &LinearRouter, method: Method, path: &String, repeats: i32) -> i32 {
+    let mut acc: i32 = 0;
+    for let mut k = 0; k < repeats; k += 1 {
+        let m = router.match_path(method, path);
+        acc += m.handler_id;
+    }
+    return acc;
+}
+
+/// Sanity check: all three engines must return identical results for
+/// every entry in the access pattern. Run before timing so a regression
+/// in one engine doesn't masquerade as a speedup.
+fn verify_engines_agree(
+    linear: &LinearRouter,
+    radix: &RadixRouter,
+    dfa: &DfaRouter,
+    pattern: &Array<AccessRequest>,
+) with Stdout {
+    let mut all_ok = true;
+    for let req of pattern {
+        let l = linear.match_path(req.method, &req.path);
+        let r = radix.match_path(req.method, &req.path);
+        let d = dfa.match_path(req.method, &req.path);
+        let expected = req.expected_handler_id;
+        if l.handler_id != expected || r.handler_id != expected || d.handler_id != expected {
+            println(`MISMATCH on {req.path}: expected={expected} linear={l.handler_id} radix={r.handler_id} dfa={d.handler_id}`);
+            all_ok = false;
+        }
+    }
+    if all_ok {
+        println("  cross-engine agreement: OK");
+    } else {
+        panic("engines disagree on access pattern; aborting benchmark");
+    }
+}
+
+export fn run() with Stdout, MonotonicClock {
+    let routes = build_routes();
+    let pattern = build_access_pattern();
+
+    println(`router-bench: {routes.len()} routes, {pattern.len()} access samples per outer iter`);
+
+    // Build phase (untimed) and engine cross-check.
+    let linear = LinearRouter::build(&routes);
+    let radix = RadixRouter::build(&routes);
+    let dfa = DfaRouter::build(&routes);
+    verify_engines_agree(&linear, &radix, &dfa, &pattern);
+
+    // Build cost (one-shot, mainly informational).
+    let mut bbuild = Benchmark::new("build cost (one-shot)");
+    bbuild.run("linear build", || LinearRouter::build(&routes));
+    bbuild.run("radix  build", || RadixRouter::build(&routes));
+    bbuild.run("dfa    build", || DfaRouter::build(&routes));
+
+    // Mixed access pattern (9 hits + 1 miss) for the engines that
+    // realistically share work across patterns.
+    let mut bmix = Benchmark::new(`mixed pattern x {OUTER_ITERATIONS} outer iter (10 lookups each)`);
+    let acc_l = bmix.run("linear (mixed)", || run_mixed_linear(&linear, &pattern));
+    let acc_r = bmix.run("radix         ", || run_mixed_radix(&radix, &pattern));
+    let acc_d = bmix.run("dfa           ", || run_mixed_dfa(&dfa, &pattern));
+    bmix.println(`accumulators: linear={acc_l} radix={acc_r} dfa={acc_d}`);
+    if acc_l != acc_r || acc_l != acc_d {
+        panic("accumulator mismatch between engines");
+    }
+
+    // Linear-only best/worst spread.
+    let best_path = "/health";        // first route in build_routes()
+    let worst_path = "/api/v1/does/not/exist";  // miss => full N-route walk
+    let mut blin = Benchmark::new(`linear best/worst x {LINEAR_REPEAT} iter`);
+    let acc_b = blin.run("linear (best ) ", || run_linear_one(&linear, Method::Get, &best_path, LINEAR_REPEAT));
+    let acc_w = blin.run("linear (worst) ", || run_linear_one(&linear, Method::Get, &worst_path, LINEAR_REPEAT));
+    blin.println(`accumulators: best={acc_b} worst={acc_w}`);
+}

--- a/example/router-common.wado
+++ b/example/router-common.wado
@@ -229,19 +229,18 @@ pub fn parse_pattern(path: &String) -> Array<Segment> {
         return out;
     }
     // Expect leading '/'.
-    let mut i = if path.get_byte(0) == 47 { 1 } else { 0 };
+    let mut i = if path.get_byte(0) == '/' as u8 { 1 } else { 0 };
     while i < bytes {
         let mut j = i;
-        while j < bytes && path.get_byte(j) != 47 {
+        while j < bytes && path.get_byte(j) != '/' as u8 {
             j += 1;
         }
         let seg = path.substr_bytes(i, j);
         if seg.len() > 0 {
-            // First byte tags the segment kind: ':' (58) -> Param,
-            // '*' (42) -> Wildcard, anything else -> Literal.
-            let item = match seg.get_byte(0) {
-                58 => Segment::Param(seg.substr_bytes(1, seg.len())),
-                42 => Segment::Wildcard(seg.substr_bytes(1, seg.len())),
+            // First byte tags the segment kind.
+            let item = match seg.get_byte(0) as char {
+                ':' => Segment::Param(seg.substr_bytes(1, seg.len())),
+                '*' => Segment::Wildcard(seg.substr_bytes(1, seg.len())),
                 _ => Segment::Literal(seg),
             };
             out.push(item);

--- a/example/router-common.wado
+++ b/example/router-common.wado
@@ -236,19 +236,15 @@ pub fn parse_pattern(path: &String) -> Array<Segment> {
             j += 1;
         }
         let seg = path.substr_bytes(i, j);
-        if seg.len() == 0 {
-            // skip empty segment from doubled slashes
-        } else {
-            let first = seg.get_byte(0);
-            if first == 58 {
-                // ':' -> param
-                out.push(Segment::Param(seg.substr_bytes(1, seg.len())));
-            } else if first == 42 {
-                // '*' -> wildcard
-                out.push(Segment::Wildcard(seg.substr_bytes(1, seg.len())));
-            } else {
-                out.push(Segment::Literal(seg));
-            }
+        if seg.len() > 0 {
+            // First byte tags the segment kind: ':' (58) -> Param,
+            // '*' (42) -> Wildcard, anything else -> Literal.
+            let item = match seg.get_byte(0) {
+                58 => Segment::Param(seg.substr_bytes(1, seg.len())),
+                42 => Segment::Wildcard(seg.substr_bytes(1, seg.len())),
+                _ => Segment::Literal(seg),
+            };
+            out.push(item);
         }
         i = j + 1;
     }

--- a/example/router-common.wado
+++ b/example/router-common.wado
@@ -146,12 +146,20 @@ pub fn build_routes() -> Array<RoutePattern> {
         "/api/v1/categories/:slug/products/:pid",
     ];
 
+    // NOTE: param names are kept consistent with the first-registered route
+    // through the same position (e.g. `/api/v1/users/:id` registered above
+    // forces every later route through that position to also use `:id`).
+    // Radix and DFA share the param node across overlapping routes, so a
+    // mismatched name there would silently surface as the first-registered
+    // name and disagree with the linear engine that stores each route
+    // independently. The cross-engine `verify_engines_agree` check would
+    // catch such a mismatch — see the bench driver.
     let param3: Array<String> = [
-        "/api/v1/users/:uid/posts/:pid/comments/:cid",
-        "/api/v1/users/:uid/posts/:pid/reactions/:rid",
-        "/api/v1/products/:pid/variants/:vid/reviews/:rid",
-        "/api/v1/orders/:oid/items/:iid/refunds/:rid",
-        "/api/v1/categories/:cat/products/:pid/reviews/:rid",
+        "/api/v1/users/:id/posts/:pid/comments/:cid",
+        "/api/v1/users/:id/posts/:pid/reactions/:rid",
+        "/api/v1/products/:id/variants/:vid/reviews/:rid",
+        "/api/v1/orders/:id/items/:item_id/refunds/:rid",
+        "/api/v1/categories/:slug/products/:pid/reviews/:rid",
     ];
 
     let wildcards: Array<String> = [
@@ -218,18 +226,17 @@ pub variant Segment {
     Wildcard(String),  // name without the leading "*", must be the last segment
 }
 
-/// Parse a route pattern path (must start with '/') into a list of
-/// segments. `/foo/:bar/*baz` -> [Literal("foo"), Param("bar"), Wildcard("baz")].
-/// The leading slash is consumed; an empty path or a single "/" yields an
-/// empty array.
+/// Parse a route pattern path into a list of segments.
+/// `/foo/:bar/*baz` -> [Literal("foo"), Param("bar"), Wildcard("baz")].
+/// `/` (the empty pattern, which terminates at the root) yields `[]`.
+/// Panics when the pattern is empty or does not start with `/`.
 pub fn parse_pattern(path: &String) -> Array<Segment> {
     let mut out: Array<Segment> = [];
     let bytes = path.len();
-    if bytes == 0 {
-        return out;
+    if bytes == 0 || path.get_byte(0) != '/' as u8 {
+        panic("route pattern must start with '/'");
     }
-    // Expect leading '/'.
-    let mut i = if path.get_byte(0) == '/' as u8 { 1 } else { 0 };
+    let mut i = 1;
     while i < bytes {
         let mut j = i;
         while j < bytes && path.get_byte(j) != '/' as u8 {
@@ -286,4 +293,19 @@ test "parse_pattern: literals, params, wildcard" {
     assert segs[3] matches { Param("id") };
     assert segs[4] matches { Literal("posts") };
     assert segs[5] matches { Wildcard("rest") };
+}
+
+test "parse_pattern: root pattern yields empty" {
+    let segs = parse_pattern(&"/");
+    assert segs.len() == 0;
+}
+
+#[expect_trap]
+test "parse_pattern: missing leading slash panics" {
+    parse_pattern(&"foo");
+}
+
+#[expect_trap]
+test "parse_pattern: empty pattern panics" {
+    parse_pattern(&"");
 }

--- a/example/router-common.wado
+++ b/example/router-common.wado
@@ -268,7 +268,7 @@ test "build_routes: 100 patterns total" {
     assert routes[70].path == "/api/v1/users/:id";
     assert routes[80].path == "/api/v1/users/:id/posts/:pid";
     assert routes[83].path == "/api/v1/users/:id/profile/:section";
-    assert routes[90].path == "/api/v1/users/:uid/posts/:pid/comments/:cid";
+    assert routes[90].path == "/api/v1/users/:id/posts/:pid/comments/:cid";
     assert routes[95].path == "/static/*path";
 }
 

--- a/example/router-common.wado
+++ b/example/router-common.wado
@@ -1,0 +1,294 @@
+//! Shared types, route set, and access pattern for the HTTP router
+//! benchmark. The same 100 route definitions are fed to each engine
+//! (Linear / Radix tree / segment-level tagged DFA) so the comparison
+//! is apples-to-apples.
+
+use { TreeMap } from "core:collections";
+
+pub enum Method { Get, Post, Put, Delete }
+
+pub struct RoutePattern {
+    pub method: Method,
+    pub path: String,
+    pub handler_id: i32,
+}
+
+pub struct MatchResult {
+    pub handler_id: i32,
+    pub params: TreeMap<String, String>,
+}
+
+pub fn no_match() -> MatchResult {
+    return MatchResult {
+        handler_id: -1,
+        params: TreeMap::<String, String>::new(),
+    };
+}
+
+pub struct AccessRequest {
+    pub method: Method,
+    pub path: String,
+    pub expected_handler_id: i32,
+}
+
+/// Returns 100 route patterns, distributed as:
+///   - 70 static (20 shallow / 30 medium / 20 deep)
+///   - 25 parametric (10 with 1 param / 10 with 2 / 5 with 3)
+///   - 5 wildcard
+/// Most routes share the `/api/v1/...` prefix so prefix-compressing
+/// engines (radix tree) can exercise their strength.
+pub fn build_routes() -> Array<RoutePattern> {
+    let mut routes: Array<RoutePattern> = [];
+    let mut id = 0;
+
+    let static_shallow: Array<String> = [
+        "/health",
+        "/version",
+        "/metrics",
+        "/ping",
+        "/robots.txt",
+        "/favicon.ico",
+        "/api/v1/health",
+        "/api/v1/version",
+        "/api/v1/status",
+        "/api/v1/metrics",
+        "/api/v2/health",
+        "/api/v2/version",
+        "/admin/login",
+        "/admin/logout",
+        "/admin/dashboard",
+        "/auth/login",
+        "/auth/logout",
+        "/auth/refresh",
+        "/docs",
+        "/openapi.json",
+    ];
+
+    let static_medium: Array<String> = [
+        "/api/v1/users/list",
+        "/api/v1/users/create",
+        "/api/v1/users/search",
+        "/api/v1/users/me",
+        "/api/v1/posts/list",
+        "/api/v1/posts/create",
+        "/api/v1/posts/search",
+        "/api/v1/posts/popular",
+        "/api/v1/products/list",
+        "/api/v1/products/create",
+        "/api/v1/products/search",
+        "/api/v1/products/featured",
+        "/api/v1/orders/list",
+        "/api/v1/orders/create",
+        "/api/v1/orders/recent",
+        "/api/v1/comments/list",
+        "/api/v1/comments/create",
+        "/api/v1/comments/recent",
+        "/api/v1/admin/users/list",
+        "/api/v1/admin/users/create",
+        "/api/v1/admin/posts/list",
+        "/api/v1/admin/posts/moderate",
+        "/api/v1/admin/products/list",
+        "/api/v1/admin/orders/list",
+        "/api/v1/admin/config/get",
+        "/api/v1/admin/config/set",
+        "/api/v1/admin/stats/users",
+        "/api/v1/admin/stats/orders",
+        "/api/v1/admin/stats/revenue",
+        "/api/v1/admin/stats/traffic",
+    ];
+
+    let static_deep: Array<String> = [
+        "/api/v1/admin/users/sessions/active",
+        "/api/v1/admin/users/sessions/expired",
+        "/api/v1/admin/users/permissions/list",
+        "/api/v1/admin/users/permissions/create",
+        "/api/v1/admin/posts/comments/flagged",
+        "/api/v1/admin/posts/comments/deleted",
+        "/api/v1/admin/products/inventory/low",
+        "/api/v1/admin/products/inventory/zero",
+        "/api/v1/admin/products/categories/list",
+        "/api/v1/admin/products/categories/create",
+        "/api/v1/admin/orders/payments/pending",
+        "/api/v1/admin/orders/payments/failed",
+        "/api/v1/admin/orders/shipments/pending",
+        "/api/v1/admin/orders/shipments/late",
+        "/api/v1/admin/system/logs/recent",
+        "/api/v1/admin/system/logs/errors",
+        "/api/v1/admin/system/jobs/running",
+        "/api/v1/admin/system/jobs/failed",
+        "/api/v1/admin/system/cache/stats",
+        "/api/v1/admin/system/cache/clear",
+    ];
+
+    let param1: Array<String> = [
+        "/api/v1/users/:id",
+        "/api/v1/posts/:id",
+        "/api/v1/products/:id",
+        "/api/v1/orders/:id",
+        "/api/v1/comments/:id",
+        "/api/v1/categories/:slug",
+        "/api/v1/tags/:tag",
+        "/api/v1/profile/:username",
+        "/api/v1/auth/sessions/:token",
+        "/api/v1/files/:filename",
+    ];
+
+    let param2: Array<String> = [
+        "/api/v1/users/:id/posts/:pid",
+        "/api/v1/users/:id/comments/:cid",
+        "/api/v1/users/:id/orders/:oid",
+        "/api/v1/users/:id/profile/:section",
+        "/api/v1/posts/:id/comments/:cid",
+        "/api/v1/posts/:id/reactions/:rid",
+        "/api/v1/products/:id/reviews/:rid",
+        "/api/v1/products/:id/variants/:vid",
+        "/api/v1/orders/:id/items/:item_id",
+        "/api/v1/categories/:slug/products/:pid",
+    ];
+
+    let param3: Array<String> = [
+        "/api/v1/users/:uid/posts/:pid/comments/:cid",
+        "/api/v1/users/:uid/posts/:pid/reactions/:rid",
+        "/api/v1/products/:pid/variants/:vid/reviews/:rid",
+        "/api/v1/orders/:oid/items/:iid/refunds/:rid",
+        "/api/v1/categories/:cat/products/:pid/reviews/:rid",
+    ];
+
+    let wildcards: Array<String> = [
+        "/static/*path",
+        "/files/:bucket/*key",
+        "/assets/*path",
+        "/downloads/:user/*path",
+        "/uploads/*path",
+    ];
+
+    for let p of static_shallow {
+        routes.push(RoutePattern { method: Method::Get, path: p, handler_id: id });
+        id += 1;
+    }
+    for let p of static_medium {
+        routes.push(RoutePattern { method: Method::Get, path: p, handler_id: id });
+        id += 1;
+    }
+    for let p of static_deep {
+        routes.push(RoutePattern { method: Method::Get, path: p, handler_id: id });
+        id += 1;
+    }
+    for let p of param1 {
+        routes.push(RoutePattern { method: Method::Get, path: p, handler_id: id });
+        id += 1;
+    }
+    for let p of param2 {
+        routes.push(RoutePattern { method: Method::Get, path: p, handler_id: id });
+        id += 1;
+    }
+    for let p of param3 {
+        routes.push(RoutePattern { method: Method::Get, path: p, handler_id: id });
+        id += 1;
+    }
+    for let p of wildcards {
+        routes.push(RoutePattern { method: Method::Get, path: p, handler_id: id });
+        id += 1;
+    }
+    return routes;
+}
+
+/// 9 hits + 1 miss, exercising every shape from the route set.
+/// `expected_handler_id` is `-1` for the miss and otherwise refers to
+/// the index assigned by `build_routes()`.
+pub fn build_access_pattern() -> Array<AccessRequest> {
+    return [
+        AccessRequest { method: Method::Get, path: "/api/v1/health",                                        expected_handler_id: 6 },
+        AccessRequest { method: Method::Get, path: "/api/v1/users/list",                                    expected_handler_id: 20 },
+        AccessRequest { method: Method::Get, path: "/api/v1/admin/users/sessions/active",                   expected_handler_id: 50 },
+        AccessRequest { method: Method::Get, path: "/api/v1/users/12345",                                   expected_handler_id: 70 },
+        AccessRequest { method: Method::Get, path: "/api/v1/users/12345/posts/678",                         expected_handler_id: 80 },
+        AccessRequest { method: Method::Get, path: "/api/v1/users/12345/posts/678/comments/9",              expected_handler_id: 90 },
+        AccessRequest { method: Method::Get, path: "/static/css/main.css",                                  expected_handler_id: 95 },
+        AccessRequest { method: Method::Get, path: "/api/v1/products/list",                                 expected_handler_id: 28 },
+        AccessRequest { method: Method::Get, path: "/api/v1/users/12345/profile/email",                     expected_handler_id: 83 },
+        AccessRequest { method: Method::Get, path: "/api/v1/does/not/exist",                                expected_handler_id: -1 },
+    ] as Array<AccessRequest>;
+}
+
+/// Parsed segment of a route pattern, shared between engines.
+pub variant Segment {
+    Literal(String),
+    Param(String),     // name without the leading ":"
+    Wildcard(String),  // name without the leading "*", must be the last segment
+}
+
+/// Parse a route pattern path (must start with '/') into a list of
+/// segments. `/foo/:bar/*baz` -> [Literal("foo"), Param("bar"), Wildcard("baz")].
+/// The leading slash is consumed; an empty path or a single "/" yields an
+/// empty array.
+pub fn parse_pattern(path: &String) -> Array<Segment> {
+    let mut out: Array<Segment> = [];
+    let bytes = path.len();
+    if bytes == 0 {
+        return out;
+    }
+    // Expect leading '/'.
+    let mut i = if path.get_byte(0) == 47 { 1 } else { 0 };
+    while i < bytes {
+        let mut j = i;
+        while j < bytes && path.get_byte(j) != 47 {
+            j += 1;
+        }
+        let seg = path.substr_bytes(i, j);
+        if seg.len() == 0 {
+            // skip empty segment from doubled slashes
+        } else {
+            let first = seg.get_byte(0);
+            if first == 58 {
+                // ':' -> param
+                out.push(Segment::Param(seg.substr_bytes(1, seg.len())));
+            } else if first == 42 {
+                // '*' -> wildcard
+                out.push(Segment::Wildcard(seg.substr_bytes(1, seg.len())));
+            } else {
+                out.push(Segment::Literal(seg));
+            }
+        }
+        i = j + 1;
+    }
+    return out;
+}
+
+test "build_routes: 100 patterns total" {
+    let routes = build_routes();
+    assert routes.len() == 100;
+    // Spot checks for indices used by the access pattern.
+    assert routes[6].path == "/api/v1/health";
+    assert routes[20].path == "/api/v1/users/list";
+    assert routes[28].path == "/api/v1/products/list";
+    assert routes[50].path == "/api/v1/admin/users/sessions/active";
+    assert routes[70].path == "/api/v1/users/:id";
+    assert routes[80].path == "/api/v1/users/:id/posts/:pid";
+    assert routes[83].path == "/api/v1/users/:id/profile/:section";
+    assert routes[90].path == "/api/v1/users/:uid/posts/:pid/comments/:cid";
+    assert routes[95].path == "/static/*path";
+}
+
+test "build_access_pattern: 10 entries, 1 miss" {
+    let pat = build_access_pattern();
+    assert pat.len() == 10;
+    let mut misses = 0;
+    for let r of pat {
+        if r.expected_handler_id < 0 {
+            misses += 1;
+        }
+    }
+    assert misses == 1;
+}
+
+test "parse_pattern: literals, params, wildcard" {
+    let segs = parse_pattern(&"/api/v1/users/:id/posts/*rest");
+    assert segs.len() == 6;
+    assert segs[0] matches { Literal("api") };
+    assert segs[1] matches { Literal("v1") };
+    assert segs[2] matches { Literal("users") };
+    assert segs[3] matches { Param("id") };
+    assert segs[4] matches { Literal("posts") };
+    assert segs[5] matches { Wildcard("rest") };
+}

--- a/example/router-dfa.wado
+++ b/example/router-dfa.wado
@@ -102,11 +102,11 @@ impl DfaRouter {
         let mut params = TreeMap::<String, String>::new();
         let plen = path.len();
         // Skip leading '/' if any.
-        let mut pos = if plen > 0 && path.get_byte(0) == 47 { 1 } else { 0 };
+        let mut pos = if plen > 0 && path.get_byte(0) == '/' as u8 { 1 } else { 0 };
         let mut state: i32 = 0;
         while pos < plen {
             let mut end = pos;
-            while end < plen && path.get_byte(end) != 47 {
+            while end < plen && path.get_byte(end) != '/' as u8 {
                 end += 1;
             }
             if end == pos {

--- a/example/router-dfa.wado
+++ b/example/router-dfa.wado
@@ -1,0 +1,204 @@
+//! Segment-level tagged DFA HTTP router.
+//!
+//! Routes are split at '/' boundaries, and each segment becomes a single
+//! transition. States are stored in a flat arena `Array<DfaState>`; literal
+//! transitions live in a per-state `TreeMap<String, i32>`, parametric and
+//! wildcard transitions are stored on the parent state. Matching is a
+//! deterministic loop with no backtracking: at each state, literal first,
+//! then param, then wildcard. The "tag" attached to a param/wildcard
+//! transition records the param name so the captured segment can be
+//! associated by name in the result `params`.
+//!
+//! The avoided byte-by-byte work makes per-state work cheaper than radix
+//! at the cost of constructing one substring per segment for the literal
+//! lookup.
+
+use { TreeMap } from "core:collections";
+use {
+    Method, MatchResult, RoutePattern, Segment,
+    no_match, parse_pattern,
+} from "./router-common.wado";
+
+struct DfaState {
+    literals: TreeMap<String, i32>,  // segment string -> next state id
+    param_target: i32,                // -1 if no param child
+    param_name: String,
+    wildcard_handler: i32,            // -1 if no wildcard route at this state
+    wildcard_method: Method,
+    wildcard_name: String,
+    handler_id: i32,                  // -1 if not terminal
+    method: Method,
+}
+
+fn new_state() -> DfaState {
+    return DfaState {
+        literals: TreeMap::<String, i32>::new(),
+        param_target: -1,
+        param_name: "",
+        wildcard_handler: -1,
+        wildcard_method: Method::Get,
+        wildcard_name: "",
+        handler_id: -1,
+        method: Method::Get,
+    };
+}
+
+pub struct DfaRouter {
+    states: Array<DfaState>,   // state 0 is the start state
+}
+
+impl DfaRouter {
+    pub fn build(patterns: &Array<RoutePattern>) -> DfaRouter {
+        let mut r = DfaRouter { states: [] };
+        r.states.push(new_state());
+        for let p of patterns {
+            r.insert_pattern(p.method, &p.path, p.handler_id);
+        }
+        return r;
+    }
+
+    fn insert_pattern(&mut self, method: Method, path: &String, handler_id: i32) {
+        let segs = parse_pattern(path);
+        let mut cur: i32 = 0;
+        let nseg = segs.len();
+        for let mut i = 0; i < nseg; i += 1 {
+            let seg = &segs[i];
+            if let Wildcard(name) = seg {
+                self.states[cur].wildcard_handler = handler_id;
+                self.states[cur].wildcard_method = method;
+                self.states[cur].wildcard_name = *name;
+                return;
+            } else if let Param(name) = seg {
+                if self.states[cur].param_target < 0 {
+                    let new_id = self.states.len();
+                    self.states.push(new_state());
+                    self.states[cur].param_target = new_id;
+                    self.states[cur].param_name = *name;
+                }
+                cur = self.states[cur].param_target;
+            } else if let Literal(lit) = seg {
+                let key = *lit;
+                let existing = self.states[cur].literals.get(key);
+                if let Some(next) = existing {
+                    cur = next;
+                } else {
+                    let new_id = self.states.len();
+                    self.states.push(new_state());
+                    self.states[cur].literals[key] = new_id;
+                    cur = new_id;
+                }
+            }
+        }
+        self.states[cur].handler_id = handler_id;
+        self.states[cur].method = method;
+    }
+
+    pub fn match_path(&self, method: Method, path: &String) -> MatchResult {
+        let mut params = TreeMap::<String, String>::new();
+        let plen = path.len();
+        // Skip leading '/' if any.
+        let mut pos = if plen > 0 && path.get_byte(0) == 47 { 1 } else { 0 };
+        let mut state: i32 = 0;
+        while pos < plen {
+            let mut end = pos;
+            while end < plen && path.get_byte(end) != 47 {
+                end += 1;
+            }
+            if end == pos {
+                // Empty segment ("//" in path).
+                return no_match();
+            }
+            // Try literal transition first.
+            let seg = path.substr_bytes(pos, end);
+            let lit_next = self.states[state].literals.get(seg);
+            if let Some(next) = lit_next {
+                state = next;
+            } else if self.states[state].param_target >= 0 {
+                let pname = self.states[state].param_name;
+                params[pname] = seg;
+                state = self.states[state].param_target;
+            } else if self.states[state].wildcard_handler >= 0
+                && self.states[state].wildcard_method == method
+            {
+                params[self.states[state].wildcard_name] = path.substr_bytes(pos, plen);
+                return MatchResult { handler_id: self.states[state].wildcard_handler, params };
+            } else {
+                return no_match();
+            }
+            pos = end + 1;
+        }
+        // Path consumed. `pos == plen + 1` means the last segment ended at
+        // the end of the path (no trailing slash). `pos == plen` means a
+        // trailing slash was consumed.
+        if pos == plen + 1 {
+            if self.states[state].handler_id >= 0 && self.states[state].method == method {
+                return MatchResult { handler_id: self.states[state].handler_id, params };
+            }
+        } else if pos == plen {
+            // Trailing '/' was consumed; only a wildcard route matches with
+            // empty captured remainder.
+            if self.states[state].wildcard_handler >= 0
+                && self.states[state].wildcard_method == method
+            {
+                params[self.states[state].wildcard_name] = "";
+                return MatchResult { handler_id: self.states[state].wildcard_handler, params };
+            }
+        }
+        return no_match();
+    }
+}
+
+test "dfa: static routes" {
+    let routes = [
+        RoutePattern { method: Method::Get, path: "/health", handler_id: 1 },
+        RoutePattern { method: Method::Get, path: "/api/v1/users/list", handler_id: 2 },
+        RoutePattern { method: Method::Get, path: "/api/v1/users/me", handler_id: 3 },
+    ] as Array<RoutePattern>;
+    let r = DfaRouter::build(&routes);
+    assert r.match_path(Method::Get, &"/health").handler_id == 1;
+    assert r.match_path(Method::Get, &"/api/v1/users/list").handler_id == 2;
+    assert r.match_path(Method::Get, &"/api/v1/users/me").handler_id == 3;
+    assert r.match_path(Method::Get, &"/missing").handler_id == -1;
+    assert r.match_path(Method::Get, &"/api/v1/users").handler_id == -1;
+}
+
+test "dfa: param + literal sibling (literal wins)" {
+    let routes = [
+        RoutePattern { method: Method::Get, path: "/users/list", handler_id: 1 },
+        RoutePattern { method: Method::Get, path: "/users/:id", handler_id: 2 },
+        RoutePattern { method: Method::Get, path: "/users/:id/profile", handler_id: 3 },
+    ] as Array<RoutePattern>;
+    let r = DfaRouter::build(&routes);
+
+    assert r.match_path(Method::Get, &"/users/list").handler_id == 1;
+
+    let m = r.match_path(Method::Get, &"/users/42");
+    assert m.handler_id == 2;
+    assert m.params["id"] == "42";
+
+    let m2 = r.match_path(Method::Get, &"/users/42/profile");
+    assert m2.handler_id == 3;
+    assert m2.params["id"] == "42";
+}
+
+test "dfa: wildcard catch-all" {
+    let routes = [
+        RoutePattern { method: Method::Get, path: "/static/*path", handler_id: 9 },
+    ] as Array<RoutePattern>;
+    let r = DfaRouter::build(&routes);
+    let m = r.match_path(Method::Get, &"/static/css/main.css");
+    assert m.handler_id == 9;
+    assert m.params["path"] == "css/main.css";
+}
+
+test "dfa: deep param chain" {
+    let routes = [
+        RoutePattern { method: Method::Get, path: "/api/v1/users/:uid/posts/:pid/comments/:cid", handler_id: 90 },
+    ] as Array<RoutePattern>;
+    let r = DfaRouter::build(&routes);
+    let m = r.match_path(Method::Get, &"/api/v1/users/12/posts/34/comments/56");
+    assert m.handler_id == 90;
+    assert m.params["uid"] == "12";
+    assert m.params["pid"] == "34";
+    assert m.params["cid"] == "56";
+}

--- a/example/router-dfa.wado
+++ b/example/router-dfa.wado
@@ -139,15 +139,21 @@ impl DfaRouter {
             pos = end + 1;
         }
         // Path consumed. `pos == plen + 1` means the last segment ended at
-        // the end of the path (no trailing slash). `pos == plen` means a
-        // trailing slash was consumed.
+        // the end of the path (no trailing slash). `pos == plen` means
+        // either a trailing slash was consumed after a segment, or the
+        // path was exactly "/" and the loop never ran.
         if pos == plen + 1 {
             if self.states[state].handler_id >= 0 && self.states[state].method == method {
                 return MatchResult { handler_id: self.states[state].handler_id, params };
             }
         } else if pos == plen {
-            // Trailing '/' was consumed; only a wildcard route matches with
-            // empty captured remainder.
+            // `state == 0` here means the loop never ran, i.e. the path was
+            // exactly "/" (or empty) — match the root handler if registered.
+            if state == 0 && self.states[state].handler_id >= 0 && self.states[state].method == method {
+                return MatchResult { handler_id: self.states[state].handler_id, params };
+            }
+            // Trailing '/' after a segment: only a wildcard route at this
+            // state matches, with empty captured remainder.
             if self.states[state].wildcard_handler >= 0
                 && self.states[state].wildcard_method == method
             {
@@ -289,4 +295,24 @@ test "dfa: bsearch keeps array sorted across many inserts" {
     assert r.match_path(Method::Get, &"/banana").handler_id == 4;
     assert r.match_path(Method::Get, &"/cherry").handler_id == 5;
     assert r.match_path(Method::Get, &"/coconut").handler_id == -1;
+}
+
+test "dfa: method mismatch is a miss" {
+    let routes = [
+        RoutePattern { method: Method::Post, path: "/login", handler_id: 1 },
+    ] as Array<RoutePattern>;
+    let r = DfaRouter::build(&routes);
+    assert r.match_path(Method::Get, &"/login").handler_id == -1;
+    assert r.match_path(Method::Post, &"/login").handler_id == 1;
+}
+
+test "dfa: root pattern matches /" {
+    let routes = [
+        RoutePattern { method: Method::Get, path: "/", handler_id: 7 },
+        RoutePattern { method: Method::Get, path: "/foo", handler_id: 8 },
+    ] as Array<RoutePattern>;
+    let r = DfaRouter::build(&routes);
+    assert r.match_path(Method::Get, &"/").handler_id == 7;
+    assert r.match_path(Method::Get, &"/foo").handler_id == 8;
+    assert r.match_path(Method::Get, &"/bar").handler_id == -1;
 }

--- a/example/router-dfa.wado
+++ b/example/router-dfa.wado
@@ -1,17 +1,16 @@
 //! Segment-level tagged DFA HTTP router.
 //!
 //! Routes are split at '/' boundaries, and each segment becomes a single
-//! transition. States are stored in a flat arena `Array<DfaState>`; literal
-//! transitions live in a per-state `TreeMap<String, i32>`, parametric and
-//! wildcard transitions are stored on the parent state. Matching is a
-//! deterministic loop with no backtracking: at each state, literal first,
-//! then param, then wildcard. The "tag" attached to a param/wildcard
-//! transition records the param name so the captured segment can be
-//! associated by name in the result `params`.
+//! transition. States are stored in a flat arena `Array<DfaState>`.
+//! Each state's literal transitions live in a sorted `Array<DfaLiteralEdge>`
+//! looked up by binary search; parametric and wildcard transitions are
+//! stored on the parent state. Matching is a deterministic loop with no
+//! backtracking: at each state, literal first, then param, then wildcard.
 //!
-//! The avoided byte-by-byte work makes per-state work cheaper than radix
-//! at the cost of constructing one substring per segment for the literal
-//! lookup.
+//! Lookup compares the stored edge label byte-for-byte against the path's
+//! `[start..end]` range without allocating a new `String` per segment.
+//! That avoids the `substr_bytes` per-segment allocation that a
+//! `TreeMap<String, i32>`-based design would force.
 
 use { TreeMap } from "core:collections";
 use {
@@ -19,20 +18,25 @@ use {
     no_match, parse_pattern,
 } from "./router-common.wado";
 
+struct DfaLiteralEdge {
+    label: String,
+    target: i32,
+}
+
 struct DfaState {
-    literals: TreeMap<String, i32>,  // segment string -> next state id
-    param_target: i32,                // -1 if no param child
+    literals: Array<DfaLiteralEdge>,  // sorted by label byte-wise
+    param_target: i32,                 // -1 if no param child
     param_name: String,
-    wildcard_handler: i32,            // -1 if no wildcard route at this state
+    wildcard_handler: i32,             // -1 if no wildcard route at this state
     wildcard_method: Method,
     wildcard_name: String,
-    handler_id: i32,                  // -1 if not terminal
+    handler_id: i32,                   // -1 if not terminal
     method: Method,
 }
 
 fn new_state() -> DfaState {
     return DfaState {
-        literals: TreeMap::<String, i32>::new(),
+        literals: [],
         param_target: -1,
         param_name: "",
         wildcard_handler: -1,
@@ -81,15 +85,17 @@ impl DfaRouter {
                 },
                 Literal(lit) => {
                     let key = *lit;
-                    let existing = self.states[cur].literals.get(key);
-                    match existing {
-                        Some(next) => { cur = next; },
-                        None => {
-                            let new_id = self.states.len();
-                            self.states.push(new_state());
-                            self.states[cur].literals[key] = new_id;
-                            cur = new_id;
-                        },
+                    let [pos, found] = bsearch_label(&self.states[cur].literals, &key);
+                    if found {
+                        cur = self.states[cur].literals[pos].target;
+                    } else {
+                        let new_id = self.states.len();
+                        self.states.push(new_state());
+                        self.states[cur].literals.insert(pos, DfaLiteralEdge {
+                            label: key,
+                            target: new_id,
+                        });
+                        cur = new_id;
                     }
                 },
             }
@@ -113,24 +119,22 @@ impl DfaRouter {
                 // Empty segment ("//" in path).
                 return no_match();
             }
-            // Try literal first; on miss fall back to param, then wildcard.
-            let seg = path.substr_bytes(pos, end);
-            match self.states[state].literals.get(seg) {
-                Some(next) => { state = next; },
-                None => {
-                    if self.states[state].param_target >= 0 {
-                        let pname = self.states[state].param_name;
-                        params[pname] = seg;
-                        state = self.states[state].param_target;
-                    } else if self.states[state].wildcard_handler >= 0
-                        && self.states[state].wildcard_method == method
-                    {
-                        params[self.states[state].wildcard_name] = path.substr_bytes(pos, plen);
-                        return MatchResult { handler_id: self.states[state].wildcard_handler, params };
-                    } else {
-                        return no_match();
-                    }
-                },
+            // Try literal first via byte-range binary search (no allocation).
+            // On miss fall back to param, then wildcard.
+            let target = bsearch_target_by_bytes(&self.states[state].literals, path, pos, end);
+            if target >= 0 {
+                state = target;
+            } else if self.states[state].param_target >= 0 {
+                let pname = self.states[state].param_name;
+                params[pname] = path.substr_bytes(pos, end);
+                state = self.states[state].param_target;
+            } else if self.states[state].wildcard_handler >= 0
+                && self.states[state].wildcard_method == method
+            {
+                params[self.states[state].wildcard_name] = path.substr_bytes(pos, plen);
+                return MatchResult { handler_id: self.states[state].wildcard_handler, params };
+            } else {
+                return no_match();
             }
             pos = end + 1;
         }
@@ -153,6 +157,66 @@ impl DfaRouter {
         }
         return no_match();
     }
+}
+
+/// Binary search for `key` in a sorted edges array. Returns
+/// `[index, found]`: when `found` is true `index` is the matched
+/// position; otherwise `index` is the insertion point.
+fn bsearch_label(edges: &Array<DfaLiteralEdge>, key: &String) -> [i32, bool] {
+    let mut lo = 0;
+    let mut hi = edges.len();
+    while lo < hi {
+        let mid = (lo + hi) / 2;
+        match edges[mid].label.cmp(key) {
+            Less => { lo = mid + 1; },
+            Greater => { hi = mid; },
+            Equal => { return [mid, true]; },
+        }
+    }
+    return [lo, false];
+}
+
+/// Binary search variant that compares edge labels against `path[start..end]`
+/// directly, with no intermediate `String` allocation. Returns the matched
+/// edge's target state id, or -1 on miss.
+fn bsearch_target_by_bytes(edges: &Array<DfaLiteralEdge>, path: &String, start: i32, end: i32) -> i32 {
+    let mut lo = 0;
+    let mut hi = edges.len();
+    while lo < hi {
+        let mid = (lo + hi) / 2;
+        match cmp_string_to_byte_range(&edges[mid].label, path, start, end) {
+            Less => { lo = mid + 1; },
+            Greater => { hi = mid; },
+            Equal => { return edges[mid].target; },
+        }
+    }
+    return -1;
+}
+
+/// Lexicographic byte comparison between `label` (whole string) and
+/// `path[start..end]`. Equivalent to `label.cmp(&path.substr_bytes(start, end))`
+/// but without the intermediate allocation.
+fn cmp_string_to_byte_range(label: &String, path: &String, start: i32, end: i32) -> Ordering {
+    let llen = label.len();
+    let blen = end - start;
+    let cmp_len = if llen < blen { llen } else { blen };
+    for let mut i = 0; i < cmp_len; i += 1 {
+        let a = label.get_byte(i);
+        let b = path.get_byte(start + i);
+        if a < b {
+            return Ordering::Less;
+        }
+        if a > b {
+            return Ordering::Greater;
+        }
+    }
+    if llen < blen {
+        return Ordering::Less;
+    }
+    if llen > blen {
+        return Ordering::Greater;
+    }
+    return Ordering::Equal;
 }
 
 test "dfa: static routes" {
@@ -208,4 +272,21 @@ test "dfa: deep param chain" {
     assert m.params["uid"] == "12";
     assert m.params["pid"] == "34";
     assert m.params["cid"] == "56";
+}
+
+test "dfa: bsearch keeps array sorted across many inserts" {
+    let routes = [
+        RoutePattern { method: Method::Get, path: "/zoo", handler_id: 1 },
+        RoutePattern { method: Method::Get, path: "/apple", handler_id: 2 },
+        RoutePattern { method: Method::Get, path: "/mango", handler_id: 3 },
+        RoutePattern { method: Method::Get, path: "/banana", handler_id: 4 },
+        RoutePattern { method: Method::Get, path: "/cherry", handler_id: 5 },
+    ] as Array<RoutePattern>;
+    let r = DfaRouter::build(&routes);
+    assert r.match_path(Method::Get, &"/zoo").handler_id == 1;
+    assert r.match_path(Method::Get, &"/apple").handler_id == 2;
+    assert r.match_path(Method::Get, &"/mango").handler_id == 3;
+    assert r.match_path(Method::Get, &"/banana").handler_id == 4;
+    assert r.match_path(Method::Get, &"/cherry").handler_id == 5;
+    assert r.match_path(Method::Get, &"/coconut").handler_id == -1;
 }

--- a/example/router-dfa.wado
+++ b/example/router-dfa.wado
@@ -63,30 +63,35 @@ impl DfaRouter {
         let nseg = segs.len();
         for let mut i = 0; i < nseg; i += 1 {
             let seg = &segs[i];
-            if let Wildcard(name) = seg {
-                self.states[cur].wildcard_handler = handler_id;
-                self.states[cur].wildcard_method = method;
-                self.states[cur].wildcard_name = *name;
-                return;
-            } else if let Param(name) = seg {
-                if self.states[cur].param_target < 0 {
-                    let new_id = self.states.len();
-                    self.states.push(new_state());
-                    self.states[cur].param_target = new_id;
-                    self.states[cur].param_name = *name;
-                }
-                cur = self.states[cur].param_target;
-            } else if let Literal(lit) = seg {
-                let key = *lit;
-                let existing = self.states[cur].literals.get(key);
-                if let Some(next) = existing {
-                    cur = next;
-                } else {
-                    let new_id = self.states.len();
-                    self.states.push(new_state());
-                    self.states[cur].literals[key] = new_id;
-                    cur = new_id;
-                }
+            match seg {
+                Wildcard(name) => {
+                    self.states[cur].wildcard_handler = handler_id;
+                    self.states[cur].wildcard_method = method;
+                    self.states[cur].wildcard_name = *name;
+                    return;
+                },
+                Param(name) => {
+                    if self.states[cur].param_target < 0 {
+                        let new_id = self.states.len();
+                        self.states.push(new_state());
+                        self.states[cur].param_target = new_id;
+                        self.states[cur].param_name = *name;
+                    }
+                    cur = self.states[cur].param_target;
+                },
+                Literal(lit) => {
+                    let key = *lit;
+                    let existing = self.states[cur].literals.get(key);
+                    match existing {
+                        Some(next) => { cur = next; },
+                        None => {
+                            let new_id = self.states.len();
+                            self.states.push(new_state());
+                            self.states[cur].literals[key] = new_id;
+                            cur = new_id;
+                        },
+                    }
+                },
             }
         }
         self.states[cur].handler_id = handler_id;
@@ -108,22 +113,24 @@ impl DfaRouter {
                 // Empty segment ("//" in path).
                 return no_match();
             }
-            // Try literal transition first.
+            // Try literal first; on miss fall back to param, then wildcard.
             let seg = path.substr_bytes(pos, end);
-            let lit_next = self.states[state].literals.get(seg);
-            if let Some(next) = lit_next {
-                state = next;
-            } else if self.states[state].param_target >= 0 {
-                let pname = self.states[state].param_name;
-                params[pname] = seg;
-                state = self.states[state].param_target;
-            } else if self.states[state].wildcard_handler >= 0
-                && self.states[state].wildcard_method == method
-            {
-                params[self.states[state].wildcard_name] = path.substr_bytes(pos, plen);
-                return MatchResult { handler_id: self.states[state].wildcard_handler, params };
-            } else {
-                return no_match();
+            match self.states[state].literals.get(seg) {
+                Some(next) => { state = next; },
+                None => {
+                    if self.states[state].param_target >= 0 {
+                        let pname = self.states[state].param_name;
+                        params[pname] = seg;
+                        state = self.states[state].param_target;
+                    } else if self.states[state].wildcard_handler >= 0
+                        && self.states[state].wildcard_method == method
+                    {
+                        params[self.states[state].wildcard_name] = path.substr_bytes(pos, plen);
+                        return MatchResult { handler_id: self.states[state].wildcard_handler, params };
+                    } else {
+                        return no_match();
+                    }
+                },
             }
             pos = end + 1;
         }

--- a/example/router-linear.wado
+++ b/example/router-linear.wado
@@ -1,0 +1,165 @@
+//! Linear-scan HTTP router.
+//!
+//! Builds an array of pre-parsed (Method, segments, handler_id) tuples and
+//! matches by walking the array from front to back. Worst case is O(N*M)
+//! where N is route count and M is average pattern depth.
+//!
+//! Acts as the baseline (slowest) engine in the benchmark. Linear's
+//! best/worst spread is also large, so the benchmark driver measures
+//! it twice with single-route access patterns.
+
+use { TreeMap } from "core:collections";
+use {
+    Method, MatchResult, RoutePattern, Segment,
+    no_match, parse_pattern,
+} from "./router-common.wado";
+
+struct LinearRoute {
+    method: Method,
+    segments: Array<Segment>,
+    handler_id: i32,
+}
+
+pub struct LinearRouter {
+    routes: Array<LinearRoute>,
+}
+
+impl LinearRouter {
+    pub fn build(patterns: &Array<RoutePattern>) -> LinearRouter {
+        let mut routes: Array<LinearRoute> = [];
+        for let p of patterns {
+            routes.push(LinearRoute {
+                method: p.method,
+                segments: parse_pattern(&p.path),
+                handler_id: p.handler_id,
+            });
+        }
+        return LinearRouter { routes };
+    }
+
+    pub fn match_path(&self, method: Method, path: &String) -> MatchResult {
+        for let r of &self.routes {
+            if r.method != method {
+                continue;
+            }
+            let mut params = TreeMap::<String, String>::new();
+            if try_match(&r.segments, path, &mut params) {
+                return MatchResult { handler_id: r.handler_id, params };
+            }
+        }
+        return no_match();
+    }
+}
+
+/// Walks `segments` against `path`, populating `params` on success.
+/// Returns true on full match.
+fn try_match(segments: &Array<Segment>, path: &String, params: &mut TreeMap<String, String>) -> bool {
+    let plen = path.len();
+    // Skip leading '/'.
+    let mut pos = if plen > 0 && path.get_byte(0) == 47 { 1 } else { 0 };
+    let nseg = segments.len();
+    for let mut idx = 0; idx < nseg; idx += 1 {
+        let seg = &segments[idx];
+        let is_last = idx == nseg - 1;
+        if let Wildcard(name) = seg {
+            // Wildcard requires that the previous segment terminated on a
+            // '/' (so `pos <= plen`). When pos > plen the previous literal
+            // ate exactly to end-of-path with no separator, so this route
+            // does not match.
+            if pos > plen {
+                return false;
+            }
+            params[*name] = path.substr_bytes(pos, plen);
+            return true;
+        }
+        if pos > plen {
+            return false;
+        }
+        if pos == plen {
+            // Out of input but still have a segment to match.
+            return false;
+        }
+        // Find end of current path segment.
+        let mut end = pos;
+        while end < plen && path.get_byte(end) != 47 {
+            end += 1;
+        }
+        if end == pos {
+            // Empty segment in path (e.g. "//").
+            return false;
+        }
+        if let Literal(lit) = seg {
+            let llen = lit.len();
+            if end - pos != llen {
+                return false;
+            }
+            for let mut k = 0; k < llen; k += 1 {
+                if path.get_byte(pos + k) != lit.get_byte(k) {
+                    return false;
+                }
+            }
+        } else if let Param(name) = seg {
+            params[*name] = path.substr_bytes(pos, end);
+        }
+        pos = end + 1;
+        // After consuming the last segment, path should be exhausted.
+        if is_last {
+            // After consuming a literal/param segment, pos == plen + 1
+            // means end == plen (no trailing slash) — the strict-match
+            // success state. pos == plen would mean the path had a
+            // trailing '/', which we treat as a different path.
+            if pos == plen + 1 {
+                return true;
+            }
+            return false;
+        }
+    }
+    // No segments at all means we must have consumed nothing.
+    return pos == 0 && plen <= 1;
+}
+
+test "linear: static hits" {
+    let routes = [
+        RoutePattern { method: Method::Get, path: "/health", handler_id: 1 },
+        RoutePattern { method: Method::Get, path: "/api/v1/users/list", handler_id: 2 },
+    ] as Array<RoutePattern>;
+    let r = LinearRouter::build(&routes);
+    assert r.match_path(Method::Get, &"/health").handler_id == 1;
+    assert r.match_path(Method::Get, &"/api/v1/users/list").handler_id == 2;
+    assert r.match_path(Method::Get, &"/missing").handler_id == -1;
+}
+
+test "linear: param extraction" {
+    let routes = [
+        RoutePattern { method: Method::Get, path: "/api/v1/users/:id", handler_id: 7 },
+        RoutePattern { method: Method::Get, path: "/api/v1/users/:id/posts/:pid", handler_id: 8 },
+    ] as Array<RoutePattern>;
+    let r = LinearRouter::build(&routes);
+
+    let m1 = r.match_path(Method::Get, &"/api/v1/users/42");
+    assert m1.handler_id == 7;
+    assert m1.params["id"] == "42";
+
+    let m2 = r.match_path(Method::Get, &"/api/v1/users/42/posts/9");
+    assert m2.handler_id == 8;
+    assert m2.params["id"] == "42";
+    assert m2.params["pid"] == "9";
+}
+
+test "linear: wildcard captures rest" {
+    let routes = [
+        RoutePattern { method: Method::Get, path: "/static/*path", handler_id: 5 },
+    ] as Array<RoutePattern>;
+    let r = LinearRouter::build(&routes);
+    let m = r.match_path(Method::Get, &"/static/css/main.css");
+    assert m.handler_id == 5;
+    assert m.params["path"] == "css/main.css";
+}
+
+test "linear: method mismatch is a miss" {
+    let routes = [
+        RoutePattern { method: Method::Post, path: "/login", handler_id: 1 },
+    ] as Array<RoutePattern>;
+    let r = LinearRouter::build(&routes);
+    assert r.match_path(Method::Get, &"/login").handler_id == -1;
+}

--- a/example/router-linear.wado
+++ b/example/router-linear.wado
@@ -56,7 +56,7 @@ impl LinearRouter {
 fn try_match(segments: &Array<Segment>, path: &String, params: &mut TreeMap<String, String>) -> bool {
     let plen = path.len();
     // Skip leading '/'.
-    let mut pos = if plen > 0 && path.get_byte(0) == 47 { 1 } else { 0 };
+    let mut pos = if plen > 0 && path.get_byte(0) == '/' as u8 { 1 } else { 0 };
     let nseg = segments.len();
     for let mut idx = 0; idx < nseg; idx += 1 {
         let seg = &segments[idx];
@@ -78,7 +78,7 @@ fn try_match(segments: &Array<Segment>, path: &String, params: &mut TreeMap<Stri
                     return false;
                 }
                 let mut end = pos;
-                while end < plen && path.get_byte(end) != 47 {
+                while end < plen && path.get_byte(end) != '/' as u8 {
                     end += 1;
                 }
                 if end == pos {
@@ -100,7 +100,7 @@ fn try_match(segments: &Array<Segment>, path: &String, params: &mut TreeMap<Stri
                     return false;
                 }
                 let mut end = pos;
-                while end < plen && path.get_byte(end) != 47 {
+                while end < plen && path.get_byte(end) != '/' as u8 {
                     end += 1;
                 }
                 if end == pos {

--- a/example/router-linear.wado
+++ b/example/router-linear.wado
@@ -120,8 +120,9 @@ fn try_match(segments: &Array<Segment>, path: &String, params: &mut TreeMap<Stri
             return false;
         }
     }
-    // No segments at all means we must have consumed nothing.
-    return pos == 0 && plen <= 1;
+    // No segments at all (empty pattern "/") means the path must also have
+    // been fully consumed. After leading-'/' skip, pos == plen on path "/".
+    return pos >= plen;
 }
 
 test "linear: static hits" {
@@ -168,4 +169,15 @@ test "linear: method mismatch is a miss" {
     ] as Array<RoutePattern>;
     let r = LinearRouter::build(&routes);
     assert r.match_path(Method::Get, &"/login").handler_id == -1;
+}
+
+test "linear: root pattern matches /" {
+    let routes = [
+        RoutePattern { method: Method::Get, path: "/", handler_id: 7 },
+        RoutePattern { method: Method::Get, path: "/foo", handler_id: 8 },
+    ] as Array<RoutePattern>;
+    let r = LinearRouter::build(&routes);
+    assert r.match_path(Method::Get, &"/").handler_id == 7;
+    assert r.match_path(Method::Get, &"/foo").handler_id == 8;
+    assert r.match_path(Method::Get, &"/bar").handler_id == -1;
 }

--- a/example/router-linear.wado
+++ b/example/router-linear.wado
@@ -61,53 +61,59 @@ fn try_match(segments: &Array<Segment>, path: &String, params: &mut TreeMap<Stri
     for let mut idx = 0; idx < nseg; idx += 1 {
         let seg = &segments[idx];
         let is_last = idx == nseg - 1;
-        if let Wildcard(name) = seg {
-            // Wildcard requires that the previous segment terminated on a
-            // '/' (so `pos <= plen`). When pos > plen the previous literal
-            // ate exactly to end-of-path with no separator, so this route
-            // does not match.
-            if pos > plen {
-                return false;
-            }
-            params[*name] = path.substr_bytes(pos, plen);
-            return true;
-        }
-        if pos > plen {
-            return false;
-        }
-        if pos == plen {
-            // Out of input but still have a segment to match.
-            return false;
-        }
-        // Find end of current path segment.
-        let mut end = pos;
-        while end < plen && path.get_byte(end) != 47 {
-            end += 1;
-        }
-        if end == pos {
-            // Empty segment in path (e.g. "//").
-            return false;
-        }
-        if let Literal(lit) = seg {
-            let llen = lit.len();
-            if end - pos != llen {
-                return false;
-            }
-            for let mut k = 0; k < llen; k += 1 {
-                if path.get_byte(pos + k) != lit.get_byte(k) {
+        match seg {
+            Wildcard(name) => {
+                // Wildcard requires the previous segment terminated on a
+                // '/'. `pos > plen` means the previous literal ate to
+                // end-of-path with no separator, so this route does not
+                // match.
+                if pos > plen {
                     return false;
                 }
-            }
-        } else if let Param(name) = seg {
-            params[*name] = path.substr_bytes(pos, end);
+                params[*name] = path.substr_bytes(pos, plen);
+                return true;
+            },
+            Literal(lit) => {
+                if pos >= plen {
+                    return false;
+                }
+                let mut end = pos;
+                while end < plen && path.get_byte(end) != 47 {
+                    end += 1;
+                }
+                if end == pos {
+                    return false;
+                }
+                let llen = lit.len();
+                if end - pos != llen {
+                    return false;
+                }
+                for let mut k = 0; k < llen; k += 1 {
+                    if path.get_byte(pos + k) != lit.get_byte(k) {
+                        return false;
+                    }
+                }
+                pos = end + 1;
+            },
+            Param(name) => {
+                if pos >= plen {
+                    return false;
+                }
+                let mut end = pos;
+                while end < plen && path.get_byte(end) != 47 {
+                    end += 1;
+                }
+                if end == pos {
+                    return false;
+                }
+                params[*name] = path.substr_bytes(pos, end);
+                pos = end + 1;
+            },
         }
-        pos = end + 1;
-        // After consuming the last segment, path should be exhausted.
+        // After consuming the last (non-wildcard) segment, path should be
+        // exhausted. `pos == plen + 1` means end == plen (no trailing
+        // slash) — the strict-match success state.
         if is_last {
-            // After consuming a literal/param segment, pos == plen + 1
-            // means end == plen (no trailing slash) — the strict-match
-            // success state. pos == plen would mean the path had a
-            // trailing '/', which we treat as a different path.
             if pos == plen + 1 {
                 return true;
             }

--- a/example/router-radix.wado
+++ b/example/router-radix.wado
@@ -174,6 +174,9 @@ impl RadixRouter {
             }
             return -1;
         }
+        // At most one literal edge can share each first byte (radix
+        // invariant), so the loop becomes "find that one candidate, then
+        // either descend or fall through to param/wildcard".
         let first = path.get_byte(pos);
         let nedges = self.nodes[node_id].edges.len();
         for let mut i = 0; i < nedges; i += 1 {
@@ -182,7 +185,7 @@ impl RadixRouter {
             }
             let elen = self.nodes[node_id].edges[i].label.len();
             if plen - pos < elen {
-                continue;
+                break;
             }
             let mut k = 1;
             let mut ok = true;
@@ -194,19 +197,21 @@ impl RadixRouter {
                 k += 1;
             }
             if !ok {
-                continue;
+                break;
             }
-            let saved = params.keys();
+            // Recursive walk handles its own param/wildcard rollback, so
+            // there is no need to snapshot/restore params at this level.
             let h = self.walk(self.nodes[node_id].edges[i].target, path, pos + elen, plen, method, params);
             if h >= 0 {
                 return h;
             }
-            rollback_params(params, &saved);
-            // Per radix invariant there is at most one edge per first byte.
             break;
         }
 
-        // Param: consume one '/'-delimited segment, then descend.
+        // Param: consume one '/'-delimited segment, then descend. Save the
+        // *previous* value (if any) of the param name so a same-name param
+        // at an outer level survives a failed inner attempt — O(log n) and
+        // allocation-free, unlike a full keys() snapshot.
         if self.nodes[node_id].param_target >= 0 {
             let mut end = pos;
             while end < plen && path.get_byte(end) != '/' as u8 {
@@ -214,40 +219,26 @@ impl RadixRouter {
             }
             if end > pos {
                 let pname = self.nodes[node_id].param_name;
-                let value = path.substr_bytes(pos, end);
-                params[pname] = value;
+                let prev = params.get(pname);
+                params[pname] = path.substr_bytes(pos, end);
                 let h = self.walk(self.nodes[node_id].param_target, path, end, plen, method, params);
                 if h >= 0 {
                     return h;
                 }
-                params.remove(pname);
+                match prev {
+                    Some(v) => { params[pname] = v; },
+                    None => { params.remove(pname); },
+                }
             }
         }
 
         // Wildcard: consume the entire remaining path.
         if self.nodes[node_id].wildcard_handler >= 0 && self.nodes[node_id].wildcard_method == method {
-            let rest = path.substr_bytes(pos, plen);
-            params[self.nodes[node_id].wildcard_name] = rest;
+            params[self.nodes[node_id].wildcard_name] = path.substr_bytes(pos, plen);
             return self.nodes[node_id].wildcard_handler;
         }
 
         return -1;
-    }
-}
-
-fn rollback_params(params: &mut TreeMap<String, String>, snapshot: &Array<String>) {
-    let cur = params.keys();
-    for let k of cur {
-        let mut found = false;
-        for let s of snapshot {
-            if *s == k {
-                found = true;
-                break;
-            }
-        }
-        if !found {
-            params.remove(k);
-        }
     }
 }
 

--- a/example/router-radix.wado
+++ b/example/router-radix.wado
@@ -62,6 +62,15 @@ impl RadixRouter {
     pub fn match_path(&self, method: Method, path: &String) -> MatchResult {
         let mut params = TreeMap::<String, String>::new();
         let plen = path.len();
+        // Empty pattern ("/") registers a handler at the root with no edge,
+        // so walk's edge-driven traversal cannot reach it. Match path "/"
+        // against root.handler_id directly before falling back to walk —
+        // walk still handles a wildcard registered at root (`/*x`).
+        if plen == 1 && path.get_byte(0) == '/' as u8
+            && self.nodes[0].handler_id >= 0
+            && self.nodes[0].method == method {
+            return MatchResult { handler_id: self.nodes[0].handler_id, params };
+        }
         let hit = self.walk(0, path, 0, plen, method, &mut params);
         if hit < 0 {
             return no_match();
@@ -295,4 +304,24 @@ test "radix: deep param chain" {
     assert m.params["uid"] == "12";
     assert m.params["pid"] == "34";
     assert m.params["cid"] == "56";
+}
+
+test "radix: method mismatch is a miss" {
+    let routes = [
+        RoutePattern { method: Method::Post, path: "/login", handler_id: 1 },
+    ] as Array<RoutePattern>;
+    let r = RadixRouter::build(&routes);
+    assert r.match_path(Method::Get, &"/login").handler_id == -1;
+    assert r.match_path(Method::Post, &"/login").handler_id == 1;
+}
+
+test "radix: root pattern matches /" {
+    let routes = [
+        RoutePattern { method: Method::Get, path: "/", handler_id: 7 },
+        RoutePattern { method: Method::Get, path: "/foo", handler_id: 8 },
+    ] as Array<RoutePattern>;
+    let r = RadixRouter::build(&routes);
+    assert r.match_path(Method::Get, &"/").handler_id == 7;
+    assert r.match_path(Method::Get, &"/foo").handler_id == 8;
+    assert r.match_path(Method::Get, &"/bar").handler_id == -1;
 }

--- a/example/router-radix.wado
+++ b/example/router-radix.wado
@@ -76,27 +76,31 @@ impl RadixRouter {
         let nseg = segs.len();
         for let mut i = 0; i < nseg; i += 1 {
             let seg = &segs[i];
-            if let Literal(lit) = seg {
-                buffer.push_str("/");
-                buffer.push_str(*lit);
-            } else if let Param(name) = seg {
-                buffer.push_str("/");
-                cur = self.insert_literal(cur, &buffer);
-                buffer = String::with_capacity(32);
-                if self.nodes[cur].param_target < 0 {
-                    let new_id = self.nodes.len();
-                    self.nodes.push(new_node());
-                    self.nodes[cur].param_target = new_id;
-                    self.nodes[cur].param_name = *name;
-                }
-                cur = self.nodes[cur].param_target;
-            } else if let Wildcard(name) = seg {
-                buffer.push_str("/");
-                cur = self.insert_literal(cur, &buffer);
-                self.nodes[cur].wildcard_handler = handler_id;
-                self.nodes[cur].wildcard_method = method;
-                self.nodes[cur].wildcard_name = *name;
-                return;
+            match seg {
+                Literal(lit) => {
+                    buffer.push_str("/");
+                    buffer.push_str(*lit);
+                },
+                Param(name) => {
+                    buffer.push_str("/");
+                    cur = self.insert_literal(cur, &buffer);
+                    buffer = String::with_capacity(32);
+                    if self.nodes[cur].param_target < 0 {
+                        let new_id = self.nodes.len();
+                        self.nodes.push(new_node());
+                        self.nodes[cur].param_target = new_id;
+                        self.nodes[cur].param_name = *name;
+                    }
+                    cur = self.nodes[cur].param_target;
+                },
+                Wildcard(name) => {
+                    buffer.push_str("/");
+                    cur = self.insert_literal(cur, &buffer);
+                    self.nodes[cur].wildcard_handler = handler_id;
+                    self.nodes[cur].wildcard_method = method;
+                    self.nodes[cur].wildcard_name = *name;
+                    return;
+                },
             }
         }
         if buffer.len() > 0 {

--- a/example/router-radix.wado
+++ b/example/router-radix.wado
@@ -209,7 +209,7 @@ impl RadixRouter {
         // Param: consume one '/'-delimited segment, then descend.
         if self.nodes[node_id].param_target >= 0 {
             let mut end = pos;
-            while end < plen && path.get_byte(end) != 47 {
+            while end < plen && path.get_byte(end) != '/' as u8 {
                 end += 1;
             }
             if end > pos {

--- a/example/router-radix.wado
+++ b/example/router-radix.wado
@@ -1,0 +1,303 @@
+//! Radix-tree HTTP router (compressed byte-level trie).
+//!
+//! Nodes are stored in a flat arena (`Array<RadixNode>`) addressed by `i32`
+//! ids; this avoids the `&mut` re-borrow gymnastics that arise when chains
+//! of mutations would have to walk through `Option<RadixNode>` fields.
+//!
+//! Each literal edge carries a byte-level label that *includes* the path
+//! separators. So `/api/v1/users/list` enters the tree as a single edge
+//! (which then splits whenever a sibling shares a prefix). Param and
+//! wildcard segments are stored on the parent node and consume one
+//! '/'-delimited segment or the whole tail respectively.
+
+use { TreeMap } from "core:collections";
+use {
+    Method, MatchResult, RoutePattern, Segment,
+    no_match, parse_pattern,
+} from "./router-common.wado";
+
+struct RadixEdge {
+    label: String,
+    target: i32,
+}
+
+struct RadixNode {
+    edges: Array<RadixEdge>,
+    param_target: i32,         // -1 if no param child
+    param_name: String,
+    wildcard_handler: i32,     // -1 if no wildcard route
+    wildcard_method: Method,
+    wildcard_name: String,
+    handler_id: i32,           // -1 if not terminal
+    method: Method,
+}
+
+fn new_node() -> RadixNode {
+    return RadixNode {
+        edges: [],
+        param_target: -1,
+        param_name: "",
+        wildcard_handler: -1,
+        wildcard_method: Method::Get,
+        wildcard_name: "",
+        handler_id: -1,
+        method: Method::Get,
+    };
+}
+
+pub struct RadixRouter {
+    nodes: Array<RadixNode>,   // node 0 is the root
+}
+
+impl RadixRouter {
+    pub fn build(patterns: &Array<RoutePattern>) -> RadixRouter {
+        let mut r = RadixRouter { nodes: [] };
+        r.nodes.push(new_node());
+        for let p of patterns {
+            r.insert_pattern(p.method, &p.path, p.handler_id);
+        }
+        return r;
+    }
+
+    pub fn match_path(&self, method: Method, path: &String) -> MatchResult {
+        let mut params = TreeMap::<String, String>::new();
+        let plen = path.len();
+        let hit = self.walk(0, path, 0, plen, method, &mut params);
+        if hit < 0 {
+            return no_match();
+        }
+        return MatchResult { handler_id: hit, params };
+    }
+
+    fn insert_pattern(&mut self, method: Method, path: &String, handler_id: i32) {
+        let segs = parse_pattern(path);
+        let mut cur: i32 = 0;
+        let mut buffer = String::with_capacity(64);
+        let nseg = segs.len();
+        for let mut i = 0; i < nseg; i += 1 {
+            let seg = &segs[i];
+            if let Literal(lit) = seg {
+                buffer.push_str("/");
+                buffer.push_str(*lit);
+            } else if let Param(name) = seg {
+                buffer.push_str("/");
+                cur = self.insert_literal(cur, &buffer);
+                buffer = String::with_capacity(32);
+                if self.nodes[cur].param_target < 0 {
+                    let new_id = self.nodes.len();
+                    self.nodes.push(new_node());
+                    self.nodes[cur].param_target = new_id;
+                    self.nodes[cur].param_name = *name;
+                }
+                cur = self.nodes[cur].param_target;
+            } else if let Wildcard(name) = seg {
+                buffer.push_str("/");
+                cur = self.insert_literal(cur, &buffer);
+                self.nodes[cur].wildcard_handler = handler_id;
+                self.nodes[cur].wildcard_method = method;
+                self.nodes[cur].wildcard_name = *name;
+                return;
+            }
+        }
+        if buffer.len() > 0 {
+            cur = self.insert_literal(cur, &buffer);
+        }
+        self.nodes[cur].handler_id = handler_id;
+        self.nodes[cur].method = method;
+    }
+
+    /// Inserts (or finds) the literal `label` starting at `node_id`. Splits
+    /// existing edges as needed to preserve longest-common-prefix sharing.
+    /// Returns the id of the node that sits at the end of the label.
+    fn insert_literal(&mut self, node_id: i32, label: &String) -> i32 {
+        let mut current = node_id;
+        let mut remaining: String = *label;
+        loop {
+            let nedges = self.nodes[current].edges.len();
+            let mut found_idx = -1;
+            let first = remaining.get_byte(0);
+            for let mut i = 0; i < nedges; i += 1 {
+                if self.nodes[current].edges[i].label.get_byte(0) == first {
+                    found_idx = i;
+                    break;
+                }
+            }
+            if found_idx < 0 {
+                let new_id = self.nodes.len();
+                self.nodes.push(new_node());
+                self.nodes[current].edges.push(RadixEdge { label: remaining, target: new_id });
+                return new_id;
+            }
+            let elen = self.nodes[current].edges[found_idx].label.len();
+            let llen = remaining.len();
+            let mut cp = 0;
+            while cp < elen && cp < llen
+                && self.nodes[current].edges[found_idx].label.get_byte(cp) == remaining.get_byte(cp) {
+                cp += 1;
+            }
+            if cp == elen {
+                if cp == llen {
+                    return self.nodes[current].edges[found_idx].target;
+                }
+                current = self.nodes[current].edges[found_idx].target;
+                remaining = remaining.substr_bytes(cp, llen);
+                continue;
+            }
+            // Split the existing edge at cp.
+            let head = self.nodes[current].edges[found_idx].label.substr_bytes(0, cp);
+            let tail = self.nodes[current].edges[found_idx].label.substr_bytes(cp, elen);
+            let original_target = self.nodes[current].edges[found_idx].target;
+            let inner_id = self.nodes.len();
+            self.nodes.push(new_node());
+            self.nodes[inner_id].edges.push(RadixEdge { label: tail, target: original_target });
+            self.nodes[current].edges[found_idx] = RadixEdge { label: head, target: inner_id };
+            if cp == llen {
+                return inner_id;
+            }
+            current = inner_id;
+            remaining = remaining.substr_bytes(cp, llen);
+        }
+    }
+
+    fn walk(&self, node_id: i32, path: &String, pos: i32, plen: i32, method: Method, params: &mut TreeMap<String, String>) -> i32 {
+        if pos >= plen {
+            if self.nodes[node_id].handler_id >= 0 && self.nodes[node_id].method == method {
+                return self.nodes[node_id].handler_id;
+            }
+            if self.nodes[node_id].wildcard_handler >= 0 && self.nodes[node_id].wildcard_method == method {
+                params[self.nodes[node_id].wildcard_name] = "";
+                return self.nodes[node_id].wildcard_handler;
+            }
+            return -1;
+        }
+        let first = path.get_byte(pos);
+        let nedges = self.nodes[node_id].edges.len();
+        for let mut i = 0; i < nedges; i += 1 {
+            if self.nodes[node_id].edges[i].label.get_byte(0) != first {
+                continue;
+            }
+            let elen = self.nodes[node_id].edges[i].label.len();
+            if plen - pos < elen {
+                continue;
+            }
+            let mut k = 1;
+            let mut ok = true;
+            while k < elen {
+                if path.get_byte(pos + k) != self.nodes[node_id].edges[i].label.get_byte(k) {
+                    ok = false;
+                    break;
+                }
+                k += 1;
+            }
+            if !ok {
+                continue;
+            }
+            let saved = params.keys();
+            let h = self.walk(self.nodes[node_id].edges[i].target, path, pos + elen, plen, method, params);
+            if h >= 0 {
+                return h;
+            }
+            rollback_params(params, &saved);
+            // Per radix invariant there is at most one edge per first byte.
+            break;
+        }
+
+        // Param: consume one '/'-delimited segment, then descend.
+        if self.nodes[node_id].param_target >= 0 {
+            let mut end = pos;
+            while end < plen && path.get_byte(end) != 47 {
+                end += 1;
+            }
+            if end > pos {
+                let pname = self.nodes[node_id].param_name;
+                let value = path.substr_bytes(pos, end);
+                params[pname] = value;
+                let h = self.walk(self.nodes[node_id].param_target, path, end, plen, method, params);
+                if h >= 0 {
+                    return h;
+                }
+                params.remove(pname);
+            }
+        }
+
+        // Wildcard: consume the entire remaining path.
+        if self.nodes[node_id].wildcard_handler >= 0 && self.nodes[node_id].wildcard_method == method {
+            let rest = path.substr_bytes(pos, plen);
+            params[self.nodes[node_id].wildcard_name] = rest;
+            return self.nodes[node_id].wildcard_handler;
+        }
+
+        return -1;
+    }
+}
+
+fn rollback_params(params: &mut TreeMap<String, String>, snapshot: &Array<String>) {
+    let cur = params.keys();
+    for let k of cur {
+        let mut found = false;
+        for let s of snapshot {
+            if *s == k {
+                found = true;
+                break;
+            }
+        }
+        if !found {
+            params.remove(k);
+        }
+    }
+}
+
+test "radix: static routes" {
+    let routes = [
+        RoutePattern { method: Method::Get, path: "/health", handler_id: 1 },
+        RoutePattern { method: Method::Get, path: "/api/v1/users/list", handler_id: 2 },
+        RoutePattern { method: Method::Get, path: "/api/v1/users/me", handler_id: 3 },
+    ] as Array<RoutePattern>;
+    let r = RadixRouter::build(&routes);
+    assert r.match_path(Method::Get, &"/health").handler_id == 1;
+    assert r.match_path(Method::Get, &"/api/v1/users/list").handler_id == 2;
+    assert r.match_path(Method::Get, &"/api/v1/users/me").handler_id == 3;
+    assert r.match_path(Method::Get, &"/missing").handler_id == -1;
+    assert r.match_path(Method::Get, &"/api/v1/users").handler_id == -1;
+}
+
+test "radix: param + literal sibling" {
+    let routes = [
+        RoutePattern { method: Method::Get, path: "/users/list", handler_id: 1 },
+        RoutePattern { method: Method::Get, path: "/users/:id", handler_id: 2 },
+        RoutePattern { method: Method::Get, path: "/users/:id/profile", handler_id: 3 },
+    ] as Array<RoutePattern>;
+    let r = RadixRouter::build(&routes);
+
+    assert r.match_path(Method::Get, &"/users/list").handler_id == 1;
+
+    let m = r.match_path(Method::Get, &"/users/42");
+    assert m.handler_id == 2;
+    assert m.params["id"] == "42";
+
+    let m2 = r.match_path(Method::Get, &"/users/42/profile");
+    assert m2.handler_id == 3;
+    assert m2.params["id"] == "42";
+}
+
+test "radix: wildcard catch-all" {
+    let routes = [
+        RoutePattern { method: Method::Get, path: "/static/*path", handler_id: 9 },
+    ] as Array<RoutePattern>;
+    let r = RadixRouter::build(&routes);
+    let m = r.match_path(Method::Get, &"/static/css/main.css");
+    assert m.handler_id == 9;
+    assert m.params["path"] == "css/main.css";
+}
+
+test "radix: deep param chain" {
+    let routes = [
+        RoutePattern { method: Method::Get, path: "/api/v1/users/:uid/posts/:pid/comments/:cid", handler_id: 90 },
+    ] as Array<RoutePattern>;
+    let r = RadixRouter::build(&routes);
+    let m = r.match_path(Method::Get, &"/api/v1/users/12/posts/34/comments/56");
+    assert m.handler_id == 90;
+    assert m.params["uid"] == "12";
+    assert m.params["pid"] == "34";
+    assert m.params["cid"] == "56";
+}


### PR DESCRIPTION
## Summary

- Implements three HTTP routing engines (`example/router-{linear,radix,dfa}.wado`) sharing a 100-route fixture, plus a benchmark driver (`example/router-bench.wado`) with cross-engine sanity checks for both `handler_id` and captured params.
- Optimises both winning engines until they hit speed parity (~46 µs/lookup, ~14× faster than mixed Linear).
- Proposes `core:router` (DFA-based) in [`docs/wep-2026-05-06-core-router.md`](./docs/wep-2026-05-06-core-router.md) with the algorithm choice grounded in the benchmark.

## What's in the box

| File | Purpose |
| --- | --- |
| `example/router-common.wado` | Shared types, 100-route fixture, 10-element access pattern, `parse_pattern` |
| `example/router-linear.wado` | Baseline linear scan |
| `example/router-radix.wado` | Arena-based byte-level radix tree |
| `example/router-dfa.wado` | Segment-level tagged DFA with sorted-array literal lookup + byte-range binary search |
| `example/router-bench.wado` | Driver: cross-engine agreement + Benchmark phases |
| `docs/wep-2026-05-06-core-router.md` | WEP proposing `core:router` (DFA), 248 lines |

## Final benchmark numbers

50 000 lookups, debug `wasmtime`, Wado `-O2`:

```
mixed pattern x 5000 outer iter (10 lookups each)
  linear (mixed): 33758.495 ms   (~676 µs/lookup)
  radix         :  2275.173 ms   (~ 46 µs/lookup)
  dfa           :  2171.856 ms   (~ 43 µs/lookup)

linear best/worst x 50000 iter
  linear (best ) :   551.361 ms  (~11 µs/lookup, hot route)
  linear (worst) : 46502.259 ms  (~930 µs/lookup, miss)
```

Cross-engine `handler_id` + `params` agreement reports OK.

## Why DFA for `core:router`

Speed parity with radix; capability/maintenance tilt is documented in the WEP:

- ~3.5× faster build (cold-start matters for serverless)
- Iterative loop, no backtracking
- Segment-level state graph is dump-friendly and easier to extend (typed params, code-gen DFA, instrumentation)

The radix tree is recommended as a separate `core:collections::PrefixTree<V>` for general byte-prefix indexing — captured as a follow-up item in the WEP.

## Notable findings during the work

1. **Allocation per segment** dominated the original DFA hot path (`TreeMap<String, i32>` literal lookup forced one `substr_bytes` per segment). Replacing with sorted `Array<DfaLiteralEdge>` + byte-range binary search gave a 3.4× speedup on DFA alone.
2. **A defensive `params.keys()` snapshot in radix's walk** was effectively dead code — the param branch already restores its own insert. Removing it gave 2.1× on radix.
3. **Cross-engine param-name disagreement**: when `/api/v1/users/:id` and `/api/v1/users/:uid/...` are both registered, Radix and DFA share a single param node and use the first-registered name (`id`); Linear stores routes independently and uses the per-route name (`uid`). The new bench check immediately surfaced this. Resolved in the bench fixture; flagged in the WEP as a follow-up for `route()` to validate at registration time.

## Test plan

- [x] `wado test example/router-{common,linear,radix,dfa}.wado` — 24 tests pass, including new coverage for `parse_pattern` panics, `/` root pattern, method-mismatch (radix/dfa parity)
- [x] `wado run example/router-bench.wado` — cross-engine agreement (handler_id + params) reports OK
- [x] No `wado-compiler` / stdlib changes; pure `example/` + WEP

## Out of scope

This PR ships the benchmark and the proposal only. The actual `core:router` implementation in `wado-compiler/lib/core/router.wado` and the `example/http-bin.wado` migration to use it are deferred to a follow-up.

https://claude.ai/code/session_01Ucyf2Z9kTj5hfXDAPuypzE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ucyf2Z9kTj5hfXDAPuypzE)_