### PR TITLE
feat: LSP: serve bundled stdlib via workspace/textDocumentContent

### DIFF
--- a/.github/workflows/wado-vscode.yml
+++ b/.github/workflows/wado-vscode.yml
@@ -43,8 +43,10 @@ jobs:
 
       # Build the bundled Wasm language server that the extension loads on
       # activation. See docs/wep-2026-04-18-lsp-architecture.md for rationale.
+      # The TS bundle is compiled by the explicit `npm ci` + `npm run compile`
+      # steps below, so this job uses the Rust-only task to avoid redoing it.
       - name: Build wado-lsp.wasm (wasm32-wasip1)
-        run: mise run build-wado-lsp-wasm
+        run: mise run build-wado-lsp-wasm-rust
 
       - name: Install npm dependencies
         working-directory: wado-vscode

--- a/mise.toml
+++ b/mise.toml
@@ -243,7 +243,7 @@ description = "Run wado-vscode tests"
 run = "cd wado-vscode && npm install && npm run test:unit && npm run test"
 
 [tasks.build-wado-lsp-wasm]
-description = "Build wado-lsp for wasm32-wasip1 and copy into wado-vscode/out/"
+description = "Build wado-lsp wasm + wado-vscode TS into wado-vscode/out/"
 run = """
 #!/usr/bin/env bash
 set -xe -o pipefail
@@ -253,18 +253,42 @@ set -xe -o pipefail
 cargo build -p wado-lsp --bin wado-lsp --target wasm32-wasip1 --release
 mkdir -p wado-vscode/out
 cp target/wasm32-wasip1/release/wado-lsp.wasm wado-vscode/out/wado_lsp.wasm
+
+# Compile the extension TS so wado-vscode/out/extension.js stays in sync —
+# otherwise a Reload Window picks up stale JS that doesn't match the wasm.
+( cd wado-vscode && [ -d node_modules ] || npm install )
+( cd wado-vscode && npm run compile )
 """
 
 [tasks.watch-wado-lsp-wasm]
-description = "Watch wado-lsp and rebuild the wasm32-wasip1 artifact on change"
+description = "Watch wado-lsp + wado-vscode TS; keep wado-vscode/out/ continuously fresh"
 run = """
 #!/usr/bin/env bash
-set -xe -o pipefail
-cargo watch \
-    -w wado-lsp \
-    -w wado-compiler \
-    -w wado-manifest \
-    -s 'mise run build-wado-lsp-wasm'
+set -e -o pipefail
+
+# Make sure node_modules exists before launching tsc -watch.
+( cd wado-vscode && [ -d node_modules ] || npm install )
+
+# tsc -watch rebuilds wado-vscode/out/extension.js on every TS edit. VS Code
+# does not auto-reload extension code, so you still need
+# "Developer: Reload Window" after a TS change — but extension.js is always
+# in sync once tsc has rebuilt it.
+( cd wado-vscode && exec npm run watch ) &
+TSC_PID=$!
+trap 'kill -TERM $TSC_PID 2>/dev/null || true; wait $TSC_PID 2>/dev/null || true' EXIT INT TERM
+
+# cargo watch rebuilds the wasm on every Rust change. The extension's
+# FileSystemWatcher picks the new wasm up and restarts the LSP server,
+# so Rust-only changes do not require a Reload Window.
+#
+# Inline the wasm rebuild rather than `mise run build-wado-lsp-wasm` so we
+# don't kick off a redundant `npm run compile` (already handled by the tsc
+# watcher above) on every Rust edit.
+cargo watch \\
+    -w wado-lsp \\
+    -w wado-compiler \\
+    -w wado-manifest \\
+    -s 'cargo build -p wado-lsp --bin wado-lsp --target wasm32-wasip1 --release && mkdir -p wado-vscode/out && cp target/wasm32-wasip1/release/wado-lsp.wasm wado-vscode/out/wado_lsp.wasm'
 """
 
 [tasks.update-wado-vscode-grammar]

--- a/mise.toml
+++ b/mise.toml
@@ -242,8 +242,8 @@ run = "rm -f ~/.vscode/extensions/wado-lang.wado-0.0.1"
 description = "Run wado-vscode tests"
 run = "cd wado-vscode && npm install && npm run test:unit && npm run test"
 
-[tasks.build-wado-lsp-wasm]
-description = "Build wado-lsp wasm + wado-vscode TS into wado-vscode/out/"
+[tasks.build-wado-lsp-wasm-rust]
+description = "Build the wado-lsp wasm32-wasip1 binary into wado-vscode/out/ (Rust only)"
 run = """
 #!/usr/bin/env bash
 set -xe -o pipefail
@@ -253,6 +253,14 @@ set -xe -o pipefail
 cargo build -p wado-lsp --bin wado-lsp --target wasm32-wasip1 --release
 mkdir -p wado-vscode/out
 cp target/wasm32-wasip1/release/wado-lsp.wasm wado-vscode/out/wado_lsp.wasm
+"""
+
+[tasks.build-wado-lsp-wasm]
+description = "Build wado-lsp wasm + wado-vscode TS into wado-vscode/out/"
+run = """
+#!/usr/bin/env bash
+set -xe -o pipefail
+mise run build-wado-lsp-wasm-rust
 
 # Compile the extension TS so wado-vscode/out/extension.js stays in sync —
 # otherwise a Reload Window picks up stale JS that doesn't match the wasm.
@@ -279,16 +287,14 @@ trap 'kill -TERM $TSC_PID 2>/dev/null || true; wait $TSC_PID 2>/dev/null || true
 
 # cargo watch rebuilds the wasm on every Rust change. The extension's
 # FileSystemWatcher picks the new wasm up and restarts the LSP server,
-# so Rust-only changes do not require a Reload Window.
-#
-# Inline the wasm rebuild rather than `mise run build-wado-lsp-wasm` so we
-# don't kick off a redundant `npm run compile` (already handled by the tsc
-# watcher above) on every Rust edit.
+# so Rust-only changes do not require a Reload Window. Use the rust-only
+# build task so we don't kick off a redundant `npm run compile` on every
+# Rust edit (the tsc watcher above already keeps extension.js fresh).
 cargo watch \\
     -w wado-lsp \\
     -w wado-compiler \\
     -w wado-manifest \\
-    -s 'cargo build -p wado-lsp --bin wado-lsp --target wasm32-wasip1 --release && mkdir -p wado-vscode/out && cp target/wasm32-wasip1/release/wado-lsp.wasm wado-vscode/out/wado_lsp.wasm'
+    -s 'mise run build-wado-lsp-wasm-rust'
 """
 
 [tasks.update-wado-vscode-grammar]

--- a/wado-cli/tests/lsp.rs
+++ b/wado-cli/tests/lsp.rs
@@ -239,7 +239,9 @@ fn lsp_workspace_text_document_content_rejects_unknown_uri() {
     );
     let resp = session.read_message();
     assert_eq!(resp["id"], id);
-    assert_eq!(resp["error"]["code"], -32602); // InvalidParams
+    // The request was syntactically valid but the URI doesn't resolve to any
+    // bundled module → RequestFailed (-32803) per LSP 3.18, not InvalidParams.
+    assert_eq!(resp["error"]["code"].as_i64(), Some(-32803));
 
     assert_eq!(session.shutdown_and_exit(), 0);
 }

--- a/wado-cli/tests/lsp.rs
+++ b/wado-cli/tests/lsp.rs
@@ -187,8 +187,59 @@ fn lsp_initialize_returns_capabilities() {
     assert_eq!(caps["textDocumentSync"]["openClose"], true);
     assert_eq!(caps["textDocumentSync"]["change"], 1); // Full sync
 
+    let schemes = caps["workspace"]["textDocumentContent"]["schemes"]
+        .as_array()
+        .expect("workspace.textDocumentContent.schemes should be advertised");
+    let schemes: Vec<&str> = schemes.iter().filter_map(Value::as_str).collect();
+    assert!(schemes.contains(&"core"));
+    assert!(schemes.contains(&"wasi"));
+
     let info = &resp["result"]["serverInfo"];
     assert_eq!(info["name"], "wado-lsp");
+
+    assert_eq!(session.shutdown_and_exit(), 0);
+}
+
+#[test]
+fn lsp_workspace_text_document_content_returns_bundled_stdlib() {
+    let mut session = LspSession::start();
+    session.initialize();
+
+    let id = session.send_request(
+        "workspace/textDocumentContent",
+        json!({ "uri": "core:cli" }),
+    );
+    let resp = session.read_message();
+    assert_eq!(resp["id"], id);
+    let text = resp["result"]["text"]
+        .as_str()
+        .expect("text field should be present");
+    assert!(text.contains("println"));
+
+    let id = session.send_request(
+        "workspace/textDocumentContent",
+        json!({ "uri": "wasi:filesystem/types.wado" }),
+    );
+    let resp = session.read_message();
+    assert_eq!(resp["id"], id);
+    let text = resp["result"]["text"].as_str().unwrap();
+    assert!(text.contains("Descriptor"));
+
+    assert_eq!(session.shutdown_and_exit(), 0);
+}
+
+#[test]
+fn lsp_workspace_text_document_content_rejects_unknown_uri() {
+    let mut session = LspSession::start();
+    session.initialize();
+
+    let id = session.send_request(
+        "workspace/textDocumentContent",
+        json!({ "uri": "core:does_not_exist" }),
+    );
+    let resp = session.read_message();
+    assert_eq!(resp["id"], id);
+    assert_eq!(resp["error"]["code"], -32602); // InvalidParams
 
     assert_eq!(session.shutdown_and_exit(), 0);
 }

--- a/wado-lsp/AGENTS.md
+++ b/wado-lsp/AGENTS.md
@@ -38,6 +38,12 @@ Language service engine for the Wado compiler toolchain.
 
 `server::run_stdio` is the binary's only entrypoint and is also re-used by `wado-cli/src/lsp.rs`. I/O is synchronous (`std::io`) so the crate builds for `wasm32-wasip2`, where tokio's `io-std` is unavailable; the dispatcher still awaits `Engine` futures between messages. Async is driven by `futures::executor::block_on` — the crate does not depend on tokio.
 
+### Bundled stdlib content
+
+Jump-to-definition into bundled stdlib modules emits `core:<name>` / `wasi:<interface>` URIs from `module_uri` (`src/location.rs`). The server advertises a `workspace.textDocumentContent` capability for the `core` and `wasi` schemes; clients call `workspace/textDocumentContent` to retrieve the source. The handler in `src/server/dispatch.rs` resolves it via `Engine::text_document_content` (`src/lib.rs`), which looks the URI up in `wado_compiler::stdlib::get_stdlib_module`. Both `core:cli` and the rfc3986-normalised form `core:/cli` are accepted.
+
+The VS Code extension (`wado-vscode/src/extension.ts`) bridges this with a `TextDocumentContentProvider` registered for both schemes, and forces opened documents to language `wado` because opaque URIs (e.g. `core:cli`) carry no extension for VS Code's language detector.
+
 ## Related Files in wado-cli
 
 | File                   | Role                                                                           |
@@ -119,7 +125,6 @@ Progress tracker for LSP 3.18 feature kinds. Each item represents a protocol kin
 - [ ] `workspace/didChangeWatchedFiles`
 - [ ] `workspace/executeCommand`
 - [ ] `workspace/applyEdit`
-- [ ] `workspace/textDocumentContent`
 - [ ] File operations (`willCreateFiles` / `didCreateFiles` / `willRenameFiles` / `didRenameFiles` / `willDeleteFiles` / `didDeleteFiles`)
 
 ### Window Features
@@ -136,13 +141,6 @@ Known gaps and quality debts in `src/definition.rs` / `src/location.rs` not tied
 to a specific LSP request kind. Each item identifies the symptom and the
 concrete code location involved.
 
-- [ ] **Serve bundled stdlib content for `core:` / `wasi:` URIs.** `module_uri`
-      in `src/location.rs` returns `core:<name>` / `wasi:<interface>` URIs for
-      jumps into bundled stdlib modules, but LSP clients cannot open them.
-      Implement `workspace/textDocumentContent` (LSP 3.18) so the server can
-      respond with the bundled source strings from `wado_compiler::stdlib::*`.
-      As a bridge, the VS Code extension can register a
-      `TextDocumentContentProvider` for the `core:` / `wasi:` schemes.
 - [ ] **Jump-to-def for non-`Simple` `UseItem` variants.**
       `Resolver::record_use_specifier_references` (`wado-compiler/src/resolver.rs`)
       skips `UseItem::{EffectFunctions, Namespace}`. Give `UseItemSimple`
@@ -171,10 +169,11 @@ concrete code location involved.
       `Item::Test` have no dedicated `name_span` field). Either give every
       decl-bearing AST node a `name_span` so `name_span_of` becomes total,
       or accept the fallback and remove this TODO.
-- [ ] **Split `module_uri` into display-vs-navigation helpers.** The current
-      single helper in `src/location.rs` is used by both CLI output (where
-      `core:<name>` is a readable pointer) and by LSP responses (where the
-      client cannot open it). Introduce `module_display_uri` for CLI /
-      informational use and keep `module_uri` strictly for URIs a client can
-      open (returning `None` for unopenable stdlib modules until
-      `workspace/textDocumentContent` lands).
+- [ ] **Serve bundled `.wat` / `.wasm` assets via `workspace/textDocumentContent`.**
+      `core:` / `wasi:` source modules are now openable, but the
+      `ModuleSource::Wasm { path, .. }` arm of `module_uri` in
+      `src/location.rs` still returns the import path verbatim — clients have
+      no way to open `core:libm.wat`. Extend `Engine::text_document_content`
+      to dispatch to `wado_compiler::stdlib::get_stdlib_wasm_asset` for `.wat`
+      assets (text) and either disassemble or skip `.wasm` (binary). Decide
+      whether to advertise additional schemes or reuse `core:` / `wasi:`.

--- a/wado-lsp/src/lib.rs
+++ b/wado-lsp/src/lib.rs
@@ -119,6 +119,24 @@ impl Engine {
         document_highlight::document_highlight(source, position, uri, host).await
     }
 
+    /// Resolve a `core:` / `wasi:` URI to its bundled stdlib source.
+    ///
+    /// Powers `workspace/textDocumentContent` so editors can open
+    /// `core:cli` / `wasi:filesystem/types.wado` jump-to-definition targets
+    /// even though the source lives only in the compiler's binary.
+    /// Tolerates the rfc3986-normalised form `core:/cli` that some clients
+    /// emit when round-tripping the URI through their parser.
+    #[must_use]
+    pub fn text_document_content(&self, uri: &str) -> Option<&'static str> {
+        let (scheme, rest) = uri.split_once(':')?;
+        if scheme != "core" && scheme != "wasi" {
+            return None;
+        }
+        let path = rest.strip_prefix('/').unwrap_or(rest);
+        let key = format!("{scheme}:{path}");
+        wado_compiler::stdlib::get_stdlib_module(&key)
+    }
+
     /// Compute semantic tokens for the given document.
     ///
     /// Returns delta-encoded token data for LSP `textDocument/semanticTokens/full`.
@@ -245,5 +263,39 @@ mod tests {
             "/home/user/test.wado"
         );
         assert_eq!(uri_to_filename("untitled:1"), "untitled:1");
+    }
+
+    #[test]
+    fn text_document_content_resolves_core_module() {
+        let engine = Engine::new();
+        let text = engine.text_document_content("core:cli").unwrap();
+        assert!(text.contains("println"));
+    }
+
+    #[test]
+    fn text_document_content_resolves_wasi_interface() {
+        let engine = Engine::new();
+        let text = engine
+            .text_document_content("wasi:filesystem/types.wado")
+            .unwrap();
+        assert!(text.contains("Descriptor"));
+    }
+
+    #[test]
+    fn text_document_content_tolerates_normalized_uri() {
+        let engine = Engine::new();
+        assert!(engine.text_document_content("core:/cli").is_some());
+    }
+
+    #[test]
+    fn text_document_content_rejects_unknown_scheme() {
+        let engine = Engine::new();
+        assert!(engine.text_document_content("file:///etc/passwd").is_none());
+    }
+
+    #[test]
+    fn text_document_content_rejects_unknown_module() {
+        let engine = Engine::new();
+        assert!(engine.text_document_content("core:nonexistent").is_none());
     }
 }

--- a/wado-lsp/src/lib.rs
+++ b/wado-lsp/src/lib.rs
@@ -132,9 +132,13 @@ impl Engine {
         if scheme != "core" && scheme != "wasi" {
             return None;
         }
-        let path = rest.strip_prefix('/').unwrap_or(rest);
-        let key = format!("{scheme}:{path}");
-        wado_compiler::stdlib::get_stdlib_module(&key)
+        // Canonical form (`core:cli`) hits get_stdlib_module without an
+        // intermediate allocation; only the normalised form (`core:/cli`)
+        // needs its slash stripped and the URI re-formed.
+        match rest.strip_prefix('/') {
+            None => wado_compiler::stdlib::get_stdlib_module(uri),
+            Some(path) => wado_compiler::stdlib::get_stdlib_module(&format!("{scheme}:{path}")),
+        }
     }
 
     /// Compute semantic tokens for the given document.

--- a/wado-lsp/src/server/dispatch.rs
+++ b/wado-lsp/src/server/dispatch.rs
@@ -10,10 +10,13 @@ use crate::server::rpc::{
     DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
     InitializeResult, JsonRpcRequest, PublishDiagnosticsParams, ReferenceParams, SemanticTokens,
     SemanticTokensLegend, SemanticTokensOptions, SemanticTokensParams, ServerCapabilities,
-    ServerInfo, TextDocumentPositionParams, TextDocumentSyncOptions, error_codes,
+    ServerInfo, TextDocumentContentOptions, TextDocumentContentParams, TextDocumentContentResult,
+    TextDocumentPositionParams, TextDocumentSyncOptions, WorkspaceServerCapabilities, error_codes,
     text_document_sync_kind,
 };
 use crate::server::transport;
+
+const STDLIB_SCHEMES: &[&str] = &["core", "wasi"];
 
 /// Tracks server lifecycle per LSP 3.18 §Server lifecycle.
 ///
@@ -95,6 +98,11 @@ pub async fn dispatch<W: Write>(
                                 token_modifiers: crate::semantic_tokens::TOKEN_MODIFIERS,
                             },
                             full: true,
+                        }),
+                        workspace: Some(WorkspaceServerCapabilities {
+                            text_document_content: Some(TextDocumentContentOptions {
+                                schemes: STDLIB_SCHEMES,
+                            }),
                         }),
                     },
                     server_info: Some(ServerInfo {
@@ -202,6 +210,31 @@ pub async fn dispatch<W: Write>(
                 let data = engine.semantic_tokens(&p.text_document.uri);
                 let result = SemanticTokens { data };
                 transport::send_response(writer, id, result)?;
+            }
+        }
+        "workspace/textDocumentContent" => {
+            if let Some(id) = id {
+                let Some(p) =
+                    transport::decode_or_error::<TextDocumentContentParams, _>(writer, id, params)?
+                else {
+                    return Ok(());
+                };
+                match engine.text_document_content(&p.uri) {
+                    Some(text) => {
+                        let result = TextDocumentContentResult {
+                            text: text.to_string(),
+                        };
+                        transport::send_response(writer, id, result)?;
+                    }
+                    None => {
+                        transport::send_error(
+                            writer,
+                            id,
+                            error_codes::INVALID_PARAMS,
+                            format!("no bundled content for URI: {}", p.uri),
+                        )?;
+                    }
+                }
             }
         }
         "textDocument/didClose" => {

--- a/wado-lsp/src/server/dispatch.rs
+++ b/wado-lsp/src/server/dispatch.rs
@@ -230,7 +230,7 @@ pub async fn dispatch<W: Write>(
                         transport::send_error(
                             writer,
                             id,
-                            error_codes::INVALID_PARAMS,
+                            error_codes::REQUEST_FAILED,
                             format!("no bundled content for URI: {}", p.uri),
                         )?;
                     }

--- a/wado-lsp/src/server/rpc.rs
+++ b/wado-lsp/src/server/rpc.rs
@@ -83,6 +83,18 @@ pub struct SemanticTokensParams {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TextDocumentContentParams {
+    pub uri: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TextDocumentContentResult {
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SemanticTokens {
     pub data: Vec<u32>,
 }
@@ -124,6 +136,20 @@ pub struct ServerCapabilities {
     pub document_highlight_provider: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub semantic_tokens_provider: Option<SemanticTokensOptions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workspace: Option<WorkspaceServerCapabilities>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceServerCapabilities {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_document_content: Option<TextDocumentContentOptions>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TextDocumentContentOptions {
+    pub schemes: &'static [&'static str],
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/wado-lsp/src/server/rpc.rs
+++ b/wado-lsp/src/server/rpc.rs
@@ -223,4 +223,7 @@ pub mod error_codes {
     /// Server received a request/notification before `initialize`.
     /// LSP 3.18 §initialize.
     pub const SERVER_NOT_INITIALIZED: i32 = -32002;
+    /// A request was syntactically correct (method known, params valid)
+    /// but failed for a request-specific reason. LSP 3.18 §responseError.
+    pub const REQUEST_FAILED: i32 = -32803;
 }

--- a/wado-vscode/src/extension.ts
+++ b/wado-vscode/src/extension.ts
@@ -9,6 +9,7 @@ const CLIENT_ID = 'wadoLanguageServer';
 const CLIENT_NAME = 'Wado Language Server';
 const WASM_PATH_SEGMENTS = ['out', 'wado_lsp.wasm'] as const;
 const RESTART_DEBOUNCE_MS = 250;
+const STDLIB_SCHEMES = ['core', 'wasi'] as const;
 
 let outputChannel: vscode.LogOutputChannel | undefined;
 let client: LanguageClient | undefined;
@@ -80,7 +81,45 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         }),
     );
 
+    registerStdlibContentProvider(context);
+
     await enqueueLifecycle(() => startClientLocked(context));
+}
+
+// Bridges `core:` / `wasi:` URIs (emitted by the LSP for jump-to-definition into
+// bundled stdlib modules) to the server's `workspace/textDocumentContent`
+// request, so VS Code can open them as read-only virtual documents. The
+// `wado` language is forced on the resulting documents because opaque URIs
+// (e.g. `core:cli`) carry no extension for VS Code's language detector.
+function registerStdlibContentProvider(context: vscode.ExtensionContext): void {
+    const provider: vscode.TextDocumentContentProvider = {
+        async provideTextDocumentContent(uri: vscode.Uri): Promise<string> {
+            const active = client;
+            if (!active) {
+                throw new Error('Wado language server is not running.');
+            }
+            const result = await active.sendRequest<{ text: string }>(
+                'workspace/textDocumentContent',
+                { uri: uri.toString() },
+            );
+            return result.text;
+        },
+    };
+    for (const scheme of STDLIB_SCHEMES) {
+        context.subscriptions.push(
+            vscode.workspace.registerTextDocumentContentProvider(scheme, provider),
+        );
+    }
+    context.subscriptions.push(
+        vscode.workspace.onDidOpenTextDocument((doc) => {
+            if (
+                (STDLIB_SCHEMES as readonly string[]).includes(doc.uri.scheme) &&
+                doc.languageId !== LANGUAGE_ID
+            ) {
+                void vscode.languages.setTextDocumentLanguage(doc, LANGUAGE_ID);
+            }
+        }),
+    );
 }
 
 export async function deactivate(): Promise<void> {

--- a/wado-vscode/src/extension.ts
+++ b/wado-vscode/src/extension.ts
@@ -89,9 +89,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 // Bridges `core:` / `wasi:` URIs (emitted by the LSP for jump-to-definition into
 // bundled stdlib modules) to the server's `workspace/textDocumentContent`
 // request, so VS Code can open them as read-only virtual documents. The
-// `wado` language is forced on the resulting documents because opaque URIs
+// `wado` language is forced on documents we served because opaque URIs
 // (e.g. `core:cli`) carry no extension for VS Code's language detector.
 function registerStdlibContentProvider(context: vscode.ExtensionContext): void {
+    // Track URIs our provider has actually served, so we only override the
+    // language on documents we own — other extensions could conceivably
+    // claim the same scheme, and we shouldn't clobber their language.
+    const ownedUris = new Set<string>();
     const provider: vscode.TextDocumentContentProvider = {
         async provideTextDocumentContent(uri: vscode.Uri): Promise<string> {
             const active = client;
@@ -102,6 +106,7 @@ function registerStdlibContentProvider(context: vscode.ExtensionContext): void {
                 'workspace/textDocumentContent',
                 { uri: uri.toString() },
             );
+            ownedUris.add(uri.toString());
             return result.text;
         },
     };
@@ -112,12 +117,12 @@ function registerStdlibContentProvider(context: vscode.ExtensionContext): void {
     }
     context.subscriptions.push(
         vscode.workspace.onDidOpenTextDocument((doc) => {
-            if (
-                (STDLIB_SCHEMES as readonly string[]).includes(doc.uri.scheme) &&
-                doc.languageId !== LANGUAGE_ID
-            ) {
+            if (ownedUris.has(doc.uri.toString()) && doc.languageId !== LANGUAGE_ID) {
                 void vscode.languages.setTextDocumentLanguage(doc, LANGUAGE_ID);
             }
+        }),
+        vscode.workspace.onDidCloseTextDocument((doc) => {
+            ownedUris.delete(doc.uri.toString());
         }),
     );
 }


### PR DESCRIPTION
## Summary
- Implement LSP 3.18 `workspace/textDocumentContent` so go-to-definition into bundled `core:` / `wasi:` modules can fetch the source from `wado_compiler::stdlib::get_stdlib_module` instead of the editor 404'ing on an unopenable URI.
- Bridge the same path in `wado-vscode` via a `TextDocumentContentProvider` registered for both schemes; force opened virtual docs to language `wado` because opaque URIs (`core:cli`) carry no extension for VS Code's detector.
- Extend `mise run build-wado-lsp-wasm` / `watch-wado-lsp-wasm` to build & watch the extension's TypeScript bundle alongside the wasm so `wado-vscode/out/extension.js` and `wado-vscode/out/wado_lsp.wasm` stay in sync.
- Drop the now-resolved TODO entry in `wado-lsp/AGENTS.md`; refocus the leftover `module_uri` follow-up on the remaining `.wat` / `.wasm` asset gap.

## Test plan
- [x] `cargo test -p wado-lsp` (5 new unit tests for `Engine::text_document_content` + existing 36)
- [x] `cargo test -p wado-cli --test lsp` (2 new integration tests + existing 65)
- [x] `cargo check -p wado-lsp --target wasm32-wasip1`
- [x] `mise run on-task-done` (full clippy / golden / format / e2e + test-wado)
- [x] Manual: VS Code with `mise run watch-wado-lsp-wasm`, click stdlib symbol → opens read-only buffer with the bundled source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)