### PR TITLE
chore: bump jdx/mise-action to v4 in GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
           save-if: false
       - uses: rui314/setup-mold@v1
 
-      - uses: jdx/mise-action@v3
+      - uses: jdx/mise-action@v4
         with:
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -121,7 +121,7 @@ jobs:
           save-if: false
       - uses: rui314/setup-mold@v1
 
-      - uses: jdx/mise-action@v3
+      - uses: jdx/mise-action@v4
         with:
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -143,7 +143,7 @@ jobs:
           save-if: false
       - uses: rui314/setup-mold@v1
 
-      - uses: jdx/mise-action@v3
+      - uses: jdx/mise-action@v4
         with:
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -165,7 +165,7 @@ jobs:
           save-if: false
       - uses: rui314/setup-mold@v1
 
-      - uses: jdx/mise-action@v3
+      - uses: jdx/mise-action@v4
         with:
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -33,7 +33,7 @@ jobs:
 
       # Install project tools via mise (wasmtime, node, …).
       # mise-action handles its own tool cache internally when cache: true.
-      - uses: jdx/mise-action@v3
+      - uses: jdx/mise-action@v4
         with:
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           shared-key: ci
 
-      - uses: jdx/mise-action@v3
+      - uses: jdx/mise-action@v4
         with:
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/wado-vscode.yml
+++ b/.github/workflows/wado-vscode.yml
@@ -28,7 +28,7 @@ jobs:
           shared-key: ci
           save-if: false
 
-      - uses: jdx/mise-action@v3
+      - uses: jdx/mise-action@v4
         with:
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Motivation
- Upgrade the `jdx/mise-action` reference from `@v3` to `@v4` across workflows to use the latest mise action release and its fixes.

### Description
- Replace all occurrences of `jdx/mise-action@v3` with `jdx/mise-action@v4` in `.github/workflows/ci.yml`, `.github/workflows/copilot-setup-steps.yml`, `.github/workflows/tidy.yml`, and `.github/workflows/wado-vscode.yml`.
- Preserve the existing `with:` inputs (`cache: true`, `github_token`) and the `env: MISE_VERBOSE` settings for each workflow step.

### Testing
- Ran `rg -n "jdx/mise-action@v3|jdx/mise-action@v4" .github` to verify all references were updated, which succeeded.
- Ran `git status --short` to confirm the workflow files were modified in the working tree, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd3e797518832f8a0d09f2a11fbeea)