### PR TITLE
ci: use GitHub App token for tagpr

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -17,3 +17,5 @@ jobs:
           # tagpr needs the full history to compute the changelog.
           fetch-depth: 0
       - uses: Songmu/tagpr@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: "${{ secrets.GH_APP_ID }}"
           private-key: "${{ secrets.GH_APP_PRIVATE_KEY }}"

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -4,18 +4,25 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: write       # push the release branch and tag
-  pull-requests: write  # open / update the Release PR
-
 jobs:
   tagpr:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: "${{ secrets.GH_APP_ID }}"
+          private-key: "${{ secrets.GH_APP_PRIVATE_KEY }}"
+          permission-contents: write
+          permission-pull-requests: write
+
       - uses: actions/checkout@v6
         with:
           # tagpr needs the full history to compute the changelog.
           fetch-depth: 0
+          token: "${{ steps.app-token.outputs.token }}"
+
       - uses: Songmu/tagpr@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: "${{ steps.app-token.outputs.token }}"

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: "${{ secrets.GH_APP_ID }}"
           private-key: "${{ secrets.GH_APP_PRIVATE_KEY }}"


### PR DESCRIPTION
## Summary

The tagpr workflow was failing on `main` with `GitHub token not found` because no token was wired into `Songmu/tagpr@v1`. Switched to the same GitHub App token pattern already used by `tidy.yml` (`GH_APP_ID` / `GH_APP_PRIVATE_KEY` via `actions/create-github-app-token@v2`).

Using the App token (rather than the default `GITHUB_TOKEN`) is also required so that pushes/PRs created by tagpr can trigger downstream workflows on the Release PR.

- Generate App token with `contents: write` + `pull-requests: write`
- Pass the token to `actions/checkout` and as `GITHUB_TOKEN` env to `Songmu/tagpr@v1`
- Removed the now-redundant job-level `permissions:` block

## Test plan

- [ ] After merge, confirm the `tagpr` workflow run on `main` succeeds and opens/updates the Release PR.

https://claude.ai/code/session_01EYQae4KQG3dqV2ojrrnPtG

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYQae4KQG3dqV2ojrrnPtG)_