### PR TITLE
perf(wado-cli serve): unblock concurrency, cache TLS roots, enforce per-request timeout, drain on shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2701,19 +2701,7 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
- "tokio-macros",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2479,6 +2479,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2689,8 +2699,21 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/wado-cli/Cargo.toml
+++ b/wado-cli/Cargo.toml
@@ -36,7 +36,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 toml = { workspace = true }
-tokio = { workspace = true, features = ["net"] }
+tokio = { workspace = true, features = ["net", "time", "signal", "macros"] }
 wasmprinter = { workspace = true }
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }

--- a/wado-cli/Cargo.toml
+++ b/wado-cli/Cargo.toml
@@ -36,7 +36,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 toml = { workspace = true }
-tokio = { workspace = true, features = ["net", "time", "signal", "macros"] }
+tokio = { workspace = true, features = ["net", "time", "signal"] }
 wasmprinter = { workspace = true }
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }
@@ -48,6 +48,7 @@ libc = { workspace = true }
 [dev-dependencies]
 assert_cmd = { workspace = true }
 jsonschema = { workspace = true }
+libc = { workspace = true }
 predicates = { workspace = true }
 serde = { workspace = true }
 tempfile = { workspace = true }

--- a/wado-cli/Cargo.toml
+++ b/wado-cli/Cargo.toml
@@ -48,7 +48,6 @@ libc = { workspace = true }
 [dev-dependencies]
 assert_cmd = { workspace = true }
 jsonschema = { workspace = true }
-libc = { workspace = true }
 predicates = { workspace = true }
 serde = { workspace = true }
 tempfile = { workspace = true }

--- a/wado-cli/src/http_hooks.rs
+++ b/wado-cli/src/http_hooks.rs
@@ -5,7 +5,7 @@
 //! not sufficient when the host sits behind a TLS-inspecting proxy that signs
 //! outgoing HTTPS with a private CA (e.g. a sandboxed dev environment).
 
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 
 use bytes::Bytes;
@@ -30,14 +30,29 @@ pub struct WadoHttpHooks {
     client_config: Arc<rustls::ClientConfig>,
 }
 
-impl WadoHttpHooks {
-    pub fn new() -> Self {
+/// Process-wide `rustls::ClientConfig` shared by every `WadoHttpHooks`.
+///
+/// `wado serve` builds a fresh `WasiState` per request and used to call
+/// `WadoHttpHooks::new()` from the per-request constructor, which in turn
+/// ran `build_root_cert_store()` — a function that reads CA bundles from
+/// disk via `SSL_CERT_FILE`/`SSL_CERT_DIR`. Doing that I/O on every request
+/// is wasted work; the configuration is immutable after process startup,
+/// so cache it in a `LazyLock` and clone the `Arc` per request.
+fn shared_client_config() -> Arc<rustls::ClientConfig> {
+    static CONFIG: LazyLock<Arc<rustls::ClientConfig>> = LazyLock::new(|| {
         install_default_crypto_provider();
-        let client_config = rustls::ClientConfig::builder()
+        let config = rustls::ClientConfig::builder()
             .with_root_certificates(build_root_cert_store())
             .with_no_client_auth();
+        Arc::new(config)
+    });
+    Arc::clone(&CONFIG)
+}
+
+impl WadoHttpHooks {
+    pub fn new() -> Self {
         Self {
-            client_config: Arc::new(client_config),
+            client_config: shared_client_config(),
         }
     }
 }

--- a/wado-cli/src/runtime.rs
+++ b/wado-cli/src/runtime.rs
@@ -311,6 +311,22 @@ pub fn create_test_engine(opt_level: OptLevel) -> Result<Engine> {
     Ok(Engine::new(&config)?)
 }
 
+/// Create a wasmtime Engine for `wado serve` with epoch interruption enabled.
+///
+/// The serve loop pairs this with a per-store `set_epoch_deadline` and a
+/// background ticker that calls `Engine::increment_epoch`, so a guest stuck
+/// in a tight loop traps after the configured request timeout instead of
+/// holding a tokio task forever.
+///
+/// # Errors
+///
+/// Returns an error if the engine cannot be created with the given configuration.
+pub fn create_serve_engine(opt_level: OptLevel) -> Result<Engine> {
+    let mut config = create_config(opt_level, &ProfileMode::None);
+    config.epoch_interruption(true);
+    Ok(Engine::new(&config)?)
+}
+
 /// Create a Store with WASI state, preopened directories, and program arguments.
 /// `preopened_dirs`: `(host_path, guest_path)` pairs.
 /// `args`: arguments passed to the guest via `wasi:cli/environment.get-arguments`.

--- a/wado-cli/src/serve.rs
+++ b/wado-cli/src/serve.rs
@@ -4,7 +4,6 @@ use std::net::SocketAddr;
 use std::pin::{Pin, pin};
 use std::process;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::task::{Context, Poll};
 use std::time::Duration;
 
@@ -407,9 +406,22 @@ async fn handle_http_request(
                     io.await
                         .map_err(|e| anyhow::anyhow!("request body I/O: {e}"))
                 });
+                // The handler is the source of truth for response progress;
+                // the io future only drives request-body delivery and
+                // typically resolves *later* than the handler (it waits for
+                // the request resource to be dropped, which happens when
+                // the guest function fully exits — well after `task return`).
+                //
+                // We must not cancel the handler the moment io resolves
+                // (would truncate streamed bodies), and we must not block
+                // forever on io after the handler is done (would hang
+                // indefinitely on guests that hold the request resource
+                // until function exit). The select-then-await pattern
+                // satisfies both: io is polled concurrently while we wait
+                // for the handler, but we never wait for io alone.
                 match select(handler, io_arm).await {
-                    Either::Left((res, _)) => res,
-                    Either::Right((res, _)) => res,
+                    Either::Left((res, _io)) => res,
+                    Either::Right((_io_res, handler)) => handler.await,
                 }
             })
             .await;
@@ -524,17 +536,30 @@ async fn run_http_server(
     let service_pre = Arc::new(service_pre);
     let preopens = Arc::new(preopens);
 
-    // Background ticker drives `Engine::increment_epoch` so the per-store
-    // `set_epoch_deadline` actually fires. Stopped via `epoch_stop` once
-    // the accept loop exits.
-    let epoch_stop = Arc::new(AtomicBool::new(false));
-    let epoch_thread = {
-        let stop = Arc::clone(&epoch_stop);
+    // Background tokio task drives `Engine::increment_epoch` so the
+    // per-store `set_epoch_deadline` actually fires. Implemented as a
+    // tokio task (rather than `std::thread`) so shutdown can wait for it
+    // without blocking the runtime: a `Notify` flips the loop to its exit
+    // arm, and we `await` the `JoinHandle` to be sure no further bumps
+    // are in flight.
+    let epoch_shutdown = Arc::new(tokio::sync::Notify::new());
+    let epoch_task = {
+        let shutdown = Arc::clone(&epoch_shutdown);
         let engine = Arc::clone(&engine);
-        std::thread::spawn(move || {
-            while !stop.load(Ordering::Relaxed) {
-                std::thread::sleep(Duration::from_millis(EPOCH_TICK_MS));
-                engine.increment_epoch();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_millis(EPOCH_TICK_MS));
+            // The first `interval.tick()` fires immediately by default.
+            // Consume it so the first real bump happens one full
+            // `EPOCH_TICK_MS` after server startup, matching the previous
+            // `std::thread::sleep` behaviour.
+            interval.tick().await;
+            loop {
+                let tick = pin!(interval.tick());
+                let stop = pin!(shutdown.notified());
+                match select(tick, stop).await {
+                    Either::Left(_) => engine.increment_epoch(),
+                    Either::Right(_) => break,
+                }
             }
         })
     };
@@ -566,7 +591,13 @@ async fn run_http_server(
                 break;
             }
             Either::Left((Err(e), _shutdown)) => {
+                // A persistent failure (file descriptor exhaustion, listener
+                // gone) would otherwise turn the loop into a hot CPU/log
+                // spammer. A short sleep is a cheap circuit-breaker: it
+                // doesn't fix the underlying problem but it stops the
+                // server from making it worse.
                 eprintln!("accept error: {e}");
+                tokio::time::sleep(Duration::from_millis(50)).await;
             }
             Either::Left((Ok((stream, remote_addr)), _shutdown)) => {
                 let io = TokioIo::new(stream);
@@ -600,8 +631,12 @@ async fn run_http_server(
 
                 // Non-blockingly reap any connections that finished while
                 // we were accepting, so the JoinSet doesn't grow unboundedly
-                // on a long-running server.
-                while connections.try_join_next().is_some() {}
+                // on a long-running server. Surface task panics here too —
+                // dropping `try_join_next()`'s `Result` would silently lose
+                // them.
+                while let Some(res) = connections.try_join_next() {
+                    log_connection_join_error(res);
+                }
             }
         }
     }
@@ -609,7 +644,11 @@ async fn run_http_server(
     // Drain phase: stop accepting, give in-flight connections a bounded
     // window to finish. Anything still alive at the deadline gets aborted.
     let drain_deadline = timeout + Duration::from_secs(5);
-    let drain = async { while connections.join_next().await.is_some() {} };
+    let drain = async {
+        while let Some(res) = connections.join_next().await {
+            log_connection_join_error(res);
+        }
+    };
     if tokio::time::timeout(drain_deadline, drain).await.is_err() {
         eprintln!(
             "Drain timeout after {}s; aborting remaining connections",
@@ -618,12 +657,24 @@ async fn run_http_server(
         connections.shutdown().await;
     }
 
-    epoch_stop.store(true, Ordering::Relaxed);
-    // The ticker sleeps `EPOCH_TICK_MS` between checks, so the join wakes
-    // up within that window.
-    let _ = epoch_thread.join();
+    // Stop the epoch ticker. `await`-ing the JoinHandle is the async
+    // equivalent of `std::thread::JoinHandle::join` — but unlike the
+    // thread version it doesn't block the runtime: the ticker sees the
+    // notify within one `EPOCH_TICK_MS` and exits.
+    epoch_shutdown.notify_one();
+    let _ = epoch_task.await;
 
     Ok(())
+}
+
+/// Log connection task panics; ignore cancellation (which is the normal
+/// outcome when shutdown aborts in-flight tasks at the drain deadline).
+fn log_connection_join_error(res: Result<(), tokio::task::JoinError>) {
+    if let Err(e) = res
+        && !e.is_cancelled()
+    {
+        eprintln!("connection task panicked: {e}");
+    }
 }
 
 pub async fn run(opts: ServeOptions) {

--- a/wado-cli/src/serve.rs
+++ b/wado-cli/src/serve.rs
@@ -441,7 +441,7 @@ async fn handle_http_request(
         Either::Left((Err(_recv), _)) => {
             HandlerOutcome::Trapped("Handler aborted without producing a response".to_string())
         }
-        Either::Right((_, _resp_rx)) => HandlerOutcome::Timeout,
+        Either::Right(((), _resp_rx)) => HandlerOutcome::Timeout,
     };
 
     Ok(match outcome {

--- a/wado-cli/src/serve.rs
+++ b/wado-cli/src/serve.rs
@@ -1,23 +1,27 @@
 use std::convert::Infallible;
 use std::fmt::Write as _;
 use std::net::SocketAddr;
-use std::pin::pin;
+use std::pin::{Pin, pin};
 use std::process;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::task::{Context, Poll};
 use std::time::Duration;
 
 use anyhow::Result;
 use bytes::Bytes;
-use futures::future::{Either, select};
-use http_body_util::combinators::BoxBody;
-use http_body_util::{BodyExt, Collected, Full};
+use futures::future::{Either, poll_fn, select};
+use http_body::{Body as _, Frame};
+use http_body_util::BodyExt as _;
+use http_body_util::Full;
+use http_body_util::combinators::UnsyncBoxBody;
 use hyper::service::service_fn;
 use hyper::{Request as HyperRequest, Response as HyperResponse};
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use hyper_util::server::conn::auto;
 use lexopt::Arg::Value;
 use tokio::net::TcpListener;
+use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinSet;
 use wasmtime::Engine;
 use wasmtime::Store;
@@ -205,37 +209,91 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<ServeOptions, CliExit> {
     })
 }
 
-/// Handle a single HTTP request using the Wasm component.
+/// Outcome the spawned handler task delivers to the request entry point.
 ///
-/// Mirrors the wasmtime p3 reference and wado-compiler e2e harness pattern:
-/// both the guest handler and the response-body collection run inside
-/// `run_concurrent`, so the guest's post-`task-return` continuation keeps
-/// getting polled until it finishes writing the body and trailers. Collecting
-/// outside `run_concurrent` deadlocks because the store stops polling as soon
-/// as the closure future resolves.
+/// `Streaming` is the success path: response head plus a `Receiver` that
+/// will yield each body frame as the guest produces it. The other variants
+/// are terminal failure modes that have to be rendered as a synthetic 5xx
+/// because no part of the response has been put on the wire yet.
+enum HandlerOutcome {
+    Streaming(http::response::Parts, mpsc::Receiver<Frame<Bytes>>),
+    GuestError(wasmtime_wasi_http::p3::bindings::http::types::ErrorCode),
+    Trapped(String),
+    Timeout,
+}
+
+/// `http_body::Body` implementation backed by a tokio `mpsc::Receiver` of
+/// frames. Used to stream the guest's response body to hyper one frame at
+/// a time without buffering the full body in memory.
 ///
-/// The handler arm and the request-body I/O arm are raced via `futures::future::select`
-/// — handler completing first is the normal case (a guest may never consume
-/// the request body, in which case the I/O future only resolves when the
-/// request resource is dropped).
+/// Trailers travel through the same channel as `Frame::trailers(...)`.
+struct ChannelBody {
+    rx: mpsc::Receiver<Frame<Bytes>>,
+}
+
+impl http_body::Body for ChannelBody {
+    type Data = Bytes;
+    type Error = Infallible;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        match self.rx.poll_recv(cx) {
+            Poll::Ready(Some(frame)) => Poll::Ready(Some(Ok(frame))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+type StreamingBody = UnsyncBoxBody<Bytes, Infallible>;
+
+fn error_response(status: u16, msg: String) -> HyperResponse<StreamingBody> {
+    let body: Full<Bytes> = Full::new(Bytes::from(msg));
+    HyperResponse::builder()
+        .status(status)
+        .body(UnsyncBoxBody::new(body))
+        .expect("static status code should always build successfully")
+}
+
+/// Handle a single HTTP request using the Wasm component, **streaming** the
+/// response body frame-by-frame.
 ///
-/// The success body is returned as a `Collected<Bytes>` (boxed) rather than
-/// `Full<Bytes>` so that response trailers written by the guest survive the
-/// hop into hyper. `Full<Bytes>` carries no trailer frames, which would silently
-/// strip e.g. `Server-Timing` written via `trailers_tx.write(Some(...))`.
+/// The store is moved into a spawned task that drives `run_concurrent` for
+/// the entire lifetime of the response, including the guest's post-`task
+/// return` continuation. As soon as the head is available the spawn task
+/// hands the response head plus a body channel back here via a oneshot;
+/// from then on hyper drains body frames directly from that channel while
+/// the spawn task keeps producing them. Because the channel is bounded
+/// (capacity 8), a slow consumer naturally back-pressures the guest.
 ///
-/// Per-request timeout is enforced two ways: `set_epoch_deadline` traps the
-/// guest if it stays inside wasm past the deadline (handles tight CPU loops
-/// that never await), and `tokio::time::timeout` cancels the future at the
-/// async boundary (handles host I/O hangs). The combination ensures a hung
-/// request never holds a tokio task longer than `timeout`.
+/// The per-request timeout is enforced in two layered ways:
+///
+/// * `Store::set_epoch_deadline` plus the engine-wide ticker traps the
+///   guest if it stays inside wasm past the deadline. This bounds the
+///   total request lifetime — even a long-lived streaming response is
+///   cut off when the deadline expires, since the wasm side traps and
+///   the spawn task drops the body sender on the way out.
+/// * A first-byte `tokio::time::sleep(timeout)` raced against the head
+///   oneshot returns 504 to the client if the guest never produces a
+///   response head — covering the case where the guest is stuck waiting
+///   on host I/O instead of running wasm code.
+///
+/// Hang avoidance:
+///
+/// * Hyper dropping the body causes `frame_tx.send` to fail, breaking the
+///   pump loop; the spawn task then exits.
+/// * If the outer first-byte timeout fires, the spawn task is left to run,
+///   but the per-store epoch deadline guarantees it terminates within one
+///   tick interval of the configured timeout.
 async fn handle_http_request(
     engine: &Engine,
     service_pre: &ServicePre<WasiState>,
     preopens: &Preopens,
     timeout: Duration,
     req: HyperRequest<hyper::body::Incoming>,
-) -> Result<HyperResponse<BoxBody<Bytes, Infallible>>> {
+) -> Result<HyperResponse<StreamingBody>> {
     type HttpErrorCode = wasmtime_wasi_http::p3::bindings::http::types::ErrorCode;
 
     // Each request gets a fresh WASI state — the WASI ctx is scoped
@@ -248,107 +306,163 @@ async fn handle_http_request(
     // inherited stdio.
     let state = WasiState::new_no_inherit_env_with_preopens(preopens, &[]);
     let mut store = Store::new(engine, state);
-    // Set the epoch deadline so a guest stuck in pure wasm traps after
-    // `timeout` ticks (the engine is incremented every `EPOCH_TICK_MS`).
-    let deadline_ticks = timeout.as_secs().max(1);
-    store.set_epoch_deadline(deadline_ticks);
+    let timeout_secs = timeout.as_secs().max(1);
+    // The engine-wide ticker bumps the epoch every `EPOCH_TICK_MS`, so
+    // setting `deadline_ticks = timeout_secs` gives second-granularity
+    // enforcement on the configured `timeout`.
+    store.set_epoch_deadline(timeout_secs);
 
-    let timeout_result = tokio::time::timeout(timeout, async {
-        let service: Service = service_pre.instantiate_async(&mut store).await?;
-
-        let (parts, body) = req.into_parts();
-        let body = body.map_err(HttpErrorCode::from_hyper_request_error);
-        let http_req = http::Request::from_parts(parts, body);
-        let (wasi_req, io) = WasiRequest::from_http(http_req);
-
-        store
-            .run_concurrent(
-                async |store| -> Result<
-                    Result<http::Response<Collected<Bytes>>, Option<HttpErrorCode>>,
-                > {
-                    let handler = pin!(async {
-                        let res = match service.handle(store, wasi_req).await? {
-                            Ok(res) => res,
-                            Err(err) => return anyhow::Ok(Err(Some(err))),
-                        };
-                        let res = store.with(|store| res.into_http(store, async { Ok(()) }))?;
-                        let (parts, body) = res.into_parts();
-                        let collected = BodyExt::collect(body)
-                            .await
-                            .map_err(|e| anyhow::anyhow!("failed to collect response body: {e}"))?;
-                        anyhow::Ok(Ok(http::Response::from_parts(parts, collected)))
-                    });
-                    let io = pin!(async {
-                        io.await
-                            .map_err(|e| anyhow::anyhow!("request body I/O: {e}"))
-                    });
-                    match select(handler, io).await {
-                        Either::Left((result, _)) => result,
-                        Either::Right((result, _)) => result.map(|()| Err(None)),
-                    }
-                },
-            )
-            .await
-    })
-    .await;
-
-    let result = match timeout_result {
-        Ok(Ok(Ok(inner))) => inner,
-        Ok(Ok(Err(e))) => {
-            eprintln!("Handler trapped: {e:?}");
-            return Ok(HyperResponse::builder()
-                .status(500)
-                .body(error_body(format!("Handler trapped:\n{e:?}")))?);
-        }
-        Ok(Err(e)) => {
-            // run_concurrent returned Err — most commonly an epoch trap from
-            // a guest that exceeded the deadline while inside wasm.
-            if is_epoch_deadline_error(&e) {
-                eprintln!("Handler timed out after {}s", timeout.as_secs());
-                return Ok(HyperResponse::builder()
-                    .status(504)
-                    .body(error_body(format!(
-                        "Handler timed out after {}s",
-                        timeout.as_secs()
-                    )))?);
+    // Instantiation runs synchronously up to the first guest yield point and
+    // could in principle spin; bound it with the same overall timeout.
+    let service: Service =
+        match tokio::time::timeout(timeout, service_pre.instantiate_async(&mut store)).await {
+            Ok(Ok(s)) => s,
+            Ok(Err(e)) => {
+                eprintln!("Instantiation failed: {e:?}");
+                return Ok(error_response(500, format!("Instantiation failed:\n{e:?}")));
             }
-            eprintln!("Handler trapped: {e:?}");
-            return Ok(HyperResponse::builder()
-                .status(500)
-                .body(error_body(format!("Handler trapped:\n{e:?}")))?);
+            Err(_) => {
+                eprintln!("Instantiation timed out after {timeout_secs}s");
+                return Ok(error_response(
+                    504,
+                    format!("Instantiation timed out after {timeout_secs}s"),
+                ));
+            }
+        };
+
+    let (parts, body) = req.into_parts();
+    let body = body.map_err(HttpErrorCode::from_hyper_request_error);
+    let http_req = http::Request::from_parts(parts, body);
+    let (wasi_req, io) = WasiRequest::from_http(http_req);
+
+    let (resp_tx, resp_rx) = oneshot::channel::<HandlerOutcome>();
+    let (frame_tx, frame_rx) = mpsc::channel::<Frame<Bytes>>(8);
+
+    // The spawn task owns `store`, `service`, and `frame_tx`. Dropping
+    // `frame_tx` (which happens automatically when the closure exits)
+    // closes the body stream from hyper's point of view.
+    tokio::spawn(async move {
+        // Both `resp_tx` and `frame_rx` are taken at most once: when the
+        // handler produces head frames it moves the receiver into the
+        // outcome and releases the sender. After `run_concurrent` returns,
+        // a still-`Some` `resp_tx` means we never produced a head and need
+        // to surface the failure synthetically.
+        let mut resp_tx = Some(resp_tx);
+        let mut frame_rx_holder = Some(frame_rx);
+
+        let drive_result: Result<anyhow::Result<()>, wasmtime::Error> = store
+            .run_concurrent(async |store| -> anyhow::Result<()> {
+                let handler = pin!(async {
+                    let res = match service.handle(store, wasi_req).await? {
+                        Ok(res) => res,
+                        Err(err) => {
+                            if let Some(tx) = resp_tx.take() {
+                                let _ = tx.send(HandlerOutcome::GuestError(err));
+                            }
+                            return anyhow::Ok(());
+                        }
+                    };
+                    let res = store.with(|store| res.into_http(store, async { Ok(()) }))?;
+                    let (parts, body) = res.into_parts();
+
+                    // Hand the response head plus the receiver to the outer
+                    // task so hyper can start writing the response while we
+                    // keep producing frames here.
+                    if let Some(tx) = resp_tx.take() {
+                        let rx = frame_rx_holder
+                            .take()
+                            .expect("frame_rx is taken at most once");
+                        if tx.send(HandlerOutcome::Streaming(parts, rx)).is_err() {
+                            // Outer side gave up before the head landed
+                            // (e.g. first-byte timeout fired). Stop here;
+                            // the body will be discarded.
+                            return anyhow::Ok(());
+                        }
+                    }
+
+                    // Pump frames until EOF, body error, or hyper drops the
+                    // body. `frame_tx.send().await` blocks on a full channel,
+                    // so a slow consumer back-pressures into the guest.
+                    let mut body = pin!(body);
+                    loop {
+                        let frame = poll_fn(|cx| body.as_mut().poll_frame(cx)).await;
+                        match frame {
+                            Some(Ok(frame)) => {
+                                if frame_tx.send(frame).await.is_err() {
+                                    // Hyper dropped the body; abandon the
+                                    // rest of the stream.
+                                    break;
+                                }
+                            }
+                            // Body read error: close the stream by exiting
+                            // the loop. `frame_tx` is dropped on return,
+                            // which surfaces as EOF on the hyper side.
+                            Some(Err(_)) => break,
+                            None => break,
+                        }
+                    }
+                    anyhow::Ok(())
+                });
+                let io_arm = pin!(async {
+                    io.await
+                        .map_err(|e| anyhow::anyhow!("request body I/O: {e}"))
+                });
+                match select(handler, io_arm).await {
+                    Either::Left((res, _)) => res,
+                    Either::Right((res, _)) => res,
+                }
+            })
+            .await;
+
+        // Surface failures that prevented the handler from producing a head.
+        if let Some(tx) = resp_tx {
+            let outcome = match drive_result {
+                Ok(Ok(())) => HandlerOutcome::Trapped(
+                    "Handler returned without producing a response".to_string(),
+                ),
+                Ok(Err(e)) => HandlerOutcome::Trapped(format!("Handler error: {e:?}")),
+                Err(e) => {
+                    if is_epoch_deadline_error(&e) {
+                        HandlerOutcome::Timeout
+                    } else {
+                        HandlerOutcome::Trapped(format!("Handler trapped:\n{e:?}"))
+                    }
+                }
+            };
+            let _ = tx.send(outcome);
         }
-        Err(_elapsed) => {
-            // Future-level timeout fired (host I/O hang or yield path).
-            eprintln!("Handler timed out after {}s", timeout.as_secs());
-            return Ok(HyperResponse::builder()
-                .status(504)
-                .body(error_body(format!(
-                    "Handler timed out after {}s",
-                    timeout.as_secs()
-                )))?);
+    });
+
+    // First-byte timeout. After the head arrives, the body stream is
+    // bounded by the per-store epoch deadline rather than by this sleep.
+    let timeout_fut = pin!(tokio::time::sleep(timeout));
+    let outcome = match select(pin!(resp_rx), timeout_fut).await {
+        Either::Left((Ok(outcome), _)) => outcome,
+        Either::Left((Err(_recv), _)) => {
+            HandlerOutcome::Trapped("Handler aborted without producing a response".to_string())
         }
+        Either::Right((_, _resp_rx)) => HandlerOutcome::Timeout,
     };
 
-    match result {
-        Ok(res) => {
-            let (parts, body) = res.into_parts();
-            Ok(HyperResponse::from_parts(parts, BoxBody::new(body)))
+    Ok(match outcome {
+        HandlerOutcome::Streaming(parts, frame_rx) => {
+            let body = ChannelBody { rx: frame_rx };
+            HyperResponse::from_parts(parts, UnsyncBoxBody::new(body))
         }
-        Err(Some(error_code)) => Ok(HyperResponse::builder()
-            .status(500)
-            .body(error_body(format!("{error_code:?}")))?),
-        Err(None) => Ok(HyperResponse::builder()
-            .status(500)
-            .body(error_body("Handler returned error".to_string()))?),
-    }
+        HandlerOutcome::GuestError(err) => error_response(500, format!("{err:?}")),
+        HandlerOutcome::Trapped(msg) => {
+            eprintln!("{msg}");
+            error_response(500, msg)
+        }
+        HandlerOutcome::Timeout => {
+            eprintln!("Handler timed out after {timeout_secs}s");
+            error_response(504, format!("Handler timed out after {timeout_secs}s"))
+        }
+    })
 }
 
 fn is_epoch_deadline_error(err: &wasmtime::Error) -> bool {
     err.downcast_ref::<wasmtime::Trap>() == Some(&wasmtime::Trap::Interrupt)
-}
-
-fn error_body(msg: String) -> BoxBody<Bytes, Infallible> {
-    BoxBody::new(Full::new(Bytes::from(msg)))
 }
 
 /// Wait for a shutdown signal (SIGINT or, on Unix, SIGTERM). Resolves on

--- a/wado-cli/src/serve.rs
+++ b/wado-cli/src/serve.rs
@@ -364,10 +364,13 @@ async fn shutdown_signal() {
                 return;
             }
         };
-        tokio::select! {
-            _ = tokio::signal::ctrl_c() => {}
-            _ = sigterm.recv() => {}
-        }
+        let ctrl_c = pin!(async {
+            let _ = tokio::signal::ctrl_c().await;
+        });
+        let term = pin!(async {
+            let _ = sigterm.recv().await;
+        });
+        let _ = select(ctrl_c, term).await;
     }
     #[cfg(not(unix))]
     {
@@ -429,65 +432,58 @@ async fn run_http_server(
     eprintln!("Send SIGINT or SIGTERM to shut down");
 
     let mut connections: JoinSet<()> = JoinSet::new();
-    let shutdown = pin!(shutdown_signal());
+    let mut shutdown = pin!(shutdown_signal());
 
     // Accept loop with graceful shutdown. On signal, stop accepting and
     // wait for in-flight connections to drain (with a hard cap so we don't
     // hang forever on misbehaving clients).
-    {
-        let mut shutdown = shutdown;
-        loop {
-            tokio::select! {
-                accepted = listener.accept() => {
-                    let (stream, remote_addr) = match accepted {
-                        Ok(v) => v,
-                        Err(e) => {
-                            eprintln!("accept error: {e}");
-                            continue;
-                        }
-                    };
-                    let io = TokioIo::new(stream);
+    loop {
+        let accept = pin!(listener.accept());
+        match select(accept, shutdown.as_mut()).await {
+            Either::Right(((), _accept)) => {
+                eprintln!(
+                    "Shutdown signal received; draining {} in-flight connection(s)…",
+                    connections.len()
+                );
+                break;
+            }
+            Either::Left((Err(e), _shutdown)) => {
+                eprintln!("accept error: {e}");
+            }
+            Either::Left((Ok((stream, remote_addr)), _shutdown)) => {
+                let io = TokioIo::new(stream);
 
-                    let engine = Arc::clone(&engine);
-                    let service_pre = Arc::clone(&service_pre);
-                    let preopens = Arc::clone(&preopens);
+                let engine = Arc::clone(&engine);
+                let service_pre = Arc::clone(&service_pre);
+                let preopens = Arc::clone(&preopens);
 
-                    connections.spawn(async move {
-                        let svc = service_fn(|req| {
-                            let engine = Arc::clone(&engine);
-                            let service_pre = Arc::clone(&service_pre);
-                            let preopens = Arc::clone(&preopens);
+                connections.spawn(async move {
+                    let svc = service_fn(|req| {
+                        let engine = Arc::clone(&engine);
+                        let service_pre = Arc::clone(&service_pre);
+                        let preopens = Arc::clone(&preopens);
 
-                            async move {
-                                handle_http_request(
-                                    &engine,
-                                    &service_pre,
-                                    &preopens,
-                                    timeout,
-                                    req,
-                                )
+                        async move {
+                            handle_http_request(&engine, &service_pre, &preopens, timeout, req)
                                 .await
-                            }
-                        });
-
-                        // Auto-detect HTTP/1.1 vs h2c (HTTP/2 cleartext, prior-knowledge)
-                        // by sniffing the connection preface. HTTP/1 callers see normal
-                        // behavior; h2c clients (e.g. `curl --http2-prior-knowledge`) get
-                        // trailers without needing the `TE: trailers` handshake hyper
-                        // requires on the HTTP/1 path.
-                        let builder = auto::Builder::new(TokioExecutor::new());
-                        if let Err(e) = builder.serve_connection(io, svc).await {
-                            eprintln!("Error serving {remote_addr}: {e}");
                         }
                     });
-                }
-                () = &mut shutdown => {
-                    eprintln!("Shutdown signal received; draining {} in-flight connection(s)…", connections.len());
-                    break;
-                }
-                // Reap finished connections so the JoinSet doesn't grow
-                // unboundedly on a long-running server.
-                Some(_res) = connections.join_next(), if !connections.is_empty() => {}
+
+                    // Auto-detect HTTP/1.1 vs h2c (HTTP/2 cleartext, prior-knowledge)
+                    // by sniffing the connection preface. HTTP/1 callers see normal
+                    // behavior; h2c clients (e.g. `curl --http2-prior-knowledge`) get
+                    // trailers without needing the `TE: trailers` handshake hyper
+                    // requires on the HTTP/1 path.
+                    let builder = auto::Builder::new(TokioExecutor::new());
+                    if let Err(e) = builder.serve_connection(io, svc).await {
+                        eprintln!("Error serving {remote_addr}: {e}");
+                    }
+                });
+
+                // Non-blockingly reap any connections that finished while
+                // we were accepting, so the JoinSet doesn't grow unboundedly
+                // on a long-running server.
+                while connections.try_join_next().is_some() {}
             }
         }
     }

--- a/wado-cli/src/serve.rs
+++ b/wado-cli/src/serve.rs
@@ -32,8 +32,9 @@ use crate::runtime::{self, Preopens, WasiState};
 use wado_compiler::LogLevel;
 
 /// Default per-request timeout in seconds. A guest that fails to produce a
-/// response within this window has its store traps via `epoch_deadline_trap`,
-/// freeing the tokio task and letting the client see a 504.
+/// response within this window has its epoch deadline expired (via
+/// `Store::set_epoch_deadline`), which causes a `Trap::Interrupt`, freeing
+/// the tokio task and letting the client see a 504.
 const DEFAULT_TIMEOUT_SECS: u64 = 30;
 
 /// Epoch ticker interval. Each tick is a unit of `set_epoch_deadline`, so
@@ -134,7 +135,7 @@ fn parse_timeout_arg(parser: &mut lexopt::Parser) -> Result<u64, CliExit> {
     let s = args::require_string(parser)?;
     let n = s.parse::<u64>().map_err(|_| {
         CliExit::error(format!(
-            "--timeout requires a non-negative integer (seconds), got '{s}'"
+            "--timeout requires a positive integer (seconds), got '{s}'"
         ))
     })?;
     if n == 0 {
@@ -429,7 +430,10 @@ async fn run_http_server(
 
     eprintln!("HTTP server listening on http://{addr}/");
     eprintln!("Per-request timeout: {}s", timeout.as_secs());
+    #[cfg(unix)]
     eprintln!("Send SIGINT or SIGTERM to shut down");
+    #[cfg(not(unix))]
+    eprintln!("Send Ctrl+C to shut down");
 
     let mut connections: JoinSet<()> = JoinSet::new();
     let mut shutdown = pin!(shutdown_signal());

--- a/wado-cli/src/serve.rs
+++ b/wado-cli/src/serve.rs
@@ -4,6 +4,8 @@ use std::net::SocketAddr;
 use std::pin::pin;
 use std::process;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
 use anyhow::Result;
 use bytes::Bytes;
@@ -16,18 +18,28 @@ use hyper_util::rt::{TokioExecutor, TokioIo};
 use hyper_util::server::conn::auto;
 use lexopt::Arg::Value;
 use tokio::net::TcpListener;
-use tokio::sync::Mutex;
+use tokio::task::JoinSet;
 use wasmtime::Engine;
 use wasmtime::Store;
-use wasmtime::component::{Component, Linker};
+use wasmtime::component::Component;
 use wasmtime_wasi_http::p3::Request as WasiRequest;
-use wasmtime_wasi_http::p3::bindings::Service;
+use wasmtime_wasi_http::p3::bindings::{Service, ServicePre};
 
 use crate::args::{self, CliExit};
 use crate::compile::{self, CompileFlags, OptLevel};
 use crate::manifest;
 use crate::runtime::{self, Preopens, WasiState};
 use wado_compiler::LogLevel;
+
+/// Default per-request timeout in seconds. A guest that fails to produce a
+/// response within this window has its store traps via `epoch_deadline_trap`,
+/// freeing the tokio task and letting the client see a 504.
+const DEFAULT_TIMEOUT_SECS: u64 = 30;
+
+/// Epoch ticker interval. Each tick is a unit of `set_epoch_deadline`, so
+/// a 1s tick + a deadline of `timeout_secs` ticks yields second-granularity
+/// timeout enforcement — sufficient for the 30s default.
+const EPOCH_TICK_MS: u64 = 1000;
 
 pub struct ServeOptions {
     pub input: String,
@@ -41,6 +53,8 @@ pub struct ServeOptions {
     /// default — services rarely need filesystem access, so unlike `wado run`
     /// we do NOT preopen the cwd unless the user passes `--dir`.
     pub preopened_dirs: Vec<(String, String)>,
+    /// Per-request timeout in seconds.
+    pub timeout_secs: u64,
 }
 
 #[derive(Clone, Copy)]
@@ -52,8 +66,16 @@ enum Opt {
     OptIterations,
     LogLevel,
     Allocator,
+    Timeout,
     Help,
 }
+
+const TIMEOUT_SPEC: args::OptSpec = args::OptSpec {
+    long: Some("timeout"),
+    short: None,
+    value: Some("<seconds>"),
+    desc: "Per-request timeout in seconds (default: 30)",
+};
 
 impl Opt {
     const ALL: &[Self] = &[
@@ -64,6 +86,7 @@ impl Opt {
         Self::OptIterations,
         Self::LogLevel,
         Self::Allocator,
+        Self::Timeout,
         Self::Help,
     ];
 
@@ -86,6 +109,7 @@ impl Opt {
             Self::OptIterations => args::OPT_ITERATIONS_SPEC,
             Self::LogLevel => args::LOG_LEVEL_SPEC,
             Self::Allocator => args::ALLOCATOR_SPEC,
+            Self::Timeout => TIMEOUT_SPEC,
             Self::Help => args::HELP_SPEC,
         }
     }
@@ -106,6 +130,19 @@ pub fn print_usage() {
     eprint!("{}", format_usage());
 }
 
+fn parse_timeout_arg(parser: &mut lexopt::Parser) -> Result<u64, CliExit> {
+    let s = args::require_string(parser)?;
+    let n = s.parse::<u64>().map_err(|_| {
+        CliExit::error(format!(
+            "--timeout requires a non-negative integer (seconds), got '{s}'"
+        ))
+    })?;
+    if n == 0 {
+        return Err(CliExit::error("--timeout must be > 0"));
+    }
+    Ok(n)
+}
+
 /// Parse command-line arguments for the `serve` subcommand.
 ///
 /// # Errors
@@ -121,6 +158,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<ServeOptions, CliExit> {
     let mut opt_iterations: Option<u32> = None;
     let mut allocator: Option<String> = None;
     let mut preopened_dirs: Vec<(String, String)> = Vec::new();
+    let mut timeout_secs: u64 = DEFAULT_TIMEOUT_SECS;
 
     while let Some(arg) = args::next_arg(&mut parser)? {
         if let Some(opt) = args::match_opt(&arg, Opt::ALL, |o| o.spec()) {
@@ -142,6 +180,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<ServeOptions, CliExit> {
                 }
                 Opt::LogLevel => log_level = args::parse_log_level_arg(&mut parser)?,
                 Opt::Allocator => allocator = Some(args::require_string(&mut parser)?),
+                Opt::Timeout => timeout_secs = parse_timeout_arg(&mut parser)?,
                 Opt::Help => return Err(CliExit::help(usage)),
             }
         } else if let Value(val) = arg {
@@ -161,6 +200,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<ServeOptions, CliExit> {
         opt_iterations,
         allocator,
         preopened_dirs,
+        timeout_secs,
     })
 }
 
@@ -182,11 +222,17 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<ServeOptions, CliExit> {
 /// `Full<Bytes>` so that response trailers written by the guest survive the
 /// hop into hyper. `Full<Bytes>` carries no trailer frames, which would silently
 /// strip e.g. `Server-Timing` written via `trailers_tx.write(Some(...))`.
+///
+/// Per-request timeout is enforced two ways: `set_epoch_deadline` traps the
+/// guest if it stays inside wasm past the deadline (handles tight CPU loops
+/// that never await), and `tokio::time::timeout` cancels the future at the
+/// async boundary (handles host I/O hangs). The combination ensures a hung
+/// request never holds a tokio task longer than `timeout`.
 async fn handle_http_request(
     engine: &Engine,
-    component: &Component,
-    linker: &Linker<WasiState>,
+    service_pre: &ServicePre<WasiState>,
     preopens: &Preopens,
+    timeout: Duration,
     req: HyperRequest<hyper::body::Incoming>,
 ) -> Result<HyperResponse<BoxBody<Bytes, Infallible>>> {
     type HttpErrorCode = wasmtime_wasi_http::p3::bindings::http::types::ErrorCode;
@@ -201,15 +247,19 @@ async fn handle_http_request(
     // inherited stdio.
     let state = WasiState::new_no_inherit_env_with_preopens(preopens, &[]);
     let mut store = Store::new(engine, state);
+    // Set the epoch deadline so a guest stuck in pure wasm traps after
+    // `timeout` ticks (the engine is incremented every `EPOCH_TICK_MS`).
+    let deadline_ticks = timeout.as_secs().max(1);
+    store.set_epoch_deadline(deadline_ticks);
 
-    let service = Service::instantiate_async(&mut store, component, linker).await?;
+    let timeout_result = tokio::time::timeout(timeout, async {
+        let service: Service = service_pre.instantiate_async(&mut store).await?;
 
-    let (parts, body) = req.into_parts();
-    let body = body.map_err(HttpErrorCode::from_hyper_request_error);
-    let http_req = http::Request::from_parts(parts, body);
-    let (wasi_req, io) = WasiRequest::from_http(http_req);
+        let (parts, body) = req.into_parts();
+        let body = body.map_err(HttpErrorCode::from_hyper_request_error);
+        let http_req = http::Request::from_parts(parts, body);
+        let (wasi_req, io) = WasiRequest::from_http(http_req);
 
-    let result =
         store
             .run_concurrent(
                 async |store| -> Result<
@@ -237,21 +287,44 @@ async fn handle_http_request(
                     }
                 },
             )
-            .await;
+            .await
+    })
+    .await;
 
-    let result = match result {
-        Ok(Ok(inner)) => inner,
-        Ok(Err(e)) => {
+    let result = match timeout_result {
+        Ok(Ok(Ok(inner))) => inner,
+        Ok(Ok(Err(e))) => {
             eprintln!("Handler trapped: {e:?}");
             return Ok(HyperResponse::builder()
                 .status(500)
                 .body(error_body(format!("Handler trapped:\n{e:?}")))?);
         }
-        Err(e) => {
+        Ok(Err(e)) => {
+            // run_concurrent returned Err — most commonly an epoch trap from
+            // a guest that exceeded the deadline while inside wasm.
+            if is_epoch_deadline_error(&e) {
+                eprintln!("Handler timed out after {}s", timeout.as_secs());
+                return Ok(HyperResponse::builder()
+                    .status(504)
+                    .body(error_body(format!(
+                        "Handler timed out after {}s",
+                        timeout.as_secs()
+                    )))?);
+            }
             eprintln!("Handler trapped: {e:?}");
             return Ok(HyperResponse::builder()
                 .status(500)
                 .body(error_body(format!("Handler trapped:\n{e:?}")))?);
+        }
+        Err(_elapsed) => {
+            // Future-level timeout fired (host I/O hang or yield path).
+            eprintln!("Handler timed out after {}s", timeout.as_secs());
+            return Ok(HyperResponse::builder()
+                .status(504)
+                .body(error_body(format!(
+                    "Handler timed out after {}s",
+                    timeout.as_secs()
+                )))?);
         }
     };
 
@@ -269,8 +342,37 @@ async fn handle_http_request(
     }
 }
 
+fn is_epoch_deadline_error(err: &wasmtime::Error) -> bool {
+    err.downcast_ref::<wasmtime::Trap>() == Some(&wasmtime::Trap::Interrupt)
+}
+
 fn error_body(msg: String) -> BoxBody<Bytes, Infallible> {
     BoxBody::new(Full::new(Bytes::from(msg)))
+}
+
+/// Wait for a shutdown signal (SIGINT or, on Unix, SIGTERM). Resolves on
+/// the first signal received.
+async fn shutdown_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{SignalKind, signal};
+        let mut sigterm = match signal(SignalKind::terminate()) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("warning: failed to install SIGTERM handler: {e}");
+                let _ = tokio::signal::ctrl_c().await;
+                return;
+            }
+        };
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = sigterm.recv() => {}
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
 }
 
 async fn run_http_server(
@@ -278,8 +380,9 @@ async fn run_http_server(
     addr: &str,
     cranelift_opt: wasmtime::OptLevel,
     preopened_dirs: Vec<(String, String)>,
+    timeout: Duration,
 ) -> Result<()> {
-    let engine = runtime::create_engine(cranelift_opt, &runtime::ProfileMode::None)?;
+    let engine = runtime::create_serve_engine(cranelift_opt)?;
     let component = Component::new(&engine, &wasm)?;
     let linker = runtime::create_linker(&engine)?;
     // Open preopens once here, then share across requests. Each request
@@ -287,52 +390,126 @@ async fn run_http_server(
     // which clones the underlying `Arc<cap_std::fs::Dir>` rather than
     // re-running `openat` per request.
     let preopens = Preopens::open(&preopened_dirs)?;
+    // Pre-link the component once. This front-loads the per-export string
+    // lookups that `Service::instantiate_async` would otherwise repeat on
+    // every request.
+    let instance_pre = linker.instantiate_pre(&component)?;
+    let service_pre = ServicePre::<WasiState>::new(instance_pre)?;
 
-    // Wrap in Arc for sharing across connections
+    // Drop the linker — the `InstancePre` already captured everything we
+    // need, and keeping the linker around would force every request to
+    // share it (the linker is `&self`, but holding it serves no purpose).
+    drop(linker);
+    drop(component);
+
     let engine = Arc::new(engine);
-    let component = Arc::new(component);
-    let linker = Arc::new(Mutex::new(linker));
+    let service_pre = Arc::new(service_pre);
     let preopens = Arc::new(preopens);
+
+    // Background ticker drives `Engine::increment_epoch` so the per-store
+    // `set_epoch_deadline` actually fires. Stopped via `epoch_stop` once
+    // the accept loop exits.
+    let epoch_stop = Arc::new(AtomicBool::new(false));
+    let epoch_thread = {
+        let stop = Arc::clone(&epoch_stop);
+        let engine = Arc::clone(&engine);
+        std::thread::spawn(move || {
+            while !stop.load(Ordering::Relaxed) {
+                std::thread::sleep(Duration::from_millis(EPOCH_TICK_MS));
+                engine.increment_epoch();
+            }
+        })
+    };
 
     let addr: SocketAddr = addr.parse()?;
     let listener = TcpListener::bind(addr).await?;
 
     eprintln!("HTTP server listening on http://{addr}/");
-    eprintln!("Press Ctrl+C to stop");
+    eprintln!("Per-request timeout: {}s", timeout.as_secs());
+    eprintln!("Send SIGINT or SIGTERM to shut down");
 
-    loop {
-        let (stream, remote_addr) = listener.accept().await?;
-        let io = TokioIo::new(stream);
+    let mut connections: JoinSet<()> = JoinSet::new();
+    let shutdown = pin!(shutdown_signal());
 
-        let engine = Arc::clone(&engine);
-        let component = Arc::clone(&component);
-        let linker = Arc::clone(&linker);
-        let preopens = Arc::clone(&preopens);
+    // Accept loop with graceful shutdown. On signal, stop accepting and
+    // wait for in-flight connections to drain (with a hard cap so we don't
+    // hang forever on misbehaving clients).
+    {
+        let mut shutdown = shutdown;
+        loop {
+            tokio::select! {
+                accepted = listener.accept() => {
+                    let (stream, remote_addr) = match accepted {
+                        Ok(v) => v,
+                        Err(e) => {
+                            eprintln!("accept error: {e}");
+                            continue;
+                        }
+                    };
+                    let io = TokioIo::new(stream);
 
-        tokio::spawn(async move {
-            let service = service_fn(|req| {
-                let engine = Arc::clone(&engine);
-                let component = Arc::clone(&component);
-                let linker = Arc::clone(&linker);
-                let preopens = Arc::clone(&preopens);
+                    let engine = Arc::clone(&engine);
+                    let service_pre = Arc::clone(&service_pre);
+                    let preopens = Arc::clone(&preopens);
 
-                async move {
-                    let linker = linker.lock().await;
-                    handle_http_request(&engine, &component, &linker, &preopens, req).await
+                    connections.spawn(async move {
+                        let svc = service_fn(|req| {
+                            let engine = Arc::clone(&engine);
+                            let service_pre = Arc::clone(&service_pre);
+                            let preopens = Arc::clone(&preopens);
+
+                            async move {
+                                handle_http_request(
+                                    &engine,
+                                    &service_pre,
+                                    &preopens,
+                                    timeout,
+                                    req,
+                                )
+                                .await
+                            }
+                        });
+
+                        // Auto-detect HTTP/1.1 vs h2c (HTTP/2 cleartext, prior-knowledge)
+                        // by sniffing the connection preface. HTTP/1 callers see normal
+                        // behavior; h2c clients (e.g. `curl --http2-prior-knowledge`) get
+                        // trailers without needing the `TE: trailers` handshake hyper
+                        // requires on the HTTP/1 path.
+                        let builder = auto::Builder::new(TokioExecutor::new());
+                        if let Err(e) = builder.serve_connection(io, svc).await {
+                            eprintln!("Error serving {remote_addr}: {e}");
+                        }
+                    });
                 }
-            });
-
-            // Auto-detect HTTP/1.1 vs h2c (HTTP/2 cleartext, prior-knowledge)
-            // by sniffing the connection preface. HTTP/1 callers see normal
-            // behavior; h2c clients (e.g. `curl --http2-prior-knowledge`) get
-            // trailers without needing the `TE: trailers` handshake hyper
-            // requires on the HTTP/1 path.
-            let builder = auto::Builder::new(TokioExecutor::new());
-            if let Err(e) = builder.serve_connection(io, service).await {
-                eprintln!("Error serving {remote_addr}: {e}");
+                () = &mut shutdown => {
+                    eprintln!("Shutdown signal received; draining {} in-flight connection(s)…", connections.len());
+                    break;
+                }
+                // Reap finished connections so the JoinSet doesn't grow
+                // unboundedly on a long-running server.
+                Some(_res) = connections.join_next(), if !connections.is_empty() => {}
             }
-        });
+        }
     }
+
+    // Drain phase: stop accepting, give in-flight connections a bounded
+    // window to finish. Anything still alive at the deadline gets aborted.
+    let drain_deadline = timeout + Duration::from_secs(5);
+    let drain = async { while connections.join_next().await.is_some() {} };
+    if tokio::time::timeout(drain_deadline, drain).await.is_err() {
+        eprintln!(
+            "Drain timeout after {}s; aborting remaining connections",
+            drain_deadline.as_secs()
+        );
+        connections.shutdown().await;
+    }
+
+    epoch_stop.store(true, Ordering::Relaxed);
+    // The ticker sleeps `EPOCH_TICK_MS` between checks, so the join wakes
+    // up within that window.
+    let _ = epoch_thread.join();
+
+    Ok(())
 }
 
 pub async fn run(opts: ServeOptions) {
@@ -348,7 +525,16 @@ pub async fn run(opts: ServeOptions) {
     let cranelift_opt = opts.opt_level.to_wasmtime();
     let wasm = compile::compile(&opts.input, &flags).await;
 
-    if let Err(e) = run_http_server(wasm, &opts.addr, cranelift_opt, opts.preopened_dirs).await {
+    let timeout = Duration::from_secs(opts.timeout_secs);
+    if let Err(e) = run_http_server(
+        wasm,
+        &opts.addr,
+        cranelift_opt,
+        opts.preopened_dirs,
+        timeout,
+    )
+    .await
+    {
         eprintln!("Server error: {e}");
         process::exit(1);
     }

--- a/wado-cli/src/serve.rs
+++ b/wado-cli/src/serve.rs
@@ -35,9 +35,10 @@ use crate::runtime::{self, Preopens, WasiState};
 use wado_compiler::LogLevel;
 
 /// Default per-request timeout in seconds. A guest that fails to produce a
-/// response within this window has its epoch deadline expired (via
-/// `Store::set_epoch_deadline`), which causes a `Trap::Interrupt`, freeing
-/// the tokio task and letting the client see a 504.
+/// response within this window is cut short by one of the three layers
+/// documented on `handle_http_request`: an epoch-deadline trap on a
+/// runaway wasm loop, a wall-clock timeout on a stuck host `await`, or a
+/// first-byte timeout on a guest that never produces a head.
 const DEFAULT_TIMEOUT_SECS: u64 = 30;
 
 /// Epoch ticker interval. Each tick is a unit of `set_epoch_deadline`, so
@@ -267,25 +268,31 @@ fn error_response(status: u16, msg: String) -> HyperResponse<StreamingBody> {
 /// the spawn task keeps producing them. Because the channel is bounded
 /// (capacity 8), a slow consumer naturally back-pressures the guest.
 ///
-/// The per-request timeout is enforced in two layered ways:
+/// The per-request timeout is enforced in three layered ways, because no
+/// single mechanism covers every kind of stall on its own:
 ///
 /// * `Store::set_epoch_deadline` plus the engine-wide ticker traps the
-///   guest if it stays inside wasm past the deadline. This bounds the
-///   total request lifetime — even a long-lived streaming response is
-///   cut off when the deadline expires, since the wasm side traps and
-///   the spawn task drops the body sender on the way out.
+///   guest if it spends more than the deadline *running wasm*. This is
+///   the only mechanism that can preempt a tight CPU loop inside the
+///   guest.
+/// * `tokio::time::timeout(timeout, run_concurrent(...))` wraps the
+///   spawn task itself. This bounds the wall-clock lifetime of the
+///   request even when the pump is stuck on a host `await` (e.g.
+///   `frame_tx.send` blocked on a slow client) — epoch interruption
+///   cannot preempt a host await, so without this layer a misbehaving
+///   downstream could pin the store and the spawn task indefinitely.
 /// * A first-byte `tokio::time::sleep(timeout)` raced against the head
 ///   oneshot returns 504 to the client if the guest never produces a
-///   response head — covering the case where the guest is stuck waiting
-///   on host I/O instead of running wasm code.
+///   response head — covering the case where the guest is stuck before
+///   any bytes have been put on the wire.
 ///
 /// Hang avoidance:
 ///
 /// * Hyper dropping the body causes `frame_tx.send` to fail, breaking the
 ///   pump loop; the spawn task then exits.
-/// * If the outer first-byte timeout fires, the spawn task is left to run,
-///   but the per-store epoch deadline guarantees it terminates within one
-///   tick interval of the configured timeout.
+/// * If the outer first-byte timeout fires, the spawn task is left to
+///   run, but the wall-clock timeout guarantees it terminates within
+///   `timeout` regardless of where it is stuck (wasm or host await).
 async fn handle_http_request(
     engine: &Engine,
     service_pre: &ServicePre<WasiState>,
@@ -349,8 +356,17 @@ async fn handle_http_request(
         let mut resp_tx = Some(resp_tx);
         let mut frame_rx_holder = Some(frame_rx);
 
-        let drive_result: Result<anyhow::Result<()>, wasmtime::Error> = store
-            .run_concurrent(async |store| -> anyhow::Result<()> {
+        // Wrap `run_concurrent` in a wall-clock timeout. The per-store
+        // `set_epoch_deadline` only traps the guest while it is *running
+        // wasm*; an epoch interrupt cannot preempt a host `await` such as
+        // `frame_tx.send(...).await` blocking on a slow or stuck consumer.
+        // Without the outer wall-clock bound, a client that stops draining
+        // the body would pin this task — and the `Store` it owns — alive
+        // forever. Letting the timeout fire here drops `frame_tx`, which
+        // hyper sees as EOF on the response body, and frees the store.
+        let drive_result = tokio::time::timeout(
+            timeout,
+            store.run_concurrent(async |store| -> anyhow::Result<()> {
                 let handler = pin!(async {
                     let res = match service.handle(store, wasi_req).await? {
                         Ok(res) => res,
@@ -423,23 +439,28 @@ async fn handle_http_request(
                     Either::Left((res, _io)) => res,
                     Either::Right((_io_res, handler)) => handler.await,
                 }
-            })
-            .await;
+            }),
+        )
+        .await;
 
         // Surface failures that prevented the handler from producing a head.
+        // After the head has already been sent, `resp_tx` is `None` here and
+        // we just exit — dropping `frame_tx` ends the body stream, which
+        // hyper translates into a normal (possibly truncated) response.
         if let Some(tx) = resp_tx {
             let outcome = match drive_result {
-                Ok(Ok(())) => HandlerOutcome::Trapped(
+                Ok(Ok(Ok(()))) => HandlerOutcome::Trapped(
                     "Handler returned without producing a response".to_string(),
                 ),
-                Ok(Err(e)) => HandlerOutcome::Trapped(format!("Handler error: {e:?}")),
-                Err(e) => {
+                Ok(Ok(Err(e))) => HandlerOutcome::Trapped(format!("Handler error: {e:?}")),
+                Ok(Err(e)) => {
                     if is_epoch_deadline_error(&e) {
                         HandlerOutcome::Timeout
                     } else {
                         HandlerOutcome::Trapped(format!("Handler trapped:\n{e:?}"))
                     }
                 }
+                Err(_elapsed) => HandlerOutcome::Timeout,
             };
             let _ = tx.send(outcome);
         }

--- a/wado-cli/tests/fixtures/serve_hang.wado
+++ b/wado-cli/tests/fixtures/serve_hang.wado
@@ -1,0 +1,21 @@
+use { Request, Response, ErrorCode, Fields, Trailers, StatusCode } from "wasi:http";
+
+// Used by `wado serve` timeout tests: the handler enters a CPU loop that
+// only exits on i64 overflow, which never happens in any reasonable
+// timeout window. The `if` is there so that wasmtime cannot prove the
+// loop is infinite at validation time.
+export async fn handle(_request: Request) -> Result<Response, ErrorCode> {
+    let mut x: i64 = 0;
+    loop {
+        x = x + 1;
+        if x < 0 {
+            break;
+        }
+    }
+    let [trailers_future, _trailers_tx] = Future::<Result<Option<Trailers>, ErrorCode>>::new();
+    let [body_rx, _body_tx] = Stream::<u8>::new();
+    let headers = Fields::new();
+    let [response, _tx_future] = Response::new(headers, Option::<Stream<u8>>::Some(body_rx), trailers_future);
+    response.set_status_code(200);
+    task return Result::<Response, ErrorCode>::Ok(response);
+}

--- a/wado-cli/tests/fixtures/serve_hello.wado
+++ b/wado-cli/tests/fixtures/serve_hello.wado
@@ -1,0 +1,13 @@
+use { Request, Response, ErrorCode, Fields, Trailers, StatusCode } from "wasi:http";
+
+export async fn handle(_request: Request) -> Result<Response, ErrorCode> {
+    let [trailers_future, trailers_tx] = Future::<Result<Option<Trailers>, ErrorCode>>::new();
+    let [body_rx, body_tx] = Stream::<u8>::new();
+    let headers = Fields::new();
+    let [response, _tx_future] = Response::new(headers, Option::<Stream<u8>>::Some(body_rx), trailers_future);
+    response.set_status_code(200);
+    task return Result::<Response, ErrorCode>::Ok(response);
+    body_tx.write("Hello\n".bytes().collect());
+    body_tx.drop();
+    trailers_tx.write(Result::<Option<Trailers>, ErrorCode>::Ok(null));
+}

--- a/wado-cli/tests/serve.rs
+++ b/wado-cli/tests/serve.rs
@@ -103,7 +103,7 @@ fn start_serve(fixture: &str, extra_args: &[&str]) -> (ServerGuard, u16, Arc<Mut
     }
 
     // Compile time at -O0 is a few seconds; 60s is generous for slow CI.
-    let deadline = Instant::now() + Duration::from_secs(60);
+    let deadline = Instant::now() + Duration::from_mins(1);
     let socket_addr: SocketAddr = addr.parse().unwrap();
     while Instant::now() < deadline {
         if TcpStream::connect_timeout(&socket_addr, Duration::from_millis(200)).is_ok() {
@@ -202,9 +202,10 @@ fn sigterm_triggers_graceful_shutdown() {
         match guard.try_wait() {
             Ok(Some(status)) => break status,
             Ok(None) => {
-                if Instant::now() >= deadline {
-                    panic!("server did not exit within 15s after SIGTERM");
-                }
+                assert!(
+                    Instant::now() < deadline,
+                    "server did not exit within 15s after SIGTERM"
+                );
                 std::thread::sleep(Duration::from_millis(50));
             }
             Err(e) => panic!("try_wait failed: {e}"),

--- a/wado-cli/tests/serve.rs
+++ b/wado-cli/tests/serve.rs
@@ -1,0 +1,223 @@
+//! E2E tests for `wado serve`: per-request timeout and graceful shutdown.
+//!
+//! These tests spawn the `wado` binary, drive it over a real TCP socket, and
+//! send Unix signals — none of which port to Windows, so the file is gated
+//! `#[cfg(unix)]`.
+
+#![cfg(unix)]
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+fn project_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name)
+}
+
+/// Reserve a free TCP port by binding to `127.0.0.1:0`, reading the assigned
+/// port, then dropping the listener. There is a tiny TOCTOU window between
+/// drop and the spawned `wado serve` re-binding the port, but in practice
+/// the kernel re-uses ports rarely enough for this to be reliable in CI.
+fn free_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind 127.0.0.1:0");
+    listener.local_addr().unwrap().port()
+}
+
+/// Drop guard that kills the spawned server on test exit so a panic
+/// mid-test doesn't leak a process holding the listening port.
+struct ServerGuard {
+    child: Child,
+}
+
+impl ServerGuard {
+    fn pid(&self) -> i32 {
+        self.child.id() as i32
+    }
+
+    fn try_wait(&mut self) -> std::io::Result<Option<std::process::ExitStatus>> {
+        self.child.try_wait()
+    }
+}
+
+impl Drop for ServerGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Spawn `wado serve` on a free port using `fixture` (relative to
+/// `wado-cli/tests/fixtures`), wait for the listening socket to accept
+/// connections, and return the guard, the bound port, and a handle to the
+/// captured stderr buffer.
+///
+/// stderr is drained on a background thread so the child never blocks on a
+/// full pipe; the captured text is also used for assertions on shutdown
+/// messages.
+fn start_serve(fixture: &str, extra_args: &[&str]) -> (ServerGuard, u16, Arc<Mutex<String>>) {
+    let port = free_port();
+    let addr = format!("127.0.0.1:{port}");
+
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("wado"));
+    cmd.current_dir(project_root())
+        .arg("serve")
+        .arg("--addr")
+        .arg(&addr)
+        .arg("-O0")
+        .arg("--log-level")
+        .arg("off")
+        .args(extra_args)
+        .arg(fixture_path(fixture))
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+
+    let mut child = cmd.spawn().expect("failed to spawn wado serve");
+
+    // Drain stderr so the kernel pipe buffer never fills, and capture the
+    // text for assertions.
+    let stderr = child.stderr.take().unwrap();
+    let stderr_buf: Arc<Mutex<String>> = Arc::new(Mutex::new(String::new()));
+    {
+        let buf = Arc::clone(&stderr_buf);
+        std::thread::spawn(move || {
+            let reader = BufReader::new(stderr);
+            for line in reader.lines() {
+                let Ok(line) = line else { break };
+                let mut guard = buf.lock().unwrap();
+                guard.push_str(&line);
+                guard.push('\n');
+            }
+        });
+    }
+
+    // Compile time at -O0 is a few seconds; 60s is generous for slow CI.
+    let deadline = Instant::now() + Duration::from_secs(60);
+    let socket_addr: SocketAddr = addr.parse().unwrap();
+    while Instant::now() < deadline {
+        if TcpStream::connect_timeout(&socket_addr, Duration::from_millis(200)).is_ok() {
+            return (ServerGuard { child }, port, stderr_buf);
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    let captured = stderr_buf.lock().unwrap().clone();
+    panic!("wado serve did not accept connections within 60s. stderr:\n{captured}");
+}
+
+/// Send a minimal HTTP/1.1 GET and return `(status_code, body)`.
+fn http_get(port: u16, path: &str, timeout: Duration) -> (u16, String) {
+    let addr = format!("127.0.0.1:{port}");
+    let mut stream = TcpStream::connect(&addr).expect("connect");
+    stream.set_read_timeout(Some(timeout)).unwrap();
+    stream.set_write_timeout(Some(timeout)).unwrap();
+
+    let req = format!("GET {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+    stream.write_all(req.as_bytes()).unwrap();
+
+    let mut response = String::new();
+    stream.read_to_string(&mut response).unwrap();
+
+    let status_line = response
+        .lines()
+        .next()
+        .expect("status line in HTTP response");
+    let status: u16 = status_line
+        .split_whitespace()
+        .nth(1)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or_else(|| panic!("could not parse status from: {status_line}"));
+
+    let body = response
+        .split_once("\r\n\r\n")
+        .map(|(_, b)| b.to_string())
+        .unwrap_or_default();
+
+    (status, body)
+}
+
+/// A guest stuck in pure wasm past `--timeout` should trap (via
+/// `set_epoch_deadline`) and the client should see a 504 — not a connection
+/// drop, not a 500, not a hang.
+#[test]
+fn timeout_returns_504_for_runaway_guest() {
+    let (_guard, port, _stderr) = start_serve("serve_hang.wado", &["--timeout", "2"]);
+
+    let start = Instant::now();
+    let (status, body) = http_get(port, "/", Duration::from_secs(15));
+    let elapsed = start.elapsed();
+
+    assert_eq!(status, 504, "expected 504 Gateway Timeout; body: {body:?}");
+    assert!(
+        body.contains("timed out"),
+        "504 body should mention the timeout; got: {body:?}",
+    );
+    // The 504 should fire near the configured 2s deadline. Allow a generous
+    // window: epoch ticker granularity is 1s, and CI machines can be slow.
+    assert!(
+        elapsed >= Duration::from_millis(1500),
+        "504 returned in {elapsed:?} — earlier than the configured 2s timeout, \
+         which suggests the timeout isn't actually being enforced",
+    );
+    assert!(
+        elapsed <= Duration::from_secs(8),
+        "504 returned in {elapsed:?} — later than expected for a 2s timeout",
+    );
+}
+
+/// SIGTERM should trigger the shutdown path: the accept loop stops, the
+/// drain phase runs, and the process exits with status 0. Verifies both
+/// the exit status and the operator-facing log line so a regression that
+/// merely SIGKILLs the child (skipping drain) would fail this test.
+#[test]
+fn sigterm_triggers_graceful_shutdown() {
+    let (mut guard, _port, stderr) = start_serve("serve_hello.wado", &[]);
+
+    let pid = guard.pid();
+    // SAFETY: pid was just observed for our owned child; the worst case
+    // from a stale pid would be ESRCH, which we ignore.
+    let rc = unsafe { libc::kill(pid, libc::SIGTERM) };
+    assert_eq!(
+        rc,
+        0,
+        "kill(SIGTERM) failed: errno={}",
+        std::io::Error::last_os_error()
+    );
+
+    // Without an in-flight request the drain phase is essentially a no-op,
+    // so 15s is far more than the shutdown should ever need.
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let exit = loop {
+        match guard.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    panic!("server did not exit within 15s after SIGTERM");
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(e) => panic!("try_wait failed: {e}"),
+        }
+    };
+
+    assert!(
+        exit.success(),
+        "graceful shutdown should exit with status 0; got {exit:?}",
+    );
+    let captured = stderr.lock().unwrap().clone();
+    assert!(
+        captured.contains("Shutdown signal received"),
+        "expected the shutdown log line in stderr; got:\n{captured}",
+    );
+}

--- a/wado-cli/tests/serve.rs
+++ b/wado-cli/tests/serve.rs
@@ -116,8 +116,9 @@ fn start_serve(fixture: &str, extra_args: &[&str]) -> (ServerGuard, u16, Arc<Mut
     panic!("wado serve did not accept connections within 60s. stderr:\n{captured}");
 }
 
-/// Send a minimal HTTP/1.1 GET and return `(status_code, body)`.
-fn http_get(port: u16, path: &str, timeout: Duration) -> (u16, String) {
+/// Send a minimal HTTP/1.1 GET and return the full raw response text
+/// (status line, headers, blank line, body — chunk framing intact).
+fn http_get_raw(port: u16, path: &str, timeout: Duration) -> String {
     let addr = format!("127.0.0.1:{port}");
     let mut stream = TcpStream::connect(&addr).expect("connect");
     stream.set_read_timeout(Some(timeout)).unwrap();
@@ -128,7 +129,13 @@ fn http_get(port: u16, path: &str, timeout: Duration) -> (u16, String) {
 
     let mut response = String::new();
     stream.read_to_string(&mut response).unwrap();
+    response
+}
 
+/// Parse `(status_code, raw_body)` from a raw HTTP/1.1 response. The body
+/// is returned exactly as it came off the wire — for chunked responses
+/// it still contains the chunk-size lines.
+fn parse_response(response: &str) -> (u16, String) {
     let status_line = response
         .lines()
         .next()
@@ -145,6 +152,11 @@ fn http_get(port: u16, path: &str, timeout: Duration) -> (u16, String) {
         .unwrap_or_default();
 
     (status, body)
+}
+
+/// Convenience wrapper for tests that don't care about chunk framing.
+fn http_get(port: u16, path: &str, timeout: Duration) -> (u16, String) {
+    parse_response(&http_get_raw(port, path, timeout))
 }
 
 /// A guest stuck in pure wasm past `--timeout` should trap (via
@@ -173,6 +185,39 @@ fn timeout_returns_504_for_runaway_guest() {
     assert!(
         elapsed <= Duration::from_secs(8),
         "504 returned in {elapsed:?} — later than expected for a 2s timeout",
+    );
+}
+
+/// The response body should leave the server one frame at a time rather
+/// than being buffered into a single `Content-Length` blob. We verify
+/// this end-to-end by asserting the response uses HTTP/1.1 chunked
+/// transfer encoding (the only way hyper can deliver a body whose total
+/// length isn't known up front), and that the literal body bytes survive
+/// the trip through the streaming pipeline.
+#[test]
+fn responds_with_streamed_chunked_body() {
+    let (_guard, port, _stderr) = start_serve("serve_hello.wado", &[]);
+
+    let raw = http_get_raw(port, "/", Duration::from_secs(15));
+    let (status, body) = parse_response(&raw);
+
+    assert_eq!(status, 200, "expected 200 OK; got raw response:\n{raw}");
+    let header_block = raw
+        .split_once("\r\n\r\n")
+        .map(|(h, _)| h.to_lowercase())
+        .unwrap_or_default();
+    assert!(
+        header_block.contains("transfer-encoding: chunked"),
+        "expected chunked transfer encoding (proof the streaming path is wired); \
+         got headers:\n{header_block}",
+    );
+    assert!(
+        !header_block.contains("content-length:"),
+        "streaming responses should not advertise a Content-Length; got headers:\n{header_block}",
+    );
+    assert!(
+        body.contains("Hello"),
+        "expected 'Hello' to survive the streaming pipeline; got chunked body:\n{body}",
     );
 }
 


### PR DESCRIPTION
Production-readiness fixes for `wado serve`. The previous implementation
had a `Mutex<Linker>` that serialized all request instantiation, rebuilt
rustls' `ClientConfig` (and re-read CA bundles from disk) per request,
re-resolved component exports per request, and had no defense against
runaway guests or unclean shutdown.

Changes:
- Replace `Arc<Mutex<Linker>>` with `Arc<ServicePre>` so concurrent
  requests no longer block on a global mutex; each request goes
  straight to `ServicePre::instantiate_async`, which front-loads the
  per-export string lookups that `Service::instantiate_async` repeated.
- Cache `rustls::ClientConfig` in a process-wide `LazyLock` inside
  `WadoHttpHooks::new` so per-request `WasiState` construction no
  longer reads `SSL_CERT_FILE` / `SSL_CERT_DIR` from disk every call.
- Add `--timeout <seconds>` (default 30) and enforce it two ways: a
  per-store `set_epoch_deadline` that traps tight-loop guests via a
  background ticker, plus `tokio::time::timeout` for host-side hangs.
  Trapped/timed-out requests now return 504 instead of holding a tokio
  task forever.
- Wait for SIGINT/SIGTERM and drain in-flight connections (with a
  bounded deadline) instead of killing them mid-request.

https://claude.ai/code/session_01Wuv6sKcAETC3XxFae9sG7j