### PR TITLE
test(wado-cli): harden test harness, dedupe helpers, refactor LSP tests

### DIFF
--- a/wado-cli/src/kiln_provider.rs
+++ b/wado-cli/src/kiln_provider.rs
@@ -260,7 +260,7 @@ impl CliGeneratorProvider {
             .unwrap_or_default();
         let sources = dedup_sort_sources(make_relative_sources(&recording_base, recorded));
         let combined_hash = combined_sources_hash(&sources);
-        artifacts.source_hash = combined_hash.clone();
+        artifacts.source_hash.clone_from(&combined_hash);
 
         // Cache writes are best-effort: if the filesystem refuses we
         // still return the fresh bytes. The next invocation just repeats

--- a/wado-cli/src/timezone_host.rs
+++ b/wado-cli/src/timezone_host.rs
@@ -55,6 +55,10 @@ pub fn add_to_linker<T: 'static>(linker: &mut Linker<T>) -> Result<()> {
 #[cfg(unix)]
 fn local_offset_nanos(secs: i64) -> Option<i64> {
     use std::mem::MaybeUninit;
+    // `time_t` is `i64` on glibc/x86_64 (the conversion is a no-op there) but
+    // `i32` on 32-bit Unix targets without `_TIME_BITS=64`. Keep `try_into`
+    // for portability and silence the lint on the platforms where it's a no-op.
+    #[allow(clippy::useless_conversion)]
     let t: libc::time_t = secs.try_into().ok()?;
     let mut tm: MaybeUninit<libc::tm> = MaybeUninit::uninit();
     let ret = unsafe { libc::localtime_r(&raw const t, tm.as_mut_ptr()) };

--- a/wado-cli/tests/cli.rs
+++ b/wado-cli/tests/cli.rs
@@ -5,22 +5,9 @@
 
 use predicates::prelude::*;
 use std::fs;
-use std::path::PathBuf;
-use std::process::Command;
 
-/// Get the project root directory (parent of wado-cli)
-fn project_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .unwrap()
-        .to_path_buf()
-}
-
-fn wado() -> assert_cmd::Command {
-    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("wado"));
-    cmd.current_dir(project_root());
-    cmd.into()
-}
+mod common;
+use common::wado;
 
 #[test]
 fn test_help() {
@@ -93,11 +80,8 @@ fn test_compile_file_not_found() {
 
 #[test]
 fn test_compile_output_wasm() {
-    let temp_dir = std::env::temp_dir();
-    let output_path = temp_dir.join("test_compile_output.wasm");
-
-    // Clean up before test
-    let _ = fs::remove_file(&output_path);
+    let dir = tempfile::tempdir().unwrap();
+    let output_path = dir.path().join("out.wasm");
 
     wado()
         .args([
@@ -110,25 +94,15 @@ fn test_compile_output_wasm() {
         .success()
         .stderr(predicate::str::contains("Generated:"));
 
-    // Verify file was created
-    assert!(output_path.exists(), "Output file should exist");
-
-    // Verify it's a valid Wasm file (starts with magic bytes)
     let content = fs::read(&output_path).unwrap();
+    // Component model starts with \0asm but version differs from core wasm.
     assert!(content.len() > 4, "Wasm file should have content");
-    // Component model starts with \0asm but version differs from core wasm
-
-    // Clean up
-    let _ = fs::remove_file(&output_path);
 }
 
 #[test]
 fn test_compile_output_wat() {
-    let temp_dir = std::env::temp_dir();
-    let output_path = temp_dir.join("test_compile_output.wat");
-
-    // Clean up before test
-    let _ = fs::remove_file(&output_path);
+    let dir = tempfile::tempdir().unwrap();
+    let output_path = dir.path().join("out.wat");
 
     wado()
         .args([
@@ -141,24 +115,18 @@ fn test_compile_output_wat() {
         .success()
         .stderr(predicate::str::contains("Generated:"));
 
-    // Verify file was created with WAT content
     let content = fs::read_to_string(&output_path).unwrap();
     assert!(
         content.contains("(component"),
         "WAT file should contain component"
     );
-
-    // Clean up
-    let _ = fs::remove_file(&output_path);
 }
 
 #[test]
 fn test_compile_format_wat() {
-    let temp_dir = std::env::temp_dir();
-    let output_path = temp_dir.join("test_compile_format.txt");
-
-    // Clean up before test
-    let _ = fs::remove_file(&output_path);
+    // Non-`.wat` extension forces format selection by `--format`, not by suffix.
+    let dir = tempfile::tempdir().unwrap();
+    let output_path = dir.path().join("out.txt");
 
     wado()
         .args([
@@ -172,24 +140,17 @@ fn test_compile_format_wat() {
         .assert()
         .success();
 
-    // Verify WAT content even with non-standard extension
     let content = fs::read_to_string(&output_path).unwrap();
     assert!(
         content.contains("(component"),
         "Should be WAT format regardless of extension"
     );
-
-    // Clean up
-    let _ = fs::remove_file(&output_path);
 }
 
 #[test]
 fn test_compile_format_wasm() {
-    let temp_dir = std::env::temp_dir();
-    let output_path = temp_dir.join("test_compile_format.bin");
-
-    // Clean up before test
-    let _ = fs::remove_file(&output_path);
+    let dir = tempfile::tempdir().unwrap();
+    let output_path = dir.path().join("out.bin");
 
     wado()
         .args([
@@ -203,12 +164,8 @@ fn test_compile_format_wasm() {
         .assert()
         .success();
 
-    // Verify binary content even with non-standard extension
     let content = fs::read(&output_path).unwrap();
     assert!(content.len() > 4, "Wasm file should have content");
-
-    // Clean up
-    let _ = fs::remove_file(&output_path);
 }
 
 #[test]

--- a/wado-cli/tests/common.rs
+++ b/wado-cli/tests/common.rs
@@ -1,0 +1,48 @@
+//! Shared helpers for wado-cli integration tests.
+//!
+//! Each test file pulls these in via `mod common;`. The file also compiles
+//! as its own (empty) integration test binary; `#![allow(dead_code)]`
+//! quiets warnings when an individual test file uses only a subset.
+
+#![allow(dead_code)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Repository root (parent of `wado-cli/`).
+pub fn project_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+/// Path to the freshly-built `wado` binary.
+pub fn wado_bin() -> PathBuf {
+    assert_cmd::cargo::cargo_bin!("wado").into()
+}
+
+/// `wado` invocation rooted at the project root. Use this when the test
+/// drives an example file (e.g. `example/hello.wado`) by relative path.
+pub fn wado() -> assert_cmd::Command {
+    let mut cmd = Command::new(wado_bin());
+    cmd.current_dir(project_root());
+    cmd.into()
+}
+
+/// `wado` invocation rooted at `dir`. Use this when the test creates a
+/// self-contained workspace (`wado.toml`, sources) under a tempdir.
+pub fn wado_in(dir: &Path) -> assert_cmd::Command {
+    let mut cmd = Command::new(wado_bin());
+    cmd.current_dir(dir);
+    cmd.into()
+}
+
+/// Single-threaded Tokio runtime for tests that drive async APIs from a
+/// synchronous `#[test]`.
+pub fn runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+}

--- a/wado-cli/tests/gale_cli.rs
+++ b/wado-cli/tests/gale_cli.rs
@@ -8,23 +8,10 @@
 
 #![allow(unused_crate_dependencies)]
 
-use std::path::PathBuf;
-use std::process::Command;
-
 use predicates::prelude::*;
 
-fn project_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .unwrap()
-        .to_path_buf()
-}
-
-fn wado() -> assert_cmd::Command {
-    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("wado"));
-    cmd.current_dir(project_root());
-    cmd.into()
-}
+mod common;
+use common::wado;
 
 #[test]
 fn gale_gen_calculator_emits_generated_parser() {

--- a/wado-cli/tests/kiln_compile.rs
+++ b/wado-cli/tests/kiln_compile.rs
@@ -20,6 +20,9 @@ use wado_cli::kiln_driver::{GeneratorProvider, ProviderError};
 use wado_cli::kiln_provider::{CACHE_DIR, CliGeneratorProvider};
 use wado_compiler::kiln::{GeneratorModule, InvocationPath};
 
+mod common;
+use common::runtime;
+
 const MINIMAL_GENERATOR: &str = r#"
 use { RawRequest, Response, Error, bind_request } from "core:kiln";
 
@@ -55,13 +58,6 @@ export fn generate(req: Request<Options>) -> Result<Response, Error> {
     return Result::Ok(Response { files: [] });
 }
 "#;
-
-fn runtime() -> tokio::runtime::Runtime {
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap()
-}
 
 fn unique_tmp(label: &str) -> PathBuf {
     std::env::temp_dir().join(format!("wado-{label}-{}", std::process::id()))

--- a/wado-cli/tests/kiln_pipeline.rs
+++ b/wado-cli/tests/kiln_pipeline.rs
@@ -20,6 +20,9 @@ use wado_compiler::compiler_host::{
 use wado_compiler::kiln::{DeclSite, GeneratorModule, Invocation, InvocationPath};
 use wado_manifest::Manifest;
 
+mod common;
+use common::runtime;
+
 struct StubProvider {
     bytes: Vec<u8>,
     calls: Mutex<u32>,
@@ -105,13 +108,6 @@ impl CompilerHost for StubHost {
             ))
         })
     }
-}
-
-fn runtime() -> tokio::runtime::Runtime {
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap()
 }
 
 fn empty_manifest() -> Manifest {

--- a/wado-cli/tests/lsp.rs
+++ b/wado-cli/tests/lsp.rs
@@ -246,6 +246,19 @@ impl LspSession {
     }
 }
 
+impl Drop for LspSession {
+    fn drop(&mut self) {
+        // `std::process::Child::drop` is a documented no-op, so a test that
+        // panics — e.g. inside `read_message_within` on timeout — would leak
+        // the `wado lsp` subprocess and risk flaking the rest of the suite.
+        // Best-effort kill+wait covers that path. On the happy
+        // `shutdown_and_exit` / `exit_now` paths the child has already
+        // exited; both calls return ESRCH/ECHILD, which we ignore.
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
 // ===========================================================================
 // LSP tests
 // ===========================================================================

--- a/wado-cli/tests/lsp.rs
+++ b/wado-cli/tests/lsp.rs
@@ -1,27 +1,23 @@
 //! Integration tests for `wado lsp` and `wado query` subcommands.
 
-use std::io::{Read, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::process::{Command, Stdio};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
 
 use predicates::prelude::*;
 use serde_json::{Value, json};
 
-fn wado_bin() -> std::path::PathBuf {
-    assert_cmd::cargo::cargo_bin!("wado").into()
-}
+mod common;
+use common::{project_root, wado, wado_bin};
 
-fn project_root() -> std::path::PathBuf {
-    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .unwrap()
-        .to_path_buf()
-}
-
-fn wado() -> assert_cmd::Command {
-    let mut cmd = Command::new(wado_bin());
-    cmd.current_dir(project_root());
-    cmd.into()
-}
+/// Cap on `read_message` so a regression that stops the LSP from
+/// responding fails the test in seconds rather than hanging until the
+/// outer cargo timeout (often minutes). Generous enough for cold starts
+/// and the bundled-stdlib parse on the first request.
+const READ_TIMEOUT: Duration = Duration::from_secs(30);
 
 // ---------------------------------------------------------------------------
 // JSON-RPC helpers
@@ -32,18 +28,57 @@ fn encode_message(msg: &Value) -> Vec<u8> {
     format!("Content-Length: {}\r\n\r\n{}", body.len(), body).into_bytes()
 }
 
+/// Read one Content-Length-framed JSON-RPC message from `reader`. Returns
+/// `Err` on EOF or a malformed frame; the caller is responsible for
+/// surfacing the error (typically as a channel close).
+fn read_framed<R: Read>(reader: &mut R) -> std::io::Result<Value> {
+    let mut header_buf = Vec::new();
+    let mut byte = [0u8; 1];
+    loop {
+        reader.read_exact(&mut byte)?;
+        header_buf.push(byte[0]);
+        if header_buf.ends_with(b"\r\n\r\n") {
+            break;
+        }
+    }
+    let header = std::str::from_utf8(&header_buf)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    let length: usize = header
+        .lines()
+        .find_map(|l| l.strip_prefix("Content-Length: "))
+        .ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::InvalidData, "missing Content-Length")
+        })?
+        .trim()
+        .parse()
+        .map_err(|e: std::num::ParseIntError| {
+            std::io::Error::new(std::io::ErrorKind::InvalidData, e)
+        })?;
+    let mut body = vec![0u8; length];
+    reader.read_exact(&mut body)?;
+    serde_json::from_slice(&body)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+}
+
 // ---------------------------------------------------------------------------
 // LSP session helper
 // ---------------------------------------------------------------------------
 
+/// Drives a `wado lsp` child process from a sync test thread. The child's
+/// stdout is parsed on a background thread and queued onto an mpsc channel
+/// so `read_message` can apply a timeout — without the channel, a regressed
+/// server that simply stops emitting frames would hang the whole test
+/// binary on a blocking `read_exact`.
 struct LspSession {
     child: std::process::Child,
     next_id: i64,
+    rx: Receiver<Value>,
+    stderr_buf: Arc<Mutex<String>>,
 }
 
 impl LspSession {
     fn start() -> Self {
-        let child = Command::new(wado_bin())
+        let mut child = Command::new(wado_bin())
             .args(["lsp"])
             .current_dir(project_root())
             .stdin(Stdio::piped())
@@ -51,7 +86,42 @@ impl LspSession {
             .stderr(Stdio::piped())
             .spawn()
             .expect("failed to spawn wado lsp");
-        Self { child, next_id: 1 }
+
+        let mut stdout = child.stdout.take().unwrap();
+        let stderr = child.stderr.take().unwrap();
+
+        let (tx, rx) = mpsc::channel::<Value>();
+        thread::spawn(move || {
+            // EOF / parse errors silently terminate the reader; the test
+            // thread sees `Disconnected` from `recv_timeout` and panics
+            // with the captured stderr.
+            while let Ok(msg) = read_framed(&mut stdout) {
+                if tx.send(msg).is_err() {
+                    return;
+                }
+            }
+        });
+
+        let stderr_buf: Arc<Mutex<String>> = Arc::new(Mutex::new(String::new()));
+        {
+            let buf = Arc::clone(&stderr_buf);
+            thread::spawn(move || {
+                let reader = BufReader::new(stderr);
+                for line in reader.lines() {
+                    let Ok(line) = line else { return };
+                    let mut g = buf.lock().unwrap();
+                    g.push_str(&line);
+                    g.push('\n');
+                }
+            });
+        }
+
+        Self {
+            child,
+            next_id: 1,
+            rx,
+            stderr_buf,
+        }
     }
 
     fn send(&mut self, msg: &Value) {
@@ -124,33 +194,39 @@ impl LspSession {
         }));
     }
 
-    /// Read one message from stdout with a timeout.
+    /// Read one message from the server with a timeout. Panics with the
+    /// captured stderr if the server fails to respond — this turns a
+    /// hung-server regression from a multi-minute cargo timeout into a
+    /// fast, diagnosable test failure.
     fn read_message(&mut self) -> Value {
-        let stdout = self.child.stdout.as_mut().unwrap();
+        self.read_message_within(READ_TIMEOUT)
+    }
 
-        // Read headers
-        let mut header_buf = Vec::new();
-        let mut byte = [0u8; 1];
-        loop {
-            stdout.read_exact(&mut byte).expect("read failed");
-            header_buf.push(byte[0]);
-            if header_buf.ends_with(b"\r\n\r\n") {
-                break;
+    fn read_message_within(&mut self, timeout: Duration) -> Value {
+        match self.rx.recv_timeout(timeout) {
+            Ok(v) => v,
+            Err(RecvTimeoutError::Timeout) => {
+                let stderr = self.stderr_buf.lock().unwrap().clone();
+                panic!(
+                    "wado lsp did not emit a framed response within {timeout:?}.\nstderr:\n{stderr}"
+                );
+            }
+            Err(RecvTimeoutError::Disconnected) => {
+                // Reader thread exited (server closed stdout, or framing
+                // error). Surface stderr so the failure is diagnosable.
+                let stderr = self.stderr_buf.lock().unwrap().clone();
+                panic!("wado lsp closed stdout before emitting a response.\nstderr:\n{stderr}");
             }
         }
+    }
 
-        let header = std::str::from_utf8(&header_buf).unwrap();
-        let length: usize = header
-            .lines()
-            .find_map(|l| l.strip_prefix("Content-Length: "))
-            .expect("missing Content-Length")
-            .trim()
-            .parse()
-            .unwrap();
-
-        let mut body = vec![0u8; length];
-        stdout.read_exact(&mut body).expect("read body failed");
-        serde_json::from_slice(&body).unwrap()
+    /// Send `exit` (with no preceding `shutdown`), close stdin, and wait.
+    /// Returns the process exit code. For the happy-path `shutdown` →
+    /// `exit` flow, use [`shutdown_and_exit`] instead.
+    fn exit_now(mut self) -> i32 {
+        self.send_notification("exit", Value::Null);
+        drop(self.child.stdin.take());
+        self.child.wait().unwrap().code().unwrap_or(-1)
     }
 
     fn shutdown_and_exit(mut self) -> i32 {
@@ -250,24 +326,13 @@ fn lsp_workspace_text_document_content_rejects_unknown_uri() {
 fn lsp_diagnostics_on_did_open_valid() {
     let mut session = LspSession::start();
 
-    session.send_request("initialize", json!({ "capabilities": {} }));
-    let _init_resp = session.read_message();
-    session.send_notification("initialized", json!({}));
+    session.initialize();
 
     // Open a valid document
-    session.send_notification(
-        "textDocument/didOpen",
-        json!({
-            "textDocument": {
-                "uri": "file:///tmp/lsp_test_valid.wado",
-                "languageId": "wado",
-                "version": 1,
-                "text": "use { println, Stdout } from \"core:cli\";\n\nexport fn run() with Stdout {\n    println(\"hello\");\n}\n"
-            }
-        }),
+    let notif = session.open_doc(
+        "file:///tmp/lsp_test_valid.wado",
+        "use { println, Stdout } from \"core:cli\";\n\nexport fn run() with Stdout {\n    println(\"hello\");\n}\n",
     );
-
-    let notif = session.read_message();
     assert_eq!(notif["method"], "textDocument/publishDiagnostics");
     assert_eq!(notif["params"]["uri"], "file:///tmp/lsp_test_valid.wado");
 
@@ -284,24 +349,13 @@ fn lsp_diagnostics_on_did_open_valid() {
 fn lsp_diagnostics_on_did_open_invalid() {
     let mut session = LspSession::start();
 
-    session.send_request("initialize", json!({ "capabilities": {} }));
-    let _init_resp = session.read_message();
-    session.send_notification("initialized", json!({}));
+    session.initialize();
 
     // Open a document with a type error
-    session.send_notification(
-        "textDocument/didOpen",
-        json!({
-            "textDocument": {
-                "uri": "file:///tmp/lsp_test_invalid.wado",
-                "languageId": "wado",
-                "version": 1,
-                "text": "export fn run() {\n    let x: i32 = \"oops\";\n}\n"
-            }
-        }),
+    let notif = session.open_doc(
+        "file:///tmp/lsp_test_invalid.wado",
+        "export fn run() {\n    let x: i32 = \"oops\";\n}\n",
     );
-
-    let notif = session.read_message();
     assert_eq!(notif["method"], "textDocument/publishDiagnostics");
 
     let diags = notif["params"]["diagnostics"].as_array().unwrap();
@@ -327,24 +381,13 @@ fn lsp_diagnostics_on_did_open_invalid() {
 fn lsp_diagnostics_update_on_did_change() {
     let mut session = LspSession::start();
 
-    session.send_request("initialize", json!({ "capabilities": {} }));
-    let _init_resp = session.read_message();
-    session.send_notification("initialized", json!({}));
+    session.initialize();
 
     // Open with errors
-    session.send_notification(
-        "textDocument/didOpen",
-        json!({
-            "textDocument": {
-                "uri": "file:///tmp/lsp_test_change.wado",
-                "languageId": "wado",
-                "version": 1,
-                "text": "export fn run() {\n    let x: i32 = \"oops\";\n}\n"
-            }
-        }),
+    let notif1 = session.open_doc(
+        "file:///tmp/lsp_test_change.wado",
+        "export fn run() {\n    let x: i32 = \"oops\";\n}\n",
     );
-
-    let notif1 = session.read_message();
     let diags1 = notif1["params"]["diagnostics"].as_array().unwrap();
     assert!(!diags1.is_empty(), "should have errors initially");
 
@@ -376,24 +419,10 @@ fn lsp_diagnostics_update_on_did_change() {
 fn lsp_did_close_clears_diagnostics() {
     let mut session = LspSession::start();
 
-    session.send_request("initialize", json!({ "capabilities": {} }));
-    let _init_resp = session.read_message();
-    session.send_notification("initialized", json!({}));
+    session.initialize();
 
-    // Open with errors
-    session.send_notification(
-        "textDocument/didOpen",
-        json!({
-            "textDocument": {
-                "uri": "file:///tmp/lsp_test_close.wado",
-                "languageId": "wado",
-                "version": 1,
-                "text": "invalid syntax here ???"
-            }
-        }),
-    );
-
-    let _notif1 = session.read_message(); // diagnostics with errors
+    // Open with errors — drop the initial `publishDiagnostics`.
+    session.open_doc("file:///tmp/lsp_test_close.wado", "invalid syntax here ???");
 
     // Close the document
     session.send_notification(
@@ -417,24 +446,11 @@ fn lsp_did_close_clears_diagnostics() {
 fn lsp_definition_same_file() {
     let mut session = LspSession::start();
 
-    session.send_request("initialize", json!({ "capabilities": {} }));
-    let _init_resp = session.read_message();
-    session.send_notification("initialized", json!({}));
+    session.initialize();
 
     let source =
         "fn helper() -> i32 {\n    return 42;\n}\n\nexport fn run() {\n    let _ = helper();\n}\n";
-    session.send_notification(
-        "textDocument/didOpen",
-        json!({
-            "textDocument": {
-                "uri": "file:///tmp/lsp_def_same.wado",
-                "languageId": "wado",
-                "version": 1,
-                "text": source,
-            }
-        }),
-    );
-    let _diag = session.read_message();
+    session.open_doc("file:///tmp/lsp_def_same.wado", source);
 
     let id = session.send_request(
         "textDocument/definition",
@@ -478,23 +494,10 @@ fn lsp_definition_cross_file() {
     let main_uri = format!("file://{}", main_path.display());
 
     let mut session = LspSession::start();
-    session.send_request("initialize", json!({ "capabilities": {} }));
-    let _init_resp = session.read_message();
-    session.send_notification("initialized", json!({}));
+    session.initialize();
 
     let source = std::fs::read_to_string(&main_path).unwrap();
-    session.send_notification(
-        "textDocument/didOpen",
-        json!({
-            "textDocument": {
-                "uri": main_uri,
-                "languageId": "wado",
-                "version": 1,
-                "text": source,
-            }
-        }),
-    );
-    let _diag = session.read_message();
+    session.open_doc(&main_uri, &source);
 
     let id = session.send_request(
         "textDocument/definition",
@@ -521,23 +524,10 @@ fn lsp_definition_cross_file() {
 fn lsp_hover_function_signature() {
     let mut session = LspSession::start();
 
-    session.send_request("initialize", json!({ "capabilities": {} }));
-    let _init_resp = session.read_message();
-    session.send_notification("initialized", json!({}));
+    session.initialize();
 
     let source = "fn add(a: i32, b: i32) -> i32 {\n    return a + b;\n}\n\nexport fn run() {\n    let _ = add(1, 2);\n}\n";
-    session.send_notification(
-        "textDocument/didOpen",
-        json!({
-            "textDocument": {
-                "uri": "file:///tmp/lsp_hover.wado",
-                "languageId": "wado",
-                "version": 1,
-                "text": source,
-            }
-        }),
-    );
-    let _diag = session.read_message();
+    session.open_doc("file:///tmp/lsp_hover.wado", source);
 
     let id = session.send_request(
         "textDocument/hover",
@@ -564,23 +554,10 @@ fn lsp_hover_function_signature() {
 fn lsp_references_includes_call_sites() {
     let mut session = LspSession::start();
 
-    session.send_request("initialize", json!({ "capabilities": {} }));
-    let _init_resp = session.read_message();
-    session.send_notification("initialized", json!({}));
+    session.initialize();
 
     let source = "fn helper() -> i32 {\n    return 1;\n}\n\nexport fn run() {\n    let _ = helper();\n    let _ = helper();\n}\n";
-    session.send_notification(
-        "textDocument/didOpen",
-        json!({
-            "textDocument": {
-                "uri": "file:///tmp/lsp_refs.wado",
-                "languageId": "wado",
-                "version": 1,
-                "text": source,
-            }
-        }),
-    );
-    let _diag = session.read_message();
+    session.open_doc("file:///tmp/lsp_refs.wado", source);
 
     let id = session.send_request(
         "textDocument/references",
@@ -612,23 +589,10 @@ fn lsp_references_includes_call_sites() {
 fn lsp_document_highlight_classifies_read_write() {
     let mut session = LspSession::start();
 
-    session.send_request("initialize", json!({ "capabilities": {} }));
-    let _init_resp = session.read_message();
-    session.send_notification("initialized", json!({}));
+    session.initialize();
 
     let source = "fn f() -> i32 {\n    let mut x = 0;\n    x = 1;\n    return x;\n}\n";
-    session.send_notification(
-        "textDocument/didOpen",
-        json!({
-            "textDocument": {
-                "uri": "file:///tmp/lsp_highlight.wado",
-                "languageId": "wado",
-                "version": 1,
-                "text": source,
-            }
-        }),
-    );
-    let _diag = session.read_message();
+    session.open_doc("file:///tmp/lsp_highlight.wado", source);
 
     let id = session.send_request(
         "textDocument/documentHighlight",
@@ -657,9 +621,7 @@ fn lsp_document_highlight_classifies_read_write() {
 #[test]
 fn lsp_unknown_method_returns_error() {
     let mut session = LspSession::start();
-
-    session.send_request("initialize", json!({ "capabilities": {} }));
-    let _init_resp = session.read_message();
+    session.initialize();
 
     let id = session.send_request(
         "textDocument/unknownMethod",
@@ -679,9 +641,7 @@ fn lsp_unknown_method_returns_error() {
 #[test]
 fn lsp_invalid_params_returns_error() {
     let mut session = LspSession::start();
-
-    session.send_request("initialize", json!({ "capabilities": {} }));
-    let _init_resp = session.read_message();
+    session.initialize();
 
     // Send a well-formed request with malformed params (missing required fields).
     let id = session.send_request("textDocument/hover", json!({ "bogus": true }));
@@ -695,58 +655,13 @@ fn lsp_invalid_params_returns_error() {
 
 #[test]
 fn lsp_exit_without_shutdown_returns_nonzero() {
-    let mut child = Command::new(wado_bin())
-        .args(["lsp"])
-        .current_dir(project_root())
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .unwrap();
-
-    let stdin = child.stdin.as_mut().unwrap();
-
-    // Send initialize
-    let init_msg = encode_message(&json!({
-        "jsonrpc": "2.0", "id": 1, "method": "initialize",
-        "params": { "capabilities": {} }
-    }));
-    stdin.write_all(&init_msg).unwrap();
-    stdin.flush().unwrap();
-
-    // Read initialize response (consume it)
-    let stdout = child.stdout.as_mut().unwrap();
-    let mut header_buf = Vec::new();
-    let mut byte = [0u8; 1];
-    loop {
-        stdout.read_exact(&mut byte).unwrap();
-        header_buf.push(byte[0]);
-        if header_buf.ends_with(b"\r\n\r\n") {
-            break;
-        }
-    }
-    let header = std::str::from_utf8(&header_buf).unwrap();
-    let length: usize = header
-        .lines()
-        .find_map(|l| l.strip_prefix("Content-Length: "))
-        .unwrap()
-        .trim()
-        .parse()
-        .unwrap();
-    let mut body = vec![0u8; length];
-    stdout.read_exact(&mut body).unwrap();
-
-    // Send exit without shutdown
-    let exit_msg = encode_message(&json!({
-        "jsonrpc": "2.0", "method": "exit", "params": null
-    }));
-    stdin.write_all(&exit_msg).unwrap();
-    stdin.flush().unwrap();
-
-    drop(child.stdin.take());
-    let status = child.wait().unwrap();
+    // Per LSP 3.18 §exit: an `exit` notification without a preceding
+    // `shutdown` request must terminate the server with a non-zero code.
+    let mut session = LspSession::start();
+    session.send_request("initialize", json!({ "capabilities": {} }));
+    let _init = session.read_message();
     assert_eq!(
-        status.code().unwrap(),
+        session.exit_now(),
         1,
         "exit without shutdown should return 1"
     );
@@ -822,9 +737,7 @@ fn lsp_initialized_notification_is_accepted() {
     let resp = session.read_message();
     assert_eq!(resp["id"], id);
     assert_eq!(resp["result"], Value::Null);
-    session.send_notification("exit", Value::Null);
-    drop(session.child.stdin.take());
-    assert_eq!(session.child.wait().unwrap().code().unwrap(), 0);
+    assert_eq!(session.exit_now(), 0);
 }
 
 #[test]
@@ -840,9 +753,7 @@ fn lsp_dollar_notification_is_silently_ignored() {
     let resp = session.read_message();
     assert_eq!(resp["id"], id);
     assert_eq!(resp["result"], Value::Null);
-    session.send_notification("exit", Value::Null);
-    drop(session.child.stdin.take());
-    assert_eq!(session.child.wait().unwrap().code().unwrap(), 0);
+    assert_eq!(session.exit_now(), 0);
 }
 
 #[test]
@@ -870,9 +781,7 @@ fn lsp_unknown_notification_is_silently_ignored() {
     let id = session.send_request("shutdown", Value::Null);
     let resp = session.read_message();
     assert_eq!(resp["id"], id);
-    session.send_notification("exit", Value::Null);
-    drop(session.child.stdin.take());
-    assert_eq!(session.child.wait().unwrap().code().unwrap(), 0);
+    assert_eq!(session.exit_now(), 0);
 }
 
 #[test]
@@ -957,9 +866,7 @@ fn lsp_shutdown_returns_null_result() {
     // Spec §shutdown: the response result is `null`.
     assert_eq!(resp["result"], Value::Null);
     // Exit with shutdown flag set → exit code 0.
-    session.send_notification("exit", Value::Null);
-    drop(session.child.stdin.take());
-    assert_eq!(session.child.wait().unwrap().code().unwrap(), 0);
+    assert_eq!(session.exit_now(), 0);
 }
 
 #[test]
@@ -1027,9 +934,7 @@ fn lsp_did_change_empty_content_changes_is_noop() {
     let id = session.send_request("shutdown", Value::Null);
     let resp = session.read_message();
     assert_eq!(resp["id"], id);
-    session.send_notification("exit", Value::Null);
-    drop(session.child.stdin.take());
-    assert_eq!(session.child.wait().unwrap().code().unwrap(), 0);
+    assert_eq!(session.exit_now(), 0);
 }
 
 #[test]
@@ -1298,9 +1203,7 @@ fn lsp_request_before_initialize_returns_server_not_initialized() {
     // Cannot `shutdown` gracefully here — that would also be rejected with
     // ServerNotInitialized. Send `exit` directly; per spec this is allowed
     // before `initialize` and must exit non-zero when no shutdown was seen.
-    session.send_notification("exit", Value::Null);
-    drop(session.child.stdin.take());
-    assert_eq!(session.child.wait().unwrap().code().unwrap(), 1);
+    assert_eq!(session.exit_now(), 1);
 }
 
 #[test]
@@ -1398,9 +1301,7 @@ fn lsp_notification_after_shutdown_is_silently_dropped() {
     assert_eq!(resp["error"]["code"], -32600);
     let _ = id_shut;
 
-    session.send_notification("exit", Value::Null);
-    drop(session.child.stdin.take());
-    assert_eq!(session.child.wait().unwrap().code().unwrap(), 0);
+    assert_eq!(session.exit_now(), 0);
 }
 
 #[test]

--- a/wado-cli/tests/manifest_integration.rs
+++ b/wado-cli/tests/manifest_integration.rs
@@ -2,13 +2,9 @@
 
 use predicates::prelude::*;
 use std::fs;
-use std::process::Command;
 
-fn wado_in(dir: &std::path::Path) -> assert_cmd::Command {
-    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("wado"));
-    cmd.current_dir(dir);
-    cmd.into()
-}
+mod common;
+use common::wado_in;
 
 #[test]
 fn test_init_creates_manifest() {

--- a/wado-cli/tests/serve.rs
+++ b/wado-cli/tests/serve.rs
@@ -13,12 +13,8 @@ use std::process::{Child, Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-fn project_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .unwrap()
-        .to_path_buf()
-}
+mod common;
+use common::{project_root, wado_bin};
 
 fn fixture_path(name: &str) -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -70,7 +66,7 @@ fn start_serve(fixture: &str, extra_args: &[&str]) -> (ServerGuard, u16, Arc<Mut
     let port = free_port();
     let addr = format!("127.0.0.1:{port}");
 
-    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("wado"));
+    let mut cmd = Command::new(wado_bin());
     cmd.current_dir(project_root())
         .arg("serve")
         .arg("--addr")

--- a/wado-cli/tests/serve.rs
+++ b/wado-cli/tests/serve.rs
@@ -62,6 +62,11 @@ impl Drop for ServerGuard {
 /// stderr is drained on a background thread so the child never blocks on a
 /// full pipe; the captured text is also used for assertions on shutdown
 /// messages.
+//
+// `clippy::zombie_processes` flags `cmd.spawn()` returning a `Child` that
+// isn't `wait()`-ed on every code path, but `ServerGuard::drop` reliably
+// calls `kill()` + `wait()` — clippy doesn't see across the type boundary.
+#[allow(clippy::zombie_processes)]
 fn start_serve(fixture: &str, extra_args: &[&str]) -> (ServerGuard, u16, Arc<Mutex<String>>) {
     let port = free_port();
     let addr = format!("127.0.0.1:{port}");


### PR DESCRIPTION
Addresses review findings on the wado-cli integration test suite (8 files / 4,766 LOC / 217 tests) on three axes: harness robustness, maintainability, and execution clarity.

## Robustness

- **Add a 30s timeout to `LspSession::read_message`.** stdout is now drained on a background thread and queued onto an mpsc channel; reads go through `recv_timeout`. A regression that stops the LSP from emitting frames now fails fast with the captured stderr instead of hanging until cargo's outer timeout.
- **Move `cli.rs` compile-output tests off fixed `std::env::temp_dir().join("test_compile_*.wasm")` paths to `tempfile::tempdir()`.** Eliminates filename collisions across parallel/concurrent runs and panic-leak of artifacts. The four affected tests are `test_compile_output_wasm`, `test_compile_output_wat`, `test_compile_format_wat`, `test_compile_format_wasm`.

## Maintainability

- **New `wado-cli/tests/common.rs`** consolidates the `project_root` / `wado` / `wado_in` / `wado_bin` / `runtime` helpers that were duplicated across five test files (`cli.rs`, `gale_cli.rs`, `lsp.rs`, `serve.rs`, `kiln_compile.rs`, `kiln_pipeline.rs`, `manifest_integration.rs`). Follows the existing `wado-compiler/tests/common.rs` convention required by the `mod_module_files = "deny"` workspace lint.
- **Refactor LSP tests to use the existing `LspSession::initialize` / `open_doc` / `shutdown_and_exit` helpers** plus a new `exit_now` helper for lifecycle-violation tests (e.g. `exit` without a preceding `shutdown`). Removes the hand-rolled child-spawn duplication in `lsp_exit_without_shutdown_returns_nonzero`. `lsp.rs` shrinks from 1,876 to 1,591 LOC with no behaviour change.

## Drive-by

- **Fix three lints introduced in clippy 1.95** that flagged previously-passing code:
  - `assigning_clones` in `wado-cli/src/kiln_provider.rs` → `clone_from`.
  - `useless_conversion` in `wado-cli/src/timezone_host.rs` → kept `try_into` for portability (32-bit `time_t`) with `#[allow]` + comment.
  - `zombie_processes` in `wado-cli/tests/serve.rs::start_serve` → false positive: `ServerGuard::drop` calls `kill()` + `wait()`. `#[allow]` + comment.

All 217 wado-cli tests pass; `cargo clippy --tests -p wado-cli -- -D warnings` is clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCyNyvkex1iKK77sbPqnvL)_