### PR TITLE
refactor(test): tidy export-name parsing, error flow, and per-module Linker

### DIFF
--- a/wado-cli/src/test.rs
+++ b/wado-cli/src/test.rs
@@ -498,54 +498,70 @@ struct TestResult {
     duration: Duration,
 }
 
-/// Parse per-test timeout from export name.
-///
-/// Export names with custom timeout contain a `tm{N}` segment:
-/// - `test-tm2000-0-name` → `Some(2000)`
-/// - `test-trap-tm500-0-name` → `Some(500)`
-/// - `test-0-name` → `None` (use default)
-fn parse_timeout_ms(test_name: &str) -> Option<u64> {
-    let rest = test_name
-        .strip_prefix("test-trap-")
-        .or_else(|| test_name.strip_prefix("test-todo-"))
-        .or_else(|| test_name.strip_prefix("test-"))?;
-    let rest = rest.strip_prefix("tm")?;
-    let end = rest.find('-')?;
-    rest[..end].parse::<u64>().ok()
+/// Kind of test, parsed from the export name prefix.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum TestKind {
+    Normal,
+    ExpectTrap,
+    Todo,
 }
 
-/// Strip the `tm{N}-` segment from the name part for display purposes.
-fn strip_timeout_segment(name_part: &str) -> &str {
-    if let Some(rest) = name_part.strip_prefix("tm")
-        && let Some(idx) = rest.find('-')
-    {
-        return &rest[idx + 1..];
-    }
-    name_part
+/// Parsed test export name.
+///
+/// Export names follow the format `test-(trap-|todo-)?(tm{N}-)?{index}(-{name})?`
+/// emitted by the compiler when targeting the `test` world.
+#[derive(Debug, PartialEq, Eq)]
+struct TestExportName {
+    kind: TestKind,
+    timeout_ms: Option<u64>,
+    /// Human-readable display: the `name` segment with `-` → `_`,
+    /// or `<test {index}>` when no name was provided.
+    display: String,
 }
 
-/// Extract display name from test export name.
+/// Parse a `test-…` component export into its kind, timeout, and display name.
 ///
-/// - `test-0-simple` → `"simple"`
-/// - `test-1` → `"<test 1>"`
-/// - `test-trap-0-panics` → `"panics"` (`expect_trap` tests use the same display convention)
-/// - `test-trap-3` → `"<test 3>"`
-/// - `test-todo-0-not-yet` → `"not_yet"` (`TODO` tests use the same display convention)
-/// - `test-todo-2` → `"<test 2>"`
-fn extract_display_name(test_name: &str) -> String {
-    // Strip "test-trap-", "test-todo-", or "test-" prefix to get the "index[-name]" part
-    let name_part = test_name
-        .strip_prefix("test-trap-")
-        .or_else(|| test_name.strip_prefix("test-todo-"))
-        .or_else(|| test_name.strip_prefix("test-"))
-        .unwrap_or(test_name);
-    // Strip optional timeout segment (e.g., "tm2000-")
-    let name_part = strip_timeout_segment(name_part);
-    if let Some(idx) = name_part.find('-') {
-        name_part[idx + 1..].replace('-', "_")
+/// Returns `None` if the name doesn't begin with the `test-` family of prefixes,
+/// so callers can use it both as a filter and as a parser.
+fn parse_test_export(name: &str) -> Option<TestExportName> {
+    let (kind, rest) = if let Some(rest) = name.strip_prefix("test-trap-") {
+        (TestKind::ExpectTrap, rest)
+    } else if let Some(rest) = name.strip_prefix("test-todo-") {
+        (TestKind::Todo, rest)
+    } else if let Some(rest) = name.strip_prefix("test-") {
+        (TestKind::Normal, rest)
     } else {
-        format!("<test {name_part}>")
-    }
+        return None;
+    };
+
+    let (timeout_ms, rest) = parse_timeout_segment(rest);
+
+    let display = match rest.find('-') {
+        Some(idx) => rest[idx + 1..].replace('-', "_"),
+        None => format!("<test {rest}>"),
+    };
+
+    Some(TestExportName {
+        kind,
+        timeout_ms,
+        display,
+    })
+}
+
+/// Strip an optional `tm{N}-` segment, returning the parsed timeout (if any)
+/// and the remainder. A malformed `tm…` (no trailing dash, non-numeric N) is
+/// treated as part of the name rather than a timeout.
+fn parse_timeout_segment(rest: &str) -> (Option<u64>, &str) {
+    let Some(after_tm) = rest.strip_prefix("tm") else {
+        return (None, rest);
+    };
+    let Some(dash) = after_tm.find('-') else {
+        return (None, rest);
+    };
+    let Ok(n) = after_tm[..dash].parse::<u64>() else {
+        return (None, rest);
+    };
+    (Some(n), &after_tm[dash + 1..])
 }
 
 /// A `#![TODO]` module that failed to compile.
@@ -567,7 +583,7 @@ enum CompileTaskResult {
         path: String,
         engine: Arc<Engine>,
         component: Arc<Component>,
-        test_names: Vec<String>,
+        tests: Vec<ParsedTest>,
     },
     TodoCompileError(TodoCompileError),
     CompileFailure(CompileFailure),
@@ -619,10 +635,13 @@ async fn compile_one_file(
     println!("[{elapsed}] Compiled {path} ({dur}, loaded in {load_dur})");
 
     let component_ty = component.component_type();
-    let mut test_names: Vec<String> = Vec::new();
+    let mut tests: Vec<ParsedTest> = Vec::new();
     for (name, _) in component_ty.exports(&engine) {
-        if name.starts_with("test-") {
-            test_names.push(name.to_string());
+        if let Some(parsed) = parse_test_export(name) {
+            tests.push(ParsedTest {
+                export_name: name.to_string(),
+                parsed,
+            });
         }
     }
 
@@ -630,8 +649,23 @@ async fn compile_one_file(
         path,
         engine,
         component,
-        test_names,
+        tests,
     })
+}
+
+/// One discovered test export, paired with its raw export name.
+struct ParsedTest {
+    export_name: String,
+    parsed: TestExportName,
+}
+
+/// Aggregate output of [`collect_test_jobs`]: every per-file outcome from
+/// Phase 1 sorted into the bucket the runner needs for Phase 2 + reporting.
+struct CollectedTests {
+    modules: Vec<Arc<CompiledTestModule>>,
+    jobs: Vec<TestJob>,
+    todo_compile_errors: Vec<TodoCompileError>,
+    compile_failures: Vec<CompileFailure>,
 }
 
 /// Phase 1: Compile all test files and collect test jobs.
@@ -644,12 +678,7 @@ async fn collect_test_jobs(
     flags: Arc<CompileFlags>,
     parallelism: usize,
     overall_start: Instant,
-) -> Result<(
-    Vec<Arc<CompiledTestModule>>,
-    Vec<TestJob>,
-    Vec<TodoCompileError>,
-    Vec<CompileFailure>,
-)> {
+) -> Result<CollectedTests> {
     // The compile future borrows `Cell`/`RefCell` internals (non-Send), so we
     // can't `tokio::spawn` it onto the multi-thread runtime. Instead, hop each
     // file onto the blocking pool and drive it on a per-thread current-thread
@@ -682,20 +711,21 @@ async fn collect_test_jobs(
                 path,
                 engine,
                 component,
-                test_names,
+                tests,
             } => {
                 let module_idx = modules.len();
-                for test_name in &test_names {
-                    let expect_trap = test_name.starts_with("test-trap-");
-                    let is_todo = test_name.starts_with("test-todo-");
-                    let timeout_ms = parse_timeout_ms(test_name).unwrap_or(DEFAULT_TIMEOUT_MS);
+                for ParsedTest {
+                    export_name,
+                    parsed,
+                } in tests
+                {
                     jobs.push(TestJob {
                         module_idx,
-                        test_name: test_name.clone(),
-                        display_name: extract_display_name(test_name),
-                        expect_trap,
-                        is_todo,
-                        timeout_ms,
+                        test_name: export_name,
+                        display_name: parsed.display,
+                        expect_trap: parsed.kind == TestKind::ExpectTrap,
+                        is_todo: parsed.kind == TestKind::Todo,
+                        timeout_ms: parsed.timeout_ms.unwrap_or(DEFAULT_TIMEOUT_MS),
                     });
                 }
                 modules.push(Arc::new(CompiledTestModule {
@@ -709,7 +739,12 @@ async fn collect_test_jobs(
         }
     }
 
-    Ok((modules, jobs, todo_compile_errors, compile_failures))
+    Ok(CollectedTests {
+        modules,
+        jobs,
+        todo_compile_errors,
+        compile_failures,
+    })
 }
 
 /// Build a `TestResult` for a setup-time failure (store/linker/instance/etc.).
@@ -1126,21 +1161,19 @@ async fn run_one_package(
     preopened_dirs: Arc<Vec<(String, String)>>,
     overall_start: Instant,
     show_banner: bool,
-) -> PackageTotals {
+) -> Result<PackageTotals> {
     if show_banner {
         println!();
         println!("=== package: {} ===", pkg_run.label);
     }
 
     // Phase 1: Compile all files and collect test jobs
-    let (modules, jobs, todo_compile_errors, compile_failures) =
-        match collect_test_jobs(&pkg_run.paths, flags, parallelism, overall_start).await {
-            Ok(result) => result,
-            Err(e) => {
-                eprintln!("Error collecting tests: {e}");
-                process::exit(1);
-            }
-        };
+    let CollectedTests {
+        modules,
+        jobs,
+        todo_compile_errors,
+        compile_failures,
+    } = collect_test_jobs(&pkg_run.paths, flags, parallelism, overall_start).await?;
 
     // `compile_ok` counts every file whose compilation finished without a
     // non-TODO error. `#![TODO]` modules whose expected compile error fired
@@ -1159,7 +1192,7 @@ async fn run_one_package(
         };
         println!();
         print_three_axis(&totals, None);
-        return totals;
+        return Ok(totals);
     }
 
     // Phase 2: Execute tests in parallel
@@ -1198,7 +1231,7 @@ async fn run_one_package(
     println!();
     print_three_axis(&totals, None);
 
-    totals
+    Ok(totals)
 }
 
 pub async fn run(opts: TestOptions) {
@@ -1211,7 +1244,7 @@ pub async fn run(opts: TestOptions) {
 
     let mut grand = PackageTotals::default();
     for pkg_run in &package_runs {
-        let totals = run_one_package(
+        match run_one_package(
             pkg_run,
             Arc::clone(&flags),
             jobs,
@@ -1219,8 +1252,14 @@ pub async fn run(opts: TestOptions) {
             overall_start,
             multi_pkg,
         )
-        .await;
-        grand.merge(&totals);
+        .await
+        {
+            Ok(totals) => grand.merge(&totals),
+            Err(e) => {
+                eprintln!("Error collecting tests: {e}");
+                process::exit(1);
+            }
+        }
     }
 
     let total_dur = format_duration(overall_start.elapsed());
@@ -1241,24 +1280,51 @@ pub async fn run(opts: TestOptions) {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_parse_timeout_ms() {
-        assert_eq!(parse_timeout_ms("test-tm2000-0-slow"), Some(2000));
-        assert_eq!(parse_timeout_ms("test-trap-tm500-0-panics"), Some(500));
-        assert_eq!(parse_timeout_ms("test-todo-tm3000-1"), Some(3000));
-        assert_eq!(parse_timeout_ms("test-0-simple"), None);
-        assert_eq!(parse_timeout_ms("test-trap-0-panics"), None);
-        assert_eq!(parse_timeout_ms("test-todo-2"), None);
+    fn parse(name: &str) -> TestExportName {
+        parse_test_export(name).unwrap_or_else(|| panic!("expected `test-` prefix in {name:?}"))
     }
 
     #[test]
-    fn test_extract_display_name_with_timeout() {
-        assert_eq!(extract_display_name("test-tm2000-0-slow"), "slow");
-        assert_eq!(extract_display_name("test-trap-tm500-0-panics"), "panics");
-        assert_eq!(extract_display_name("test-todo-tm3000-1"), "<test 1>");
-        // Existing behavior preserved
-        assert_eq!(extract_display_name("test-0-simple"), "simple");
-        assert_eq!(extract_display_name("test-trap-0-panics"), "panics");
-        assert_eq!(extract_display_name("test-1"), "<test 1>");
+    fn parses_kind() {
+        assert_eq!(parse("test-0-simple").kind, TestKind::Normal);
+        assert_eq!(parse("test-trap-0-panics").kind, TestKind::ExpectTrap);
+        assert_eq!(parse("test-todo-1").kind, TestKind::Todo);
+    }
+
+    #[test]
+    fn parses_timeout() {
+        assert_eq!(parse("test-tm2000-0-slow").timeout_ms, Some(2000));
+        assert_eq!(parse("test-trap-tm500-0-panics").timeout_ms, Some(500));
+        assert_eq!(parse("test-todo-tm3000-1").timeout_ms, Some(3000));
+        assert_eq!(parse("test-0-simple").timeout_ms, None);
+        assert_eq!(parse("test-trap-0-panics").timeout_ms, None);
+        assert_eq!(parse("test-todo-2").timeout_ms, None);
+    }
+
+    #[test]
+    fn parses_display_name() {
+        assert_eq!(parse("test-0-simple").display, "simple");
+        assert_eq!(parse("test-trap-0-panics").display, "panics");
+        assert_eq!(parse("test-todo-0-not-yet").display, "not_yet");
+        assert_eq!(parse("test-tm2000-0-slow").display, "slow");
+        assert_eq!(parse("test-trap-tm500-0-panics").display, "panics");
+        assert_eq!(parse("test-1").display, "<test 1>");
+        assert_eq!(parse("test-trap-3").display, "<test 3>");
+        assert_eq!(parse("test-todo-tm3000-1").display, "<test 1>");
+    }
+
+    #[test]
+    fn rejects_non_test_exports() {
+        assert!(parse_test_export("foo").is_none());
+        assert!(parse_test_export("testfoo").is_none());
+    }
+
+    #[test]
+    fn malformed_timeout_segment_is_kept_as_name() {
+        // `tm` not followed by digits-then-dash should fall through into the
+        // index/name branch instead of being silently swallowed as a timeout.
+        let parsed = parse("test-tmfoo-0-x");
+        assert_eq!(parsed.timeout_ms, None);
+        assert_eq!(parsed.display, "0_x");
     }
 }

--- a/wado-cli/src/test.rs
+++ b/wado-cli/src/test.rs
@@ -12,13 +12,13 @@ use lexopt::Arg::Value;
 use tokio::sync::mpsc;
 use wado_compiler::hashmap::IndexMap;
 use wasmtime::Engine;
-use wasmtime::component::Component;
+use wasmtime::component::{Component, Linker};
 
 use crate::args::{self, CliExit};
 use crate::compile::{self, CompileFlags, OptLevel};
 use crate::discover;
 use crate::manifest as project_manifest;
-use crate::runtime;
+use crate::runtime::{self, WasiState};
 use wado_compiler::LogLevel;
 
 const DEFAULT_TIMEOUT_MS: u64 = 5000;
@@ -457,11 +457,16 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<TestOptions, CliExit> {
     })
 }
 
-/// A compiled test module ready for parallel execution
+/// A compiled test module ready for parallel execution.
+///
+/// The `Linker` is built once per engine alongside compilation; every test
+/// in the module instantiates against the same linker so the WASI binding
+/// registration (`p3::add_to_linker` × 4) is paid once instead of per-test.
 struct CompiledTestModule {
     path: String,
     engine: Arc<Engine>,
     component: Arc<Component>,
+    linker: Arc<Linker<WasiState>>,
 }
 
 /// A single test job to execute
@@ -583,6 +588,7 @@ enum CompileTaskResult {
         path: String,
         engine: Arc<Engine>,
         component: Arc<Component>,
+        linker: Arc<Linker<WasiState>>,
         tests: Vec<ParsedTest>,
     },
     TodoCompileError(TodoCompileError),
@@ -628,6 +634,11 @@ async fn compile_one_file(
     let load_start = Instant::now();
     let engine = Arc::new(runtime::create_test_engine(flags.opt_level.to_wasmtime())?);
     let component = Arc::new(Component::new(&engine, &compile_result.wasm)?);
+    // Build the linker once per module: WASI P3 import registration is
+    // non-trivial and would otherwise repeat for every `run_single_test`
+    // call. Sharing a single linker across all tests in this module is
+    // safe — `instantiate_async` only borrows the linker.
+    let linker = Arc::new(runtime::create_linker(&engine)?);
     let load_duration = load_start.elapsed();
 
     let dur = format_duration(compile_duration);
@@ -649,6 +660,7 @@ async fn compile_one_file(
         path,
         engine,
         component,
+        linker,
         tests,
     })
 }
@@ -711,6 +723,7 @@ async fn collect_test_jobs(
                 path,
                 engine,
                 component,
+                linker,
                 tests,
             } => {
                 let module_idx = modules.len();
@@ -732,6 +745,7 @@ async fn collect_test_jobs(
                     path,
                     engine,
                     component,
+                    linker,
                 }));
             }
             CompileTaskResult::TodoCompileError(e) => todo_compile_errors.push(e),
@@ -780,12 +794,8 @@ async fn run_single_test(
     let deadline_ticks = (job.timeout_ms / EPOCH_INTERVAL_MS).max(1);
     store.set_epoch_deadline(deadline_ticks);
 
-    let linker = match runtime::create_linker(&module.engine) {
-        Ok(l) => l,
-        Err(e) => return fail_result(module, job, format!("failed to set up linker: {e}"), start),
-    };
-
-    let instance = match linker
+    let instance = match module
+        .linker
         .instantiate_async(&mut store, &module.component)
         .await
     {

--- a/wado-cli/src/test.rs
+++ b/wado-cli/src/test.rs
@@ -513,8 +513,14 @@ enum TestKind {
 
 /// Parsed test export name.
 ///
-/// Export names follow the format `test-(trap-|todo-)?(tm{N}-)?{index}(-{name})?`
-/// emitted by the compiler when targeting the `test` world.
+/// The compiler emits names of the shape
+/// `test-(trap-|todo-)?(tm{N}-)?{index}(-{name})?` when targeting the
+/// `test` world. The parser is intentionally tolerant of two edges so a
+/// stray name doesn't drop a test from the run:
+/// - a `tm…-` prefix that doesn't have a parseable `u64` (e.g. `tmfoo-…`)
+///   falls through into the index/name branch instead of being rejected;
+/// - a trailing dash with no name segment (`test-0-`) is treated as
+///   "no name provided" and rendered as `<test {index}>`.
 #[derive(Debug, PartialEq, Eq)]
 struct TestExportName {
     kind: TestKind,
@@ -542,7 +548,11 @@ fn parse_test_export(name: &str) -> Option<TestExportName> {
     let (timeout_ms, rest) = parse_timeout_segment(rest);
 
     let display = match rest.find('-') {
-        Some(idx) => rest[idx + 1..].replace('-', "_"),
+        Some(idx) if idx + 1 < rest.len() => rest[idx + 1..].replace('-', "_"),
+        // No `-` at all, or a trailing `-` with no name segment: fall
+        // back to the bare-index display so we never produce an empty
+        // string.
+        Some(idx) => format!("<test {}>", &rest[..idx]),
         None => format!("<test {rest}>"),
     };
 
@@ -631,15 +641,31 @@ async fn compile_one_file(
         }
     };
 
+    // Engine, Component, and Linker setup are grouped: the linker is
+    // built here (once per module) so WASI P3 import registration is
+    // not redone in every `run_single_test`, and the linker can be
+    // shared across all tests because `instantiate_async` only borrows
+    // it. A failure in any of the three is reported as a per-file
+    // `CompileFailure` instead of aborting the whole package run, so a
+    // single bad module doesn't prevent the rest from being tested.
     let load_start = Instant::now();
-    let engine = Arc::new(runtime::create_test_engine(flags.opt_level.to_wasmtime())?);
-    let component = Arc::new(Component::new(&engine, &compile_result.wasm)?);
-    // Build the linker once per module: WASI P3 import registration is
-    // non-trivial and would otherwise repeat for every `run_single_test`
-    // call. Sharing a single linker across all tests in this module is
-    // safe — `instantiate_async` only borrows the linker.
-    let linker = Arc::new(runtime::create_linker(&engine)?);
+    let load_result: Result<_> = (|| {
+        let engine = Arc::new(runtime::create_test_engine(flags.opt_level.to_wasmtime())?);
+        let component = Arc::new(Component::new(&engine, &compile_result.wasm)?);
+        let linker = Arc::new(runtime::create_linker(&engine)?);
+        Ok((engine, component, linker))
+    })();
     let load_duration = load_start.elapsed();
+
+    let (engine, component, linker) = match load_result {
+        Ok(t) => t,
+        Err(e) => {
+            let dur = format_duration(compile_duration);
+            let load_dur = format_duration(load_duration);
+            eprintln!("[{elapsed}] FAILED to load {path} ({dur}, load attempt {load_dur}): {e}");
+            return Ok(CompileTaskResult::CompileFailure(CompileFailure { path }));
+        }
+    };
 
     let dur = format_duration(compile_duration);
     let load_dur = format_duration(load_duration);
@@ -1336,5 +1362,14 @@ mod tests {
         let parsed = parse("test-tmfoo-0-x");
         assert_eq!(parsed.timeout_ms, None);
         assert_eq!(parsed.display, "0_x");
+    }
+
+    #[test]
+    fn trailing_dash_falls_back_to_index_form() {
+        // Empty post-dash segment shouldn't render as an empty display
+        // string — fall back to the bare-index form.
+        assert_eq!(parse("test-0-").display, "<test 0>");
+        assert_eq!(parse("test-trap-3-").display, "<test 3>");
+        assert_eq!(parse("test-tm2000-0-").display, "<test 0>");
     }
 }


### PR DESCRIPTION
`wado-cli/src/test.rs` had accumulated three sets of ad-hoc extensions. This branch tidies them in place without splitting the file (kept for a follow-up).

## What changes

**Test export-name parsing.** `parse_timeout_ms`, `strip_timeout_segment`, `extract_display_name`, and the `starts_with("test-trap-")` / `"test-todo-"` checks inside `collect_test_jobs` are collapsed into a single `parse_test_export()` returning `TestExportName { kind, timeout_ms, display }`. Each component export is now parsed exactly once. As a side effect, malformed `tm…-` segments are no longer silently swallowed as timeouts — the old `parse_timeout_ms` and `extract_display_name` disagreed on this edge, the new parser is consistent.

**Error flow.** `run_one_package` no longer calls `process::exit(1)` on a `collect_test_jobs` failure; it returns `Result<PackageTotals>` and the top-level `run()` owns the print + exit decision alongside the existing failed-tests path. `collect_test_jobs` returns a `CollectedTests` struct in place of the previous 4-tuple.

**Wasmtime Linker reuse.** `runtime::create_linker` is now invoked once per module in Phase 1 and stored on `CompiledTestModule`. `run_single_test` no longer rebuilds it for every test job, so the WASI P3 / HTTP / TLS / timezone bindings (≈ 4× `add_to_linker`) are registered once per file instead of once per test.

Parser unit tests are refreshed to cover kind / timeout / display name plus the malformed-timeout edge.

## Performance

Measured with `time ./target/debug/wado test` at the repo root on a 4-core machine (default `jobs = (cpus/2).max(2) = 2`):

|             | Wall    | User CPU |
|-------------|---------|----------|
| Baseline    | 6m55.4s | 13m19.6s |
| This branch | 4m52.3s | 11m05.9s |

The wall delta overstates the isolated Linker-reuse contribution: the second run benefited from a warm OS page cache and cranelift caches (one 38.6s `sqlite_highlight.wado` compile shrank to 4.3s on rerun, which the Linker change cannot explain). The pure Linker-reuse effect is on the order of seconds; the rest of the gap is cache warmth. The change is still worth keeping because Phase 2 no longer redoes O(tests) bytecode-import registration, so the per-test floor goes down on every machine.

## Follow-ups (not in this PR)

- Split `test.rs` into a `test/` submodule (`args.rs` / `discover.rs` / `naming.rs` / `compile.rs` / `exec.rs` / `report.rs`).
- Lock-free Phase 2 job queue (`AtomicUsize` index instead of `Mutex<IntoIter>`).
- Reuse the `tokio` current-thread runtime in Phase 1 rather than building a fresh one per file.
- Engine pooling (one Engine per `(opt_level, allocator, world, …)` config). Since allocator/world can vary per file, this needs the engine decision to move from "create up front" to "after compile, look up from a pool".

https://claude.ai/code/session_01Xx1cjVtXaMLxF2EoSpeWyt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xx1cjVtXaMLxF2EoSpeWyt)_