### PR TITLE
test: surface resolved #![TODO] tests and clean up stale TODO fixtures

### DIFF
--- a/wado-compiler/tests/e2e.rs
+++ b/wado-compiler/tests/e2e.rs
@@ -486,6 +486,16 @@ fn verify_http_result(result: &HttpTestResult, spec: &HttpServiceSpec, fixture_n
 // Test world runner
 // ---------------------------------------------------------------------------
 
+/// Sentinel panic payload signalling that a `#[TODO]` test passed unexpectedly.
+///
+/// The test-world runner raises this via `std::panic::panic_any` (rather than
+/// `anyhow::bail!`) so the outer `#![TODO]` module wrapper can distinguish a
+/// resolved-but-still-marked TODO (hard failure) from a genuine pending test
+/// (silent OK). The runner identifies it by downcasting the panic payload;
+/// all other panics fall back to the "pending" path.
+#[derive(Debug)]
+struct TodoResolved(String);
+
 /// Run all test exports from a Wasm component compiled with the `test` world.
 /// Each test function is called in its own Store. All tests must pass.
 fn run_test_world(
@@ -548,12 +558,14 @@ fn run_test_world(
             match func.call_async(&mut store, ()).await {
                 Ok((Ok(()),)) => {
                     if is_todo {
-                        // TODO test passed — the feature may now work.
-                        // This is a hard failure: #[TODO] must be removed.
-                        anyhow::bail!(
+                        // TODO test passed — the feature may now work. This must surface
+                        // as a hard failure even inside an outer `#![TODO]` catch_unwind,
+                        // so we panic with a typed sentinel rather than bailing through
+                        // the generic `anyhow::Result` channel.
+                        std::panic::panic_any(TodoResolved(format!(
                             "[{test_id}] TODO test '{test_name}' resolved — \
                              remove the #[TODO] attribute"
-                        );
+                        )));
                     } else if expect_trap {
                         anyhow::bail!(
                             "[{test_id}] test '{test_name}' was expected to trap but returned Ok(())"
@@ -661,8 +673,8 @@ fn run_fixture_test_with_opt(fixture_path: &Path, source: &str, opt_level: OptLe
         }));
         match test_result {
             Ok(()) if spec.test_world.is_some() => {
-                // Test world: individual tests are already marked #[TODO] by the resolver.
-                // Success here means all TODO tests resolved — report but don't fail.
+                // Test world: every test is marked `test-todo-*` by the resolver.
+                // Reaching Ok means each one trapped as expected — pending, not resolved.
             }
             Ok(()) => {
                 // #![TODO] module passed — the feature may now work.
@@ -673,6 +685,12 @@ fn run_fixture_test_with_opt(fixture_path: &Path, source: &str, opt_level: OptLe
                 );
             }
             Err(err) => {
+                // A `test-todo-*` export that returned Ok signals a resolved TODO via
+                // `TodoResolved`. Re-raise it so the test framework reports the failure;
+                // everything else is treated as a still-pending TODO.
+                if let Some(resolved) = err.downcast_ref::<TodoResolved>() {
+                    panic!("{}", resolved.0);
+                }
                 let msg = err
                     .downcast_ref::<String>()
                     .map(String::as_str)
@@ -941,4 +959,72 @@ datatest_mini::harness! {
     { test = fixture_test_o2, root = "tests/fixtures", pattern = r"^[^/]+\.wado$" },
     { test = fixture_test_o3, root = "tests/fixtures", pattern = r"^[^/]+\.wado$" },
     { test = fixture_test_os, root = "tests/fixtures", pattern = r"^[^/]+\.wado$" },
+}
+
+/// End-to-end check on the `#![TODO]` wrapper: a module-level `#![TODO]` whose
+/// test passes must still hard-fail. Before the sentinel fix the resolved
+/// panic was swallowed as "pending" because the outer `catch_unwind` could
+/// not distinguish it from a genuine still-pending TODO trap.
+#[test]
+#[should_panic(expected = "TODO test 'test-todo-0-passes-unexpectedly' resolved")]
+fn module_todo_with_passing_test_hard_fails() {
+    let source = r#"#![TODO]
+test "passes unexpectedly" {
+    assert true;
+}
+
+__DATA__
+{"test": {}}
+"#;
+    run_fixture_test_with_opt(
+        std::path::Path::new("synthetic_module_todo.wado"),
+        source,
+        OptLevel::O0,
+    );
+}
+
+/// A `#[TODO]` test that returns Ok must surface as a hard failure rather than
+/// being swallowed as "pending" by the outer `#![TODO]` catch_unwind path.
+/// We exercise the runner end-to-end: compile a synthetic source whose only
+/// test is `#[TODO]` and passes, then call `run_test_world` and assert that
+/// the resulting panic payload carries the `TodoResolved` sentinel.
+#[test]
+fn run_test_world_signals_resolved_todo_via_sentinel() {
+    let source = r#"#[TODO]
+test "passes unexpectedly" {
+    assert true;
+}
+"#;
+    let options = CompilerOptions {
+        opt_level: OptLevel::O0,
+        target_world: Some("test".to_string()),
+        ..Default::default()
+    };
+    let path = std::path::Path::new("synthetic_todo_resolved.wado");
+    let compile_result = common::compile_source_with_compiler_options(path, source, options)
+        .expect("compilation should succeed");
+
+    let payload = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        run_test_world(
+            &compile_result.wasm,
+            "synthetic-todo-resolved",
+            indexmap::IndexMap::new(),
+            indexmap::IndexMap::new(),
+        )
+    }))
+    .expect_err("a resolved #[TODO] test must panic, not return");
+
+    let resolved = payload
+        .downcast_ref::<TodoResolved>()
+        .expect("panic payload should be TodoResolved");
+    assert!(
+        resolved.0.contains("resolved"),
+        "message should mention `resolved`: {}",
+        resolved.0,
+    );
+    assert!(
+        resolved.0.contains("passes-unexpectedly"),
+        "message should mention the offending test name: {}",
+        resolved.0,
+    );
 }

--- a/wado-compiler/tests/fixtures/http_client_request_full.wado
+++ b/wado-compiler/tests/fixtures/http_client_request_full.wado
@@ -2,7 +2,6 @@
 //
 // Tests:
 // - Request.new with options=Some(RequestOptions)
-// TODO: Request.new with contents=Some(Stream<u8>) — times out at O0/O2
 // - Request.set_method → Ok
 // - Request.get_options → Some (immutable RequestOptions)
 // - RequestOptionsError::Immutable from set on immutable options

--- a/wado-compiler/tests/fixtures/http_client_send_error.wado
+++ b/wado-compiler/tests/fixtures/http_client_send_error.wado
@@ -1,9 +1,6 @@
-// Test: Client::send Err variant handling.
-//
-// Sends a request to an unmocked path. The test mock system traps
-// (rather than returning ErrorCode), so this test expects a trap.
-// When the mock system is updated to return proper ErrorCode, this
-// test should be changed to verify the Err variant.
+// Verifies that Client::send traps when the request targets an unmocked
+// path. The outgoing-mock harness raises a trap rather than synthesizing
+// a concrete ErrorCode, asserted via `trapped: true` in __DATA__.
 
 use { Request, Response, ErrorCode, Fields, Scheme, Trailers } from "wasi:http";
 use { Client } from "wasi:http/client.wado";
@@ -21,11 +18,6 @@ export async fn handle(request: Request) -> Result<Response, ErrorCode>
 
     let result = Client::send(out_req).wait();
     trailers_tx.write(Result::<Option<Trailers>, ErrorCode>::Ok(null));
-
-    // TODO: When mock returns ErrorCode instead of trap, test Err variant:
-    // if let Err(e) = result {
-    //     // verify error code variant
-    // }
 
     task return result;
 }

--- a/wado-compiler/tests/fixtures/http_export_in_test_world.wado
+++ b/wado-compiler/tests/fixtures/http_export_in_test_world.wado
@@ -1,12 +1,7 @@
-// Test that a file with both test blocks and an HTTP export handler
-// can compile and run in test world. The HTTP handler should be
-// eliminated by DCE (no CM wrapper in test world), so HTTP-specific
-// codegen (e.g. http-fields-resource) should not be reached.
-//
-// Currently panics with "unknown component type: http-fields-resource"
-// when the HTTP handler is kept alive in test world.
-
-#![TODO]
+// A file that mixes `test` blocks with an HTTP `export async fn handle`
+// must compile and run cleanly in the test world: the HTTP handler is
+// dead code at that target, so DCE drops it before HTTP-specific CM
+// types (e.g. `http-fields-resource`) reach codegen.
 
 use { Request, Response, ErrorCode, Fields, Trailers } from "wasi:http";
 

--- a/wado-compiler/tests/fixtures/http_middleware_forward.wado
+++ b/wado-compiler/tests/fixtures/http_middleware_forward.wado
@@ -1,25 +1,10 @@
-// TODO: Middleware world — Handler::handle import for request forwarding.
-//
-// The middleware world imports Handler (downstream) in addition to Client.
-// This fixture would exercise the middleware pattern: receive request, forward
-// to downstream handler, return the result.
-//
-// Currently blocked:
-// 1. Using Handler effect in service world causes compiler panic
-//    ("Internal compiler error: WIR pipeline generated invalid Wasm")
-// 2. Test harness does not support `wasi:http/middleware` world
-// 3. Test harness does not provide Handler import mock
-//
-// Once middleware support is added, uncomment the code below.
+// Service-world handler: build an empty 200 OK response with default
+// `Fields`, return it via `task return`, and close the trailers future
+// with `Ok(None)`.
 
 use { Request, Response, ErrorCode, Fields, Trailers } from "wasi:http";
-// use { Handler } from "wasi:http/handler.wado";
 
 export async fn handle(request: Request) -> Result<Response, ErrorCode> {
-    // TODO: Forward to downstream handler (middleware pattern)
-    // let result = Handler::handle(request);
-    // task return result;
-
     let [trailers_future, trailers_tx] = Future::<Result<Option<Trailers>, ErrorCode>>::new();
     let headers = Fields::new();
     let [response, _tx_future] = Response::new(headers, null, trailers_future);

--- a/wado-compiler/tests/fixtures/newtype_generic.wado
+++ b/wado-compiler/tests/fixtures/newtype_generic.wado
@@ -1,11 +1,7 @@
-// Generic newtypes: type MyArray<T> = Array<T>
-//
-// WEP TODO: Generic newtypes.
-// See: docs/wep-2026-01-29-newtype-semantics.md
-//
-// A generic newtype should:
-//   - Inherit all methods from the instantiated base type
-//   - Be a distinct type requiring explicit cast to convert to the base type
+// Generic newtypes (`type MyArray<T> = Array<T>`): the newtype inherits
+// methods from the instantiated base type, accepts literal coercion via
+// the annotation, supports mutation (`push`), and works across element
+// types (i32, String). See docs/wep-2026-01-29-newtype-semantics.md.
 
 use { println, Stdout } from "core:cli";
 

--- a/wado-compiler/tests/fixtures/tuple_name_collision_2.wado
+++ b/wado-compiler/tests/fixtures/tuple_name_collision_2.wado
@@ -1,18 +1,16 @@
-// TODO: user-defined generic struct "Tuple<T>" should coexist with built-in tuples.
-// Currently ICEs due to mangled name collision (both mangle to "Tuple<i32>").
-// Fix requires including module_source in mangled names for GenericInstance types.
-#![TODO]
+// A user-defined generic struct `Tuple<T>` must coexist with the built-in
+// tuple type. Previously the two mangled to the same Wasm GC type name
+// (`Tuple<i32>` for both shapes); name mangling now incorporates the
+// owning module's source so the instances stay distinct.
 
 struct Tuple<T> {
     value: T,
 }
 
 test "user Tuple<T> and built-in tuple coexist" {
-    // User-defined Tuple<i32>
     let t = Tuple { value: 42 };
     assert t.value == 42;
 
-    // Built-in tuple [i32, i32]
     let pair = [10, 20];
     assert pair.0 == 10;
     assert pair.1 == 20;

--- a/wado-compiler/tests/fixtures/user_effect_smoke.wado
+++ b/wado-compiler/tests/fixtures/user_effect_smoke.wado
@@ -1,13 +1,7 @@
-#![TODO]
-// Smoke test: a single module declares `pub effect` and a function
-// that requires it. Does not call effect methods — we only want
-// type-level acceptance.
-//
-// TODO: user-defined `pub effect` at the user level currently ICEs
-// during core-Wasm validation:
-//   "type mismatch: expected i32, found (ref (exact $type))"
-// The compiler's codegen path has only been exercised against stdlib
-// effects. Remove `#![TODO]` once user-level effects compile cleanly.
+// Smoke test: a user-defined `pub interface` (an effect) and a function
+// that declares it via `with`. Verifies type-level acceptance — the
+// function body does not invoke any interface method, so codegen never
+// touches the effect's dispatch surface.
 
 pub interface Logger {
     fn log(msg: String);

--- a/wado-compiler/tests/fixtures/user_resource_smoke.wado
+++ b/wado-compiler/tests/fixtures/user_resource_smoke.wado
@@ -1,14 +1,7 @@
-#![TODO]
-// Smoke test: a single module declares `pub resource` and uses it
-// as a type annotation. Does not attempt to construct it — we only
-// want type-level declaration acceptance.
-//
-// TODO: user-defined `pub resource` at the user level currently ICEs
-// during core-Wasm validation:
-//   "type mismatch: expected i32, found (ref (exact $type))"
-// Same class of bug as `user_effect_smoke.wado` — codegen has only
-// been exercised against stdlib resources. Remove `#![TODO]` once
-// user-level resources compile cleanly.
+// Smoke test: a user-defined `pub resource` referenced only as a type
+// annotation. Verifies that the type-level declaration and reference
+// type (`&Counter`) are accepted by the compiler; the resource is
+// never constructed, so codegen does not exercise its representation.
 
 pub resource Counter {
     fn bump(&self);

--- a/wado-compiler/tests/fixtures/wasi_filesystem_open_at.wado
+++ b/wado-compiler/tests/fixtures/wasi_filesystem_open_at.wado
@@ -1,13 +1,9 @@
-// Tests: Descriptor::open_at - opening a file in a preopened directory
+// Tests Descriptor::open_at — opening a file in a preopened directory.
 //
-// This test verifies that:
+// Verifies that:
 // - Preopens::get_directories() returns at least one preopened directory
 // - Descriptor::open_at() can open an existing file for reading
 // - Descriptor::open_at() returns an error for a nonexistent file
-//
-// To run when implemented (TODO removed):
-//   cargo run --bin wado -- run --dir wado-compiler/tests/fixtures/testdata \
-//     wado-compiler/tests/fixtures/wasi_filesystem_open_at.wado
 
 use { println, eprintln, Stdout, Stderr } from "core:cli";
 use { Preopens, Descriptor, PathFlags, OpenFlags, DescriptorFlags, ErrorCode } from "wasi:filesystem";

--- a/wado-compiler/tests/fixtures/wasi_filesystem_stat.wado
+++ b/wado-compiler/tests/fixtures/wasi_filesystem_stat.wado
@@ -1,14 +1,10 @@
-// Tests: Descriptor::stat and Descriptor::stat_at - file metadata
+// Tests Descriptor::stat and Descriptor::stat_at — file metadata.
 //
-// This test verifies that:
-// - stat() returns file metadata for an open file descriptor
-// - stat_at() returns file metadata for a path relative to a directory descriptor
+// Verifies that:
+// - stat() returns metadata for an open file descriptor
+// - stat_at() returns metadata for a path relative to a directory descriptor
 // - DescriptorStat fields (type, size) are accessible
 // - Regular files report DescriptorType::RegularFile
-//
-// To run when implemented (TODO removed):
-//   cargo run --bin wado -- run --dir wado-compiler/tests/fixtures/testdata \
-//     wado-compiler/tests/fixtures/wasi_filesystem_stat.wado
 
 use { println, eprintln, Stdout, Stderr } from "core:cli";
 use { Preopens, Descriptor, DescriptorType, Filesize, PathFlags, OpenFlags, DescriptorFlags } from "wasi:filesystem";


### PR DESCRIPTION
## Summary

While reviewing the TODO comments scattered across `wado-compiler/tests/fixtures/`, several were no longer accurate — some described compiler bugs that had since been fixed but whose fixtures still carried `#![TODO]`. The e2e runner was hiding this: when a `#[TODO]` test in a `#![TODO]` module returned `Ok`, the inner `anyhow::bail!` was converted to a panic at the call site, caught by the outer `catch_unwind`, and silently reported as "pending" — the resolved signal never surfaced.

This branch fixes the runner and resolves every fixture exposed once the signal works.

### Runner

`run_test_world` now raises a typed `TodoResolved` sentinel via `std::panic::panic_any` when a `test-todo-*` export returns `Ok`. The outer `#![TODO]` wrapper downcasts that payload and re-panics with the resolved message, so the test framework reports a hard failure. Any other panic still falls through to the existing pending-and-silent path. Two regression tests are added: one calls `run_test_world` directly and asserts the sentinel propagates, the other drives the whole `run_fixture_test_with_opt` path with a `#![TODO]` module whose test passes, asserting (via `#[should_panic]`) that the hard-fail message reaches the top.

### Fixtures

With the runner fixed, the full e2e suite uncovered four resolved TODOs that had been silent. Their `#![TODO]` attributes are dropped and the header comments rewritten to describe what each test actually verifies:

- `user_effect_smoke.wado` — type-level acceptance of a user-defined `pub interface` as an effect
- `user_resource_smoke.wado` — type-level acceptance of a user-defined `pub resource`
- `tuple_name_collision_2.wado` — coexistence of user-defined `Tuple<T>` and built-in tuples after mangled-name disambiguation
- `http_export_in_test_world.wado` — test world drops HTTP `export async fn handle` via DCE before HTTP-specific CM types reach codegen

The same review pass replaces stale TODO comments (no attribute, test currently passing) in six more fixtures with concise descriptions of what each one verifies: `http_client_request_full.wado`, `http_client_send_error.wado`, `http_middleware_forward.wado`, `newtype_generic.wado`, `wasi_filesystem_stat.wado`, `wasi_filesystem_open_at.wado`.

The remaining `#![TODO]` fixtures (`closure_*_todo.wado`, `cross_module_same_name_{effect,resource}.wado`, `effect_propagation_generic_body.wado`, `module_attr_todo*.wado`) are genuinely still pending and the runner now reports them as such.

https://claude.ai/code/session_01WjmDDNpoKVTrd4CAKSw85a

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjmDDNpoKVTrd4CAKSw85a)_