### PR TITLE
docs: align value-semantics across spec, cheatsheet, and WEPs

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -669,16 +669,18 @@ let compute = |x: i32| {
 // Struct literal return
 let make_point = |x: i32, y: i32| Point { x, y };
 
-// Capturing outer variables (value semantics - copy)
+// Capturing outer variables: deep copy at closure creation
 let multiplier = 10;
 let scale = |x: i32| x * multiplier;
 
-// Mutable capture: use &mut || to mutate captured variables
+// Shared mutable state: capture a reference (the only types that alias)
 let mut count = 0;
-let inc = &mut || { count += 1; };
+let cref: &mut i32 = &mut count;
+let inc = || { *cref += 1; };
+let get = || *cref;
 inc();
 inc();
-println(`{count}`);  // 2
+assert get() == 2;
 ```
 
 ### Mut Parameters

--- a/docs/research-code-generation.md
+++ b/docs/research-code-generation.md
@@ -404,7 +404,7 @@ impl CodeWriter {
     fn dedent(&mut self) { self.indent -= 1; }
 
     // Block helper: emits opener, runs body indented, emits closer
-    fn block(&mut self, opener: &String, f: fn() with stores[self]) { ... }
+    fn block(&mut self, opener: &String, f: fn()) { ... }
 
     // Unique ID generation (replaces manual counter threading)
     fn next_id(&mut self) -> i32 { ... }

--- a/docs/research-code-generation.md
+++ b/docs/research-code-generation.md
@@ -404,7 +404,7 @@ impl CodeWriter {
     fn dedent(&mut self) { self.indent -= 1; }
 
     // Block helper: emits opener, runs body indented, emits closer
-    fn block(&mut self, opener: &String, f: &mut || with stores[self]) { ... }
+    fn block(&mut self, opener: &String, f: fn() with stores[self]) { ... }
 
     // Unique ID generation (replaces manual counter threading)
     fn next_id(&mut self) -> i32 { ... }
@@ -417,13 +417,13 @@ Usage would look like:
 
 ```wado
 fn gen_lexer_struct(w: &mut CodeWriter) {
-    w.block("struct Lexer {", &mut || {
+    w.block("struct Lexer {", || {
         w.line("chars: Array<char>,");
         w.line("pos: i32,");
     });
     w.blank();
-    w.block("impl Lexer {", &mut || {
-        w.block("fn new(input: &String) -> Lexer {", &mut || {
+    w.block("impl Lexer {", || {
+        w.block("fn new(input: &String) -> Lexer {", || {
             w.line("return Lexer { chars: input.chars().collect(), pos: 0 };");
         });
         // ...
@@ -467,12 +467,12 @@ let s = WadoStruct::new("Lexer")
 w.emit_struct(&s);
 
 // Emit function with builder for signature, writer for body
-w.emit_fn("new", [Param::new("input", "&String")], "Lexer", &mut || {
+w.emit_fn("new", [Param::new("input", "&String")], "Lexer", || {
     w.line("return Lexer { chars: input.chars().collect(), pos: 0 };");
 });
 
 // Complex control flow still uses the writer
-w.block(`if pos >= chars.len() {`, &mut || {
+w.block(`if pos >= chars.len() {`, || {
     w.line(`{fail_action};`);
 });
 ```

--- a/docs/research-rust-reference-semantics.md
+++ b/docs/research-rust-reference-semantics.md
@@ -500,15 +500,15 @@ Wado's closure design is simpler due to GC:
 
 ### Skip (Rust-specific, unnecessary with GC)
 
-| Feature                         | Reason                                                        |
-| ------------------------------- | ------------------------------------------------------------- |
-| Lifetime annotations (`'a`)     | GC manages memory; `stores[...]` handles escape analysis      |
-| Reborrowing                     | `&mut T` is Copy-like in Wado; no uniqueness invariant        |
-| `ref` / `ref mut` in patterns   | No move semantics; pattern matching always copies values      |
-| `Fn`/`FnMut`/`FnOnce` hierarchy | Wado uses `fn(...)` + `&mut \|\|`                             |
-| `into_iter()` (consuming)       | No ownership transfer; one iteration mode suffices            |
-| Temporary lifetime extension    | GC keeps values alive                                         |
-| `&mut T` is non-Copy            | No borrow checker; both `&T` and `&mut T` are freely copyable |
+| Feature                         | Reason                                                                  |
+| ------------------------------- | ----------------------------------------------------------------------- |
+| Lifetime annotations (`'a`)     | GC manages memory; `stores[...]` handles escape analysis                |
+| Reborrowing                     | `&mut T` is Copy-like in Wado; no uniqueness invariant                  |
+| `ref` / `ref mut` in patterns   | No move semantics; pattern matching always copies values                |
+| `Fn`/`FnMut`/`FnOnce` hierarchy | Wado has a single `fn(...)` closure type; share mutation via references |
+| `into_iter()` (consuming)       | No ownership transfer; one iteration mode suffices                      |
+| Temporary lifetime extension    | GC keeps values alive                                                   |
+| `&mut T` is non-Copy            | No borrow checker; both `&T` and `&mut T` are freely copyable           |
 
 ### Open Design Questions
 

--- a/docs/research-rust-reference-semantics.md
+++ b/docs/research-rust-reference-semantics.md
@@ -481,9 +481,9 @@ println!("{}", val);  // OK after last use of c (NLL)
 
 Wado's closure design is simpler due to GC:
 
-- **No `Fn`/`FnMut`/`FnOnce` distinction**: Wado uses `fn(...)` type and `&mut ||` syntax for mutable captures. No ownership-based hierarchy needed.
-- **No `move` keyword**: With value semantics, closures capture by copy (primitives) or by reference (heap types). `&mut ||` explicitly opts into mutable capture.
-- **No uniqueness conflicts**: Multiple closures can capture `&mut` to the same variable without compiler errors. This is a deliberate design choice (no borrow checker).
+- **No `Fn`/`FnMut`/`FnOnce` distinction**: Wado has a single `fn(...)` closure type. Captures are always by deep copy at closure creation, so no Fn/FnMut split is needed to police mutable borrows.
+- **No `move` keyword**: All captures are already by value; there is no alternative mode to opt out of.
+- **No uniqueness conflicts**: Multiple closures can each capture a copy of the same `&mut T` reference value, and writes through any of them are visible to the others (references are the only aliasing types in Wado). This is a deliberate design choice (no borrow checker).
 
 ## Summary: What Wado Should Adopt vs Skip
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -773,14 +773,39 @@ if opt matches { Some(x) && x > 0 } { }  // OK
 
 - **Wasm-GC based**: Garbage collection delegated to runtime
 - **Lifetime inference**: No explicit lifetime annotations required
+- **Value semantics**: Every value is deeply copied on assignment, parameter passing, and return — references (`&T`, `&mut T`) are the only types that share state
 - **Explicit move**: Ownership transfer only when explicitly stated
+
+### Value Semantics
+
+See [WEP: Value Semantics and Reference Stores](./wep-2026-01-12-value-semantics-and-stores.md).
+
+Assignment, parameter passing, and return all perform a deep copy of the value. Primitives, structs, `String`, and `Array<T>` all follow this rule uniformly. The only exceptions are reference types (`&T`, `&mut T`), which alias the underlying value.
+
+```wado
+struct Point { x: i32, y: i32 }
+
+let a = Point { x: 1, y: 2 };
+let b = a;       // b is a deep copy of a
+b.x = 10;        // does not affect a
+assert a.x == 1;
+```
+
+In-place mutation through a parameter binding (field writes, method calls, index writes) operates on the callee's local copy and is not visible to the caller. To allow callee-side mutation, pass a reference explicitly:
+
+```wado
+fn translate(p: &mut Point, dx: i32, dy: i32) {
+    p.x += dx;   // visible to caller (reference)
+    p.y += dy;
+}
+```
 
 ### Move Syntax (not yet implemented)
 
 ```wado
-// Default: copy or reference (depending on type)
+// Default: deep copy (references alias)
 let a = some_value;
-let b = a;          // a is still usable
+let b = a;          // a is still usable; b is a copy
 
 // Explicit move
 let b = move a;     // a is invalidated
@@ -1075,7 +1100,7 @@ fn normalize(mut s: String) -> String {
 }
 ```
 
-The `mut` keyword grants write access to the local parameter binding inside the function. Due to Wado's value semantics for primitives (i32, f64, bool, char, etc.), reassigning a `mut` primitive parameter never affects the caller's variable — primitives are passed as Wasm stack values. For GC-managed reference types (struct, String, Array), reassigning the parameter binding (`p = new_value`) does not affect the caller's variable, but in-place mutations via method calls or field writes (`p.x = ...`) operate on the shared GC object and are visible to the caller.
+The `mut` keyword grants write access to the local parameter binding inside the function. Wado uses value semantics for every parameter: every value is deeply copied when passed to a function, except references (`&T`, `&mut T`) which share state with the caller. This applies uniformly to primitives, structs, `String`, and `Array<T>`. Inside the callee, both reassignment (`p = new_value`) and in-place mutations — field writes (`p.x = ...`), method calls (`s.push_str("!")`, `arr.push(0)`), and index writes (`arr[0] = ...`) — operate on the callee's local copy and are not visible to the caller. To let the callee mutate the caller's value, pass an explicit reference (`&mut p`).
 
 ```wado
 fn countdown(mut n: i32) with Stdout {

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1890,35 +1890,29 @@ let result = compute(4);  // 20
 // Pure closure (no captures)
 let pure = |x: i32| x * 2;
 
-// Capturing outer variables (value semantics - copy)
+// Capturing outer variables: deep copy at closure creation
 let outer = 10;
-let capture = |x: i32| x + outer;  // Captures `outer` by value
+let capture = |x: i32| x + outer;  // outer is copied into the closure
 capture(5);  // Returns 15
 ```
 
-Closures capture variables by value (copy semantics) by default. Use `&mut ||` for mutable capture (see below).
+Closures capture each free variable by deep copy at closure creation time — the same value semantics that applies to assignment, parameter passing, and return (see [Value Semantics](#value-semantics)). The closure body operates on its own copies and cannot write to outer bindings.
 
-Note: `stores[...]` is a separate concept for declaring that a _function_ stores reference _parameters_ beyond the call. It is not yet implemented. See [Reference Storage](#reference-storage-stores) and [`docs/wep-2026-01-12-value-semantics-and-stores.md`](./wep-2026-01-12-value-semantics-and-stores.md).
-
-**Mutable Closures (`&mut ||`):**
-
-`&mut ||` creates a closure that captures variables by mutable reference instead of by value:
+For shared mutable state across closures, capture a reference. References (`&T`, `&mut T`) are the only types in Wado that alias their referent, so the copied reference value still points to the same underlying location:
 
 ```wado
 let mut count = 0;
-let inc = &mut || { count += 1; };
+let cref: &mut i32 = &mut count;
+let inc = || { *cref += 1; };
+let get = || *cref;
 inc();
 inc();
-println(`{count}`);  // 2
-
-// Multiple closures sharing the same mutable variable
-let mut count = 0;
-let inc = &mut || { count += 1; };
-let get = || count;
-inc();
-inc();
-println(`{get()}`);  // 2
+assert get() == 2;   // both closures observe mutation through the shared reference
 ```
+
+There is no special `&mut ||` syntax; closures use the same value semantics as the rest of the language and reach mutable state via references.
+
+Note: `stores[...]` is a separate concept for declaring that a _function_ stores reference _parameters_ beyond the call. It is not yet implemented. See [Reference Storage](#reference-storage-stores) and [`docs/wep-2026-01-12-value-semantics-and-stores.md`](./wep-2026-01-12-value-semantics-and-stores.md).
 
 ### Default Arguments
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1074,7 +1074,7 @@ fn normalize(mut s: String) -> String {
 }
 ```
 
-The `mut` keyword grants write access to the local parameter binding inside the function. Wado uses value semantics for every parameter: every value is deeply copied when passed to a function, except references (`&T`, `&mut T`) which share state with the caller. This applies uniformly to primitives, structs, `String`, and `Array<T>`. Inside the callee, both reassignment (`p = new_value`) and in-place mutations — field writes (`p.x = ...`), method calls (`s.push_str("!")`, `arr.push(0)`), and index writes (`arr[0] = ...`) — operate on the callee's local copy and are not visible to the caller. To let the callee mutate the caller's value, pass an explicit reference (`&mut p`).
+The `mut` keyword grants write access to the local parameter binding inside the function. Wado uses value semantics for every parameter: every value is deeply copied when passed to a function, except references (`&T`, `&mut T`) which share state with the caller. This applies uniformly to primitives, structs, `String`, and `Array<T>`. Inside the callee, both reassignment (`p = new_value`) and in-place mutations — field writes (`p.x = ...`), method calls (`s.push_str("!")`, `arr.push(0)`), and index writes (`arr[0] = ...`) — operate on the callee's local copy and are not visible to the caller. To let the callee mutate the caller's value, declare the parameter as `&mut T` and pass a `&mut`-reference at the call site.
 
 ```wado
 fn countdown(mut n: i32) with Stdout {

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1910,8 +1910,6 @@ inc();
 assert get() == 2;   // both closures observe mutation through the shared reference
 ```
 
-There is no special `&mut ||` syntax; closures use the same value semantics as the rest of the language and reach mutable state via references.
-
 Note: `stores[...]` is a separate concept for declaring that a _function_ stores reference _parameters_ beyond the call. It is not yet implemented. See [Reference Storage](#reference-storage-stores) and [`docs/wep-2026-01-12-value-semantics-and-stores.md`](./wep-2026-01-12-value-semantics-and-stores.md).
 
 ### Default Arguments

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4,13 +4,13 @@ Wado is a programming language targeting Wasm/WASI -- Wasm in plain sight.
 
 ## Overview
 
-| Item      | Description                         |
-| --------- | ----------------------------------- |
-| Name      | Wado                                |
-| Extension | `.wado`                             |
-| Paradigm  | Imperative, Reactive, Effect System |
-| Typing    | Static, Strong, Inferred            |
-| Target    | Wasm/WASI                           |
+| Item      | Description               |
+| --------- | ------------------------- |
+| Name      | Wado                      |
+| Extension | `.wado`                   |
+| Paradigm  | Imperative, Effect System |
+| Typing    | Static, Strong, Inferred  |
+| Target    | Wasm/WASI                 |
 
 See also: [Cheatsheet](docs/cheatsheet.md) for quick syntax reference.
 
@@ -774,7 +774,6 @@ if opt matches { Some(x) && x > 0 } { }  // OK
 - **Wasm-GC based**: Garbage collection delegated to runtime
 - **Lifetime inference**: No explicit lifetime annotations required
 - **Value semantics**: Every value is deeply copied on assignment, parameter passing, and return — references (`&T`, `&mut T`) are the only types that share state
-- **Explicit move**: Ownership transfer only when explicitly stated
 
 ### Value Semantics
 
@@ -786,7 +785,7 @@ Assignment, parameter passing, and return all perform a deep copy of the value. 
 struct Point { x: i32, y: i32 }
 
 let a = Point { x: 1, y: 2 };
-let b = a;       // b is a deep copy of a
+let mut b = a;   // b is a deep copy of a
 b.x = 10;        // does not affect a
 assert a.x == 1;
 ```
@@ -798,30 +797,6 @@ fn translate(p: &mut Point, dx: i32, dy: i32) {
     p.x += dx;   // visible to caller (reference)
     p.y += dy;
 }
-```
-
-### Move Syntax (not yet implemented)
-
-```wado
-// Default: deep copy (references alias)
-let a = some_value;
-let b = a;          // a is still usable; b is a copy
-
-// Explicit move
-let b = move a;     // a is invalidated
-println(a);         // Compile error: a has been moved
-
-// Move to function
-consume(move data);
-```
-
-### Unique Ownership (not yet implemented)
-
-```wado
-// Enforce unique ownership
-let unique handle = open_file("data.txt");
-let other = handle;       // Error: unique cannot be implicitly copied
-let other = move handle;  // OK: explicit move
 ```
 
 ## Type System
@@ -870,7 +845,6 @@ The **prelude** (`core:prelude`) is automatically imported into every module, pr
 - `String` - UTF-8 string type
 - `Array<T>` - Dynamic array type
 - `Tuple<T1, T2, ...>` - Alias for `[T1, T2, ...]`
-- `Reactive<T>` - Reactive value
 - `Option<T>` and its variants: `Some(x)`, `None` (also accessible via `null` keyword)
 - `Result<T, E>` and its variants: `Ok(x)`, `Err(e)`
 - `Stream<T>` - Component Model async stream
@@ -884,7 +858,7 @@ The **prelude** (`core:prelude`) is automatically imported into every module, pr
 #![no_prelude]  // At the top of a module
 
 // Now you must explicitly import everything
-use {String, Array, Tuple, Reactive, Option, Result, Stream, Future, Pollable} from "core:prelude";
+use {String, Array, Tuple, Option, Result, Stream, Future, Pollable} from "core:prelude";
 ```
 
 ### Primitive Types
@@ -1112,7 +1086,7 @@ fn countdown(mut n: i32) with Stdout {
 
 let x = 3;
 countdown(x);
-// x is still 3 — primitive parameters are value types
+// x is still 3 — every parameter is passed by value
 ```
 
 Closures also support `mut` parameters:
@@ -1138,8 +1112,8 @@ fn bad(n: i32) {
 
 **Design Principles**:
 
-- Value semantics: Conceptually behaves like a value type
-- Immutable content: String data cannot be modified in-place
+- Value semantics: deep-copied on assignment, parameter passing, and return — passing a `String` to a function gives the callee its own buffer
+- Mutable through the local binding: methods like `push_str` and operators like `+=` modify the receiver in place, but never the caller's binding
 - GC-managed: Memory is automatically managed by Wasm GC
 - UTF-8 encoding: Direct mapping to Component Model `string`
 
@@ -1246,33 +1220,6 @@ let mut result = String::with_capacity(1000);
 for let item of items {
     result += item;  // No reallocations if within capacity
 }
-```
-
-#### Semantic vs Implementation
-
-```wado
-// Semantically: value copy
-let s1 = "hello";
-let s2 = s1;  // s1 still usable
-
-// Implementation: reference sharing (safe because immutable)
-// No actual copy of string data occurs
-```
-
-**Explicit move**:
-
-```wado
-let s1 = "hello";
-let s2 = move s1;  // s1 invalidated, no copy
-// s1 is no longer accessible
-```
-
-**Implicit move optimization**:
-
-```wado
-let mut s = "hello";
-let temp = "world";
-s = temp;  // If temp is not used after, compiler may optimize to move
 ```
 
 #### Operator Consistency
@@ -3761,12 +3708,6 @@ test "add negative numbers" {
 }
 ```
 
-## Reactive System
-
-Wado has built-in reactive signals with compile-time dependency analysis and a push-pull update algorithm. See [WEP: Reactive Signals](./wep-2026-04-04-reactive-signals.md) for the full design. **Not yet implemented.**
-
----
-
 ## Concurrency Model
 
 ### Stack Switching Based (Colorless)
@@ -4241,38 +4182,6 @@ match result {
     Ok(value) => process(value),
     Err(e) => handle_error(e),
 }
-```
-
-## JSX
-
-JSX is built into the language:
-
-```wado
-fn App() -> Element with Dom {
-    let reactive mut count = 0;
-
-    return <div class="container">
-        <h1>Counter</h1>
-        <p>Count: {count}</p>
-        <button onclick={|_| count += 1}>
-            Increment
-        </button>
-    </div>;
-}
-
-// Conditional rendering
-<div>
-    {match status {
-        "loading" => <Spinner />,
-        "success" => <Content data={data} />,
-        "error" => <Error message={error} />,
-    }}
-</div>
-
-// Lists
-<ul>
-    {items.map(|item| <li key={item.id}>{item.name}</li>)}
-</ul>
 ```
 
 ## WASI / Browser Support

--- a/docs/wep-2026-01-12-value-semantics-and-stores.md
+++ b/docs/wep-2026-01-12-value-semantics-and-stores.md
@@ -197,40 +197,44 @@ fn caller() {
 - No runtime checks needed
 - Transparent to programmer
 
-### 6. Closures Always Capture by Reference
+### 6. Closures Capture by Value
 
-Unlike C++ which distinguishes `[a]` (by value) vs `[&a]` (by reference), Wado closures always capture by reference:
+To keep one rule across the entire language, closures capture each free variable by **deep copy at closure creation time** — the same value semantics that applies to assignment, parameter passing, and return. The closure body operates on its own copies; later mutations to the outer binding are not observed by the closure, and the closure body cannot mutate outer variables directly.
+
+```wado
+let outer = 10;
+let f = || outer;          // outer is copied into the closure
+let outer = 20;            // rebinding the outer name does not affect f
+assert f() == 10;
+```
+
+For stateful or shared-mutable closures, capture a reference. References (`&T`, `&mut T`) are the only types in Wado that alias their referent, so a copied reference still points to the same underlying value.
 
 ```wado
 fn make_counter() -> Fn() -> i32 {
     let mut count = 0;
+    let cref: &mut i32 = &mut count;
     return || {
-        count += 1;  // captures `count` by reference
-        return count;
+        *cref += 1;        // mutation goes through the captured reference
+        return *cref;
     };
 }
 ```
 
-Note: Closures that capture variables use "capture" terminology (closures capture). The `stores[...]` keyword is for functions that store _parameters_ passed to them.
+There is no special `&mut ||` syntax and no per-closure capture-mode keyword: a closure that needs to mutate or share state captures a reference, exactly like any other piece of code that wants to alias.
 
 **Rationale**:
 
-- Simpler mental model (one capture mode)
-- GC handles the lifetime
-- Consistent with value-to-heap promotion
+- One rule for the whole language; closures are not a special case
+- Aliasing requires the same syntactic marker (`&T` / `&mut T`) everywhere
+- GC manages the lifetime of any captured reference's referent
+- Escape tracking for closures reuses the existing `stores[...]` machinery — if a returned closure captures `&local`, the local is heap-promoted by the same rules that govern any escaping reference
 
-### 7. Implementation Optimization (Non-Normative)
+Note: Closures that capture variables use "capture" terminology; the `stores[...]` keyword is for functions that store reference _parameters_ passed to them.
 
-For non-mutable captured variables, the compiler MAY copy instead of heap-promote:
+### 7. Heap Promotion of Referents Captured by Closures (Non-Normative)
 
-```wado
-fn example() {
-    let x = 42;  // immutable
-    let f = || { return x; };  // compiler may copy x into closure
-}
-```
-
-This is an **implementation detail**, not language semantics. From the programmer's perspective, captures are always by reference.
+Because the language-level capture is always by value, the closure's environment struct itself contains plain copies and references. The compiler's job is the same one it does for escaping references in any other context: if a closure captures `&local` and the closure outlives `local`'s lexical scope (e.g. the closure is returned), `local` is heap-promoted via the rules in §2 / §5. No closure-specific lifetime tracking is required beyond the existing escape analysis.
 
 ### 8. Edge Cases
 
@@ -318,25 +322,25 @@ fn use_int(x: &i32) -> i32 {
 }
 ```
 
-#### Multiple Closures Capturing Same Variable
+#### Multiple Closures Sharing Mutable State
 
-Multiple closures can capture the same variable. The variable is heap-promoted once:
+Closures capture by value, so two closures that name the same outer variable each receive their own copy. To share mutable state across closures, capture a reference and let aliasing do the work:
 
 ```wado
-fn multi_capture() {
+fn multi_share() {
     let mut x = 0;
+    let xref: &mut i32 = &mut x;
 
-    let inc = || { x += 1; };      // captures x by reference
-    let get = || { return x; };   // captures x by reference
+    let inc = || { *xref += 1; };
+    let get = || { return *xref; };
 
-    // Both closures share the same heap-promoted x
     inc();
     inc();
-    println(get());  // Prints: 2
+    println(get());  // Prints: 2 — both closures see the same i32 via the shared reference
 }
 ```
 
-Both closures capture `x` by reference. The compiler promotes `x` to the heap once, and both closures hold references to the same heap location.
+Each closure's environment holds its own copy of the reference value `xref`, but `&mut i32` aliases the underlying `i32`, so every read and write lands on the same location. If the closures escape `multi_share`, `x` is heap-promoted by the existing escape rules.
 
 ### 9. Component Model Boundaries
 
@@ -380,7 +384,7 @@ The external component receives a **copy**, not a GC reference. Even if it "stor
 4. **Type-safe escaping**: Can't accidentally escape references without declaration
 5. **Go-like ergonomics**: Escape analysis is familiar pattern
 6. **C++-like syntax**: `stores[...]` familiar to C++ developers (lambda capture syntax)
-7. **Simple closure capture model**: Always by reference, no `[a]` vs `[&a]` confusion
+7. **Uniform closure capture model**: Captures use the same value semantics as everything else; share mutable state via references (`&T` / `&mut T`), no closure-specific syntax
 8. **CM boundaries protect external calls**: No annotation needed for cross-component calls
 9. **Clear terminology**: "stores" for function parameters, "captures" for closures
 

--- a/docs/wep-2026-01-12-value-semantics-and-stores.md
+++ b/docs/wep-2026-01-12-value-semantics-and-stores.md
@@ -221,7 +221,7 @@ fn make_counter() -> Fn() -> i32 {
 }
 ```
 
-There is no special `&mut ||` syntax and no per-closure capture-mode keyword: a closure that needs to mutate or share state captures a reference, exactly like any other piece of code that wants to alias.
+A closure that needs to mutate or share state captures a reference, exactly like any other piece of code that wants to alias.
 
 **Rationale**:
 

--- a/docs/wep-2026-01-12-value-semantics-and-stores.md
+++ b/docs/wep-2026-01-12-value-semantics-and-stores.md
@@ -147,7 +147,7 @@ fn process(data: &Data) -> Result {
 | ------------------------------ | ------------------------------------------- |
 | Named function with `&T` param | Must declare `stores[param]` if storing     |
 | Closure using outer variable   | Closure captures inferred from usage        |
-| Functor type (`Fn(...)`)       | Must declare `stores[0]` etc. if it stores  |
+| Functor type (`fn(...)`)       | Must declare `stores[0]` etc. if it stores  |
 | Functor value itself           | No stores needed (functors are value types) |
 
 **Note on functors**: In Wasm, functors are `funcref` values. Storing a functor itself (not its parameters) does not require `stores[...]` because functors have value semantics—they are copied when assigned or passed.
@@ -164,7 +164,7 @@ fn process(data: &Data) -> Result { ... }  // no stores = cannot store
 ```wado
 // Closure captures inferred from usage
 let f = || { return local_var; };
-// Inferred type: Fn() -> i32 (captures local_var)
+// Inferred type: fn() -> i32 (captures local_var)
 
 // Explicit stores annotation for parameters
 let g = |data| stores[data] { ... };
@@ -174,8 +174,8 @@ let g = |data| stores[data] { ... };
 
 ```wado
 // Must declare stores in type (positional: 0 = first parameter)
-fn take_storing(f: Fn(&Data) with stores[0]) { ... }
-fn take_pure(f: Fn(&Data) -> Result) { ... }  // cannot store
+fn take_storing(f: fn(&Data) with stores[0]) { ... }
+fn take_pure(f: fn(&Data) -> Result) { ... }  // cannot store
 ```
 
 ### 5. Heap Promotion Based on Stores
@@ -211,7 +211,7 @@ assert f() == 10;
 For stateful or shared-mutable closures, capture a reference. References (`&T`, `&mut T`) are the only types in Wado that alias their referent, so a copied reference still points to the same underlying value.
 
 ```wado
-fn make_counter() -> Fn() -> i32 {
+fn make_counter() -> fn() -> i32 {
     let mut count = 0;
     let cref: &mut i32 = &mut count;
     return || {
@@ -298,11 +298,11 @@ fn example(list: &mut Array<&Data>, data: &Data) with stores[data] {
 The compiler detects stores through type propagation:
 
 ```wado
-fn apply<T, R>(f: Fn(T) -> R, x: T) -> R {
+fn apply<T, R>(f: fn(T) -> R, x: T) -> R {
     return f(x);  // apply doesn't store, just passes through
 }
 
-// If f's type is Fn(&Data) -> R with stores[0],
+// If f's type is fn(&Data) -> R with stores[0],
 // compiler traces that x may be stored
 ```
 
@@ -394,7 +394,7 @@ The external component receives a **copy**, not a GC reference. Even if it "stor
    - **Mitigation**: Use `move` for large values, profiler will identify hotspots
 2. **Learning curve**: `stores[...]` is a new concept
    - **Mitigation**: Clear error messages when stores declaration is missing
-3. **Verbose functor types**: `Fn(&Data) with stores[0]` is long
+3. **Verbose functor types**: `fn(&Data) with stores[0]` is long
    - **Mitigation**: Type inference reduces explicit annotations
 4. **Different from Rust**: No lifetimes, different model
    - **Mitigation**: Simpler model is easier to learn
@@ -415,19 +415,19 @@ let c = move a; // move, `a` invalidated
 
 ```wado
 // Storing a functor: no stores needed (functors are value types)
-fn register_callback(cb: Fn(&Event)) -> Id {
+fn register_callback(cb: fn(&Event)) -> Id {
     callbacks.push(cb);  // OK: cb is a funcref, copied by value
     return new_id();
 }
 
 // Functor that stores its parameter
-fn register_storing_callback(cb: Fn(&Event) with stores[0]) -> Id {
+fn register_storing_callback(cb: fn(&Event) with stores[0]) -> Id {
     // cb may store references passed to it
     callbacks.push(cb);
     return new_id();
 }
 
-fn process_once(cb: Fn(&Event)) {
+fn process_once(cb: fn(&Event)) {
     cb(&event);  // uses but doesn't store
 }
 ```
@@ -435,7 +435,7 @@ fn process_once(cb: Fn(&Event)) {
 **Closure capture inference**:
 
 ```wado
-fn create_adder(x: i32) -> Fn(i32) -> i32 {
+fn create_adder(x: i32) -> fn(i32) -> i32 {
     return |y| { return x + y; };  // closure captures x (inferred)
 }
 ```

--- a/docs/wep-2026-01-13-struct-and-trait.md
+++ b/docs/wep-2026-01-13-struct-and-trait.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Wado needs a type system for defining custom data types and shared behavior. This WEP defines the syntax and semantics for structs (product types) and traits (behavior abstraction), building on the value semantics established in `wep-2026-01-12-value-semantics-and-captures.md`.
+Wado needs a type system for defining custom data types and shared behavior. This WEP defines the syntax and semantics for structs (product types) and traits (behavior abstraction), building on the value semantics established in `wep-2026-01-12-value-semantics-and-stores.md`.
 
 ### Design Goals
 
@@ -629,4 +629,4 @@ impl<T: Display> Display for Stack<T> {
 - [Rust Traits](https://doc.rust-lang.org/book/ch10-02-traits.html)
 - [Rust Clone vs Copy](https://doc.rust-lang.org/std/clone/trait.Clone.html)
 - [Rust Drop](https://doc.rust-lang.org/std/ops/trait.Drop.html)
-- [WEP: Value Semantics and Captures](./wep-2026-01-12-value-semantics-and-captures.md)
+- [WEP: Value Semantics and Reference Stores](./wep-2026-01-12-value-semantics-and-stores.md)

--- a/docs/wep-2026-01-16-closure-implementation.md
+++ b/docs/wep-2026-01-16-closure-implementation.md
@@ -12,7 +12,7 @@ let g = || { return count; };  // Captures outer variable 'count'
 The language design requires:
 
 1. First-class functions (closures can be passed as values)
-2. Capture by reference (per [WEP: Value Semantics and Reference Captures](./wep-2026-01-12-value-semantics-and-captures.md))
+2. Capture by reference (per [WEP: Value Semantics and Reference Stores](./wep-2026-01-12-value-semantics-and-stores.md))
 3. Multiple closures can capture the same variable
 4. Closures must work with effect system and `captures[...]` tracking
 5. Efficient representation targeting Wasm GC
@@ -431,7 +431,7 @@ Most languages with GC targeting Wasm use **Option 1** (struct + funcref) becaus
 
 ### Integration with `captures[...]` Tracking
 
-Per the [Value Semantics WEP](./wep-2026-01-12-value-semantics-and-captures.md), closures that capture variables require `captures[...]` annotation in function types:
+Per the [Value Semantics WEP](./wep-2026-01-12-value-semantics-and-stores.md), closures that capture variables require `captures[...]` annotation in function types:
 
 ```wado
 // Closure type with captures
@@ -914,7 +914,7 @@ The specialised path (closure local stays as `&__Closure_N`) does not use the vt
 
 ## References
 
-- [WEP: Value Semantics and Reference Captures](./wep-2026-01-12-value-semantics-and-captures.md)
+- [WEP: Value Semantics and Reference Stores](./wep-2026-01-12-value-semantics-and-stores.md)
 - [WebAssembly GC Proposal](https://github.com/WebAssembly/gc)
 - [Wasm Component Model](https://github.com/WebAssembly/component-model)
 - [Rust Closure Implementation](https://doc.rust-lang.org/book/ch13-01-closures.html)

--- a/docs/wep-2026-01-16-closure-implementation.md
+++ b/docs/wep-2026-01-16-closure-implementation.md
@@ -394,11 +394,11 @@ resource closure-env {
 Closures have function types with capture annotations:
 
 ```wado
-// Type: Fn(i32) -> i32 with captures[count]
+// Type: fn(i32) -> i32 with captures[count]
 let f = |x| { return x + count; };
 
 // Generic function taking a closure
-fn apply<T, R>(f: Fn(T) -> R, x: T) -> R {
+fn apply<T, R>(f: fn(T) -> R, x: T) -> R {
     return f(x);
 }
 ```
@@ -411,8 +411,8 @@ fn apply<T, R>(f: Fn(T) -> R, x: T) -> R {
 **Subtyping:**
 
 ```wado
-Fn(T) -> R                    // Pure function (no captures)
-  <: Fn(T) -> R with captures[x]  // Can capture x
+fn(T) -> R                    // Pure function (no captures)
+  <: fn(T) -> R with captures[x]  // Can capture x
 ```
 
 A pure function can be used where a capturing function is expected, but not vice versa.
@@ -440,14 +440,14 @@ Per the [Value Semantics WEP](./wep-2026-01-12-value-semantics-and-stores.md), c
 
 ```wado
 // Closure type with captures
-fn register(f: Fn(i32) -> i32 with captures[0]) {
+fn register(f: fn(i32) -> i32 with captures[0]) {
     callbacks.push(f);
 }
 
 // Inferred captures
 let count = 0;
 let f = |x| { return x + count; };
-// Type: Fn(i32) -> i32 with captures[count]
+// Type: fn(i32) -> i32 with captures[count]
 ```
 
 **Implementation requirement:**
@@ -460,7 +460,7 @@ let f = |x| { return x + count; };
 **Heap promotion:**
 
 ```wado
-fn make_counter() -> Fn() -> i32 with captures[count] {
+fn make_counter() -> fn() -> i32 with captures[count] {
     let mut count = 0;  // Must be heap-promoted
     return || {
         count += 1;
@@ -623,7 +623,7 @@ When a closure escapes (returned from function, stored in struct, etc.), capture
 
 ```wado
 // Source
-fn make_counter() -> Fn() -> i32 with captures[count] {
+fn make_counter() -> fn() -> i32 with captures[count] {
     let mut count = 0;
     return || {
         count += 1;
@@ -706,8 +706,8 @@ Each unique `(params, ret, capture_types)` tuple generates distinct Wasm types.
 **Type checking:**
 
 ```wado
-fn takes_pure(f: Fn(i32) -> i32) { ... }
-fn takes_capturing(f: Fn(i32) -> i32 with captures[0]) { ... }
+fn takes_pure(f: fn(i32) -> i32) { ... }
+fn takes_capturing(f: fn(i32) -> i32 with captures[0]) { ... }
 
 let pure = |x| { return x + 1; };
 let capturing = |x| { return x + count; };
@@ -721,7 +721,7 @@ takes_capturing(capturing); // OK
 **Subtyping rule:**
 
 ```
-Fn(P) -> R  <:  Fn(P) -> R with captures[...]
+fn(P) -> R  <:  fn(P) -> R with captures[...]
 ```
 
 A pure function can be used where a capturing function is expected.
@@ -732,7 +732,7 @@ There is a single closure type. Captures are by value, so the closure body canno
 
 | Type         | Description           |
 | ------------ | --------------------- |
-| `Fn(T) -> U` | Closure (or function) |
+| `fn(T) -> U` | Closure (or function) |
 
 **Comparison with Rust:** Rust splits closures into `Fn` / `FnMut` / `FnOnce` so the borrow checker can track captured `&mut` borrows. Wado has no borrow checker and captures by deep copy, so the distinction is unnecessary: a closure that needs to mutate or share state captures a reference value, which aliases like any other reference.
 
@@ -744,7 +744,7 @@ Unlike Rust, Wado does not have bare function pointers. All callable values are 
 // Read-only capture
 let outer = 10;
 let f = |x: i32| x + outer;
-// Type: Fn(i32) -> i32
+// Type: fn(i32) -> i32
 
 // Mutation via captured reference (no special closure syntax)
 let mut count = 0;
@@ -753,7 +753,7 @@ let counter = || {
     *cref += 1;
     *cref
 };
-// Type: Fn() -> i32
+// Type: fn() -> i32
 ```
 
 **Compiler enforcement:**
@@ -777,7 +777,7 @@ At Component Model boundaries, closures cannot be passed directly (Component Mod
 
 ```wado
 // ERROR: Cannot export/import closures across Component Model boundary
-export fn take_callback(f: Fn() -> i32) { ... }
+export fn take_callback(f: fn() -> i32) { ... }
 ```
 
 **Option B: Resource adapter** (Future work)
@@ -859,7 +859,7 @@ The specialised path (closure local stays as `&__Closure_N`) does not use the vt
 2. **Shared mutable state via references**: Closures sharing a captured reference observe the same underlying value, without special-cased closure syntax
 3. **Type-safe**: Each closure signature has distinct Wasm types
 4. **Compatible with value semantics**: Closures follow the same deep-copy rule as assignment, parameter passing, and return — references remain the only types that alias
-5. **Single closure type**: No `Fn` / `FnMut` / `FnOnce` hierarchy; one `Fn(T) -> U`
+5. **Single closure type**: No `Fn` / `FnMut` / `FnOnce` hierarchy; one `fn(T) -> U`
 6. **Optimization-friendly**: Compiler can optimize non-escaping closures to use locals
 
 ### Negative
@@ -896,7 +896,7 @@ The specialised path (closure local stays as `&__Closure_N`) does not use the vt
    - Promote captured variables to environment struct
 
 6. **Phase 6: Type system integration**
-   - Implement subtyping for `Fn(P) -> R` <: `Fn(P) -> R with captures[...]`
+   - Implement subtyping for `fn(P) -> R` <: `fn(P) -> R with captures[...]`
    - Type check closure passing at call sites
 
 ### Future Work
@@ -905,7 +905,7 @@ The specialised path (closure local stays as `&__Closure_N`) does not use the vt
 - **Optimization**: Inline small closures at call sites
 - **Optimization**: Auto-switch between type-erased (`fn(T) -> U`) and monomorphized (generic `F`) forms based on whether closure escapes. This would enable inlining for iterator chains like `arr.iter().map(|x| x * 2).collect()`.
 - **Component Model export**: Support closures at CM boundary via resource adapters
-- **Generic closures**: Support `Fn<T>(T) -> T` with type parameters
+- **Generic closures**: Support `fn<T>(T) -> T` with type parameters
 
 ## References
 

--- a/docs/wep-2026-01-16-closure-implementation.md
+++ b/docs/wep-2026-01-16-closure-implementation.md
@@ -73,12 +73,12 @@ fn closure_get_impl(env: &ClosureEnv_Get) -> i32 {
 }
 
 struct Closure_Inc {
-    env: &ClosureEnv_Inc,
+    env: ClosureEnv_Inc,
     func: FnRef(&ClosureEnv_Inc),
 }
 
 struct Closure_Get {
-    env: &ClosureEnv_Get,
+    env: ClosureEnv_Get,
     func: FnRef(&ClosureEnv_Get) -> i32,
 }
 
@@ -94,10 +94,10 @@ let get = Closure_Get {
     func: closure_get_impl,
 };
 
-// Calling closures:
-inc.func(inc.env);            // *cref becomes 1
-inc.func(inc.env);            // *cref becomes 2
-println(get.func(get.env));   // Prints "2" — both envs hold a copy of the same reference
+// Calling closures (env passed by reference to the impl function):
+inc.func(&inc.env);            // *cref becomes 1
+inc.func(&inc.env);            // *cref becomes 2
+println(get.func(&get.env));   // Prints "2" — both envs hold a copy of the same reference
 ```
 
 **Key insight:** Each environment is a deep-copy snapshot at closure creation time. Mutability and sharing come from capturing a reference, not from sharing the environment struct itself.
@@ -732,7 +732,7 @@ There is a single closure type. Captures are by value, so the closure body canno
 
 | Type         | Description           |
 | ------------ | --------------------- |
-| `fn(T) -> U` | Closure (or function) |
+| `Fn(T) -> U` | Closure (or function) |
 
 **Comparison with Rust:** Rust splits closures into `Fn` / `FnMut` / `FnOnce` so the borrow checker can track captured `&mut` borrows. Wado has no borrow checker and captures by deep copy, so the distinction is unnecessary: a closure that needs to mutate or share state captures a reference value, which aliases like any other reference.
 
@@ -744,7 +744,7 @@ Unlike Rust, Wado does not have bare function pointers. All callable values are 
 // Read-only capture
 let outer = 10;
 let f = |x: i32| x + outer;
-// Type: fn(i32) -> i32
+// Type: Fn(i32) -> i32
 
 // Mutation via captured reference (no special closure syntax)
 let mut count = 0;
@@ -753,7 +753,7 @@ let counter = || {
     *cref += 1;
     *cref
 };
-// Type: fn() -> i32
+// Type: Fn() -> i32
 ```
 
 **Compiler enforcement:**
@@ -859,7 +859,7 @@ The specialised path (closure local stays as `&__Closure_N`) does not use the vt
 2. **Shared mutable state via references**: Closures sharing a captured reference observe the same underlying value, without special-cased closure syntax
 3. **Type-safe**: Each closure signature has distinct Wasm types
 4. **Compatible with value semantics**: Closures follow the same deep-copy rule as assignment, parameter passing, and return — references remain the only types that alias
-5. **Single closure type**: No `Fn` / `FnMut` / `FnOnce` hierarchy; one `fn(T) -> U`
+5. **Single closure type**: No `Fn` / `FnMut` / `FnOnce` hierarchy; one `Fn(T) -> U`
 6. **Optimization-friendly**: Compiler can optimize non-escaping closures to use locals
 
 ### Negative

--- a/docs/wep-2026-01-16-closure-implementation.md
+++ b/docs/wep-2026-01-16-closure-implementation.md
@@ -12,8 +12,8 @@ let g = || { return count; };  // Captures outer variable 'count'
 The language design requires:
 
 1. First-class functions (closures can be passed as values)
-2. Capture by reference (per [WEP: Value Semantics and Reference Stores](./wep-2026-01-12-value-semantics-and-stores.md))
-3. Multiple closures can capture the same variable
+2. Capture by value (deep copy at closure creation, per [WEP: Value Semantics and Reference Stores](./wep-2026-01-12-value-semantics-and-stores.md))
+3. Multiple closures can share state by each capturing a reference to the same target
 4. Closures must work with effect system and `captures[...]` tracking
 5. Efficient representation targeting Wasm GC
 
@@ -46,56 +46,61 @@ Create a Wasm GC struct to hold the environment, paired with a function referenc
 
 **Conceptual representation (desugared Wado):**
 
+Because captures are by value, each closure carries its own environment struct populated by a deep copy of the captured values at closure creation. Sharing mutable state is expressed by capturing a reference (which aliases per Wado's value semantics).
+
 ```wado
 // Original code:
 let mut count = 0;
-let inc = || { count += 1; };
-let get = || { return count; };
+let cref: &mut i32 = &mut count;
+let inc = || { *cref += 1; };
+let get = || { return *cref; };
 
 // Desugared to (conceptually):
-struct ClosureEnv_0 {
-    mut count: i32,
+struct ClosureEnv_Inc {
+    cref: &mut i32,   // reference value, copied at closure creation
 }
 
-fn closure_inc_impl(env: &mut ClosureEnv_0) {
-    env.count += 1;
+struct ClosureEnv_Get {
+    cref: &mut i32,
 }
 
-fn closure_get_impl(env: &ClosureEnv_0) -> i32 {
-    return env.count;
+fn closure_inc_impl(env: &ClosureEnv_Inc) {
+    *env.cref += 1;   // mutation goes through the captured reference
+}
+
+fn closure_get_impl(env: &ClosureEnv_Get) -> i32 {
+    return *env.cref;
 }
 
 struct Closure_Inc {
-    env: &mut ClosureEnv_0,
-    func: FnRef(&mut ClosureEnv_0),
+    env: &ClosureEnv_Inc,
+    func: FnRef(&ClosureEnv_Inc),
 }
 
 struct Closure_Get {
-    env: &ClosureEnv_0,
-    func: FnRef(&ClosureEnv_0) -> i32,
+    env: &ClosureEnv_Get,
+    func: FnRef(&ClosureEnv_Get) -> i32,
 }
 
-// Shared environment (allocated once)
-let shared_env = ClosureEnv_0 { count: 0 };
-
-// Both closures reference the same environment
+// Each closure builds its own environment from a deep copy of the captures.
+// `cref` is a reference value, so the copy still aliases the original i32.
 let inc = Closure_Inc {
-    env: &mut shared_env,
+    env: ClosureEnv_Inc { cref: cref },
     func: closure_inc_impl,
 };
 
 let get = Closure_Get {
-    env: &shared_env,
+    env: ClosureEnv_Get { cref: cref },
     func: closure_get_impl,
 };
 
 // Calling closures:
-inc.func(inc.env);      // count becomes 1
-inc.func(inc.env);      // count becomes 2
-println(get.func(get.env));  // Prints "2" ✓
+inc.func(inc.env);            // *cref becomes 1
+inc.func(inc.env);            // *cref becomes 2
+println(get.func(get.env));   // Prints "2" — both envs hold a copy of the same reference
 ```
 
-**Key insight:** Both `inc` and `get` share the same `shared_env` struct, so mutations in one closure are visible to the other.
+**Key insight:** Each environment is a deep-copy snapshot at closure creation time. Mutability and sharing come from capturing a reference, not from sharing the environment struct itself.
 
 **Wasm representation:**
 
@@ -131,8 +136,8 @@ println(get.func(get.env));  // Prints "2" ✓
 
 - Native Wasm GC representation
 - Environment is garbage collected automatically
-- Multiple closures can share the same environment struct (reference semantics)
-- Efficient: no copying, direct field access
+- Multiple closures share mutable state by independently capturing the same reference value (no special-cased shared-env struct required)
+- Efficient: direct field access on the captured copy
 - Type-safe: each closure has distinct struct type
 
 **Cons:**
@@ -721,38 +726,34 @@ Fn(P) -> R  <:  Fn(P) -> R with captures[...]
 
 A pure function can be used where a capturing function is expected.
 
-#### Closure Mutability
+#### Closure Type
 
-Closures are distinguished by whether they mutate their captures:
+There is a single closure type. Captures are by value, so the closure body cannot write to outer bindings — there is no `Fn` / `FnMut` / `FnOnce` hierarchy and no `&mut ||` syntax.
 
-| Type             | Description              |
-| ---------------- | ------------------------ |
-| `fn(T) -> U`     | Pure/stateless closure   |
-| `fn mut(T) -> U` | Stateful/mutable closure |
+| Type         | Description           |
+| ------------ | --------------------- |
+| `fn(T) -> U` | Closure (or function) |
 
-**Comparison with Rust:**
+**Comparison with Rust:** Rust splits closures into `Fn` / `FnMut` / `FnOnce` so the borrow checker can track captured `&mut` borrows. Wado has no borrow checker and captures by deep copy, so the distinction is unnecessary: a closure that needs to mutate or share state captures a reference value, which aliases like any other reference.
 
-| Wado             | Rust equivalent          |
-| ---------------- | ------------------------ |
-| `fn(T) -> U`     | `&dyn Fn(T) -> U`        |
-| `fn mut(T) -> U` | `&mut dyn FnMut(T) -> U` |
-
-Unlike Rust, Wado does not have bare function pointers (`fn(T) -> U` in Rust). All callable values are closures (reference types), possibly with empty captures. This simplifies the type system since functions without captures are just closures with empty functor structs.
+Unlike Rust, Wado does not have bare function pointers. All callable values are closures (reference types), possibly with an empty environment struct. Functions without captures are just closures with empty environments.
 
 **Syntax:**
 
 ```wado
-// Pure closure (default)
-let double = |x: i32| x * 2;
+// Read-only capture
+let outer = 10;
+let f = |x: i32| x + outer;
 // Type: fn(i32) -> i32
 
-// Stateful closure (explicit &mut prefix)
+// Mutation via captured reference (no special closure syntax)
 let mut count = 0;
-let counter = &mut || {
-    count += 1;
-    count
+let cref: &mut i32 = &mut count;
+let counter = || {
+    *cref += 1;
+    *cref
 };
-// Type: fn mut() -> i32
+// Type: fn() -> i32
 ```
 
 **Compiler enforcement:**
@@ -760,19 +761,13 @@ let counter = &mut || {
 ```wado
 let mut count = 0;
 
-// ERROR: closure mutates capture, must use &mut
+// ERROR: closure body cannot write to a value-captured binding
 let f = || { count += 1; count };
 
-// OK: explicit mutable closure
-let f = &mut || { count += 1; count };
-
-// OK: pure closure (reads only)
-let f = || count + 1;
+// OK: capture a reference; aliasing makes the write visible
+let cref: &mut i32 = &mut count;
+let f = || { *cref += 1; *cref };
 ```
-
-**Subtyping:**
-
-`fn(T) -> U` coerces to `fn mut(T) -> U`, but not vice versa.
 
 #### Component Model Boundary
 
@@ -861,10 +856,10 @@ The specialised path (closure local stays as `&__Closure_N`) does not use the vt
 ### Positive
 
 1. **Native Wasm GC representation**: Efficient, garbage collected automatically
-2. **Shared mutable state**: Multiple closures can capture and mutate the same variable correctly
+2. **Shared mutable state via references**: Closures sharing a captured reference observe the same underlying value, without special-cased closure syntax
 3. **Type-safe**: Each closure signature has distinct Wasm types
-4. **Matches Rust/Go/Swift semantics**: Familiar to users of these languages
-5. **Compatible with value semantics**: Closures capture by reference, consistent with WEP
+4. **Compatible with value semantics**: Closures follow the same deep-copy rule as assignment, parameter passing, and return — references remain the only types that alias
+5. **Single closure type**: No `Fn` / `FnMut` / `FnOnce` hierarchy; one `fn(T) -> U`
 6. **Optimization-friendly**: Compiler can optimize non-escaping closures to use locals
 
 ### Negative

--- a/docs/wep-2026-01-16-closure-implementation.md
+++ b/docs/wep-2026-01-16-closure-implementation.md
@@ -728,7 +728,7 @@ A pure function can be used where a capturing function is expected.
 
 #### Closure Type
 
-There is a single closure type. Captures are by value, so the closure body cannot write to outer bindings — there is no `Fn` / `FnMut` / `FnOnce` hierarchy and no `&mut ||` syntax.
+There is a single closure type. Captures are by value, so the closure body cannot write to outer bindings, and there is no `Fn` / `FnMut` / `FnOnce` hierarchy.
 
 | Type         | Description           |
 | ------------ | --------------------- |


### PR DESCRIPTION
## Summary

Documentation-only pass to make value semantics consistent across `spec.md`, `cheatsheet.md`, and the relevant WEPs. No code or fixture changes — implementation and fixtures will catch up in a follow-up.

Two design points were decided during the review:

1. **Parameter passing uses real value semantics.** Every value is deep-copied across assignment, parameter passing, and return; the only types that alias are `&T` / `&mut T`. spec.md previously claimed in-place mutations on a `struct`/`String`/`Array` parameter were visible to the caller, which contradicted `CLAUDE.md`, the value-semantics WEP, and the e2e fixtures (`mut_param_merged.wado` asserts the opposite for every case).

2. **Closures capture by value (no `&mut ||`).** spec/cheatsheet said "by value (copy) by default" while the WEP said "always by reference"; the fixtures showed reference behavior. Going zero-base, the design that fits Wado's value-semantics rule is *pure value capture*: closures deep-copy each free variable at creation; shared mutable state is expressed by capturing a reference (which aliases like any other reference). This drops the `&mut ||` syntax and collapses any `Fn`/`FnMut`/`FnOnce`-style distinction into one `fn(T) -> U`.

## Commits

- `2be753cd` — align spec.md mut-param wording with the WEP/CLAUDE.md/fixtures; rewrite the Memory Model section; fix five broken links to a non-existent `wep-2026-01-12-value-semantics-and-captures.md`.
- `ece30b26` — switch closure capture to pure value capture across the value-semantics WEP, the closure-implementation WEP, spec.md, cheatsheet.md, and the Rust-comparison research note.
- `6794ae42` — remove leftover mentions of the deprecated `&mut ||` syntax (including from research-doc code sketches).
- `2aa228d4` — tighten value semantics in spec.md and drop three premature top-level sections that had been added on impulse: Move Syntax / Unique Ownership, Reactive System, and JSX. (Reactive Signals still has its WEP; JSX has no design yet.) Also fixes the `let b = a; b.x = 10` example (now `let mut b`) and the misleading "Immutable content" claim on `String`.

## Test plan

- [x] Documentation-only; no code touched
- [x] `mise run format` clean
- [ ] Reviewer to sanity-check that the new value-semantics rule reads consistently with `mut_param_merged.wado` and `closure_2.wado` (the fixtures the new wording was derived from)

https://claude.ai/code/session_013euAkExthXPKYyL7Tani8c

---
_Generated by [Claude Code](https://claude.ai/code/session_013euAkExthXPKYyL7Tani8c)_