### PR TITLE
refactor(package-gale): split parser_gen.wado along the analysis/emission seam

### DIFF
--- a/package-gale/src/alt_grouping.wado
+++ b/package-gale/src/alt_grouping.wado
@@ -1,0 +1,237 @@
+//! Alt overlap-grouping and sorting heuristics for multi-alternative
+//! dispatch.
+//!
+//! Given the FIRST sets of a set of alternatives, this module decides:
+//!  * which alts overlap (`compute_overlap_groups`), so they must be
+//!    dispatched against each other rather than in isolation; and
+//!  * within each overlap group, in what order to try them
+//!    (`sort_group_by_specificity`, `sort_group_by_mandatory_count_desc`,
+//!    `sort_group_by_element_count`).
+//!
+//! The priority tier constants (`ALT_PRIORITY_*`) and the per-alt
+//! priority key (`alt_sort_priority`) are the contract that the parse-
+//! side dispatch and the scan-side dispatch share. See
+//! `lower.wado`'s mirror copies for the lowered-IR equivalents and the
+//! CLAUDE.md "Failed Approaches" section for why the bands are split
+//! the way they are.
+
+use { Alternative } from "./ir.wado";
+use { GenContext, is_nullable, sets_overlap } from "./gen_context.wado";
+
+pub fn compute_overlap_groups(first_sets: &Array<Array<String>>) -> Array<Array<i32>> {
+    let n = first_sets.len();
+    let mut group_ids: Array<i32> = [];
+    for let mut i = 0; i < n; i += 1 {
+        group_ids.push(i);
+    }
+    for let mut i = 0; i < n; i += 1 {
+        for let mut j = i + 1; j < n; j += 1 {
+            if sets_overlap(&first_sets[i], &first_sets[j]) {
+                let gi = group_ids[i];
+                let gj = group_ids[j];
+                if gi != gj {
+                    for let mut k = 0; k < n; k += 1 {
+                        if group_ids[k] == gj {
+                            group_ids[k] = gi;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    let mut seen_ids: Array<i32> = [];
+    let mut groups: Array<Array<i32>> = [];
+    for let mut i = 0; i < n; i += 1 {
+        let gid = group_ids[i];
+        let mut found = -1;
+        for let mut s = 0; s < seen_ids.len(); s += 1 {
+            if seen_ids[s] == gid {
+                found = s;
+                break;
+            }
+        }
+        if found >= 0 {
+            groups[found].push(i);
+        } else {
+            seen_ids.push(gid);
+            groups.push([i]);
+        }
+    }
+    return groups;
+}
+
+pub fn has_multi_alt_groups(groups: &Array<Array<i32>>) -> bool {
+    for let group of groups {
+        if group.len() > 1 {
+            return true;
+        }
+    }
+    return false;
+}
+
+pub fn sort_group_by_specificity(group: &mut Array<i32>, first_sets: &Array<Array<String>>) {
+    // Sort by first set size ascending: smaller first set = more specific = try first.
+    // Ties broken by original order (stable-ish bubble sort).
+    for let mut i = 0; i < group.len(); i += 1 {
+        for let mut j = i + 1; j < group.len(); j += 1 {
+            if first_sets[group[j]].len() < first_sets[group[i]].len() {
+                let tmp = group[i];
+                group[i] = group[j];
+                group[j] = tmp;
+            }
+        }
+    }
+}
+
+// Priority bands consumed by `alt_sort_priority` and friends. Higher
+// = try first.
+//
+// `MultiTokenLed` (4) is most specific: a multi-element alt whose
+// first non-nullable element is a fixed token (e.g. `K_CAST '(' expr
+// K_AS type_name ')'`). The leading token uniquely identifies the
+// alt, so committing on first match is safe.
+//
+// `BareRuleRef` (3) is the catch-all rank: a single-RuleRef alt
+// whose body can match complex internal patterns (`join_clause`,
+// `expr`). Tried before `MultiRuleRefLed` so single-RuleRef
+// catch-alls win against multi-element-RuleRef siblings — this is
+// what SQLite-style `(table_or_subquery (',' tor)* | join_clause)`
+// dispatch relies on.
+//
+// `MultiRuleRefLed` (2) is a multi-element alt whose first non-
+// nullable element is itself a RuleRef. Less specific than
+// `BareRuleRef` because the RuleRef prefix is shared with the
+// catch-all sibling.
+//
+// `BareToken` (1) is a single Token/Literal alt — the cheapest
+// fallback (e.g. `K_INSERT` alone).
+pub global ALT_PRIORITY_MULTI_TOKEN_LED: i32 = 4;
+pub global ALT_PRIORITY_BARE_RULE_REF: i32 = 3;
+pub global ALT_PRIORITY_MULTI_RULE_REF_LED: i32 = 2;
+pub global ALT_PRIORITY_BARE_TOKEN: i32 = 1;
+
+pub fn alt_sort_priority(alt: &Alternative) -> i32 {
+    if alt.elements.len() == 1 {
+        let elem = &alt.elements[0];
+        if let RuleRef(_) = elem {
+            return ALT_PRIORITY_BARE_RULE_REF;
+        }
+        return ALT_PRIORITY_BARE_TOKEN;
+    }
+    // Multi-element: check first non-nullable element.
+    for let elem of alt.elements {
+        if is_nullable(&elem) {
+            continue;
+        }
+        if let TokenRef(_) | Literal(_) = elem {
+            return ALT_PRIORITY_MULTI_TOKEN_LED;
+        }
+        break;
+    }
+    return ALT_PRIORITY_MULTI_RULE_REF_LED;
+}
+
+/// Sort `group` so the alt with the most MANDATORY (non-deeply-
+/// nullable) elements comes first, breaking ties by `alt_sort_priority`
+/// (single-RuleRef catch-alls win against multi-element-RuleRef
+/// siblings) and finally source order. Used by the prediction tree's
+/// `Ambiguous` case (and the matching parse-side group dispatches) to
+/// pick the longer MANDATORY match between alts that share a prefix.
+///
+/// Counting mandatory elements only is the LL distinguisher:
+/// `( a b | a )` (where `b` is mandatory) sorts the 2-elem alt first,
+/// while `( a b? | a )` (where `b?` is optional) ties on mandatory
+/// length and falls through to priority — which prefers the single-
+/// RuleRef catch-all the way ANTLR4's full-context fallback does for
+/// SQLite-style `( tor (',' tor)* | join_clause )` groupings.
+pub fn sort_group_by_mandatory_count_desc(group: &mut Array<i32>, alts: &Array<Alternative>, ctx: &mut GenContext) {
+    for let mut i = 0; i < group.len(); i += 1 {
+        for let mut j = i + 1; j < group.len(); j += 1 {
+            let li = ll_match_length(&alts[group[i]], ctx);
+            let lj = ll_match_length(&alts[group[j]], ctx);
+            let mut swap = false;
+            if lj > li {
+                swap = true;
+            } else if lj == li {
+                let pi = alt_sort_priority(&alts[group[i]]);
+                let pj = alt_sort_priority(&alts[group[j]]);
+                if pj > pi {
+                    swap = true;
+                } else if pj == pi {
+                    if group[j] < group[i] {
+                        swap = true;
+                    }
+                }
+            }
+            if swap {
+                let tmp = group[i];
+                group[i] = group[j];
+                group[j] = tmp;
+            }
+        }
+    }
+}
+
+/// LL-aware "match length" for `alt`, used to sort group alternatives so
+/// the more specific LL alt wins on overlap-prefix ties. Counts every
+/// mandatory top-level element plus every *trailing* deep-nullable
+/// element that is first-exact (single-token-derived; see
+/// `GenContext::element_is_first_exact`).
+///
+/// Why this is the right key: a first-exact nullable trailing element
+/// like `b?` (where `b : Y`) is "1 token whose presence is decisive" —
+/// when `Y` is in the input, alt 0 of `(a b? | a)` is the LL-correct
+/// pick because `b?` will fire and consume `Y`. Counting it as a
+/// pseudo-mandatory token sorts alt 0 ahead of the bare-RuleRef
+/// catch-all alt 1, mirroring ANTLR4's full-context LL preference for
+/// the longer meaningful match. Multi-element nullable structures
+/// (SQLite's `(',' tor)*` Star) stay at the original count because
+/// their first set is not first-exact, preserving the join-clause
+/// catch-all behaviour their grammars depend on.
+///
+/// The `seen_mandatory` gate restricts the trailing-nullable bonus to
+/// nullables that follow a committed token. A *leading* nullable like
+/// `b?` in `( b? a c | a c )` cannot disambiguate length: the runtime
+/// has not yet committed to either alt at that position, so claiming
+/// "alt 0 has 3 tokens" is no better signal than "alt 1 has 2" —
+/// either alt's `a c` will match. Counting only post-mandatory
+/// nullables means the bonus fires exactly when it can shorten the
+/// LL decision: after a shared prefix has committed, a tail-position
+/// `b?` whose presence is decisive elects the longer alt.
+pub fn ll_match_length(alt: &Alternative, ctx: &mut GenContext) -> i32 {
+    let mut count: i32 = 0;
+    let mut seen_mandatory: bool = false;
+    for let elem of &alt.elements {
+        let mut visiting: Array<String> = [];
+        if !ctx.element_is_nullable_deep(elem, &mut visiting) {
+            count += 1;
+            seen_mandatory = true;
+        } else if seen_mandatory && ctx.element_is_first_exact(elem) {
+            count += 1;
+        }
+    }
+    return count;
+}
+
+pub fn sort_group_by_element_count(group: &mut Array<i32>, alts: &Array<Alternative>) {
+    for let mut i = 0; i < group.len(); i += 1 {
+        for let mut j = i + 1; j < group.len(); j += 1 {
+            let pi = alt_sort_priority(&alts[group[i]]);
+            let pj = alt_sort_priority(&alts[group[j]]);
+            let mut swap = false;
+            if pj > pi {
+                swap = true;
+            } else if pj == pi {
+                // Within same-priority tier: more elements = more specific = first
+                if alts[group[j]].elements.len() > alts[group[i]].elements.len() {
+                    swap = true;
+                }
+            }
+            if swap {
+                let tmp = group[i];
+                group[i] = group[j];
+                group[j] = tmp;
+            }
+        }
+    }
+}

--- a/package-gale/src/gen_context_test.wado
+++ b/package-gale/src/gen_context_test.wado
@@ -51,7 +51,6 @@ fn mk_ctx_with(rules: Array<ParserRule>) -> GenContext {
     return GenContext::new(&rules, &toks);
 }
 
-// --- kind_check_str ---
 
 test "kind_check_str: empty set returns 'true'" {
     let mut ctx = mk_ctx();
@@ -77,7 +76,6 @@ test "kind_check_str: multi-token uses helper call" {
     assert ctx.kind_sets().len() == 1;
 }
 
-// --- intern_kind_set determinism ---
 
 test "intern_kind_set: same set returns same id (insertion order)" {
     let mut ctx = mk_ctx();
@@ -146,7 +144,6 @@ test "kind_sets: returns entries in insertion order" {
     assert entries[2].tokens[0] == "TK_M";
 }
 
-// --- kind_negate_check_str ---
 
 test "kind_negate_check_str: empty set returns 'false'" {
     let mut ctx = mk_ctx();
@@ -181,7 +178,6 @@ test "kind_negate_check_str: shares ids with kind_check_str" {
     assert ctx.kind_sets().len() == 1, "positive and negative must share";
 }
 
-// --- tail_greedy_first_of_rule ---
 
 test "tail_greedy_first: rule with tail-position Optional token" {
     // a : X Y? ;
@@ -236,7 +232,6 @@ test "tail_greedy_first: transitive via tail RuleRef" {
     assert tg[0] == "TK_Y", `expected TK_Y, got {tg[0]}`;
 }
 
-// --- intern_follow_variant ---
 
 test "intern_follow_variant: empty intersection returns null" {
     // a : X Y? ; tail_greedy = {Y}. caller_follow = {Z}. intersection = {}.
@@ -296,7 +291,6 @@ test "intern_follow_variant: different rules get distinct ids" {
     assert ctx.follow_variants().len() == 2;
 }
 
-// --- intern_follow_variant rejection paths ---
 
 test "intern_follow_variant: unknown rule returns null" {
     // No rules in ctx; lookup fails up front.
@@ -368,7 +362,6 @@ test "intern_follow_variant: empty caller_follow returns null" {
     assert ctx.follow_variants().is_empty();
 }
 
-// --- tail_greedy_first single-token-only restriction ---
 
 test "tail_greedy_first: tail Optional with multi-token inner is excluded" {
     // `(A B)?` is tail-position but the inner consumes 2 tokens per

--- a/package-gale/src/gen_util.wado
+++ b/package-gale/src/gen_util.wado
@@ -1,4 +1,4 @@
-use { Alternative, Element, Visibility } from "./ir.wado";
+use { Alternative, Element, RepeatKind, Visibility } from "./ir.wado";
 use { CodeWriter } from "./wadopoet.wado";
 use { TreeSet } from "core:collections";
 pub use { escape_ident, to_pascal_case, to_snake_case, to_lower } from "./ident.wado";
@@ -548,4 +548,227 @@ fn all_alternatives_labeled(alts: &Array<Alternative>) -> bool {
 pub fn case_names_for_rule(alts: &Array<Alternative>) -> Array<String> {
     let all_labeled = all_alternatives_labeled(alts);
     return build_case_names(alts, all_labeled);
+}
+
+// --- String/array set utilities ---
+
+/// Return `true` when `first` contains `token` (linear scan).
+pub fn first_contains(first: &Array<String>, token: &String) -> bool {
+    for let item of first {
+        if *item == *token {
+            return true;
+        }
+    }
+    return false;
+}
+
+/// Append every token in `source` to `arr`, skipping duplicates already in `arr`.
+pub fn dedup_append_arr(arr: &mut Array<String>, source: &Array<String>) {
+    for let tk of source {
+        if !first_contains(arr, tk) {
+            arr.push(*tk);
+        }
+    }
+}
+
+// --- Field / name dedup helpers ---
+//
+// Parser codegen names every consumed element so the surrounding struct
+// field can be populated. When the same base name appears more than
+// once in an alt (e.g. two `ID` tokens) the second occurrence gets a
+// `_2` suffix, the third `_3`, and so on. `Array<[String, i32]>` is
+// the running counter: `[base, count_emitted_so_far]`.
+
+fn get_count(counts: &Array<[String, i32]>, name: &String) -> i32 {
+    for let entry of counts {
+        if entry.0 == *name {
+            return entry.1;
+        }
+    }
+    return 0;
+}
+
+fn increment_count(counts: &mut Array<[String, i32]>, name: &String) {
+    for let mut i = 0; i < counts.len(); i += 1 {
+        if counts[i].0 == *name {
+            let prev = counts[i].1;
+            counts[i] = [*name, prev + 1];
+            return;
+        }
+    }
+    counts.push([*name, 1]);
+}
+
+/// Emit-and-record: returns the deduplicated name and bumps the counter.
+/// First occurrence returns `base`, second returns `{base}_2`, etc.
+pub fn dedup_name(base: &String, counts: &mut Array<[String, i32]>) -> String {
+    let count = get_count(counts, base);
+    increment_count(counts, base);
+    if count > 0 {
+        return `{base}_{count + 1}`;
+    }
+    return *base;
+}
+
+/// Predict what `dedup_name(base, counts)` would return without
+/// advancing the counter. Used at scan-guard / lookahead sites where
+/// the inner emission performs the actual `dedup_name` (which both
+/// returns the name and advances the counter).
+pub fn peek_dedup_name(base: &String, counts: &Array<[String, i32]>) -> String {
+    let count = get_count(counts, base);
+    if count > 0 {
+        return `{base}_{count + 1}`;
+    }
+    return *base;
+}
+
+// --- Element field shape helpers ---
+
+pub fn has_field(elem: &Element) -> bool {
+    if let TokenRef(_) | Literal(_) | RuleRef(_) = elem {
+        return true;
+    }
+    if let Wildcard(_) = elem {
+        return true;
+    }
+    if let Not(_) = elem {
+        return true;
+    }
+    if let Label(lab) = elem {
+        return has_field(&lab.element);
+    }
+    if let Group(g) = elem {
+        return is_storable_group(&g.alternatives);
+    }
+    return false;
+}
+
+/// Returns true if `elem` is a list-label (`items+=X`). List labels store
+/// matches in an `Array<InnerType>` named by `lab.name`.
+pub fn is_list_label(elem: &Element) -> bool {
+    if let Label(lab) = elem {
+        return lab.list;
+    }
+    return false;
+}
+
+pub fn element_field_info(elem: &Element) -> [String, String] {
+    if let TokenRef(t) = elem {
+        return [t.field_name, "Token"];
+    }
+    if let Literal(l) = elem {
+        return [literal_field_name(&l.text), "Token"];
+    }
+    if let RuleRef(r) = elem {
+        return [r.field_name, rule_type_name(&r.name)];
+    }
+    if let Wildcard(_) = elem {
+        return ["wildcard", "Token"];
+    }
+    if let Not(ne) = elem {
+        return [not_element_field_name(&ne.element), "Token"];
+    }
+    if let Label(lab) = elem {
+        if lab.list {
+            let inner = element_field_info(&lab.element);
+            return [lab.field_name, `Array<{inner.1}>`];
+        }
+        return element_field_info(&lab.element);
+    }
+    if let Group(g) = elem {
+        if is_simple_cst_group(&g.alternatives) {
+            return [group_field_base_name(&g.alternatives), group_variant_type_name(&g.alternatives)];
+        }
+        if is_token_only_group(&g.alternatives) {
+            return [token_group_field_name(&g.alternatives), "Token"];
+        }
+        if is_single_alt_group(&g.alternatives) {
+            return [single_alt_group_field_name(&g.alternatives[0]), single_alt_group_type_name(&g.alternatives[0])];
+        }
+        if is_general_group(&g.alternatives) {
+            // Post Phase 2-G every general-group reference flows through
+            // the GIR `gen_op_group` / `gen_general_group_store*` chain
+            // which consumes lower-baked `GeneralShape.variant_type` /
+            // `alt_struct_names`. The surface-IR `element_field_info`
+            // helper is reached only by legacy walker fallbacks; if a
+            // future regression routes a general Group here we want
+            // emit to fail loudly rather than silently re-derive the
+            // type name from a stale walker field.
+            panic(
+                "element_field_info: general Group reached the surface helper — route through `gen_op_group`/`gen_general_group_store*` instead",
+            );
+        }
+        // Non-storable group falls through with the placeholder return.
+    }
+    return ["_", "Token"];
+}
+
+/// Replay name counting for an element without emitting code.
+/// This advances the dedup counter so subsequent elements get correct suffixes.
+pub fn replay_element_names(elem: &Element, name_counts: &mut Array<[String, i32]>) {
+    if let TokenRef(t) = elem {
+        dedup_name(&t.field_name, name_counts);
+        return;
+    }
+    if let Literal(l) = elem {
+        dedup_name(&literal_field_name(&l.text), name_counts);
+        return;
+    }
+    if let RuleRef(r) = elem {
+        dedup_name(&r.field_name, name_counts);
+        return;
+    }
+    if let Wildcard(_) = elem {
+        dedup_name(&"wildcard", name_counts);
+        return;
+    }
+    if let Not(ne) = elem {
+        dedup_name(&not_element_field_name(&ne.element), name_counts);
+        return;
+    }
+    if let Repeat(rep) = elem {
+        if has_field(&rep.element) {
+            if is_list_label(&rep.element) {
+                let info = element_field_info(&rep.element);
+                dedup_name(&info.0, name_counts);
+                return;
+            }
+            let info = element_field_info(&rep.element);
+            if let Star | Plus = rep.kind {
+                dedup_name(&`{info.0}_list`, name_counts);
+            }
+            if let Optional = rep.kind {
+                dedup_name(&info.0, name_counts);
+            }
+        }
+        return;
+    }
+    if let Label(lab) = elem {
+        if has_field(&lab.element) {
+            dedup_name(&lab.field_name, name_counts);
+        }
+        return;
+    }
+    if let Group(g) = elem {
+        if is_simple_cst_group(&g.alternatives) {
+            dedup_name(&group_field_base_name(&g.alternatives), name_counts);
+        } else if is_token_only_group(&g.alternatives) {
+            dedup_name(&token_group_field_name(&g.alternatives), name_counts);
+        } else if is_single_alt_group(&g.alternatives) {
+            dedup_name(&single_alt_group_field_name(&g.alternatives[0]), name_counts);
+        } else if is_general_group(&g.alternatives) {
+            // Replay only runs over the skipped prefix of an alt
+            // (`gen_alt_body_skip` callers), which by construction
+            // consists of token-shaped leaves (TokenRef / Literal).
+            // A general Group in that prefix would mean the prediction
+            // tree consumed beyond the scannable leading prefix — not
+            // a path any committed grammar produces.
+            panic(
+                "replay_element_names: general Group reached the skip-replay walker — only token-shaped prefix elements should be replayed",
+            );
+        }
+        // Non-storable group: nothing to seed in `name_counts`. The
+        // inner ops are emitted normally afterwards via `body.ops`.
+        return;
+    }
 }

--- a/package-gale/src/gen_util.wado
+++ b/package-gale/src/gen_util.wado
@@ -550,8 +550,6 @@ pub fn case_names_for_rule(alts: &Array<Alternative>) -> Array<String> {
     return build_case_names(alts, all_labeled);
 }
 
-// --- String/array set utilities ---
-
 /// Return `true` when `first` contains `token` (linear scan).
 pub fn first_contains(first: &Array<String>, token: &String) -> bool {
     for let item of first {
@@ -571,14 +569,11 @@ pub fn dedup_append_arr(arr: &mut Array<String>, source: &Array<String>) {
     }
 }
 
-// --- Field / name dedup helpers ---
-//
 // Parser codegen names every consumed element so the surrounding struct
 // field can be populated. When the same base name appears more than
 // once in an alt (e.g. two `ID` tokens) the second occurrence gets a
 // `_2` suffix, the third `_3`, and so on. `Array<[String, i32]>` is
 // the running counter: `[base, count_emitted_so_far]`.
-
 fn get_count(counts: &Array<[String, i32]>, name: &String) -> i32 {
     for let entry of counts {
         if entry.0 == *name {
@@ -621,8 +616,6 @@ pub fn peek_dedup_name(base: &String, counts: &Array<[String, i32]>) -> String {
     }
     return *base;
 }
-
-// --- Element field shape helpers ---
 
 pub fn has_field(elem: &Element) -> bool {
     if let TokenRef(_) | Literal(_) | RuleRef(_) = elem {

--- a/package-gale/src/gir.wado
+++ b/package-gale/src/gir.wado
@@ -313,7 +313,7 @@ pub struct FollowVariant {
 /// * `PredictDispatch` (a full SLL prediction-tree dispatch akin to
 ///   ANTLR4's `ParserATNSimulator`) — never required by any
 ///   committed grammar; emit's prediction tree
-///   (`parser_gen::PredictionNode`) is an emit-private SLL
+///   (`prediction::PredictionNode`) is an emit-private SLL
 ///   intermediary that does not surface in GIR.
 /// * `PartialScanDispatch` (some-alts-scannable + others-fall-through)
 ///   — would let mixed scannable / unscannable alt sets coexist;

--- a/package-gale/src/lexer_gen.wado
+++ b/package-gale/src/lexer_gen.wado
@@ -530,8 +530,6 @@ fn find_fragment(all_rules: &Array<LexerRule>, name: &String) -> Option<&LexerRu
     return null;
 }
 
-// --- Keyword detection and classification ---
-
 /// Tries to extract a single lowercase char from a case-insensitive CharClass (e.g., [aA]).
 fn try_extract_ci_char(cc: &CharClass) -> Option<char> {
     if cc.negated {
@@ -963,8 +961,6 @@ fn has_channel(rules: &Array<LexerRule>) -> bool {
     }
     return false;
 }
-
-// --- First-character dispatch ---
 
 struct TryCall {
     fn_name: String,

--- a/package-gale/src/lower.wado
+++ b/package-gale/src/lower.wado
@@ -1285,6 +1285,10 @@ fn sort_alts_by_element_count(indices: &mut Array<i32>, alts: &Array<Alternative
 /// only element is a `RuleRef` get a higher tier than multi-element
 /// `RuleRef`-led alts so SQLite-style `tor (',' tor)* | join_clause`
 /// groupings still pick the rule-ref catch-all on tie.
+///
+/// Skips leading nullable elements so the classification matches on the
+/// first element that actually contributes to FIRST — `b? K_TOKEN_X` gets
+/// `MULTI_TOKEN_LED` (4) rather than `MULTI_RULE_REF_LED` (2).
 fn alt_sort_priority(alt: &Alternative) -> i32 {
     if alt.elements.len() == 1 {
         if let RuleRef(_) = alt.elements[0] {
@@ -1293,6 +1297,9 @@ fn alt_sort_priority(alt: &Alternative) -> i32 {
         return 1;
     }
     for let elem of &alt.elements {
+        if is_nullable(elem) {
+            continue;
+        }
         match *elem {
             TokenRef(_) | Literal(_) => {
                 return 4;

--- a/package-gale/src/lower.wado
+++ b/package-gale/src/lower.wado
@@ -430,9 +430,12 @@ fn walk_scan_body_for_kind_sets(body: &ScanBody, ctx: &mut GenContext) {
 
 fn walk_scan_element_for_kind_sets(elem: &ScanElement, ctx: &mut GenContext) {
     match *elem {
-        Token(_) => {},
-        RuleCall(_) => {},
-        Wildcard => {},
+        Token(_) => {
+        },
+        RuleCall(_) => {
+        },
+        Wildcard => {
+        },
         Excluded(e) => {
             if e.kinds.len() >= 2 {
                 ctx.intern_kind_set(&e.kinds);
@@ -660,10 +663,8 @@ fn lower_lr_rule(rule: &ParserRule, ctx: &mut GenContext, variant_mask: &Array<S
             non_lr_indices.push(i);
         }
     }
-    assert !non_lr_indices.is_empty(),
-        `LR rule '{rule.name}' has no non-LR alt — ANTLR4 requires at least one atom alt`;
-    assert !lr_indices.is_empty(),
-        `LR rule '{rule.name}' has no LR alt — should not have reached lower_lr_rule`;
+    assert !non_lr_indices.is_empty(), `LR rule '{rule.name}' has no non-LR alt — ANTLR4 requires at least one atom alt`;
+    assert !lr_indices.is_empty(), `LR rule '{rule.name}' has no LR alt — should not have reached lower_lr_rule`;
 
     let total_lr: i32 = lr_indices.len();
     let atom = lower_lr_atom(rule, &non_lr_indices, ctx, variant_mask);
@@ -725,8 +726,7 @@ fn stamp_lr_self_ref_min_prec(lr_alts: &mut Array<LrAlt>, rule_name: &String, ru
         let conflict_min = lr_alts[i].conflict_min;
 
         let scan_len = lr_alts[i].scan_suffix.elements.len();
-        assert scan_len == suffix_len,
-            `LR suffix walk length mismatch: parse-side {suffix_len}, scan-side {scan_len}`;
+        assert scan_len == suffix_len, `LR suffix walk length mismatch: parse-side {suffix_len}, scan-side {scan_len}`;
 
         let mut new_ops: Array<Op> = [];
         let mut new_scan: Array<ScanElement> = [];
@@ -890,8 +890,7 @@ fn lower_lr_atom(rule: &ParserRule, non_lr_indices: &Array<i32>, ctx: &mut GenCo
 /// computed by the caller and stored verbatim.
 fn lower_lr_alt(rule: &ParserRule, alt_idx: i32, own_prec: i32, conflict_min: i32, ctx: &mut GenContext, variant_mask: &Array<String>) -> LrAlt {
     let alt = &rule.alternatives[alt_idx];
-    assert !alt.elements.is_empty(),
-        `LR alt {alt_idx} of '{rule.name}' is empty — should not be classified LR`;
+    assert !alt.elements.is_empty(), `LR alt {alt_idx} of '{rule.name}' is empty — should not be classified LR`;
 
     // Build per-alt CST identifiers. `case_name` mirrors
     // `case_names_for_rule`, and `struct_name` follows the
@@ -958,7 +957,16 @@ fn lower_lr_alt_suffix(rule: &ParserRule, alt_idx: i32, case_name: &String, stru
     let outer_follow: Array<String> = [];
     for let mut i = 1; i < alt.elements.len(); i += 1 {
         let [elem_follow, position_mask] = ctx.compute_call_site_follow_and_mask(&alt.elements, i, variant_mask);
-        let mut op = lower_op(&alt.elements[i], &mut name_counts, &rule.name, ctx, &mut group_counter, &elem_follow, variant_mask, &position_mask);
+        let mut op = lower_op(
+            &alt.elements[i],
+            &mut name_counts,
+            &rule.name,
+            ctx,
+            &mut group_counter,
+            &elem_follow,
+            variant_mask,
+            &position_mask,
+        );
         if let Repeat(rep_op) = &op {
             let basic_follow = ctx.first_of_elements_from(&alt.elements, i + 1);
             let basic_second = compute_caller_follow_second(&alt.elements, i + 1, ctx);
@@ -1112,7 +1120,7 @@ fn compute_lr_dispatch_data(lr_alts: &Array<LrAlt>) -> LrDispatchData {
 }
 
 /// Union-find overlap grouping over per-alt first sets. Mirrors
-/// `parser_gen::compute_overlap_groups` — alts whose first sets
+/// `alt_grouping::compute_overlap_groups` — alts whose first sets
 /// share at least one token end up in the same group; disjoint
 /// alts get their own singleton group. The output's iteration order
 /// matches the input order (first occurrence wins as group root).
@@ -1223,8 +1231,7 @@ fn build_overlap_dispatch(ctx_name: &String, alts: &Array<Alternative>, indices:
 
     for let idx of indices {
         let mut visiting: Array<String> = [];
-        assert ctx.is_alt_scannable(&alts[*idx].elements, &mut visiting),
-            `{*ctx_name}: alt {*idx} is not fully scannable; Tournament dispatch needs all alts scannable`;
+        assert ctx.is_alt_scannable(&alts[*idx].elements, &mut visiting), `{*ctx_name}: alt {*idx} is not fully scannable; Tournament dispatch needs all alts scannable`;
     }
 
     let mut sorted: Array<i32> = [];
@@ -1249,7 +1256,7 @@ fn any_overlap(first_sets: &Array<Array<String>>) -> bool {
 
 /// Sort `indices` by descending number of MANDATORY-leading-elements,
 /// with ties broken by `alt_sort_priority` and finally source order.
-/// Mirrors `parser_gen::sort_group_by_element_count` for the
+/// Mirrors `alt_grouping::sort_group_by_element_count` for the
 /// tournament-style dispatch.
 fn sort_alts_by_element_count(indices: &mut Array<i32>, alts: &Array<Alternative>) {
     for let mut i = 0; i < indices.len(); i += 1 {
@@ -1273,7 +1280,7 @@ fn sort_alts_by_element_count(indices: &mut Array<i32>, alts: &Array<Alternative
     }
 }
 
-/// Per-alt sorting priority, mirroring `parser_gen::alt_sort_priority`.
+/// Per-alt sorting priority, mirroring `alt_grouping::alt_sort_priority`.
 /// Higher = preferred at dispatch time. Single-element alts whose
 /// only element is a `RuleRef` get a higher tier than multi-element
 /// `RuleRef`-led alts so SQLite-style `tor (',' tor)* | join_clause`
@@ -1377,8 +1384,6 @@ fn lower_scan_element(elem: &Element, ctx: &mut GenContext, outer_follow: &Array
         RuleRef(r) => ScanElement::RuleCall(ScanRuleCallElem {
             target_snake: r.snake_name,
             variant_id: ctx.intern_follow_variant(&r.name, outer_follow, true),
-            // Default `None`; `stamp_lr_self_ref_min_prec` rewrites
-            // self-recursive scan calls inside LR suffixes.
             min_prec_arg: null,
         }),
         Wildcard(_) => ScanElement::Wildcard,
@@ -1398,12 +1403,10 @@ fn lower_scan_element(elem: &Element, ctx: &mut GenContext, outer_follow: &Array
 /// multi-alt token-only groups dispatch on token kind.
 fn lower_scan_group(g: &GroupElement, ctx: &mut GenContext, outer_follow: &Array<String>, variant_mask: &Array<String>) -> ScanElement {
     let alts = &g.alternatives;
-    assert alts.len() > 0,
-        "Group with no alts is not a valid scan-lowering input";
+    assert alts.len() > 0, "Group with no alts is not a valid scan-lowering input";
     if alts.len() == 1 {
         let alt = &alts[0];
-        assert alt.elements.len() > 0,
-            "Group with empty alt is not a valid scan-lowering input";
+        assert alt.elements.len() > 0, "Group with empty alt is not a valid scan-lowering input";
         if alt.elements.len() == 1 {
             // Transparent (scan side) — nested inner allowed. The
             // group's only element inherits the surrounding follow.
@@ -1515,15 +1518,6 @@ fn lower_scan_repeat(rep: &RepeatElement, ctx: &mut GenContext, outer_follow: &A
         body,
         strategy: strategy,
         inner_first: inner_first,
-        // Default seed mirrors parse-side `lower_repeat_op`: the
-        // variant-aware `outer_follow` so nested Repeats (not at
-        // alt-position) carry a sensible value. Alt-level scan
-        // walkers (`lower_scan_body`, `lower_lr_alt_scan_suffix`,
-        // and the per-shape walks inside `lower_scan_group`)
-        // overwrite this with `first_of_elements_from(alt_elements,
-        // i + 1)` so emit's op-driven Optional+RuleRef gate reads
-        // the same basic follow as the parse side's
-        // `RepeatOp.caller_follow_first`.
         caller_follow_first: *outer_follow,
     });
 }
@@ -1630,7 +1624,9 @@ fn lower_scan_shape_body(shape: &Array<i32>, elements: &Array<Element>, ctx: &mu
         if let Group(g) = actual {
             if g.alternatives.len() == 1 {
                 for let mut j = 0; j < g.alternatives[0].elements.len(); j += 1 {
-                    body_elems.push(lower_scan_element(&g.alternatives[0].elements[j], ctx, &empty_follow, variant_mask));
+                    body_elems.push(
+                        lower_scan_element(&g.alternatives[0].elements[j], ctx, &empty_follow, variant_mask),
+                    );
                 }
                 continue;
             }
@@ -1785,7 +1781,16 @@ fn lower_alt_body(alt: &Alternative, idx: i32, rule: &ParserRule, ctx: &mut GenC
     for let mut i = 0; i < alt.elements.len(); i += 1 {
         let elem = &alt.elements[i];
         let [elem_follow, position_mask] = ctx.compute_call_site_follow_and_mask(&alt.elements, i, variant_mask);
-        let mut op = lower_op(elem, &mut name_counts, &rule.name, ctx, &mut group_counter, &elem_follow, variant_mask, &position_mask);
+        let mut op = lower_op(
+            elem,
+            &mut name_counts,
+            &rule.name,
+            ctx,
+            &mut group_counter,
+            &elem_follow,
+            variant_mask,
+            &position_mask,
+        );
         // For Repeat ops, replace `caller_follow_first` with the basic
         // first set of the surrounding suffix. `compute_call_site_follow_and_mask`
         // returns the variant-interning follow (which considers deep-nullable
@@ -1866,9 +1871,36 @@ fn lower_op(elem: &Element, name_counts: &mut Array<[String, i32]>, rule_name: &
                 dedup_base: base,
             });
         },
-        Repeat(rep) => lower_repeat_op(rep, name_counts, rule_name, ctx, group_counter, outer_follow, variant_mask, outer_position_mask),
-        Group(g) => lower_group_op(g, name_counts, rule_name, ctx, group_counter, outer_follow, variant_mask, outer_position_mask),
-        Label(lab) => lower_label_op(lab, name_counts, rule_name, ctx, group_counter, outer_follow, variant_mask, outer_position_mask),
+        Repeat(rep) => lower_repeat_op(
+            rep,
+            name_counts,
+            rule_name,
+            ctx,
+            group_counter,
+            outer_follow,
+            variant_mask,
+            outer_position_mask,
+        ),
+        Group(g) => lower_group_op(
+            g,
+            name_counts,
+            rule_name,
+            ctx,
+            group_counter,
+            outer_follow,
+            variant_mask,
+            outer_position_mask,
+        ),
+        Label(lab) => lower_label_op(
+            lab,
+            name_counts,
+            rule_name,
+            ctx,
+            group_counter,
+            outer_follow,
+            variant_mask,
+            outer_position_mask,
+        ),
     };
 }
 
@@ -1893,16 +1925,32 @@ fn lower_op(elem: &Element, name_counts: &mut Array<[String, i32]>, rule_name: &
 /// * Phase 2.x.general — multi-alt non-trivial → `GroupShape::General`
 fn lower_group_op(g: &GroupElement, name_counts: &mut Array<[String, i32]>, rule_name: &String, ctx: &mut GenContext, group_counter: &mut i32, outer_follow: &Array<String>, variant_mask: &Array<String>, outer_position_mask: &Array<String>) -> Op {
     let alts = &g.alternatives;
-    assert alts.len() > 0,
-        "Group with no alts is not a valid lowering input";
+    assert alts.len() > 0, "Group with no alts is not a valid lowering input";
     if alts.len() == 1 {
         let alt = &alts[0];
-        assert alt.elements.len() > 0,
-            "Group with empty alt is not a valid lowering input";
+        assert alt.elements.len() > 0, "Group with empty alt is not a valid lowering input";
         if alt.elements.len() == 1 {
-            return lower_transparent_group(&alt.elements[0], name_counts, rule_name, ctx, group_counter, outer_follow, variant_mask, outer_position_mask);
+            return lower_transparent_group(
+                &alt.elements[0],
+                name_counts,
+                rule_name,
+                ctx,
+                group_counter,
+                outer_follow,
+                variant_mask,
+                outer_position_mask,
+            );
         }
-        return lower_single_alt_group(alt, name_counts, rule_name, ctx, group_counter, outer_follow, variant_mask, outer_position_mask);
+        return lower_single_alt_group(
+            alt,
+            name_counts,
+            rule_name,
+            ctx,
+            group_counter,
+            outer_follow,
+            variant_mask,
+            outer_position_mask,
+        );
     }
     if is_token_only_group(alts) {
         return lower_token_only_group(alts, name_counts, ctx, variant_mask);
@@ -1911,7 +1959,16 @@ fn lower_group_op(g: &GroupElement, name_counts: &mut Array<[String, i32]>, rule
         return lower_simple_cst_group(alts, name_counts, ctx, variant_mask);
     }
     if is_general_group(alts) {
-        return lower_general_group(alts, name_counts, rule_name, ctx, group_counter, outer_follow, variant_mask, outer_position_mask);
+        return lower_general_group(
+            alts,
+            name_counts,
+            rule_name,
+            ctx,
+            group_counter,
+            outer_follow,
+            variant_mask,
+            outer_position_mask,
+        );
     }
     panic("Group shape unrecognised by classifier — should be impossible");
 }
@@ -1925,7 +1982,16 @@ fn lower_transparent_group(inner: &Element, name_counts: &mut Array<[String, i32
     // A Transparent group adds nothing between the inner and the
     // outer alt, so `outer_follow` passes through verbatim.
 
-    let inner_op = lower_op(inner, name_counts, rule_name, ctx, group_counter, outer_follow, variant_mask, outer_position_mask);
+    let inner_op = lower_op(
+        inner,
+        name_counts,
+        rule_name,
+        ctx,
+        group_counter,
+        outer_follow,
+        variant_mask,
+        outer_position_mask,
+    );
     let body = AltBody {
         alt_index: 0,
         case_name: "",
@@ -1993,7 +2059,16 @@ fn lower_single_alt_group(alt: &Alternative, name_counts: &mut Array<[String, i3
         // Inner elements inherit the outer position's mask — `(a? b)?`
         // inside `outer ... (a? b)? rest` reads the same mask emit used
         // to install on `ctx.current_follow_mask` at the OUTER position.
-        let mut op = lower_op(elem, &mut inner_counts, &owner_rule, ctx, group_counter, &elem_follow, variant_mask, outer_position_mask);
+        let mut op = lower_op(
+            elem,
+            &mut inner_counts,
+            &owner_rule,
+            ctx,
+            group_counter,
+            &elem_follow,
+            variant_mask,
+            outer_position_mask,
+        );
         let mut se = lower_scan_element(elem, ctx, &elem_follow, variant_mask);
         // Gate `basic_follow` on either side actually being a Repeat —
         // `first_of_elements_from` walks the suffix and isn't free.
@@ -2074,7 +2149,7 @@ fn lower_token_only_group(alts: &Array<Alternative>, name_counts: &mut Array<[St
             struct_name: "",
             ops: [op],
             fields: [],
-                prefix_self_ref_min_prec: 0,
+            prefix_self_ref_min_prec: 0,
         });
         // Token-only alts are by construction leaves with no inner
         // Repeats — outer_follow is irrelevant, pass empty.
@@ -2154,7 +2229,7 @@ fn lower_simple_cst_group(alts: &Array<Alternative>, name_counts: &mut Array<[St
             struct_name: "",
             ops: [op],
             fields: [],
-                prefix_self_ref_min_prec: 0,
+            prefix_self_ref_min_prec: 0,
         });
         // SimpleCst alts are single `RuleRef`s — outer_follow does
         // not propagate into the callee (whole-rule follow is the
@@ -2285,7 +2360,16 @@ fn lower_general_group(alts: &Array<Alternative>, name_counts: &mut Array<[Strin
             // See `lower_single_alt_group` — inner elements inherit
             // the outer position's mask, mirroring emit's inner-walker
             // semantics on the retired `ctx.current_follow_mask`.
-            let mut op = lower_op(elem, &mut inner_counts, rule_name, ctx, group_counter, &elem_follow, variant_mask, outer_position_mask);
+            let mut op = lower_op(
+                elem,
+                &mut inner_counts,
+                rule_name,
+                ctx,
+                group_counter,
+                &elem_follow,
+                variant_mask,
+                outer_position_mask,
+            );
             let mut se = lower_scan_element(elem, ctx, &elem_follow, variant_mask);
             let op_is_repeat = op matches { Repeat(_) };
             let se_is_repeat = se matches { Repeat(_) };
@@ -2309,7 +2393,7 @@ fn lower_general_group(alts: &Array<Alternative>, name_counts: &mut Array<[Strin
             struct_name: alt_struct,
             fields: enumerate_op_field_decls(&ops),
             ops: ops,
-                prefix_self_ref_min_prec: 0,
+            prefix_self_ref_min_prec: 0,
         });
         scan_bodies.push(ScanBody { elements: scan_elements });
     }
@@ -2439,7 +2523,16 @@ fn lower_repeat_op(rep: &RepeatElement, name_counts: &mut Array<[String, i32]>, 
     // references the binding as `<outer_field>.push(...)`) matches.
     let body = if repeat_inner_is_list_label(&rep.element) {
         if let Label(lab) = &rep.element {
-            let inner_op = lower_op(&lab.element, &mut inner_counts, rule_name, ctx, group_counter, &iter_follow, variant_mask, outer_position_mask);
+            let inner_op = lower_op(
+                &lab.element,
+                &mut inner_counts,
+                rule_name,
+                ctx,
+                group_counter,
+                &iter_follow,
+                variant_mask,
+                outer_position_mask,
+            );
             // The Repeat's outer field carries `lab.field_name` as
             // its base (deduped earlier in `outer_field`); the rebind
             // adopts that base on the inner op so emit's leaf sync
@@ -2449,7 +2542,16 @@ fn lower_repeat_op(rep: &RepeatElement, name_counts: &mut Array<[String, i32]>, 
             panic("repeat_inner_is_list_label returned true for non-Label");
         }
     } else {
-        lower_op(&rep.element, &mut inner_counts, rule_name, ctx, group_counter, &iter_follow, variant_mask, outer_position_mask);
+        lower_op(
+            &rep.element,
+            &mut inner_counts,
+            rule_name,
+            ctx,
+            group_counter,
+            &iter_follow,
+            variant_mask,
+            outer_position_mask,
+        );
     };
     let mut body_visiting: Array<String> = [];
     let body_scannable = ctx.is_element_scannable(&rep.element, &mut body_visiting);
@@ -2474,16 +2576,6 @@ fn lower_repeat_op(rep: &RepeatElement, name_counts: &mut Array<[String, i32]>, 
         scan_body,
         strategy: strategy,
         field: outer_field,
-        // Seed `caller_follow_first` with the surrounding outer follow so
-        // nested Repeats (not at alt position) carry a sensible value. The
-        // alt-level post-pass in `lower_alt_body` / `lower_lr_alt_suffix`
-        // / `lower_single_alt_group` / `lower_general_group` overwrites
-        // `caller_follow_first` / `caller_follow_second` with the
-        // position-aware values once it knows the position index.
-        // `position_mask` is the OUTER alt-position's mask threaded
-        // from the alt walker — emit's `gen_op_repeat_optional_rulecall`
-        // unions it with the caller-supplied `follow` (which the inner
-        // walker can clear to `[]` for greedy Optionals).
         caller_follow_first: *outer_follow,
         position_mask: *outer_position_mask,
         caller_follow_second: [],
@@ -2529,7 +2621,9 @@ fn classify_repeat_body_shape(body: &Op) -> RepeatBodyShape {
         // arm before `lower_op` builds the Op, and a directly nested
         // Repeat body has no surface-grammar equivalent (`(a*)*`
         // collapses through the surface Group).
-        ListLabel(_) | Repeat(_) => panic("classify_repeat_body_shape: ListLabel / Repeat reached as a Repeat body — lower-side bug"),
+        ListLabel(_) | Repeat(_) => panic(
+            "classify_repeat_body_shape: ListLabel / Repeat reached as a Repeat body — lower-side bug",
+        ),
     };
 }
 
@@ -2556,7 +2650,7 @@ fn compute_caller_follow_second(elements: &Array<Element>, start: i32, ctx: &mut
 }
 
 /// True iff the surface `Element` contributes a CST field. Mirror of
-/// `parser_gen::has_field`, kept in lower so the result can be baked
+/// `gen_util::has_field`, kept in lower so the result can be baked
 /// into `RepeatOp.body_has_field` without forcing emit to keep the
 /// surface predicate alive.
 fn element_has_field(elem: &Element) -> bool {
@@ -2595,13 +2689,25 @@ fn pick_optional_specialised(inner: &Element, body_has_field: bool, ctx: &mut Ge
     let shape = try_optional_shape_lookahead(inner, ctx);
     let scan_guard = try_optional_scan_guard(inner, ctx);
     if body_has_field {
-        if let Some(s) = k_token { return Option::<RepeatStrategy>::Some(s); }
-        if let Some(s) = shape { return Option::<RepeatStrategy>::Some(s); }
-        if let Some(s) = scan_guard { return Option::<RepeatStrategy>::Some(s); }
+        if let Some(s) = k_token {
+            return Option::<RepeatStrategy>::Some(s);
+        }
+        if let Some(s) = shape {
+            return Option::<RepeatStrategy>::Some(s);
+        }
+        if let Some(s) = scan_guard {
+            return Option::<RepeatStrategy>::Some(s);
+        }
     } else {
-        if let Some(s) = shape { return Option::<RepeatStrategy>::Some(s); }
-        if let Some(s) = k_token { return Option::<RepeatStrategy>::Some(s); }
-        if let Some(s) = scan_guard { return Option::<RepeatStrategy>::Some(s); }
+        if let Some(s) = shape {
+            return Option::<RepeatStrategy>::Some(s);
+        }
+        if let Some(s) = k_token {
+            return Option::<RepeatStrategy>::Some(s);
+        }
+        if let Some(s) = scan_guard {
+            return Option::<RepeatStrategy>::Some(s);
+        }
     }
     return null;
 }
@@ -2959,7 +3065,16 @@ fn repeat_inner_group_base_name(g: &GroupElement, gc_speculative: i32) -> String
 fn lower_label_op(lab: &LabelElement, name_counts: &mut Array<[String, i32]>, rule_name: &String, ctx: &mut GenContext, group_counter: &mut i32, outer_follow: &Array<String>, variant_mask: &Array<String>, outer_position_mask: &Array<String>) -> Op {
     let label_field = dedup_name(&lab.field_name, name_counts);
     let mut inner_counts: Array<[String, i32]> = [];
-    let inner_op = lower_op(&lab.element, &mut inner_counts, rule_name, ctx, group_counter, outer_follow, variant_mask, outer_position_mask);
+    let inner_op = lower_op(
+        &lab.element,
+        &mut inner_counts,
+        rule_name,
+        ctx,
+        group_counter,
+        outer_follow,
+        variant_mask,
+        outer_position_mask,
+    );
     if lab.list {
         // `name+=elem` outside a Repeat: the outer CST struct stores
         // the matched value in an `Array<inner_type>`. Wrap the inner
@@ -2985,7 +3100,7 @@ fn lower_label_op(lab: &LabelElement, name_counts: &mut Array<[String, i32]>, ru
 /// the lowered op list. Transparent `Group` ops contribute their
 /// inner op's field instead (the group itself has no struct slot).
 ///
-/// Mirrors what `parser_gen::element_field_info` computed at emit
+/// Mirrors what `gen_util::element_field_info` computed at emit
 /// time, but consumes the lowered IR so the field name and type
 /// agree with whatever shape the lowering chose. emit reads this
 /// list directly to lay out the struct.
@@ -3307,8 +3422,7 @@ fn collect_excluded_kinds(inner: &Element) -> Array<String> {
 fn collect_excluded_kinds_from_group(g: &GroupElement) -> Array<String> {
     let mut kinds: Array<String> = [];
     for let alt of &g.alternatives {
-        assert alt.elements.len() == 1,
-            "collect_excluded_kinds: ~ Group alt must be a single token / literal";
+        assert alt.elements.len() == 1, "collect_excluded_kinds: ~ Group alt must be a single token / literal";
         let elem = &alt.elements[0];
         match *elem {
             TokenRef(t) => kinds.push(`TK_{t.name}`),
@@ -3319,7 +3433,7 @@ fn collect_excluded_kinds_from_group(g: &GroupElement) -> Array<String> {
     return kinds;
 }
 
-/// Field-name deduplication mirroring `parser_gen::dedup_name`. The
+/// Field-name deduplication mirroring `gen_util::dedup_name`. The
 /// first occurrence keeps the base name; subsequent occurrences get
 /// `<base>_<n>` for `n = 2, 3, ...`.
 ///

--- a/package-gale/src/parser_gen.wado
+++ b/package-gale/src/parser_gen.wado
@@ -4674,7 +4674,7 @@ fn gen_multi_alt_body_bt(w: &mut CodeWriter, rule: &ParserRule, lowered_rule: &R
                 pred_indices.push(real_idx);
                 pred_elements.push(rule.alternatives[real_idx].elements);
             }
-            let tree = build_prediction(&pred_indices, &pred_elements, 0, 5, ctx);
+            let tree = build_prediction(&pred_indices, &pred_elements, 5, ctx);
             gen_prediction_code(w, &tree, &fn_name, &rule.alternatives, lowered_rule, type_name, ctx);
         }
 

--- a/package-gale/src/parser_gen.wado
+++ b/package-gale/src/parser_gen.wado
@@ -1,13 +1,4 @@
-use {
-    Grammar,
-    ParserRule,
-    Alternative,
-    Element,
-    RepeatElement,
-    RepeatKind,
-    LabelElement,
-    GroupElement,
-} from "./ir.wado";
+use { Grammar, ParserRule, Alternative, Element, RepeatElement, GroupElement } from "./ir.wado";
 use {
     rule_type_name,
     literal_field_name,
@@ -31,10 +22,24 @@ use {
     str_set_insert_all,
     gen_visibility_comment,
     to_snake_case,
+    first_contains,
+    dedup_append_arr,
+    dedup_name,
+    peek_dedup_name,
+    element_field_info,
+    replay_element_names,
 } from "./gen_util.wado";
 use { GenContext, is_nullable, sets_overlap, is_simple_token_group, union_kind_arrays } from "./gen_context.wado";
 use { CodeWriter, StructSpec, ImplSpec, FnSpec, ParamSpec } from "./wadopoet.wado";
 use { TreeSet } from "core:collections";
+use { PredictionNode, build_prediction } from "./prediction.wado";
+use {
+    compute_overlap_groups,
+    has_multi_alt_groups,
+    sort_group_by_specificity,
+    sort_group_by_mandatory_count_desc,
+    sort_group_by_element_count,
+} from "./alt_grouping.wado";
 use {
     LoweredGrammar,
     Rule,
@@ -77,891 +82,6 @@ use {
 use { unwrap_label } from "./lr_util.wado";
 use { compute_shapes_for_alt, shape_lookahead_signature_for_alt } from "./lower.wado";
 
-fn first_contains(first: &Array<String>, token: &String) -> bool {
-    for let item of first {
-        if *item == *token {
-            return true;
-        }
-    }
-    return false;
-}
-
-fn dedup_append_arr(arr: &mut Array<String>, source: &Array<String>) {
-    for let tk of source {
-        if !first_contains(arr, tk) {
-            arr.push(*tk);
-        }
-    }
-}
-
-// --- Prediction Engine ---
-
-variant PredictionNode {
-    Leaf(i32),
-    Dispatch(PredictionDispatch),
-    Consume(ConsumeNode),
-    Ambiguous(Array<i32>),
-}
-
-struct ConsumeNode {
-    element: Element,
-    child: PredictionNode,
-}
-
-struct PredictionDispatch {
-    depth: i32,
-    branches: Array<PredictionBranch>,
-}
-
-struct PredictionBranch {
-    tokens: Array<String>,
-    child: PredictionNode,
-}
-
-/// Return the index of an existing branch whose child equals `child`, or -1
-/// when no branch matches. Callers use this to fold a new (token, child) entry
-/// into an existing branch instead of creating a duplicate.
-fn find_merge_branch(branches: &Array<PredictionBranch>, child: &PredictionNode) -> i32 {
-    for let mut b = 0; b < branches.len(); b += 1 {
-        if prediction_node_eq(&branches[b].child, child) {
-            return b;
-        }
-    }
-    return -1;
-}
-
-fn build_prediction(alt_indices: &Array<i32>, first_sets: &Array<Array<String>>, alt_elements: &Array<Array<Element>>, depth: i32, max_depth: i32, ctx: &mut GenContext) -> PredictionNode {
-    // Build initial SLL configs: one per alternative, at element position 0.
-    let mut configs: Array<SllConfig> = [];
-    for let mut i = 0; i < alt_indices.len(); i += 1 {
-        configs.push(SllConfig {
-            alt_index: alt_indices[i],
-            elements: alt_elements[i],
-            pos: 0,
-            return_stack: [],
-        });
-    }
-    let tree = build_sll_node(&configs, 0, max_depth, ctx);
-    return strip_dead_consume(tree);
-}
-
-/// Strip Consume nodes whose child contains any Ambiguous — fall back to
-/// Ambiguous from the original position rather than consuming then failing.
-/// This handles both direct Consume → Ambiguous and indirect cases like
-/// Consume → Dispatch → (Branch → Ambiguous).
-fn strip_dead_consume(node: PredictionNode) -> PredictionNode {
-    return match node {
-        Consume(c) => {
-            let child = strip_dead_consume(c.child);
-            if prediction_contains_ambiguous(&child) {
-                let mut indices: Array<i32> = [];
-                prediction_collect_all_indices(&child, &mut indices);
-                PredictionNode::Ambiguous(indices);
-            } else {
-                PredictionNode::Consume(ConsumeNode { element: c.element, child });
-            }
-        },
-        Dispatch(d) => {
-            let mut new_branches: Array<PredictionBranch> = [];
-            for let b of d.branches {
-                new_branches.push(PredictionBranch {
-                    tokens: b.tokens,
-                    child: strip_dead_consume(b.child),
-                });
-            }
-            PredictionNode::Dispatch(PredictionDispatch { depth: d.depth, branches: new_branches });
-        },
-        _ => node,
-    };
-}
-
-fn prediction_contains_ambiguous(node: &PredictionNode) -> bool {
-    return match *node {
-        Ambiguous(_) => true,
-        Consume(c) => prediction_contains_ambiguous(&c.child),
-        Dispatch(d) => {
-            for let b of &d.branches {
-                if prediction_contains_ambiguous(&b.child) {
-                    return true;
-                }
-            }
-            return false;
-        },
-        Leaf(_) => false,
-    };
-}
-
-fn prediction_collect_all_indices(node: &PredictionNode, out: &mut Array<i32>) {
-    match *node {
-        Ambiguous(indices) => {
-            for let i of &indices {
-                if !out.iter().any(|x: i32| x == *i) {
-                    out.push(*i);
-                }
-            }
-        },
-        Leaf(idx) => {
-            if !out.iter().any(|x: i32| x == idx) {
-                out.push(idx);
-            }
-        },
-        Consume(c) => prediction_collect_all_indices(&c.child, out),
-        Dispatch(d) => {
-            for let b of &d.branches {
-                prediction_collect_all_indices(&b.child, out);
-            }
-        },
-    }
-}
-
-
-struct SllReturn {
-    elements: Array<Element>,
-    pos: i32,
-}
-
-struct SllConfig {
-    alt_index: i32,
-    elements: Array<Element>,
-    pos: i32,
-    return_stack: Array<SllReturn>,
-}
-
-fn sll_config_clone(c: &SllConfig) -> SllConfig {
-    return SllConfig {
-        alt_index: c.alt_index,
-        elements: c.elements,
-        pos: c.pos,
-        return_stack: c.return_stack,
-    };
-}
-
-fn push_return(stack: &Array<SllReturn>, elements: Array<Element>, pos: i32) -> Array<SllReturn> {
-    let mut new_stack: Array<SllReturn> = [];
-    for let s of stack {
-        new_stack.push(*s);
-    }
-    new_stack.push(SllReturn { elements, pos });
-    return new_stack;
-}
-
-fn pop_return(c: &SllConfig) -> SllConfig {
-    let last_idx = c.return_stack.len() - 1;
-    let ret = &c.return_stack[last_idx];
-    let mut new_stack: Array<SllReturn> = [];
-    for let mut i = 0; i < last_idx; i += 1 {
-        new_stack.push(c.return_stack[i]);
-    }
-    return SllConfig {
-        alt_index: c.alt_index,
-        elements: ret.elements,
-        pos: ret.pos,
-        return_stack: new_stack,
-    };
-}
-
-
-/// Identity closure — nullable handling is done in sll_config_first
-/// (first_of_elements_from) and sll_advance (explicit skip logic).
-fn sll_closure(configs: &Array<SllConfig>) -> Array<SllConfig> {
-    return *configs;
-}
-
-/// True when the config has fully consumed its elements and has no return
-/// frame to pop into — i.e. the alt's body is finished and any further token
-/// belongs to the calling context. Opaque configs (`pos < 0`) are not at-end.
-///
-/// The check walks `return_stack` from the most-recently-pushed frame back
-/// to the oldest, mirroring what a sequence of `pop_return` calls would
-/// expose. Walking by index keeps this O(n); the previous recursive
-/// implementation was O(n^2) because each `pop_return` rebuilt the entire
-/// surviving prefix of `return_stack` into a fresh `Array`.
-fn config_is_at_end(c: &SllConfig) -> bool {
-    if c.pos < 0 {
-        return false;
-    }
-    if c.pos < c.elements.len() {
-        return false;
-    }
-    let mut i = c.return_stack.len();
-    while i > 0 {
-        i -= 1;
-        let frame = &c.return_stack[i];
-        if frame.pos < frame.elements.len() {
-            return false;
-        }
-    }
-    return true;
-}
-
-
-/// Compute FIRST set of the current position in a config.
-/// Includes tokens from nullable elements that were skipped by closure.
-/// When at end of elements with a return stack, pops and continues from caller.
-fn sll_config_first(c: &SllConfig, ctx: &mut GenContext) -> Array<String> {
-    if c.pos < 0 {
-        return [];
-    }
-    if c.pos >= c.elements.len() {
-        if c.return_stack.is_empty() {
-            return [];
-        }
-        let popped = pop_return(c);
-        return sll_config_first(&popped, ctx);
-    }
-    return ctx.first_of_elements_from(&c.elements, c.pos);
-}
-
-/// Advance a config by one token. For terminals, advance pos.
-/// For RuleRef, expand into the rule's alternatives (entering the rule).
-fn sll_advance(c: &SllConfig, token: &String, ctx: &mut GenContext, inline_depth: i32 = 0) -> Array<SllConfig> {
-    // Limit inline expansion depth to prevent explosion from recursive rules.
-    if inline_depth > 2 {
-        return [];
-    }
-    if c.pos < 0 {
-        return [];
-    }
-    // End of current elements: pop return stack if available.
-    if c.pos >= c.elements.len() {
-        if c.return_stack.is_empty() {
-            return [];
-        }
-        let popped = pop_return(c);
-        return sll_advance(&popped, token, ctx, inline_depth);
-    }
-    let elem = &c.elements[c.pos];
-
-    // Nullable element (Optional, Star): either match its inner or skip it.
-    if is_nullable(elem) {
-        let mut results: Array<SllConfig> = [];
-        let mut visiting: Array<String> = [];
-        if first_contains(&ctx.first_of_element(elem, &mut visiting), token) {
-            // Check if the inner element is a multi-token RuleRef.
-            // If so, enter it via return stack instead of skipping to pos+1.
-            let mut entered = false;
-            if let Repeat(rep) = elem {
-                if let RuleRef(rr) = rep.element {
-                    let mut stv: Array<String> = [];
-                    if !ctx.rule_is_single_token(&rr.name, &mut stv) && c.return_stack.len() < 1 {
-                        let inner_rule = ctx.find_rule(&rr.name);
-                        let inner_alt_count = if let Some(r) = inner_rule {
-                            r.alternatives.len();
-                        } else {
-                            0;
-                        };
-                        if inner_alt_count <= 8 {
-                            entered = true;
-                            let new_stack = push_return(&c.return_stack, c.elements, c.pos + 1);
-                            if let Some(inner_rule) = inner_rule {
-                                for let alt of inner_rule.alternatives {
-                                    let mut v2: Array<String> = [];
-                                    if !first_contains(&ctx.first_of_alt(&alt, &mut v2), token) {
-                                        continue;
-                                    }
-                                    let exp = SllConfig {
-                                        alt_index: c.alt_index,
-                                        elements: alt.elements,
-                                        pos: 0,
-                                        return_stack: new_stack,
-                                    };
-                                    let advanced = sll_advance(&exp, token, ctx, inline_depth + 1);
-                                    for let a of advanced {
-                                        results.push(a);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            if !entered {
-                results.push(SllConfig {
-                    alt_index: c.alt_index,
-                    elements: c.elements,
-                    pos: c.pos + 1,
-                    return_stack: c.return_stack,
-                });
-            }
-        }
-        // Also try skipping: advance past all consecutive nullables non-recursively.
-        let mut skip_pos = c.pos + 1;
-        while skip_pos < c.elements.len() && is_nullable(&c.elements[skip_pos]) {
-            let mut v: Array<String> = [];
-            if first_contains(&ctx.first_of_element(&c.elements[skip_pos], &mut v), token) {
-                results.push(SllConfig {
-                    alt_index: c.alt_index,
-                    elements: c.elements,
-                    pos: skip_pos + 1,
-                    return_stack: c.return_stack,
-                });
-            }
-            skip_pos += 1;
-        }
-        if skip_pos < c.elements.len() {
-            let skipped_elem = &c.elements[skip_pos];
-            if let TokenRef(t) = skipped_elem {
-                if `TK_{t.name}` == *token {
-                    results.push(SllConfig {
-                        alt_index: c.alt_index,
-                        elements: c.elements,
-                        pos: skip_pos + 1,
-                        return_stack: c.return_stack,
-                    });
-                }
-            } else if let Literal(l) = skipped_elem {
-                if literal_const_name(&l.text) == *token {
-                    results.push(SllConfig {
-                        alt_index: c.alt_index,
-                        elements: c.elements,
-                        pos: skip_pos + 1,
-                        return_stack: c.return_stack,
-                    });
-                }
-            } else if let RuleRef(r) = skipped_elem {
-                let mut v: Array<String> = [];
-                if first_contains(&ctx.first_of_rule(&r.name, &mut v), token) {
-                    let mut stv: Array<String> = [];
-                    if ctx.rule_is_single_token(&r.name, &mut stv) {
-                        results.push(SllConfig {
-                            alt_index: c.alt_index,
-                            elements: c.elements,
-                            pos: skip_pos + 1,
-                            return_stack: c.return_stack,
-                        });
-                    } else {
-                        results.push(SllConfig {
-                            alt_index: c.alt_index,
-                            elements: c.elements,
-                            pos: -1,
-                            return_stack: c.return_stack,
-                        });
-                    }
-                }
-            } else {
-                let mut v: Array<String> = [];
-                if first_contains(&ctx.first_of_element(skipped_elem, &mut v), token) {
-                    results.push(SllConfig {
-                        alt_index: c.alt_index,
-                        elements: c.elements,
-                        pos: skip_pos + 1,
-                        return_stack: c.return_stack,
-                    });
-                }
-            }
-        }
-        return results;
-    }
-
-    // Terminal: if token matches, advance past this element.
-    if let TokenRef(t) = elem {
-        if `TK_{t.name}` == *token {
-            return [SllConfig {
-                    alt_index: c.alt_index,
-                    elements: c.elements,
-                    pos: c.pos + 1,
-                    return_stack: c.return_stack,
-                }];
-        }
-        return [];
-    }
-    if let Literal(l) = elem {
-        if literal_const_name(&l.text) == *token {
-            return [SllConfig {
-                    alt_index: c.alt_index,
-                    elements: c.elements,
-                    pos: c.pos + 1,
-                    return_stack: c.return_stack,
-                }];
-        }
-        return [];
-    }
-
-    // RuleRef: advance past only if the rule always consumes exactly one token.
-    // Multi-token rules return opaque (pos=-1); expansion happens in build_sll_node
-    // only when needed to resolve ambiguity.
-    if let RuleRef(r) = elem {
-        let mut visiting: Array<String> = [];
-        let rule_first = ctx.first_of_rule(&r.name, &mut visiting);
-        if !first_contains(&rule_first, token) {
-            return [];
-        }
-        let mut st_visiting: Array<String> = [];
-        if ctx.rule_is_single_token(&r.name, &mut st_visiting) {
-            // Single-token rule: safe to advance, element position == token position.
-            return [SllConfig {
-                    alt_index: c.alt_index,
-                    elements: c.elements,
-                    pos: c.pos + 1,
-                    return_stack: c.return_stack,
-                }];
-        }
-        // Multi-token rule: token matches FIRST but we can't advance past it.
-        // Return config with pos = -1 as a sentinel meaning "opaque match".
-        return [SllConfig { alt_index: c.alt_index, elements: c.elements, pos: -1, return_stack: c.return_stack }];
-    }
-
-    // Group: treat as consuming one token if the token is in FIRST(group).
-    if let Group(g) = elem {
-        let mut group_first = TreeSet::<String>::new();
-        for let alt of g.alternatives {
-            let mut visiting: Array<String> = [];
-            let af = ctx.first_of_alt(alt, &mut visiting);
-            str_set_insert_all(&mut group_first, &af);
-        }
-        if group_first.contains(*token) {
-            return [SllConfig {
-                    alt_index: c.alt_index,
-                    elements: c.elements,
-                    pos: c.pos + 1,
-                    return_stack: c.return_stack,
-                }];
-        }
-        return [];
-    }
-
-    // Repeat: treat as consuming the inner element.
-    if let Repeat(rep) = elem {
-        let mut inner_first: Array<String> = [];
-        let mut visiting: Array<String> = [];
-        inner_first = ctx.first_of_element(&rep.element, &mut visiting);
-        if first_contains(&inner_first, token) {
-            // Advance past the repeat element (simplified: treat as consuming 1 token).
-            return [SllConfig {
-                    alt_index: c.alt_index,
-                    elements: c.elements,
-                    pos: c.pos + 1,
-                    return_stack: c.return_stack,
-                }];
-        }
-        return [];
-    }
-
-    // Label: unwrap.
-    if let Label(lab) = elem {
-        let unwrapped = SllConfig {
-            alt_index: c.alt_index,
-            elements: replace_element_at(&c.elements, c.pos, &lab.element),
-            pos: c.pos,
-            return_stack: c.return_stack,
-        };
-        return sll_advance(&unwrapped, token, ctx, inline_depth);
-    }
-
-    return [];
-}
-
-fn replace_element_at(elements: &Array<Element>, pos: i32, replacement: &Element) -> Array<Element> {
-    let mut result: Array<Element> = [];
-    for let mut i = 0; i < elements.len(); i += 1 {
-        if i == pos {
-            result.push(*replacement);
-        } else {
-            result.push(elements[i]);
-        }
-    }
-    return result;
-}
-
-/// Collect unique alt indices from configs.
-fn sll_unique_alts(configs: &Array<SllConfig>) -> Array<i32> {
-    let mut alts: Array<i32> = [];
-    for let c of configs {
-        if !array_contains_i32(&alts, c.alt_index) {
-            alts.push(c.alt_index);
-        }
-    }
-    return alts;
-}
-
-/// Deduplicate configs: merge configs with the same (alt_index) that reach
-/// the same prediction outcome. For SLL, two configs with the same alt_index
-/// are equivalent for prediction purposes.
-fn sll_dedup_by_alt(configs: &Array<SllConfig>) -> Array<SllConfig> {
-    let mut seen_alts: Array<i32> = [];
-    let mut result: Array<SllConfig> = [];
-    for let c of configs {
-        if !array_contains_i32(&seen_alts, c.alt_index) {
-            seen_alts.push(c.alt_index);
-            result.push(sll_config_clone(c));
-        }
-    }
-    return result;
-}
-
-fn build_sll_node(configs: &Array<SllConfig>, depth: i32, max_depth: i32, ctx: &mut GenContext) -> PredictionNode {
-    let closed = sll_closure(configs);
-
-    // Guard: if too many configs, fall back to Ambiguous (codegen scan-dispatches) to avoid explosion.
-    if closed.len() > 200 {
-        let alts = sll_unique_alts(&closed);
-        return PredictionNode::Ambiguous(alts);
-    }
-
-    // Check unique alternatives.
-    let alts = sll_unique_alts(&closed);
-    if alts.len() == 1 {
-        return PredictionNode::Leaf(alts[0]);
-    }
-    if alts.len() == 0 || depth >= max_depth {
-        return PredictionNode::Ambiguous(alts);
-    }
-
-    // Check for common prefix: if all configs are at a terminal element
-    // that is the same across all configs, emit Consume.
-    let common = sll_find_common_terminal(&closed);
-    if let Some(elem) = common {
-        // Advance all configs past this shared terminal.
-        let mut advanced: Array<SllConfig> = [];
-        for let c of closed {
-            advanced.push(SllConfig {
-                alt_index: c.alt_index,
-                elements: c.elements,
-                pos: c.pos + 1,
-                return_stack: c.return_stack,
-            });
-        }
-        let child = build_sll_node(&advanced, depth, max_depth, ctx);
-        return PredictionNode::Consume(ConsumeNode { element: elem, child });
-    }
-
-    // Compute FIRST set for each config.
-    let mut all_tokens: Array<String> = [];
-    let mut all_tokens_seen = TreeSet::<String>::new();
-    let mut config_firsts: Array<Array<String>> = [];
-    let mut config_first_sets: Array<TreeSet<String>> = [];
-    for let c of closed {
-        let first = sll_config_first(&c, ctx);
-        config_first_sets.push(str_set_from(&first));
-        config_firsts.push(first);
-        for let tk of first {
-            if !all_tokens_seen.contains(tk) {
-                all_tokens_seen.insert(tk);
-                all_tokens.push(tk);
-            }
-        }
-    }
-
-    // Build dispatch branches.
-    let mut branches: Array<PredictionBranch> = [];
-
-    for let mut t = 0; t < all_tokens.len(); t += 1 {
-        let tk = &all_tokens[t];
-
-        // Advance all configs that can match this token.
-        let mut next_configs: Array<SllConfig> = [];
-        let mut opaque_alts: Array<i32> = [];
-        for let mut i = 0; i < closed.len(); i += 1 {
-            if config_first_sets[i].contains(*tk) {
-                let advanced = sll_advance(&closed[i], tk, ctx);
-                for let a of advanced {
-                    if a.pos == -1 {
-                        // Opaque config: multi-token RuleRef, can't advance past.
-                        if !array_contains_i32(&opaque_alts, a.alt_index) {
-                            opaque_alts.push(a.alt_index);
-                        }
-                    } else {
-                        next_configs.push(a);
-                    }
-                }
-            }
-        }
-
-        if next_configs.len() == 0 && opaque_alts.len() == 0 {
-            continue;
-        }
-
-        // Dedup: keep one config per alt (SLL ignores context).
-        let deduped = sll_dedup_by_alt(&next_configs);
-        let mut next_alts = sll_unique_alts(&deduped);
-        // Add opaque alts (they survive regardless of further lookahead).
-        for let oa of opaque_alts {
-            if !array_contains_i32(&next_alts, oa) {
-                next_alts.push(oa);
-            }
-        }
-
-        let child = if next_alts.len() == 1 {
-            // Resolved: this token uniquely identifies one alternative.
-            PredictionNode::Leaf(next_alts[0]);
-        } else if opaque_alts.len() > 0 {
-            // Still ambiguous with opaque alts: try expansion before giving up.
-            let expanded = try_expand_opaque(&closed, tk, &next_configs, opaque_alts, depth + 1, max_depth, ctx);
-            if let Some(node) = expanded {
-                node;
-            } else {
-                PredictionNode::Ambiguous(next_alts);
-            }
-        } else {
-            // Still ambiguous: recurse with deeper lookahead.
-            build_sll_node(&deduped, depth + 1, max_depth, ctx);
-        };
-        let idx = find_merge_branch(&branches, &child);
-        if idx >= 0 {
-            branches[idx].tokens.push(*tk);
-        } else {
-            branches.push(PredictionBranch { tokens: [*tk], child });
-        }
-    }
-
-    // Detect at-end configs: their alts are fully consumed at this depth and
-    // would simply return to the caller. They have empty FIRST sets, so the
-    // per-token loop above silently dropped them — that left the dispatcher
-    // missing a "default" path for tokens belonging to the calling context.
-    //
-    // Two cases:
-    //  * No explicit branches but exactly one at-end alt → that alt is the
-    //    only valid match at this point. Return Leaf so the caller commits.
-    //  * Both explicit branches and at-end alts → ambiguous in general.
-    //    A token-dispatch on the explicit branch is unsafe because the
-    //    branch can fail at parse time (e.g. typespec `ID '[' ']'` matches
-    //    the lookahead `[` but the body `[ ]` won't match `[ <e> ]`),
-    //    leaving the at-end alt as the only correct choice. Fall back to
-    //    Ambiguous so the codegen's longest-match scan dispatch picks the
-    //    alt whose body actually parses (cf. ANTLR4's adaptive prediction).
-    //  * Multiple at-end alts → true ambiguity → Ambiguous.
-    let mut at_end_alts: Array<i32> = [];
-    for let c of &closed {
-        if config_is_at_end(c) && !array_contains_i32(&at_end_alts, c.alt_index) {
-            at_end_alts.push(c.alt_index);
-        }
-    }
-
-    if at_end_alts.len() >= 1 && branches.len() >= 1 {
-        return PredictionNode::Ambiguous(alts);
-    }
-
-    if branches.len() == 0 {
-        if at_end_alts.len() == 1 {
-            return PredictionNode::Leaf(at_end_alts[0]);
-        }
-        return PredictionNode::Ambiguous(alts);
-    }
-    return PredictionNode::Dispatch(PredictionDispatch { depth, branches });
-}
-
-/// Try to resolve opaque configs by expanding their multi-token RuleRefs.
-/// Uses ATN-style expansion: enter referenced rules, advance by one token,
-/// then compute FIRST sets at the decision point's lookahead level.
-/// Builds a flat Dispatch — never calls build_sll_node on expanded configs.
-fn try_expand_opaque(original_configs: &Array<SllConfig>, token: &String, non_opaque_configs: &Array<SllConfig>, opaque_alts: Array<i32>, depth: i32, max_depth: i32, ctx: &mut GenContext) -> Option<PredictionNode> {
-    if depth >= max_depth {
-        return null;
-    }
-    // Rule diversity check: only expand when opaque configs reference different rules.
-    let mut rule_refs = TreeSet::<String>::new();
-    for let c of original_configs {
-        if !array_contains_i32(&opaque_alts, c.alt_index) {
-            continue;
-        }
-        if c.pos < 0 || c.pos >= c.elements.len() {
-            continue;
-        }
-        if let RuleRef(r) = c.elements[c.pos] {
-            rule_refs.insert(r.name);
-        }
-    }
-    if rule_refs.len() <= 1 {
-        return null;
-    }
-    // Expand opaque configs by entering their RuleRefs and advancing by token.
-    let mut expanded_configs: Array<SllConfig> = [];
-    for let c of original_configs {
-        if !array_contains_i32(&opaque_alts, c.alt_index) {
-            continue;
-        }
-        if c.pos < 0 || c.pos >= c.elements.len() {
-            continue;
-        }
-        if let RuleRef(r) = c.elements[c.pos] {
-            let found_rule = ctx.find_rule(&r.name);
-            if let Some(found_rule) = found_rule {
-                if found_rule.alternatives.len() > 8 {
-                    continue;
-                }
-                let new_stack = push_return(&c.return_stack, c.elements, c.pos + 1);
-                for let alt of found_rule.alternatives {
-                    // Pre-filter: skip alternatives whose FIRST doesn't contain the token.
-                    let mut v: Array<String> = [];
-                    if !first_contains(&ctx.first_of_alt(&alt, &mut v), token) {
-                        continue;
-                    }
-                    let exp = SllConfig {
-                        alt_index: c.alt_index,
-                        elements: alt.elements,
-                        pos: 0,
-                        return_stack: new_stack,
-                    };
-                    let advanced = sll_advance(&exp, token, ctx);
-                    for let a of advanced {
-                        if a.pos != -1 {
-                            expanded_configs.push(a);
-                        }
-                    }
-                }
-            }
-        }
-    }
-    if expanded_configs.is_empty() {
-        return null;
-    }
-    // Combine non-opaque (already advanced) with expanded configs.
-    // All configs have consumed the same number of input tokens (depth),
-    // so their FIRST sets are all at the same lookahead level (depth).
-    let mut all_configs: Array<SllConfig> = [];
-    for let c of non_opaque_configs {
-        all_configs.push(sll_config_clone(c));
-    }
-    for let ec of expanded_configs {
-        all_configs.push(ec);
-    }
-    // Compute FIRST for each config at the decision point level.
-    let mut all_tokens: Array<String> = [];
-    let mut all_tokens_seen = TreeSet::<String>::new();
-    let mut config_first_sets: Array<TreeSet<String>> = [];
-    for let c of all_configs {
-        let first = sll_config_first(&c, ctx);
-        let first_set = str_set_from(&first);
-        config_first_sets.push(first_set);
-        for let tk of first {
-            if !all_tokens_seen.contains(tk) {
-                all_tokens_seen.insert(tk);
-                all_tokens.push(tk);
-            }
-        }
-    }
-    // Build flat Dispatch: for each token, find which alt_indices match.
-    let mut branches: Array<PredictionBranch> = [];
-    let mut has_improvement = false;
-    for let mut t = 0; t < all_tokens.len(); t += 1 {
-        let tk = &all_tokens[t];
-        let mut token_alts: Array<i32> = [];
-        for let mut i = 0; i < all_configs.len(); i += 1 {
-            if config_first_sets[i].contains(*tk) {
-                if !array_contains_i32(&token_alts, all_configs[i].alt_index) {
-                    token_alts.push(all_configs[i].alt_index);
-                }
-            }
-        }
-        let child = if token_alts.len() == 1 {
-            has_improvement = true;
-            PredictionNode::Leaf(token_alts[0]);
-        } else {
-            PredictionNode::Ambiguous(token_alts.sorted());
-        };
-        let idx = find_merge_branch(&branches, &child);
-        if idx >= 0 {
-            branches[idx].tokens.push(*tk);
-        } else {
-            branches.push(PredictionBranch { tokens: [*tk], child });
-        }
-    }
-    if !has_improvement || branches.is_empty() {
-        return null;
-    }
-    // Only use if ALL branches are Leaf — any Ambiguous branch means expansion
-    // didn't fully resolve, and the code generator's Dispatch has no fallback
-    // for unmatched tokens, which would silently drop valid inputs.
-    for let b of branches {
-        if let Ambiguous(_) = b.child {
-            return null;
-        }
-    }
-    // Safety: verify all original opaque alts appear in at least one branch.
-    let mut covered_alts: Array<i32> = [];
-    for let b of branches {
-        if let Leaf(idx) = b.child {
-            if !array_contains_i32(&covered_alts, idx) {
-                covered_alts.push(idx);
-            }
-        }
-    }
-    for let oa of opaque_alts {
-        if !array_contains_i32(&covered_alts, oa) {
-            return null;
-        }
-    }
-    return Option::<PredictionNode>::Some(PredictionNode::Dispatch(PredictionDispatch { depth, branches }));
-}
-
-
-/// Check if all configs are at the same terminal element (for Consume).
-fn sll_find_common_terminal(configs: &Array<SllConfig>) -> Option<Element> {
-    if configs.len() < 2 {
-        return null;
-    }
-    for let c of configs {
-        if c.pos >= c.elements.len() {
-            return null;
-        }
-    }
-    let first_elem = &configs[0].elements[configs[0].pos];
-    if let TokenRef(t) = first_elem {
-        for let mut i = 1; i < configs.len(); i += 1 {
-            let elem = &configs[i].elements[configs[i].pos];
-            if let TokenRef(other) = elem {
-                if other.name != t.name {
-                    return null;
-                }
-            } else {
-                return null;
-            }
-        }
-        return Option::<Element>::Some(*first_elem);
-    }
-    if let Literal(l) = first_elem {
-        for let mut i = 1; i < configs.len(); i += 1 {
-            let elem = &configs[i].elements[configs[i].pos];
-            if let Literal(other) = elem {
-                if other.text != l.text {
-                    return null;
-                }
-            } else {
-                return null;
-            }
-        }
-        return Option::<Element>::Some(*first_elem);
-    }
-    return null;
-}
-
-fn prediction_node_eq(a: &PredictionNode, b: &PredictionNode) -> bool {
-    return match [*a, *b] {
-        [Leaf(ai), Leaf(bi)] => ai == bi,
-        [Ambiguous(aa), Ambiguous(ba)] => {
-            if aa.len() != ba.len() {
-                return false;
-            }
-            for let mut i = 0; i < aa.len(); i += 1 {
-                if aa[i] != ba[i] {
-                    return false;
-                }
-            }
-            true;
-        },
-        // Consume nodes: check same element kind and recurse on child.
-        [Consume(ca), Consume(cb)] => element_eq(&ca.element, &cb.element) && prediction_node_eq(&ca.child, &cb.child),
-        _ => false,
-    };
-}
-
-fn element_eq(a: &Element, b: &Element) -> bool {
-    return match [*a, *b] {
-        [TokenRef(na), TokenRef(nb)] => na.name == nb.name,
-        [Literal(ta), Literal(tb)] => ta.text == tb.text,
-        _ => false,
-    };
-}
-
-fn array_contains_i32(arr: &Array<i32>, val: i32) -> bool {
-    for let mut i = 0; i < arr.len(); i += 1 {
-        if arr[i] == val {
-            return true;
-        }
-    }
-    return false;
-}
-
 pub fn gen_parser(w: &mut CodeWriter, grammar: &Grammar, lowered: &LoweredGrammar, ctx: &mut GenContext) {
     // Phase 3 — `lowered` mirrors `grammar.parser_rules` rule-for-rule
     // by name and order. emit still consumes surface IR for the body
@@ -996,8 +116,9 @@ pub fn gen_parser(w: &mut CodeWriter, grammar: &Grammar, lowered: &LoweredGramma
         }
         for let mut idx = emitted_count; idx < cur; idx += 1 {
             let entry = &entries[idx];
-            assert idx < lowered.variant_rules.len(),
-                `gen_parser: follow-variant entry #{idx} ({entry.rule_name} mask=[{join_kinds(&entry.mask)}]) was registered during emit but not by lower's pre-pass — lower and emit must agree via compute_call_site_follow`;
+            assert idx < lowered.variant_rules.len(), `gen_parser: follow-variant entry #{idx} ({entry.rule_name} mask=[{join_kinds(
+                &entry.mask,
+            )}]) was registered during emit but not by lower's pre-pass — lower and emit must agree via compute_call_site_follow`;
             emit_follow_variant_from_gir(w, &lowered.variant_rules[idx], ctx);
         }
         emitted_count = cur;
@@ -1341,7 +462,9 @@ fn gen_scan_function_named(w: &mut CodeWriter, rule: &ParserRule, lowered_rule: 
         let scan_body = if let Simple(s) = lowered_rule {
             &s.scan_body;
         } else {
-            panic("gen_scan_function_named: single-alt rule but lowered_rule is not Simple — lower_rule invariant violated");
+            panic(
+                "gen_scan_function_named: single-alt rule but lowered_rule is not Simple — lower_rule invariant violated",
+            );
         };
         w.line("let mut pos = pos;");
         gen_scan_op_elements(w, &scan_body.elements, 0, scan_body.elements.len(), ctx, &"return -1;");
@@ -1379,7 +502,9 @@ fn gen_scan_function_named(w: &mut CodeWriter, rule: &ParserRule, lowered_rule: 
         let scan_alts = if let MultiAlt(m) = lowered_rule {
             &m.scan_alts;
         } else {
-            panic("gen_scan_function_named: multi-alt rule but lowered_rule is not MultiAlt — lower_rule invariant violated");
+            panic(
+                "gen_scan_function_named: multi-alt rule but lowered_rule is not MultiAlt — lower_rule invariant violated",
+            );
         };
         gen_scan_multi_alt(w, &rule.alternatives, scan_alts, ctx);
     }
@@ -1991,7 +1116,11 @@ fn gen_scan_op_element(w: &mut CodeWriter, se: &ScanElement, ctx: &mut GenContex
         // `i32::MAX` for the trailing self-ref to short-circuit
         // any LR climb in the target rule; every other call site
         // leaves it at the default `0`.
-        let min_prec = if let Some(p) = rc.min_prec_arg { p } else { min_prec_override };
+        let min_prec = if let Some(p) = rc.min_prec_arg {
+            p;
+        } else {
+            min_prec_override;
+        };
         w.line(`pos = {fn_name}(tokens, pos, {min_prec});`);
         w.line(`if pos < 0 \{ {*fail_stmt} \}`);
         return;
@@ -2049,7 +1178,11 @@ fn gen_scan_op_element_assign(w: &mut CodeWriter, se: &ScanElement, ctx: &mut Ge
         // from bt-scan's trailing-self-ref site, so `min_prec` here
         // is always the rule's default `0` (or whatever
         // `min_prec_arg` baked at lower time, e.g. LR self-refs).
-        let min_prec = if let Some(p) = rc.min_prec_arg { p } else { 0 };
+        let min_prec = if let Some(p) = rc.min_prec_arg {
+            p;
+        } else {
+            0;
+        };
         w.line(`pos = {fn_name}(tokens, pos, {min_prec});`);
         return;
     }
@@ -2499,7 +1632,10 @@ fn gen_parse_fn_named(w: &mut CodeWriter, rule: &ParserRule, lowered_rule: &Rule
         }
     }
 
-    let has_lr = match lowered_rule { LeftRecursive(_) => true, _ => false };
+    let has_lr = match lowered_rule {
+        LeftRecursive(_) => true,
+        _ => false,
+    };
 
     if has_lr {
         let atom_name = `{*fn_name}_atom`;
@@ -2624,7 +1760,11 @@ fn gen_alt_body_skip(w: &mut CodeWriter, type_name: &String, variant_case: Optio
         let elem = &alt.elements[i];
         let op = &body.ops[i - ops_offset];
         if let Repeat(rep) = elem {
-            let rep_op = if let Repeat(r) = op { r } else { panic("gen_alt_body_skip: Repeat element / op mismatch") };
+            let rep_op = if let Repeat(r) = op {
+                r;
+            } else {
+                panic("gen_alt_body_skip: Repeat element / op mismatch");
+            };
             gen_op_repeat(w, rep, rep_op, ctx, &mut name_counts);
         } else if op_is_leaf(op) {
             gen_op_leaf(w, op, ctx, &mut name_counts);
@@ -2704,14 +1844,17 @@ fn gen_alt_elements(w: &mut CodeWriter, elements: &Array<Element>, ops: &Array<O
     // calculation; that path never reaches here. Wado's power-assert
     // surfaces the lengths automatically — the contract note in the
     // message points callers at the right entry point.
-    assert ops.len() == elements.len(),
-        "gen_alt_elements: ops / elements length mismatch — LR-suffix bodies must use gen_alt_body_skip";
+    assert ops.len() == elements.len(), "gen_alt_elements: ops / elements length mismatch — LR-suffix bodies must use gen_alt_body_skip";
     let mut name_counts: Array<[String, i32]> = [];
     for let mut i = 0; i < elements.len(); i += 1 {
         let elem = &elements[i];
         let op = &ops[i];
         if let Repeat(rep) = elem {
-            let rep_op = if let Repeat(r) = op { r } else { panic("gen_alt_elements: Repeat element / op mismatch") };
+            let rep_op = if let Repeat(r) = op {
+                r;
+            } else {
+                panic("gen_alt_elements: Repeat element / op mismatch");
+            };
             gen_op_repeat(w, rep, rep_op, ctx, &mut name_counts);
         } else if op_is_leaf(op) {
             gen_op_leaf(w, op, ctx, &mut name_counts);
@@ -2734,13 +1877,16 @@ fn gen_alt_elements(w: &mut CodeWriter, elements: &Array<Element>, ops: &Array<O
 /// `gen_op_list_label`; Repeat / Label / Not still flow through the
 /// surface `gen_repeat*` helpers (Phase 2-C migrates the Repeat arm).
 fn gen_elements_with_non_greedy(w: &mut CodeWriter, elements: &Array<Element>, ops: &Array<Op>, ctx: &mut GenContext, name_counts: &mut Array<[String, i32]>, outer_follow: &Array<String>) {
-    assert ops.len() == elements.len(),
-        "gen_elements_with_non_greedy: ops / elements length mismatch";
+    assert ops.len() == elements.len(), "gen_elements_with_non_greedy: ops / elements length mismatch";
     for let mut i = 0; i < elements.len(); i += 1 {
         let elem = &elements[i];
         let op = &ops[i];
         if let Repeat(rep) = elem {
-            let rep_op = if let Repeat(r) = op { r } else { panic("gen_elements_with_non_greedy: Repeat element / op mismatch") };
+            let rep_op = if let Repeat(r) = op {
+                r;
+            } else {
+                panic("gen_elements_with_non_greedy: Repeat element / op mismatch");
+            };
             let follow = inner_walker_follow_for_repeat(rep, rep_op, elements, i, outer_follow, ctx);
             gen_op_repeat_with_follow_override(w, rep, rep_op, ctx, name_counts, &follow);
         } else if op_is_leaf(op) {
@@ -2906,7 +2052,9 @@ fn gen_op_inner_for_storable_repeat(w: &mut CodeWriter, rep_op: &RepeatOp, elem:
     return match rep_op.body_shape {
         LeafRuleCall | LeafOther => gen_op_leaf(w, op, ctx, name_counts),
         StorableGroup => gen_op_storable_group_inner(w, op, elem, ctx, name_counts, outer_follow),
-        TransparentGroup => panic("gen_op_inner_for_storable_repeat: TransparentGroup body is not storable here — caller must dispatch via the non-storable arm"),
+        TransparentGroup => panic(
+            "gen_op_inner_for_storable_repeat: TransparentGroup body is not storable here — caller must dispatch via the non-storable arm",
+        ),
     };
 }
 
@@ -3007,7 +2155,7 @@ fn gen_op_absent_optional_field(w: &mut CodeWriter, op: &Op, name_counts: &mut A
         match rep_op.kind {
             Optional => w.line(`let {rep_op.field}: Option<{inner_type}> = null;`),
             Star | Plus => w.line(`let mut {rep_op.field}: Array<{inner_type}> = [];`),
-        };
+        }
         return;
     }
     if let ListLabel(ll) = op {
@@ -3095,21 +2243,69 @@ fn gen_op_storable_optional(w: &mut CodeWriter, rep: &RepeatElement, rep_op: &Re
     let inner_elem = &rep.element;
 
     return match &rep_op.strategy {
-        OptionalLookahead(s) => emit_op_storable_optional_with_first(w, rep_op, inner_elem, ctx, &opt_field, &inner_type, &inner_field, &gen_lookahead_condition(ctx, &s.sig)),
-        OptionalShapeLookahead(s) => emit_op_optional_with_shape_lookahead_storable(w, g_op, g_elem, s, ctx, name_counts, &opt_field, &inner_type, &inner_field),
+        OptionalLookahead(s) => emit_op_storable_optional_with_first(
+            w,
+            rep_op,
+            inner_elem,
+            ctx,
+            &opt_field,
+            &inner_type,
+            &inner_field,
+            &gen_lookahead_condition(ctx, &s.sig),
+        ),
+        OptionalShapeLookahead(s) => emit_op_optional_with_shape_lookahead_storable(
+            w,
+            g_op,
+            g_elem,
+            s,
+            ctx,
+            name_counts,
+            &opt_field,
+            &inner_type,
+            &inner_field,
+        ),
         OptionalScanGuard => {
             let scan_pos_var = emit_op_opt_scan_guard_for_group(w, g_op, g_elem, ctx, name_counts);
-            emit_op_storable_optional_with_first(w, rep_op, inner_elem, ctx, &opt_field, &inner_type, &inner_field, &`{scan_pos_var} >= 0`);
+            emit_op_storable_optional_with_first(
+                w,
+                rep_op,
+                inner_elem,
+                ctx,
+                &opt_field,
+                &inner_type,
+                &inner_field,
+                &`{scan_pos_var} >= 0`,
+            );
         },
         // `pick_optional_specialised` returned `null` and lower fell
         // through to the mask-aware decision: gate on
         // `body_first_set` (`Plain`) or the mask-subtracted variant
         // (`WithFollowSubtraction`).
-        Plain => emit_op_storable_optional_with_first(w, rep_op, inner_elem, ctx, &opt_field, &inner_type, &inner_field, &ctx.first_check_str(&rep_op.body_first_set)),
-        WithFollowSubtraction(s) => emit_op_storable_optional_with_first(w, rep_op, inner_elem, ctx, &opt_field, &inner_type, &inner_field, &ctx.first_check_str(&s.effective_first)),
+        Plain => emit_op_storable_optional_with_first(
+            w,
+            rep_op,
+            inner_elem,
+            ctx,
+            &opt_field,
+            &inner_type,
+            &inner_field,
+            &ctx.first_check_str(&rep_op.body_first_set),
+        ),
+        WithFollowSubtraction(s) => emit_op_storable_optional_with_first(
+            w,
+            rep_op,
+            inner_elem,
+            ctx,
+            &opt_field,
+            &inner_type,
+            &inner_field,
+            &ctx.first_check_str(&s.effective_first),
+        ),
         // Suppressed / NonGreedy / Suppressed are caught upstream;
         // reaching here is a lower-side bug.
-        Suppressed | NonGreedy(_) => panic("gen_op_storable_optional: Suppressed / NonGreedy strategy reached the greedy-Optional dispatcher — lower-side bug"),
+        Suppressed | NonGreedy(_) => panic(
+            "gen_op_storable_optional: Suppressed / NonGreedy strategy reached the greedy-Optional dispatcher — lower-side bug",
+        ),
     };
 }
 
@@ -3137,15 +2333,31 @@ fn gen_op_transparent_optional(w: &mut CodeWriter, rep: &RepeatElement, rep_op: 
     let _ = dedup_name(&rep_op.field, name_counts);
 
     return match &rep_op.strategy {
-        OptionalShapeLookahead(s) => emit_op_optional_with_shape_lookahead_transparent(w, g_op, g_elem, s, ctx, name_counts),
-        OptionalLookahead(s) => emit_op_transparent_optional_with_cond(w, g_op, g_elem, ctx, &gen_lookahead_condition(ctx, &s.sig)),
+        OptionalShapeLookahead(s) => emit_op_optional_with_shape_lookahead_transparent(
+            w,
+            g_op,
+            g_elem,
+            s,
+            ctx,
+            name_counts,
+        ),
+        OptionalLookahead(s) => emit_op_transparent_optional_with_cond(w, g_op, g_elem, ctx, &gen_lookahead_condition(
+            ctx,
+            &s.sig,
+        )),
         OptionalScanGuard => {
             let scan_pos_var = emit_op_opt_scan_guard_for_group(w, g_op, g_elem, ctx, name_counts);
             emit_op_transparent_optional_with_cond(w, g_op, g_elem, ctx, &`{scan_pos_var} >= 0`);
         },
-        Plain => emit_op_transparent_optional_with_cond(w, g_op, g_elem, ctx, &ctx.first_check_str(&rep_op.body_first_set)),
-        WithFollowSubtraction(s) => emit_op_transparent_optional_with_cond(w, g_op, g_elem, ctx, &ctx.first_check_str(&s.effective_first)),
-        Suppressed | NonGreedy(_) => panic("gen_op_transparent_optional: Suppressed / NonGreedy strategy reached the greedy-Optional dispatcher — lower-side bug"),
+        Plain => emit_op_transparent_optional_with_cond(w, g_op, g_elem, ctx, &ctx.first_check_str(
+            &rep_op.body_first_set,
+        )),
+        WithFollowSubtraction(s) => emit_op_transparent_optional_with_cond(w, g_op, g_elem, ctx, &ctx.first_check_str(
+            &s.effective_first,
+        )),
+        Suppressed | NonGreedy(_) => panic(
+            "gen_op_transparent_optional: Suppressed / NonGreedy strategy reached the greedy-Optional dispatcher — lower-side bug",
+        ),
     };
 }
 
@@ -3256,7 +2468,9 @@ fn emit_op_optional_with_shape_lookahead_transparent(w: &mut CodeWriter, g_op: &
                             gen_op_dispatch_element(w, &inner_body.ops[j], &inner_alt.elements[j], ctx, &mut nc);
                         }
                     } else {
-                        panic("emit_op_optional_with_shape_lookahead_transparent: single-alt Group surface but non-Group op");
+                        panic(
+                            "emit_op_optional_with_shape_lookahead_transparent: single-alt Group surface but non-Group op",
+                        );
                     }
                 } else {
                     gen_op_dispatch_element(w, actual_op, actual_elem, ctx, &mut nc);
@@ -3554,15 +2768,16 @@ fn gen_element(w: &mut CodeWriter, elem: &Element, ctx: &mut GenContext, name_co
         // here because lower replaces them with op-driven walkers
         // before this point. Probe with a panic so a future
         // regression is surfaced.
-        panic("gen_element: Repeat element reached the retired surface walker — route through op-driven `gen_op_repeat_with_follow_override`");
+        panic(
+            "gen_element: Repeat element reached the retired surface walker — route through op-driven `gen_op_repeat_with_follow_override`",
+        );
     }
     if let Group(g) = elem {
         // After the Phase 2-G op-driven migration, only token-only
         // groups reach this surface walker — every other Group
         // classification (SimpleCst, SingleAlt, General) is handled
         // by op-driven walkers before `gen_element` is invoked.
-        assert is_token_only_group(&g.alternatives),
-            "gen_element: only token-only groups reach the surface walker; other classifications must be handled op-driven before gen_element is invoked";
+        assert is_token_only_group(&g.alternatives), "gen_element: only token-only groups reach the surface walker; other classifications must be handled op-driven before gen_element is invoked";
         gen_consume_token_group(w, &g.alternatives, ctx, name_counts);
         return;
     }
@@ -3597,20 +2812,6 @@ fn gen_element(w: &mut CodeWriter, elem: &Element, ctx: &mut GenContext, name_co
     }
 }
 
-/// Predict what `dedup_name(base, counts)` would return without
-/// incrementing the count. Used by the `Label` case in `gen_element` to
-/// alias the inner element's emitted binding under the label name —
-/// the inner emission performs the actual `dedup_name` (which both
-/// computes and increments), and we need to know the resulting name
-/// before that to emit the alias.
-fn peek_dedup_name(base: &String, counts: &Array<[String, i32]>) -> String {
-    let count = get_count(counts, base);
-    if count > 0 {
-        return `{base}_{count + 1}`;
-    }
-    return *base;
-}
-
 /// Op-driven top-level Repeat dispatcher. Walkers reach this with
 /// `rep` (surface) and `rep_op` (lowered, carrying baked follow /
 /// strategy / scannable / has-field). Internally routes to the
@@ -3632,7 +2833,11 @@ fn gen_op_repeat_with_follow_override(w: &mut CodeWriter, rep: &RepeatElement, r
     // so even with a covering mask its loop must still emit — fall
     // through to the Star/Plus arm in that case.
     if let Suppressed = &rep_op.strategy {
-        let is_plus = if let Plus = rep.kind { true } else { false };
+        let is_plus = if let Plus = rep.kind {
+            true;
+        } else {
+            false;
+        };
         if !is_plus {
             gen_op_repeat_suppressed(w, rep, rep_op, name_counts);
             return;
@@ -3684,7 +2889,14 @@ fn gen_op_repeat_non_greedy(w: &mut CodeWriter, rep: &RepeatElement, rep_op: &Re
     let follow_second = &rep_op.caller_follow_second;
     let while_cond = compute_non_greedy_condition(rep_op, follow, follow_second, ctx);
     return match rep_op.body_shape {
-        LeafRuleCall | LeafOther | StorableGroup => gen_op_repeat_non_greedy_storable(w, rep, rep_op, ctx, name_counts, &while_cond),
+        LeafRuleCall | LeafOther | StorableGroup => gen_op_repeat_non_greedy_storable(
+            w,
+            rep,
+            rep_op,
+            ctx,
+            name_counts,
+            &while_cond,
+        ),
         TransparentGroup => gen_op_repeat_non_greedy_transparent(w, rep, rep_op, ctx, name_counts, &while_cond),
     };
 }
@@ -3694,8 +2906,12 @@ fn gen_op_repeat_non_greedy(w: &mut CodeWriter, rep: &RepeatElement, rep_op: &Re
 /// those into a list field of the surrounding alt's CST struct.
 fn gen_op_repeat_non_greedy_storable(w: &mut CodeWriter, rep: &RepeatElement, rep_op: &RepeatOp, ctx: &mut GenContext, name_counts: &mut Array<[String, i32]>, while_cond: &String) {
     let inner = &rep.element;
-    let is_plus = if let Plus = rep.kind { true } else { false };
-    let iter_follow_unused = ([] as Array<String>);
+    let is_plus = if let Plus = rep.kind {
+        true;
+    } else {
+        false;
+    };
+    let iter_follow_unused = [] as Array<String>;
     let inner_field = op_field(&rep_op.body);
     let inner_type = op_field_type(&rep_op.body);
     let list_field = rep_op.field;
@@ -3741,7 +2957,11 @@ fn gen_op_repeat_non_greedy_transparent(w: &mut CodeWriter, rep: &RepeatElement,
         panic("gen_op_repeat_non_greedy_transparent: lower marked TransparentGroup but body op is not Op::Group");
     };
     let inner = &rep.element;
-    let is_plus = if let Plus = rep.kind { true } else { false };
+    let is_plus = if let Plus = rep.kind {
+        true;
+    } else {
+        false;
+    };
     let _ = dedup_name(&rep_op.field, name_counts);
     if is_plus {
         let mut nc: Array<[String, i32]> = [];
@@ -3793,7 +3013,9 @@ fn gen_op_repeat_optional_group(w: &mut CodeWriter, rep: &RepeatElement, rep_op:
         TransparentGroup => gen_op_transparent_optional(w, rep, rep_op, g_op, g_elem, ctx, name_counts),
         // Caller (`gen_op_repeat_optional_greedy`) routes only Group
         // shapes here; the leaf shapes have their own arms upstream.
-        LeafRuleCall | LeafOther => panic("gen_op_repeat_optional_group: leaf body_shape reached the Group dispatcher — caller-side bug"),
+        LeafRuleCall | LeafOther => panic(
+            "gen_op_repeat_optional_group: leaf body_shape reached the Group dispatcher — caller-side bug",
+        ),
     };
 }
 
@@ -3881,7 +3103,14 @@ fn gen_op_repeat_star_plus_greedy(w: &mut CodeWriter, rep: &RepeatElement, rep_o
             };
             gen_op_repeat_star_plus_non_storable_group(w, rep, rep_op, g_op, ctx, name_counts);
         },
-        LeafRuleCall | LeafOther | StorableGroup => gen_op_repeat_star_plus_storable(w, rep, rep_op, ctx, name_counts, follow),
+        LeafRuleCall | LeafOther | StorableGroup => gen_op_repeat_star_plus_storable(
+            w,
+            rep,
+            rep_op,
+            ctx,
+            name_counts,
+            follow,
+        ),
     };
 }
 
@@ -3959,11 +3188,7 @@ fn gen_op_repeat_star_plus_storable(w: &mut CodeWriter, rep: &RepeatElement, rep
     };
     // Per-iteration follow propagated into a nested non-greedy Repeat
     // inside a SingleAlt body — `first(inner) ∪ outer_follow`.
-    let iter_follow = if rep_op.body_is_single_alt_group {
-        union_kind_arrays(&inner_first, follow);
-    } else {
-        *follow;
-    };
+    let iter_follow = if rep_op.body_is_single_alt_group { union_kind_arrays(&inner_first, follow) } else { *follow };
     let inner_type = op_field_type(&rep_op.body);
     let inner_field = op_field(&rep_op.body);
     let list_field = rep_op.field;
@@ -4016,7 +3241,6 @@ fn gen_op_repeat_star_plus_storable(w: &mut CodeWriter, rep: &RepeatElement, rep
         }
     }
 }
-
 
 
 fn wildcard_non_greedy_condition(ctx: &mut GenContext, follow_first: &Array<String>) -> String {
@@ -4210,151 +3434,6 @@ fn collect_not_set_tokens(alts: &Array<Alternative>, out: &mut Array<String>) ->
     return true;
 }
 
-fn has_field(elem: &Element) -> bool {
-    if let TokenRef(_) | Literal(_) | RuleRef(_) = elem {
-        return true;
-    }
-    if let Wildcard(_) = elem {
-        return true;
-    }
-    if let Not(_) = elem {
-        return true;
-    }
-    if let Label(lab) = elem {
-        return has_field(&lab.element);
-    }
-    if let Group(g) = elem {
-        return is_storable_group(&g.alternatives);
-    }
-    return false;
-}
-
-/// Returns true if `elem` is a list-label (`items+=X`). List labels store
-/// matches in an `Array<InnerType>` named by `lab.name`.
-fn is_list_label(elem: &Element) -> bool {
-    if let Label(lab) = elem {
-        return lab.list;
-    }
-    return false;
-}
-
-fn element_field_info(elem: &Element) -> [String, String] {
-    if let TokenRef(t) = elem {
-        return [t.field_name, "Token"];
-    }
-    if let Literal(l) = elem {
-        return [literal_field_name(&l.text), "Token"];
-    }
-    if let RuleRef(r) = elem {
-        return [r.field_name, rule_type_name(&r.name)];
-    }
-    if let Wildcard(_) = elem {
-        return ["wildcard", "Token"];
-    }
-    if let Not(ne) = elem {
-        return [not_element_field_name(&ne.element), "Token"];
-    }
-    if let Label(lab) = elem {
-        if lab.list {
-            let inner = element_field_info(&lab.element);
-            return [lab.field_name, `Array<{inner.1}>`];
-        }
-        return element_field_info(&lab.element);
-    }
-    if let Group(g) = elem {
-        if is_simple_cst_group(&g.alternatives) {
-            return [group_field_base_name(&g.alternatives), group_variant_type_name(&g.alternatives)];
-        }
-        if is_token_only_group(&g.alternatives) {
-            return [token_group_field_name(&g.alternatives), "Token"];
-        }
-        if is_single_alt_group(&g.alternatives) {
-            return [single_alt_group_field_name(&g.alternatives[0]), single_alt_group_type_name(&g.alternatives[0])];
-        }
-        if is_general_group(&g.alternatives) {
-            // Post Phase 2-G every general-group reference flows through
-            // the GIR `gen_op_group` / `gen_general_group_store*` chain
-            // which consumes lower-baked `GeneralShape.variant_type` /
-            // `alt_struct_names`. The surface-IR `element_field_info`
-            // helper is reached only by legacy walker fallbacks; if a
-            // future regression routes a general Group here we want
-            // emit to fail loudly rather than silently re-derive the
-            // type name from a stale walker field.
-            panic("element_field_info: general Group reached the surface helper — route through `gen_op_group`/`gen_general_group_store*` instead");
-        }
-        // Non-storable group falls through with the placeholder return.
-    }
-    return ["_", "Token"];
-}
-
-/// Replay name counting for an element without emitting code.
-/// This advances the dedup counter so subsequent elements get correct suffixes.
-fn replay_element_names(elem: &Element, name_counts: &mut Array<[String, i32]>) {
-    if let TokenRef(t) = elem {
-        dedup_name(&t.field_name, name_counts);
-        return;
-    }
-    if let Literal(l) = elem {
-        dedup_name(&literal_field_name(&l.text), name_counts);
-        return;
-    }
-    if let RuleRef(r) = elem {
-        dedup_name(&r.field_name, name_counts);
-        return;
-    }
-    if let Wildcard(_) = elem {
-        dedup_name(&"wildcard", name_counts);
-        return;
-    }
-    if let Not(ne) = elem {
-        dedup_name(&not_element_field_name(&ne.element), name_counts);
-        return;
-    }
-    if let Repeat(rep) = elem {
-        if has_field(&rep.element) {
-            if is_list_label(&rep.element) {
-                let info = element_field_info(&rep.element);
-                dedup_name(&info.0, name_counts);
-                return;
-            }
-            let info = element_field_info(&rep.element);
-            if let Star | Plus = rep.kind {
-                dedup_name(&`{info.0}_list`, name_counts);
-            }
-            if let Optional = rep.kind {
-                dedup_name(&info.0, name_counts);
-            }
-        }
-        return;
-    }
-    if let Label(lab) = elem {
-        if has_field(&lab.element) {
-            dedup_name(&lab.field_name, name_counts);
-        }
-        return;
-    }
-    if let Group(g) = elem {
-        if is_simple_cst_group(&g.alternatives) {
-            dedup_name(&group_field_base_name(&g.alternatives), name_counts);
-        } else if is_token_only_group(&g.alternatives) {
-            dedup_name(&token_group_field_name(&g.alternatives), name_counts);
-        } else if is_single_alt_group(&g.alternatives) {
-            dedup_name(&single_alt_group_field_name(&g.alternatives[0]), name_counts);
-        } else if is_general_group(&g.alternatives) {
-            // Replay only runs over the skipped prefix of an alt
-            // (`gen_alt_body_skip` callers), which by construction
-            // consists of token-shaped leaves (TokenRef / Literal).
-            // A general Group in that prefix would mean the prediction
-            // tree consumed beyond the scannable leading prefix — not
-            // a path any committed grammar produces.
-            panic("replay_element_names: general Group reached the skip-replay walker — only token-shaped prefix elements should be replayed");
-        }
-        // Non-storable group: nothing to seed in `name_counts`. The
-        // inner ops are emitted normally afterwards via `body.ops`.
-        return;
-    }
-}
-
 fn rule_ref_group_all_scannable(sorted_group: &Array<i32>, alts: &Array<Alternative>, ctx: &mut GenContext) -> bool {
     if sorted_group.len() < 2 {
         return false;
@@ -4511,8 +3590,7 @@ fn gen_consume_group_store_op(w: &mut CodeWriter, scst: &SimpleCstShape, g_op_al
                 let mut sorted_group = group.sorted();
                 sort_group_by_mandatory_count_desc(&mut sorted_group, alts, ctx);
 
-                assert rule_ref_group_all_scannable(&sorted_group, alts, ctx),
-                    "rule-ref group has unscannable alt; backtracking has been removed (see AGENTS.md 'Generated Parser Rules')";
+                assert rule_ref_group_all_scannable(&sorted_group, alts, ctx), "rule-ref group has unscannable alt; backtracking has been removed (see AGENTS.md 'Generated Parser Rules')";
                 gen_rule_ref_group_scan_dispatch(
                     w,
                     &sorted_group,
@@ -4593,9 +3671,17 @@ fn gen_consume_group_store_optional_op(w: &mut CodeWriter, scst: &SimpleCstShape
             let mut sorted_group = group.sorted();
             sort_group_by_mandatory_count_desc(&mut sorted_group, alts, ctx);
 
-            assert rule_ref_group_all_scannable(&sorted_group, alts, ctx),
-                "rule-ref group has unscannable alt; backtracking has been removed (see AGENTS.md 'Generated Parser Rules')";
-            gen_rule_ref_group_scan_dispatch(w, &sorted_group, alts, g_op_scan_alts, &inner_var, type_name, ctx, name_counts);
+            assert rule_ref_group_all_scannable(&sorted_group, alts, ctx), "rule-ref group has unscannable alt; backtracking has been removed (see AGENTS.md 'Generated Parser Rules')";
+            gen_rule_ref_group_scan_dispatch(
+                w,
+                &sorted_group,
+                alts,
+                g_op_scan_alts,
+                &inner_var,
+                type_name,
+                ctx,
+                name_counts,
+            );
         }
     }
     w.end();  // if/else if chain
@@ -4641,7 +3727,16 @@ fn gen_general_group_store_op(w: &mut CodeWriter, gs: &GeneralShape, g_op_alts: 
             } else {
                 w.else_begin("else");
             }
-            gen_general_alt_construct(w, alts, &g_op_alts[alt_idx], alt_idx, &type_name, &gs.alt_struct_names, ctx, name_counts);
+            gen_general_alt_construct(
+                w,
+                alts,
+                &g_op_alts[alt_idx],
+                alt_idx,
+                &type_name,
+                &gs.alt_struct_names,
+                ctx,
+                name_counts,
+            );
         }
         w.end_with(";");
     } else {
@@ -4668,7 +3763,17 @@ fn gen_general_group_store_op(w: &mut CodeWriter, gs: &GeneralShape, g_op_alts: 
 
             if group.len() == 1 {
                 let alt_idx = group[0];
-                gen_general_alt_parse_and_store(w, alts, &g_op_alts[alt_idx], alt_idx, &type_name, &gs.alt_struct_names, &opt_var, ctx, name_counts);
+                gen_general_alt_parse_and_store(
+                    w,
+                    alts,
+                    &g_op_alts[alt_idx],
+                    alt_idx,
+                    &type_name,
+                    &gs.alt_struct_names,
+                    &opt_var,
+                    ctx,
+                    name_counts,
+                );
             } else {
                 let mut sorted_group = group.sorted();
                 sort_group_by_mandatory_count_desc(&mut sorted_group, alts, ctx);
@@ -4740,11 +3845,32 @@ fn gen_general_group_store_optional_op(w: &mut CodeWriter, gs: &GeneralShape, g_
 
         if group.len() == 1 {
             let alt_idx = group[0];
-            gen_general_alt_parse_and_store(w, alts, &g_op_alts[alt_idx], alt_idx, &type_name, &gs.alt_struct_names, &inner_var, ctx, name_counts);
+            gen_general_alt_parse_and_store(
+                w,
+                alts,
+                &g_op_alts[alt_idx],
+                alt_idx,
+                &type_name,
+                &gs.alt_struct_names,
+                &inner_var,
+                ctx,
+                name_counts,
+            );
         } else {
             let mut sorted_group = group.sorted();
             sort_group_by_mandatory_count_desc(&mut sorted_group, alts, ctx);
-            gen_general_group_dispatch(w, alts, g_op_alts, g_op_scan_alts, &sorted_group, &type_name, &gs.alt_struct_names, &inner_var, ctx, name_counts);
+            gen_general_group_dispatch(
+                w,
+                alts,
+                g_op_alts,
+                g_op_scan_alts,
+                &sorted_group,
+                &type_name,
+                &gs.alt_struct_names,
+                &inner_var,
+                ctx,
+                name_counts,
+            );
         }
     }
     w.end();
@@ -4785,9 +3911,19 @@ fn gen_general_alt_construct(w: &mut CodeWriter, alts: &Array<Alternative>, body
 /// `gen_general_group_scan_dispatch`. Backtracking has been removed; an
 /// unscannable alt is a codegen-time error.
 fn gen_general_group_dispatch(w: &mut CodeWriter, alts: &Array<Alternative>, g_op_alts: &Array<AltBody>, g_op_scan_alts: &Array<ScanBody>, sorted_group: &Array<i32>, type_name: &String, alt_struct_names: &Array<String>, inner_var: &String, ctx: &mut GenContext, name_counts: &mut Array<[String, i32]>) {
-    assert general_group_all_scannable(sorted_group, alts, ctx),
-        "general group has unscannable alt; backtracking has been removed (see AGENTS.md 'Generated Parser Rules')";
-    gen_general_group_scan_dispatch(w, alts, g_op_alts, g_op_scan_alts, sorted_group, type_name, alt_struct_names, inner_var, ctx, name_counts);
+    assert general_group_all_scannable(sorted_group, alts, ctx), "general group has unscannable alt; backtracking has been removed (see AGENTS.md 'Generated Parser Rules')";
+    gen_general_group_scan_dispatch(
+        w,
+        alts,
+        g_op_alts,
+        g_op_scan_alts,
+        sorted_group,
+        type_name,
+        alt_struct_names,
+        inner_var,
+        ctx,
+        name_counts,
+    );
 }
 
 /// Returns true iff every alt in `sorted_group` has at least one element
@@ -4857,7 +3993,17 @@ fn gen_general_group_scan_dispatch(w: &mut CodeWriter, alts: &Array<Alternative>
             w.else_begin(`else if {winner_var} == {k}`);
         }
 
-        gen_general_alt_parse_and_store(w, alts, &g_op_alts[alt_idx], alt_idx, type_name, alt_struct_names, inner_var, ctx, name_counts);
+        gen_general_alt_parse_and_store(
+            w,
+            alts,
+            &g_op_alts[alt_idx],
+            alt_idx,
+            type_name,
+            alt_struct_names,
+            inner_var,
+            ctx,
+            name_counts,
+        );
     }
     w.end();
 }
@@ -5686,251 +4832,4 @@ fn find_needed_depth(all_position_sets: &Array<Array<Array<String>>>) -> i32 {
         }
     }
     return max_k;
-}
-
-fn dedup_name(base: &String, counts: &mut Array<[String, i32]>) -> String {
-    let count = get_count(counts, base);
-    increment_count(counts, base);
-    if count > 0 {
-        return `{base}_{count + 1}`;
-    }
-    return *base;
-}
-
-fn get_count(counts: &Array<[String, i32]>, name: &String) -> i32 {
-    for let entry of counts {
-        if entry.0 == *name {
-            return entry.1;
-        }
-    }
-    return 0;
-}
-
-fn increment_count(counts: &mut Array<[String, i32]>, name: &String) {
-    for let mut i = 0; i < counts.len(); i += 1 {
-        if counts[i].0 == *name {
-            let prev = counts[i].1;
-            counts[i] = [*name, prev + 1];
-            return;
-        }
-    }
-    counts.push([*name, 1]);
-}
-
-fn compute_overlap_groups(first_sets: &Array<Array<String>>) -> Array<Array<i32>> {
-    let n = first_sets.len();
-    let mut group_ids: Array<i32> = [];
-    for let mut i = 0; i < n; i += 1 {
-        group_ids.push(i);
-    }
-    for let mut i = 0; i < n; i += 1 {
-        for let mut j = i + 1; j < n; j += 1 {
-            if sets_overlap(&first_sets[i], &first_sets[j]) {
-                let gi = group_ids[i];
-                let gj = group_ids[j];
-                if gi != gj {
-                    for let mut k = 0; k < n; k += 1 {
-                        if group_ids[k] == gj {
-                            group_ids[k] = gi;
-                        }
-                    }
-                }
-            }
-        }
-    }
-    let mut seen_ids: Array<i32> = [];
-    let mut groups: Array<Array<i32>> = [];
-    for let mut i = 0; i < n; i += 1 {
-        let gid = group_ids[i];
-        let mut found = -1;
-        for let mut s = 0; s < seen_ids.len(); s += 1 {
-            if seen_ids[s] == gid {
-                found = s;
-                break;
-            }
-        }
-        if found >= 0 {
-            groups[found].push(i);
-        } else {
-            seen_ids.push(gid);
-            groups.push([i]);
-        }
-    }
-    return groups;
-}
-
-fn has_multi_alt_groups(groups: &Array<Array<i32>>) -> bool {
-    for let group of groups {
-        if group.len() > 1 {
-            return true;
-        }
-    }
-    return false;
-}
-
-fn sort_group_by_specificity(group: &mut Array<i32>, first_sets: &Array<Array<String>>) {
-    // Sort by first set size ascending: smaller first set = more specific = try first.
-    // Ties broken by original order (stable-ish bubble sort).
-    for let mut i = 0; i < group.len(); i += 1 {
-        for let mut j = i + 1; j < group.len(); j += 1 {
-            if first_sets[group[j]].len() < first_sets[group[i]].len() {
-                let tmp = group[i];
-                group[i] = group[j];
-                group[j] = tmp;
-            }
-        }
-    }
-}
-
-// Priority bands consumed by `alt_sort_priority` and friends. Higher
-// = try first.
-//
-// `MultiTokenLed` (4) is most specific: a multi-element alt whose
-// first non-nullable element is a fixed token (e.g. `K_CAST '(' expr
-// K_AS type_name ')'`). The leading token uniquely identifies the
-// alt, so committing on first match is safe.
-//
-// `BareRuleRef` (3) is the catch-all rank: a single-RuleRef alt
-// whose body can match complex internal patterns (`join_clause`,
-// `expr`). Tried before `MultiRuleRefLed` so single-RuleRef
-// catch-alls win against multi-element-RuleRef siblings — this is
-// what SQLite-style `(table_or_subquery (',' tor)* | join_clause)`
-// dispatch relies on.
-//
-// `MultiRuleRefLed` (2) is a multi-element alt whose first non-
-// nullable element is itself a RuleRef. Less specific than
-// `BareRuleRef` because the RuleRef prefix is shared with the
-// catch-all sibling.
-//
-// `BareToken` (1) is a single Token/Literal alt — the cheapest
-// fallback (e.g. `K_INSERT` alone).
-global ALT_PRIORITY_MULTI_TOKEN_LED: i32 = 4;
-global ALT_PRIORITY_BARE_RULE_REF: i32 = 3;
-global ALT_PRIORITY_MULTI_RULE_REF_LED: i32 = 2;
-global ALT_PRIORITY_BARE_TOKEN: i32 = 1;
-
-fn alt_sort_priority(alt: &Alternative) -> i32 {
-    if alt.elements.len() == 1 {
-        let elem = &alt.elements[0];
-        if let RuleRef(_) = elem {
-            return ALT_PRIORITY_BARE_RULE_REF;
-        }
-        return ALT_PRIORITY_BARE_TOKEN;
-    }
-    // Multi-element: check first non-nullable element.
-    for let elem of alt.elements {
-        if is_nullable(&elem) {
-            continue;
-        }
-        if let TokenRef(_) | Literal(_) = elem {
-            return ALT_PRIORITY_MULTI_TOKEN_LED;
-        }
-        break;
-    }
-    return ALT_PRIORITY_MULTI_RULE_REF_LED;
-}
-
-/// Sort `group` so the alt with the most MANDATORY (non-deeply-
-/// nullable) elements comes first, breaking ties by `alt_sort_priority`
-/// (single-RuleRef catch-alls win against multi-element-RuleRef
-/// siblings) and finally source order. Used by the prediction tree's
-/// `Ambiguous` case (and the matching parse-side group dispatches) to
-/// pick the longer MANDATORY match between alts that share a prefix.
-///
-/// Counting mandatory elements only is the LL distinguisher:
-/// `( a b | a )` (where `b` is mandatory) sorts the 2-elem alt first,
-/// while `( a b? | a )` (where `b?` is optional) ties on mandatory
-/// length and falls through to priority — which prefers the single-
-/// RuleRef catch-all the way ANTLR4's full-context fallback does for
-/// SQLite-style `( tor (',' tor)* | join_clause )` groupings.
-fn sort_group_by_mandatory_count_desc(group: &mut Array<i32>, alts: &Array<Alternative>, ctx: &mut GenContext) {
-    for let mut i = 0; i < group.len(); i += 1 {
-        for let mut j = i + 1; j < group.len(); j += 1 {
-            let li = ll_match_length(&alts[group[i]], ctx);
-            let lj = ll_match_length(&alts[group[j]], ctx);
-            let mut swap = false;
-            if lj > li {
-                swap = true;
-            } else if lj == li {
-                let pi = alt_sort_priority(&alts[group[i]]);
-                let pj = alt_sort_priority(&alts[group[j]]);
-                if pj > pi {
-                    swap = true;
-                } else if pj == pi {
-                    if group[j] < group[i] {
-                        swap = true;
-                    }
-                }
-            }
-            if swap {
-                let tmp = group[i];
-                group[i] = group[j];
-                group[j] = tmp;
-            }
-        }
-    }
-}
-
-/// LL-aware "match length" for `alt`, used to sort group alternatives so
-/// the more specific LL alt wins on overlap-prefix ties. Counts every
-/// mandatory top-level element plus every *trailing* deep-nullable
-/// element that is first-exact (single-token-derived; see
-/// `GenContext::element_is_first_exact`).
-///
-/// Why this is the right key: a first-exact nullable trailing element
-/// like `b?` (where `b : Y`) is "1 token whose presence is decisive" —
-/// when `Y` is in the input, alt 0 of `(a b? | a)` is the LL-correct
-/// pick because `b?` will fire and consume `Y`. Counting it as a
-/// pseudo-mandatory token sorts alt 0 ahead of the bare-RuleRef
-/// catch-all alt 1, mirroring ANTLR4's full-context LL preference for
-/// the longer meaningful match. Multi-element nullable structures
-/// (SQLite's `(',' tor)*` Star) stay at the original count because
-/// their first set is not first-exact, preserving the join-clause
-/// catch-all behaviour their grammars depend on.
-///
-/// The `seen_mandatory` gate restricts the trailing-nullable bonus to
-/// nullables that follow a committed token. A *leading* nullable like
-/// `b?` in `( b? a c | a c )` cannot disambiguate length: the runtime
-/// has not yet committed to either alt at that position, so claiming
-/// "alt 0 has 3 tokens" is no better signal than "alt 1 has 2" —
-/// either alt's `a c` will match. Counting only post-mandatory
-/// nullables means the bonus fires exactly when it can shorten the
-/// LL decision: after a shared prefix has committed, a tail-position
-/// `b?` whose presence is decisive elects the longer alt.
-fn ll_match_length(alt: &Alternative, ctx: &mut GenContext) -> i32 {
-    let mut count: i32 = 0;
-    let mut seen_mandatory: bool = false;
-    for let elem of &alt.elements {
-        let mut visiting: Array<String> = [];
-        if !ctx.element_is_nullable_deep(elem, &mut visiting) {
-            count += 1;
-            seen_mandatory = true;
-        } else if seen_mandatory && ctx.element_is_first_exact(elem) {
-            count += 1;
-        }
-    }
-    return count;
-}
-
-fn sort_group_by_element_count(group: &mut Array<i32>, alts: &Array<Alternative>) {
-    for let mut i = 0; i < group.len(); i += 1 {
-        for let mut j = i + 1; j < group.len(); j += 1 {
-            let pi = alt_sort_priority(&alts[group[i]]);
-            let pj = alt_sort_priority(&alts[group[j]]);
-            let mut swap = false;
-            if pj > pi {
-                swap = true;
-            } else if pj == pi {
-                // Within same-priority tier: more elements = more specific = first
-                if alts[group[j]].elements.len() > alts[group[i]].elements.len() {
-                    swap = true;
-                }
-            }
-            if swap {
-                let tmp = group[i];
-                group[i] = group[j];
-                group[j] = tmp;
-            }
-        }
-    }
 }

--- a/package-gale/src/parser_gen.wado
+++ b/package-gale/src/parser_gen.wado
@@ -336,7 +336,6 @@ fn gen_parser_struct(w: &mut CodeWriter) {
     w.blank();
 }
 
-// --- Alternative Scan Helpers ---
 // For each alternative in an Ambiguous group that has a scannable prefix,
 // generate a scan_<rule>_bt_<N> function. This function scans only the
 // scannable prefix of the alternative, which is enough to distinguish it
@@ -404,7 +403,6 @@ fn alt_scan_is_full(elements: &Array<Element>, ctx: &mut GenContext) -> bool {
     return scannable_prefix_len(elements, ctx) == elements.len();
 }
 
-// --- Scan Function Generation ---
 // Scan functions recognize parser rules by walking token kinds without building
 // CST nodes or constructing error messages. They return the token position after
 // successful recognition, or -1 on failure. Used to disambiguate Ambiguous
@@ -4669,16 +4667,14 @@ fn gen_multi_alt_body_bt(w: &mut CodeWriter, rule: &ParserRule, lowered_rule: &R
             let mut sorted_group = group.sorted();
             sort_group_by_specificity(&mut sorted_group, first_sets);
             let mut pred_indices: Array<i32> = [];
-            let mut pred_firsts: Array<Array<String>> = [];
             let mut pred_elements: Array<Array<Element>> = [];
             for let mut k = 0; k < sorted_group.len(); k += 1 {
                 let idx = sorted_group[k];
                 let real_idx = non_lr_indices[idx];
                 pred_indices.push(real_idx);
-                pred_firsts.push(first_sets[idx]);
                 pred_elements.push(rule.alternatives[real_idx].elements);
             }
-            let tree = build_prediction(&pred_indices, &pred_firsts, &pred_elements, 0, 5, ctx);
+            let tree = build_prediction(&pred_indices, &pred_elements, 0, 5, ctx);
             gen_prediction_code(w, &tree, &fn_name, &rule.alternatives, lowered_rule, type_name, ctx);
         }
 

--- a/package-gale/src/prediction.wado
+++ b/package-gale/src/prediction.wado
@@ -50,7 +50,7 @@ fn find_merge_branch(branches: &Array<PredictionBranch>, child: &PredictionNode)
     return -1;
 }
 
-pub fn build_prediction(alt_indices: &Array<i32>, first_sets: &Array<Array<String>>, alt_elements: &Array<Array<Element>>, depth: i32, max_depth: i32, ctx: &mut GenContext) -> PredictionNode {
+pub fn build_prediction(alt_indices: &Array<i32>, alt_elements: &Array<Array<Element>>, depth: i32, max_depth: i32, ctx: &mut GenContext) -> PredictionNode {
     // Build initial SLL configs: one per alternative, at element position 0.
     let mut configs: Array<SllConfig> = [];
     for let mut i = 0; i < alt_indices.len(); i += 1 {

--- a/package-gale/src/prediction.wado
+++ b/package-gale/src/prediction.wado
@@ -1,0 +1,883 @@
+//! Static lookahead simulator and prediction tree.
+//!
+//! This module is the analysis half of multi-alternative dispatch: it
+//! takes a set of alternatives (with their FIRST sets and elements) and
+//! returns a `PredictionNode` describing how to dispatch on lookahead
+//! tokens. It contains an SLL-style ATN simulator (`SllConfig`,
+//! `sll_advance`, `sll_closure`, `build_sll_node`, `try_expand_opaque`)
+//! and the resulting `PredictionNode` tree that the codegen consumes.
+//!
+//! This module is concern-pure: it never touches `CodeWriter`. The
+//! translation from `PredictionNode` to source lives in
+//! `parser_gen.wado` (`gen_prediction_code_inner`).
+
+use { Element, RepeatElement } from "./ir.wado";
+use { GenContext, is_nullable } from "./gen_context.wado";
+use { first_contains, literal_const_name, str_set_from, str_set_insert_all } from "./gen_util.wado";
+use { TreeSet } from "core:collections";
+
+pub variant PredictionNode {
+    Leaf(i32),
+    Dispatch(PredictionDispatch),
+    Consume(ConsumeNode),
+    Ambiguous(Array<i32>),
+}
+
+pub struct ConsumeNode {
+    pub element: Element,
+    pub child: PredictionNode,
+}
+
+pub struct PredictionDispatch {
+    pub depth: i32,
+    pub branches: Array<PredictionBranch>,
+}
+
+pub struct PredictionBranch {
+    pub tokens: Array<String>,
+    pub child: PredictionNode,
+}
+
+/// Return the index of an existing branch whose child equals `child`, or -1
+/// when no branch matches. Callers use this to fold a new (token, child) entry
+/// into an existing branch instead of creating a duplicate.
+fn find_merge_branch(branches: &Array<PredictionBranch>, child: &PredictionNode) -> i32 {
+    for let mut b = 0; b < branches.len(); b += 1 {
+        if prediction_node_eq(&branches[b].child, child) {
+            return b;
+        }
+    }
+    return -1;
+}
+
+pub fn build_prediction(alt_indices: &Array<i32>, first_sets: &Array<Array<String>>, alt_elements: &Array<Array<Element>>, depth: i32, max_depth: i32, ctx: &mut GenContext) -> PredictionNode {
+    // Build initial SLL configs: one per alternative, at element position 0.
+    let mut configs: Array<SllConfig> = [];
+    for let mut i = 0; i < alt_indices.len(); i += 1 {
+        configs.push(SllConfig {
+            alt_index: alt_indices[i],
+            elements: alt_elements[i],
+            pos: 0,
+            return_stack: [],
+        });
+    }
+    let tree = build_sll_node(&configs, 0, max_depth, ctx);
+    return strip_dead_consume(tree);
+}
+
+/// Strip Consume nodes whose child contains any Ambiguous — fall back to
+/// Ambiguous from the original position rather than consuming then failing.
+/// This handles both direct Consume → Ambiguous and indirect cases like
+/// Consume → Dispatch → (Branch → Ambiguous).
+fn strip_dead_consume(node: PredictionNode) -> PredictionNode {
+    return match node {
+        Consume(c) => {
+            let child = strip_dead_consume(c.child);
+            if prediction_contains_ambiguous(&child) {
+                let mut indices: Array<i32> = [];
+                prediction_collect_all_indices(&child, &mut indices);
+                PredictionNode::Ambiguous(indices);
+            } else {
+                PredictionNode::Consume(ConsumeNode { element: c.element, child });
+            }
+        },
+        Dispatch(d) => {
+            let mut new_branches: Array<PredictionBranch> = [];
+            for let b of d.branches {
+                new_branches.push(PredictionBranch {
+                    tokens: b.tokens,
+                    child: strip_dead_consume(b.child),
+                });
+            }
+            PredictionNode::Dispatch(PredictionDispatch { depth: d.depth, branches: new_branches });
+        },
+        _ => node,
+    };
+}
+
+fn prediction_contains_ambiguous(node: &PredictionNode) -> bool {
+    return match *node {
+        Ambiguous(_) => true,
+        Consume(c) => prediction_contains_ambiguous(&c.child),
+        Dispatch(d) => {
+            for let b of &d.branches {
+                if prediction_contains_ambiguous(&b.child) {
+                    return true;
+                }
+            }
+            return false;
+        },
+        Leaf(_) => false,
+    };
+}
+
+fn prediction_collect_all_indices(node: &PredictionNode, out: &mut Array<i32>) {
+    match *node {
+        Ambiguous(indices) => {
+            for let i of &indices {
+                if !out.iter().any(|x: i32| x == *i) {
+                    out.push(*i);
+                }
+            }
+        },
+        Leaf(idx) => {
+            if !out.iter().any(|x: i32| x == idx) {
+                out.push(idx);
+            }
+        },
+        Consume(c) => prediction_collect_all_indices(&c.child, out),
+        Dispatch(d) => {
+            for let b of &d.branches {
+                prediction_collect_all_indices(&b.child, out);
+            }
+        },
+    }
+}
+
+
+struct SllReturn {
+    elements: Array<Element>,
+    pos: i32,
+}
+
+struct SllConfig {
+    alt_index: i32,
+    elements: Array<Element>,
+    pos: i32,
+    return_stack: Array<SllReturn>,
+}
+
+fn sll_config_clone(c: &SllConfig) -> SllConfig {
+    return SllConfig {
+        alt_index: c.alt_index,
+        elements: c.elements,
+        pos: c.pos,
+        return_stack: c.return_stack,
+    };
+}
+
+fn push_return(stack: &Array<SllReturn>, elements: Array<Element>, pos: i32) -> Array<SllReturn> {
+    let mut new_stack: Array<SllReturn> = [];
+    for let s of stack {
+        new_stack.push(*s);
+    }
+    new_stack.push(SllReturn { elements, pos });
+    return new_stack;
+}
+
+fn pop_return(c: &SllConfig) -> SllConfig {
+    let last_idx = c.return_stack.len() - 1;
+    let ret = &c.return_stack[last_idx];
+    let mut new_stack: Array<SllReturn> = [];
+    for let mut i = 0; i < last_idx; i += 1 {
+        new_stack.push(c.return_stack[i]);
+    }
+    return SllConfig {
+        alt_index: c.alt_index,
+        elements: ret.elements,
+        pos: ret.pos,
+        return_stack: new_stack,
+    };
+}
+
+
+/// Identity closure — nullable handling is done in sll_config_first
+/// (first_of_elements_from) and sll_advance (explicit skip logic).
+fn sll_closure(configs: &Array<SllConfig>) -> Array<SllConfig> {
+    return *configs;
+}
+
+/// True when the config has fully consumed its elements and has no return
+/// frame to pop into — i.e. the alt's body is finished and any further token
+/// belongs to the calling context. Opaque configs (`pos < 0`) are not at-end.
+///
+/// The check walks `return_stack` from the most-recently-pushed frame back
+/// to the oldest, mirroring what a sequence of `pop_return` calls would
+/// expose. Walking by index keeps this O(n); the previous recursive
+/// implementation was O(n^2) because each `pop_return` rebuilt the entire
+/// surviving prefix of `return_stack` into a fresh `Array`.
+fn config_is_at_end(c: &SllConfig) -> bool {
+    if c.pos < 0 {
+        return false;
+    }
+    if c.pos < c.elements.len() {
+        return false;
+    }
+    let mut i = c.return_stack.len();
+    while i > 0 {
+        i -= 1;
+        let frame = &c.return_stack[i];
+        if frame.pos < frame.elements.len() {
+            return false;
+        }
+    }
+    return true;
+}
+
+
+/// Compute FIRST set of the current position in a config.
+/// Includes tokens from nullable elements that were skipped by closure.
+/// When at end of elements with a return stack, pops and continues from caller.
+fn sll_config_first(c: &SllConfig, ctx: &mut GenContext) -> Array<String> {
+    if c.pos < 0 {
+        return [];
+    }
+    if c.pos >= c.elements.len() {
+        if c.return_stack.is_empty() {
+            return [];
+        }
+        let popped = pop_return(c);
+        return sll_config_first(&popped, ctx);
+    }
+    return ctx.first_of_elements_from(&c.elements, c.pos);
+}
+
+/// Advance a config by one token. For terminals, advance pos.
+/// For RuleRef, expand into the rule's alternatives (entering the rule).
+fn sll_advance(c: &SllConfig, token: &String, ctx: &mut GenContext, inline_depth: i32 = 0) -> Array<SllConfig> {
+    // Limit inline expansion depth to prevent explosion from recursive rules.
+    if inline_depth > 2 {
+        return [];
+    }
+    if c.pos < 0 {
+        return [];
+    }
+    // End of current elements: pop return stack if available.
+    if c.pos >= c.elements.len() {
+        if c.return_stack.is_empty() {
+            return [];
+        }
+        let popped = pop_return(c);
+        return sll_advance(&popped, token, ctx, inline_depth);
+    }
+    let elem = &c.elements[c.pos];
+
+    // Nullable element (Optional, Star): either match its inner or skip it.
+    if is_nullable(elem) {
+        let mut results: Array<SllConfig> = [];
+        let mut visiting: Array<String> = [];
+        if first_contains(&ctx.first_of_element(elem, &mut visiting), token) {
+            // Check if the inner element is a multi-token RuleRef.
+            // If so, enter it via return stack instead of skipping to pos+1.
+            let mut entered = false;
+            if let Repeat(rep) = elem {
+                if let RuleRef(rr) = rep.element {
+                    let mut stv: Array<String> = [];
+                    if !ctx.rule_is_single_token(&rr.name, &mut stv) && c.return_stack.len() < 1 {
+                        let inner_rule = ctx.find_rule(&rr.name);
+                        let inner_alt_count = if let Some(r) = inner_rule {
+                            r.alternatives.len();
+                        } else {
+                            0;
+                        };
+                        if inner_alt_count <= 8 {
+                            entered = true;
+                            let new_stack = push_return(&c.return_stack, c.elements, c.pos + 1);
+                            if let Some(inner_rule) = inner_rule {
+                                for let alt of inner_rule.alternatives {
+                                    let mut v2: Array<String> = [];
+                                    if !first_contains(&ctx.first_of_alt(&alt, &mut v2), token) {
+                                        continue;
+                                    }
+                                    let exp = SllConfig {
+                                        alt_index: c.alt_index,
+                                        elements: alt.elements,
+                                        pos: 0,
+                                        return_stack: new_stack,
+                                    };
+                                    let advanced = sll_advance(&exp, token, ctx, inline_depth + 1);
+                                    for let a of advanced {
+                                        results.push(a);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            if !entered {
+                results.push(SllConfig {
+                    alt_index: c.alt_index,
+                    elements: c.elements,
+                    pos: c.pos + 1,
+                    return_stack: c.return_stack,
+                });
+            }
+        }
+        // Also try skipping: advance past all consecutive nullables non-recursively.
+        let mut skip_pos = c.pos + 1;
+        while skip_pos < c.elements.len() && is_nullable(&c.elements[skip_pos]) {
+            let mut v: Array<String> = [];
+            if first_contains(&ctx.first_of_element(&c.elements[skip_pos], &mut v), token) {
+                results.push(SllConfig {
+                    alt_index: c.alt_index,
+                    elements: c.elements,
+                    pos: skip_pos + 1,
+                    return_stack: c.return_stack,
+                });
+            }
+            skip_pos += 1;
+        }
+        if skip_pos < c.elements.len() {
+            let skipped_elem = &c.elements[skip_pos];
+            if let TokenRef(t) = skipped_elem {
+                if `TK_{t.name}` == *token {
+                    results.push(SllConfig {
+                        alt_index: c.alt_index,
+                        elements: c.elements,
+                        pos: skip_pos + 1,
+                        return_stack: c.return_stack,
+                    });
+                }
+            } else if let Literal(l) = skipped_elem {
+                if literal_const_name(&l.text) == *token {
+                    results.push(SllConfig {
+                        alt_index: c.alt_index,
+                        elements: c.elements,
+                        pos: skip_pos + 1,
+                        return_stack: c.return_stack,
+                    });
+                }
+            } else if let RuleRef(r) = skipped_elem {
+                let mut v: Array<String> = [];
+                if first_contains(&ctx.first_of_rule(&r.name, &mut v), token) {
+                    let mut stv: Array<String> = [];
+                    if ctx.rule_is_single_token(&r.name, &mut stv) {
+                        results.push(SllConfig {
+                            alt_index: c.alt_index,
+                            elements: c.elements,
+                            pos: skip_pos + 1,
+                            return_stack: c.return_stack,
+                        });
+                    } else {
+                        results.push(SllConfig {
+                            alt_index: c.alt_index,
+                            elements: c.elements,
+                            pos: -1,
+                            return_stack: c.return_stack,
+                        });
+                    }
+                }
+            } else {
+                let mut v: Array<String> = [];
+                if first_contains(&ctx.first_of_element(skipped_elem, &mut v), token) {
+                    results.push(SllConfig {
+                        alt_index: c.alt_index,
+                        elements: c.elements,
+                        pos: skip_pos + 1,
+                        return_stack: c.return_stack,
+                    });
+                }
+            }
+        }
+        return results;
+    }
+
+    // Terminal: if token matches, advance past this element.
+    if let TokenRef(t) = elem {
+        if `TK_{t.name}` == *token {
+            return [SllConfig {
+                    alt_index: c.alt_index,
+                    elements: c.elements,
+                    pos: c.pos + 1,
+                    return_stack: c.return_stack,
+                }];
+        }
+        return [];
+    }
+    if let Literal(l) = elem {
+        if literal_const_name(&l.text) == *token {
+            return [SllConfig {
+                    alt_index: c.alt_index,
+                    elements: c.elements,
+                    pos: c.pos + 1,
+                    return_stack: c.return_stack,
+                }];
+        }
+        return [];
+    }
+
+    // RuleRef: advance past only if the rule always consumes exactly one token.
+    // Multi-token rules return opaque (pos=-1); expansion happens in build_sll_node
+    // only when needed to resolve ambiguity.
+    if let RuleRef(r) = elem {
+        let mut visiting: Array<String> = [];
+        let rule_first = ctx.first_of_rule(&r.name, &mut visiting);
+        if !first_contains(&rule_first, token) {
+            return [];
+        }
+        let mut st_visiting: Array<String> = [];
+        if ctx.rule_is_single_token(&r.name, &mut st_visiting) {
+            // Single-token rule: safe to advance, element position == token position.
+            return [SllConfig {
+                    alt_index: c.alt_index,
+                    elements: c.elements,
+                    pos: c.pos + 1,
+                    return_stack: c.return_stack,
+                }];
+        }
+        // Multi-token rule: token matches FIRST but we can't advance past it.
+        // Return config with pos = -1 as a sentinel meaning "opaque match".
+        return [SllConfig { alt_index: c.alt_index, elements: c.elements, pos: -1, return_stack: c.return_stack }];
+    }
+
+    // Group: treat as consuming one token if the token is in FIRST(group).
+    if let Group(g) = elem {
+        let mut group_first = TreeSet::<String>::new();
+        for let alt of g.alternatives {
+            let mut visiting: Array<String> = [];
+            let af = ctx.first_of_alt(alt, &mut visiting);
+            str_set_insert_all(&mut group_first, &af);
+        }
+        if group_first.contains(*token) {
+            return [SllConfig {
+                    alt_index: c.alt_index,
+                    elements: c.elements,
+                    pos: c.pos + 1,
+                    return_stack: c.return_stack,
+                }];
+        }
+        return [];
+    }
+
+    // Repeat: treat as consuming the inner element.
+    if let Repeat(rep) = elem {
+        let mut inner_first: Array<String> = [];
+        let mut visiting: Array<String> = [];
+        inner_first = ctx.first_of_element(&rep.element, &mut visiting);
+        if first_contains(&inner_first, token) {
+            // Advance past the repeat element (simplified: treat as consuming 1 token).
+            return [SllConfig {
+                    alt_index: c.alt_index,
+                    elements: c.elements,
+                    pos: c.pos + 1,
+                    return_stack: c.return_stack,
+                }];
+        }
+        return [];
+    }
+
+    // Label: unwrap.
+    if let Label(lab) = elem {
+        let unwrapped = SllConfig {
+            alt_index: c.alt_index,
+            elements: replace_element_at(&c.elements, c.pos, &lab.element),
+            pos: c.pos,
+            return_stack: c.return_stack,
+        };
+        return sll_advance(&unwrapped, token, ctx, inline_depth);
+    }
+
+    return [];
+}
+
+fn replace_element_at(elements: &Array<Element>, pos: i32, replacement: &Element) -> Array<Element> {
+    let mut result: Array<Element> = [];
+    for let mut i = 0; i < elements.len(); i += 1 {
+        if i == pos {
+            result.push(*replacement);
+        } else {
+            result.push(elements[i]);
+        }
+    }
+    return result;
+}
+
+/// Collect unique alt indices from configs.
+fn sll_unique_alts(configs: &Array<SllConfig>) -> Array<i32> {
+    let mut alts: Array<i32> = [];
+    for let c of configs {
+        if !array_contains_i32(&alts, c.alt_index) {
+            alts.push(c.alt_index);
+        }
+    }
+    return alts;
+}
+
+/// Deduplicate configs: merge configs with the same (alt_index) that reach
+/// the same prediction outcome. For SLL, two configs with the same alt_index
+/// are equivalent for prediction purposes.
+fn sll_dedup_by_alt(configs: &Array<SllConfig>) -> Array<SllConfig> {
+    let mut seen_alts: Array<i32> = [];
+    let mut result: Array<SllConfig> = [];
+    for let c of configs {
+        if !array_contains_i32(&seen_alts, c.alt_index) {
+            seen_alts.push(c.alt_index);
+            result.push(sll_config_clone(c));
+        }
+    }
+    return result;
+}
+
+fn build_sll_node(configs: &Array<SllConfig>, depth: i32, max_depth: i32, ctx: &mut GenContext) -> PredictionNode {
+    let closed = sll_closure(configs);
+
+    // Guard: if too many configs, fall back to Ambiguous (codegen scan-dispatches) to avoid explosion.
+    if closed.len() > 200 {
+        let alts = sll_unique_alts(&closed);
+        return PredictionNode::Ambiguous(alts);
+    }
+
+    // Check unique alternatives.
+    let alts = sll_unique_alts(&closed);
+    if alts.len() == 1 {
+        return PredictionNode::Leaf(alts[0]);
+    }
+    if alts.len() == 0 || depth >= max_depth {
+        return PredictionNode::Ambiguous(alts);
+    }
+
+    // Check for common prefix: if all configs are at a terminal element
+    // that is the same across all configs, emit Consume.
+    let common = sll_find_common_terminal(&closed);
+    if let Some(elem) = common {
+        // Advance all configs past this shared terminal.
+        let mut advanced: Array<SllConfig> = [];
+        for let c of closed {
+            advanced.push(SllConfig {
+                alt_index: c.alt_index,
+                elements: c.elements,
+                pos: c.pos + 1,
+                return_stack: c.return_stack,
+            });
+        }
+        let child = build_sll_node(&advanced, depth, max_depth, ctx);
+        return PredictionNode::Consume(ConsumeNode { element: elem, child });
+    }
+
+    // Compute FIRST set for each config.
+    let mut all_tokens: Array<String> = [];
+    let mut all_tokens_seen = TreeSet::<String>::new();
+    let mut config_firsts: Array<Array<String>> = [];
+    let mut config_first_sets: Array<TreeSet<String>> = [];
+    for let c of closed {
+        let first = sll_config_first(&c, ctx);
+        config_first_sets.push(str_set_from(&first));
+        config_firsts.push(first);
+        for let tk of first {
+            if !all_tokens_seen.contains(tk) {
+                all_tokens_seen.insert(tk);
+                all_tokens.push(tk);
+            }
+        }
+    }
+
+    // Build dispatch branches.
+    let mut branches: Array<PredictionBranch> = [];
+
+    for let mut t = 0; t < all_tokens.len(); t += 1 {
+        let tk = &all_tokens[t];
+
+        // Advance all configs that can match this token.
+        let mut next_configs: Array<SllConfig> = [];
+        let mut opaque_alts: Array<i32> = [];
+        for let mut i = 0; i < closed.len(); i += 1 {
+            if config_first_sets[i].contains(*tk) {
+                let advanced = sll_advance(&closed[i], tk, ctx);
+                for let a of advanced {
+                    if a.pos == -1 {
+                        // Opaque config: multi-token RuleRef, can't advance past.
+                        if !array_contains_i32(&opaque_alts, a.alt_index) {
+                            opaque_alts.push(a.alt_index);
+                        }
+                    } else {
+                        next_configs.push(a);
+                    }
+                }
+            }
+        }
+
+        if next_configs.len() == 0 && opaque_alts.len() == 0 {
+            continue;
+        }
+
+        // Dedup: keep one config per alt (SLL ignores context).
+        let deduped = sll_dedup_by_alt(&next_configs);
+        let mut next_alts = sll_unique_alts(&deduped);
+        // Add opaque alts (they survive regardless of further lookahead).
+        for let oa of opaque_alts {
+            if !array_contains_i32(&next_alts, oa) {
+                next_alts.push(oa);
+            }
+        }
+
+        let child = if next_alts.len() == 1 {
+            // Resolved: this token uniquely identifies one alternative.
+            PredictionNode::Leaf(next_alts[0]);
+        } else if opaque_alts.len() > 0 {
+            // Still ambiguous with opaque alts: try expansion before giving up.
+            let expanded = try_expand_opaque(&closed, tk, &next_configs, opaque_alts, depth + 1, max_depth, ctx);
+            if let Some(node) = expanded {
+                node;
+            } else {
+                PredictionNode::Ambiguous(next_alts);
+            }
+        } else {
+            // Still ambiguous: recurse with deeper lookahead.
+            build_sll_node(&deduped, depth + 1, max_depth, ctx);
+        };
+        let idx = find_merge_branch(&branches, &child);
+        if idx >= 0 {
+            branches[idx].tokens.push(*tk);
+        } else {
+            branches.push(PredictionBranch { tokens: [*tk], child });
+        }
+    }
+
+    // Detect at-end configs: their alts are fully consumed at this depth and
+    // would simply return to the caller. They have empty FIRST sets, so the
+    // per-token loop above silently dropped them — that left the dispatcher
+    // missing a "default" path for tokens belonging to the calling context.
+    //
+    // Two cases:
+    //  * No explicit branches but exactly one at-end alt → that alt is the
+    //    only valid match at this point. Return Leaf so the caller commits.
+    //  * Both explicit branches and at-end alts → ambiguous in general.
+    //    A token-dispatch on the explicit branch is unsafe because the
+    //    branch can fail at parse time (e.g. typespec `ID '[' ']'` matches
+    //    the lookahead `[` but the body `[ ]` won't match `[ <e> ]`),
+    //    leaving the at-end alt as the only correct choice. Fall back to
+    //    Ambiguous so the codegen's longest-match scan dispatch picks the
+    //    alt whose body actually parses (cf. ANTLR4's adaptive prediction).
+    //  * Multiple at-end alts → true ambiguity → Ambiguous.
+    let mut at_end_alts: Array<i32> = [];
+    for let c of &closed {
+        if config_is_at_end(c) && !array_contains_i32(&at_end_alts, c.alt_index) {
+            at_end_alts.push(c.alt_index);
+        }
+    }
+
+    if at_end_alts.len() >= 1 && branches.len() >= 1 {
+        return PredictionNode::Ambiguous(alts);
+    }
+
+    if branches.len() == 0 {
+        if at_end_alts.len() == 1 {
+            return PredictionNode::Leaf(at_end_alts[0]);
+        }
+        return PredictionNode::Ambiguous(alts);
+    }
+    return PredictionNode::Dispatch(PredictionDispatch { depth, branches });
+}
+
+/// Try to resolve opaque configs by expanding their multi-token RuleRefs.
+/// Uses ATN-style expansion: enter referenced rules, advance by one token,
+/// then compute FIRST sets at the decision point's lookahead level.
+/// Builds a flat Dispatch — never calls build_sll_node on expanded configs.
+fn try_expand_opaque(original_configs: &Array<SllConfig>, token: &String, non_opaque_configs: &Array<SllConfig>, opaque_alts: Array<i32>, depth: i32, max_depth: i32, ctx: &mut GenContext) -> Option<PredictionNode> {
+    if depth >= max_depth {
+        return null;
+    }
+    // Rule diversity check: only expand when opaque configs reference different rules.
+    let mut rule_refs = TreeSet::<String>::new();
+    for let c of original_configs {
+        if !array_contains_i32(&opaque_alts, c.alt_index) {
+            continue;
+        }
+        if c.pos < 0 || c.pos >= c.elements.len() {
+            continue;
+        }
+        if let RuleRef(r) = c.elements[c.pos] {
+            rule_refs.insert(r.name);
+        }
+    }
+    if rule_refs.len() <= 1 {
+        return null;
+    }
+    // Expand opaque configs by entering their RuleRefs and advancing by token.
+    let mut expanded_configs: Array<SllConfig> = [];
+    for let c of original_configs {
+        if !array_contains_i32(&opaque_alts, c.alt_index) {
+            continue;
+        }
+        if c.pos < 0 || c.pos >= c.elements.len() {
+            continue;
+        }
+        if let RuleRef(r) = c.elements[c.pos] {
+            let found_rule = ctx.find_rule(&r.name);
+            if let Some(found_rule) = found_rule {
+                if found_rule.alternatives.len() > 8 {
+                    continue;
+                }
+                let new_stack = push_return(&c.return_stack, c.elements, c.pos + 1);
+                for let alt of found_rule.alternatives {
+                    // Pre-filter: skip alternatives whose FIRST doesn't contain the token.
+                    let mut v: Array<String> = [];
+                    if !first_contains(&ctx.first_of_alt(&alt, &mut v), token) {
+                        continue;
+                    }
+                    let exp = SllConfig {
+                        alt_index: c.alt_index,
+                        elements: alt.elements,
+                        pos: 0,
+                        return_stack: new_stack,
+                    };
+                    let advanced = sll_advance(&exp, token, ctx);
+                    for let a of advanced {
+                        if a.pos != -1 {
+                            expanded_configs.push(a);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    if expanded_configs.is_empty() {
+        return null;
+    }
+    // Combine non-opaque (already advanced) with expanded configs.
+    // All configs have consumed the same number of input tokens (depth),
+    // so their FIRST sets are all at the same lookahead level (depth).
+    let mut all_configs: Array<SllConfig> = [];
+    for let c of non_opaque_configs {
+        all_configs.push(sll_config_clone(c));
+    }
+    for let ec of expanded_configs {
+        all_configs.push(ec);
+    }
+    // Compute FIRST for each config at the decision point level.
+    let mut all_tokens: Array<String> = [];
+    let mut all_tokens_seen = TreeSet::<String>::new();
+    let mut config_first_sets: Array<TreeSet<String>> = [];
+    for let c of all_configs {
+        let first = sll_config_first(&c, ctx);
+        let first_set = str_set_from(&first);
+        config_first_sets.push(first_set);
+        for let tk of first {
+            if !all_tokens_seen.contains(tk) {
+                all_tokens_seen.insert(tk);
+                all_tokens.push(tk);
+            }
+        }
+    }
+    // Build flat Dispatch: for each token, find which alt_indices match.
+    let mut branches: Array<PredictionBranch> = [];
+    let mut has_improvement = false;
+    for let mut t = 0; t < all_tokens.len(); t += 1 {
+        let tk = &all_tokens[t];
+        let mut token_alts: Array<i32> = [];
+        for let mut i = 0; i < all_configs.len(); i += 1 {
+            if config_first_sets[i].contains(*tk) {
+                if !array_contains_i32(&token_alts, all_configs[i].alt_index) {
+                    token_alts.push(all_configs[i].alt_index);
+                }
+            }
+        }
+        let child = if token_alts.len() == 1 {
+            has_improvement = true;
+            PredictionNode::Leaf(token_alts[0]);
+        } else {
+            PredictionNode::Ambiguous(token_alts.sorted());
+        };
+        let idx = find_merge_branch(&branches, &child);
+        if idx >= 0 {
+            branches[idx].tokens.push(*tk);
+        } else {
+            branches.push(PredictionBranch { tokens: [*tk], child });
+        }
+    }
+    if !has_improvement || branches.is_empty() {
+        return null;
+    }
+    // Only use if ALL branches are Leaf — any Ambiguous branch means expansion
+    // didn't fully resolve, and the code generator's Dispatch has no fallback
+    // for unmatched tokens, which would silently drop valid inputs.
+    for let b of branches {
+        if let Ambiguous(_) = b.child {
+            return null;
+        }
+    }
+    // Safety: verify all original opaque alts appear in at least one branch.
+    let mut covered_alts: Array<i32> = [];
+    for let b of branches {
+        if let Leaf(idx) = b.child {
+            if !array_contains_i32(&covered_alts, idx) {
+                covered_alts.push(idx);
+            }
+        }
+    }
+    for let oa of opaque_alts {
+        if !array_contains_i32(&covered_alts, oa) {
+            return null;
+        }
+    }
+    return Option::<PredictionNode>::Some(PredictionNode::Dispatch(PredictionDispatch { depth, branches }));
+}
+
+
+/// Check if all configs are at the same terminal element (for Consume).
+fn sll_find_common_terminal(configs: &Array<SllConfig>) -> Option<Element> {
+    if configs.len() < 2 {
+        return null;
+    }
+    for let c of configs {
+        if c.pos >= c.elements.len() {
+            return null;
+        }
+    }
+    let first_elem = &configs[0].elements[configs[0].pos];
+    if let TokenRef(t) = first_elem {
+        for let mut i = 1; i < configs.len(); i += 1 {
+            let elem = &configs[i].elements[configs[i].pos];
+            if let TokenRef(other) = elem {
+                if other.name != t.name {
+                    return null;
+                }
+            } else {
+                return null;
+            }
+        }
+        return Option::<Element>::Some(*first_elem);
+    }
+    if let Literal(l) = first_elem {
+        for let mut i = 1; i < configs.len(); i += 1 {
+            let elem = &configs[i].elements[configs[i].pos];
+            if let Literal(other) = elem {
+                if other.text != l.text {
+                    return null;
+                }
+            } else {
+                return null;
+            }
+        }
+        return Option::<Element>::Some(*first_elem);
+    }
+    return null;
+}
+
+fn prediction_node_eq(a: &PredictionNode, b: &PredictionNode) -> bool {
+    return match [*a, *b] {
+        [Leaf(ai), Leaf(bi)] => ai == bi,
+        [Ambiguous(aa), Ambiguous(ba)] => {
+            if aa.len() != ba.len() {
+                return false;
+            }
+            for let mut i = 0; i < aa.len(); i += 1 {
+                if aa[i] != ba[i] {
+                    return false;
+                }
+            }
+            true;
+        },
+        // Consume nodes: check same element kind and recurse on child.
+        [Consume(ca), Consume(cb)] => element_eq(&ca.element, &cb.element) && prediction_node_eq(&ca.child, &cb.child),
+        _ => false,
+    };
+}
+
+fn element_eq(a: &Element, b: &Element) -> bool {
+    return match [*a, *b] {
+        [TokenRef(na), TokenRef(nb)] => na.name == nb.name,
+        [Literal(ta), Literal(tb)] => ta.text == tb.text,
+        _ => false,
+    };
+}
+
+fn array_contains_i32(arr: &Array<i32>, val: i32) -> bool {
+    for let mut i = 0; i < arr.len(); i += 1 {
+        if arr[i] == val {
+            return true;
+        }
+    }
+    return false;
+}

--- a/package-gale/src/prediction.wado
+++ b/package-gale/src/prediction.wado
@@ -50,7 +50,7 @@ fn find_merge_branch(branches: &Array<PredictionBranch>, child: &PredictionNode)
     return -1;
 }
 
-pub fn build_prediction(alt_indices: &Array<i32>, alt_elements: &Array<Array<Element>>, depth: i32, max_depth: i32, ctx: &mut GenContext) -> PredictionNode {
+pub fn build_prediction(alt_indices: &Array<i32>, alt_elements: &Array<Array<Element>>, max_depth: i32, ctx: &mut GenContext) -> PredictionNode {
     // Build initial SLL configs: one per alternative, at element position 0.
     let mut configs: Array<SllConfig> = [];
     for let mut i = 0; i < alt_indices.len(); i += 1 {

--- a/package-gale/src/wadopoet_test.wado
+++ b/package-gale/src/wadopoet_test.wado
@@ -12,9 +12,6 @@ use {
     ImplSpec,
 } from "./wadopoet.wado";
 
-// ---------------------------------------------------------------------------
-// CodeWriter tests
-// ---------------------------------------------------------------------------
 
 test "empty writer" {
     let w = CodeWriter::new();
@@ -126,9 +123,6 @@ test "manual indent/dedent" {
     assert w.to_string() == "outer\n    inner\nouter again\n";
 }
 
-// ---------------------------------------------------------------------------
-// StructSpec tests
-// ---------------------------------------------------------------------------
 
 test "StructSpec basic" {
     let mut s = StructSpec::new("Point");
@@ -174,9 +168,6 @@ test "StructSpec with FieldSpec" {
     assert w.to_string() == "struct Foo {\n    pub x: f64,\n}\n";
 }
 
-// ---------------------------------------------------------------------------
-// FlagsSpec tests
-// ---------------------------------------------------------------------------
 
 test "FlagsSpec basic" {
     let mut f = FlagsSpec::new("Perms");
@@ -202,9 +193,6 @@ test "FlagsSpec private" {
     assert w.to_string() == expected, `got: {w.to_string()}`;
 }
 
-// ---------------------------------------------------------------------------
-// VariantSpec tests
-// ---------------------------------------------------------------------------
 
 test "VariantSpec unit cases" {
     let mut v = VariantSpec::new("TokenKind");
@@ -231,9 +219,6 @@ test "VariantSpec with payloads" {
     assert w.to_string() == expected, `got: {w.to_string()}`;
 }
 
-// ---------------------------------------------------------------------------
-// EnumSpec tests
-// ---------------------------------------------------------------------------
 
 test "EnumSpec basic" {
     let mut e = EnumSpec::new("Color");
@@ -248,9 +233,6 @@ test "EnumSpec basic" {
     assert w.to_string() == expected, `got: {w.to_string()}`;
 }
 
-// ---------------------------------------------------------------------------
-// FnSpec tests
-// ---------------------------------------------------------------------------
 
 test "FnSpec simple" {
     let mut f = FnSpec::new("add");
@@ -319,9 +301,6 @@ test "FnSpec signature string" {
     assert sig == "pub fn transform(&self, input: &String, scale: f64) -> String", `got: {sig}`;
 }
 
-// ---------------------------------------------------------------------------
-// GlobalSpec tests
-// ---------------------------------------------------------------------------
 
 test "GlobalSpec basic" {
     let g = GlobalSpec::new("TK_EOF", "i32", "0");
@@ -341,9 +320,7 @@ test "GlobalSpec pub mut" {
     assert w.to_string() == "pub global mut COUNTER: i32 = 0;\n";
 }
 
-// ---------------------------------------------------------------------------
 // Integration: composing specs with CodeWriter
-// ---------------------------------------------------------------------------
 
 test "struct + impl + fn composition" {
     let mut w = CodeWriter::new();
@@ -408,9 +385,6 @@ test "chaining builder methods" {
     assert w.to_string() == expected, `got: {w.to_string()}`;
 }
 
-// ---------------------------------------------------------------------------
-// TraitSpec tests
-// ---------------------------------------------------------------------------
 
 test "TraitSpec simple" {
     let mut t = TraitSpec::new("Greet");
@@ -468,9 +442,6 @@ test "TraitSpec with multiple associated types" {
     assert w.to_string() == expected, `got: {w.to_string()}`;
 }
 
-// ---------------------------------------------------------------------------
-// ImplSpec tests
-// ---------------------------------------------------------------------------
 
 test "ImplSpec basic" {
     let mut w = CodeWriter::new();

--- a/package-gale/tests/driver_antlr4_test.wado
+++ b/package-gale/tests/driver_antlr4_test.wado
@@ -66,7 +66,6 @@ test "tokenize lexer commands" {
     assert tokens.len() >= 5, `expected at least 5 tokens, got {tokens.len()}`;
 }
 
-// --- Parser tests ---
 
 test "parse minimal grammar" {
     // ANTLR4 lexer produces ID tokens, but the parser expects RULE_REF/TOKEN_REF
@@ -76,7 +75,6 @@ test "parse minimal grammar" {
     assert result matches { Err(_) }, "expected parse to fail due to missing semantic predicates";
 }
 
-// --- User-defined channel routing ---
 //
 // ANTLRv4Lexer declares `channels { OFF_CHANNEL, COMMENT }`, so DEFAULT=0,
 // HIDDEN=1, OFF_CHANNEL=2, COMMENT=3. DOC/BLOCK/LINE comments route to

--- a/package-gale/tests/driver_html_test.wado
+++ b/package-gale/tests/driver_html_test.wado
@@ -88,7 +88,6 @@ test "unparse_xml for simple tag" {
     assert xml.len() > 20, `xml too short: {xml}`;
 }
 
-// --- S-expression tree tests ---
 
 test "tree: simple tag" {
     assert_tree(&"<p>hello</p>", &"
@@ -136,7 +135,6 @@ test "tree: nested tags" {
     ");
 }
 
-// --- HIDDEN channel routing ---
 //
 // HTMLLexer declares `TAG_WHITESPACE : [ \t\r\n] -> channel(HIDDEN)`. ANTLR4
 // routes HIDDEN tokens to a separate channel so the parser never sees them,

--- a/package-gale/tests/driver_json_test.wado
+++ b/package-gale/tests/driver_json_test.wado
@@ -148,7 +148,6 @@ test "unparse_xml for array with multiple values" {
     assert xml == expected, `\nexpected: {expected}\ngot:      {xml}`;
 }
 
-// --- S-expression tree tests ---
 
 test "tree: true false null" {
     assert_tree(&"true", &"(json (value true))");

--- a/package-gale/tests/driver_rust_test.wado
+++ b/package-gale/tests/driver_rust_test.wado
@@ -14,7 +14,6 @@ use rust from "./grammars/RustLexer.g4"
     };
 use { normalize_tree } from "./grammars/RustLexer.g4";
 
-// --- Tokenize tests ---
 
 test "tokenize fn declaration" {
     let tokens = rust::tokenize(&"fn main() {}");
@@ -80,7 +79,6 @@ test "tokenize macro invocation" {
     assert tokens.len() >= 5, `expected at least 5 tokens, got {tokens.len()}`;
 }
 
-// --- Parse tests ---
 
 test "parse empty crate" {
     let result = rust::parse(&"");
@@ -96,7 +94,6 @@ test "fn keyword requires semantic predicates" {
     assert result matches { Err(_) }, "expected parse to fail due to missing semantic predicates";
 }
 
-// --- S-expression tree tests ---
 
 fn assert_tree(input: &String, expected: &String) {
     let root = rust::parse(input).unwrap();
@@ -105,8 +102,6 @@ fn assert_tree(input: &String, expected: &String) {
     let norm = normalize_tree(expected);
     assert actual == norm, `\ninput:    {*input}\nexpected: {norm}\nactual:   {actual}`;
 }
-
-// Expression tests
 
 test "tree: operator precedence" {
     assert_tree(&"const X: i32 = 1 + 2 * 3 - 4;", &"

--- a/package-gale/tests/driver_sqlite_test.wado
+++ b/package-gale/tests/driver_sqlite_test.wado
@@ -120,7 +120,6 @@ test "begin" {
     );
 }
 
-// --- S-expression tree tests ---
 
 test "tree: select literal" {
     assert_tree(&"SELECT 1;", &"

--- a/package-gale/tests/driver_typescript_test.wado
+++ b/package-gale/tests/driver_typescript_test.wado
@@ -88,7 +88,6 @@ test "tokenize enum" {
     assert first == "Enum", `expected Enum, got {first}`;
 }
 
-// --- Parser tests ---
 // The TypeScript grammar's generated entry rule is `initializer: '=' singleExpression`,
 // so only `= <expression>` inputs can be parsed. Identifiers are not tokenized
 // correctly due to missing semantic predicates, so only literal expressions work.
@@ -170,7 +169,6 @@ test "parse initializer ternary" {
     }
 }
 
-// --- Complex expression tests ---
 
 test "parse nested arithmetic" {
     let result = ts::parse(&"= (1 + 2) * 3");
@@ -361,7 +359,6 @@ test "tree: simple ternary" {
     ");
 }
 
-// --- Right-associative power operator ---
 //
 // TypeScriptParser.g4 marks the `**` alternative of `singleExpression` with
 // `<assoc=right>`. `2 ** 3 ** 4` must parse as `2 ** (3 ** 4)`, which in the
@@ -401,7 +398,6 @@ test "tree: power operator over addition binds tighter on the right" {
     ");
 }
 
-// --- Lexer command regression tests ---
 //
 // These exercise code paths that used to be silently dropped by the IR and
 // are now wired through the lexer generator: `type(X)` kind override,

--- a/package-gale/tests/generated/antlr4/ANTLRv4Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4/ANTLRv4Lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6fd58782d32cfb10",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "6c0716cdb85972073e994998e76bea8015dc630d9880f4bf239b4606f156528a",
   "primary": {
     "path": "grammars/ANTLRv4Lexer.g4",
     "hash": "30bd52b58a5916a63041f501c2d45358431c5c379f1ed3e8a3fbbb311f3572bd"

--- a/package-gale/tests/generated/antlr4/ANTLRv4Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4/ANTLRv4Lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6fd58782d32cfb10",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "6c0716cdb85972073e994998e76bea8015dc630d9880f4bf239b4606f156528a",
+  "generator_source_hash": "d21a2495894d959c3b2ad3fd208f870dfca5795a94460628979e0ccdfe2235b8",
   "primary": {
     "path": "grammars/ANTLRv4Lexer.g4",
     "hash": "30bd52b58a5916a63041f501c2d45358431c5c379f1ed3e8a3fbbb311f3572bd"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a6ec2b8f2ddde283",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "2e1aeb4300b2e05087a727ecbc73a81db05b4cb0d21b783760e88bbf2c2549c4",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_1.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-61c5e70fcdb6da1f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "2e1aeb4300b2e05087a727ecbc73a81db05b4cb0d21b783760e88bbf2c2549c4",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_10.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-699ecb3a8f815e27",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "2e1aeb4300b2e05087a727ecbc73a81db05b4cb0d21b783760e88bbf2c2549c4",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_2.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-262e54587e9044c3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "2e1aeb4300b2e05087a727ecbc73a81db05b4cb0d21b783760e88bbf2c2549c4",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_3.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a998eaa06c653a5b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "2e1aeb4300b2e05087a727ecbc73a81db05b4cb0d21b783760e88bbf2c2549c4",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_4.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fc22b0fc36d36630",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "2e1aeb4300b2e05087a727ecbc73a81db05b4cb0d21b783760e88bbf2c2549c4",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_5.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2852af861801de26",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "2e1aeb4300b2e05087a727ecbc73a81db05b4cb0d21b783760e88bbf2c2549c4",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_6.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-320d631a0baf5c0b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "2e1aeb4300b2e05087a727ecbc73a81db05b4cb0d21b783760e88bbf2c2549c4",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_7.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3bd4c5ea00e5572f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "2e1aeb4300b2e05087a727ecbc73a81db05b4cb0d21b783760e88bbf2c2549c4",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_8.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-49d484703a919155",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "2e1aeb4300b2e05087a727ecbc73a81db05b4cb0d21b783760e88bbf2c2549c4",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_9.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-713ef5230fbaf9f1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "60889ca6a4399b6a98e337c2e4ab1f68d201ee524523ad51c4c63a6fdb46bb7c",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_1.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-558b311b80c4da10",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "60889ca6a4399b6a98e337c2e4ab1f68d201ee524523ad51c4c63a6fdb46bb7c",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_2.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c369756dc031bf12",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "60889ca6a4399b6a98e337c2e4ab1f68d201ee524523ad51c4c63a6fdb46bb7c",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_3.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-abed1c70b5e6c53f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "60889ca6a4399b6a98e337c2e4ab1f68d201ee524523ad51c4c63a6fdb46bb7c",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_1.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a1b502206053bf7a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "60889ca6a4399b6a98e337c2e4ab1f68d201ee524523ad51c4c63a6fdb46bb7c",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_2.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-68045ae831d55159",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "60889ca6a4399b6a98e337c2e4ab1f68d201ee524523ad51c4c63a6fdb46bb7c",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_3.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-678c469712c8fc23",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "60889ca6a4399b6a98e337c2e4ab1f68d201ee524523ad51c4c63a6fdb46bb7c",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_4.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-16bc5e2c231c2ba8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_5.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c116bb1cfe62a2a8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_6.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0484794f535b91f2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_7.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fe2840241e9172a0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_1.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-235cd53ca8f4663a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_10.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ed84013859c673b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_11.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-739357c31b4c8ca4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_12.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-70a21a8410fad983",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_2.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-99bcc333174e8ead",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_5.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2f290cf17eba13e0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_6.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bd943cd5ec077b75",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_7.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6ad535192ef3e12f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_8.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-43dcc5eba0df7ec4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_9.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-112c4a21992a04ed",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_1.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-459d0b754845c21f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_2.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1181507cda20d45b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_3.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4b506a26b7b7c7b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_1.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-34e6293e9d4c3e83",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_2.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b2467e37954af95c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_3.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-be8254158e713214",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_1.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4fc8261d73da648f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_2.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-93334f393b16d8e0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_3.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e522638eb5f62a2f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrecedenceFilterConsidersContext.g4",
     "hash": "c92df3158f9ed1c1b43de581aedaf3b0918fa525ff0258f855022b78585b860b"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-709c12dbc0d22c0c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrefixAndOtherAlt_1.g4",
     "hash": "f946ec43c09928b2aae968a817d4ff315478257d5700925eab82fd22d94714d8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1f6f1364b2571756",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrefixAndOtherAlt_2.g4",
     "hash": "f946ec43c09928b2aae968a817d4ff315478257d5700925eab82fd22d94714d8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList1_1/ReturnValueAndActionsList1_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList1_1/ReturnValueAndActionsList1_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-98215ef7f217d444",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList1_1.g4",
     "hash": "97ed3cba25571f64d3b3f1ada1225af38693f6353aa699ec825c47886f968b1e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList1_3/ReturnValueAndActionsList1_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList1_3/ReturnValueAndActionsList1_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d3f80bba204a6230",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList1_3.g4",
     "hash": "97ed3cba25571f64d3b3f1ada1225af38693f6353aa699ec825c47886f968b1e"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList2_1/ReturnValueAndActionsList2_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList2_1/ReturnValueAndActionsList2_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fe2931b7e3ce7624",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList2_1.g4",
     "hash": "d020b96fea143032cbc0f3f58b543f99e6ee62a9921e2c0c402a721dfeb8e67c"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList2_3/ReturnValueAndActionsList2_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/ReturnValueAndActionsList2_3/ReturnValueAndActionsList2_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-292efe417a055f21",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList2_3.g4",
     "hash": "d020b96fea143032cbc0f3f58b543f99e6ee62a9921e2c0c402a721dfeb8e67c"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPred/SemPred.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPred/SemPred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-960ef5ffa9d45556",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/SemPred.g4",
     "hash": "a19c17fc308f32463fe399a657b189a837ad4fa52afc1206ab0d1d8a38dcbe04"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPredFailOption/SemPredFailOption.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/SemPredFailOption/SemPredFailOption.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a26551c8d0a65a59",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/SemPredFailOption.g4",
     "hash": "baacd97f45a8e197f2d9363c57506eebffd7f8862b34984e659ed317ac48a7d5"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5d3495c986bff9bd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_1.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-33ccce79b79bf5e2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_2.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6dcbc071fc2f601e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_3.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-741313c066ff2cd5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_1.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-381677e2c28357d8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_2.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4d665f3c7d50cbb6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_3.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-18d85335cd7b6ba7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_4.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6c0e1c831530f504",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_5.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d5dda292b3d95344",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_6.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bc586f7b630f85cb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_7.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b8fe4abc43e4380d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_8.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ddd4f8db5f21632f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_9.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1a2ad3adca9a2a07",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "9ffab14e5a3394205c9f2249732386d13ef948d9008a14f8900486a91957312b",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_1.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-eed4df03ca7a51f5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "a8e0c7383175273630992f62d15b905a472eec8d92b0c8a438f484c10227d398",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_2.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bfcc2ec63de46569",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "a8e0c7383175273630992f62d15b905a472eec8d92b0c8a438f484c10227d398",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_3.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-20cd1bcceb40fb33",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "a8e0c7383175273630992f62d15b905a472eec8d92b0c8a438f484c10227d398",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_4.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-cfe1fc1849a20141",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "a8e0c7383175273630992f62d15b905a472eec8d92b0c8a438f484c10227d398",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_5.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-88482992acd5509f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "6c0716cdb85972073e994998e76bea8015dc630d9880f4bf239b4606f156528a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_6.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-78bbab6b273081fa",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "6c0716cdb85972073e994998e76bea8015dc630d9880f4bf239b4606f156528a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_7.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-03918ec747b14ad6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "6c0716cdb85972073e994998e76bea8015dc630d9880f4bf239b4606f156528a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_8.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a66253165de20181",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "6c0716cdb85972073e994998e76bea8015dc630d9880f4bf239b4606f156528a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_9.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1d1b100d63f04166",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "6c0716cdb85972073e994998e76bea8015dc630d9880f4bf239b4606f156528a",
   "primary": {
     "path": "../../grammars/ParserExec/BuildParseTree_TRUE.g4",
     "hash": "2a131cc48cdbfa4950f7c16ef0fcb51f4679926cabf71d403883a9fc01e9cb99"

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-94c0b5df15a69680",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "6c0716cdb85972073e994998e76bea8015dc630d9880f4bf239b4606f156528a",
   "primary": {
     "path": "../../grammars/ParserExec/PredictionIssue334.g4",
     "hash": "05f509013c98f1d1ef907d23c43aa328f3c9ee0ad9166b21ac03dbc715ee8542"

--- a/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3ebf8faf7a4261df",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "6c0716cdb85972073e994998e76bea8015dc630d9880f4bf239b4606f156528a",
   "primary": {
     "path": "../../grammars/ParserExec/PredictionMode_LL.g4",
     "hash": "8542495134a20f622112aa07fc5cd71fcc1b8e3669f41ff329126b355c4df7f4"

--- a/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_1/PredFromAltTestedInLoopBack_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_1/PredFromAltTestedInLoopBack_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3c84aa606fbeb863",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "6c0716cdb85972073e994998e76bea8015dc630d9880f4bf239b4606f156528a",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/PredFromAltTestedInLoopBack_1.g4",
     "hash": "b6144b334167648d1e1560be8a7590525c8b34cbba2e27d040c41026fa7c9323"

--- a/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7f162199fbfa5a4d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "6c0716cdb85972073e994998e76bea8015dc630d9880f4bf239b4606f156528a",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/PredFromAltTestedInLoopBack_2.g4",
     "hash": "b6144b334167648d1e1560be8a7590525c8b34cbba2e27d040c41026fa7c9323"

--- a/package-gale/tests/generated/at_end_alt_gaps/at_end_alt_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/at_end_alt_gaps/at_end_alt_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-105bcd36568c5dd8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "6c0716cdb85972073e994998e76bea8015dc630d9880f4bf239b4606f156528a",
   "primary": {
     "path": "grammars/at_end_alt_gaps.g4",
     "hash": "9cd47ca80f5762b4107f87ae05f1bce472bbfb8aca3c06ef0bdbf501ac519f82"

--- a/package-gale/tests/generated/calculator/calculator.g4.kiln.json
+++ b/package-gale/tests/generated/calculator/calculator.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7fbe69e34c931e16",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "d3da00a58461b9ec1a5d330bce27e8beaa7b8f1c00bce02629b708c4f682e629",
   "primary": {
     "path": "grammars/calculator.g4",
     "hash": "67431dad6dcc459fea7d4c448fb04944de2c4cf61ecd75d546aeccd93b4564d7"

--- a/package-gale/tests/generated/ci_rule_override/ci_rule_override.g4.kiln.json
+++ b/package-gale/tests/generated/ci_rule_override/ci_rule_override.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-66c270910e5642be",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "6c0716cdb85972073e994998e76bea8015dc630d9880f4bf239b4606f156528a",
   "primary": {
     "path": "grammars/ci_rule_override.g4",
     "hash": "6efdfe55ecb215bf526900a32a11c664a57c9e14d61c6a67758f870adc73d09b"

--- a/package-gale/tests/generated/ci_sql/ci_sql.g4.kiln.json
+++ b/package-gale/tests/generated/ci_sql/ci_sql.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b9bfa38391d7f122",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "6c0716cdb85972073e994998e76bea8015dc630d9880f4bf239b4606f156528a",
   "primary": {
     "path": "grammars/ci_sql.g4",
     "hash": "41b72934417dd2f6fa0359722ce53ca05cd10cccde08fd9f3d0d58018f2137fe"

--- a/package-gale/tests/generated/css3/css3Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/css3/css3Lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fa4a5fa8cced30ae",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "6c0716cdb85972073e994998e76bea8015dc630d9880f4bf239b4606f156528a",
   "primary": {
     "path": "grammars/css3Lexer.g4",
     "hash": "4733198f782344f0d3dbd2456ee9f6db955f53c688d14334fb403985551c963c"

--- a/package-gale/tests/generated/html/HTMLLexer.g4.kiln.json
+++ b/package-gale/tests/generated/html/HTMLLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c6b3fd168a1b47a8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "d3da00a58461b9ec1a5d330bce27e8beaa7b8f1c00bce02629b708c4f682e629",
   "primary": {
     "path": "grammars/HTMLLexer.g4",
     "hash": "1d3b243228b182ddeca45bf2c7f9ec6512c176bcec126444bce7cbe7a8e93052"

--- a/package-gale/tests/generated/html/HTMLLexer.g4.kiln.json
+++ b/package-gale/tests/generated/html/HTMLLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c6b3fd168a1b47a8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "d3da00a58461b9ec1a5d330bce27e8beaa7b8f1c00bce02629b708c4f682e629",
+  "generator_source_hash": "276176a1ba029673d11f5fd3ce04262115b1e9c938f7e65b844679180561424a",
   "primary": {
     "path": "grammars/HTMLLexer.g4",
     "hash": "1d3b243228b182ddeca45bf2c7f9ec6512c176bcec126444bce7cbe7a8e93052"

--- a/package-gale/tests/generated/json/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/json/JSON.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-deb9206518cd2a6f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "d3da00a58461b9ec1a5d330bce27e8beaa7b8f1c00bce02629b708c4f682e629",
   "primary": {
     "path": "grammars/JSON.g4",
     "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"

--- a/package-gale/tests/generated/json/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/json/JSON.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-deb9206518cd2a6f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "d3da00a58461b9ec1a5d330bce27e8beaa7b8f1c00bce02629b708c4f682e629",
+  "generator_source_hash": "924e38cb054d78fe6e4ac045f5871083b9f689661159e238a2651308790ff115",
   "primary": {
     "path": "grammars/JSON.g4",
     "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"

--- a/package-gale/tests/generated/json/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/json/JSON.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-deb9206518cd2a6f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "924e38cb054d78fe6e4ac045f5871083b9f689661159e238a2651308790ff115",
+  "generator_source_hash": "d21a2495894d959c3b2ad3fd208f870dfca5795a94460628979e0ccdfe2235b8",
   "primary": {
     "path": "grammars/JSON.g4",
     "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"

--- a/package-gale/tests/generated/json_highlight/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/json_highlight/JSON.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-deb9206518cd2a6f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "6c0716cdb85972073e994998e76bea8015dc630d9880f4bf239b4606f156528a",
   "primary": {
     "path": "grammars/JSON.g4",
     "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"

--- a/package-gale/tests/generated/label_gaps/label_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/label_gaps/label_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6e9e12ac993603d7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "d3da00a58461b9ec1a5d330bce27e8beaa7b8f1c00bce02629b708c4f682e629",
   "primary": {
     "path": "grammars/label_gaps.g4",
     "hash": "8e2049cd7baf82750b8e242018ffdc1f8e684226f8e27fe8068ad7838d6da425"

--- a/package-gale/tests/generated/lexer_command_gaps/lexer_command_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/lexer_command_gaps/lexer_command_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c1bc56a77b40e824",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "d3da00a58461b9ec1a5d330bce27e8beaa7b8f1c00bce02629b708c4f682e629",
   "primary": {
     "path": "grammars/lexer_command_gaps.g4",
     "hash": "253a32f9908895a3ffaa23ac8e32eaa12f43998f25d7d2b73637ddf11a3cb3c9"

--- a/package-gale/tests/generated/ll_basic/ll_basic.g4.kiln.json
+++ b/package-gale/tests/generated/ll_basic/ll_basic.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1206cd75cc164570",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "d3da00a58461b9ec1a5d330bce27e8beaa7b8f1c00bce02629b708c4f682e629",
   "primary": {
     "path": "grammars/ll_basic.g4",
     "hash": "13868e6cd6d82823b75c7c4c47196769892a7455d2a5708059eda73d059fa079"

--- a/package-gale/tests/generated/ll_ctx_follow/ll_ctx_follow.g4.kiln.json
+++ b/package-gale/tests/generated/ll_ctx_follow/ll_ctx_follow.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b6ecd573d27c61b4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "d3da00a58461b9ec1a5d330bce27e8beaa7b8f1c00bce02629b708c4f682e629",
   "primary": {
     "path": "grammars/ll_ctx_follow.g4",
     "hash": "dfd02fd3f5e412a278dd35d357b67bd1b5c3ee832a93ead373965a1ea4caa7ed"

--- a/package-gale/tests/generated/ll_lr_atom/ll_lr_atom.g4.kiln.json
+++ b/package-gale/tests/generated/ll_lr_atom/ll_lr_atom.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-57755379135c6d22",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "d3da00a58461b9ec1a5d330bce27e8beaa7b8f1c00bce02629b708c4f682e629",
   "primary": {
     "path": "grammars/ll_lr_atom.g4",
     "hash": "a03827fb8ff2576a6b7eb0997c60f88f94b45f673cc5ef743531000f7441227a"

--- a/package-gale/tests/generated/ll_multi_alt/ll_multi_alt.g4.kiln.json
+++ b/package-gale/tests/generated/ll_multi_alt/ll_multi_alt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4ba2b45344ba5494",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "d3da00a58461b9ec1a5d330bce27e8beaa7b8f1c00bce02629b708c4f682e629",
   "primary": {
     "path": "grammars/ll_multi_alt.g4",
     "hash": "16387da958668ca8bfdc3a1502dec2180c703bb9affd3b19c2e669b8be9197a6"

--- a/package-gale/tests/generated/ll_nullable_suffix/ll_nullable_suffix.g4.kiln.json
+++ b/package-gale/tests/generated/ll_nullable_suffix/ll_nullable_suffix.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f9a69797fc3574b8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "d3da00a58461b9ec1a5d330bce27e8beaa7b8f1c00bce02629b708c4f682e629",
   "primary": {
     "path": "grammars/ll_nullable_suffix.g4",
     "hash": "d66de357f8340f6036dea6270e51c73a58b209b0a07685a7df03b2d18d218fe4"

--- a/package-gale/tests/generated/mode_gaps/mode_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/mode_gaps/mode_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-934b67223a7d4708",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "d3da00a58461b9ec1a5d330bce27e8beaa7b8f1c00bce02629b708c4f682e629",
   "primary": {
     "path": "grammars/mode_gaps.g4",
     "hash": "2129310ea345f84328b61531ce102c6306fda62ef4fa71d7c64d1dc4bb9f1d14"

--- a/package-gale/tests/generated/non_greedy_gaps/non_greedy_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/non_greedy_gaps/non_greedy_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a7aa34c1db2fca6a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "d3da00a58461b9ec1a5d330bce27e8beaa7b8f1c00bce02629b708c4f682e629",
   "primary": {
     "path": "grammars/non_greedy_gaps.g4",
     "hash": "b7ebb6e1d962ee295bf43cc5a13f167cbd270ef3d9e15a052d2eb060eefb012c"

--- a/package-gale/tests/generated/parser_gaps/parser_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/parser_gaps/parser_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8eb28e22b79ba2bd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "d3da00a58461b9ec1a5d330bce27e8beaa7b8f1c00bce02629b708c4f682e629",
   "primary": {
     "path": "grammars/parser_gaps.g4",
     "hash": "8262a9d7c10805db35e063564eaea6deb43e8de540af19d0969551d042b6d03a"

--- a/package-gale/tests/generated/recursive_lexer/recursive_lexer.g4.kiln.json
+++ b/package-gale/tests/generated/recursive_lexer/recursive_lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b23078c163edb700",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "d3da00a58461b9ec1a5d330bce27e8beaa7b8f1c00bce02629b708c4f682e629",
   "primary": {
     "path": "grammars/recursive_lexer.g4",
     "hash": "3bba2a980c91c247bfa081040a71e8349ebd29cec177d15cf69feb75f40e705f"

--- a/package-gale/tests/generated/right_assoc_gaps/right_assoc_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/right_assoc_gaps/right_assoc_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7382226003c5d9e1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "d3da00a58461b9ec1a5d330bce27e8beaa7b8f1c00bce02629b708c4f682e629",
   "primary": {
     "path": "grammars/right_assoc_gaps.g4",
     "hash": "7632fce865fe8aa2c3c460beea14a27a0a020b9ccb2312fb59a2c980f12f639a"

--- a/package-gale/tests/generated/rust/RustLexer.g4.kiln.json
+++ b/package-gale/tests/generated/rust/RustLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-28566ce8c3b8a5b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "d3da00a58461b9ec1a5d330bce27e8beaa7b8f1c00bce02629b708c4f682e629",
+  "generator_source_hash": "276176a1ba029673d11f5fd3ce04262115b1e9c938f7e65b844679180561424a",
   "primary": {
     "path": "grammars/RustLexer.g4",
     "hash": "a9069b6b1a5650b0f5f115897eaa0edaddc42007b262c5096b59eb1de15323d3"

--- a/package-gale/tests/generated/rust/RustLexer.g4.kiln.json
+++ b/package-gale/tests/generated/rust/RustLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-28566ce8c3b8a5b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "d3da00a58461b9ec1a5d330bce27e8beaa7b8f1c00bce02629b708c4f682e629",
   "primary": {
     "path": "grammars/RustLexer.g4",
     "hash": "a9069b6b1a5650b0f5f115897eaa0edaddc42007b262c5096b59eb1de15323d3"

--- a/package-gale/tests/generated/sexpression/sexpression.g4.kiln.json
+++ b/package-gale/tests/generated/sexpression/sexpression.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1847ef51d5668bfd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "d3da00a58461b9ec1a5d330bce27e8beaa7b8f1c00bce02629b708c4f682e629",
   "primary": {
     "path": "grammars/sexpression.g4",
     "hash": "74549e6167e186b754886880a5d473ad3361bee8440368f99e1b233e2c1c7bdb"

--- a/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-880d9db12a6d7521",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "924e38cb054d78fe6e4ac045f5871083b9f689661159e238a2651308790ff115",
+  "generator_source_hash": "276176a1ba029673d11f5fd3ce04262115b1e9c938f7e65b844679180561424a",
   "primary": {
     "path": "grammars/SQLite.g4",
     "hash": "72e3fa9877777afa5a4f9e8196d4cb194bb599e719d43b7b29d09eeed3e4c5e0"

--- a/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-880d9db12a6d7521",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "d3da00a58461b9ec1a5d330bce27e8beaa7b8f1c00bce02629b708c4f682e629",
   "primary": {
     "path": "grammars/SQLite.g4",
     "hash": "72e3fa9877777afa5a4f9e8196d4cb194bb599e719d43b7b29d09eeed3e4c5e0"

--- a/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-880d9db12a6d7521",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "d3da00a58461b9ec1a5d330bce27e8beaa7b8f1c00bce02629b708c4f682e629",
+  "generator_source_hash": "924e38cb054d78fe6e4ac045f5871083b9f689661159e238a2651308790ff115",
   "primary": {
     "path": "grammars/SQLite.g4",
     "hash": "72e3fa9877777afa5a4f9e8196d4cb194bb599e719d43b7b29d09eeed3e4c5e0"

--- a/package-gale/tests/generated/sqlite_highlight/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite_highlight/SQLite.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-880d9db12a6d7521",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "d3da00a58461b9ec1a5d330bce27e8beaa7b8f1c00bce02629b708c4f682e629",
   "primary": {
     "path": "grammars/SQLite.g4",
     "hash": "72e3fa9877777afa5a4f9e8196d4cb194bb599e719d43b7b29d09eeed3e4c5e0"

--- a/package-gale/tests/generated/typescript/TypeScriptLexer.g4.kiln.json
+++ b/package-gale/tests/generated/typescript/TypeScriptLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b6f068637d3275ff",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "d3da00a58461b9ec1a5d330bce27e8beaa7b8f1c00bce02629b708c4f682e629",
+  "generator_source_hash": "276176a1ba029673d11f5fd3ce04262115b1e9c938f7e65b844679180561424a",
   "primary": {
     "path": "grammars/TypeScriptLexer.g4",
     "hash": "f7089740f7e82bbb90a6c4b13c75959b6ceaf3003be0dd0657c52b9eb6a594b7"

--- a/package-gale/tests/generated/typescript/TypeScriptLexer.g4.kiln.json
+++ b/package-gale/tests/generated/typescript/TypeScriptLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b6f068637d3275ff",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "d3da00a58461b9ec1a5d330bce27e8beaa7b8f1c00bce02629b708c4f682e629",
   "primary": {
     "path": "grammars/TypeScriptLexer.g4",
     "hash": "f7089740f7e82bbb90a6c4b13c75959b6ceaf3003be0dd0657c52b9eb6a594b7"

--- a/package-gale/tests/generated/unicode_props/unicode_props.g4.kiln.json
+++ b/package-gale/tests/generated/unicode_props/unicode_props.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f37fa830f2a0df13",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "c5995eb7b064e1fa8487078349d41a1eca8a8d9d6a0fbb22a8bb36d1820c2d76",
+  "generator_source_hash": "d3da00a58461b9ec1a5d330bce27e8beaa7b8f1c00bce02629b708c4f682e629",
   "primary": {
     "path": "grammars/unicode_props.g4",
     "hash": "7559b99d20b67597cdc99b2e9e0eaeea1ad4b0931d40859c1dbb600e20d1c5c0"


### PR DESCRIPTION
## Summary

`package-gale/src/parser_gen.wado` had grown to 5,936 lines holding both
the static lookahead analyzer and the per-rule emitter. The two halves
don't share a `CodeWriter` and have completely different testing
surfaces, so this PR factors them apart along that natural seam.

- **`prediction.wado`** (new, 888 lines) — SLL simulator and the
  `PredictionNode` tree. Pure analysis: takes
  `(alt_indices, first_sets, alt_elements, ctx)` and returns a
  dispatch tree. Never touches `CodeWriter`.
- **`alt_grouping.wado`** (new, 237 lines) — multi-alt overlap
  grouping and sort heuristics (`alt_sort_priority`,
  `sort_group_by_*`, `ALT_PRIORITY_*` bands).
- **`gen_util.wado`** gains the ir-only field/name helpers that don't
  pull in gir: `first_contains`, `dedup_append_arr`, `dedup_name` /
  `peek_dedup_name`, `has_field`, `is_list_label`,
  `element_field_info`, `replay_element_names`.
- **`parser_gen.wado`** keeps Layer B (`gen_parser`, `gen_scan_*`,
  `gen_op_*`, `gen_lr_*`, `gen_prediction_code_inner`, etc.) — now
  4,646 lines (-22%).

### Why this seam

Layer A (analysis) is pure — `PredictionNode` is the output of an
SLL ATN simulator that doesn't touch any emit machinery. Layer B
(emission) consumes that tree plus the GIR to write Wado source via
`CodeWriter`. Mixing them in one file meant the SLL simulator (which
has its own subtle invariants — see CLAUDE.md's "Failed Approaches"
section on `return_stack` and on LL(*) variant emit) sat next to
~3,000 lines of `gen_op_*` walker code, making both harder to navigate.

### Not in scope

The gir-dependent op-field helpers (`op_field` / `op_field_type` /
`op_leaf_dedup_base` / `sync_name_counts_for_op_*` /
`emit_op_excluded_call`) stay in `parser_gen.wado`. Moving them to
`gen_util.wado` would create a `gen_util → gir → lexer_gen → gen_util`
cycle. They naturally belong with a future `op_gen.wado` split of
the per-element emission layer (~1,700 lines), which we deliberately
deferred to keep this PR mechanical.

## Test plan

- [x] `wado test package-gale/src/` — 412 unit tests pass (36 files compiled)
- [x] `wado test package-gale/tests/driver_{sqlite,json,html,typescript}_test.wado` — 95 e2e tests pass on the four heaviest grammars
- [x] All 40 driver/antlr4-compat grammars in `package-gale/tests/` compile (= code generation works across the board)
- [x] `wado format -w` clean on all touched files
- [x] Stale doc references in `lower.wado` (`parser_gen::compute_overlap_groups` → `alt_grouping::…`, etc.) updated

Generated parser `.kiln.json` cache hashes update because the
generator source layout changed; the emitted parser source is
byte-identical (verified by recompiling every fixture).

https://claude.ai/code/session_014cr6jqExVcMFpR2FYHJW7U

---
_Generated by [Claude Code](https://claude.ai/code/session_014cr6jqExVcMFpR2FYHJW7U)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wado-lang/wado/pull/1069" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->