### PR TITLE
docs: WEP for unused diagnostics

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -109,3 +109,4 @@ It may include TODOs on WIP.
 - [WIT Interoperability](./wep-2026-05-02-wit-interoperability.md)
 - [HTTP Path Router (`core:router`)](./wep-2026-05-06-core-router.md)
 - [Normalized IR (NIR) Layer](./wep-2026-05-11-nir.md)
+- [Unused Diagnostics](./wep-2026-05-16-unused-diagnostics.md)

--- a/docs/wep-2026-05-16-unused-diagnostics.md
+++ b/docs/wep-2026-05-16-unused-diagnostics.md
@@ -14,19 +14,19 @@ but no pass turns those into user-facing diagnostics.
 
 The reachability roots for "unused" in Wado are not what rustc uses:
 
-- `pub` in Wado is "same-package public", not package-external. A
-  private `pub fn helper()` that no caller invokes is **dead code**, not
-  a public API surface.
-- `export` is what crosses the Wasm Component Model boundary. The world
-  declaration determines which exports a binary must produce.
+- `export` is the only modifier that crosses the package boundary. It
+  applies uniformly across `command`, `service`, and `lib` entry
+  points: a `lib` package exposes `export` items as its public API
+  (see [Package Manifest](./wep-2026-02-14-package-manifest.md)).
+- `pub` is package-internal visibility. A `pub fn` that no caller
+  invokes inside the package is dead code, even in a `lib` package —
+  it is not part of the package's public API surface.
 - The standard library is a separate package whose `pub` items are
   visible from user code under special rules. Stdlib must never receive
   user-facing unused warnings.
 - Synthesised functions (CM bindings, effect-dispatch wrappers,
   monomorphisation clones, auto-derived impls) are not source-authored
   and must not be reported regardless of reachability.
-- A package that is itself published as a library (manifest's `lib`
-  field) needs every `pub` item to be treated as a reachability root.
 
 Without explicit lints, three problems persist: silent dead code
 accumulates across refactors, unused imports pollute namespace
@@ -49,9 +49,9 @@ HIR-level `unused_*` lints and `dead_code` reachability:
    removed. Emits `DeadFunction`.
 
 Both passes are guarded by `CompilerOptions::unused_diagnostics` (on by
-default). Library packages set
-`CompilerOptions::package_is_library`, which adds every `is_pub`
-function in user-authored modules to the reachability root set.
+default). No package-kind toggle is needed: `export` already names the
+complete set of package-external roots for every entry-point kind
+(`command`, `service`, `lib`).
 
 ### What is in scope (MVP)
 
@@ -75,15 +75,16 @@ function in user-authored modules to the reachability root set.
 
 The DCE layer treats these as always-reachable:
 
-| Root                                                        | Source                                                                                 |
-| ----------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| `is_cm_export`                                              | World export wrappers from synthesis                                                   |
-| `is_export` in `wasm_module_sources`                        | Raw Wasm exports                                                                       |
-| `is_pub` in user-authored modules when `package_is_library` | Library API surface                                                                    |
-| `defining_ast_id.is_none()`                                 | Synthesised functions (CM bindings, dispatch wrappers, monomorph clones, auto-derives) |
+| Root                                 | Source                                                                                 |
+| ------------------------------------ | -------------------------------------------------------------------------------------- |
+| `is_cm_export`                       | World export wrappers from synthesis (covers `command` / `service` / `lib` exports)    |
+| `is_export` in `wasm_module_sources` | Raw Wasm exports                                                                       |
+| `defining_ast_id.is_none()`          | Synthesised functions (CM bindings, dispatch wrappers, monomorph clones, auto-derives) |
 
-`is_pub` alone is never a root: in Wado it is same-package visibility,
-not external API. The library flag is what promotes it.
+`is_pub` is never a root. In Wado it denotes package-internal
+visibility, never package-external API — that is `export`'s job, and
+`export` covers `lib` packages as well as `command` / `service`. An
+unreferenced `pub fn` is dead code regardless of the entry-point kind.
 
 ### Stdlib exclusion
 
@@ -120,18 +121,18 @@ This is the only structural change required outside the new
 
 ### Source files
 
-| File                                  | Description                                                                                                                                                                           |
-| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `wado-compiler/src/analyze/unused.rs` | New module hosting `check_unused` (Annotated layer) and `check_dead_functions` (DCE hook).                                                                                            |
-| `wado-compiler/src/compiler_host.rs`  | Adds `Code::UnusedImport`, `UnusedVariable`, `UnusedParameter`, `DeadFunction` and their `Display` mappings.                                                                          |
-| `wado-compiler/src/logger.rs`         | Adds `Logger::warn_at(code, message, span, file)` for span-bearing warnings.                                                                                                          |
-| `wado-compiler/src/lib.rs`            | Adds `CompilerOptions::unused_diagnostics`, `CompilerOptions::package_is_library`. Calls `check_unused` after `annotate_loaded` and `check_dead_functions` after DCE reachability.    |
-| `wado-compiler/src/tir.rs`            | `TirFunction::defining_ast_id: Option<AstId>`.                                                                                                                                        |
-| `wado-compiler/src/nir.rs`            | `NirFunction::defining_ast_id: Option<AstId>`.                                                                                                                                        |
-| `wado-compiler/src/optimize/dce.rs`   | Splits `analyze_project` into reachability computation and removal so the diagnostic hook fits between them. Extends `compute_reachable_from_entries` to honour `package_is_library`. |
-| `wado-compiler/src/ast_index.rs`      | Adds `is_param(id)` predicate (1-bit table) so the locals pass can distinguish `UnusedVariable` from `UnusedParameter`.                                                               |
-| `wado-cli`                            | Adds `--no-unused` flag; sets `package_is_library` from `wado.toml`'s `[package].lib`.                                                                                                |
-| `wado-lsp`                            | Calls `analyze::unused::check_unused` from `Engine::diagnostics`.                                                                                                                     |
+| File                                  | Description                                                                                                                                 |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `wado-compiler/src/analyze/unused.rs` | New module hosting `check_unused` (Annotated layer) and `check_dead_functions` (DCE hook).                                                  |
+| `wado-compiler/src/compiler_host.rs`  | Adds `Code::UnusedImport`, `UnusedVariable`, `UnusedParameter`, `DeadFunction` and their `Display` mappings.                                |
+| `wado-compiler/src/logger.rs`         | Adds `Logger::warn_at(code, message, span, file)` for span-bearing warnings.                                                                |
+| `wado-compiler/src/lib.rs`            | Adds `CompilerOptions::unused_diagnostics`. Calls `check_unused` after `annotate_loaded` and `check_dead_functions` after DCE reachability. |
+| `wado-compiler/src/tir.rs`            | `TirFunction::defining_ast_id: Option<AstId>`.                                                                                              |
+| `wado-compiler/src/nir.rs`            | `NirFunction::defining_ast_id: Option<AstId>`.                                                                                              |
+| `wado-compiler/src/optimize/dce.rs`   | Splits `analyze_project` into reachability computation and removal so the diagnostic hook fits between them.                                |
+| `wado-compiler/src/ast_index.rs`      | Adds `is_param(id)` predicate (1-bit table) so the locals pass can distinguish `UnusedVariable` from `UnusedParameter`.                     |
+| `wado-cli`                            | Adds `--no-unused` flag.                                                                                                                    |
+| `wado-lsp`                            | Calls `analyze::unused::check_unused` from `Engine::diagnostics`.                                                                           |
 
 ### Algorithms
 
@@ -185,9 +186,7 @@ group when:
 - `defining_ast_id` is `Some` (skip synthesised),
 - the module is not a stdlib module,
 - the function is not `is_export` / `is_cm_export`,
-- no monomorphisation is reachable,
-- and, when `package_is_library`, the function is not `is_pub` in a
-  user-authored module.
+- no monomorphisation is reachable.
 
 The diagnostic's span is `Annotated::name_span_of(SymbolKey)`,
 falling back to `NirFunction::span`.
@@ -228,7 +227,7 @@ calls `check_unused` after `annotate_loaded` without any extra cost.
 
 - [ ] Add `Code::UnusedImport`, `UnusedVariable`, `UnusedParameter`, `DeadFunction` and their `Display` strings.
 - [ ] Add `Logger::warn_at(code, message, span, file)`.
-- [ ] Add `CompilerOptions::unused_diagnostics` (default `true`) and `CompilerOptions::package_is_library` (default `false`).
+- [ ] Add `CompilerOptions::unused_diagnostics` (default `true`).
 - [ ] Add `AstIndex::is_param(id)` and tests.
 
 #### Phase 2 — `defining_ast_id` propagation
@@ -250,14 +249,12 @@ calls `check_unused` after `annotate_loaded` without any extra cost.
 
 - [ ] Split `optimize/dce.rs::analyze_project` into a reachability function and a removal function.
 - [ ] Implement `check_dead_functions`.
-- [ ] Extend `compute_reachable_from_entries` to honour `package_is_library`.
 - [ ] Wire `defining_ast_id.is_none()` as an additional DCE root so synthesised functions stay alive without being reported.
 - [ ] Add fixtures under `tests/fixtures/dead_*.wado`.
 
-#### Phase 5 — CLI and manifest wiring
+#### Phase 5 — CLI wiring
 
 - [ ] `wado-cli`: add `--no-unused` flag for `compile` / `run` / `serve` / `dump`.
-- [ ] `wado-cli`: read `[package].lib` from `wado.toml` and set `package_is_library`.
 
 ### Test plan
 
@@ -274,7 +271,7 @@ E2E fixtures (under `tests/fixtures/`):
 - `dead_function_export_root.wado`
 - `dead_function_generic.wado`
 - `dead_function_test_world.wado`
-- `dead_function_library_pub_root.wado`
+- `dead_function_lib_pub_is_dead.wado`
 - `unused_stdlib_no_report.wado`
 
 Each carries the appropriate `stderr_contains` entries in its `__DATA__`
@@ -321,7 +318,8 @@ through the diagnostics path.
   effect dispatch) could leave one monomorph reachable from an
   unreported path. Mitigation: rely on the existing DCE call-graph,
   which already handles these edges for removal.
-- Risk: `pub`-vs-`export` confusion in the wider ecosystem. Mitigation:
-  documentation in the lint message explicitly names the package
-  boundary, and the `package_is_library` toggle gives library authors
-  a way to opt out of `pub`-as-dead reports.
+- Risk: users coming from Rust expect `pub fn` in a `lib` package to
+  be a public API root and may be surprised that it is reported as
+  dead. Mitigation: the lint message names the rule
+  ("`pub` is package-internal; use `export` to expose at the package
+  boundary") and points at [Package Manifest](./wep-2026-02-14-package-manifest.md).

--- a/docs/wep-2026-05-16-unused-diagnostics.md
+++ b/docs/wep-2026-05-16-unused-diagnostics.md
@@ -44,9 +44,11 @@ HIR-level `unused_*` lints and `dead_code` reachability:
    `&Annotated`. Emits `UnusedImport`, `UnusedVariable`,
    `UnusedParameter`. LSP and batch compilation share this pass for
    free.
-2. NIR + DCE layer — runs as a hook inside `optimize/dce.rs`,
-   after reachability is computed but before unreachable functions are
-   removed. Emits `DeadFunction`.
+2. NIR + DCE layer — runs as hooks inside `optimize.rs::run_dce`, on
+   each iteration of DCE's fixed-point loop, between reachability
+   analysis and removal. Emits `DeadFunction` and `DeadGlobal`. A
+   cross-iteration dedup set keyed by `SymbolKey` ensures each item
+   is reported at most once.
 
 Both passes are guarded by `CompilerOptions::unused_diagnostics` (on by
 default). No package-kind toggle is needed: `export` already names the
@@ -61,11 +63,12 @@ complete set of package-external roots for every entry-point kind
 | `UnusedVariable`  | Annotated      | `UnusedVariable`  |
 | `UnusedParameter` | Annotated      | `UnusedParameter` |
 | `DeadFunction`    | NIR (post-DCE) | `DeadFunction`    |
+| `DeadGlobal`      | NIR (post-DCE) | `DeadGlobal`      |
 
 ### What is out of scope (deferred to follow-up WEPs / PRs)
 
 - `unused_mut`, `unused_type_param`, `unused_assignment`
-- `dead_type`, `dead_trait_impl`, `unreachable_pattern`
+- `dead_type`, `dead_trait_impl`, `unreachable_pattern`, `dead_closure_functor`
 - `#[allow(unused)]` / `#[deny(unused)]` attribute mechanism
 - Per-`UseItem::InterfaceFunctions` granularity (function-level inside
   an interface import)
@@ -75,11 +78,17 @@ complete set of package-external roots for every entry-point kind
 
 The DCE layer treats these as always-reachable:
 
-| Root                                 | Source                                                                                 |
-| ------------------------------------ | -------------------------------------------------------------------------------------- |
-| `is_cm_export`                       | World export wrappers from synthesis (covers `command` / `service` / `lib` exports)    |
-| `is_export` in `wasm_module_sources` | Raw Wasm exports                                                                       |
-| `defining_ast_id.is_none()`          | Synthesised functions (CM bindings, dispatch wrappers, monomorph clones, auto-derives) |
+| Root                                 | Source                                                                              |
+| ------------------------------------ | ----------------------------------------------------------------------------------- |
+| `is_cm_export`                       | World export wrappers from synthesis (covers `command` / `service` / `lib` exports) |
+| `is_export` in `wasm_module_sources` | Raw Wasm exports                                                                    |
+
+This matches the existing DCE root set in `optimize/dce.rs`
+(`compute_reachable_from_entries`). No new roots are introduced.
+Synthesised functions and globals stay subject to the normal call-graph
+rules: a CM binding for an unreachable export, or an auto-derived impl
+that nothing references, is still removed by DCE. The synthesis
+exclusion only suppresses the diagnostic emission, never the removal.
 
 `is_pub` is never a root. In Wado it denotes package-internal
 visibility, never package-external API — that is `export`'s job, and
@@ -105,14 +114,13 @@ user's build output.
 
 ### Defining-ast-id field
 
-`TirFunction` and `NirFunction` gain a `defining_ast_id: Option<AstId>`
-field. Together with `module_source`, this forms a `SymbolKey` back to
-the originating AST node — the canonical identity already used by
-`Annotated`, the symbol table, and the LSP query API. `None` marks
-synthesised functions, which automatically:
-
-- become DCE roots (no source location to warn at), and
-- are excluded from `DeadFunction` reporting.
+`TirFunction` / `NirFunction` and `TirGlobal` / `NirGlobal` each gain a
+`defining_ast_id: Option<AstId>` field. Together with `module_source`,
+this forms a `SymbolKey` back to the originating AST node — the
+canonical identity already used by `Annotated`, the symbol table, and
+the LSP query API. `None` marks synthesised items, which are excluded
+from `DeadFunction` / `DeadGlobal` reporting (but still subject to
+normal DCE removal).
 
 This is the only structural change required outside the new
 `analyze/unused.rs` module.
@@ -121,18 +129,19 @@ This is the only structural change required outside the new
 
 ### Source files
 
-| File                                  | Description                                                                                                                                 |
-| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `wado-compiler/src/analyze/unused.rs` | New module hosting `check_unused` (Annotated layer) and `check_dead_functions` (DCE hook).                                                  |
-| `wado-compiler/src/compiler_host.rs`  | Adds `Code::UnusedImport`, `UnusedVariable`, `UnusedParameter`, `DeadFunction` and their `Display` mappings.                                |
-| `wado-compiler/src/logger.rs`         | Adds `Logger::warn_at(code, message, span, file)` for span-bearing warnings.                                                                |
-| `wado-compiler/src/lib.rs`            | Adds `CompilerOptions::unused_diagnostics`. Calls `check_unused` after `annotate_loaded` and `check_dead_functions` after DCE reachability. |
-| `wado-compiler/src/tir.rs`            | `TirFunction::defining_ast_id: Option<AstId>`.                                                                                              |
-| `wado-compiler/src/nir.rs`            | `NirFunction::defining_ast_id: Option<AstId>`.                                                                                              |
-| `wado-compiler/src/optimize/dce.rs`   | Splits `analyze_project` into reachability computation and removal so the diagnostic hook fits between them.                                |
-| `wado-compiler/src/ast_index.rs`      | Adds `is_param(id)` predicate (1-bit table) so the locals pass can distinguish `UnusedVariable` from `UnusedParameter`.                     |
-| `wado-cli`                            | Adds `--no-unused` flag.                                                                                                                    |
-| `wado-lsp`                            | Calls `analyze::unused::check_unused` from `Engine::diagnostics`.                                                                           |
+| File                                  | Description                                                                                                                                                                                    |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `wado-compiler/src/analyze/unused.rs` | New module hosting `check_unused` (Annotated layer), `emit_dead_function_diagnostics`, and `emit_dead_global_diagnostics` (DCE-loop hooks).                                                    |
+| `wado-compiler/src/compiler_host.rs`  | Adds `Code::UnusedImport`, `UnusedVariable`, `UnusedParameter`, `DeadFunction`, `DeadGlobal` and their `Display` mappings.                                                                     |
+| `wado-compiler/src/logger.rs`         | Adds `Logger::warn_at(code, message, span, file)` for span-bearing warnings.                                                                                                                   |
+| `wado-compiler/src/lib.rs`            | Adds `CompilerOptions::unused_diagnostics`. Calls `check_unused` after `annotate_loaded`. The DCE-layer diagnostic emitters are invoked from `optimize.rs::run_dce`.                           |
+| `wado-compiler/src/tir.rs`            | `TirFunction::defining_ast_id: Option<AstId>`, `TirGlobal::defining_ast_id: Option<AstId>`.                                                                                                    |
+| `wado-compiler/src/nir.rs`            | `NirFunction::defining_ast_id: Option<AstId>`, `NirGlobal::defining_ast_id: Option<AstId>`.                                                                                                    |
+| `wado-compiler/src/optimize/dce.rs`   | Adds `pub(crate) fn unreachable_function_source_keys(&NirPackage, &IndexSet<FunctionId>) -> Vec<SymbolKey>` and `pub(crate) fn unreachable_global_source_keys(&NirPackage) -> Vec<SymbolKey>`. |
+| `wado-compiler/src/optimize.rs`       | `run_dce` invokes the diagnostic emitters inside its fixed-point loop, with a cross-iteration dedup set keyed by `SymbolKey`.                                                                  |
+| `wado-compiler/src/ast_index.rs`      | Adds `is_param(id)` predicate (1-bit table) so the locals pass can distinguish `UnusedVariable` from `UnusedParameter`.                                                                        |
+| `wado-cli`                            | Adds `--no-unused` flag.                                                                                                                                                                       |
+| `wado-lsp`                            | Calls `analyze::unused::check_unused` from `Engine::diagnostics`.                                                                                                                              |
 
 ### Algorithms
 
@@ -176,20 +185,44 @@ Walk `Annotated::locals`. For each `(key, sym)` whose kind is
   `sym.span` (which is the `name_span` recorded by
   `record_local_symbol`).
 
-#### Dead functions
+#### Dead functions and globals
 
-Group all NIR functions by `(module_source, defining_ast_id)`. For each
-group, compute whether any monomorphisation is in the reachable set
-from `compute_reachable_from_entries`. Emit `DeadFunction` for the
-group when:
+`optimize.rs::run_dce` runs DCE in a fixed-point loop:
+`analyze_project` → `remove_unreachable_functions` →
+`remove_unreachable_globals`, repeating until the function set
+stabilises. The cascade is real (removing a dead global may rewrite
+bodies and orphan a previously-reachable callee), so a single pre-loop
+snapshot is not enough.
 
-- `defining_ast_id` is `Some` (skip synthesised),
-- the module is not a stdlib module,
-- the function is not `is_export` / `is_cm_export`,
-- no monomorphisation is reachable.
+Strategy: emit diagnostics inside the loop, on each iteration, with a
+`reported: IndexSet<SymbolKey>` carried across iterations to dedup.
 
-The diagnostic's span is `Annotated::name_span_of(SymbolKey)`,
-falling back to `NirFunction::span`.
+At the start of each iteration, after `analyze_project` returns the
+reachable set:
+
+1. `dce::unreachable_function_source_keys(project, &reachable)` walks
+   `project.functions` and returns the set of source `SymbolKey`s for
+   functions whose every monomorphisation is unreachable, skipping
+   entries with `defining_ast_id == None` (synthesised) and entries in
+   stdlib modules. Grouping by `(module_source, defining_ast_id)`
+   collapses monomorphisations to a single source-level key.
+2. `dce::unreachable_global_source_keys(project)` returns the source
+   keys for globals not referenced by any reachable function, with the
+   same exclusions.
+3. The emitter inserts each new key into `reported` and calls
+   `Logger::warn_at` with `Code::DeadFunction` or `Code::DeadGlobal`,
+   span from `Annotated::name_span_of(key)` (fallback to the item's
+   `span`).
+
+`is_export` / `is_cm_export` items are already roots, so they will not
+appear in the unreachable set. The diagnostic emitter does not need
+extra checks for them.
+
+The dedup set ensures a function or global is reported at most once
+even though it may be observed across multiple iterations
+(`analyze_project` is called each iteration; only items the previous
+iteration's `remove_unreachable_*` actually removed are gone from
+`project.functions` / `project.globals` next time round).
 
 ### Pipeline integration
 
@@ -205,19 +238,29 @@ parse → bind → desugar → load → analyze → annotate
                                   → lower → optimize
                                             │
                                             ▼
-                          compute_reachable_from_entries
-                                            │
-                                            ▼
-                                check_dead_functions
-                                            │
-                                            ▼
-                                  remove unreachable
-                                            │
-                                            ▼
-                                       codegen
+                              run_dce (fixed-point loop)
+                              ┌───────────────────────────┐
+                              │ analyze_project           │
+                              │   │                       │
+                              │   ▼                       │
+                              │ emit dead-function /      │
+                              │   dead-global diagnostics │
+                              │   (dedup across iters)    │
+                              │   │                       │
+                              │   ▼                       │
+                              │ remove_unreachable_*      │
+                              │   │                       │
+                              │   ▼                       │
+                              │ converged? ──no──┐        │
+                              │   │ yes          │        │
+                              │   ▼              │        │
+                              └───┼──────────────┘        │
+                                  ▼                       │
+                                                          ▼
+                                                       codegen
 ```
 
-`compile_with_options` gates both passes on
+`compile_with_options` gates both layers on
 `CompilerOptions::unused_diagnostics`. `Engine::diagnostics` (LSP)
 calls `check_unused` after `annotate_loaded` without any extra cost.
 
@@ -225,16 +268,16 @@ calls `check_unused` after `annotate_loaded` without any extra cost.
 
 #### Phase 1 — diagnostic plumbing
 
-- [ ] Add `Code::UnusedImport`, `UnusedVariable`, `UnusedParameter`, `DeadFunction` and their `Display` strings.
+- [ ] Add `Code::UnusedImport`, `UnusedVariable`, `UnusedParameter`, `DeadFunction`, `DeadGlobal` and their `Display` strings.
 - [ ] Add `Logger::warn_at(code, message, span, file)`.
 - [ ] Add `CompilerOptions::unused_diagnostics` (default `true`).
 - [ ] Add `AstIndex::is_param(id)` and tests.
 
 #### Phase 2 — `defining_ast_id` propagation
 
-- [ ] Add `TirFunction::defining_ast_id: Option<AstId>`; default to `None`.
-- [ ] Set `Some(function.id)` at every source-authored construction site (in `resolver`).
-- [ ] Add `NirFunction::defining_ast_id`; propagate from TIR through `link`, `monomorphize`, `erase`, `lower`. Monomorphisation clones inherit the original `defining_ast_id`.
+- [ ] Add `TirFunction::defining_ast_id: Option<AstId>` and `TirGlobal::defining_ast_id: Option<AstId>`; default to `None`.
+- [ ] Set `Some(function.id)` / `Some(global.id)` at every source-authored construction site (in `resolver`).
+- [ ] Add `NirFunction::defining_ast_id` and `NirGlobal::defining_ast_id`; propagate from TIR through `link`, `monomorphize`, `erase`, `lower`. Monomorphisation clones inherit the original `defining_ast_id`.
 - [ ] Synthesis sites (`synthesis/cm_binding.rs`, `synthesis/effect_dispatch.rs`, auto-derives, etc.) leave the field as `None`.
 - [ ] No behaviour change in this phase — codegen output is bit-identical.
 
@@ -247,12 +290,19 @@ calls `check_unused` after `annotate_loaded` without any extra cost.
 
 #### Phase 4 — DCE-layer dead-function lint
 
-- [ ] Split `optimize/dce.rs::analyze_project` into a reachability function and a removal function.
-- [ ] Implement `check_dead_functions`.
-- [ ] Wire `defining_ast_id.is_none()` as an additional DCE root so synthesised functions stay alive without being reported.
-- [ ] Add fixtures under `tests/fixtures/dead_*.wado`.
+- [ ] Add `pub(crate) fn unreachable_function_source_keys(&NirPackage, &IndexSet<FunctionId>) -> Vec<SymbolKey>` to `optimize/dce.rs`. Skip entries with `defining_ast_id == None` or stdlib module sources. Group monomorphisations by `(module_source, defining_ast_id)`.
+- [ ] Implement `analyze::unused::emit_dead_function_diagnostics` consuming the helper above.
+- [ ] Modify `optimize.rs::run_dce` to thread a `reported: IndexSet<SymbolKey>` through the fixed-point loop and invoke the emitter inside it, before the `remove_unreachable_*` calls.
+- [ ] Add fixtures under `tests/fixtures/dead_fn_*.wado`.
 
-#### Phase 5 — CLI wiring
+#### Phase 5 — DCE-layer dead-global lint
+
+- [ ] Add `pub(crate) fn unreachable_global_source_keys(&NirPackage) -> Vec<SymbolKey>` to `optimize/dce.rs`, mirroring the function variant. Use the analysis already performed inside `remove_unreachable_globals` (extract the reachability predicate if needed).
+- [ ] Implement `analyze::unused::emit_dead_global_diagnostics`.
+- [ ] Wire into `run_dce` next to the dead-function emission, sharing the `reported` dedup set.
+- [ ] Add fixtures under `tests/fixtures/dead_global_*.wado`.
+
+#### Phase 6 — CLI wiring
 
 - [ ] `wado-cli`: add `--no-unused` flag for `compile` / `run` / `serve` / `dump`.
 
@@ -267,11 +317,14 @@ E2E fixtures (under `tests/fixtures/`):
 - `unused_var_underscore_silent.wado`
 - `unused_param_basic.wado`
 - `unused_param_underscore_silent.wado`
-- `dead_function_private.wado`
-- `dead_function_export_root.wado`
-- `dead_function_generic.wado`
-- `dead_function_test_world.wado`
-- `dead_function_lib_pub_is_dead.wado`
+- `dead_fn_private.wado`
+- `dead_fn_export_root.wado`
+- `dead_fn_generic.wado`
+- `dead_fn_test_world.wado`
+- `dead_fn_lib_pub_is_dead.wado`
+- `dead_fn_cascade_via_global.wado` (function reachable until a dead global is removed)
+- `dead_global_basic.wado`
+- `dead_global_used_by_dead_fn.wado` (cascade across iterations)
 - `unused_stdlib_no_report.wado`
 
 Each carries the appropriate `stderr_contains` entries in its `__DATA__`
@@ -294,18 +347,20 @@ through the diagnostics path.
 
 ### Costs
 
-- One new optional field on `TirFunction` and `NirFunction`. Memory
-  cost is negligible (`Option<AstId>` is a `u32` + niche).
-- Every TIR construction site for a source-authored function gains one
-  line to thread the AST id through. The change is mechanical but
-  touches several files (`resolver/item.rs`, closure construction,
-  global lowering).
-- The DCE pass's public shape changes (one function becomes two). All
-  current callers live in `optimize.rs`; the refactor is local.
+- One new optional field on each of `TirFunction`, `NirFunction`,
+  `TirGlobal`, `NirGlobal`. Memory cost is negligible
+  (`Option<AstId>` is a `u32` + niche).
+- Every TIR construction site for a source-authored function or
+  global gains one line to thread the AST id through. The change is
+  mechanical but touches several files (`resolver/item.rs`, closure
+  construction, global lowering).
+- `optimize.rs::run_dce` gains a `reported: IndexSet<SymbolKey>` set
+  threaded through its fixed-point loop. No structural change to the
+  loop itself.
 - New warnings will fire on every existing Wado source file the first
   time CI runs the new compiler. The MVP defaults `unused_diagnostics`
   to `true`; a one-time cleanup pass on the in-tree examples and
-  fixtures is part of Phase 3 / Phase 4 landing.
+  fixtures is part of Phase 3 / Phase 4 / Phase 5 landing.
 
 ### Risks and mitigations
 
@@ -318,6 +373,13 @@ through the diagnostics path.
   effect dispatch) could leave one monomorph reachable from an
   unreported path. Mitigation: rely on the existing DCE call-graph,
   which already handles these edges for removal.
+- Risk: DCE's fixed-point loop interacts with the diagnostic emission
+  — a function that becomes dead only after a global is dropped on
+  iteration 2 must still be reported, while items already reported on
+  iteration 1 must not be repeated. Mitigation: the cross-iteration
+  `reported: IndexSet<SymbolKey>` dedup set; tests in
+  `dead_global_used_by_dead_fn.wado` and
+  `dead_fn_cascade_via_global.wado` exercise the cascade.
 - Risk: users coming from Rust expect `pub fn` in a `lib` package to
   be a public API root and may be surprised that it is reported as
   dead. Mitigation: the lint message names the rule

--- a/docs/wep-2026-05-16-unused-diagnostics.md
+++ b/docs/wep-2026-05-16-unused-diagnostics.md
@@ -1,0 +1,327 @@
+# WEP: Unused Diagnostics
+
+## Context
+
+The Wado compiler today has no equivalent of rustc's `unused_imports`,
+`unused_variables`, or `dead_code` lints. Users get no signal when
+imports, locals, parameters, or private functions are written but never
+consumed. The infrastructure for warnings exists (`Severity::Warning`,
+`Logger`, `CompilerHost::emit_diagnostic`), and the analysis substrate
+for the policy questions has matured — use→def edges (`Annotated::references`),
+local-binding registry (`Annotated::locals`), per-module structural
+indices (`AstIndex`), and the DCE reachability pass (`optimize/dce.rs`) —
+but no pass turns those into user-facing diagnostics.
+
+The reachability roots for "unused" in Wado are not what rustc uses:
+
+- `pub` in Wado is "same-package public", not package-external. A
+  private `pub fn helper()` that no caller invokes is **dead code**, not
+  a public API surface.
+- `export` is what crosses the Wasm Component Model boundary. The world
+  declaration determines which exports a binary must produce.
+- The standard library is a separate package whose `pub` items are
+  visible from user code under special rules. Stdlib must never receive
+  user-facing unused warnings.
+- Synthesised functions (CM bindings, effect-dispatch wrappers,
+  monomorphisation clones, auto-derived impls) are not source-authored
+  and must not be reported regardless of reachability.
+- A package that is itself published as a library (manifest's `lib`
+  field) needs every `pub` item to be treated as a reachability root.
+
+Without explicit lints, three problems persist: silent dead code
+accumulates across refactors, unused imports pollute namespace
+resolution and slow type checking, and the LSP cannot offer the
+"greyed-out unused" hint that editor users expect.
+
+## Decision
+
+Add an unused-diagnostics subsystem split across two layers, each
+producing `Severity::Warning` diagnostics through the existing
+`CompilerHost`. The two layers map cleanly onto rustc's split between
+HIR-level `unused_*` lints and `dead_code` reachability:
+
+1. Annotated layer — runs immediately after `annotate_loaded`, on
+   `&Annotated`. Emits `UnusedImport`, `UnusedVariable`,
+   `UnusedParameter`. LSP and batch compilation share this pass for
+   free.
+2. NIR + DCE layer — runs as a hook inside `optimize/dce.rs`,
+   after reachability is computed but before unreachable functions are
+   removed. Emits `DeadFunction`.
+
+Both passes are guarded by `CompilerOptions::unused_diagnostics` (on by
+default). Library packages set
+`CompilerOptions::package_is_library`, which adds every `is_pub`
+function in user-authored modules to the reachability root set.
+
+### What is in scope (MVP)
+
+| Lint              | Layer          | Code              |
+| ----------------- | -------------- | ----------------- |
+| `UnusedImport`    | Annotated      | `UnusedImport`    |
+| `UnusedVariable`  | Annotated      | `UnusedVariable`  |
+| `UnusedParameter` | Annotated      | `UnusedParameter` |
+| `DeadFunction`    | NIR (post-DCE) | `DeadFunction`    |
+
+### What is out of scope (deferred to follow-up WEPs / PRs)
+
+- `unused_mut`, `unused_type_param`, `unused_assignment`
+- `dead_type`, `dead_trait_impl`, `unreachable_pattern`
+- `#[allow(unused)]` / `#[deny(unused)]` attribute mechanism
+- Per-`UseItem::InterfaceFunctions` granularity (function-level inside
+  an interface import)
+- Workspace-aware multi-package root computation
+
+### Reachability roots (package-external boundary)
+
+The DCE layer treats these as always-reachable:
+
+| Root                                                        | Source                                                                                 |
+| ----------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `is_cm_export`                                              | World export wrappers from synthesis                                                   |
+| `is_export` in `wasm_module_sources`                        | Raw Wasm exports                                                                       |
+| `is_pub` in user-authored modules when `package_is_library` | Library API surface                                                                    |
+| `defining_ast_id.is_none()`                                 | Synthesised functions (CM bindings, dispatch wrappers, monomorph clones, auto-derives) |
+
+`is_pub` alone is never a root: in Wado it is same-package visibility,
+not external API. The library flag is what promotes it.
+
+### Stdlib exclusion
+
+Functions, imports, and locals whose `ModuleSource` is `Core`, `Wasi`,
+`Builtin`, or `Wasm` are excluded from both passes when the entry
+module is user-authored. Stdlib never emits unused diagnostics into the
+user's build output.
+
+### Suppression
+
+- Variables and parameters whose source name begins with `_` are
+  silent. This is the same convention rustc uses and is what
+  `wado format` is expected to produce when auto-fixing.
+- `Wildcard` imports (`use _ from "..."`) are silent — they exist for
+  side effects.
+- No attribute-based suppression in MVP; deferred to a follow-up that
+  reuses the existing `#[...]` attribute machinery.
+
+### Defining-ast-id field
+
+`TirFunction` and `NirFunction` gain a `defining_ast_id: Option<AstId>`
+field. Together with `module_source`, this forms a `SymbolKey` back to
+the originating AST node — the canonical identity already used by
+`Annotated`, the symbol table, and the LSP query API. `None` marks
+synthesised functions, which automatically:
+
+- become DCE roots (no source location to warn at), and
+- are excluded from `DeadFunction` reporting.
+
+This is the only structural change required outside the new
+`analyze/unused.rs` module.
+
+## Implementation
+
+### Source files
+
+| File                                  | Description                                                                                                                                                                           |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `wado-compiler/src/analyze/unused.rs` | New module hosting `check_unused` (Annotated layer) and `check_dead_functions` (DCE hook).                                                                                            |
+| `wado-compiler/src/compiler_host.rs`  | Adds `Code::UnusedImport`, `UnusedVariable`, `UnusedParameter`, `DeadFunction` and their `Display` mappings.                                                                          |
+| `wado-compiler/src/logger.rs`         | Adds `Logger::warn_at(code, message, span, file)` for span-bearing warnings.                                                                                                          |
+| `wado-compiler/src/lib.rs`            | Adds `CompilerOptions::unused_diagnostics`, `CompilerOptions::package_is_library`. Calls `check_unused` after `annotate_loaded` and `check_dead_functions` after DCE reachability.    |
+| `wado-compiler/src/tir.rs`            | `TirFunction::defining_ast_id: Option<AstId>`.                                                                                                                                        |
+| `wado-compiler/src/nir.rs`            | `NirFunction::defining_ast_id: Option<AstId>`.                                                                                                                                        |
+| `wado-compiler/src/optimize/dce.rs`   | Splits `analyze_project` into reachability computation and removal so the diagnostic hook fits between them. Extends `compute_reachable_from_entries` to honour `package_is_library`. |
+| `wado-compiler/src/ast_index.rs`      | Adds `is_param(id)` predicate (1-bit table) so the locals pass can distinguish `UnusedVariable` from `UnusedParameter`.                                                               |
+| `wado-cli`                            | Adds `--no-unused` flag; sets `package_is_library` from `wado.toml`'s `[package].lib`.                                                                                                |
+| `wado-lsp`                            | Calls `analyze::unused::check_unused` from `Engine::diagnostics`.                                                                                                                     |
+
+### Algorithms
+
+#### Unused imports
+
+Walk every `UseDecl` in user-authored modules. For each `UseItem`:
+
+- `Simple { id, .. }` and `Namespace { name, .. }`: report
+  `UnusedImport` when no entry in `Annotated::references` has the
+  item's use-site `SymbolKey` as its `use_key` and no entry resolves to
+  the item's imported `def_key`.
+- `Wildcard`: skipped (side-effect imports).
+- `InterfaceFunctions`: reported only at the whole-`UseDecl` level for
+  MVP; per-function granularity is deferred.
+
+If every item in a single `UseDecl` is unused, emit one diagnostic at
+`UseDecl.span`; otherwise emit per-item diagnostics at
+`AstIndex::name_span_of(item.id)`.
+
+Prerequisite check: confirm `resolver` records `UseItem::Simple.id` as
+a use-site in `references` during use-decl resolution. If not, add the
+single `record_reference_to_decl` call there.
+
+#### Unused variables and parameters
+
+Build a single inverted index from `Annotated::iter_references()`:
+
+```
+use_count: IndexMap<SymbolKey, usize>
+for (_use_key, def_key) in annotated.iter_references():
+    *use_count.entry(def_key).or_insert(0) += 1
+```
+
+Walk `Annotated::locals`. For each `(key, sym)` whose kind is
+`Variable`:
+
+- Skip if `sym.name` starts with `_`.
+- Skip if `use_count.get(&key) > 0`.
+- Determine `is_param` via `AstIndex::is_param(key.ast_id)` on the
+  module's index. Emit `UnusedParameter` or `UnusedVariable` at
+  `sym.span` (which is the `name_span` recorded by
+  `record_local_symbol`).
+
+#### Dead functions
+
+Group all NIR functions by `(module_source, defining_ast_id)`. For each
+group, compute whether any monomorphisation is in the reachable set
+from `compute_reachable_from_entries`. Emit `DeadFunction` for the
+group when:
+
+- `defining_ast_id` is `Some` (skip synthesised),
+- the module is not a stdlib module,
+- the function is not `is_export` / `is_cm_export`,
+- no monomorphisation is reachable,
+- and, when `package_is_library`, the function is not `is_pub` in a
+  user-authored module.
+
+The diagnostic's span is `Annotated::name_span_of(SymbolKey)`,
+falling back to `NirFunction::span`.
+
+### Pipeline integration
+
+```
+parse → bind → desugar → load → analyze → annotate
+                                            │
+                                            ▼
+                                   check_unused
+                                  (imports, locals, params)
+                                            │
+                                            ▼
+                              lower_tir → monomorphize
+                                  → lower → optimize
+                                            │
+                                            ▼
+                          compute_reachable_from_entries
+                                            │
+                                            ▼
+                                check_dead_functions
+                                            │
+                                            ▼
+                                  remove unreachable
+                                            │
+                                            ▼
+                                       codegen
+```
+
+`compile_with_options` gates both passes on
+`CompilerOptions::unused_diagnostics`. `Engine::diagnostics` (LSP)
+calls `check_unused` after `annotate_loaded` without any extra cost.
+
+### Migration plan
+
+#### Phase 1 — diagnostic plumbing
+
+- [ ] Add `Code::UnusedImport`, `UnusedVariable`, `UnusedParameter`, `DeadFunction` and their `Display` strings.
+- [ ] Add `Logger::warn_at(code, message, span, file)`.
+- [ ] Add `CompilerOptions::unused_diagnostics` (default `true`) and `CompilerOptions::package_is_library` (default `false`).
+- [ ] Add `AstIndex::is_param(id)` and tests.
+
+#### Phase 2 — `defining_ast_id` propagation
+
+- [ ] Add `TirFunction::defining_ast_id: Option<AstId>`; default to `None`.
+- [ ] Set `Some(function.id)` at every source-authored construction site (in `resolver`).
+- [ ] Add `NirFunction::defining_ast_id`; propagate from TIR through `link`, `monomorphize`, `erase`, `lower`. Monomorphisation clones inherit the original `defining_ast_id`.
+- [ ] Synthesis sites (`synthesis/cm_binding.rs`, `synthesis/effect_dispatch.rs`, auto-derives, etc.) leave the field as `None`.
+- [ ] No behaviour change in this phase — codegen output is bit-identical.
+
+#### Phase 3 — Annotated-layer lints
+
+- [ ] Confirm `resolver` records `UseItem::Simple.id` as a use-site; patch if missing.
+- [ ] Implement `analyze::unused::check_unused` (imports, locals, params).
+- [ ] Wire into `lib.rs::compile_with_options` and `wado-lsp::Engine::diagnostics`.
+- [ ] Add fixtures under `tests/fixtures/unused_*.wado`; touch `tests/e2e.rs`.
+
+#### Phase 4 — DCE-layer dead-function lint
+
+- [ ] Split `optimize/dce.rs::analyze_project` into a reachability function and a removal function.
+- [ ] Implement `check_dead_functions`.
+- [ ] Extend `compute_reachable_from_entries` to honour `package_is_library`.
+- [ ] Wire `defining_ast_id.is_none()` as an additional DCE root so synthesised functions stay alive without being reported.
+- [ ] Add fixtures under `tests/fixtures/dead_*.wado`.
+
+#### Phase 5 — CLI and manifest wiring
+
+- [ ] `wado-cli`: add `--no-unused` flag for `compile` / `run` / `serve` / `dump`.
+- [ ] `wado-cli`: read `[package].lib` from `wado.toml` and set `package_is_library`.
+
+### Test plan
+
+E2E fixtures (under `tests/fixtures/`):
+
+- `unused_import_basic.wado`
+- `unused_import_partial.wado`
+- `unused_import_wildcard_silent.wado`
+- `unused_var_basic.wado`
+- `unused_var_underscore_silent.wado`
+- `unused_param_basic.wado`
+- `unused_param_underscore_silent.wado`
+- `dead_function_private.wado`
+- `dead_function_export_root.wado`
+- `dead_function_generic.wado`
+- `dead_function_test_world.wado`
+- `dead_function_library_pub_root.wado`
+- `unused_stdlib_no_report.wado`
+
+Each carries the appropriate `stderr_contains` entries in its `__DATA__`
+block. `wado-lsp` integration tests cover the Annotated-layer lints
+through the diagnostics path.
+
+## Consequences
+
+### Benefits
+
+- Users get immediate, location-precise feedback on dead imports,
+  locals, parameters, and private functions, matching the experience
+  every rustc user expects.
+- LSP "greyed-out unused" works for free because the Annotated layer
+  shares a code path between batch compilation and `Engine::diagnostics`.
+- DCE keeps doing its silent removal job; the only addition is a
+  diagnostic hook in front of removal.
+- `defining_ast_id` becomes a reusable back-pointer for future
+  diagnostics and tooling (e.g., span-aware optimisation traces).
+
+### Costs
+
+- One new optional field on `TirFunction` and `NirFunction`. Memory
+  cost is negligible (`Option<AstId>` is a `u32` + niche).
+- Every TIR construction site for a source-authored function gains one
+  line to thread the AST id through. The change is mechanical but
+  touches several files (`resolver/item.rs`, closure construction,
+  global lowering).
+- The DCE pass's public shape changes (one function becomes two). All
+  current callers live in `optimize.rs`; the refactor is local.
+- New warnings will fire on every existing Wado source file the first
+  time CI runs the new compiler. The MVP defaults `unused_diagnostics`
+  to `true`; a one-time cleanup pass on the in-tree examples and
+  fixtures is part of Phase 3 / Phase 4 landing.
+
+### Risks and mitigations
+
+- Risk: synthesised functions accidentally receive `Some(ast_id)` and
+  start emitting spurious dead-code warnings. Mitigation:
+  `defining_ast_id` defaults to `None`; synthesis sites must
+  affirmatively opt in. Tests cover the synthesis paths.
+- Risk: a generic function with all monomorphisations unreachable is
+  reported once per group, but rare edge cases (specialisation through
+  effect dispatch) could leave one monomorph reachable from an
+  unreported path. Mitigation: rely on the existing DCE call-graph,
+  which already handles these edges for removal.
+- Risk: `pub`-vs-`export` confusion in the wider ecosystem. Mitigation:
+  documentation in the lint message explicitly names the package
+  boundary, and the `package_is_library` toggle gives library authors
+  a way to opt out of `pub`-as-dead reports.


### PR DESCRIPTION
## Summary

Adds a WEP specifying how the Wado compiler will produce `unused_imports`-, `unused_variables`-, `unused_parameters`-, `dead_code`-, and `dead_global`-style diagnostics.

The proposal splits the work across two layers so each lint runs where its evidence is cleanest:

- Annotated layer (post `annotate_loaded`, before lower / monomorphize). Reuses `Annotated::references` and `Annotated::locals` to emit `UnusedImport`, `UnusedVariable`, `UnusedParameter`. Shared with the LSP `Engine::diagnostics` path at zero extra cost.
- NIR + DCE layer. Hooks into `optimize.rs::run_dce`'s fixed-point loop, between reachability analysis and removal. Emits `DeadFunction` and `DeadGlobal`. A cross-iteration `IndexSet<SymbolKey>` dedup set ensures each item is reported once even though DCE may observe it across multiple iterations as removal of dead globals cascades into newly-dead functions.

The Wado-specific shape of "what is a root" is the heart of the design:

- `export` is the only modifier that crosses the package boundary, and per [WEP 2026-02-14 (Package Manifest)](https://github.com/wado-lang/wado/blob/main/docs/wep-2026-02-14-package-manifest.md) it applies uniformly across `command`, `service`, and `lib` entry points.
- `pub` is package-internal visibility in every package kind, including `lib`. An unreferenced `pub fn` (or `pub global`) is dead code regardless of the entry-point kind — no per-package-kind toggle is needed.
- Synthesised items (CM bindings, dispatch wrappers, monomorphisation clones, auto-derives) are excluded by carrying `defining_ast_id: None` on `TirFunction` / `NirFunction` / `TirGlobal` / `NirGlobal` — the only structural compiler change required outside the new `analyze/unused.rs` module. They remain subject to normal DCE removal; only diagnostic emission is suppressed.
- Stdlib (`ModuleSource::Core` / `Wasi` / `Builtin` / `Wasm`) never emits unused diagnostics into a user build.

Suppression is `_`-prefix only for MVP; attribute-based `#[allow(unused)]` is deferred.

The WEP includes a phased migration plan (diagnostic plumbing → `defining_ast_id` propagation → Annotated lints → DCE-layer `DeadFunction` → DCE-layer `DeadGlobal` → CLI wiring), the source-file table, the E2E fixture set, and the consequences (benefits, costs, risks).

No code changes in this PR — design only.
