### PR TITLE
docs: clarify General Rules wording in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,11 +42,12 @@ mise run report-wasm-size  # hello_world, pi_approx, zlib, and so on
 
 ## General Rules
 
-- Documents and comments must be written in English.
+- Documentation and comments must be written in English.
 - Avoid ad-hoc workarounds. Write proper code based on a sound design.
 - Do not use comment sections to separate or organize code.
 - Perform red/green TDD.
-- If you find a compiler bug, always write a minimal reproducible e2e fixture as a P0 task. If the bug blocks the current task, fix it immediately before continuing.
+- A compiler bug is always P0 — no exceptions. Stop, write a minimal reproducible e2e fixture, and fix it before continuing if it blocks the current task.
+- A pre-existing issue — whether you find it or a reviewer points it out — must be fixed, with TDD when practical.
 - Use the `rust` skill when writing Rust.
 - Use the `wado` skill when writing Wado code or designing Wado language features.
 


### PR DESCRIPTION
## Summary

- Tighten the English in the General Rules section of `AGENTS.md`:
  - `Documents` → `Documentation`.
  - Rewrite the pre-existing-issue bullet so the subject/voice agree.
- Sharpen the priority distinction:
  - A compiler bug is always P0, no exceptions — stop and write a minimal reproducible e2e fixture immediately.
  - A pre-existing issue (found by you or a reviewer) must be fixed, but is not labeled P0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wado-lang/wado/pull/1071" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->