### PR TITLE
chore: add .github/FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: gfx


### PR DESCRIPTION
Adds a `.github/FUNDING.yml` pointing to the `gfx` GitHub Sponsors account so the repository shows a Sponsor button.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JWx8iiijwfhtDxYGiFRbkF)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wado-lang/wado/pull/1073" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->