### PR TITLE
chore: point FUNDING.yml to wado-lang org

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: gfx
+github: wado-lang


### PR DESCRIPTION
Switches the Sponsor button target from the individual `gfx` account to the `wado-lang` org sponsorship page, so contributions flow to the org rather than an individual.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JWx8iiijwfhtDxYGiFRbkF)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wado-lang/wado/pull/1075" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->