### PR TITLE
Mark *.kiln.json as linguist-generated to collapse PR diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 wado-compiler/tests/fixtures.golden*/** linguist-generated=true
 package-gale/tests/generated/** linguist-generated=true
+*.kiln.json linguist-generated=true


### PR DESCRIPTION
## Summary

Add `*.kiln.json linguist-generated=true` to `.gitattributes` so GitHub auto-collapses these files in PR diffs.

## Context: why not change the schema?

`<primary>.kiln.json` records `generator_source_hash`, which flips on every refactor of a Kiln generator — even when the regenerated outputs are byte-identical. This produces noisy `chore: refresh kiln cache hashes after ...` commits touching every fixture under `package-gale/tests/generated/`.

We considered redesigning the cache file (schema v3) to split it into a thin committed contract and a gitignored sidecar holding `generator_source_hash`. That would eliminate the noise, but on closer inspection the committed `.kiln.json` is doing real work that we want to keep:

1. **Input-driven auto-regeneration** — committed input hashes let `wado compile` decide on a fresh checkout whether outputs are still valid, without launching the generator. This is the CI fast-path that motivated the whole design.
2. **Output-set manifest** — knowing which `#[generated]` files belong to which invocation enables cleanup when a generator renames/removes outputs.
3. **Entry resolution in consume-only mode** (LSP/Web), where the generator cannot run at all.
4. **Hand-edit detection** (`KilnGeneratedModified`), diagnostic-level.

So the committed file is effectively a *per-invocation lockfile*, analogous to `Cargo.lock` / `yarn.lock` / `.terraform.lock.hcl`. Splitting it adds a second source of truth (sidecar vs. committed), weakens the CI-side check that today catches a stale-output commit without `wado check`, and requires a WEP rewrite plus migration of all existing cache files. The cost is real; the benefit is cosmetic.

## Decision

Keep the schema as-is. The noise is purely a review-experience issue, so address it at the review layer: mark `*.kiln.json` as `linguist-generated`, and GitHub will collapse the diff by default.

All 101 currently tracked `.kiln.json` files live under `package-gale/tests/generated/**`, which is already covered by an existing rule. The new glob is for future committed-source workflows (e.g. `src/generated/<feature>/`) that the Kiln WEP allows.

If pain ever scales beyond cosmetic — many generators, frequent merge conflicts on cache files — we can revisit the v3 split with a clear motivation.

## Test plan

- [x] `.gitattributes` parses (`git check-attr linguist-generated -- <path>` reports `set` for any `*.kiln.json`).
- [ ] Verify on a future PR that touches a `.kiln.json` outside `package-gale/tests/generated/` that GitHub collapses it.
