### PR TITLE
feat: `[test].include` for stdlib test discovery + dedupe ArrayCopy scratch locals

### DIFF
--- a/docs/wep-2026-05-02-test-discovery.md
+++ b/docs/wep-2026-05-02-test-discovery.md
@@ -46,6 +46,9 @@ exclude = [
     "wado-compiler/tests/**",
     "wado-from-idl/tests/**",
 ]
+include = [
+    "lib/**/*_test.wado",
+]
 ```
 
 `exclude` is a list of shell-style glob patterns relative to the package
@@ -56,6 +59,15 @@ list at invocation time.
 `src/` only. Use `**` to cross directories. As a convenience, `dir/**` also
 excludes the bare `dir` entry (otherwise the walker would still descend into
 it, since `**` requires at least one trailing path component).
+
+`include` is a list of glob patterns that "carve out" files from excluded
+subtrees. A file matched by an include pattern is discovered even when it
+also matches an exclude pattern, and the walker descends into excluded
+directories whenever any include patterns are present (to look for matches
+deeper down). Typical use is the stdlib pattern shown above: exclude an
+entire `lib/**` source tree because the fragments inside define the prelude
+and can't compile standalone, but keep the companion `*_test.wado` files
+visible to discovery so they actually run.
 
 ### Filter
 

--- a/wado-cli/src/discover.rs
+++ b/wado-cli/src/discover.rs
@@ -281,7 +281,9 @@ fn walk_dir(
                 continue;
             }
 
-            walk_dir(&path, root, excludes, includes, submodules, rules, visited, out)?;
+            walk_dir(
+                &path, root, excludes, includes, submodules, rules, visited, out,
+            )?;
         } else if path.extension().is_some_and(|ext| ext == "wado") {
             out.files.push(path);
         }
@@ -586,7 +588,8 @@ pathology = should-not-match\n\
         )
         .unwrap();
 
-        let result = discover_test_files(root, &ExcludeSet::default(), &IncludeSet::default()).unwrap();
+        let result =
+            discover_test_files(root, &ExcludeSet::default(), &IncludeSet::default()).unwrap();
         let got = names_of(root, &result.files);
         assert!(got.contains("a.wado"));
         assert!(!got.contains("subpkg/main.wado"));

--- a/wado-cli/src/discover.rs
+++ b/wado-cli/src/discover.rs
@@ -94,7 +94,7 @@ impl IncludeSet {
             .iter()
             .flat_map(|raw| augmented_patterns(raw.as_ref()))
             .map(|(pattern, source)| {
-                Pattern::new(&pattern).map_err(|e| WalkError::InvalidExclude {
+                Pattern::new(&pattern).map_err(|e| WalkError::InvalidInclude {
                     pattern: source,
                     source: e,
                 })
@@ -137,6 +137,10 @@ pub enum WalkError {
         pattern: String,
         source: PatternError,
     },
+    InvalidInclude {
+        pattern: String,
+        source: PatternError,
+    },
 }
 
 impl std::fmt::Display for WalkError {
@@ -147,6 +151,9 @@ impl std::fmt::Display for WalkError {
             }
             WalkError::InvalidExclude { pattern, source } => {
                 write!(f, "invalid exclude pattern {pattern:?}: {source}")
+            }
+            WalkError::InvalidInclude { pattern, source } => {
+                write!(f, "invalid include pattern {pattern:?}: {source}")
             }
         }
     }
@@ -254,14 +261,20 @@ fn walk_dir(
         // regions, so excluded directories must still be descended (any
         // depth, since includes use globs); only files matched by exclude
         // *without* also matching include are dropped.
+        //
+        // `excluded_descend` records that we entered an excluded directory
+        // only because the include set might match something inside it.
+        // In that state we still walk for include-matching files, but we
+        // do **not** record the directory as a sub-package boundary: the
+        // user's `exclude` overrides cross-package recursion regardless of
+        // what include patterns this package declares.
+        let mut excluded_descend = false;
         if let Ok(rel) = path.strip_prefix(root)
             && excludes.matches(rel)
             && !includes.matches(rel)
         {
             if is_dir && !includes.is_empty() {
-                // Descend: a file inside this excluded subtree may still
-                // match an include pattern (e.g. `lib/**/*_test.wado` under
-                // an `lib/core/prelude/**` exclude).
+                excluded_descend = true;
             } else {
                 continue;
             }
@@ -270,7 +283,11 @@ fn walk_dir(
         if is_dir {
             // Nested wado.toml: separate package boundary; record it for the
             // caller to recurse into and do not enter it ourselves.
-            if path.join("wado.toml").is_file() {
+            //
+            // Skip the boundary check when we're only descending under
+            // `excluded_descend`: the parent excluded this subtree, so the
+            // sub-package shouldn't be queued for its own `wado test` run.
+            if !excluded_descend && path.join("wado.toml").is_file() {
                 out.subpackages.push(path);
                 continue;
             }
@@ -789,5 +806,45 @@ pathology = should-not-match\n\
         // Without includes, even `*_test.wado` under an excluded dir is pruned.
         assert!(!got.contains("excluded/b.wado"));
         assert!(!got.contains("excluded/b_test.wado"));
+    }
+
+    #[test]
+    fn excluded_subpackage_not_recorded_even_with_includes() {
+        // Regression: when `[test].include` is non-empty, the walker
+        // descends excluded directories to look for include matches. It
+        // must not, however, treat a nested `wado.toml` inside an excluded
+        // subtree as a sub-package — the user's exclude should still
+        // suppress cross-package recursion.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        touch(&root.join("vendor/wado.toml"));
+        touch(&root.join("vendor/src/a.wado"));
+        touch(&root.join("lib/stdlib_test.wado"));
+
+        let result = discover_test_files(
+            root,
+            &ExcludeSet::compile(&["vendor/**".to_string()]).unwrap(),
+            &IncludeSet::compile(&["lib/**/*_test.wado".to_string()]).unwrap(),
+        )
+        .unwrap();
+        let got = names_of(root, &result.files);
+        // The include-matched test in `lib/` is still discovered.
+        assert!(got.contains("lib/stdlib_test.wado"));
+        // The excluded sub-package directory is not queued for recursion.
+        assert!(result.subpackages.is_empty(), "{:?}", result.subpackages);
+        // And nothing inside it was discovered.
+        assert!(!got.contains("vendor/src/a.wado"));
+    }
+
+    #[test]
+    fn invalid_include_pattern_says_include() {
+        // Regression: `IncludeSet::compile` used to report a bad glob via
+        // `WalkError::InvalidExclude`, producing a misleading "invalid
+        // exclude pattern" message for what is really an `[test].include`
+        // problem.
+        let err = IncludeSet::compile(&["[unterminated".to_string()]).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("invalid include pattern"), "{msg}");
+        assert!(!msg.contains("invalid exclude pattern"), "{msg}");
     }
 }

--- a/wado-cli/src/discover.rs
+++ b/wado-cli/src/discover.rs
@@ -68,6 +68,50 @@ impl ExcludeSet {
     pub fn matches_str(&self, path: &str) -> bool {
         self.matches(Path::new(path))
     }
+
+    /// True when no patterns were compiled. Used by the walker to decide
+    /// whether to honour `[test].exclude` as a directory-pruning shortcut
+    /// (no includes ⇒ exclude is authoritative) or as a file-level filter
+    /// only (some includes ⇒ excluded directories may still contain
+    /// includable test files and must be descended).
+    pub fn is_empty(&self) -> bool {
+        self.patterns.is_empty()
+    }
+}
+
+/// Compiled set of `[test].include` glob patterns: positive overrides that
+/// keep files visible to `wado test` even when they match `[test].exclude`.
+/// Sharing the same compile pipeline as [`ExcludeSet`] keeps the matcher
+/// semantics identical between the two layers.
+#[derive(Debug, Default)]
+pub struct IncludeSet {
+    patterns: Vec<Pattern>,
+}
+
+impl IncludeSet {
+    pub fn compile<S: AsRef<str>>(patterns: &[S]) -> Result<Self, WalkError> {
+        let compiled = patterns
+            .iter()
+            .flat_map(|raw| augmented_patterns(raw.as_ref()))
+            .map(|(pattern, source)| {
+                Pattern::new(&pattern).map_err(|e| WalkError::InvalidExclude {
+                    pattern: source,
+                    source: e,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self { patterns: compiled })
+    }
+
+    pub fn matches(&self, path: &Path) -> bool {
+        self.patterns
+            .iter()
+            .any(|p| p.matches_path_with(path, WALK_MATCH_OPTIONS))
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.patterns.is_empty()
+    }
 }
 
 /// Yield the patterns we actually compile for one user-supplied glob.
@@ -129,6 +173,7 @@ pub struct DiscoveryResult {
 pub fn discover_test_files(
     root: &Path,
     excludes: &ExcludeSet,
+    includes: &IncludeSet,
 ) -> Result<DiscoveryResult, WalkError> {
     let submodules = read_submodule_paths(root)?
         .into_iter()
@@ -146,6 +191,7 @@ pub fn discover_test_files(
         root,
         root,
         excludes,
+        includes,
         &submodules,
         &mut rules,
         &mut visited,
@@ -162,6 +208,7 @@ fn walk_dir(
     dir: &Path,
     root: &Path,
     excludes: &ExcludeSet,
+    includes: &IncludeSet,
     submodules: &IndexSet<PathBuf>,
     rules: &mut Vec<GitignoreRule>,
     visited: &mut IndexSet<PathBuf>,
@@ -201,10 +248,23 @@ fn walk_dir(
             continue;
         }
 
+        // Apply `[test].exclude`. With no `[test].include` patterns this is
+        // straightforward: a matching path (file or directory) is pruned.
+        // When `include` patterns are present they "carve out" excluded
+        // regions, so excluded directories must still be descended (any
+        // depth, since includes use globs); only files matched by exclude
+        // *without* also matching include are dropped.
         if let Ok(rel) = path.strip_prefix(root)
             && excludes.matches(rel)
+            && !includes.matches(rel)
         {
-            continue;
+            if is_dir && !includes.is_empty() {
+                // Descend: a file inside this excluded subtree may still
+                // match an include pattern (e.g. `lib/**/*_test.wado` under
+                // an `lib/core/prelude/**` exclude).
+            } else {
+                continue;
+            }
         }
 
         if is_dir {
@@ -221,7 +281,7 @@ fn walk_dir(
                 continue;
             }
 
-            walk_dir(&path, root, excludes, submodules, rules, visited, out)?;
+            walk_dir(&path, root, excludes, includes, submodules, rules, visited, out)?;
         } else if path.extension().is_some_and(|ext| ext == "wado") {
             out.files.push(path);
         }
@@ -398,7 +458,7 @@ mod tests {
         touch(&root.join("readme.md"));
         touch(&root.join("nested/notes.txt"));
 
-        let files = discover_test_files(root, &ExcludeSet::default())
+        let files = discover_test_files(root, &ExcludeSet::default(), &IncludeSet::default())
             .unwrap()
             .files;
         let got = names_of(root, &files);
@@ -416,7 +476,7 @@ mod tests {
         touch(&root.join("a.wado"));
         touch(&root.join(".hidden/secret.wado"));
 
-        let files = discover_test_files(root, &ExcludeSet::default())
+        let files = discover_test_files(root, &ExcludeSet::default(), &IncludeSet::default())
             .unwrap()
             .files;
         let got = names_of(root, &files);
@@ -432,7 +492,7 @@ mod tests {
         touch(&root.join("target/build.wado"));
         fs::write(root.join(".gitignore"), "target/\n").unwrap();
 
-        let files = discover_test_files(root, &ExcludeSet::default())
+        let files = discover_test_files(root, &ExcludeSet::default(), &IncludeSet::default())
             .unwrap()
             .files;
         let got = names_of(root, &files);
@@ -449,7 +509,7 @@ mod tests {
         touch(&root.join("pkg/skip/keep.wado"));
         fs::write(root.join("pkg/.gitignore"), "skip/\n!skip/keep.wado\n").unwrap();
 
-        let files = discover_test_files(root, &ExcludeSet::default())
+        let files = discover_test_files(root, &ExcludeSet::default(), &IncludeSet::default())
             .unwrap()
             .files;
         let got = names_of(root, &files);
@@ -468,7 +528,7 @@ mod tests {
         touch(&root.join("nested/skipme.wado"));
         fs::write(root.join(".gitignore"), "skipme.wado\n").unwrap();
 
-        let files = discover_test_files(root, &ExcludeSet::default())
+        let files = discover_test_files(root, &ExcludeSet::default(), &IncludeSet::default())
             .unwrap()
             .files;
         let got = names_of(root, &files);
@@ -506,7 +566,7 @@ pathology = should-not-match\n\
         )
         .unwrap();
 
-        let files = discover_test_files(root, &ExcludeSet::default())
+        let files = discover_test_files(root, &ExcludeSet::default(), &IncludeSet::default())
             .unwrap()
             .files;
         let got = names_of(root, &files);
@@ -526,7 +586,7 @@ pathology = should-not-match\n\
         )
         .unwrap();
 
-        let result = discover_test_files(root, &ExcludeSet::default()).unwrap();
+        let result = discover_test_files(root, &ExcludeSet::default(), &IncludeSet::default()).unwrap();
         let got = names_of(root, &result.files);
         assert!(got.contains("a.wado"));
         assert!(!got.contains("subpkg/main.wado"));
@@ -544,6 +604,7 @@ pathology = should-not-match\n\
         let files = discover_test_files(
             root,
             &ExcludeSet::compile(&["compiler/tests/**".to_string()]).unwrap(),
+            &IncludeSet::default(),
         )
         .unwrap()
         .files;
@@ -567,6 +628,7 @@ pathology = should-not-match\n\
         let result = discover_test_files(
             root,
             &ExcludeSet::compile(&["skip/**".to_string()]).unwrap(),
+            &IncludeSet::default(),
         )
         .unwrap();
         let got = names_of(root, &result.files);
@@ -592,6 +654,7 @@ pathology = should-not-match\n\
         let result = discover_test_files(
             root,
             &ExcludeSet::compile(&["subpkg/**".to_string()]).unwrap(),
+            &IncludeSet::default(),
         )
         .unwrap();
         let got = names_of(root, &result.files);
@@ -618,6 +681,7 @@ pathology = should-not-match\n\
         let files = discover_test_files(
             root,
             &ExcludeSet::compile(&["src/*.wado".to_string()]).unwrap(),
+            &IncludeSet::default(),
         )
         .unwrap()
         .files;
@@ -639,6 +703,7 @@ pathology = should-not-match\n\
         let files = discover_test_files(
             root,
             &ExcludeSet::compile(&["**/foo.wado".to_string()]).unwrap(),
+            &IncludeSet::default(),
         )
         .unwrap()
         .files;
@@ -663,7 +728,7 @@ pathology = should-not-match\n\
         // Create a symlink loop: root/loop -> root
         symlink(root, root.join("loop")).unwrap();
 
-        let files = discover_test_files(root, &ExcludeSet::default())
+        let files = discover_test_files(root, &ExcludeSet::default(), &IncludeSet::default())
             .unwrap()
             .files;
         let got = names_of(root, &files);
@@ -671,5 +736,55 @@ pathology = should-not-match\n\
         // The loop must not produce duplicate entries; each canonical path is
         // visited once.
         assert_eq!(files.len(), 1);
+    }
+
+    #[test]
+    fn include_carves_out_excluded_subtree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        touch(&root.join("lib/core/prelude/string.wado"));
+        touch(&root.join("lib/core/prelude/string_test.wado"));
+        touch(&root.join("lib/core/prelude/nested/array.wado"));
+        touch(&root.join("lib/core/prelude/nested/array_test.wado"));
+        touch(&root.join("lib/core/cli.wado"));
+
+        let files = discover_test_files(
+            root,
+            &ExcludeSet::compile(&["lib/core/prelude/**".to_string()]).unwrap(),
+            &IncludeSet::compile(&["lib/**/*_test.wado".to_string()]).unwrap(),
+        )
+        .unwrap()
+        .files;
+        let got = names_of(root, &files);
+        // Non-test files in excluded subtree are still pruned.
+        assert!(!got.contains("lib/core/prelude/string.wado"));
+        assert!(!got.contains("lib/core/prelude/nested/array.wado"));
+        // *_test.wado in excluded subtree (at any depth) is discovered.
+        assert!(got.contains("lib/core/prelude/string_test.wado"));
+        assert!(got.contains("lib/core/prelude/nested/array_test.wado"));
+        // Files outside the excluded subtree are unaffected.
+        assert!(got.contains("lib/core/cli.wado"));
+    }
+
+    #[test]
+    fn empty_include_keeps_exclude_pruning_behaviour() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        touch(&root.join("a.wado"));
+        touch(&root.join("excluded/b.wado"));
+        touch(&root.join("excluded/b_test.wado"));
+
+        let files = discover_test_files(
+            root,
+            &ExcludeSet::compile(&["excluded/**".to_string()]).unwrap(),
+            &IncludeSet::default(),
+        )
+        .unwrap()
+        .files;
+        let got = names_of(root, &files);
+        assert!(got.contains("a.wado"));
+        // Without includes, even `*_test.wado` under an excluded dir is pruned.
+        assert!(!got.contains("excluded/b.wado"));
+        assert!(!got.contains("excluded/b_test.wado"));
     }
 }

--- a/wado-cli/src/test.rs
+++ b/wado-cli/src/test.rs
@@ -262,10 +262,9 @@ fn walk_into(
 /// contribute no filters.
 fn package_manifest_test_filters(pkg_root: &Path) -> Result<(Vec<String>, Vec<String>), CliExit> {
     match project_manifest::discover(pkg_root) {
-        Ok(Some(project)) if project.root == pkg_root => Ok((
-            project.manifest.test.exclude,
-            project.manifest.test.include,
-        )),
+        Ok(Some(project)) if project.root == pkg_root => {
+            Ok((project.manifest.test.exclude, project.manifest.test.include))
+        }
         Ok(_) => Ok((Vec::new(), Vec::new())),
         Err(e) => Err(CliExit::error(e)),
     }

--- a/wado-cli/src/test.rs
+++ b/wado-cli/src/test.rs
@@ -178,27 +178,31 @@ fn discover_packages(
     let mut runs: Vec<PackageRun> = Vec::new();
     let mut queue: Vec<PathBuf> = Vec::new();
 
-    let root_manifest = if apply_manifest_excludes {
-        package_manifest_excludes(&invocation_root)?
+    let (root_exclude_manifest, root_include_manifest) = if apply_manifest_excludes {
+        package_manifest_test_filters(&invocation_root)?
     } else {
-        Vec::new()
+        (Vec::new(), Vec::new())
     };
-    let root_excludes = compile_excludes(&root_manifest, extra_excludes)?;
+    let root_excludes = compile_excludes(&root_exclude_manifest, extra_excludes)?;
+    let root_includes = compile_includes(&root_include_manifest)?;
     walk_into(
         &invocation_root,
         &invocation_root,
         &root_excludes,
+        &root_includes,
         &mut runs,
         &mut queue,
     )?;
 
     while let Some(pkg_root) = queue.pop() {
-        let manifest = package_manifest_excludes(&pkg_root)?;
-        let excludes = compile_excludes(&manifest, extra_excludes)?;
+        let (exclude_manifest, include_manifest) = package_manifest_test_filters(&pkg_root)?;
+        let excludes = compile_excludes(&exclude_manifest, extra_excludes)?;
+        let includes = compile_includes(&include_manifest)?;
         walk_into(
             &pkg_root,
             &invocation_root,
             &excludes,
+            &includes,
             &mut runs,
             &mut queue,
         )?;
@@ -222,6 +226,14 @@ fn compile_excludes(
     discover::ExcludeSet::compile(&combined).map_err(CliExit::error)
 }
 
+/// Compile a package's include set from the manifest's `[test].include`
+/// patterns. There is no CLI counterpart (yet) — includes are a manifest
+/// concept that lets stdlib-style packages keep `*_test.wado` files visible
+/// inside an otherwise-excluded directory.
+fn compile_includes(manifest: &[String]) -> Result<discover::IncludeSet, CliExit> {
+    discover::IncludeSet::compile(manifest).map_err(CliExit::error)
+}
+
 /// Walk a single package root, append its `PackageRun`, and queue its
 /// sub-packages (in source order — pushed in reverse so the LIFO `pop`
 /// emits them root-first).
@@ -229,10 +241,12 @@ fn walk_into(
     pkg_root: &Path,
     invocation_root: &Path,
     excludes: &discover::ExcludeSet,
+    includes: &discover::IncludeSet,
     runs: &mut Vec<PackageRun>,
     queue: &mut Vec<PathBuf>,
 ) -> Result<(), CliExit> {
-    let result = discover::discover_test_files(pkg_root, excludes).map_err(CliExit::error)?;
+    let result =
+        discover::discover_test_files(pkg_root, excludes, includes).map_err(CliExit::error)?;
     let label = relative_label(invocation_root, pkg_root);
     let paths = result.files.iter().map(|p| display_path(p)).collect();
     runs.push(PackageRun { label, paths });
@@ -242,13 +256,17 @@ fn walk_into(
     Ok(())
 }
 
-/// Read `[test].exclude` from the `wado.toml` rooted at `pkg_root` (if any).
-/// Returns the empty list when no manifest sits exactly at that directory —
-/// sub-packages without their own `wado.toml` simply contribute no excludes.
-fn package_manifest_excludes(pkg_root: &Path) -> Result<Vec<String>, CliExit> {
+/// Read `[test].exclude` and `[test].include` from the `wado.toml` rooted at
+/// `pkg_root` (if any). Returns empty lists when no manifest sits exactly at
+/// that directory — sub-packages without their own `wado.toml` simply
+/// contribute no filters.
+fn package_manifest_test_filters(pkg_root: &Path) -> Result<(Vec<String>, Vec<String>), CliExit> {
     match project_manifest::discover(pkg_root) {
-        Ok(Some(project)) if project.root == pkg_root => Ok(project.manifest.test.exclude),
-        Ok(_) => Ok(Vec::new()),
+        Ok(Some(project)) if project.root == pkg_root => Ok((
+            project.manifest.test.exclude,
+            project.manifest.test.include,
+        )),
+        Ok(_) => Ok((Vec::new(), Vec::new())),
         Err(e) => Err(CliExit::error(e)),
     }
 }

--- a/wado-compiler/src/codegen/emit.rs
+++ b/wado-compiler/src/codegen/emit.rs
@@ -48,6 +48,13 @@ struct WirEmitter<'a> {
     current_locals: IndexMap<String, u32>,
     /// Locals declared with ref types (need `ref.as_non_null` on `local.get`).
     ref_locals: IndexSet<String>,
+    /// Names of scratch locals (used by `ArrayClone` / `ArrayCopy` emission)
+    /// that have already been collected for the current function. Lets the
+    /// pre-emission walker push each unique scratch name once even when the
+    /// same (dst, src) type pair appears in multiple `ArrayCopy` sites or
+    /// the same `type_id` appears in multiple `ArrayClone` sites — without
+    /// the de-dup, every visit grew the Wasm locals table.
+    scratch_local_names: IndexSet<String>,
     /// Next local index for current function.
     next_local: u32,
     /// Wasm type section counter.
@@ -74,6 +81,7 @@ impl<'a> WirEmitter<'a> {
             global_name_map: IndexMap::default(),
             current_locals: IndexMap::default(),
             ref_locals: IndexSet::default(),
+            scratch_local_names: IndexSet::default(),
             next_local: 0,
             next_type_idx: 0,
             variant_pre_assigned: IndexMap::default(),
@@ -736,6 +744,7 @@ impl<'a> WirEmitter<'a> {
         // Reset local tracking
         self.current_locals.clear();
         self.ref_locals.clear();
+        self.scratch_local_names.clear();
         self.next_local = 0;
 
         // Get function type info — check if it has a non-void return type
@@ -973,12 +982,17 @@ impl<'a> WirEmitter<'a> {
                     dest_type_id.index(),
                     src_type_id.index()
                 );
-                locals.push((dst_name, ValType::Ref(dst_ref)));
-                locals.push((src_name, ValType::Ref(src_ref)));
-                locals.push((dst_off_name, ValType::I32));
-                locals.push((src_off_name, ValType::I32));
-                locals.push((len_name, ValType::I32));
-                locals.push((i_name, ValType::I32));
+                // Dedup: multiple ArrayCopy sites with the same type pair
+                // share these slot names. Without the guard, every site
+                // would grow the locals table by 6 unused entries.
+                if self.scratch_local_names.insert(dst_name.clone()) {
+                    locals.push((dst_name, ValType::Ref(dst_ref)));
+                    locals.push((src_name, ValType::Ref(src_ref)));
+                    locals.push((dst_off_name, ValType::I32));
+                    locals.push((src_off_name, ValType::I32));
+                    locals.push((len_name, ValType::I32));
+                    locals.push((i_name, ValType::I32));
+                }
             }
             WirInstr::ArrayClone {
                 type_id,
@@ -996,15 +1010,21 @@ impl<'a> WirEmitter<'a> {
                 let dst_name = format!("__copy_arr_dst_{}", type_id.index());
                 let len_name = format!("__copy_arr_len_{}", type_id.index());
                 let loop_idx_name = format!("__copy_arr_i_{}", type_id.index());
-                locals.push((src_name, ValType::Ref(arr_ref)));
-                locals.push((dst_name, ValType::Ref(arr_ref)));
-                locals.push((len_name, ValType::I32));
-                locals.push((loop_idx_name, ValType::I32));
+                // Dedup: multiple ArrayClone sites with the same type_id
+                // share these slot names. See `ArrayCopy` above for rationale.
+                let new_clone_site = self.scratch_local_names.insert(src_name.clone());
+                if new_clone_site {
+                    locals.push((src_name, ValType::Ref(arr_ref)));
+                    locals.push((dst_name, ValType::Ref(arr_ref)));
+                    locals.push((len_name, ValType::I32));
+                    locals.push((loop_idx_name, ValType::I32));
+                }
                 // When `element_copy_func` is set, the loop also
                 // branches on per-element nullability (slots beyond
                 // `Array<T>::used` are default-null) so it needs an
                 // extra temp of element-nullable-ref type.
-                if element_copy_func.is_some()
+                if new_clone_site
+                    && element_copy_func.is_some()
                     && let Some(elem_val) = self.array_element_val_type(type_id.index())
                 {
                     let elem_name = format!("__copy_arr_elem_{}", type_id.index());

--- a/wado-compiler/wado.toml
+++ b/wado-compiler/wado.toml
@@ -24,3 +24,13 @@ exclude = [
     "lib/core/prelude/**",
     "lib/core/allocator.wado",
 ]
+
+# `*_test.wado` files inside the excluded stdlib directories *are* meant to
+# be run by `wado test` — they exercise the stdlib via `test "…" { … }`
+# blocks and only *use* prelude types (`Array`, `String`, …) rather than
+# defining them, so the prelude-bundling conflict above does not apply.
+# The include override keeps them visible to discovery despite the
+# directory-level exclude.
+include = [
+    "lib/**/*_test.wado",
+]

--- a/wado-manifest/src/manifest.rs
+++ b/wado-manifest/src/manifest.rs
@@ -27,6 +27,12 @@ pub struct TestSettings {
     /// Glob patterns (relative to the package root) for paths to exclude from
     /// test discovery. See WEP 2026-05-02.
     pub exclude: Vec<String>,
+    /// Glob patterns (relative to the package root) for paths to keep in test
+    /// discovery even when they would otherwise be excluded. Patterns here win
+    /// over `exclude` — typical use is `lib/**/*_test.wado` inside a stdlib
+    /// package whose non-test sources have to be excluded (e.g. because they
+    /// re-export the prelude and can't compile as their own entry).
+    pub include: Vec<String>,
 }
 
 /// The `[package]` section of `wado.toml`.
@@ -197,6 +203,7 @@ struct RawManifest {
 #[derive(Deserialize)]
 struct RawTestSettings {
     exclude: Option<Vec<String>>,
+    include: Option<Vec<String>>,
 }
 
 #[derive(Deserialize)]
@@ -253,6 +260,7 @@ fn convert_raw(raw: RawManifest) -> Result<Manifest, ManifestError> {
 fn convert_test(raw: RawTestSettings) -> TestSettings {
     TestSettings {
         exclude: raw.exclude.unwrap_or_default(),
+        include: raw.include.unwrap_or_default(),
     }
 }
 
@@ -570,6 +578,24 @@ command = "main.wado"
 "#;
         let m = toml.parse::<Manifest>().unwrap();
         assert!(m.test.exclude.is_empty());
+        assert!(m.test.include.is_empty());
+    }
+
+    #[test]
+    fn parse_test_include() {
+        let toml = r#"
+[package]
+name = "app"
+version = "0.1.0"
+command = "main.wado"
+
+[test]
+exclude = ["lib/core/prelude/**"]
+include = ["lib/**/*_test.wado"]
+"#;
+        let m = toml.parse::<Manifest>().unwrap();
+        assert_eq!(m.test.exclude, vec!["lib/core/prelude/**"]);
+        assert_eq!(m.test.include, vec!["lib/**/*_test.wado"]);
     }
 
     #[test]


### PR DESCRIPTION
Two independent follow-ups from the WEP-2026-05-16 review (#1072):

## `[test].include` for stdlib test discovery

`wado-compiler/wado.toml` excludes `lib/core/prelude/**` because the
fragments inside *define* prelude types and would conflict with the prelude
they get bundled into. The same exclude also pruned the companion
`*_test.wado` files in that subtree, leaving the stdlib's actual test
files (`string_test.wado`, `fpfmt_comprehensive_test.wado`,
`int128_test.wado`, …) unreachable through `wado test`. Until this PR,
those tests only ever ran when invoked by an explicit path argument.

Add a `[test].include` manifest field that "carves out" files from
excluded subtrees:

```toml
[test]
exclude = ["lib/core/prelude/**"]
include = ["lib/**/*_test.wado"]
```

Semantics (`wado-cli/discover.rs`):

- File matches an include pattern → keep (overrides exclude).
- File matches exclude but no include → drop.
- Directory matches exclude → still descend when any include patterns
  are present; a deeper file might match. With an empty include set
  the walker keeps its existing directory-pruning shortcut.

Plumbing:

- `wado-manifest`: `TestSettings { exclude, include }` + parser test.
- `wado-cli/discover.rs`: new `IncludeSet` shaped like `ExcludeSet`;
  `discover_test_files(root, &excludes, &includes)`. Two new unit tests
  cover the carve-out and the empty-include-keeps-old-behaviour cases.
- `wado-cli/test.rs`: `package_manifest_test_filters` returns both
  vectors and threads them through `walk_into`. No CLI `--include` is
  added — the field is currently a manifest concept whose first consumer
  is the stdlib package itself.
- `wado-compiler/wado.toml`: opts in `lib/**/*_test.wado`.
- `docs/wep-2026-05-02-test-discovery.md`: documents the new field.

After this change `mise run test-wado` reports **2573 passed** (up from
1943); the +630 tests are the stdlib test bundles that were previously
invisible to CI.

## ArrayCopy / ArrayClone scratch local dedup

`emit_function` pre-walks the function body and pushes named scratch
locals (`__array_copy_*_<dst>_<src>`, `__copy_arr_*_<type_id>`) for every
`ArrayCopy` / `ArrayClone` instruction it encounters. Multiple sites in
the same function that shared a type pair reused the same names —
`current_locals` is an `IndexMap` so the second `insert` clobbered the
older index, but the Wasm locals table still grew by one slot per
duplicate. In larger functions this added up to dozens of unreferenced
locals.

Track scratch names that have already been collected for the current
function in a per-function `scratch_local_names: IndexSet`. Skip the
`push` (and the companion `element_copy_func` push for `ArrayClone`) on
duplicates, but only for scratch names — user `DeclareLocal` names can
legitimately shadow parameters in WIR, and a naive blanket dedup
collapsed them into the wrong slot and broke `gale_cli` codegen with
`type mismatch: expected i32, found (ref $type)`. The per-function
`IndexSet` is reset alongside `current_locals` in every function so
state doesn't leak between functions.

---
_Generated by [Claude Code](https://claude.ai/code/session_013jgvqeTZyMdSyt84vQbkp5)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wado-lang/wado/pull/1081" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->