### PR TITLE
refactor(compiler): unify CM-attribute handling under `CmBoundary`

### DIFF
--- a/wado-compiler/src/analyze.rs
+++ b/wado-compiler/src/analyze.rs
@@ -308,7 +308,7 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
                         return_type: func.return_type.as_ref().map(|_| "unknown".to_string()),
                         effects: func.effects.clone(),
                         is_builtin,
-                        cm_import: func.attrs.first().and_then(|a| a.cm_import.clone()),
+                        cm_import: func.attrs.first().and_then(|a| a.as_cm_import().cloned()),
                     });
 
                     self.define_unique(module_source, func.id, &func.name, kind, func.span);
@@ -316,7 +316,8 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
 
                 Item::Interface(effect) => {
                     // Extract effect-level CM import from attributes
-                    let effect_cm_import = effect.attrs.first().and_then(|a| a.cm_import.clone());
+                    let effect_cm_import =
+                        effect.attrs.first().and_then(|a| a.as_cm_import().cloned());
 
                     let kind = SymbolKind::Effect(EffectSymbol {
                         methods: effect.methods.iter().map(|m| m.name.clone()).collect(),
@@ -329,7 +330,8 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
                     // with the fully qualified name "{Effect}.{method}"
                     // This allows importing them via use statements
                     for method in &effect.methods {
-                        let cm_import = method.attrs.first().and_then(|a| a.cm_import.clone());
+                        let cm_import =
+                            method.attrs.first().and_then(|a| a.as_cm_import().cloned());
 
                         let func_kind = SymbolKind::Function(FunctionSymbol {
                             params: method.params.iter().map(|p| p.name.clone()).collect(),
@@ -429,7 +431,10 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
                 Item::Resource(resource) => {
                     let kind = SymbolKind::Resource(ResourceSymbol {
                         methods: resource.methods.iter().map(|m| m.name.clone()).collect(),
-                        cm_import: resource.attrs.first().and_then(|a| a.cm_import.clone()),
+                        cm_import: resource
+                            .attrs
+                            .first()
+                            .and_then(|a| a.as_cm_import().cloned()),
                     });
 
                     self.define_unique(
@@ -443,7 +448,8 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
                     // Register each resource method as a function symbol
                     // with the fully qualified name "{Resource}::{method}"
                     for method in &resource.methods {
-                        let cm_import = method.attrs.first().and_then(|a| a.cm_import.clone());
+                        let cm_import =
+                            method.attrs.first().and_then(|a| a.as_cm_import().cloned());
 
                         let func_kind = SymbolKind::Function(FunctionSymbol {
                             params: method.params.iter().map(|p| p.name.clone()).collect(),

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -1522,9 +1522,11 @@ pub struct TaskReturnStmt {
 /// A single element in a let-chain condition
 #[derive(Debug, Clone)]
 pub enum ConditionElement {
-    /// `let PAT = EXPR` — pattern match element
+    /// `let PAT = EXPR` — pattern match element. `pattern` is boxed to keep
+    /// the variant compact (without it, the enum is dominated by the
+    /// 300+ byte `Pattern` and clippy fires `large_enum_variant`).
     Let {
-        pattern: Pattern,
+        pattern: Box<Pattern>,
         expr: Expr,
         span: Span,
     },

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -1021,6 +1021,19 @@ impl Attribute {
     pub fn as_cm_import(&self) -> Option<&CmImport> {
         self.cm_boundary.as_ref().and_then(CmBoundary::as_import)
     }
+
+    /// Returns the raw argument string of a `#[cm("...")]` attribute, regardless of
+    /// whether the argument parses as a full CM interface path or is just a
+    /// CM-side identifier (variant case / field / method rename). Returns
+    /// `None` for `#[canonical(...)]` and for non-CM attributes.
+    pub fn cm_arg_str(&self) -> Option<&str> {
+        match &self.cm_boundary {
+            Some(CmBoundary::Import(_) | CmBoundary::Rename(_)) => {
+                self.args.first().map(AttrArg::as_str)
+            }
+            Some(CmBoundary::Canonical { .. }) | None => None,
+        }
+    }
 }
 
 /// Component Model boundary metadata extracted from `#[cm(...)]` or
@@ -1114,6 +1127,12 @@ impl CmImport {
             path.push_str(ver);
         }
         path
+    }
+
+    /// Get the bare interface path without version or function
+    /// (e.g., "wasi:cli/stdout").
+    pub fn bare_path(&self) -> String {
+        format!("{}:{}/{}", self.namespace, self.package, self.interface)
     }
 }
 

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -1027,7 +1027,9 @@ impl Attribute {
     /// from `self.args`. Returns `None` for `#[canonical(...)]` and for
     /// non-CM attributes.
     pub fn cm_identifier(&self) -> Option<String> {
-        self.cm_boundary.as_ref().and_then(CmBoundary::cm_identifier)
+        self.cm_boundary
+            .as_ref()
+            .and_then(CmBoundary::cm_identifier)
     }
 }
 

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -983,7 +983,11 @@ pub struct Attribute {
     /// - `#[serde(rename = "type")]`           → `[KeyValue("rename", "type")]`
     /// - `#[serde(default)]`                   → `[Ident("default")]`
     pub args: Vec<AttrArg>,
-    pub cm_import: Option<CmImport>,
+    /// Component Model boundary metadata, populated by the parser when the
+    /// attribute is `#[cm(...)]` or `#[canonical(...)]`. A `Some` value means
+    /// the carrying item (function, method, effect, resource, variant case,
+    /// world, ...) participates in the Component Model boundary in some form.
+    pub cm_boundary: Option<CmBoundary>,
     pub span: Span,
 }
 
@@ -1009,6 +1013,44 @@ impl Attribute {
             AttrArg::Str(s) | AttrArg::Ident(s) | AttrArg::Number(s) => s == name,
             AttrArg::KeyValue(k, _) | AttrArg::KeyArray(k, _) => k == name,
         })
+    }
+
+    /// Returns the parsed CM interface import (`namespace:package/interface[@v][#fn]`)
+    /// carried by this attribute, if any. Returns `None` for `#[canonical(...)]`,
+    /// for `#[cm("simple-name")]`, and for non-CM attributes.
+    pub fn as_cm_import(&self) -> Option<&CmImport> {
+        self.cm_boundary.as_ref().and_then(CmBoundary::as_import)
+    }
+}
+
+/// Component Model boundary metadata extracted from `#[cm(...)]` or
+/// `#[canonical(...)]`.
+///
+/// Functions, methods, effects, resources, variant cases, and worlds tagged
+/// with one of these attributes cross the Component Model boundary, but the
+/// kind of boundary differs:
+///
+/// - `Canonical` — `#[canonical("namespace", "name")]` lowers to a CM
+///   canonical built-in (e.g. `canon.task.return`, `canon.stream.new`), not
+///   to an interface import.
+/// - `Import` — `#[cm("namespace:package/interface[@version][#function]")]`
+///   resolves to a real import from a CM interface.
+/// - `Rename` — `#[cm("simple-name")]` is a single CM-side identifier used
+///   for renaming a field, variant case, or method (no interface attached).
+#[derive(Debug, Clone)]
+pub enum CmBoundary {
+    Canonical { namespace: String, name: String },
+    Import(CmImport),
+    Rename(String),
+}
+
+impl CmBoundary {
+    /// Returns the `CmImport` payload if this boundary is an interface import.
+    pub fn as_import(&self) -> Option<&CmImport> {
+        match self {
+            CmBoundary::Import(cm) => Some(cm),
+            CmBoundary::Canonical { .. } | CmBoundary::Rename(_) => None,
+        }
     }
 }
 

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -1022,17 +1022,12 @@ impl Attribute {
         self.cm_boundary.as_ref().and_then(CmBoundary::as_import)
     }
 
-    /// Returns the raw argument string of a `#[cm("...")]` attribute, regardless of
-    /// whether the argument parses as a full CM interface path or is just a
-    /// CM-side identifier (variant case / field / method rename). Returns
-    /// `None` for `#[canonical(...)]` and for non-CM attributes.
-    pub fn cm_arg_str(&self) -> Option<&str> {
-        match &self.cm_boundary {
-            Some(CmBoundary::Import(_) | CmBoundary::Rename(_)) => {
-                self.args.first().map(AttrArg::as_str)
-            }
-            Some(CmBoundary::Canonical { .. }) | None => None,
-        }
+    /// Returns the CM-side identifier carried by a `#[cm("...")]` attribute,
+    /// reconstructed from the parsed `CmBoundary` payload rather than read
+    /// from `self.args`. Returns `None` for `#[canonical(...)]` and for
+    /// non-CM attributes.
+    pub fn cm_identifier(&self) -> Option<String> {
+        self.cm_boundary.as_ref().and_then(CmBoundary::cm_identifier)
     }
 }
 
@@ -1048,13 +1043,13 @@ impl Attribute {
 ///   to an interface import.
 /// - `Import` — `#[cm("namespace:package/interface[@version][#function]")]`
 ///   resolves to a real import from a CM interface.
-/// - `Rename` — `#[cm("simple-name")]` is a single CM-side identifier used
-///   for renaming a field, variant case, or method (no interface attached).
+/// - `Name` — `#[cm("simple-name")]` is a single CM-side identifier used
+///   for naming a field, variant case, or method (no interface attached).
 #[derive(Debug, Clone)]
 pub enum CmBoundary {
     Canonical { namespace: String, name: String },
     Import(CmImport),
-    Rename(String),
+    Name(String),
 }
 
 impl CmBoundary {
@@ -1062,7 +1057,23 @@ impl CmBoundary {
     pub fn as_import(&self) -> Option<&CmImport> {
         match self {
             CmBoundary::Import(cm) => Some(cm),
-            CmBoundary::Canonical { .. } | CmBoundary::Rename(_) => None,
+            CmBoundary::Canonical { .. } | CmBoundary::Name(_) => None,
+        }
+    }
+
+    /// Returns the CM-side identifier carried by this boundary.
+    ///
+    /// - `Canonical` returns `None` (canonical built-ins are addressed by a
+    ///   `(namespace, name)` pair, not by a single string identifier).
+    /// - `Import` reconstructs the full path
+    ///   `"namespace:package/interface[@version][#function]"` from the parsed
+    ///   components.
+    /// - `Name` returns the bare CM-side name.
+    pub fn cm_identifier(&self) -> Option<String> {
+        match self {
+            CmBoundary::Canonical { .. } => None,
+            CmBoundary::Import(cm) => Some(cm.full_path()),
+            CmBoundary::Name(s) => Some(s.clone()),
         }
     }
 }
@@ -1133,6 +1144,18 @@ impl CmImport {
     /// (e.g., "wasi:cli/stdout").
     pub fn bare_path(&self) -> String {
         format!("{}:{}/{}", self.namespace, self.package, self.interface)
+    }
+
+    /// Get the full path including the function fragment when present
+    /// (e.g., "wasi:cli/stdout@0.3.0-rc-2025-09-16#write-via-stream").
+    /// Reconstructs the canonical form parsed by `CmImport::parse`.
+    pub fn full_path(&self) -> String {
+        let mut path = self.interface_path();
+        if let Some(ref f) = self.function {
+            path.push('#');
+            path.push_str(f);
+        }
+        path
     }
 }
 

--- a/wado-compiler/src/ast_index.rs
+++ b/wado-compiler/src/ast_index.rs
@@ -606,7 +606,7 @@ mod tests {
         };
         // pattern should be `Some(v)`; the binding pattern is the first
         // child.
-        let crate::ast::Pattern::Variant { bindings, .. } = pattern else {
+        let crate::ast::Pattern::Variant { bindings, .. } = pattern.as_ref() else {
             panic!("expected variant pattern");
         };
         let crate::ast::Pattern::Ident { id, span, .. } = &bindings[0] else {

--- a/wado-compiler/src/builtin_registry.rs
+++ b/wado-compiler/src/builtin_registry.rs
@@ -122,24 +122,21 @@ impl BuiltinRegistry {
             (TypeTable::UNIT, false)
         };
 
-        // Extract canonical info from `#[canonical("namespace", "name")]` attribute.
-        // The parser populates `cm_boundary` with `CmBoundary::Canonical` for
-        // well-formed two-argument forms; anything else is rejected here.
-        let canonical_attr = func.attrs.iter().find(|a| a.name == "canonical");
-        let (namespace, canonical_name) = match canonical_attr {
-            Some(attr) => match &attr.cm_boundary {
+        // Extract canonical info from `#[canonical("namespace", "name")]`.
+        // The parser is the single source of truth for this attribute's shape;
+        // a malformed form (`#[canonical(...)]` without two string arguments)
+        // never reaches `CmBoundary::Canonical`, so the function falls back to
+        // the Wasm-instruction default below.
+        let (namespace, canonical_name) = func
+            .attrs
+            .iter()
+            .find_map(|a| match &a.cm_boundary {
                 Some(CmBoundary::Canonical { namespace, name }) => {
-                    (namespace.clone(), Some(name.clone()))
+                    Some((namespace.clone(), Some(name.clone())))
                 }
-                Some(CmBoundary::Import(_) | CmBoundary::Rename(_)) | None => {
-                    panic!(
-                        "Invalid #[canonical] attribute on `{}`: expected 2 string arguments (namespace, name)",
-                        func.name
-                    );
-                }
-            },
-            None => ("wasi".to_string(), None),
-        };
+                Some(CmBoundary::Import(_) | CmBoundary::Rename(_)) | None => None,
+            })
+            .unwrap_or_else(|| ("wasi".to_string(), None));
 
         let info = BuiltinFunctionInfo {
             name: func.name.clone(),

--- a/wado-compiler/src/builtin_registry.rs
+++ b/wado-compiler/src/builtin_registry.rs
@@ -6,7 +6,7 @@
 use crate::hashmap::IndexMap;
 use std::cell::RefCell;
 
-use crate::ast::{Function, Type};
+use crate::ast::{CmBoundary, Function, Type};
 use crate::tir::{ResolvedType, TypeId, TypeTable};
 
 /// Information about a builtin function
@@ -91,7 +91,7 @@ impl BuiltinRegistry {
         for item in &module.items {
             if let crate::ast::Item::Function(func) = item
                 && func.body.is_none()
-                && func.attrs.iter().any(|a| a.name == "canonical")
+                && func.attrs.iter().any(is_canonical_builtin)
             {
                 self.register(func, type_table);
             }
@@ -122,28 +122,23 @@ impl BuiltinRegistry {
             (TypeTable::UNIT, false)
         };
 
-        // Extract canonical info from #[canonical("namespace", "name")] attribute
-        // args[0] = namespace, args[1] = canonical name
+        // Extract canonical info from `#[canonical("namespace", "name")]` attribute.
+        // The parser populates `cm_boundary` with `CmBoundary::Canonical` for
+        // well-formed two-argument forms; anything else is rejected here.
         let canonical_attr = func.attrs.iter().find(|a| a.name == "canonical");
-        let (namespace, canonical_name) = if let Some(attr) = canonical_attr {
-            if attr.args.len() >= 2 {
-                // New format: #[canonical("wasi", "stream-new")]
-                (
-                    attr.args[0].as_str().to_string(),
-                    Some(attr.args[1].as_str().to_string()),
-                )
-            } else if attr.args.len() == 1 {
-                // Legacy single-arg format not supported anymore
-                panic!(
-                    "Invalid #[canonical] attribute: expected 2 arguments (namespace, name), got 1"
-                );
-            } else {
-                // No arguments - this is an error
-                panic!("Invalid #[canonical] attribute: expected 2 arguments (namespace, name)");
-            }
-        } else {
-            // No canonical attribute - not an imported builtin
-            ("wasi".to_string(), None)
+        let (namespace, canonical_name) = match canonical_attr {
+            Some(attr) => match &attr.cm_boundary {
+                Some(CmBoundary::Canonical { namespace, name }) => {
+                    (namespace.clone(), Some(name.clone()))
+                }
+                Some(CmBoundary::Import(_) | CmBoundary::Rename(_)) | None => {
+                    panic!(
+                        "Invalid #[canonical] attribute on `{}`: expected 2 string arguments (namespace, name)",
+                        func.name
+                    );
+                }
+            },
+            None => ("wasi".to_string(), None),
         };
 
         let info = BuiltinFunctionInfo {
@@ -266,6 +261,12 @@ impl BuiltinRegistry {
             .values()
             .filter(|f| f.canonical_name.is_some())
     }
+}
+
+/// Returns true if the attribute is a well-formed `#[canonical(ns, name)]` that
+/// marks a CM canonical built-in.
+fn is_canonical_builtin(attr: &crate::ast::Attribute) -> bool {
+    matches!(attr.cm_boundary, Some(CmBoundary::Canonical { .. }))
 }
 
 #[cfg(test)]

--- a/wado-compiler/src/builtin_registry.rs
+++ b/wado-compiler/src/builtin_registry.rs
@@ -134,7 +134,7 @@ impl BuiltinRegistry {
                 Some(CmBoundary::Canonical { namespace, name }) => {
                     Some((namespace.clone(), Some(name.clone())))
                 }
-                Some(CmBoundary::Import(_) | CmBoundary::Rename(_)) | None => None,
+                Some(CmBoundary::Import(_) | CmBoundary::Name(_)) | None => None,
             })
             .unwrap_or_else(|| ("wasi".to_string(), None));
 

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -1123,7 +1123,7 @@ impl WasiRegistry {
         for item in &module.items {
             if let Item::Interface(effect) = item {
                 for method in &effect.methods {
-                    if let Some(wasi) = method.attrs.first().and_then(|a| a.cm_import.as_ref()) {
+                    if let Some(wasi) = method.attrs.first().and_then(|a| a.as_cm_import()) {
                         // Extract CM param names from #[cm_params] attribute
                         let cm_param_names = extract_cm_params_attr(&method.attrs);
                         let params: Vec<(String, String, Type)> = method
@@ -1174,7 +1174,7 @@ impl WasiRegistry {
         for item in &module.items {
             if let Item::Resource(resource) = item {
                 for method in &resource.methods {
-                    if let Some(wasi) = method.attrs.first().and_then(|a| a.cm_import.as_ref()) {
+                    if let Some(wasi) = method.attrs.first().and_then(|a| a.as_cm_import()) {
                         // Extract CM param names from #[cm_params] attribute
                         let cm_param_names = extract_cm_params_attr(&method.attrs);
                         let params: Vec<(String, String, Type)> = method

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -76,16 +76,18 @@ pub fn is_unit_type(ty: &Type) -> bool {
 fn cm_attr_cm_name(attrs: &[crate::ast::Attribute], wado_name: &str) -> String {
     attrs
         .iter()
-        .find(|a| a.name == "cm")
-        .and_then(|a| a.args.first())
-        .map(|arg| {
-            let s = arg.as_str();
-            // Type-level attrs contain a `#` separator; case-level attrs do not
-            if let Some(fragment) = s.split('#').nth(1) {
-                fragment.to_owned()
-            } else {
-                s.to_owned()
+        .find_map(|a| match &a.cm_boundary {
+            // Type-level CM imports use the function fragment (after `#`)
+            // as the CM name. If the path has no function fragment, fall
+            // back to the whole interface path to preserve the previous
+            // behaviour.
+            Some(crate::ast::CmBoundary::Import(cm)) => {
+                Some(cm.function.clone().unwrap_or_else(|| cm.interface_path()))
             }
+            // Case-level CM names (variant cases, fields, ...) carry just
+            // the CM-side identifier.
+            Some(crate::ast::CmBoundary::Rename(s)) => Some(s.clone()),
+            Some(crate::ast::CmBoundary::Canonical { .. }) | None => None,
         })
         .unwrap_or_else(|| panic!("missing #[cm] attribute for CM name: {wado_name}"))
 }
@@ -555,9 +557,7 @@ fn collect_interface_decls(modules: &[(&'static str, crate::ast::Module)]) -> In
             let Some(cm_fq) = iface
                 .attrs
                 .iter()
-                .find(|a| a.name == "cm")
-                .and_then(|a| a.args.first())
-                .map(|arg| arg.as_str().to_string())
+                .find_map(|a| a.cm_arg_str().map(str::to_string))
             else {
                 continue;
             };
@@ -878,11 +878,8 @@ impl WasiRegistry {
     fn cm_source_interface(attrs: &[crate::ast::Attribute]) -> String {
         attrs
             .iter()
-            .find(|a| a.name == "cm")
-            .and_then(|a| a.args.first())
-            .and_then(|arg| arg.as_str().split('#').next())
-            .unwrap_or("")
-            .to_string()
+            .find_map(|a| a.as_cm_import().map(crate::ast::CmImport::interface_path))
+            .unwrap_or_default()
     }
 
     /// Build the registry from the embedded stdlib

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -10,7 +10,7 @@ use crate::hashmap::{IndexMap, IndexSet};
 
 use wasm_encoder::ValType;
 
-use crate::ast::{CmImport, GenericType, Type};
+use crate::ast::{Attribute, CmImport, GenericType, Type};
 use crate::tir::{TypeId, TypeTable};
 
 /// A variant case with both CM and Wado names.
@@ -86,7 +86,7 @@ fn cm_attr_cm_name(attrs: &[crate::ast::Attribute], wado_name: &str) -> String {
             }
             // Case-level CM names (variant cases, fields, ...) carry just
             // the CM-side identifier.
-            Some(crate::ast::CmBoundary::Rename(s)) => Some(s.clone()),
+            Some(crate::ast::CmBoundary::Name(s)) => Some(s.clone()),
             Some(crate::ast::CmBoundary::Canonical { .. }) | None => None,
         })
         .unwrap_or_else(|| panic!("missing #[cm] attribute for CM name: {wado_name}"))
@@ -554,11 +554,7 @@ fn collect_interface_decls(modules: &[(&'static str, crate::ast::Module)]) -> In
             // `"wasi:http/handler@0.3.0-rc-2026-03-15"`). Skip anonymous
             // interfaces without a CM attribute — they are not boundary-
             // visible and cannot back a world export.
-            let Some(cm_fq) = iface
-                .attrs
-                .iter()
-                .find_map(|a| a.cm_arg_str().map(str::to_string))
-            else {
+            let Some(cm_fq) = iface.attrs.iter().find_map(Attribute::cm_identifier) else {
                 continue;
             };
 

--- a/wado-compiler/src/desugar.rs
+++ b/wado-compiler/src/desugar.rs
@@ -1669,7 +1669,7 @@ fn strip_ns_from_condition(cond: Condition, ctx: &DesugarContext) -> Condition {
                         expr,
                         span,
                     } => ConditionElement::Let {
-                        pattern: strip_ns_from_pattern(pattern, ctx),
+                        pattern: Box::new(strip_ns_from_pattern(*pattern, ctx)),
                         expr: strip_ns_from_expr(expr, ctx),
                         span,
                     },

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -875,8 +875,10 @@ impl Parser {
 
         self.expect(&TokenKind::RBracket)?;
 
-        let cm_boundary = parse_cm_boundary(&name, &args)
-            .map_err(|message| ParseError { message, span: start_span })?;
+        let cm_boundary = parse_cm_boundary(&name, &args).map_err(|message| ParseError {
+            message,
+            span: start_span,
+        })?;
 
         Ok(Attribute {
             name,
@@ -5692,12 +5694,16 @@ mod tests {
 
     #[test]
     fn test_canonical_attribute_with_wrong_arg_count_errors() {
-        let err = parse(r#"
+        let err = parse(
+            r#"
             #[canonical("only-one-arg")]
             pub fn bad();
-        "#).unwrap_err();
+        "#,
+        )
+        .unwrap_err();
         assert!(
-            err.message.contains("#[canonical] expects exactly 2 string arguments"),
+            err.message
+                .contains("#[canonical] expects exactly 2 string arguments"),
             "unexpected error: {}",
             err.message
         );
@@ -5705,12 +5711,16 @@ mod tests {
 
     #[test]
     fn test_canonical_attribute_with_non_string_arg_errors() {
-        let err = parse(r#"
+        let err = parse(
+            r#"
             #[canonical(default, "foo")]
             pub fn bad();
-        "#).unwrap_err();
+        "#,
+        )
+        .unwrap_err();
         assert!(
-            err.message.contains("#[canonical] arguments must be string literals"),
+            err.message
+                .contains("#[canonical] arguments must be string literals"),
             "unexpected error: {}",
             err.message
         );
@@ -5728,7 +5738,8 @@ mod tests {
         )
         .unwrap_err();
         assert!(
-            err.message.contains("#[cm] expects exactly 1 string argument"),
+            err.message
+                .contains("#[cm] expects exactly 1 string argument"),
             "unexpected error: {}",
             err.message
         );
@@ -5736,14 +5747,18 @@ mod tests {
 
     #[test]
     fn test_cm_attribute_with_multiple_args_errors() {
-        let err = parse(r#"
+        let err = parse(
+            r#"
             pub interface Foo {
                 #[cm("a", "b")]
                 async fn bar();
             }
-        "#).unwrap_err();
+        "#,
+        )
+        .unwrap_err();
         assert!(
-            err.message.contains("#[cm] expects exactly 1 string argument"),
+            err.message
+                .contains("#[cm] expects exactly 1 string argument"),
             "unexpected error: {}",
             err.message
         );

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -5233,7 +5233,7 @@ impl Parser {
 /// - `#[canonical("namespace", "name")]` becomes `CmBoundary::Canonical`.
 /// - `#[cm("ns:pkg/iface[@v][#fn]")]` becomes `CmBoundary::Import`.
 /// - `#[cm("simple-name")]` (anything that doesn't parse as a full CM path)
-///   becomes `CmBoundary::Rename`.
+///   becomes `CmBoundary::Name`.
 /// - Any other attribute returns `Ok(None)`.
 ///
 /// Both `#[canonical(...)]` and `#[cm(...)]` are validated strictly: argument
@@ -5267,7 +5267,7 @@ fn parse_cm_boundary(name: &str, args: &[AttrArg]) -> Result<Option<CmBoundary>,
         };
         return Ok(Some(match CmImport::parse(s) {
             Some(cm) => CmBoundary::Import(cm),
-            None => CmBoundary::Rename(s.clone()),
+            None => CmBoundary::Name(s.clone()),
         }));
     }
     Ok(None)
@@ -5765,7 +5765,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cm_attribute_with_simple_name_populates_rename() {
+    fn test_cm_attribute_with_simple_name_populates_name_variant() {
         let source = r#"
             pub variant Op {
                 #[cm("byte-start")]
@@ -5779,11 +5779,12 @@ mod tests {
         let case = &variant.cases[0];
         let attr = &case.attrs[0];
         assert_eq!(attr.name, "cm");
-        let Some(CmBoundary::Rename(s)) = attr.cm_boundary.as_ref() else {
-            panic!("expected CmBoundary::Rename, got {:?}", attr.cm_boundary);
+        let Some(CmBoundary::Name(s)) = attr.cm_boundary.as_ref() else {
+            panic!("expected CmBoundary::Name, got {:?}", attr.cm_boundary);
         };
         assert_eq!(s, "byte-start");
         assert!(attr.as_cm_import().is_none());
+        assert_eq!(attr.cm_identifier().as_deref(), Some("byte-start"));
     }
 
     #[test]

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -4,7 +4,7 @@
 use crate::ast::{
     AssertStmt, AssignExpr, AssociatedConst, AssociatedTypeBinding, AssociatedTypeDecl, AstId,
     AttrArg, Attribute, BinaryExpr, BinaryOp, Block, BreakStmt, CallExpr, CastExpr,
-    ChainedComparison, ClosureExpr, ClosureParam, CmImport, ComparisonChainExpr,
+    ChainedComparison, ClosureExpr, ClosureParam, CmBoundary, CmImport, ComparisonChainExpr,
     CompoundAssignExpr, CompoundAssignOp, Condition, ConditionElement, ContinueStmt, EnumCase,
     EnumDecl, Expr, ExprStmt, FieldAccessExpr, FlagsDecl, FlagsVariant, ForOfStmt, ForStmt,
     FormatSpec, Function, FunctionType, GenericType, GlobalDecl, IdentExpr, IfExpr, IfStmt,
@@ -875,17 +875,12 @@ impl Parser {
 
         self.expect(&TokenKind::RBracket)?;
 
-        // Parse CM import path if this is a cm attribute
-        let cm_import = if name == "cm" {
-            args.first().and_then(|s| CmImport::parse(s.as_str()))
-        } else {
-            None
-        };
+        let cm_boundary = parse_cm_boundary(&name, &args);
 
         Ok(Attribute {
             name,
             args,
-            cm_import,
+            cm_boundary,
             span: start_span,
         })
     }
@@ -5230,6 +5225,34 @@ impl Parser {
     }
 }
 
+/// Populate `Attribute::cm_boundary` based on the attribute name.
+///
+/// - `#[canonical("namespace", "name")]` becomes `CmBoundary::Canonical`.
+/// - `#[cm("ns:pkg/iface[@v][#fn]")]` becomes `CmBoundary::Import`.
+/// - `#[cm("simple-name")]` (anything that doesn't parse as a full CM path)
+///   becomes `CmBoundary::Rename`.
+/// - Any other attribute returns `None`.
+fn parse_cm_boundary(name: &str, args: &[AttrArg]) -> Option<CmBoundary> {
+    if name == "canonical" {
+        if let [namespace, function] = args {
+            return Some(CmBoundary::Canonical {
+                namespace: namespace.as_str().to_string(),
+                name: function.as_str().to_string(),
+            });
+        }
+        return None;
+    }
+    if name == "cm" {
+        let arg = args.first()?;
+        let s = arg.as_str();
+        return Some(match CmImport::parse(s) {
+            Some(cm) => CmBoundary::Import(cm),
+            None => CmBoundary::Rename(s.to_string()),
+        });
+    }
+    None
+}
+
 fn parse_attr_number(repr: &str, negate: bool, span: Span) -> ParseResult<crate::ast::AttrValue> {
     // Strip numeric underscores for parsing; keep them in the original repr for errors.
     let cleaned: String = repr.chars().filter(|c| *c != '_').collect();
@@ -5618,9 +5641,7 @@ mod tests {
 
             let attr = &method.attrs[0];
             assert_eq!(attr.name, "cm");
-            assert!(attr.cm_import.is_some());
-
-            let cm = attr.cm_import.as_ref().unwrap();
+            let cm = attr.as_cm_import().expect("cm boundary import");
             assert_eq!(cm.namespace, "wasi");
             assert_eq!(cm.package, "cli");
             assert_eq!(cm.interface, "stdout");
@@ -5628,6 +5649,49 @@ mod tests {
         } else {
             panic!("expected interface declaration");
         }
+    }
+
+    #[test]
+    fn test_canonical_attribute_populates_cm_boundary() {
+        let source = r#"
+            #[canonical("wasi", "stream-new")]
+            pub fn stream_new() -> i64;
+        "#;
+        let module = parse(source).unwrap();
+        let Item::Function(func) = &module.items[0] else {
+            panic!("expected function declaration");
+        };
+        assert_eq!(func.attrs.len(), 1);
+        let attr = &func.attrs[0];
+        assert_eq!(attr.name, "canonical");
+        let Some(CmBoundary::Canonical { namespace, name }) = attr.cm_boundary.as_ref() else {
+            panic!("expected CmBoundary::Canonical, got {:?}", attr.cm_boundary);
+        };
+        assert_eq!(namespace, "wasi");
+        assert_eq!(name, "stream-new");
+        assert!(attr.as_cm_import().is_none());
+    }
+
+    #[test]
+    fn test_cm_attribute_with_simple_name_populates_rename() {
+        let source = r#"
+            pub variant Op {
+                #[cm("byte-start")]
+                ByteStart,
+            }
+        "#;
+        let module = parse(source).unwrap();
+        let Item::Variant(variant) = &module.items[0] else {
+            panic!("expected variant declaration");
+        };
+        let case = &variant.cases[0];
+        let attr = &case.attrs[0];
+        assert_eq!(attr.name, "cm");
+        let Some(CmBoundary::Rename(s)) = attr.cm_boundary.as_ref() else {
+            panic!("expected CmBoundary::Rename, got {:?}", attr.cm_boundary);
+        };
+        assert_eq!(s, "byte-start");
+        assert!(attr.as_cm_import().is_none());
     }
 
     #[test]

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -875,7 +875,8 @@ impl Parser {
 
         self.expect(&TokenKind::RBracket)?;
 
-        let cm_boundary = parse_cm_boundary(&name, &args);
+        let cm_boundary = parse_cm_boundary(&name, &args)
+            .map_err(|message| ParseError { message, span: start_span })?;
 
         Ok(Attribute {
             name,
@@ -1919,7 +1920,7 @@ impl Parser {
                 let expr = self.parse_chain_element_expr()?;
                 let span = elem_span.merge(&expr.span());
                 elements.push(ConditionElement::Let {
-                    pattern,
+                    pattern: Box::new(pattern),
                     expr,
                     span,
                 });
@@ -1960,7 +1961,7 @@ impl Parser {
         let expr = self.parse_chain_element_expr()?;
         let span = elem_span.merge(&expr.span());
         elements.push(ConditionElement::Let {
-            pattern,
+            pattern: Box::new(pattern),
             expr,
             span,
         });
@@ -1976,7 +1977,7 @@ impl Parser {
                 let expr = self.parse_chain_element_expr()?;
                 let span = elem_span.merge(&expr.span());
                 elements.push(ConditionElement::Let {
-                    pattern,
+                    pattern: Box::new(pattern),
                     expr,
                     span,
                 });
@@ -5231,26 +5232,43 @@ impl Parser {
 /// - `#[cm("ns:pkg/iface[@v][#fn]")]` becomes `CmBoundary::Import`.
 /// - `#[cm("simple-name")]` (anything that doesn't parse as a full CM path)
 ///   becomes `CmBoundary::Rename`.
-/// - Any other attribute returns `None`.
-fn parse_cm_boundary(name: &str, args: &[AttrArg]) -> Option<CmBoundary> {
+/// - Any other attribute returns `Ok(None)`.
+///
+/// Both `#[canonical(...)]` and `#[cm(...)]` are validated strictly: argument
+/// count and types must match the canonical form. Malformed shapes return
+/// `Err` so the caller can surface a parse-time diagnostic.
+fn parse_cm_boundary(name: &str, args: &[AttrArg]) -> Result<Option<CmBoundary>, String> {
     if name == "canonical" {
-        if let [namespace, function] = args {
-            return Some(CmBoundary::Canonical {
-                namespace: namespace.as_str().to_string(),
-                name: function.as_str().to_string(),
-            });
-        }
-        return None;
+        let [namespace, function] = args else {
+            return Err(format!(
+                "#[canonical] expects exactly 2 string arguments (namespace, name), got {}",
+                args.len()
+            ));
+        };
+        let (AttrArg::Str(ns), AttrArg::Str(fname)) = (namespace, function) else {
+            return Err("#[canonical] arguments must be string literals".to_string());
+        };
+        return Ok(Some(CmBoundary::Canonical {
+            namespace: ns.clone(),
+            name: fname.clone(),
+        }));
     }
     if name == "cm" {
-        let arg = args.first()?;
-        let s = arg.as_str();
-        return Some(match CmImport::parse(s) {
+        let [arg] = args else {
+            return Err(format!(
+                "#[cm] expects exactly 1 string argument, got {}",
+                args.len()
+            ));
+        };
+        let AttrArg::Str(s) = arg else {
+            return Err("#[cm] argument must be a string literal".to_string());
+        };
+        return Ok(Some(match CmImport::parse(s) {
             Some(cm) => CmBoundary::Import(cm),
-            None => CmBoundary::Rename(s.to_string()),
-        });
+            None => CmBoundary::Rename(s.clone()),
+        }));
     }
-    None
+    Ok(None)
 }
 
 fn parse_attr_number(repr: &str, negate: bool, span: Span) -> ParseResult<crate::ast::AttrValue> {
@@ -5673,6 +5691,65 @@ mod tests {
     }
 
     #[test]
+    fn test_canonical_attribute_with_wrong_arg_count_errors() {
+        let err = parse(r#"
+            #[canonical("only-one-arg")]
+            pub fn bad();
+        "#).unwrap_err();
+        assert!(
+            err.message.contains("#[canonical] expects exactly 2 string arguments"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn test_canonical_attribute_with_non_string_arg_errors() {
+        let err = parse(r#"
+            #[canonical(default, "foo")]
+            pub fn bad();
+        "#).unwrap_err();
+        assert!(
+            err.message.contains("#[canonical] arguments must be string literals"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn test_cm_attribute_with_no_args_errors() {
+        let err = parse(
+            r"
+            pub interface Foo {
+                #[cm]
+                async fn bar();
+            }
+        ",
+        )
+        .unwrap_err();
+        assert!(
+            err.message.contains("#[cm] expects exactly 1 string argument"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn test_cm_attribute_with_multiple_args_errors() {
+        let err = parse(r#"
+            pub interface Foo {
+                #[cm("a", "b")]
+                async fn bar();
+            }
+        "#).unwrap_err();
+        assert!(
+            err.message.contains("#[cm] expects exactly 1 string argument"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
+    #[test]
     fn test_cm_attribute_with_simple_name_populates_rename() {
         let source = r#"
             pub variant Op {
@@ -6000,7 +6077,7 @@ line 2
                 && let Condition::LetChain { elements, .. } = &if_stmt.condition
                 && let crate::ast::ConditionElement::Let { pattern, .. } = &elements[0]
             {
-                return pattern.clone();
+                return (**pattern).clone();
             }
         }
         panic!("failed to parse pattern from: {source}");

--- a/wado-compiler/src/resolver/item.rs
+++ b/wado-compiler/src/resolver/item.rs
@@ -403,9 +403,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
             let cm_name = method
                 .attrs
                 .iter()
-                .find(|a| a.name == "cm")
-                .and_then(|a| a.args.first())
-                .map(|a| a.as_str().to_string());
+                .find_map(|a| a.cm_arg_str().map(str::to_string));
             ops.push(TirEffectOp {
                 name: method.name.clone(),
                 params,

--- a/wado-compiler/src/resolver/item.rs
+++ b/wado-compiler/src/resolver/item.rs
@@ -403,7 +403,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
             let cm_name = method
                 .attrs
                 .iter()
-                .find_map(|a| a.cm_arg_str().map(str::to_string));
+                .find_map(crate::ast::Attribute::cm_identifier);
             ops.push(TirEffectOp {
                 name: method.name.clone(),
                 params,

--- a/wado-compiler/src/resolver/item.rs
+++ b/wado-compiler/src/resolver/item.rs
@@ -788,15 +788,11 @@ impl<H: CompilerHost> Resolver<'_, H> {
         // parameter at the boundary, so defaults cannot divergently exist
         // only on the Wado side.
         // A function crosses the Component Model boundary when it is either
-        // exported (`export fn ...`) or imported (declaration with no body,
-        // typically carrying `#[canonical(...)]` or `#[cm(...)]`). Closures
-        // may not appear in either side's signature.
-        let is_cm_import = func.body.is_none()
-            && (func.attrs.iter().any(|a| a.cm_import.is_some())
-                || func
-                    .attrs
-                    .iter()
-                    .any(|a| a.name == "canonical" || a.name == "cm"));
+        // exported (`export fn ...`) or imported (declaration with no body
+        // carrying `#[canonical(...)]` or `#[cm(...)]`). Closures may not
+        // appear in either side's signature.
+        let is_cm_import =
+            func.body.is_none() && func.attrs.iter().any(|a| a.cm_boundary.is_some());
         let crosses_cm_boundary = func.is_export || is_cm_import;
 
         let mut params = Vec::new();

--- a/wado-compiler/src/resolver/method_call.rs
+++ b/wado-compiler/src/resolver/method_call.rs
@@ -1369,9 +1369,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         return method
                             .attrs
                             .iter()
-                            .find(|a| a.name == "cm")
-                            .and_then(|a| a.args.first())
-                            .map(|a| a.as_str().to_string());
+                            .find_map(|a| a.cm_arg_str().map(str::to_string));
                     }
                 }
             }

--- a/wado-compiler/src/resolver/method_call.rs
+++ b/wado-compiler/src/resolver/method_call.rs
@@ -1369,7 +1369,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         return method
                             .attrs
                             .iter()
-                            .find_map(|a| a.cm_arg_str().map(str::to_string));
+                            .find_map(crate::ast::Attribute::cm_identifier);
                     }
                 }
             }

--- a/wado-compiler/src/resolver/method_lookup.rs
+++ b/wado-compiler/src/resolver/method_lookup.rs
@@ -944,9 +944,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
             let cm_name = method
                 .attrs
                 .iter()
-                .find(|a| a.name == "cm")
-                .and_then(|a| a.args.first())
-                .map(|a| a.as_str().to_string());
+                .find_map(|a| a.cm_arg_str().map(str::to_string));
 
             return Some(MethodInfo {
                 return_type,

--- a/wado-compiler/src/resolver/method_lookup.rs
+++ b/wado-compiler/src/resolver/method_lookup.rs
@@ -944,7 +944,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
             let cm_name = method
                 .attrs
                 .iter()
-                .find_map(|a| a.cm_arg_str().map(str::to_string));
+                .find_map(crate::ast::Attribute::cm_identifier);
 
             return Some(MethodInfo {
                 return_type,

--- a/wado-compiler/src/resolver/stmt.rs
+++ b/wado-compiler/src/resolver/stmt.rs
@@ -2607,7 +2607,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
             id: for_of.id,
             condition: Condition::LetChain {
                 elements: vec![ConditionElement::Let {
-                    pattern: some_pattern,
+                    pattern: Box::new(some_pattern),
                     expr: next_call,
                     span,
                 }],

--- a/wado-compiler/src/world_registry.rs
+++ b/wado-compiler/src/world_registry.rs
@@ -237,17 +237,7 @@ pub struct WorldRegistry {
 fn fq_name_from_attrs(attrs: &[crate::ast::Attribute]) -> Option<String> {
     attrs
         .iter()
-        .find(|a| a.name == "cm")
-        .and_then(|a| a.args.first())
-        .map(|arg| {
-            let s = arg.as_str();
-            // Strip version suffix (e.g., "@0.3.0-rc-2026-01-06")
-            if let Some(at_pos) = s.find('@') {
-                s[..at_pos].to_string()
-            } else {
-                s.to_string()
-            }
-        })
+        .find_map(|a| a.as_cm_import().map(crate::ast::CmImport::bare_path))
 }
 
 impl WorldRegistry {
@@ -397,7 +387,9 @@ mod tests {
             attrs: vec![Attribute {
                 name: "cm".to_string(),
                 args: vec![ast::AttrArg::Str("wasi:cli/command@0.3.0".to_string())],
-                cm_boundary: None,
+                cm_boundary: Some(crate::ast::CmBoundary::Import(
+                    crate::ast::CmImport::parse("wasi:cli/command@0.3.0").unwrap(),
+                )),
                 span: make_span(),
             }],
             imports: vec![],

--- a/wado-compiler/src/world_registry.rs
+++ b/wado-compiler/src/world_registry.rs
@@ -397,7 +397,7 @@ mod tests {
             attrs: vec![Attribute {
                 name: "cm".to_string(),
                 args: vec![ast::AttrArg::Str("wasi:cli/command@0.3.0".to_string())],
-                cm_import: None,
+                cm_boundary: None,
                 span: make_span(),
             }],
             imports: vec![],

--- a/wado-compiler/tests/common.rs
+++ b/wado-compiler/tests/common.rs
@@ -659,6 +659,10 @@ mod timezone_host {
     #[cfg(unix)]
     fn local_offset_nanos(secs: i64) -> Option<i64> {
         use std::mem::MaybeUninit;
+        // `libc::time_t` is `i64` on 64-bit Linux/macOS but `i32` on some
+        // platforms; keep the conversion fallible for portability even where
+        // clippy would call it useless on the current target.
+        #[allow(clippy::useless_conversion)]
         let t: libc::time_t = secs.try_into().ok()?;
         let mut tm: MaybeUninit<libc::tm> = MaybeUninit::uninit();
         let ret = unsafe { libc::localtime_r(&raw const t, tm.as_mut_ptr()) };


### PR DESCRIPTION
Closes #1082.

## Summary

Component Model boundary attributes were spread across three different signals — `Attribute::cm_import: Option<CmImport>`, the string match `attr.name == "cm"`, and the string match `attr.name == "canonical"` — and seven different consumers each re-parsed the same `ns:pkg/iface[@v][#fn]` format with their own `split('#')` / `split('@')` calls. Detecting "this function crosses the CM boundary" required OR-ing three signals together.

This branch consolidates the model so that:

- The parser is the single source of truth for the shape of `#[cm(...)]` and `#[canonical(...)]`.
- Every consumer reads a typed `CmBoundary` enum or one of its accessors; no consumer pattern-matches attribute names by string except the parser itself.
- Consumers read the parsed `cm_boundary` payload rather than reaching back into `attr.args[0]`, so the source-text of the attribute is no longer a parallel source of truth.
- Malformed shapes (`#[canonical("one")]`, `#[cm]`, `#[cm("a", "b")]`, non-string arguments) are rejected as parse errors instead of being silently dropped.

## Design

`Attribute::cm_import: Option<CmImport>` becomes `Attribute::cm_boundary: Option<CmBoundary>`:

```rust
pub enum CmBoundary {
    /// `#[canonical("namespace", "name")]` — CM canonical built-in
    /// (e.g. `canon.task.return`, `canon.stream.new`).
    Canonical { namespace: String, name: String },
    /// `#[cm("namespace:package/interface[@version][#function]")]` — an
    /// import from a real CM interface.
    Import(CmImport),
    /// `#[cm("simple-name")]` — a single CM-side identifier used for a
    /// variant case, field, or method.
    Name(String),
}
```

Helpers added:

- `Attribute::as_cm_import(&self) -> Option<&CmImport>` — typed access for consumers that only care about full CM imports.
- `Attribute::cm_identifier(&self) -> Option<String>` / `CmBoundary::cm_identifier(&self) -> Option<String>` — reconstructs the CM-side identifier (`"ns:pkg/iface[@v][#fn]"` for `Import`, the bare string for `Name`, `None` for `Canonical`) from the parsed payload. Replaces the four ad-hoc `attr.args[0]` reads that previously did this.
- `CmImport::full_path(&self) -> String` — reconstructs `"ns:pkg/iface[@v][#fn]"`.
- `CmImport::bare_path(&self) -> String` — returns `"ns:pkg/iface"` without version or function.

The seven existing consumers (`component_model.rs`, three `resolver/*` files, `world_registry.rs`, `builtin_registry.rs`) are migrated to these typed entry points. `builtin_registry::register` in particular replaces positional `args[0]` / `args[1]` indexing with a `match` on `CmBoundary::Canonical { namespace, name }`.

After the migration, `name == "cm"` and `name == "canonical"` survive only inside `parser::parse_cm_boundary`, the one function that owns the mapping from attribute names to typed variants.

## Behaviour changes

- `#[canonical(...)]` without exactly two string arguments, and `#[cm(...)]` without exactly one string argument, now produce parse errors at the offending span. Previously these slipped through the parser silently.
- The closure CM-boundary check in `resolver::item` (the motivating site for #1082) is now `attr.cm_boundary.is_some()` instead of OR-ing `cm_import.is_some()` with two name-based string matches.

## Incidental

- `ConditionElement::Let::pattern` is boxed to silence the pre-existing `clippy::large_enum_variant` lint that was tripping `cargo clippy --all-targets` on the wado-compiler crate.
- The portable `i64`-to-`libc::time_t` cast in `tests/common.rs` is annotated `#[allow(useless_conversion)]` for the same reason.
