### PR TITLE
Route remaining hard-coded stdlib references through `CompilerItem`

### DIFF
--- a/docs/stdlib-core-simd.md
+++ b/docs/stdlib-core-simd.md
@@ -10,11 +10,11 @@ All types are newtypes of the primitive `v128` and can be freely reinterpreted v
 
 ## Types
 
-| Category         | Types                              |
-| ---------------- | ---------------------------------- |
-| Signed integer   | `i8x16`, `i16x8`, `i32x4`, `i64x2` |
+| Category | Types |
+|----------|-------|
+| Signed integer | `i8x16`, `i16x8`, `i32x4`, `i64x2` |
 | Unsigned integer | `u8x16`, `u16x8`, `u32x4`, `u64x2` |
-| Floating-point   | `f32x4`, `f64x2`                   |
+| Floating-point | `f32x4`, `f64x2` |
 
 ## Construction
 

--- a/docs/stdlib-core-simd.md
+++ b/docs/stdlib-core-simd.md
@@ -10,11 +10,11 @@ All types are newtypes of the primitive `v128` and can be freely reinterpreted v
 
 ## Types
 
-| Category | Types |
-|----------|-------|
-| Signed integer | `i8x16`, `i16x8`, `i32x4`, `i64x2` |
+| Category         | Types                              |
+| ---------------- | ---------------------------------- |
+| Signed integer   | `i8x16`, `i16x8`, `i32x4`, `i64x2` |
 | Unsigned integer | `u8x16`, `u16x8`, `u32x4`, `u64x2` |
-| Floating-point | `f32x4`, `f64x2` |
+| Floating-point   | `f32x4`, `f64x2`                   |
 
 ## Construction
 

--- a/wado-compiler/lib/core/prelude/array.wado
+++ b/wado-compiler/lib/core/prelude/array.wado
@@ -27,6 +27,7 @@ fn i32_max(a: i32, b: i32) -> i32 {
     return builtin::select(a > b, a, b);
 }
 
+#[compiler_item("array")]
 pub struct Array<T> {
     repr: builtin::array<T>,
     used: i32,

--- a/wado-compiler/lib/core/prelude/int128.wado
+++ b/wado-compiler/lib/core/prelude/int128.wado
@@ -22,12 +22,14 @@ pub struct u128 {
 
 impl u128 {
     /// Create a u128 from a u64 value (zero-extended)
+    #[compiler_item("u128_from_u64")]
     pub fn from_u64(value: u64) -> u128 {
         return u128 { low: value, high: 0 };
     }
 
     /// Create a u128 from low and high 64-bit parts
     /// Used by the compiler for efficient large literal construction
+    #[compiler_item("u128_from_pair")]
     pub fn from_pair(low: u64, high: u64) -> u128 {
         return u128 { low, high };
     }
@@ -616,6 +618,7 @@ pub struct i128 {
 
 impl i128 {
     /// Create an i128 from an i64 value (sign-extended)
+    #[compiler_item("i128_from_i64")]
     pub fn from_i64(value: i64) -> i128 {
         // Sign extend: if value is negative, high bits are all 1s (-1)
         let high: i64 = if value < 0 { -1 } else { 0 };
@@ -624,6 +627,7 @@ impl i128 {
 
     /// Create an i128 from low and high 64-bit parts
     /// Used by the compiler for efficient large literal construction
+    #[compiler_item("i128_from_pair")]
     pub fn from_pair(low: u64, high: i64) -> i128 {
         return i128 { low, high };
     }

--- a/wado-compiler/lib/core/prelude/int128.wado
+++ b/wado-compiler/lib/core/prelude/int128.wado
@@ -14,6 +14,7 @@ use {
 
 /// Unsigned 128-bit integer
 /// Stored as two 64-bit parts: low (bits 0-63) and high (bits 64-127)
+#[compiler_item("u128")]
 pub struct u128 {
     low: u64,
     high: u64,
@@ -607,6 +608,7 @@ impl Rem for u128 {
 
 /// Signed 128-bit integer
 /// Stored as two 64-bit parts: low (bits 0-63, unsigned) and high (bits 64-127, signed)
+#[compiler_item("i128")]
 pub struct i128 {
     low: u64,
     high: i64,

--- a/wado-compiler/lib/core/prelude/string.wado
+++ b/wado-compiler/lib/core/prelude/string.wado
@@ -18,6 +18,7 @@ fn byte_to_ascii_lowercase(b: u8) -> u8 {
     return b | (b >= 'A' as u8 && b <= 'Z' as u8) as u8 * ('A' as u8 ^ 'a' as u8);
 }
 /// UTF-8 encoded string type with O(1) amortized push_str
+#[compiler_item("string")]
 pub struct String {
     repr: builtin::array<u8>,
     used: i32,

--- a/wado-compiler/lib/core/prelude/traits.wado
+++ b/wado-compiler/lib/core/prelude/traits.wado
@@ -4,6 +4,7 @@
 #![stdlib("core:prelude/traits.wado")]
 
 /// Result of a comparison between two values.
+#[compiler_item("ordering")]
 pub enum Ordering {
     /// The first value is less than the second.
     Less,
@@ -35,6 +36,7 @@ impl<T> Eq for &mut T {
 
 /// Trait for ordering comparisons.
 /// Types implementing this trait can be compared with `<`, `<=`, `>`, `>=` operators.
+#[compiler_item("ord")]
 pub trait Ord {
     /// Compares self with other and returns an Ordering.
     fn cmp(&self, other: &Self) -> Ordering;

--- a/wado-compiler/lib/core/prelude/traits.wado
+++ b/wado-compiler/lib/core/prelude/traits.wado
@@ -15,6 +15,7 @@ pub enum Ordering {
 
 /// Trait for equality comparisons.
 /// Types implementing this trait can be compared with `==` and `!=` operators.
+#[compiler_item("eq")]
 pub trait Eq {
     /// Returns true if self equals other.
     fn eq(&self, other: &Self) -> bool;

--- a/wado-compiler/src/compiler_host.rs
+++ b/wado-compiler/src/compiler_host.rs
@@ -152,6 +152,10 @@ pub enum Code {
     /// `wado check` re-ran the generator and the output bytes differ from
     /// the on-disk (committed) file. Promoted to error in CI default.
     KilnGeneratedStaleOnDisk,
+    /// A `#[compiler_item("...")]` attribute is malformed — the name
+    /// is unknown, the attribute is attached to the wrong declaration
+    /// kind, or it appears outside a `core::*` stdlib module.
+    CompilerItemAttr,
 }
 
 impl std::fmt::Display for Code {
@@ -189,6 +193,7 @@ impl std::fmt::Display for Code {
             Code::KilnGeneratedModified => "KILN_GENERATED_MODIFIED",
             Code::KilnGeneratedRegenerated => "KILN_GENERATED_REGENERATED",
             Code::KilnGeneratedStaleOnDisk => "KILN_GENERATED_STALE_ON_DISK",
+            Code::CompilerItemAttr => "COMPILER_ITEM_ATTR",
         };
         write!(f, "{name}")
     }

--- a/wado-compiler/src/compiler_item.rs
+++ b/wado-compiler/src/compiler_item.rs
@@ -200,6 +200,59 @@ impl CompilerItem {
         Self::ALL.iter().copied().find(|i| i.attr_name() == name)
     }
 
+    /// Whether the registry must contain this item by the end of
+    /// resolution for compilation of `world` to succeed.
+    ///
+    /// Items declared in `core::prelude::*` are always required — they
+    /// underpin the core type system and the prelude is auto-loaded
+    /// regardless of target world. Items declared in worlds the user
+    /// did not opt into (e.g. `core:kiln/generator` for
+    /// [`Self::KilnRequest`], `core:serde` for [`Self::Serialize`] /
+    /// [`Self::Deserialize`]) are only required when the matching
+    /// world / module is actually loaded; tracking that here keeps the
+    /// validator from spuriously failing in CLI / HTTP builds that
+    /// don't pull in kiln or serde.
+    ///
+    /// The validator scans this method for every [`Self::ALL`]
+    /// variant after `annotate_modules` runs; a `true` return on an
+    /// unregistered item is a hard error at compile time, surfacing
+    /// the missing stdlib annotation immediately rather than at the
+    /// first synthesis call that reaches for it.
+    pub fn is_required(self, world: &str) -> bool {
+        match self {
+            // Always loaded — `core:prelude` is auto-imported.
+            Self::Array
+            | Self::Box
+            | Self::I128
+            | Self::U128
+            | Self::RangeExclusive
+            | Self::RangeInclusive
+            | Self::String
+            | Self::Option
+            | Self::Result
+            | Self::Default
+            | Self::Eq
+            | Self::From
+            | Self::ArrayPush
+            | Self::StringPushStr
+            | Self::StringPushChar
+            | Self::StringGetByteUnchecked
+            | Self::I128FromI64
+            | Self::I128FromPair
+            | Self::U128FromU64
+            | Self::U128FromPair
+            | Self::Tuple => true,
+            // Kiln generator world only.
+            Self::KilnRequest => world == "core:kiln/generator",
+            // Loaded only when the user imports `core:serde` (which
+            // happens implicitly for kiln-options decoding). The
+            // validator skips the check; downstream synthesis ICEs
+            // with a clear message if the items are reached for
+            // without being registered.
+            Self::Serialize | Self::Deserialize => false,
+        }
+    }
+
     /// The kind of declaration this item must be attached to. Used by
     /// the resolver to reject misuse like
     /// `#[compiler_item("option")]` on a trait.
@@ -538,6 +591,19 @@ impl CompilerItems {
             _ => None,
         }
     }
+
+    /// List every required-but-missing [`CompilerItem`] for the given
+    /// `world`. The resolver calls this after `annotate_modules` so an
+    /// unregistered prelude item (or world-specific item for the
+    /// active world) fails the compile with a clear diagnostic
+    /// instead of an ICE deep inside synthesis.
+    pub fn missing_required(&self, world: &str) -> Vec<CompilerItem> {
+        CompilerItem::ALL
+            .iter()
+            .copied()
+            .filter(|item| item.is_required(world) && self.get(*item).is_none())
+            .collect()
+    }
 }
 
 #[cold]
@@ -726,6 +792,88 @@ mod tests {
         let reg = CompilerItems::default();
         for &item in CompilerItem::ALL {
             assert!(reg.get(item).is_none(), "{item} should start empty");
+        }
+    }
+
+    /// Regression for issue #1077: the Rust side must not depend on
+    /// the source-level method name. Register `StringPushStr` with a
+    /// name that does *not* match the conventional `push_str` spelling
+    /// and verify the registry hands that name back through
+    /// [`CompilerItems::require_method`]. This locks in the contract:
+    /// a Wado-side rename of a stdlib method is transparent to the
+    /// Rust compiler as long as `#[compiler_item("...")]` stays put.
+    #[test]
+    fn method_name_round_trips_through_registry_even_when_renamed() {
+        let mut reg = CompilerItems::new();
+        reg.register(
+            CompilerItem::StringPushStr,
+            Resolved::Method {
+                module_source: ModuleSource::string(),
+                owner_type: "String".to_string(),
+                name: "push_str_v2".to_string(),
+            },
+        )
+        .unwrap();
+        let (module, owner, name) = reg.require_method(CompilerItem::StringPushStr);
+        assert_eq!(module, &ModuleSource::string());
+        assert_eq!(owner, "String");
+        assert_eq!(name, "push_str_v2");
+    }
+
+    /// Counterpart to the rename-rewrite test: omitting the
+    /// `#[compiler_item("...")]` annotation entirely leaves the
+    /// registry empty for that item, so `get()` returns `None`. The
+    /// documented ICE in `require_method` only fires when a downstream
+    /// pass reaches for the item — the validator detects the missing
+    /// registration before that point. This test pins both halves of
+    /// the contract.
+    #[test]
+    fn missing_registration_returns_none() {
+        let reg = CompilerItems::new();
+        assert!(reg.get(CompilerItem::StringPushStr).is_none());
+    }
+
+    /// `require_method` is documented to panic with a clear ICE
+    /// message when the item is unregistered. Lock that message
+    /// shape so the validator's failure mode and the post-validator
+    /// ICE remain consistent.
+    #[test]
+    #[should_panic(expected = "compiler item `string_push_str` is not registered")]
+    fn require_panics_on_unregistered() {
+        let reg = CompilerItems::new();
+        let _ = reg.require_method(CompilerItem::StringPushStr);
+    }
+
+    /// Validator covers every required item in `ALL`. With an empty
+    /// registry, every prelude-required item should appear in
+    /// `missing_required`; world-specific items (KilnRequest,
+    /// Serialize, Deserialize) should appear only for their world.
+    #[test]
+    fn missing_required_scopes_by_world() {
+        let reg = CompilerItems::new();
+        let cli_missing = reg.missing_required("core:cli/command");
+        let kiln_missing = reg.missing_required("core:kiln/generator");
+        assert!(
+            !cli_missing.contains(&CompilerItem::KilnRequest),
+            "KilnRequest is kiln-specific and must not be required in CLI builds",
+        );
+        assert!(
+            kiln_missing.contains(&CompilerItem::KilnRequest),
+            "KilnRequest must be required when targeting kiln/generator",
+        );
+        // Prelude items must show up regardless of world.
+        for &core in &[
+            CompilerItem::Option,
+            CompilerItem::Result,
+            CompilerItem::Eq,
+            CompilerItem::From,
+            CompilerItem::String,
+            CompilerItem::Array,
+            CompilerItem::I128,
+            CompilerItem::U128,
+        ] {
+            assert!(cli_missing.contains(&core), "{core} should be required in CLI world");
+            assert!(kiln_missing.contains(&core), "{core} should be required in kiln world");
         }
     }
 }

--- a/wado-compiler/src/compiler_item.rs
+++ b/wado-compiler/src/compiler_item.rs
@@ -105,6 +105,18 @@ pub enum CompilerItem {
     /// through this item so renames in the stdlib do not silently
     /// break code generation. See issue #1077.
     StringGetByteUnchecked,
+    /// `i128::from_i64` — sign-extending constructor used by the
+    /// wide-int literal lowering pass.
+    I128FromI64,
+    /// `i128::from_pair` — low/high pair constructor used by the
+    /// wide-int literal lowering pass.
+    I128FromPair,
+    /// `u128::from_u64` — zero-extending constructor used by the
+    /// wide-int literal lowering pass.
+    U128FromU64,
+    /// `u128::from_pair` — low/high pair constructor used by the
+    /// wide-int literal lowering pass.
+    U128FromPair,
 
     // ── Type families ─────────────────────────────────────────────────
     /// The tuple type family (`pub type [..T];`). The owning module is
@@ -136,6 +148,10 @@ impl CompilerItem {
         Self::StringPushStr,
         Self::StringPushChar,
         Self::StringGetByteUnchecked,
+        Self::I128FromI64,
+        Self::I128FromPair,
+        Self::U128FromU64,
+        Self::U128FromPair,
         Self::Tuple,
     ];
 
@@ -169,6 +185,10 @@ impl CompilerItem {
             Self::StringPushStr => "string_push_str",
             Self::StringPushChar => "string_push_char",
             Self::StringGetByteUnchecked => "string_get_byte_unchecked",
+            Self::I128FromI64 => "i128_from_i64",
+            Self::I128FromPair => "i128_from_pair",
+            Self::U128FromU64 => "u128_from_u64",
+            Self::U128FromPair => "u128_from_pair",
             Self::Tuple => "tuple",
         }
     }
@@ -200,7 +220,11 @@ impl CompilerItem {
             Self::ArrayPush
             | Self::StringPushStr
             | Self::StringPushChar
-            | Self::StringGetByteUnchecked => CompilerItemKind::Method,
+            | Self::StringGetByteUnchecked
+            | Self::I128FromI64
+            | Self::I128FromPair
+            | Self::U128FromU64
+            | Self::U128FromPair => CompilerItemKind::Method,
             Self::Tuple => CompilerItemKind::TupleFamily,
         }
     }

--- a/wado-compiler/src/compiler_item.rs
+++ b/wado-compiler/src/compiler_item.rs
@@ -74,6 +74,12 @@ pub enum CompilerItem {
     /// `Result<T, E>` — `Ok(_)` / `Err(_)`.
     Result,
 
+    // ── Enums (sum types without payload) ─────────────────────────────
+    /// `Ordering` — return type of `Ord::cmp`. Recognised by operator
+    /// dispatch and by the trait-synthesis pass that emits
+    /// `T^Ord::cmp` bodies.
+    Ordering,
+
     // ── Traits ────────────────────────────────────────────────────────
     /// `Default` — `Default::default()` synthesis anchor.
     Default,
@@ -81,6 +87,9 @@ pub enum CompilerItem {
     /// auto-derive checks that decide whether a compound type
     /// (struct, variant, generic instance) implements `Eq`.
     Eq,
+    /// `Ord` — anchor for synthesised `<` / `>` / `<=` / `>=`
+    /// lowering and for auto-derived `T^Ord::cmp` bodies.
+    Ord,
     /// `From<T>` — synthesised by the `From` synthesiser.
     From,
     /// `core:serde::Serialize` — anchor for `Serialize` impl synthesis.
@@ -139,8 +148,10 @@ impl CompilerItem {
         Self::String,
         Self::Option,
         Self::Result,
+        Self::Ordering,
         Self::Default,
         Self::Eq,
+        Self::Ord,
         Self::From,
         Self::Serialize,
         Self::Deserialize,
@@ -176,8 +187,10 @@ impl CompilerItem {
             Self::String => "string",
             Self::Option => "option",
             Self::Result => "result",
+            Self::Ordering => "ordering",
             Self::Default => "default",
             Self::Eq => "eq",
+            Self::Ord => "ord",
             Self::From => "from",
             Self::Serialize => "serialize",
             Self::Deserialize => "deserialize",
@@ -230,8 +243,10 @@ impl CompilerItem {
             | Self::String
             | Self::Option
             | Self::Result
+            | Self::Ordering
             | Self::Default
             | Self::Eq
+            | Self::Ord
             | Self::From
             | Self::ArrayPush
             | Self::StringPushStr
@@ -267,9 +282,13 @@ impl CompilerItem {
             | Self::KilnRequest
             | Self::String => CompilerItemKind::Struct,
             Self::Option | Self::Result => CompilerItemKind::Variant,
-            Self::Default | Self::Eq | Self::From | Self::Serialize | Self::Deserialize => {
-                CompilerItemKind::Trait
-            }
+            Self::Ordering => CompilerItemKind::Enum,
+            Self::Default
+            | Self::Eq
+            | Self::Ord
+            | Self::From
+            | Self::Serialize
+            | Self::Deserialize => CompilerItemKind::Trait,
             Self::ArrayPush
             | Self::StringPushStr
             | Self::StringPushChar
@@ -301,6 +320,8 @@ pub enum CompilerItemKind {
     Struct,
     /// A `variant` declaration (`Option`, `Result`).
     Variant,
+    /// An `enum` declaration (`Ordering`).
+    Enum,
     /// A `trait` declaration.
     Trait,
     /// A method inside an `impl` block.
@@ -314,6 +335,7 @@ impl fmt::Display for CompilerItemKind {
         f.write_str(match self {
             Self::Struct => "struct",
             Self::Variant => "variant",
+            Self::Enum => "enum",
             Self::Trait => "trait",
             Self::Method => "method",
             Self::TupleFamily => "tuple type family",
@@ -341,6 +363,10 @@ pub enum Resolved {
         module_source: ModuleSource,
         name: String,
     },
+    Enum {
+        module_source: ModuleSource,
+        name: String,
+    },
     Trait {
         module_source: ModuleSource,
         name: String,
@@ -364,6 +390,7 @@ impl Resolved {
         match self {
             Self::Struct { .. } => CompilerItemKind::Struct,
             Self::Variant { .. } => CompilerItemKind::Variant,
+            Self::Enum { .. } => CompilerItemKind::Enum,
             Self::Trait { .. } => CompilerItemKind::Trait,
             Self::Method { .. } => CompilerItemKind::Method,
             Self::TupleFamily { .. } => CompilerItemKind::TupleFamily,
@@ -376,6 +403,7 @@ impl Resolved {
         match self {
             Self::Struct { module_source, .. }
             | Self::Variant { module_source, .. }
+            | Self::Enum { module_source, .. }
             | Self::Trait { module_source, .. }
             | Self::Method { module_source, .. }
             | Self::TupleFamily { module_source } => module_source,
@@ -520,6 +548,18 @@ impl CompilerItems {
         }
     }
 
+    /// Module + enum name of a [`CompilerItemKind::Enum`] item
+    /// (`Ordering`).
+    pub fn require_enum(&self, item: CompilerItem) -> (&ModuleSource, &str) {
+        match self.require(item) {
+            Resolved::Enum {
+                module_source,
+                name,
+            } => (module_source, name.as_str()),
+            other => kind_mismatch_ice(item, "Enum", other),
+        }
+    }
+
     /// Module + trait name of a [`CompilerItemKind::Trait`] item.
     pub fn require_trait(&self, item: CompilerItem) -> (&ModuleSource, &str) {
         match self.require(item) {
@@ -547,6 +587,11 @@ impl CompilerItems {
     /// Name-only convenience for a [`CompilerItemKind::Variant`] item.
     pub fn variant_name(&self, item: CompilerItem) -> &str {
         self.require_variant(item).1
+    }
+
+    /// Name-only convenience for a [`CompilerItemKind::Enum`] item.
+    pub fn enum_name(&self, item: CompilerItem) -> &str {
+        self.require_enum(item).1
     }
 
     /// Name-only convenience for a [`CompilerItemKind::Method`] item.

--- a/wado-compiler/src/compiler_item.rs
+++ b/wado-compiler/src/compiler_item.rs
@@ -45,9 +45,17 @@ use crate::module_source::ModuleSource;
 #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum CompilerItem {
     // ── Types (structs / generic structs) ────────────────────────────
+    /// `Array<T>` — the heap-backed sequence struct. Recognised by
+    /// the CM lift, value-copy synthesis, and serde codegen so the
+    /// compiler always points at the right concrete `Array` struct.
+    Array,
     /// `Box<T>` — boxes primitive values into a struct that
     /// participates in GC tracing.
     Box,
+    /// `i128` — the signed 128-bit wide-int struct.
+    I128,
+    /// `u128` — the unsigned 128-bit wide-int struct.
+    U128,
     /// `RangeExclusive<T>` — `a..b` literals.
     RangeExclusive,
     /// `RangeInclusive<T>` — `a..=b` literals.
@@ -55,6 +63,10 @@ pub enum CompilerItem {
     /// `Request<T>` — the Kiln CM adapter wraps decoded options in
     /// this struct.
     KilnRequest,
+    /// `String` — the GC-backed UTF-8 string struct. Synthesised
+    /// codegen (CM binding, serde, format) refers to it through this
+    /// item so the Rust side never hard-codes the struct name.
+    String,
 
     // ── Variants (sum types) ──────────────────────────────────────────
     /// `Option<T>` — `Some(_)` / `None`.
@@ -105,10 +117,14 @@ impl CompilerItem {
     /// Every variant, in declaration order. Used by validation passes
     /// that need to check the full registry.
     pub const ALL: &'static [CompilerItem] = &[
+        Self::Array,
         Self::Box,
+        Self::I128,
+        Self::U128,
         Self::RangeExclusive,
         Self::RangeInclusive,
         Self::KilnRequest,
+        Self::String,
         Self::Option,
         Self::Result,
         Self::Default,
@@ -134,10 +150,14 @@ impl CompilerItem {
     /// references must agree.
     pub fn attr_name(self) -> &'static str {
         match self {
+            Self::Array => "array",
             Self::Box => "box",
+            Self::I128 => "i128",
+            Self::U128 => "u128",
             Self::RangeExclusive => "range_exclusive",
             Self::RangeInclusive => "range_inclusive",
             Self::KilnRequest => "kiln_request",
+            Self::String => "string",
             Self::Option => "option",
             Self::Result => "result",
             Self::Default => "default",
@@ -165,9 +185,14 @@ impl CompilerItem {
     /// `#[compiler_item("option")]` on a trait.
     pub fn expected_kind(self) -> CompilerItemKind {
         match self {
-            Self::Box | Self::RangeExclusive | Self::RangeInclusive | Self::KilnRequest => {
-                CompilerItemKind::Struct
-            }
+            Self::Array
+            | Self::Box
+            | Self::I128
+            | Self::U128
+            | Self::RangeExclusive
+            | Self::RangeInclusive
+            | Self::KilnRequest
+            | Self::String => CompilerItemKind::Struct,
             Self::Option | Self::Result => CompilerItemKind::Variant,
             Self::Default | Self::Eq | Self::From | Self::Serialize | Self::Deserialize => {
                 CompilerItemKind::Trait

--- a/wado-compiler/src/compiler_item.rs
+++ b/wado-compiler/src/compiler_item.rs
@@ -846,7 +846,7 @@ mod tests {
 
     /// Validator covers every required item in `ALL`. With an empty
     /// registry, every prelude-required item should appear in
-    /// `missing_required`; world-specific items (KilnRequest,
+    /// `missing_required`; world-specific items (`KilnRequest`,
     /// Serialize, Deserialize) should appear only for their world.
     #[test]
     fn missing_required_scopes_by_world() {
@@ -872,8 +872,14 @@ mod tests {
             CompilerItem::I128,
             CompilerItem::U128,
         ] {
-            assert!(cli_missing.contains(&core), "{core} should be required in CLI world");
-            assert!(kiln_missing.contains(&core), "{core} should be required in kiln world");
+            assert!(
+                cli_missing.contains(&core),
+                "{core} should be required in CLI world"
+            );
+            assert!(
+                kiln_missing.contains(&core),
+                "{core} should be required in kiln world"
+            );
         }
     }
 }

--- a/wado-compiler/src/compiler_item.rs
+++ b/wado-compiler/src/compiler_item.rs
@@ -65,6 +65,10 @@ pub enum CompilerItem {
     // ── Traits ────────────────────────────────────────────────────────
     /// `Default` — `Default::default()` synthesis anchor.
     Default,
+    /// `Eq` — anchor for synthesised `==` / `!=` lowering and the
+    /// auto-derive checks that decide whether a compound type
+    /// (struct, variant, generic instance) implements `Eq`.
+    Eq,
     /// `From<T>` — synthesised by the `From` synthesiser.
     From,
     /// `core:serde::Serialize` — anchor for `Serialize` impl synthesis.
@@ -108,6 +112,7 @@ impl CompilerItem {
         Self::Option,
         Self::Result,
         Self::Default,
+        Self::Eq,
         Self::From,
         Self::Serialize,
         Self::Deserialize,
@@ -136,6 +141,7 @@ impl CompilerItem {
             Self::Option => "option",
             Self::Result => "result",
             Self::Default => "default",
+            Self::Eq => "eq",
             Self::From => "from",
             Self::Serialize => "serialize",
             Self::Deserialize => "deserialize",
@@ -163,7 +169,7 @@ impl CompilerItem {
                 CompilerItemKind::Struct
             }
             Self::Option | Self::Result => CompilerItemKind::Variant,
-            Self::Default | Self::From | Self::Serialize | Self::Deserialize => {
+            Self::Default | Self::Eq | Self::From | Self::Serialize | Self::Deserialize => {
                 CompilerItemKind::Trait
             }
             Self::ArrayPush
@@ -421,6 +427,30 @@ impl CompilerItems {
             } => (module_source, name.as_str()),
             other => kind_mismatch_ice(item, "Trait", other),
         }
+    }
+
+    /// Name-only convenience for a [`CompilerItemKind::Trait`] item.
+    /// Equivalent to `require_trait(item).1`; the dedicated helper
+    /// keeps use sites readable when only the trait name is needed
+    /// (e.g. when constructing a synthesised `LocalMethodName`).
+    pub fn trait_name(&self, item: CompilerItem) -> &str {
+        self.require_trait(item).1
+    }
+
+    /// Name-only convenience for a [`CompilerItemKind::Struct`] item.
+    pub fn struct_name(&self, item: CompilerItem) -> &str {
+        self.require_struct(item).1
+    }
+
+    /// Name-only convenience for a [`CompilerItemKind::Variant`] item.
+    pub fn variant_name(&self, item: CompilerItem) -> &str {
+        self.require_variant(item).1
+    }
+
+    /// Name-only convenience for a [`CompilerItemKind::Method`] item.
+    /// Returns the unmangled method name (e.g. `"push_str"`).
+    pub fn method_name(&self, item: CompilerItem) -> &str {
+        self.require_method(item).2
     }
 
     /// Module-only accessor for a trait.

--- a/wado-compiler/src/doc.rs
+++ b/wado-compiler/src/doc.rs
@@ -262,7 +262,12 @@ fn build_doc_trait(t: &TraitDecl, trivia: &TriviaMap) -> DocTrait {
 
     DocTrait {
         signature: sig,
-        doc: extract_doc_comment(trivia, t.id, &t.span),
+        // Pass `t.attrs` so the doc comment lookup bridges over any
+        // `#[compiler_item("...")]` (or other) attribute that sits
+        // between the `///` block and the `pub trait` keyword.
+        // Without it the doc tool stops at the attribute line and the
+        // generated stdlib reference loses the trait's description.
+        doc: extract_doc_comment_with_attrs(trivia, t.id, &t.span, &t.attrs),
         associated_types,
         methods,
     }

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -451,6 +451,43 @@ fn compile_after_load<H: CompilerHost>(
         return Err(Bail);
     }
 
+    // Validate that every required `CompilerItem` was registered by the
+    // resolver. A missing required item is a stdlib bug — every Wado-side
+    // declaration that anchors a compiler item must carry the matching
+    // `#[compiler_item("...")]` attribute. Surfacing it here means the
+    // failure happens at compile time with a clear message, not at the
+    // first synthesis call that reaches for the unregistered item.
+    {
+        let module = package
+            .tir_modules
+            .values()
+            .next()
+            .expect("Package always has at least one TIR module after annotate");
+        let missing = module
+            .type_table
+            .borrow()
+            .compiler_items()
+            .missing_required(&package.target_world);
+        if !missing.is_empty() {
+            for item in &missing {
+                let _ = logger.error(compiler_host::Diagnostic {
+                    severity: compiler_host::Severity::Error,
+                    code: compiler_host::Code::CompilerItemAttr,
+                    message: format!(
+                        "required compiler item `{name}` is not registered; \
+                         the stdlib must declare a `#[compiler_item(\"{name}\")]` \
+                         attribute on the matching {kind} for target world `{world}`",
+                        name = item.attr_name(),
+                        kind = item.expected_kind(),
+                        world = package.target_world,
+                    ),
+                    span: None,
+                });
+            }
+            return Err(Bail);
+        }
+    }
+
     // === Phase 7b: Default-Value Purity Check ===
     // Every `param: T = expr` and `field: T = expr` must be pure. Runs before
     // synthesis so that auto-derived `Default::default()` bodies (which clone

--- a/wado-compiler/src/lower/plan/closure.rs
+++ b/wado-compiler/src/lower/plan/closure.rs
@@ -713,7 +713,8 @@ impl ClosureLowerer {
         let formatter_type =
             type_table.make_struct("Formatter".to_string(), ModuleSource::format());
         let formatter_mut_ref = type_table.make_mut_ref(formatter_type);
-        let string_type = type_table.make_compiler_struct(crate::compiler_item::CompilerItem::String);
+        let string_type =
+            type_table.make_compiler_struct(crate::compiler_item::CompilerItem::String);
 
         for (trait_name, method_name, payload) in [
             ("Inspect", "inspect", signature),

--- a/wado-compiler/src/lower/plan/closure.rs
+++ b/wado-compiler/src/lower/plan/closure.rs
@@ -704,7 +704,7 @@ impl ClosureLowerer {
         let formatter_type =
             type_table.make_struct("Formatter".to_string(), ModuleSource::format());
         let formatter_mut_ref = type_table.make_mut_ref(formatter_type);
-        let string_type = type_table.make_struct("String".to_string(), ModuleSource::string());
+        let string_type = type_table.make_compiler_struct(crate::compiler_item::CompilerItem::String);
 
         for (trait_name, method_name, payload) in [
             ("Inspect", "inspect", signature),

--- a/wado-compiler/src/lower/plan/closure.rs
+++ b/wado-compiler/src/lower/plan/closure.rs
@@ -466,7 +466,11 @@ impl ClosureLowerer {
                 _ => collected.return_type,
             };
 
-            let struct_name = format!("__Closure_{}", collected.id);
+            let struct_name = format!(
+                "{prefix}{id}",
+                prefix = crate::name::CLOSURE_STRUCT_PREFIX,
+                id = collected.id,
+            );
             let struct_type_id =
                 type_table.make_struct(struct_name.clone(), self.module_source.clone());
 
@@ -501,7 +505,8 @@ impl ClosureLowerer {
             // Use a qualified name to avoid collisions in the inliner's
             // candidate map. `LocalMethodName` stays unqualified so codegen
             // re-mangles it consistently with other methods.
-            let qualified_method_name = MethodName::format_local(&struct_name, None, "__call");
+            let qualified_method_name =
+                MethodName::format_local(&struct_name, None, crate::name::CLOSURE_CALL_METHOD);
             let self_ref_type = type_table.make_ref(struct_type_id);
 
             let mut params = Vec::with_capacity(1 + collected.params.len());
@@ -596,7 +601,11 @@ impl ClosureLowerer {
 
             // `method_info` carries the unmangled (struct, trait, method)
             // triple so codegen can produce the canonical mangled name.
-            let method_info = LocalMethodName::new(struct_name.clone(), None, "__call".to_string());
+            let method_info = LocalMethodName::new(
+                struct_name.clone(),
+                None,
+                crate::name::CLOSURE_CALL_METHOD.to_string(),
+            );
 
             let call_method = TirFunction {
                 module_source: self.module_source.clone(),

--- a/wado-compiler/src/lower/plan/globals.rs
+++ b/wado-compiler/src/lower/plan/globals.rs
@@ -81,9 +81,9 @@ fn default_value_for_type(type_id: TypeId, type_table: &TypeTable, span: Span) -
             crate::tir::PrimitiveType::I128 | crate::tir::PrimitiveType::U128 => {
                 // i128/u128 need special handling - call from_i64(0) / from_u64(0)
                 if matches!(prim, crate::tir::PrimitiveType::I128) {
-                    create_i128_literal(0, type_id, span)
+                    create_i128_literal(0, type_id, type_table, span)
                 } else {
-                    create_u128_literal(0, type_id, span)
+                    create_u128_literal(0, type_id, type_table, span)
                 }
             }
             crate::tir::PrimitiveType::F32 => TirExpr::new(

--- a/wado-compiler/src/lower/plan/pattern.rs
+++ b/wado-compiler/src/lower/plan/pattern.rs
@@ -43,6 +43,10 @@ pub fn plan(flat: &mut FlatPackage) {
     }
 
     let type_table = flat.type_table.borrow();
+    let eq_trait_name = type_table
+        .compiler_items()
+        .trait_name(crate::compiler_item::CompilerItem::Eq)
+        .to_string();
     for func_rc in &flat.functions {
         let mut func = func_rc.borrow_mut();
         if let Some(mut body) = func.body.take() {
@@ -50,8 +54,13 @@ pub fn plan(flat: &mut FlatPackage) {
             let local_count = func.local_count;
             let locals = std::mem::take(&mut func.locals);
 
-            let mut lowerer =
-                PatternLowerer::new(local_count, locals, &variant_case_map, &struct_fields_map);
+            let mut lowerer = PatternLowerer::new(
+                local_count,
+                locals,
+                eq_trait_name.clone(),
+                &variant_case_map,
+                &struct_fields_map,
+            );
             lowerer.lower_block(&mut body, &type_table);
 
             // Put the values back
@@ -255,6 +264,11 @@ struct PatternLowerer<'a> {
     local_count: u32,
     locals: Vec<TirLocal>,
     temp_counter: u32,
+    /// Canonical stdlib name of the `Eq` trait. Resolved once from the
+    /// compiler-item registry so synthesised `String^Eq::eq` calls
+    /// follow stdlib renames without falling back to a hard-coded
+    /// `"Eq"` literal.
+    eq_trait_name: String,
     /// Map from (`variant_name`, `module_source`) to a list of
     /// (`case_name`, `case_index`) pairs. The `module_source` axis
     /// is required because Wado allows two modules to each declare a
@@ -270,6 +284,7 @@ impl<'a> PatternLowerer<'a> {
     fn new(
         local_count: u32,
         locals: Vec<TirLocal>,
+        eq_trait_name: String,
         variant_case_map: &'a IndexMap<(String, ModuleSource), Vec<(String, u32)>>,
         struct_fields_map: &'a IndexMap<(String, ModuleSource), Vec<TirField>>,
     ) -> Self {
@@ -277,6 +292,7 @@ impl<'a> PatternLowerer<'a> {
             local_count,
             locals,
             temp_counter: 0,
+            eq_trait_name,
             variant_case_map,
             struct_fields_map,
         }
@@ -1342,18 +1358,20 @@ impl<'a> PatternLowerer<'a> {
         // The WIR translate phase handles ref wrapping for method calls,
         // so we pass the values directly and let translate handle self-kind adjustment.
         // However, the arg explicitly needs &String since that's the method signature.
+        let method_info = LocalMethodName::new(
+            "String".to_string(),
+            Some(self.eq_trait_name.clone()),
+            "eq".to_string(),
+        );
+        let mangled_name = method_info.to_mangled_name();
         TirExpr::new(
             TirExprKind::method_call(
                 Box::new(receiver),
                 FunctionRef {
                     module_source: ModuleSource::string(),
-                    name: "String^Eq::eq".to_string(),
+                    name: mangled_name,
                     monomorph_info: None,
-                    method_info: Some(LocalMethodName::new(
-                        "String".to_string(),
-                        Some("Eq".to_string()),
-                        "eq".to_string(),
-                    )),
+                    method_info: Some(method_info),
                 },
                 vec![],
                 vec![CallArg::new(

--- a/wado-compiler/src/lower/plan/pattern.rs
+++ b/wado-compiler/src/lower/plan/pattern.rs
@@ -47,6 +47,10 @@ pub fn plan(flat: &mut FlatPackage) {
         .compiler_items()
         .trait_name(crate::compiler_item::CompilerItem::Eq)
         .to_string();
+    let string_struct_name = type_table
+        .compiler_items()
+        .struct_name(crate::compiler_item::CompilerItem::String)
+        .to_string();
     for func_rc in &flat.functions {
         let mut func = func_rc.borrow_mut();
         if let Some(mut body) = func.body.take() {
@@ -58,6 +62,7 @@ pub fn plan(flat: &mut FlatPackage) {
                 local_count,
                 locals,
                 eq_trait_name.clone(),
+                string_struct_name.clone(),
                 &variant_case_map,
                 &struct_fields_map,
             );
@@ -269,6 +274,10 @@ struct PatternLowerer<'a> {
     /// follow stdlib renames without falling back to a hard-coded
     /// `"Eq"` literal.
     eq_trait_name: String,
+    /// Canonical stdlib name of the `String` struct, resolved through
+    /// the same registry so the receiver-type slot of the synthesised
+    /// `String^Eq::eq` `LocalMethodName` tracks renames too.
+    string_struct_name: String,
     /// Map from (`variant_name`, `module_source`) to a list of
     /// (`case_name`, `case_index`) pairs. The `module_source` axis
     /// is required because Wado allows two modules to each declare a
@@ -285,6 +294,7 @@ impl<'a> PatternLowerer<'a> {
         local_count: u32,
         locals: Vec<TirLocal>,
         eq_trait_name: String,
+        string_struct_name: String,
         variant_case_map: &'a IndexMap<(String, ModuleSource), Vec<(String, u32)>>,
         struct_fields_map: &'a IndexMap<(String, ModuleSource), Vec<TirField>>,
     ) -> Self {
@@ -293,6 +303,7 @@ impl<'a> PatternLowerer<'a> {
             locals,
             temp_counter: 0,
             eq_trait_name,
+            string_struct_name,
             variant_case_map,
             struct_fields_map,
         }
@@ -1359,7 +1370,7 @@ impl<'a> PatternLowerer<'a> {
         // so we pass the values directly and let translate handle self-kind adjustment.
         // However, the arg explicitly needs &String since that's the method signature.
         let method_info = LocalMethodName::new(
-            "String".to_string(),
+            self.string_struct_name.clone(),
             Some(self.eq_trait_name.clone()),
             "eq".to_string(),
         );

--- a/wado-compiler/src/lower/plan/value_copy.rs
+++ b/wado-compiler/src/lower/plan/value_copy.rs
@@ -73,17 +73,20 @@ pub fn plan(flat: &mut FlatPackage) -> ValueCopyPlan {
 /// `(ref X) / nullref` mismatch — an invalid Wasm module at compile
 /// time.
 pub fn needs_value_copy(type_id: TypeId, type_table: &TypeTable) -> bool {
+    let items = type_table.compiler_items();
+    let box_name = items.struct_name(crate::compiler_item::CompilerItem::Box);
+    let array_name = items.struct_name(crate::compiler_item::CompilerItem::Array);
     match type_table.get(type_id) {
         // Concrete structs need a field-by-field deep copy, except for
         // the `Box<T>` shortcut whose semantics intentionally share
         // the underlying cell.
-        ResolvedType::Struct { base_name, .. } => base_name.as_deref() != Some("Box"),
+        ResolvedType::Struct { base_name, .. } => base_name.as_deref() != Some(box_name),
         ResolvedType::GenericInstance {
             name,
             module_source,
             type_args,
         } => {
-            if name == "Box" {
+            if name == box_name {
                 return false;
             }
             if TypeTable::is_tuple_type(name, module_source) {
@@ -91,7 +94,7 @@ pub fn needs_value_copy(type_id: TypeId, type_table: &TypeTable) -> bool {
                 // element-wise deep copy.
                 return !type_args.is_empty();
             }
-            if name == "Array" {
+            if name == array_name {
                 return true;
             }
             // `Option<T>` / `Result<T, E>` are reference-shaped variants

--- a/wado-compiler/src/lower/plan/value_copy/synthesize.rs
+++ b/wado-compiler/src/lower/plan/value_copy/synthesize.rs
@@ -292,10 +292,15 @@ fn build_copy_return_expr(
     // type in the closure happens to be a non-monomorphized template
     // wrapper. The shape that *does* need a non-identity copy
     // (Array<T> / tuple) is recovered by the explicit checks below.
+    let array_name = type_table
+        .borrow()
+        .compiler_items()
+        .struct_name(crate::compiler_item::CompilerItem::Array)
+        .to_string();
     if let ResolvedType::GenericInstance {
         name, type_args, ..
     } = resolved
-        && name == "Array"
+        && name == &array_name
         && type_args.len() == 1
         && is_synth_safe_element(type_args[0], type_table, project)
     {
@@ -493,7 +498,22 @@ fn is_synth_safe_element(
             if TypeTable::is_tuple_type(&name, &module_source) {
                 return true;
             }
-            if name == "Array" || name == "String" || name == "Box" {
+            let (array_name, string_name, box_name) = {
+                let tt = type_table.borrow();
+                let items = tt.compiler_items();
+                (
+                    items
+                        .struct_name(crate::compiler_item::CompilerItem::Array)
+                        .to_string(),
+                    items
+                        .struct_name(crate::compiler_item::CompilerItem::String)
+                        .to_string(),
+                    items
+                        .struct_name(crate::compiler_item::CompilerItem::Box)
+                        .to_string(),
+                )
+            };
+            if name == array_name || name == string_name || name == box_name {
                 return true;
             }
             // A concrete monomorphised struct entry is the strongest

--- a/wado-compiler/src/lower/translate.rs
+++ b/wado-compiler/src/lower/translate.rs
@@ -565,9 +565,16 @@ impl FunctionTranslator<'_, '_> {
                 .get(spec.functor_id as usize)
         {
             let nir_receiver = self.convert_expr(callee);
-            let call_method_name = MethodName::format_local(&functor.struct_name, None, "__call");
-            let call_method_info =
-                LocalMethodName::new(functor.struct_name.clone(), None, "__call".to_string());
+            let call_method_name = MethodName::format_local(
+                &functor.struct_name,
+                None,
+                crate::name::CLOSURE_CALL_METHOD,
+            );
+            let call_method_info = LocalMethodName::new(
+                functor.struct_name.clone(),
+                None,
+                crate::name::CLOSURE_CALL_METHOD.to_string(),
+            );
             let call_method_borrow = functor.call_method.borrow();
             let params_is_mut: Vec<bool> = call_method_borrow
                 .params

--- a/wado-compiler/src/lower/translate/wide_int.rs
+++ b/wado-compiler/src/lower/translate/wide_int.rs
@@ -213,18 +213,25 @@ fn create_i128_eq_call(
         right_ref_type,
         span,
     );
+    let eq_trait_name = type_table
+        .borrow()
+        .compiler_items()
+        .trait_name(crate::compiler_item::CompilerItem::Eq)
+        .to_string();
+    let method_info = LocalMethodName::new(
+        "i128".to_string(),
+        Some(eq_trait_name),
+        "eq".to_string(),
+    );
+    let mangled_name = method_info.to_mangled_name();
     TirExpr::new(
         TirExprKind::method_call(
             Box::new(receiver),
             FunctionRef {
                 module_source: ModuleSource::int128(),
-                name: "i128^Eq::eq".to_string(),
+                name: mangled_name,
                 monomorph_info: None,
-                method_info: Some(LocalMethodName::new(
-                    "i128".to_string(),
-                    Some("Eq".to_string()),
-                    "eq".to_string(),
-                )),
+                method_info: Some(method_info),
             },
             vec![],
             vec![CallArg::new(arg_ref, false)],
@@ -262,18 +269,25 @@ fn create_u128_eq_call(
         right_ref_type,
         span,
     );
+    let eq_trait_name = type_table
+        .borrow()
+        .compiler_items()
+        .trait_name(crate::compiler_item::CompilerItem::Eq)
+        .to_string();
+    let method_info = LocalMethodName::new(
+        "u128".to_string(),
+        Some(eq_trait_name),
+        "eq".to_string(),
+    );
+    let mangled_name = method_info.to_mangled_name();
     TirExpr::new(
         TirExprKind::method_call(
             Box::new(receiver),
             FunctionRef {
                 module_source: ModuleSource::int128(),
-                name: "u128^Eq::eq".to_string(),
+                name: mangled_name,
                 monomorph_info: None,
-                method_info: Some(LocalMethodName::new(
-                    "u128".to_string(),
-                    Some("Eq".to_string()),
-                    "eq".to_string(),
-                )),
+                method_info: Some(method_info),
             },
             vec![],
             vec![CallArg::new(arg_ref, false)],

--- a/wado-compiler/src/lower/translate/wide_int.rs
+++ b/wado-compiler/src/lower/translate/wide_int.rs
@@ -218,13 +218,19 @@ fn create_i128_eq_call(
         right_ref_type,
         span,
     );
-    let eq_trait_name = type_table
-        .borrow()
-        .compiler_items()
-        .trait_name(crate::compiler_item::CompilerItem::Eq)
-        .to_string();
-    let method_info =
-        LocalMethodName::new("i128".to_string(), Some(eq_trait_name), "eq".to_string());
+    let (eq_trait_name, i128_struct_name) = {
+        let tt = type_table.borrow();
+        let items = tt.compiler_items();
+        (
+            items
+                .trait_name(crate::compiler_item::CompilerItem::Eq)
+                .to_string(),
+            items
+                .struct_name(crate::compiler_item::CompilerItem::I128)
+                .to_string(),
+        )
+    };
+    let method_info = LocalMethodName::new(i128_struct_name, Some(eq_trait_name), "eq".to_string());
     let mangled_name = method_info.to_mangled_name();
     TirExpr::new(
         TirExprKind::method_call(
@@ -271,13 +277,19 @@ fn create_u128_eq_call(
         right_ref_type,
         span,
     );
-    let eq_trait_name = type_table
-        .borrow()
-        .compiler_items()
-        .trait_name(crate::compiler_item::CompilerItem::Eq)
-        .to_string();
-    let method_info =
-        LocalMethodName::new("u128".to_string(), Some(eq_trait_name), "eq".to_string());
+    let (eq_trait_name, u128_struct_name) = {
+        let tt = type_table.borrow();
+        let items = tt.compiler_items();
+        (
+            items
+                .trait_name(crate::compiler_item::CompilerItem::Eq)
+                .to_string(),
+            items
+                .struct_name(crate::compiler_item::CompilerItem::U128)
+                .to_string(),
+        )
+    };
+    let method_info = LocalMethodName::new(u128_struct_name, Some(eq_trait_name), "eq".to_string());
     let mangled_name = method_info.to_mangled_name();
     TirExpr::new(
         TirExprKind::method_call(

--- a/wado-compiler/src/lower/translate/wide_int.rs
+++ b/wado-compiler/src/lower/translate/wide_int.rs
@@ -60,12 +60,8 @@ pub(super) fn build_if_chain(
     for arm in arms.iter().rev() {
         match &arm.pattern {
             TirPattern::Literal(TirLiteralPattern::I128(value)) => {
-                let literal_expr = create_i128_literal(
-                    *value,
-                    scrutinee.type_id,
-                    &type_table.borrow(),
-                    span,
-                );
+                let literal_expr =
+                    create_i128_literal(*value, scrutinee.type_id, &type_table.borrow(), span);
                 let eq_call =
                     create_i128_eq_call(scrutinee.clone(), literal_expr, type_table, span);
                 let condition = with_guard(eq_call, arm.guard.as_ref(), span);
@@ -78,12 +74,8 @@ pub(super) fn build_if_chain(
                 ));
             }
             TirPattern::Literal(TirLiteralPattern::U128(value)) => {
-                let literal_expr = create_u128_literal(
-                    *value,
-                    scrutinee.type_id,
-                    &type_table.borrow(),
-                    span,
-                );
+                let literal_expr =
+                    create_u128_literal(*value, scrutinee.type_id, &type_table.borrow(), span);
                 let eq_call =
                     create_u128_eq_call(scrutinee.clone(), literal_expr, type_table, span);
                 let condition = with_guard(eq_call, arm.guard.as_ref(), span);
@@ -231,11 +223,8 @@ fn create_i128_eq_call(
         .compiler_items()
         .trait_name(crate::compiler_item::CompilerItem::Eq)
         .to_string();
-    let method_info = LocalMethodName::new(
-        "i128".to_string(),
-        Some(eq_trait_name),
-        "eq".to_string(),
-    );
+    let method_info =
+        LocalMethodName::new("i128".to_string(), Some(eq_trait_name), "eq".to_string());
     let mangled_name = method_info.to_mangled_name();
     TirExpr::new(
         TirExprKind::method_call(
@@ -287,11 +276,8 @@ fn create_u128_eq_call(
         .compiler_items()
         .trait_name(crate::compiler_item::CompilerItem::Eq)
         .to_string();
-    let method_info = LocalMethodName::new(
-        "u128".to_string(),
-        Some(eq_trait_name),
-        "eq".to_string(),
-    );
+    let method_info =
+        LocalMethodName::new("u128".to_string(), Some(eq_trait_name), "eq".to_string());
     let mangled_name = method_info.to_mangled_name();
     TirExpr::new(
         TirExprKind::method_call(

--- a/wado-compiler/src/lower/translate/wide_int.rs
+++ b/wado-compiler/src/lower/translate/wide_int.rs
@@ -60,7 +60,12 @@ pub(super) fn build_if_chain(
     for arm in arms.iter().rev() {
         match &arm.pattern {
             TirPattern::Literal(TirLiteralPattern::I128(value)) => {
-                let literal_expr = create_i128_literal(*value, scrutinee.type_id, span);
+                let literal_expr = create_i128_literal(
+                    *value,
+                    scrutinee.type_id,
+                    &type_table.borrow(),
+                    span,
+                );
                 let eq_call =
                     create_i128_eq_call(scrutinee.clone(), literal_expr, type_table, span);
                 let condition = with_guard(eq_call, arm.guard.as_ref(), span);
@@ -73,7 +78,12 @@ pub(super) fn build_if_chain(
                 ));
             }
             TirPattern::Literal(TirLiteralPattern::U128(value)) => {
-                let literal_expr = create_u128_literal(*value, scrutinee.type_id, span);
+                let literal_expr = create_u128_literal(
+                    *value,
+                    scrutinee.type_id,
+                    &type_table.borrow(),
+                    span,
+                );
                 let eq_call =
                     create_u128_eq_call(scrutinee.clone(), literal_expr, type_table, span);
                 let condition = with_guard(eq_call, arm.guard.as_ref(), span);

--- a/wado-compiler/src/lower/translate/wide_int.rs
+++ b/wado-compiler/src/lower/translate/wide_int.rs
@@ -28,8 +28,11 @@ pub(super) fn should_rewrite(
     arms: &[TirMatchArm],
     type_table: &TypeTable,
 ) -> bool {
+    let items = type_table.compiler_items();
+    let i128_name = items.struct_name(crate::compiler_item::CompilerItem::I128);
+    let u128_name = items.struct_name(crate::compiler_item::CompilerItem::U128);
     let is_wide_int = match type_table.get(scrutinee_type) {
-        ResolvedType::Struct { name, .. } => name == "i128" || name == "u128",
+        ResolvedType::Struct { name, .. } => name == i128_name || name == u128_name,
         _ => false,
     };
     if !is_wide_int {

--- a/wado-compiler/src/lower/wide_int_literal.rs
+++ b/wado-compiler/src/lower/wide_int_literal.rs
@@ -100,8 +100,7 @@ fn build_i128_from_i64_call(
         TypeTable::I64,
         span,
     );
-    let method_info =
-        LocalMethodName::new(ctor.type_name.clone(), None, ctor.method_name.clone());
+    let method_info = LocalMethodName::new(ctor.type_name.clone(), None, ctor.method_name.clone());
     let mangled_name = method_info.to_mangled_name();
     TirExpr::new(
         TirExprKind::Call {
@@ -134,8 +133,7 @@ fn build_u128_from_u64_call(
         TypeTable::U64,
         span,
     );
-    let method_info =
-        LocalMethodName::new(ctor.type_name.clone(), None, ctor.method_name.clone());
+    let method_info = LocalMethodName::new(ctor.type_name.clone(), None, ctor.method_name.clone());
     let mangled_name = method_info.to_mangled_name();
     TirExpr::new(
         TirExprKind::Call {
@@ -176,8 +174,7 @@ fn build_i128_from_pair_call(
         TypeTable::I64,
         span,
     );
-    let method_info =
-        LocalMethodName::new(ctor.type_name.clone(), None, ctor.method_name.clone());
+    let method_info = LocalMethodName::new(ctor.type_name.clone(), None, ctor.method_name.clone());
     TirExpr::new(
         TirExprKind::Call {
             func: FunctionRef {
@@ -220,8 +217,7 @@ fn build_u128_from_pair_call(
         TypeTable::U64,
         span,
     );
-    let method_info =
-        LocalMethodName::new(ctor.type_name.clone(), None, ctor.method_name.clone());
+    let method_info = LocalMethodName::new(ctor.type_name.clone(), None, ctor.method_name.clone());
     TirExpr::new(
         TirExprKind::Call {
             func: FunctionRef {

--- a/wado-compiler/src/lower/wide_int_literal.rs
+++ b/wado-compiler/src/lower/wide_int_literal.rs
@@ -18,31 +18,80 @@
 //! `u128::from_pair(lo, hi)` so the full 128 bits round-trip — same
 //! split the resolver uses for source-level literals (see
 //! `resolver::util::unpack_i128`, `resolver::call::build_from_pair_call`).
+//!
+//! The struct, module source, and method names are all resolved
+//! through the `CompilerItem` registry so a stdlib rename of `i128`,
+//! `u128`, or any of their `from_*` constructors stays transparent.
 
+use crate::compiler_item::CompilerItem;
 use crate::module_source::ModuleSource;
 use crate::name::LocalMethodName;
 use crate::tir::{CallArg, FunctionRef, TirExpr, TirExprKind, TypeId, TypeTable};
 use crate::token::Span;
 
+/// Snapshot of a wide-int constructor's registry coordinates, taken
+/// before we lock the type table for builders that mutate it.
+struct CtorRef {
+    module_source: ModuleSource,
+    type_name: String,
+    method_name: String,
+}
+
+fn ctor_ref(type_table: &TypeTable, owner: CompilerItem, ctor: CompilerItem) -> CtorRef {
+    let items = type_table.compiler_items();
+    let (owner_module, type_name) = items.require_struct(owner);
+    let (method_module, _, method_name) = items.require_method(ctor);
+    // Production stdlib places i128 / u128 and their constructors in
+    // the same module; assert that invariant so a future split is
+    // diagnosed rather than silently producing mismatched `Call.module_source`
+    // versus `method_info.struct_name` pairs.
+    debug_assert_eq!(owner_module, method_module);
+    CtorRef {
+        module_source: owner_module.clone(),
+        type_name: type_name.to_string(),
+        method_name: method_name.to_string(),
+    }
+}
+
 /// Create an i128 literal TIR expression that evaluates to `value`.
-pub(super) fn create_i128_literal(value: i128, type_id: TypeId, span: Span) -> TirExpr {
+pub(super) fn create_i128_literal(
+    value: i128,
+    type_id: TypeId,
+    type_table: &TypeTable,
+    span: Span,
+) -> TirExpr {
     if let Ok(fits) = i64::try_from(value) {
-        return build_i128_from_i64_call(fits, value, type_id, span);
+        let ctor = ctor_ref(type_table, CompilerItem::I128, CompilerItem::I128FromI64);
+        return build_i128_from_i64_call(fits, value, type_id, &ctor, span);
     }
     let (low, high) = (value as u64, (value >> 64) as i64);
-    build_i128_from_pair_call(low, high, type_id, span)
+    let ctor = ctor_ref(type_table, CompilerItem::I128, CompilerItem::I128FromPair);
+    build_i128_from_pair_call(low, high, type_id, &ctor, span)
 }
 
 /// Create a u128 literal TIR expression that evaluates to `value`.
-pub(super) fn create_u128_literal(value: u128, type_id: TypeId, span: Span) -> TirExpr {
+pub(super) fn create_u128_literal(
+    value: u128,
+    type_id: TypeId,
+    type_table: &TypeTable,
+    span: Span,
+) -> TirExpr {
     if let Ok(fits) = u64::try_from(value) {
-        return build_u128_from_u64_call(fits, value, type_id, span);
+        let ctor = ctor_ref(type_table, CompilerItem::U128, CompilerItem::U128FromU64);
+        return build_u128_from_u64_call(fits, value, type_id, &ctor, span);
     }
     let (low, high) = (value as u64, (value >> 64) as u64);
-    build_u128_from_pair_call(low, high, type_id, span)
+    let ctor = ctor_ref(type_table, CompilerItem::U128, CompilerItem::U128FromPair);
+    build_u128_from_pair_call(low, high, type_id, &ctor, span)
 }
 
-fn build_i128_from_i64_call(value: i64, original: i128, type_id: TypeId, span: Span) -> TirExpr {
+fn build_i128_from_i64_call(
+    value: i64,
+    original: i128,
+    type_id: TypeId,
+    ctor: &CtorRef,
+    span: Span,
+) -> TirExpr {
     let inner_literal = TirExpr::new(
         TirExprKind::IntLiteral {
             value: value.cast_unsigned(),
@@ -51,12 +100,14 @@ fn build_i128_from_i64_call(value: i64, original: i128, type_id: TypeId, span: S
         TypeTable::I64,
         span,
     );
-    let method_info = LocalMethodName::new("i128".to_string(), None, "from_i64".to_string());
+    let method_info =
+        LocalMethodName::new(ctor.type_name.clone(), None, ctor.method_name.clone());
+    let mangled_name = method_info.to_mangled_name();
     TirExpr::new(
         TirExprKind::Call {
             func: FunctionRef {
-                module_source: ModuleSource::int128(),
-                name: "i128::from_i64".to_string(),
+                module_source: ctor.module_source.clone(),
+                name: mangled_name,
                 monomorph_info: None,
                 method_info: Some(method_info),
             },
@@ -68,7 +119,13 @@ fn build_i128_from_i64_call(value: i64, original: i128, type_id: TypeId, span: S
     )
 }
 
-fn build_u128_from_u64_call(value: u64, original: u128, type_id: TypeId, span: Span) -> TirExpr {
+fn build_u128_from_u64_call(
+    value: u64,
+    original: u128,
+    type_id: TypeId,
+    ctor: &CtorRef,
+    span: Span,
+) -> TirExpr {
     let inner_literal = TirExpr::new(
         TirExprKind::IntLiteral {
             value,
@@ -77,12 +134,14 @@ fn build_u128_from_u64_call(value: u64, original: u128, type_id: TypeId, span: S
         TypeTable::U64,
         span,
     );
-    let method_info = LocalMethodName::new("u128".to_string(), None, "from_u64".to_string());
+    let method_info =
+        LocalMethodName::new(ctor.type_name.clone(), None, ctor.method_name.clone());
+    let mangled_name = method_info.to_mangled_name();
     TirExpr::new(
         TirExprKind::Call {
             func: FunctionRef {
-                module_source: ModuleSource::int128(),
-                name: "u128::from_u64".to_string(),
+                module_source: ctor.module_source.clone(),
+                name: mangled_name,
                 monomorph_info: None,
                 method_info: Some(method_info),
             },
@@ -94,7 +153,13 @@ fn build_u128_from_u64_call(value: u64, original: u128, type_id: TypeId, span: S
     )
 }
 
-fn build_i128_from_pair_call(low: u64, high: i64, type_id: TypeId, span: Span) -> TirExpr {
+fn build_i128_from_pair_call(
+    low: u64,
+    high: i64,
+    type_id: TypeId,
+    ctor: &CtorRef,
+    span: Span,
+) -> TirExpr {
     let low_literal = TirExpr::new(
         TirExprKind::IntLiteral {
             value: low,
@@ -111,11 +176,12 @@ fn build_i128_from_pair_call(low: u64, high: i64, type_id: TypeId, span: Span) -
         TypeTable::I64,
         span,
     );
-    let method_info = LocalMethodName::new("i128".to_string(), None, "from_pair".to_string());
+    let method_info =
+        LocalMethodName::new(ctor.type_name.clone(), None, ctor.method_name.clone());
     TirExpr::new(
         TirExprKind::Call {
             func: FunctionRef {
-                module_source: ModuleSource::int128(),
+                module_source: ctor.module_source.clone(),
                 name: method_info.to_mangled_name(),
                 monomorph_info: None,
                 method_info: Some(method_info),
@@ -131,7 +197,13 @@ fn build_i128_from_pair_call(low: u64, high: i64, type_id: TypeId, span: Span) -
     )
 }
 
-fn build_u128_from_pair_call(low: u64, high: u64, type_id: TypeId, span: Span) -> TirExpr {
+fn build_u128_from_pair_call(
+    low: u64,
+    high: u64,
+    type_id: TypeId,
+    ctor: &CtorRef,
+    span: Span,
+) -> TirExpr {
     let low_literal = TirExpr::new(
         TirExprKind::IntLiteral {
             value: low,
@@ -148,11 +220,12 @@ fn build_u128_from_pair_call(low: u64, high: u64, type_id: TypeId, span: Span) -
         TypeTable::U64,
         span,
     );
-    let method_info = LocalMethodName::new("u128".to_string(), None, "from_pair".to_string());
+    let method_info =
+        LocalMethodName::new(ctor.type_name.clone(), None, ctor.method_name.clone());
     TirExpr::new(
         TirExprKind::Call {
             func: FunctionRef {
-                module_source: ModuleSource::int128(),
+                module_source: ctor.module_source.clone(),
                 name: method_info.to_mangled_name(),
                 monomorph_info: None,
                 method_info: Some(method_info),

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -35,6 +35,23 @@ use fluent_uri::UriRef;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
+/// Canonical method name of the synthesised `__call` impl on every
+/// closure functor struct. Defined as a single constant so the
+/// compiler-internal naming convention has one source of truth — the
+/// closure planner, the translator, and DCE all reach for this
+/// constant instead of writing the literal `"__call"` at each site.
+///
+/// Unlike stdlib items wired through [`crate::compiler_item`], the
+/// `__call` symbol has no Wado-side declaration, so a `CompilerItem`
+/// anchor would have nothing to bind to. A `const` is the right shape.
+pub const CLOSURE_CALL_METHOD: &str = "__call";
+
+/// Prefix the compiler stamps onto every synthesised closure-functor
+/// struct (`__Closure_0`, `__Closure_1`, …). Like
+/// [`CLOSURE_CALL_METHOD`], this is purely a compiler-internal
+/// convention — there is no Wado-side declaration to anchor it to.
+pub const CLOSURE_STRUCT_PREFIX: &str = "__Closure_";
+
 /// A free function name (not a method on a struct).
 ///
 /// Format: `{module_source}/{name}`
@@ -540,7 +557,8 @@ impl LocalMethodName {
     /// the vtable slot they're installed into, so callers that reshape
     /// ABIs need to filter them out.
     pub fn is_closure_call(&self) -> bool {
-        self.method_name == "__call" && self.struct_name.starts_with("__Closure_")
+        self.method_name == CLOSURE_CALL_METHOD
+            && self.struct_name.starts_with(CLOSURE_STRUCT_PREFIX)
     }
 }
 

--- a/wado-compiler/src/optimize/dce.rs
+++ b/wado-compiler/src/optimize/dce.rs
@@ -1499,12 +1499,15 @@ fn analyze_expr(
             );
             // The `__call` method is always reached via `ref.func` baked
             // into the canonical closure struct's `func` slot.
-            let struct_name = format!("__Closure_{functor_id}");
+            let struct_name = format!(
+                "{prefix}{functor_id}",
+                prefix = crate::name::CLOSURE_STRUCT_PREFIX,
+            );
             analysis.callees.insert(FunctionId::Method(MethodName::new(
                 closure_module.clone(),
                 struct_name.clone(),
                 None,
-                "__call".to_string(),
+                crate::name::CLOSURE_CALL_METHOD.to_string(),
             )));
 
             // The per-functor `__Closure_N^Inspect` and `^InspectAlt`

--- a/wado-compiler/src/resolver/call.rs
+++ b/wado-compiler/src/resolver/call.rs
@@ -1164,9 +1164,25 @@ impl<H: CompilerHost> Resolver<'_, H> {
         ty: &Type,
         wasi_package: Option<&str>,
     ) -> TypeId {
+        let string_struct_name = self
+            .type_table
+            .borrow()
+            .compiler_items()
+            .struct_name(crate::compiler_item::CompilerItem::String)
+            .to_string();
+        let array_struct_name = self
+            .type_table
+            .borrow()
+            .compiler_items()
+            .struct_name(crate::compiler_item::CompilerItem::Array)
+            .to_string();
+        if let Type::Named(named) = ty
+            && named.name == string_struct_name
+        {
+            return self.get_string_struct_type();
+        }
         match ty {
             Type::Named(named) => match named.name.as_str() {
-                "String" => self.get_string_struct_type(),
                 "i8" => TypeTable::I8,
                 "i16" => TypeTable::I16,
                 "i32" => TypeTable::I32,
@@ -1316,11 +1332,13 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     }
                 }
             },
+            Type::Generic(generic)
+                if generic.name == array_struct_name && generic.args.len() == 1 =>
+            {
+                let elem_type = self.resolve_wasi_type_scoped(&generic.args[0], wasi_package);
+                self.type_table.borrow_mut().make_array(elem_type)
+            }
             Type::Generic(generic) => match generic.name.as_str() {
-                "Array" if generic.args.len() == 1 => {
-                    let elem_type = self.resolve_wasi_type_scoped(&generic.args[0], wasi_package);
-                    self.type_table.borrow_mut().make_array(elem_type)
-                }
                 "Option" if generic.args.len() == 1 => {
                     let inner_type = self.resolve_wasi_type_scoped(&generic.args[0], wasi_package);
                     self.type_table.borrow_mut().make_option(inner_type)

--- a/wado-compiler/src/resolver/call.rs
+++ b/wado-compiler/src/resolver/call.rs
@@ -607,11 +607,17 @@ impl<H: CompilerHost> Resolver<'_, H> {
                             );
                             let from_type = args[0].type_id;
                             let from_type_name = self.type_table.borrow().type_name(from_type);
+                            let from_trait_name = self
+                                .type_table
+                                .borrow()
+                                .compiler_items()
+                                .trait_name(crate::compiler_item::CompilerItem::From)
+                                .to_string();
                             let matching_impl = self.current_module_items.iter().any(|item| {
                                 if let Item::Impl(impl_block) = item
                                     && impl_block.is_synthesize_request
                                     && let Some(trait_type) = &impl_block.trait_type
-                                    && Self::get_type_name_static(trait_type) == "From"
+                                    && Self::get_type_name_static(trait_type) == from_trait_name
                                     && Self::get_type_name_static(&impl_block.ty) == prefix
                                 {
                                     if let ast::Type::Generic(generic) = trait_type

--- a/wado-compiler/src/resolver/call.rs
+++ b/wado-compiler/src/resolver/call.rs
@@ -1378,7 +1378,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
     pub(super) fn get_string_struct_type(&mut self) -> TypeId {
         self.type_table
             .borrow_mut()
-            .make_struct("String".to_string(), ModuleSource::string())
+            .make_compiler_struct(crate::compiler_item::CompilerItem::String)
     }
 
     /// Build a `from_pair` call for i128/u128 large literal construction

--- a/wado-compiler/src/resolver/coercion.rs
+++ b/wado-compiler/src/resolver/coercion.rs
@@ -498,7 +498,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         let string_type = self
             .type_table
             .borrow_mut()
-            .make_struct("String".to_string(), ModuleSource::string());
+            .make_compiler_struct(crate::compiler_item::CompilerItem::String);
         let i32_type = TypeTable::I32;
 
         // Get type args for monomorphization from builder type

--- a/wado-compiler/src/resolver/coercion.rs
+++ b/wado-compiler/src/resolver/coercion.rs
@@ -408,9 +408,15 @@ impl<H: CompilerHost> Resolver<'_, H> {
 
         if is_string_or_template {
             let base_id = self.type_table.borrow().get_ultimate_base_type(target_type);
+            let string_struct_name = self
+                .type_table
+                .borrow()
+                .compiler_items()
+                .struct_name(crate::compiler_item::CompilerItem::String)
+                .to_string();
             let is_string_newtype = matches!(
                 self.type_table.borrow().get(base_id),
-                ResolvedType::Struct { name, .. } if name == "String"
+                ResolvedType::Struct { name, .. } if name == &string_struct_name
             ) && target_type != base_id;
             if is_string_newtype {
                 let mut resolved = self.resolve_expr(expr, ctx, None);

--- a/wado-compiler/src/resolver/expr.rs
+++ b/wado-compiler/src/resolver/expr.rs
@@ -3329,11 +3329,19 @@ impl<H: CompilerHost> Resolver<'_, H> {
         let element_type = start.type_id;
 
         // Check that the element type implements Ord
-        if element_type != TypeTable::ERROR && !self.type_implements_trait(element_type, "Ord") {
+        let ord_trait_name = self
+            .type_table
+            .borrow()
+            .compiler_items()
+            .trait_name(crate::compiler_item::CompilerItem::Ord)
+            .to_string();
+        if element_type != TypeTable::ERROR
+            && !self.type_implements_trait(element_type, &ord_trait_name)
+        {
             let type_name = self.type_id_to_string(element_type);
             let _ = self.logger.error(TypeError::TraitBoundNotSatisfied {
                 type_name,
-                trait_name: "Ord".to_string(),
+                trait_name: ord_trait_name,
                 param_name: "T".to_string(),
                 span: range.span,
             });

--- a/wado-compiler/src/resolver/expr.rs
+++ b/wado-compiler/src/resolver/expr.rs
@@ -3124,11 +3124,15 @@ impl<H: CompilerHost> Resolver<'_, H> {
         let tt = self.type_table.borrow();
         let target_name = tt.type_name(target_type);
         let from_name = tt.type_name(from_type);
+        let from_trait_name = tt
+            .compiler_items()
+            .trait_name(crate::compiler_item::CompilerItem::From)
+            .to_string();
         drop(tt);
 
         // Use "From<SourceType>" as the trait name in mangled names to disambiguate
         // multiple From impls on the same target type.
-        let from_trait = format!("From<{from_name}>");
+        let from_trait = format!("{from_trait_name}<{from_name}>");
         let method_name = MethodName::format_local(&target_name, Some(&from_trait), "from");
 
         // Find the module source that provides the From impl
@@ -3144,7 +3148,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         struct_name: target_name.clone(),
                         base_struct_name: target_name,
                         trait_name: Some(from_trait),
-                        base_trait_name: Some("From".to_string()),
+                        base_trait_name: Some(from_trait_name),
                         trait_type_args: vec![],
                         method_name: "from".to_string(),
                         method_type_args: vec![],
@@ -3163,6 +3167,12 @@ impl<H: CompilerHost> Resolver<'_, H> {
 
     /// Find the module that provides `impl From<FromType> for TargetType`.
     fn find_from_impl_module(&self, target_name: &str, from_name: &str) -> ModuleSource {
+        let from_trait_name = self
+            .type_table
+            .borrow()
+            .compiler_items()
+            .trait_name(crate::compiler_item::CompilerItem::From)
+            .to_string();
         let check_impl = |impl_block: &ast::ImplBlock| -> bool {
             let impl_target = Self::get_type_name_static(&impl_block.ty);
             if impl_target != target_name {
@@ -3170,7 +3180,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
             }
             if let Some(trait_type) = &impl_block.trait_type {
                 let base = Self::get_type_name_static(trait_type);
-                if base != "From" {
+                if base != from_trait_name {
                     return false;
                 }
                 // Check the type arg matches from_name

--- a/wado-compiler/src/resolver/infer.rs
+++ b/wado-compiler/src/resolver/infer.rs
@@ -46,6 +46,11 @@ pub(super) fn unify(
     actual: TypeId,
     bindings: &mut IndexMap<TypeId, TypeId>,
 ) {
+    let array_name = type_table
+        .borrow()
+        .compiler_items()
+        .struct_name(crate::compiler_item::CompilerItem::Array)
+        .to_string();
     let expected_type = type_table.borrow().get(expected).clone();
     let actual_type = type_table.borrow().get(actual).clone();
 
@@ -141,7 +146,7 @@ pub(super) fn unify(
                 module_source: actual_module_source,
                 type_args: actual_elems,
             },
-        ) if name == "Array"
+        ) if name == &array_name
             && TypeTable::is_tuple_type(actual_name, actual_module_source)
             && expected_args.len() == 1
             && !actual_elems.is_empty() =>

--- a/wado-compiler/src/resolver/item.rs
+++ b/wado-compiler/src/resolver/item.rs
@@ -149,6 +149,34 @@ pub(super) fn register_variant_compiler_item<H: CompilerHost>(
     }
 }
 
+/// Register an enum declaration's `#[compiler_item(...)]` annotation, if any.
+pub(super) fn register_enum_compiler_item<H: CompilerHost>(
+    type_table: &RefCell<TypeTable>,
+    attrs: &[crate::ast::Attribute],
+    name: &str,
+    module_source: &ModuleSource,
+    span: Span,
+    logger: &Logger<'_, H>,
+) {
+    let Some(item) = extract_compiler_item(attrs, span, logger) else {
+        return;
+    };
+    if !check_compiler_item_placement(item, CompilerItemKind::Enum, module_source, span, logger) {
+        return;
+    }
+    let resolved = Resolved::Enum {
+        module_source: module_source.clone(),
+        name: name.to_string(),
+    };
+    if let Err(err) = type_table
+        .borrow_mut()
+        .compiler_items_mut()
+        .register(item, resolved)
+    {
+        report_register_error(err, span, logger);
+    }
+}
+
 /// Register a trait declaration's `#[compiler_item(...)]` annotation, if any.
 pub(super) fn register_trait_compiler_item<H: CompilerHost>(
     type_table: &RefCell<TypeTable>,

--- a/wado-compiler/src/resolver/item.rs
+++ b/wado-compiler/src/resolver/item.rs
@@ -45,11 +45,7 @@ pub(super) fn extract_compiler_item<H: CompilerHost>(
 /// stdlib bug (two declarations claiming the same anchor); kind
 /// mismatches are reported by [`check_kind`] before reaching this
 /// path, so the error surface here is small.
-fn report_register_error<H: CompilerHost>(
-    err: RegisterError,
-    span: Span,
-    logger: &Logger<'_, H>,
-) {
+fn report_register_error<H: CompilerHost>(err: RegisterError, span: Span, logger: &Logger<'_, H>) {
     let _ = logger.error(TypeError::CompilerItemAttr {
         message: err.to_string(),
         span,
@@ -194,8 +190,7 @@ pub(super) fn register_method_compiler_item<H: CompilerHost>(
     let Some(item) = extract_compiler_item(attrs, span, logger) else {
         return;
     };
-    if !check_compiler_item_placement(item, CompilerItemKind::Method, module_source, span, logger)
-    {
+    if !check_compiler_item_placement(item, CompilerItemKind::Method, module_source, span, logger) {
         return;
     }
     let resolved = Resolved::Method {

--- a/wado-compiler/src/resolver/item.rs
+++ b/wado-compiler/src/resolver/item.rs
@@ -4,126 +4,244 @@ use std::cell::RefCell;
 
 use crate::ast::{self, Function, GlobalDecl, SelfKind, Type};
 use crate::compiler_host::CompilerHost;
-use crate::compiler_item::{CompilerItem, CompilerItemKind, Resolved, parse_compiler_item_attrs};
+use crate::compiler_item::{
+    CompilerItem, CompilerItemKind, RegisterError, Resolved, parse_compiler_item_attrs,
+};
 use crate::hashmap::IndexSet;
+use crate::logger::Logger;
 use crate::module_source::ModuleSource;
 use crate::name::{LocalMethodName, MethodName};
 use crate::tir::{
     FunctionKind, TirEffect, TirEffectOp, TirFunction, TirGlobal, TirParam, TirResource, TirStruct,
     TirTest, TirVariantCase, TirVariantDecl, TypeId, TypeTable,
 };
+use crate::token::Span;
 
 use super::Resolver;
 use super::types::{FunctionContext, TypeError};
 
 /// Extract the [`CompilerItem`] marker — if any — from a declaration's
-/// `#[compiler_item("...")]` attributes.
+/// `#[compiler_item("...")]` attributes, emitting a diagnostic for
+/// each unrecognised name. Returns the first matched [`CompilerItem`]
+/// (in attribute order); subsequent matches are silently dropped — a
+/// declaration may carry at most one marker per the design contract.
+pub(super) fn extract_compiler_item<H: CompilerHost>(
+    attrs: &[crate::ast::Attribute],
+    decl_span: Span,
+    logger: &Logger<'_, H>,
+) -> Option<CompilerItem> {
+    let (items, unknown) = parse_compiler_item_attrs(attrs);
+    for raw in unknown {
+        let _ = logger.error(TypeError::CompilerItemAttr {
+            message: format!("unknown compiler item `{raw}`"),
+            span: decl_span,
+        });
+    }
+    items.into_iter().next()
+}
+
+/// Push a [`RegisterError`] into the diagnostic stream. Duplicate
+/// registrations are kept as errors because they always indicate a
+/// stdlib bug (two declarations claiming the same anchor); kind
+/// mismatches are reported by [`check_kind`] before reaching this
+/// path, so the error surface here is small.
+fn report_register_error<H: CompilerHost>(
+    err: RegisterError,
+    span: Span,
+    logger: &Logger<'_, H>,
+) {
+    let _ = logger.error(TypeError::CompilerItemAttr {
+        message: err.to_string(),
+        span,
+    });
+}
+
+/// Run the per-attribute validation that applies to every kind:
 ///
-/// Each declaration carries at most one marker. The parser handles
-/// repeated arguments and multiple attributes; this helper folds them
-/// to the first match and silently drops the rest. (A future
-/// diagnostic pass should reject extras at the attribute site.)
-/// Unknown names are dropped here too — they're caught by the
-/// dedicated diagnostic in [`super::orchestration`].
-pub(super) fn extract_compiler_item(attrs: &[crate::ast::Attribute]) -> Option<CompilerItem> {
-    parse_compiler_item_attrs(attrs).0.into_iter().next()
+/// 1. The attribute is only meaningful inside `core::*` modules; reject
+///    it elsewhere.
+/// 2. The declared kind must match [`CompilerItem::expected_kind`];
+///    otherwise emit a diagnostic and skip registration.
+///
+/// Returns `true` when registration should proceed.
+fn check_compiler_item_placement<H: CompilerHost>(
+    item: CompilerItem,
+    actual_kind: CompilerItemKind,
+    module_source: &ModuleSource,
+    span: Span,
+    logger: &Logger<'_, H>,
+) -> bool {
+    if !module_source.is_core() {
+        let _ = logger.error(TypeError::CompilerItemAttr {
+            message: format!(
+                "`#[compiler_item(\"{name}\")]` is only valid inside `core::*` modules",
+                name = item.attr_name(),
+            ),
+            span,
+        });
+        return false;
+    }
+    if item.expected_kind() != actual_kind {
+        let _ = logger.error(TypeError::CompilerItemAttr {
+            message: format!(
+                "`#[compiler_item(\"{name}\")]` expects a {expected}, but it is attached to a {actual}",
+                name = item.attr_name(),
+                expected = item.expected_kind(),
+                actual = actual_kind,
+            ),
+            span,
+        });
+        return false;
+    }
+    true
 }
 
 /// Register a struct declaration's `#[compiler_item(...)]` annotation, if any.
-///
-/// Silently ignores items whose [`CompilerItem::expected_kind`] is not
-/// [`CompilerItemKind::Struct`] — the resolver emits a dedicated
-/// diagnostic for kind mismatches in [`super::orchestration`]. The
-/// registry itself ICEs on duplicate registrations; per the design
-/// contract, every `CompilerItem` variant is owned by exactly one
-/// stdlib declaration.
-pub(super) fn register_struct_compiler_item(
+pub(super) fn register_struct_compiler_item<H: CompilerHost>(
     type_table: &RefCell<TypeTable>,
     attrs: &[crate::ast::Attribute],
     name: &str,
     module_source: &ModuleSource,
+    span: Span,
+    logger: &Logger<'_, H>,
 ) {
-    let Some(item) = extract_compiler_item(attrs) else {
+    let Some(item) = extract_compiler_item(attrs, span, logger) else {
         return;
     };
-    if item.expected_kind() != CompilerItemKind::Struct {
+    if !check_compiler_item_placement(item, CompilerItemKind::Struct, module_source, span, logger) {
         return;
     }
     let resolved = Resolved::Struct {
         module_source: module_source.clone(),
         name: name.to_string(),
     };
-    let _ = type_table
+    if let Err(err) = type_table
         .borrow_mut()
         .compiler_items_mut()
-        .register(item, resolved);
+        .register(item, resolved)
+    {
+        report_register_error(err, span, logger);
+    }
 }
 
 /// Register a variant declaration's `#[compiler_item(...)]` annotation, if any.
-pub(super) fn register_variant_compiler_item(
+pub(super) fn register_variant_compiler_item<H: CompilerHost>(
     type_table: &RefCell<TypeTable>,
     attrs: &[crate::ast::Attribute],
     name: &str,
     module_source: &ModuleSource,
+    span: Span,
+    logger: &Logger<'_, H>,
 ) {
-    let Some(item) = extract_compiler_item(attrs) else {
+    let Some(item) = extract_compiler_item(attrs, span, logger) else {
         return;
     };
-    if item.expected_kind() != CompilerItemKind::Variant {
+    if !check_compiler_item_placement(item, CompilerItemKind::Variant, module_source, span, logger)
+    {
         return;
     }
     let resolved = Resolved::Variant {
         module_source: module_source.clone(),
         name: name.to_string(),
     };
-    let _ = type_table
+    if let Err(err) = type_table
         .borrow_mut()
         .compiler_items_mut()
-        .register(item, resolved);
+        .register(item, resolved)
+    {
+        report_register_error(err, span, logger);
+    }
 }
 
 /// Register a trait declaration's `#[compiler_item(...)]` annotation, if any.
-pub(super) fn register_trait_compiler_item(
+pub(super) fn register_trait_compiler_item<H: CompilerHost>(
     type_table: &RefCell<TypeTable>,
     attrs: &[crate::ast::Attribute],
     name: &str,
     module_source: &ModuleSource,
+    span: Span,
+    logger: &Logger<'_, H>,
 ) {
-    let Some(item) = extract_compiler_item(attrs) else {
+    let Some(item) = extract_compiler_item(attrs, span, logger) else {
         return;
     };
-    if item.expected_kind() != CompilerItemKind::Trait {
+    if !check_compiler_item_placement(item, CompilerItemKind::Trait, module_source, span, logger) {
         return;
     }
     let resolved = Resolved::Trait {
         module_source: module_source.clone(),
         name: name.to_string(),
     };
-    let _ = type_table
+    if let Err(err) = type_table
         .borrow_mut()
         .compiler_items_mut()
-        .register(item, resolved);
+        .register(item, resolved)
+    {
+        report_register_error(err, span, logger);
+    }
+}
+
+/// Register an impl-block method's `#[compiler_item(...)]` annotation, if any.
+pub(super) fn register_method_compiler_item<H: CompilerHost>(
+    type_table: &RefCell<TypeTable>,
+    attrs: &[crate::ast::Attribute],
+    method_name: &str,
+    owner_type: &str,
+    module_source: &ModuleSource,
+    span: Span,
+    logger: &Logger<'_, H>,
+) {
+    let Some(item) = extract_compiler_item(attrs, span, logger) else {
+        return;
+    };
+    if !check_compiler_item_placement(item, CompilerItemKind::Method, module_source, span, logger)
+    {
+        return;
+    }
+    let resolved = Resolved::Method {
+        module_source: module_source.clone(),
+        owner_type: owner_type.to_string(),
+        name: method_name.to_string(),
+    };
+    if let Err(err) = type_table
+        .borrow_mut()
+        .compiler_items_mut()
+        .register(item, resolved)
+    {
+        report_register_error(err, span, logger);
+    }
 }
 
 /// Register a `pub type [..T];` declaration's `#[compiler_item("tuple")]` annotation.
-pub(super) fn register_tuple_compiler_item(
+pub(super) fn register_tuple_compiler_item<H: CompilerHost>(
     type_table: &RefCell<TypeTable>,
     attrs: &[crate::ast::Attribute],
     module_source: &ModuleSource,
+    span: Span,
+    logger: &Logger<'_, H>,
 ) {
-    let Some(item) = extract_compiler_item(attrs) else {
+    let Some(item) = extract_compiler_item(attrs, span, logger) else {
         return;
     };
-    if item.expected_kind() != CompilerItemKind::TupleFamily {
+    if !check_compiler_item_placement(
+        item,
+        CompilerItemKind::TupleFamily,
+        module_source,
+        span,
+        logger,
+    ) {
         return;
     }
     let resolved = Resolved::TupleFamily {
         module_source: module_source.clone(),
     };
-    let _ = type_table
+    if let Err(err) = type_table
         .borrow_mut()
         .compiler_items_mut()
-        .register(item, resolved);
+        .register(item, resolved)
+    {
+        report_register_error(err, span, logger);
+    }
 }
 
 impl<H: CompilerHost> Resolver<'_, H> {
@@ -530,6 +648,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
             &variant_decl.attrs,
             &variant_decl.name,
             &self.current_module_source,
+            variant_decl.span,
+            self.logger,
         );
 
         TirVariantDecl {
@@ -935,7 +1055,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
             is_cm_export: false,
             is_ambient: Self::extract_is_ambient(&func.attrs),
             inline_hint: Self::extract_inline_hint(&func.attrs),
-            compiler_item: extract_compiler_item(&func.attrs),
+            compiler_item: extract_compiler_item(&func.attrs, func.span, self.logger),
             export_name: Self::extract_export_name(&func.attrs),
             allocator_tag: Self::extract_allocator_tag(&func.attrs),
             kind: FunctionKind::Regular,
@@ -1511,7 +1631,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
             is_cm_export: false,
             is_ambient: Self::extract_is_ambient(&func.attrs),
             inline_hint: Self::extract_inline_hint(&func.attrs),
-            compiler_item: extract_compiler_item(&func.attrs),
+            compiler_item: extract_compiler_item(&func.attrs, func.span, self.logger),
             export_name: None,
             allocator_tag: None,
             kind: FunctionKind::Regular,

--- a/wado-compiler/src/resolver/method_call.rs
+++ b/wado-compiler/src/resolver/method_call.rs
@@ -2144,9 +2144,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
             .compiler_items()
             .trait_name(crate::compiler_item::CompilerItem::From)
             .to_string();
-        let is_from_or_try_from = |base: &str| -> bool {
-            base == from_trait_name || base == "TryFrom"
-        };
+        let is_from_or_try_from =
+            |base: &str| -> bool { base == from_trait_name || base == "TryFrom" };
         let resolve_trait_name = |trait_type: &ast::Type| -> String {
             let base = Self::get_type_name_static(trait_type);
             if is_from_or_try_from(&base) {

--- a/wado-compiler/src/resolver/method_call.rs
+++ b/wado-compiler/src/resolver/method_call.rs
@@ -2063,6 +2063,12 @@ impl<H: CompilerHost> Resolver<'_, H> {
     ) -> bool {
         let target_name = Self::get_type_name_static(target_type);
         let arg_type_name = self.type_table.borrow().type_name(*arg_type_id);
+        let from_trait_name = self
+            .type_table
+            .borrow()
+            .compiler_items()
+            .trait_name(crate::compiler_item::CompilerItem::From)
+            .to_string();
         let check_impl = |impl_block: &ast::ImplBlock| -> bool {
             if !impl_block.is_synthesize_request {
                 return false;
@@ -2070,7 +2076,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
             let Some(trait_type) = &impl_block.trait_type else {
                 return false;
             };
-            if Self::get_type_name_static(trait_type) != "From"
+            if Self::get_type_name_static(trait_type) != from_trait_name
                 || Self::get_type_name_static(&impl_block.ty) != target_name
             {
                 return false;
@@ -2132,9 +2138,18 @@ impl<H: CompilerHost> Resolver<'_, H> {
         method_name: &str,
         arg_type_name: Option<&str>,
     ) -> Option<StaticMethodRef> {
+        let from_trait_name = self
+            .type_table
+            .borrow()
+            .compiler_items()
+            .trait_name(crate::compiler_item::CompilerItem::From)
+            .to_string();
+        let is_from_or_try_from = |base: &str| -> bool {
+            base == from_trait_name || base == "TryFrom"
+        };
         let resolve_trait_name = |trait_type: &ast::Type| -> String {
             let base = Self::get_type_name_static(trait_type);
-            if base == "From" || base == "TryFrom" {
+            if is_from_or_try_from(&base) {
                 self.get_type_name_full(trait_type)
             } else {
                 base
@@ -2146,13 +2161,13 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 return true;
             };
             let base = Self::get_type_name_static(trait_type);
-            if (base == "From" || base == "TryFrom")
+            if is_from_or_try_from(&base)
                 && let ast::Type::Generic(g) = trait_type
                 && let Some(arg) = g.args.first()
             {
                 return Self::get_type_name_static(arg) == expected;
             }
-            base != "From" && base != "TryFrom"
+            !is_from_or_try_from(&base)
         };
 
         let check_impl = |impl_block: &ast::ImplBlock| -> Option<String> {

--- a/wado-compiler/src/resolver/method_call.rs
+++ b/wado-compiler/src/resolver/method_call.rs
@@ -2243,11 +2243,17 @@ impl<H: CompilerHost> Resolver<'_, H> {
         // Auto-derived `Default::default()` — no user impl block exists, but
         // the synthesis pass emits one in the struct's own module.
         if method_name == "default" && self.auto_derive_default_struct_type(struct_name).is_some() {
+            let default_trait_name = self
+                .type_table
+                .borrow()
+                .compiler_items()
+                .trait_name(crate::compiler_item::CompilerItem::Default)
+                .to_string();
             return Some(StaticMethodRef::new(
                 self.find_struct_module_source(struct_name),
                 struct_name,
                 method_name,
-                Some("Default".to_string()),
+                Some(default_trait_name),
             ));
         }
 

--- a/wado-compiler/src/resolver/method_lookup.rs
+++ b/wado-compiler/src/resolver/method_lookup.rs
@@ -169,10 +169,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
     /// transparent. For traits that don't yet have a `CompilerItem`
     /// anchor (`Add`, `Sub`, …, `Ord`), the canonical stdlib name is
     /// returned as a literal.
-    pub(super) fn operator_trait_method(
-        &self,
-        op: &BinaryOp,
-    ) -> Option<(String, &'static str)> {
+    pub(super) fn operator_trait_method(&self, op: &BinaryOp) -> Option<(String, &'static str)> {
         match op {
             BinaryOp::Add => Some(("Add".to_string(), "add")),
             BinaryOp::Sub => Some(("Sub".to_string(), "sub")),

--- a/wado-compiler/src/resolver/method_lookup.rs
+++ b/wado-compiler/src/resolver/method_lookup.rs
@@ -189,9 +189,14 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     .to_string(),
                 "eq",
             )),
-            BinaryOp::Lt | BinaryOp::LtEq | BinaryOp::Gt | BinaryOp::GtEq => {
-                Some(("Ord".to_string(), "cmp"))
-            }
+            BinaryOp::Lt | BinaryOp::LtEq | BinaryOp::Gt | BinaryOp::GtEq => Some((
+                self.type_table
+                    .borrow()
+                    .compiler_items()
+                    .trait_name(CompilerItem::Ord)
+                    .to_string(),
+                "cmp",
+            )),
             _ => None,
         }
     }

--- a/wado-compiler/src/resolver/method_lookup.rs
+++ b/wado-compiler/src/resolver/method_lookup.rs
@@ -4,6 +4,7 @@ use crate::hashmap::{IndexMap, IndexSet};
 
 use crate::ast::{self, BinaryOp, Expr, Item, Literal, Type, UnaryOp};
 use crate::compiler_host::CompilerHost;
+use crate::compiler_item::CompilerItem;
 use crate::module_source::ModuleSource;
 use crate::name::{LocalMethodName, MethodName};
 use crate::tir::{
@@ -159,20 +160,41 @@ impl<H: CompilerHost> Resolver<'_, H> {
         declared
     }
 
-    pub(super) fn operator_trait_method(op: &BinaryOp) -> Option<(&'static str, &'static str)> {
+    /// Map a binary operator to its `(trait_name, method_name)` pair, or
+    /// `None` when the operator does not dispatch through a trait.
+    ///
+    /// For operators that dispatch through a [`CompilerItem`] trait
+    /// (`Eq` for `==` / `!=`), the trait name is resolved through the
+    /// compiler-item registry so a rename on the stdlib side stays
+    /// transparent. For traits that don't yet have a `CompilerItem`
+    /// anchor (`Add`, `Sub`, …, `Ord`), the canonical stdlib name is
+    /// returned as a literal.
+    pub(super) fn operator_trait_method(
+        &self,
+        op: &BinaryOp,
+    ) -> Option<(String, &'static str)> {
         match op {
-            BinaryOp::Add => Some(("Add", "add")),
-            BinaryOp::Sub => Some(("Sub", "sub")),
-            BinaryOp::Mul => Some(("Mul", "mul")),
-            BinaryOp::Div => Some(("Div", "div")),
-            BinaryOp::Mod => Some(("Rem", "rem")),
-            BinaryOp::BitAnd => Some(("BitAnd", "bitand")),
-            BinaryOp::BitOr => Some(("BitOr", "bitor")),
-            BinaryOp::BitXor => Some(("BitXor", "bitxor")),
-            BinaryOp::Shl => Some(("Shl", "shl")),
-            BinaryOp::Shr => Some(("Shr", "shr")),
-            BinaryOp::Eq | BinaryOp::NotEq => Some(("Eq", "eq")),
-            BinaryOp::Lt | BinaryOp::LtEq | BinaryOp::Gt | BinaryOp::GtEq => Some(("Ord", "cmp")),
+            BinaryOp::Add => Some(("Add".to_string(), "add")),
+            BinaryOp::Sub => Some(("Sub".to_string(), "sub")),
+            BinaryOp::Mul => Some(("Mul".to_string(), "mul")),
+            BinaryOp::Div => Some(("Div".to_string(), "div")),
+            BinaryOp::Mod => Some(("Rem".to_string(), "rem")),
+            BinaryOp::BitAnd => Some(("BitAnd".to_string(), "bitand")),
+            BinaryOp::BitOr => Some(("BitOr".to_string(), "bitor")),
+            BinaryOp::BitXor => Some(("BitXor".to_string(), "bitxor")),
+            BinaryOp::Shl => Some(("Shl".to_string(), "shl")),
+            BinaryOp::Shr => Some(("Shr".to_string(), "shr")),
+            BinaryOp::Eq | BinaryOp::NotEq => Some((
+                self.type_table
+                    .borrow()
+                    .compiler_items()
+                    .trait_name(CompilerItem::Eq)
+                    .to_string(),
+                "eq",
+            )),
+            BinaryOp::Lt | BinaryOp::LtEq | BinaryOp::Gt | BinaryOp::GtEq => {
+                Some(("Ord".to_string(), "cmp"))
+            }
             _ => None,
         }
     }
@@ -215,9 +237,9 @@ impl<H: CompilerHost> Resolver<'_, H> {
         op: &BinaryOp,
     ) -> Option<TypeId> {
         let struct_name = self.struct_name_for_type(self_type_id)?;
-        let (trait_name, method_name) = Self::operator_trait_method(op)?;
+        let (trait_name, method_name) = self.operator_trait_method(op)?;
         let trait_info =
-            self.find_arithmetic_trait_impl(&struct_name, self_type_id, trait_name, method_name)?;
+            self.find_arithmetic_trait_impl(&struct_name, self_type_id, &trait_name, method_name)?;
         // Unwrap the &T reference wrapper if present (e.g., rhs: &Self → return Self)
         trait_info.rhs_type.map(|t| {
             let resolved = self.type_table.borrow().get(t).clone();
@@ -237,9 +259,9 @@ impl<H: CompilerHost> Resolver<'_, H> {
         op: &BinaryOp,
     ) -> Option<TypeId> {
         let struct_name = self.struct_name_for_type(rhs_type_id)?;
-        let (trait_name, method_name) = Self::operator_trait_method(op)?;
+        let (trait_name, method_name) = self.operator_trait_method(op)?;
         // Verify the trait impl exists; the self type is the struct type itself
-        self.find_arithmetic_trait_impl(&struct_name, rhs_type_id, trait_name, method_name)?;
+        self.find_arithmetic_trait_impl(&struct_name, rhs_type_id, &trait_name, method_name)?;
         Some(rhs_type_id)
     }
 

--- a/wado-compiler/src/resolver/module.rs
+++ b/wado-compiler/src/resolver/module.rs
@@ -240,6 +240,20 @@ impl<H: CompilerHost> Resolver<'_, H> {
                             cases,
                         ),
                     );
+                    // Mirror the variant / trait paths: register the enum's
+                    // `#[compiler_item("...")]` annotation here so a future
+                    // enum compiler item declared in a lazily-loaded module
+                    // (i.e. one reached only through `module.rs` and not the
+                    // first-pass walk in `orchestration.rs`) still lands in
+                    // the registry.
+                    super::item::register_enum_compiler_item(
+                        &self.type_table,
+                        &enum_decl.attrs,
+                        &enum_decl.name,
+                        &self.current_module_source,
+                        enum_decl.span,
+                        self.logger,
+                    );
                 }
                 Item::Flags(flags_decl) => {
                     // Create a distinct Flags type (not a newtype over u32)

--- a/wado-compiler/src/resolver/module.rs
+++ b/wado-compiler/src/resolver/module.rs
@@ -421,23 +421,16 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     // against the impl's owning type. This is the only place
                     // where the method declaration AND its owner type are
                     // simultaneously in scope.
-                    {
-                        use crate::compiler_item::Resolved;
-                        for method in &impl_block.methods {
-                            super::item::register_method_compiler_item(
-                                &scope.type_table,
-                                &method.attrs,
-                                &method.name,
-                                &scope.get_type_name(&impl_block.ty),
-                                &scope.current_module_source,
-                                method.span,
-                                scope.logger,
-                            );
-                            // Keep `Resolved` referenced even if the helper
-                            // ends up renamed; this comment is a placeholder
-                            // for IDE find-usages searches.
-                            let _ = std::marker::PhantomData::<Resolved>;
-                        }
+                    for method in &impl_block.methods {
+                        super::item::register_method_compiler_item(
+                            &scope.type_table,
+                            &method.attrs,
+                            &method.name,
+                            &scope.get_type_name(&impl_block.ty),
+                            &scope.current_module_source,
+                            method.span,
+                            scope.logger,
+                        );
                     }
 
                     for method in &impl_block.methods {

--- a/wado-compiler/src/resolver/module.rs
+++ b/wado-compiler/src/resolver/module.rs
@@ -214,6 +214,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         &variant_decl.attrs,
                         &variant_decl.name,
                         &module_source,
+                        variant_decl.span,
+                        scope.logger,
                     );
 
                     drop(scope);
@@ -274,6 +276,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         &trait_decl.attrs,
                         &trait_decl.name,
                         &self.current_module_source,
+                        trait_decl.span,
+                        self.logger,
                     );
                 }
                 _ => {}
@@ -418,25 +422,21 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     // where the method declaration AND its owner type are
                     // simultaneously in scope.
                     {
-                        use crate::compiler_item::{CompilerItemKind, Resolved};
+                        use crate::compiler_item::Resolved;
                         for method in &impl_block.methods {
-                            let Some(item) = super::item::extract_compiler_item(&method.attrs)
-                            else {
-                                continue;
-                            };
-                            if item.expected_kind() != CompilerItemKind::Method {
-                                continue;
-                            }
-                            let resolved = Resolved::Method {
-                                module_source: scope.current_module_source.clone(),
-                                owner_type: scope.get_type_name(&impl_block.ty),
-                                name: method.name.clone(),
-                            };
-                            let _ = scope
-                                .type_table
-                                .borrow_mut()
-                                .compiler_items_mut()
-                                .register(item, resolved);
+                            super::item::register_method_compiler_item(
+                                &scope.type_table,
+                                &method.attrs,
+                                &method.name,
+                                &scope.get_type_name(&impl_block.ty),
+                                &scope.current_module_source,
+                                method.span,
+                                scope.logger,
+                            );
+                            // Keep `Resolved` referenced even if the helper
+                            // ends up renamed; this comment is a placeholder
+                            // for IDE find-usages searches.
+                            let _ = std::marker::PhantomData::<Resolved>;
                         }
                     }
 

--- a/wado-compiler/src/resolver/operators.rs
+++ b/wado-compiler/src/resolver/operators.rs
@@ -653,7 +653,9 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     BinaryOp::Shl => "Shl".to_string(),
                     BinaryOp::Shr => "Shr".to_string(),
                     BinaryOp::Eq | BinaryOp::NotEq => eq_trait_name,
-                    BinaryOp::Lt | BinaryOp::LtEq | BinaryOp::Gt | BinaryOp::GtEq => "Ord".to_string(),
+                    BinaryOp::Lt | BinaryOp::LtEq | BinaryOp::Gt | BinaryOp::GtEq => {
+                        "Ord".to_string()
+                    }
                     _ => "?".to_string(),
                 };
                 drop(type_table);

--- a/wado-compiler/src/resolver/operators.rs
+++ b/wado-compiler/src/resolver/operators.rs
@@ -3,7 +3,6 @@
 use crate::ast::{self, BinaryOp, UnaryOp};
 use crate::compiler_host::CompilerHost;
 use crate::compiler_item::CompilerItem;
-use crate::module_source::ModuleSource;
 use crate::name::{LocalMethodName, MethodName};
 use crate::tir::{
     CallArg, FunctionRef, PrimitiveType, ResolvedType, TirBinaryOp, TirExpr, TirExprKind,
@@ -236,10 +235,16 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     binary.op,
                     BinaryOp::Lt | BinaryOp::Gt | BinaryOp::LtEq | BinaryOp::GtEq
                 ) {
+                    let ord_trait_name = self
+                        .type_table
+                        .borrow()
+                        .compiler_items()
+                        .trait_name(CompilerItem::Ord)
+                        .to_string();
                     let Some(resolved) = self.resolve_trait_method_for_op(
                         &struct_name,
                         lookup_type_id,
-                        "Ord",
+                        &ord_trait_name,
                         "cmp",
                         false,
                     ) else {
@@ -328,8 +333,14 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 ) && let Some((_trait_name, info)) =
                     self.find_method_in_trait_bounds(&bound_names, "cmp", left.type_id)
                 {
+                    let ord_trait_name = self
+                        .type_table
+                        .borrow()
+                        .compiler_items()
+                        .trait_name(CompilerItem::Ord)
+                        .to_string();
                     let resolved = ResolvedTraitMethod {
-                        trait_name: "Ord".to_string(),
+                        trait_name: ord_trait_name,
                         method_name: "cmp".to_string(),
                         impl_name: name.clone(),
                         self_kind: info.self_kind,
@@ -637,10 +648,13 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     BinaryOp::GtEq => ">=",
                     _ => "?",
                 };
-                let eq_trait_name = type_table
-                    .compiler_items()
-                    .trait_name(CompilerItem::Eq)
-                    .to_string();
+                let (eq_trait_name, ord_trait_name) = {
+                    let items = type_table.compiler_items();
+                    (
+                        items.trait_name(CompilerItem::Eq).to_string(),
+                        items.trait_name(CompilerItem::Ord).to_string(),
+                    )
+                };
                 let trait_name: String = match binary.op {
                     BinaryOp::Add => "Add".to_string(),
                     BinaryOp::Sub => "Sub".to_string(),
@@ -653,9 +667,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     BinaryOp::Shl => "Shl".to_string(),
                     BinaryOp::Shr => "Shr".to_string(),
                     BinaryOp::Eq | BinaryOp::NotEq => eq_trait_name,
-                    BinaryOp::Lt | BinaryOp::LtEq | BinaryOp::Gt | BinaryOp::GtEq => {
-                        "Ord".to_string()
-                    }
+                    BinaryOp::Lt | BinaryOp::LtEq | BinaryOp::Gt | BinaryOp::GtEq => ord_trait_name,
                     _ => "?".to_string(),
                 };
                 drop(type_table);
@@ -1302,10 +1314,10 @@ impl<H: CompilerHost> Resolver<'_, H> {
     /// `<`   → `cmp == Less`, `>` → `cmp == Greater`,
     /// `<=`  → `cmp != Greater`, `>=` → `cmp != Less`.
     fn ord_bool_from_cmp(&mut self, cmp_call: TirExpr, op: BinaryOp, span: Span) -> TirExpr {
-        let ordering_type_id = self.type_table.borrow_mut().intern(ResolvedType::Enum {
-            name: "Ordering".to_string(),
-            module_source: ModuleSource::prelude(),
-        });
+        let ordering_type_id = self
+            .type_table
+            .borrow_mut()
+            .make_compiler_enum(CompilerItem::Ordering);
         let (compare_op, case_name, case_index): (TirBinaryOp, &str, u32) = match op {
             BinaryOp::Lt => (TirBinaryOp::Eq, "Less", 0),
             BinaryOp::Gt => (TirBinaryOp::Eq, "Greater", 2),

--- a/wado-compiler/src/resolver/operators.rs
+++ b/wado-compiler/src/resolver/operators.rs
@@ -2,6 +2,7 @@
 
 use crate::ast::{self, BinaryOp, UnaryOp};
 use crate::compiler_host::CompilerHost;
+use crate::compiler_item::CompilerItem;
 use crate::module_source::ModuleSource;
 use crate::name::{LocalMethodName, MethodName};
 use crate::tir::{
@@ -184,10 +185,16 @@ impl<H: CompilerHost> Resolver<'_, H> {
 
                 // Handle Eq trait (== and !=)
                 if matches!(binary.op, BinaryOp::Eq | BinaryOp::NotEq) {
+                    let eq_trait_name = self
+                        .type_table
+                        .borrow()
+                        .compiler_items()
+                        .trait_name(CompilerItem::Eq)
+                        .to_string();
                     let Some(resolved) = self.resolve_trait_method_for_op(
                         &struct_name,
                         lookup_type_id,
-                        "Eq",
+                        &eq_trait_name,
                         "eq",
                         false,
                     ) else {
@@ -282,8 +289,14 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     && let Some((_trait_name, info)) =
                         self.find_method_in_trait_bounds(&bound_names, "eq", left.type_id)
                 {
+                    let eq_trait_name = self
+                        .type_table
+                        .borrow()
+                        .compiler_items()
+                        .trait_name(CompilerItem::Eq)
+                        .to_string();
                     let resolved = ResolvedTraitMethod {
-                        trait_name: "Eq".to_string(),
+                        trait_name: eq_trait_name,
                         method_name: "eq".to_string(),
                         impl_name: name.clone(),
                         self_kind: info.self_kind,
@@ -624,20 +637,24 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     BinaryOp::GtEq => ">=",
                     _ => "?",
                 };
-                let trait_name = match binary.op {
-                    BinaryOp::Add => "Add",
-                    BinaryOp::Sub => "Sub",
-                    BinaryOp::Mul => "Mul",
-                    BinaryOp::Div => "Div",
-                    BinaryOp::Mod => "Rem",
-                    BinaryOp::BitAnd => "BitAnd",
-                    BinaryOp::BitOr => "BitOr",
-                    BinaryOp::BitXor => "BitXor",
-                    BinaryOp::Shl => "Shl",
-                    BinaryOp::Shr => "Shr",
-                    BinaryOp::Eq | BinaryOp::NotEq => "Eq",
-                    BinaryOp::Lt | BinaryOp::LtEq | BinaryOp::Gt | BinaryOp::GtEq => "Ord",
-                    _ => "?",
+                let eq_trait_name = type_table
+                    .compiler_items()
+                    .trait_name(CompilerItem::Eq)
+                    .to_string();
+                let trait_name: String = match binary.op {
+                    BinaryOp::Add => "Add".to_string(),
+                    BinaryOp::Sub => "Sub".to_string(),
+                    BinaryOp::Mul => "Mul".to_string(),
+                    BinaryOp::Div => "Div".to_string(),
+                    BinaryOp::Mod => "Rem".to_string(),
+                    BinaryOp::BitAnd => "BitAnd".to_string(),
+                    BinaryOp::BitOr => "BitOr".to_string(),
+                    BinaryOp::BitXor => "BitXor".to_string(),
+                    BinaryOp::Shl => "Shl".to_string(),
+                    BinaryOp::Shr => "Shr".to_string(),
+                    BinaryOp::Eq | BinaryOp::NotEq => eq_trait_name,
+                    BinaryOp::Lt | BinaryOp::LtEq | BinaryOp::Gt | BinaryOp::GtEq => "Ord".to_string(),
+                    _ => "?".to_string(),
                 };
                 drop(type_table);
                 let _ = self.logger.error(TypeError::InvalidPattern {

--- a/wado-compiler/src/resolver/orchestration.rs
+++ b/wado-compiler/src/resolver/orchestration.rs
@@ -189,6 +189,8 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                             &struct_decl.attrs,
                             &struct_decl.name,
                             module_source,
+                            struct_decl.span,
+                            logger,
                         );
                     }
                     Item::Variant(variant_decl) => {
@@ -216,6 +218,8 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                             &variant_decl.attrs,
                             &variant_decl.name,
                             module_source,
+                            variant_decl.span,
+                            logger,
                         );
                     }
                     Item::Enum(enum_decl) => {
@@ -255,6 +259,8 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                             &trait_decl.attrs,
                             &trait_decl.name,
                             module_source,
+                            trait_decl.span,
+                            logger,
                         );
                     }
                     Item::TupleTypeDecl(decl) => {
@@ -262,6 +268,8 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                             &type_table,
                             &decl.attrs,
                             module_source,
+                            decl.span,
+                            logger,
                         );
                     }
                     _ => {}

--- a/wado-compiler/src/resolver/orchestration.rs
+++ b/wado-compiler/src/resolver/orchestration.rs
@@ -235,6 +235,14 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                                     Vec::new(),
                                 ),
                             );
+                        super::item::register_enum_compiler_item(
+                            &type_table,
+                            &enum_decl.attrs,
+                            &enum_decl.name,
+                            module_source,
+                            enum_decl.span,
+                            logger,
+                        );
                     }
                     Item::Resource(resource_decl) => {
                         all_resource_types

--- a/wado-compiler/src/resolver/trait_query.rs
+++ b/wado-compiler/src/resolver/trait_query.rs
@@ -1211,7 +1211,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         };
         let trait_name: String = match method_name {
             "eq" => eq_name.clone(),
-            "cmp" => ord_name.clone(),
+            "cmp" => ord_name,
             _ => return None,
         };
         let base_type_id = self.get_base_type(receiver_type_id);

--- a/wado-compiler/src/resolver/trait_query.rs
+++ b/wado-compiler/src/resolver/trait_query.rs
@@ -5,6 +5,7 @@ use crate::hashmap::{IndexMap, IndexSet};
 
 use crate::ast::{self, Item, Type};
 use crate::compiler_host::CompilerHost;
+use crate::compiler_item::CompilerItem;
 use crate::module_source::ModuleSource;
 use crate::tir::{PrimitiveType, ResolvedType, TypeId, TypeTable};
 use crate::token::Span;
@@ -94,18 +95,31 @@ impl<H: CompilerHost> Resolver<'_, H> {
             return false;
         }
 
+        // Resolve the canonical stdlib trait names through the
+        // compiler-item registry so the auto-derive predicates below
+        // stay aligned with the actual stdlib decls (and a rename of
+        // `Eq` / `Default` does not silently disable auto-impl).
+        let (eq_name, default_name) = {
+            let tt = self.type_table.borrow();
+            let items = tt.compiler_items();
+            (
+                items.trait_name(CompilerItem::Eq).to_string(),
+                items.trait_name(CompilerItem::Default).to_string(),
+            )
+        };
+        let is_eq = |n: &str| n == eq_name;
+        let is_eq_or_ord = |n: &str| n == eq_name || n == "Ord";
+
         // Primitives have built-in implementations for certain traits
         if let ResolvedType::Primitive(prim) = &resolved {
-            match trait_name {
-                // All primitives implement Eq and Ord
-                "Eq" | "Ord" => return true,
-                // Numeric primitives implement arithmetic traits
-                "Add" | "Sub" | "Mul" | "Div" | "Rem"
-                    if !matches!(prim, PrimitiveType::Bool | PrimitiveType::Char) =>
-                {
-                    return true;
-                }
-                _ => {}
+            if is_eq_or_ord(trait_name) {
+                return true;
+            }
+            // Numeric primitives implement arithmetic traits
+            if matches!(trait_name, "Add" | "Sub" | "Mul" | "Div" | "Rem")
+                && !matches!(prim, PrimitiveType::Bool | PrimitiveType::Char)
+            {
+                return true;
             }
             // For other traits, check the type name
             let type_name = format!("{prim:?}").to_lowercase();
@@ -113,16 +127,15 @@ impl<H: CompilerHost> Resolver<'_, H> {
         }
 
         // All enums automatically implement Eq and Ord
-        if let ResolvedType::Enum { .. } = &resolved {
-            match trait_name {
-                "Eq" | "Ord" => return true,
-                _ => {}
-            }
+        if let ResolvedType::Enum { .. } = &resolved
+            && is_eq_or_ord(trait_name)
+        {
+            return true;
         }
 
         // Variants auto-implement Eq when all payload types implement Eq
         if let ResolvedType::Variant { name, .. } = &resolved
-            && trait_name == "Eq"
+            && is_eq(trait_name)
             && let Some(info) = self.lookup_variant_case(name)
         {
             let all_impl = info.cases.iter().all(|c| {
@@ -135,7 +148,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
 
         // Structs auto-implement Eq/Ord when all fields implement the trait
         if let ResolvedType::Struct { name, .. } = &resolved
-            && matches!(trait_name, "Eq" | "Ord")
+            && is_eq_or_ord(trait_name)
             && let Some(info) = self.lookup_struct_fields(name)
         {
             let field_types: Vec<TypeId> = info.fields.iter().map(|(_, tid, _)| *tid).collect();
@@ -152,7 +165,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         // Share the eligibility predicate with the method-lookup helper so
         // the bound check and `S::default()` resolution agree.
         if let ResolvedType::Struct { name, .. } = &resolved
-            && trait_name == "Default"
+            && trait_name == default_name
             && self.auto_derive_default_struct_type(name).is_some()
         {
             return true;
@@ -163,7 +176,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         if let ResolvedType::GenericInstance {
             name, type_args, ..
         } = &resolved
-            && matches!(trait_name, "Eq" | "Ord")
+            && is_eq_or_ord(trait_name)
             && let Some(info) = self.lookup_struct_fields(name)
         {
             // Build type param -> concrete type arg mapping
@@ -187,7 +200,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         if let ResolvedType::GenericInstance {
             name, type_args, ..
         } = &resolved
-            && trait_name == "Eq"
+            && is_eq(trait_name)
             && let Some(info) = self.lookup_variant_case(name)
         {
             let param_map: IndexMap<TypeId, TypeId> = info
@@ -236,7 +249,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
             }
             ResolvedType::Ref(inner) => {
                 // References always implement Eq via ref.eq (identity comparison)
-                if trait_name == "Eq" {
+                if is_eq(trait_name) {
                     return true;
                 }
                 // Check for a specific impl Trait for &T first (e.g., impl Inspect for &T)
@@ -248,7 +261,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
             }
             ResolvedType::MutRef(inner) => {
                 // Mutable references always implement Eq via ref.eq (identity comparison)
-                if trait_name == "Eq" {
+                if is_eq(trait_name) {
                     return true;
                 }
                 let inner_id = *inner;
@@ -1084,33 +1097,41 @@ impl<H: CompilerHost> Resolver<'_, H> {
         // those here. `find_arithmetic_trait_impl` would otherwise default
         // `output_type` to the receiver type when no `type Output` is
         // declared.
+        let eq_name = self
+            .type_table
+            .borrow()
+            .compiler_items()
+            .trait_name(CompilerItem::Eq)
+            .to_string();
+        let is_eq = trait_name == eq_name;
+        let is_ord = trait_name == "Ord";
         let (info_trait_name, self_kind, param_types, return_type) = if let Some(info) =
             self.find_arithmetic_trait_impl(struct_name, lookup_type_id, trait_name, method_name)
         {
-            let return_type = match trait_name {
-                "Eq" => TypeTable::BOOL,
-                "Ord" => self.type_table.borrow_mut().intern(ResolvedType::Enum {
+            let return_type = if is_eq {
+                TypeTable::BOOL
+            } else if is_ord {
+                self.type_table.borrow_mut().intern(ResolvedType::Enum {
                     name: "Ordering".to_string(),
                     module_source: ModuleSource::prelude(),
-                }),
-                _ => info.output_type,
+                })
+            } else {
+                info.output_type
             };
             let param_types = info.rhs_type.map(|t| vec![t]).unwrap_or_default();
             (info.trait_name, info.self_kind, param_types, return_type)
-        } else if matches!(trait_name, "Eq" | "Ord")
-            && self.type_implements_trait(lookup_type_id, trait_name)
-        {
+        } else if (is_eq || is_ord) && self.type_implements_trait(lookup_type_id, trait_name) {
             let ref_self_ty = self
                 .type_table
                 .borrow_mut()
                 .intern(ResolvedType::Ref(lookup_type_id));
-            let return_type = match trait_name {
-                "Eq" => TypeTable::BOOL,
-                "Ord" => self.type_table.borrow_mut().intern(ResolvedType::Enum {
+            let return_type = if is_eq {
+                TypeTable::BOOL
+            } else {
+                self.type_table.borrow_mut().intern(ResolvedType::Enum {
                     name: "Ordering".to_string(),
                     module_source: ModuleSource::prelude(),
-                }),
-                _ => unreachable!(),
+                })
             };
             (
                 trait_name.to_string(),
@@ -1175,29 +1196,36 @@ impl<H: CompilerHost> Resolver<'_, H> {
         method_name: &str,
         receiver_type_id: TypeId,
     ) -> Option<TraitMethodMatch> {
-        let trait_name = match method_name {
-            "eq" => "Eq",
-            "cmp" => "Ord",
+        let eq_name = self
+            .type_table
+            .borrow()
+            .compiler_items()
+            .trait_name(CompilerItem::Eq)
+            .to_string();
+        let trait_name: String = match method_name {
+            "eq" => eq_name.clone(),
+            "cmp" => "Ord".to_string(),
             _ => return None,
         };
         let base_type_id = self.get_base_type(receiver_type_id);
         if !self.auto_derive_eligible_kind(base_type_id) {
             return None;
         }
-        if !self.type_implements_trait(base_type_id, trait_name) {
+        if !self.type_implements_trait(base_type_id, &trait_name) {
             return None;
         }
         let ref_self_ty = self
             .type_table
             .borrow_mut()
             .intern(ResolvedType::Ref(base_type_id));
-        let return_type = match trait_name {
-            "Eq" => TypeTable::BOOL,
-            "Ord" => self.type_table.borrow_mut().intern(ResolvedType::Enum {
+        let is_eq_match = trait_name == eq_name;
+        let return_type = if is_eq_match {
+            TypeTable::BOOL
+        } else {
+            self.type_table.borrow_mut().intern(ResolvedType::Enum {
                 name: "Ordering".to_string(),
                 module_source: ModuleSource::prelude(),
-            }),
-            _ => unreachable!(),
+            })
         };
         let method_info = MethodInfo {
             return_type,
@@ -1213,7 +1241,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         };
         let impl_module_source = self.find_struct_module_source(struct_name);
         Some(TraitMethodMatch {
-            trait_name: trait_name.to_string(),
+            trait_name,
             method_info,
             impl_module_source,
             blanket_type_param: None,

--- a/wado-compiler/src/resolver/trait_query.rs
+++ b/wado-compiler/src/resolver/trait_query.rs
@@ -781,12 +781,16 @@ impl<H: CompilerHost> Resolver<'_, H> {
         let (type_name, concrete_type_args) = {
             let tt = self.type_table.borrow();
             let effective_id = tt.get_ultimate_base_type(concrete_type_id);
+            let array_name = tt
+                .compiler_items()
+                .struct_name(crate::compiler_item::CompilerItem::Array)
+                .to_string();
             match tt.get(effective_id).clone() {
                 ResolvedType::GenericInstance {
                     name, type_args, ..
                 } => (name, type_args),
                 ResolvedType::Struct { name, .. } => (name, vec![]),
-                ResolvedType::BuiltinArray(elem) => ("Array".to_string(), vec![elem]),
+                ResolvedType::BuiltinArray(elem) => (array_name, vec![elem]),
                 // Primitives (`i32`, `f64`, `bool`, ...) can implement traits
                 // with associated types just like structs. Without this arm,
                 // a generic call like `parse_range::<i32>(...)` would skip

--- a/wado-compiler/src/resolver/trait_query.rs
+++ b/wado-compiler/src/resolver/trait_query.rs
@@ -98,17 +98,18 @@ impl<H: CompilerHost> Resolver<'_, H> {
         // Resolve the canonical stdlib trait names through the
         // compiler-item registry so the auto-derive predicates below
         // stay aligned with the actual stdlib decls (and a rename of
-        // `Eq` / `Default` does not silently disable auto-impl).
-        let (eq_name, default_name) = {
+        // `Eq` / `Ord` / `Default` does not silently disable auto-impl).
+        let (eq_name, ord_name, default_name) = {
             let tt = self.type_table.borrow();
             let items = tt.compiler_items();
             (
                 items.trait_name(CompilerItem::Eq).to_string(),
+                items.trait_name(CompilerItem::Ord).to_string(),
                 items.trait_name(CompilerItem::Default).to_string(),
             )
         };
         let is_eq = |n: &str| n == eq_name;
-        let is_eq_or_ord = |n: &str| n == eq_name || n == "Ord";
+        let is_eq_or_ord = |n: &str| n == eq_name || n == ord_name;
 
         // Primitives have built-in implementations for certain traits
         if let ResolvedType::Primitive(prim) = &resolved {
@@ -1101,24 +1102,25 @@ impl<H: CompilerHost> Resolver<'_, H> {
         // those here. `find_arithmetic_trait_impl` would otherwise default
         // `output_type` to the receiver type when no `type Output` is
         // declared.
-        let eq_name = self
-            .type_table
-            .borrow()
-            .compiler_items()
-            .trait_name(CompilerItem::Eq)
-            .to_string();
+        let (eq_name, ord_name) = {
+            let tt = self.type_table.borrow();
+            let items = tt.compiler_items();
+            (
+                items.trait_name(CompilerItem::Eq).to_string(),
+                items.trait_name(CompilerItem::Ord).to_string(),
+            )
+        };
         let is_eq = trait_name == eq_name;
-        let is_ord = trait_name == "Ord";
+        let is_ord = trait_name == ord_name;
         let (info_trait_name, self_kind, param_types, return_type) = if let Some(info) =
             self.find_arithmetic_trait_impl(struct_name, lookup_type_id, trait_name, method_name)
         {
             let return_type = if is_eq {
                 TypeTable::BOOL
             } else if is_ord {
-                self.type_table.borrow_mut().intern(ResolvedType::Enum {
-                    name: "Ordering".to_string(),
-                    module_source: ModuleSource::prelude(),
-                })
+                self.type_table
+                    .borrow_mut()
+                    .make_compiler_enum(CompilerItem::Ordering)
             } else {
                 info.output_type
             };
@@ -1132,10 +1134,9 @@ impl<H: CompilerHost> Resolver<'_, H> {
             let return_type = if is_eq {
                 TypeTable::BOOL
             } else {
-                self.type_table.borrow_mut().intern(ResolvedType::Enum {
-                    name: "Ordering".to_string(),
-                    module_source: ModuleSource::prelude(),
-                })
+                self.type_table
+                    .borrow_mut()
+                    .make_compiler_enum(CompilerItem::Ordering)
             };
             (
                 trait_name.to_string(),
@@ -1200,15 +1201,17 @@ impl<H: CompilerHost> Resolver<'_, H> {
         method_name: &str,
         receiver_type_id: TypeId,
     ) -> Option<TraitMethodMatch> {
-        let eq_name = self
-            .type_table
-            .borrow()
-            .compiler_items()
-            .trait_name(CompilerItem::Eq)
-            .to_string();
+        let (eq_name, ord_name) = {
+            let tt = self.type_table.borrow();
+            let items = tt.compiler_items();
+            (
+                items.trait_name(CompilerItem::Eq).to_string(),
+                items.trait_name(CompilerItem::Ord).to_string(),
+            )
+        };
         let trait_name: String = match method_name {
             "eq" => eq_name.clone(),
-            "cmp" => "Ord".to_string(),
+            "cmp" => ord_name.clone(),
             _ => return None,
         };
         let base_type_id = self.get_base_type(receiver_type_id);
@@ -1226,10 +1229,9 @@ impl<H: CompilerHost> Resolver<'_, H> {
         let return_type = if is_eq_match {
             TypeTable::BOOL
         } else {
-            self.type_table.borrow_mut().intern(ResolvedType::Enum {
-                name: "Ordering".to_string(),
-                module_source: ModuleSource::prelude(),
-            })
+            self.type_table
+                .borrow_mut()
+                .make_compiler_enum(CompilerItem::Ordering)
         };
         let method_info = MethodInfo {
             return_type,

--- a/wado-compiler/src/resolver/types.rs
+++ b/wado-compiler/src/resolver/types.rs
@@ -336,6 +336,12 @@ pub enum TypeError {
     /// time, so it cannot generate dispatch infrastructure. See WEP
     /// 2026-01-27 § Generic Effect Parameters Are Propagation-Only.
     GenericEffectParamNotInstallable { name: String, span: Span },
+
+    /// `#[compiler_item("...")]` attribute that failed validation —
+    /// unknown name, kind mismatch (e.g. `#[compiler_item("option")]`
+    /// on a struct), or used outside a `core::*` module. The
+    /// `message` carries the specific problem.
+    CompilerItemAttr { message: String, span: Span },
 }
 
 impl std::fmt::Display for TypeError {
@@ -642,6 +648,9 @@ impl std::fmt::Display for TypeError {
                     span.line, span.column, name
                 )
             }
+            TypeError::CompilerItemAttr { message, span } => {
+                write!(f, "{}:{}: {}", span.line, span.column, message)
+            }
         }
     }
 }
@@ -913,6 +922,9 @@ impl From<TypeError> for crate::compiler_host::Diagnostic {
                 ),
                 *span,
             ),
+            TypeError::CompilerItemAttr { message, span } => {
+                (Code::CompilerItemAttr, message.clone(), *span)
+            }
         };
         crate::compiler_host::Diagnostic {
             severity: Severity::Error,

--- a/wado-compiler/src/synthesis/cm_binding.rs
+++ b/wado-compiler/src/synthesis/cm_binding.rs
@@ -502,7 +502,8 @@ mod tests {
 
     use super::export_adapter::synthesize_lift_from_flat_params;
     use super::types::{
-        compute_export_flat_param_types, export_needs_param_lifting, param_needs_lifting,
+        CmStdlibNames, compute_export_flat_param_types, export_needs_param_lifting,
+        param_needs_lifting,
     };
     use super::*;
     use crate::ast::{NamedType, Type};
@@ -597,7 +598,7 @@ mod tests {
     fn flatten_param_i32() {
         let reg = WasiRegistry::new();
         assert_eq!(
-            flatten_param_type(&named_type("i32"), &reg),
+            flatten_param_type(&named_type("i32"), &reg, &CmStdlibNames::for_tests()),
             vec![TypeTable::I32]
         );
     }
@@ -606,7 +607,7 @@ mod tests {
     fn flatten_param_i64() {
         let reg = WasiRegistry::new();
         assert_eq!(
-            flatten_param_type(&named_type("i64"), &reg),
+            flatten_param_type(&named_type("i64"), &reg, &CmStdlibNames::for_tests()),
             vec![TypeTable::I64]
         );
     }
@@ -615,7 +616,7 @@ mod tests {
     fn flatten_param_f64() {
         let reg = WasiRegistry::new();
         assert_eq!(
-            flatten_param_type(&named_type("f64"), &reg),
+            flatten_param_type(&named_type("f64"), &reg, &CmStdlibNames::for_tests()),
             vec![TypeTable::F64]
         );
     }
@@ -624,7 +625,7 @@ mod tests {
     fn flatten_param_string() {
         let reg = WasiRegistry::new();
         assert_eq!(
-            flatten_param_type(&named_type("String"), &reg),
+            flatten_param_type(&named_type("String"), &reg, &CmStdlibNames::for_tests()),
             vec![TypeTable::I32, TypeTable::I32]
         );
     }
@@ -633,7 +634,7 @@ mod tests {
     fn flatten_param_bool() {
         let reg = WasiRegistry::new();
         assert_eq!(
-            flatten_param_type(&named_type("bool"), &reg),
+            flatten_param_type(&named_type("bool"), &reg, &CmStdlibNames::for_tests()),
             vec![TypeTable::I32]
         );
     }
@@ -641,18 +642,20 @@ mod tests {
     #[test]
     fn flatten_param_unit() {
         let reg = WasiRegistry::new();
-        assert!(flatten_param_type(&Type::Tuple(vec![]), &reg).is_empty());
+        assert!(
+            flatten_param_type(&Type::Tuple(vec![]), &reg, &CmStdlibNames::for_tests()).is_empty()
+        );
     }
 
     #[test]
     fn flatten_param_newtype_u64() {
         let (reg, _) = WasiRegistry::build_from_stdlib();
         assert_eq!(
-            flatten_param_type(&named_type("Duration"), reg),
+            flatten_param_type(&named_type("Duration"), reg, &CmStdlibNames::for_tests()),
             vec![TypeTable::I64]
         );
         assert_eq!(
-            flatten_param_type(&named_type("Mark"), reg),
+            flatten_param_type(&named_type("Mark"), reg, &CmStdlibNames::for_tests()),
             vec![TypeTable::I64]
         );
     }
@@ -909,6 +912,7 @@ mod tests {
             i32_const(100),
             &mut 0,
             &mut vec![],
+            &CmStdlibNames::for_tests(),
         );
         assert_eq!(stmts.len(), 1);
     }
@@ -926,6 +930,7 @@ mod tests {
             i32_const(100),
             &mut 0,
             &mut vec![],
+            &CmStdlibNames::for_tests(),
         );
         assert_eq!(stmts.len(), 1);
     }
@@ -939,6 +944,7 @@ mod tests {
             i32_const(100),
             &mut 0,
             &mut vec![],
+            &CmStdlibNames::for_tests(),
         );
         assert!(stmts.is_empty());
     }
@@ -957,6 +963,7 @@ mod tests {
             i32_const(100),
             &mut next_local,
             &mut vec![],
+            &CmStdlibNames::for_tests(),
         );
         // Should produce: let __packed = cm_lower_string(value); store ptr; store len
         assert_eq!(stmts.len(), 3);
@@ -1165,7 +1172,8 @@ mod tests {
     #[test]
     fn compute_flat_params_empty() {
         let params: Vec<(String, Type)> = vec![];
-        let type_table = TypeTable::new();
+        let mut type_table = TypeTable::new();
+        register_option_result_for_tests(&mut type_table);
         let tir_modules = IndexMap::default();
         let flat = compute_export_flat_param_types(&params, &tir_modules, &type_table);
         assert!(flat.is_empty());
@@ -1177,7 +1185,8 @@ mod tests {
             ("a".to_string(), named_type("i32")),
             ("b".to_string(), named_type("f64")),
         ];
-        let type_table = TypeTable::new();
+        let mut type_table = TypeTable::new();
+        register_option_result_for_tests(&mut type_table);
         let tir_modules = IndexMap::default();
         let flat = compute_export_flat_param_types(&params, &tir_modules, &type_table);
         assert_eq!(flat, vec![cm_abi::CmValType::I32, cm_abi::CmValType::F64]);
@@ -1186,7 +1195,8 @@ mod tests {
     #[test]
     fn compute_flat_params_string() {
         let params = vec![("name".to_string(), named_type("String"))];
-        let type_table = TypeTable::new();
+        let mut type_table = TypeTable::new();
+        register_option_result_for_tests(&mut type_table);
         let tir_modules = IndexMap::default();
         let flat = compute_export_flat_param_types(&params, &tir_modules, &type_table);
         assert_eq!(flat, vec![cm_abi::CmValType::I32, cm_abi::CmValType::I32]);
@@ -1199,7 +1209,8 @@ mod tests {
             ("name".to_string(), named_type("String")),
             ("b".to_string(), named_type("f32")),
         ];
-        let type_table = TypeTable::new();
+        let mut type_table = TypeTable::new();
+        register_option_result_for_tests(&mut type_table);
         let tir_modules = IndexMap::default();
         let flat = compute_export_flat_param_types(&params, &tir_modules, &type_table);
         assert_eq!(

--- a/wado-compiler/src/synthesis/cm_binding.rs
+++ b/wado-compiler/src/synthesis/cm_binding.rs
@@ -554,7 +554,7 @@ mod tests {
         let _ = tt.compiler_items_mut().register(
             CompilerItem::Array,
             Resolved::Struct {
-                module_source: ModuleSource::prelude(),
+                module_source: ModuleSource::array(),
                 name: "Array".to_string(),
             },
         );

--- a/wado-compiler/src/synthesis/cm_binding.rs
+++ b/wado-compiler/src/synthesis/cm_binding.rs
@@ -332,10 +332,14 @@ pub fn generate_adapters(mut project: Package) -> Result<Package, String> {
                         let user_returns_result = {
                             let user_func = user_func_rc.borrow();
                             let tt = entry_type_table.borrow();
+                            let result_name = tt
+                                .compiler_items()
+                                .variant_name(crate::compiler_item::CompilerItem::Result)
+                                .to_string();
                             matches!(
                                 tt.get(user_func.return_type),
                                 ResolvedType::GenericInstance { name, .. }
-                                    if name == "Result"
+                                    if *name == result_name
                             )
                         };
 
@@ -518,10 +522,11 @@ mod tests {
         })
     }
 
-    /// Register the `Option` and `Result` compiler items against
-    /// `ModuleSource::prelude()` so `make_option` / `make_result` work
-    /// in unit tests. Production resolution wires these up when the
-    /// stdlib resolver visits `core:prelude`.
+    /// Register the `Option`, `Result`, `String`, and `Array` compiler
+    /// items against the relevant prelude modules so `make_option` /
+    /// `make_result` and the type-identity reads inside `lift` /
+    /// `cm_binding` succeed in unit tests. Production resolution wires
+    /// these up when the stdlib resolver visits `core:prelude`.
     fn register_option_result_for_tests(tt: &mut TypeTable) {
         use crate::compiler_item::{CompilerItem, Resolved};
         let _ = tt.compiler_items_mut().register(
@@ -536,6 +541,20 @@ mod tests {
             Resolved::Variant {
                 module_source: ModuleSource::prelude(),
                 name: "Result".to_string(),
+            },
+        );
+        let _ = tt.compiler_items_mut().register(
+            CompilerItem::String,
+            Resolved::Struct {
+                module_source: ModuleSource::string(),
+                name: "String".to_string(),
+            },
+        );
+        let _ = tt.compiler_items_mut().register(
+            CompilerItem::Array,
+            Resolved::Struct {
+                module_source: ModuleSource::prelude(),
+                name: "Array".to_string(),
             },
         );
     }

--- a/wado-compiler/src/synthesis/cm_binding/export_adapter.rs
+++ b/wado-compiler/src/synthesis/cm_binding/export_adapter.rs
@@ -96,6 +96,7 @@ fn lower_to_flat_inner(
     tir_modules: &IndexMap<ModuleSource, TirModule>,
     ctx: LiftContext<'_>,
 ) -> Vec<FlatLocal> {
+    let names = super::types::CmStdlibNames::from_type_table(&ctx.type_table.borrow());
     match resolved {
         ResolvedType::Primitive(p) => {
             let (flat_type_id, cm_type) = match p {
@@ -138,7 +139,7 @@ fn lower_to_flat_inner(
                 cm_type: cm_abi::CmValType::I32,
             }]
         }
-        ResolvedType::Struct { name, .. } if name == "String" => {
+        ResolvedType::Struct { name, .. } if name == &names.string => {
             // String → cm_lower_string → packed i64, split to ptr(i32) and len(i32)
             let packed = internal_call("cm_lower_string", vec![value], TypeTable::I64);
             let packed_local = alloc_local(next_local, locals, TypeTable::I64);
@@ -177,7 +178,7 @@ fn lower_to_flat_inner(
         ResolvedType::Unit => vec![],
         ResolvedType::GenericInstance {
             name, type_args, ..
-        } if name == "Array" && type_args.len() == 1 => {
+        } if name == &names.array && type_args.len() == 1 => {
             // Array<T> flat ABI: (ptr: i32, len: i32) pointing at
             // `len * cm_size(T)` bytes of linear memory with `cm_align(T)`
             // alignment, laid out per the Canonical ABI.
@@ -203,7 +204,7 @@ fn lower_to_flat_inner(
                 TypeTable::I32,
                 generic_method_call(
                     local_ref(arr_local, "__arr_val", type_id),
-                    "Array",
+                    &names.array,
                     "len",
                     ModuleSource::prelude(),
                     vec![],
@@ -274,7 +275,7 @@ fn lower_to_flat_inner(
             // __elem = (__arr[__i]) via the IndexValue<i32> trait method.
             let elem_local = alloc_local(next_local, locals, elem_type_id);
             let iv_info = LocalMethodName::new(
-                "Array".to_string(),
+                names.array.clone(),
                 Some("IndexValue<i32>".to_string()),
                 "index_value".to_string(),
             );
@@ -456,7 +457,7 @@ fn lower_to_flat_inner(
 
             result
         }
-        ResolvedType::Struct { name, .. } if name != "String" => {
+        ResolvedType::Struct { name, .. } if name != &names.string => {
             // Struct: concatenation of field flat types
             if let Some(struct_decl) = find_struct_decl(name, tir_modules) {
                 let mut result = Vec::new();
@@ -528,7 +529,15 @@ pub(super) fn synthesize_lift_from_flat_params(
     type_table_cell: &RefCell<TypeTable>,
     lift_ctx: LiftContext<'_>,
 ) -> (TirExpr, usize) {
+    let names = super::types::CmStdlibNames::from_type_table(&type_table_cell.borrow());
     match ty {
+        Type::Named(named) if named.name == names.string => {
+            // String flat ABI: (ptr: i32, len: i32) pointing to linear memory
+            let ptr = local_ref(flat_param_locals[0], "__p", TypeTable::I32);
+            let len = local_ref(flat_param_locals[1], "__p", TypeTable::I32);
+            let lifted = internal_call("memory_to_gc_string", vec![ptr, len], target_type_id);
+            (lifted, 2)
+        }
         Type::Named(named) => match named.name.as_str() {
             "i32" | "u32" => (local_ref(flat_param_locals[0], "__p", TypeTable::I32), 1),
             "i64" | "u64" => (local_ref(flat_param_locals[0], "__p", TypeTable::I64), 1),
@@ -543,13 +552,6 @@ pub(super) fn synthesize_lift_from_flat_params(
                 (lifted, 1)
             }
             "char" => (local_ref(flat_param_locals[0], "__p", TypeTable::CHAR), 1),
-            "String" => {
-                // String flat ABI: (ptr: i32, len: i32) pointing to linear memory
-                let ptr = local_ref(flat_param_locals[0], "__p", TypeTable::I32);
-                let len = local_ref(flat_param_locals[1], "__p", TypeTable::I32);
-                let lifted = internal_call("memory_to_gc_string", vec![ptr, len], target_type_id);
-                (lifted, 2)
-            }
             "()" => {
                 let unit = TirExpr::new(TirExprKind::Unit, TypeTable::UNIT, synth_span());
                 (unit, 0)
@@ -640,9 +642,9 @@ pub(super) fn synthesize_lift_from_flat_params(
             }
         },
         Type::Generic(generic) => match generic.name.as_str() {
-            "Array"
-                if generic.args.len() == 1
-                    && matches!(generic.args[0], Type::Named(ref n) if n.name == "u8") =>
+            n if n == names.array
+                && generic.args.len() == 1
+                && matches!(generic.args[0], Type::Named(ref n) if n.name == "u8") =>
             {
                 // Array<u8> flat ABI: (ptr: i32, len: i32) pointing to linear memory
                 let ptr = local_ref(flat_param_locals[0], "__p", TypeTable::I32);
@@ -650,7 +652,7 @@ pub(super) fn synthesize_lift_from_flat_params(
                 let lifted = internal_call("memory_to_gc_array", vec![ptr, len], target_type_id);
                 (lifted, 2)
             }
-            "Array" => {
+            n if n == names.array => {
                 // list<T> flat ABI: (ptr: i32, len: i32) — elements in linear memory
                 // Write ptr/len to a temp memory block so we can reuse synthesize_lift
                 let ptr = local_ref(flat_param_locals[0], "__p", TypeTable::I32);

--- a/wado-compiler/src/synthesis/cm_binding/export_adapter.rs
+++ b/wado-compiler/src/synthesis/cm_binding/export_adapter.rs
@@ -275,7 +275,7 @@ fn lower_to_flat_inner(
             // __elem = (__arr[__i]) via the IndexValue<i32> trait method.
             let elem_local = alloc_local(next_local, locals, elem_type_id);
             let iv_info = LocalMethodName::new(
-                names.array.clone(),
+                names.array,
                 Some("IndexValue<i32>".to_string()),
                 "index_value".to_string(),
             );

--- a/wado-compiler/src/synthesis/cm_binding/import_adapter.rs
+++ b/wado-compiler/src/synthesis/cm_binding/import_adapter.rs
@@ -361,6 +361,7 @@ pub(super) fn synthesize_adapter(
     owner_module: &ModuleSource,
     entry_source: &ModuleSource,
 ) -> AdapterArtifacts {
+    let names = super::types::CmStdlibNames::from_type_table(&type_table.borrow());
     let name = binding_func_name(&func_info.interface_name, &func_info.method_name);
     let local_name = func_info.local_alias_name();
 
@@ -424,14 +425,14 @@ pub(super) fn synthesize_adapter(
     // Track (start_param_idx, param_count) per WASI param for Pass 2 indexing.
     let mut param_mapping: Vec<(usize, usize)> = Vec::new();
     for (param_name, _, param_type) in &func_info.params {
-        let flat_tys = flatten_param_type(param_type, wasi_registry);
+        let flat_tys = flatten_param_type(param_type, wasi_registry, &names);
         if flat_tys.is_empty() {
             continue; // unit param, skip
         }
         let start = params.len();
         match param_type {
             // String: single placeholder param (binding body lowers to ptr+len)
-            Type::Named(n) if n.name == "String" => {
+            Type::Named(n) if n.name == names.string => {
                 params.push(TirParam {
                     name: param_name.clone(),
                     type_id: TypeTable::I32,
@@ -446,7 +447,7 @@ pub(super) fn synthesize_adapter(
             }
             // Array<u8>: single placeholder param (binding body lowers to ptr+len)
             Type::Generic(g)
-                if g.name == "Array"
+                if g.name == names.array
                     && g.args.len() == 1
                     && matches!(&g.args[0], Type::Named(n) if n.name == "u8") =>
             {
@@ -463,7 +464,7 @@ pub(super) fn synthesize_adapter(
                 param_mapping.push((start, 1));
             }
             // General Array<T>: single placeholder param (binding body lowers to ptr+len)
-            Type::Generic(g) if g.name == "Array" && g.args.len() == 1 => {
+            Type::Generic(g) if g.name == names.array && g.args.len() == 1 => {
                 params.push(TirParam {
                     name: param_name.clone(),
                     type_id: TypeTable::I32,
@@ -572,7 +573,7 @@ pub(super) fn synthesize_adapter(
     // Intermediate locals (packed i64, etc.) are allocated after all params.
     let mut mapping_idx = 0usize;
     for (param_name, _, param_type) in &func_info.params {
-        let flat_tys = flatten_param_type(param_type, wasi_registry);
+        let flat_tys = flatten_param_type(param_type, wasi_registry, &names);
         if flat_tys.is_empty() {
             continue; // unit param, skip
         }
@@ -582,7 +583,7 @@ pub(super) fn synthesize_adapter(
 
         match param_type {
             // String param: accept Wado String, lower to (ptr, len) pair
-            Type::Named(n) if n.name == "String" => {
+            Type::Named(n) if n.name == names.string => {
                 // Call cm_lower_string → packed i64
                 let packed_local = next_local;
                 let packed = internal_call(
@@ -626,7 +627,7 @@ pub(super) fn synthesize_adapter(
 
             // Array<u8> param: accept Wado Array<u8>, lower to (ptr, len) pair
             Type::Generic(g)
-                if g.name == "Array"
+                if g.name == names.array
                     && g.args.len() == 1
                     && matches!(&g.args[0], Type::Named(n) if n.name == "u8") =>
             {
@@ -671,7 +672,7 @@ pub(super) fn synthesize_adapter(
             }
 
             // General Array<T> param: lower to (ptr, len) in linear memory
-            Type::Generic(g) if g.name == "Array" && g.args.len() == 1 => {
+            Type::Generic(g) if g.name == names.array && g.args.len() == 1 => {
                 let elem_type = &g.args[0];
                 // Use registry-aware layout so named WASI struct/variant/enum/flags
                 // element types walk at their true CM stride/alignment instead of
@@ -704,7 +705,7 @@ pub(super) fn synthesize_adapter(
                     TypeTable::I32,
                     generic_method_call(
                         local_ref(param_local, param_name, array_type_id),
-                        "Array",
+                        &names.array,
                         "len",
                         ModuleSource::prelude(),
                         vec![],
@@ -781,7 +782,7 @@ pub(super) fn synthesize_adapter(
                 // __elem = param[__i] (IndexValue trait method)
                 let elem_local = alloc_local(&mut next_local, &mut locals, elem_type_id);
                 let iv_info = LocalMethodName::new(
-                    "Array".to_string(),
+                    names.array.clone(),
                     Some("IndexValue<i32>".to_string()),
                     "index_value".to_string(),
                 );
@@ -825,7 +826,14 @@ pub(super) fn synthesize_adapter(
                         type_table,
                     )
                 } else {
-                    synthesize_lower(elem_type, elem_ref, addr_ref, &mut next_local, &mut locals)
+                    synthesize_lower(
+                        elem_type,
+                        elem_ref,
+                        addr_ref,
+                        &mut next_local,
+                        &mut locals,
+                        &names,
+                    )
                 };
                 loop_body.extend(lower_stmts);
                 // __i += 1
@@ -1135,7 +1143,7 @@ pub(super) fn synthesize_adapter(
                     );
                     continue;
                 }
-                let stores = cm_param_store_plan(ty, wasi_registry);
+                let stores = cm_param_store_plan(ty, wasi_registry, &names);
                 for (sub_offset, store_name) in &stores {
                     let offset = base_offset + sub_offset;
                     let addr = if offset == 0 {

--- a/wado-compiler/src/synthesis/cm_binding/lift.rs
+++ b/wado-compiler/src/synthesis/cm_binding/lift.rs
@@ -136,83 +136,83 @@ fn synthesize_lift_inner(
                 return internal_call("memory_to_gc_string", vec![ptr, len], string_type_id);
             }
             match named_name {
-            "i32" | "u32" => builtin_call("i32_load", vec![addr], TypeTable::I32),
-            "i64" | "u64" => builtin_call("i64_load", vec![addr], TypeTable::I64),
-            "f32" => builtin_call("f32_load", vec![addr], TypeTable::F32),
-            "f64" => builtin_call("f64_load", vec![addr], TypeTable::F64),
-            "i8" | "u8" => builtin_call("i32_load8_u", vec![addr], TypeTable::U8),
-            "i16" | "u16" => builtin_call("i32_load16_u", vec![addr], TypeTable::U16),
-            "bool" => {
-                let raw = builtin_call("i32_load8_u", vec![addr], TypeTable::U8);
-                binary(TirBinaryOp::NotEq, raw, i32_const(0), TypeTable::BOOL)
-            }
-            "char" => builtin_call("i32_load", vec![addr], TypeTable::CHAR),
-            _ => {
-                // CM named types arrive with `source_interface` populated
-                // either by stdlib bootstrap or by `resolve_cm_source_for`
-                // (fallback to the unique `wasi:*` registrant, biased by the
-                // current binding's WASI package, then to `core:kiln/*` for
-                // generator-world bindings). Non-CM references fall through
-                // to the i32-handle default.
-                if let Some(source) = ctx
-                    .wasi_registry
-                    .resolve_cm_source_for(named, Some(ctx.cm_package))
-                    .map(str::to_string)
-                {
-                    let source = source.as_str();
-                    if let Some(lifted) = try_lift_wasi_variant_or_enum(
-                        named,
-                        source,
-                        addr.clone(),
-                        next_local,
-                        stmts,
-                        locals,
-                        ctx,
-                    ) {
-                        return lifted;
-                    }
-                    if let Some(lifted) = try_lift_wasi_struct(
-                        named,
-                        source,
-                        addr.clone(),
-                        next_local,
-                        stmts,
-                        locals,
-                        ctx,
-                    ) {
-                        return lifted;
-                    }
-                    if let Some(members) = ctx
-                        .wasi_registry
-                        .get_flags_members_by_source(source, &named.name)
-                    {
-                        let load_name = match cm_flags_byte_size(members.len()) {
-                            0 => return i32_const(0),
-                            1 => "i32_load8_u",
-                            2 => "i32_load16_u",
-                            _ => "i32_load",
-                        };
-                        return builtin_call(load_name, vec![addr], TypeTable::I32);
-                    }
-                    if let Some(variants) = ctx
-                        .wasi_registry
-                        .get_enum_variants_by_source(source, &named.name)
-                    {
-                        let load_name = if variants.len() <= 256 {
-                            "i32_load8_u"
-                        } else if variants.len() <= 65536 {
-                            "i32_load16_u"
-                        } else {
-                            "i32_load"
-                        };
-                        return builtin_call(load_name, vec![addr], TypeTable::I32);
-                    }
+                "i32" | "u32" => builtin_call("i32_load", vec![addr], TypeTable::I32),
+                "i64" | "u64" => builtin_call("i64_load", vec![addr], TypeTable::I64),
+                "f32" => builtin_call("f32_load", vec![addr], TypeTable::F32),
+                "f64" => builtin_call("f64_load", vec![addr], TypeTable::F64),
+                "i8" | "u8" => builtin_call("i32_load8_u", vec![addr], TypeTable::U8),
+                "i16" | "u16" => builtin_call("i32_load16_u", vec![addr], TypeTable::U16),
+                "bool" => {
+                    let raw = builtin_call("i32_load8_u", vec![addr], TypeTable::U8);
+                    binary(TirBinaryOp::NotEq, raw, i32_const(0), TypeTable::BOOL)
                 }
-                // Default: treat as i32 handles (resources, unknown types)
-                builtin_call("i32_load", vec![addr], TypeTable::I32)
+                "char" => builtin_call("i32_load", vec![addr], TypeTable::CHAR),
+                _ => {
+                    // CM named types arrive with `source_interface` populated
+                    // either by stdlib bootstrap or by `resolve_cm_source_for`
+                    // (fallback to the unique `wasi:*` registrant, biased by the
+                    // current binding's WASI package, then to `core:kiln/*` for
+                    // generator-world bindings). Non-CM references fall through
+                    // to the i32-handle default.
+                    if let Some(source) = ctx
+                        .wasi_registry
+                        .resolve_cm_source_for(named, Some(ctx.cm_package))
+                        .map(str::to_string)
+                    {
+                        let source = source.as_str();
+                        if let Some(lifted) = try_lift_wasi_variant_or_enum(
+                            named,
+                            source,
+                            addr.clone(),
+                            next_local,
+                            stmts,
+                            locals,
+                            ctx,
+                        ) {
+                            return lifted;
+                        }
+                        if let Some(lifted) = try_lift_wasi_struct(
+                            named,
+                            source,
+                            addr.clone(),
+                            next_local,
+                            stmts,
+                            locals,
+                            ctx,
+                        ) {
+                            return lifted;
+                        }
+                        if let Some(members) = ctx
+                            .wasi_registry
+                            .get_flags_members_by_source(source, &named.name)
+                        {
+                            let load_name = match cm_flags_byte_size(members.len()) {
+                                0 => return i32_const(0),
+                                1 => "i32_load8_u",
+                                2 => "i32_load16_u",
+                                _ => "i32_load",
+                            };
+                            return builtin_call(load_name, vec![addr], TypeTable::I32);
+                        }
+                        if let Some(variants) = ctx
+                            .wasi_registry
+                            .get_enum_variants_by_source(source, &named.name)
+                        {
+                            let load_name = if variants.len() <= 256 {
+                                "i32_load8_u"
+                            } else if variants.len() <= 65536 {
+                                "i32_load16_u"
+                            } else {
+                                "i32_load"
+                            };
+                            return builtin_call(load_name, vec![addr], TypeTable::I32);
+                        }
+                    }
+                    // Default: treat as i32 handles (resources, unknown types)
+                    builtin_call("i32_load", vec![addr], TypeTable::I32)
+                }
             }
-            }
-        },
+        }
         Type::Generic(g) => {
             let gname = g.name.as_str();
             if gname == array_name && g.args.len() == 1 {

--- a/wado-compiler/src/synthesis/cm_binding/lift.rs
+++ b/wado-compiler/src/synthesis/cm_binding/lift.rs
@@ -98,8 +98,44 @@ fn synthesize_lift_inner(
     // shapes pass through `resolve_type` unchanged.
     let resolved = ctx.wasi_registry.resolve_type(ty);
     let ty = &resolved;
+    // Resolve stdlib struct names through the compiler-item registry so
+    // a rename of `String` / `Array` / `Option` / `Result` flows through
+    // CM lifting without code changes here.
+    let (string_name, array_name, option_name, result_name) = {
+        let tt = ctx.type_table.borrow();
+        let items = tt.compiler_items();
+        (
+            items
+                .struct_name(crate::compiler_item::CompilerItem::String)
+                .to_string(),
+            items
+                .struct_name(crate::compiler_item::CompilerItem::Array)
+                .to_string(),
+            items
+                .variant_name(crate::compiler_item::CompilerItem::Option)
+                .to_string(),
+            items
+                .variant_name(crate::compiler_item::CompilerItem::Result)
+                .to_string(),
+        )
+    };
     match ty {
-        Type::Named(named) => match named.name.as_str() {
+        Type::Named(named) => {
+            let named_name = named.name.as_str();
+            if named_name == string_name {
+                let ptr = builtin_call("i32_load", vec![addr.clone()], TypeTable::I32);
+                let len = builtin_call(
+                    "i32_load",
+                    vec![binary_add(addr, i32_const(4))],
+                    TypeTable::I32,
+                );
+                let string_type_id = ctx
+                    .type_table
+                    .borrow_mut()
+                    .make_compiler_struct(crate::compiler_item::CompilerItem::String);
+                return internal_call("memory_to_gc_string", vec![ptr, len], string_type_id);
+            }
+            match named_name {
             "i32" | "u32" => builtin_call("i32_load", vec![addr], TypeTable::I32),
             "i64" | "u64" => builtin_call("i64_load", vec![addr], TypeTable::I64),
             "f32" => builtin_call("f32_load", vec![addr], TypeTable::F32),
@@ -111,19 +147,6 @@ fn synthesize_lift_inner(
                 binary(TirBinaryOp::NotEq, raw, i32_const(0), TypeTable::BOOL)
             }
             "char" => builtin_call("i32_load", vec![addr], TypeTable::CHAR),
-            "String" => {
-                let ptr = builtin_call("i32_load", vec![addr.clone()], TypeTable::I32);
-                let len = builtin_call(
-                    "i32_load",
-                    vec![binary_add(addr, i32_const(4))],
-                    TypeTable::I32,
-                );
-                let string_type_id = ctx
-                    .type_table
-                    .borrow_mut()
-                    .make_struct("String".to_string(), ModuleSource::string());
-                internal_call("memory_to_gc_string", vec![ptr, len], string_type_id)
-            }
             _ => {
                 // CM named types arrive with `source_interface` populated
                 // either by stdlib bootstrap or by `resolve_cm_source_for`
@@ -188,20 +211,23 @@ fn synthesize_lift_inner(
                 // Default: treat as i32 handles (resources, unknown types)
                 builtin_call("i32_load", vec![addr], TypeTable::I32)
             }
+            }
         },
-        Type::Generic(g) => match g.name.as_str() {
-            "Array" if g.args.len() == 1 => {
+        Type::Generic(g) => {
+            let gname = g.name.as_str();
+            if gname == array_name && g.args.len() == 1 {
                 synthesize_lift_list(&g.args[0], addr, next_local, stmts, locals, ctx)
-            }
-            "Option" if g.args.len() == 1 => {
+            } else if gname == option_name && g.args.len() == 1 {
                 synthesize_lift_option_inner(&g.args[0], addr, next_local, stmts, locals, ctx)
+            } else if gname == result_name && g.args.len() == 2 {
+                synthesize_lift_result_inner(
+                    &g.args[0], &g.args[1], addr, next_local, stmts, locals, ctx,
+                )
+            } else {
+                // Own<T>, Borrow<T>, Stream<T>, Future<T> are i32 handles
+                builtin_call("i32_load", vec![addr], TypeTable::I32)
             }
-            "Result" if g.args.len() == 2 => synthesize_lift_result_inner(
-                &g.args[0], &g.args[1], addr, next_local, stmts, locals, ctx,
-            ),
-            // Own<T>, Borrow<T>, Stream<T>, Future<T> are i32 handles
-            _ => builtin_call("i32_load", vec![addr], TypeTable::I32),
-        },
+        }
         Type::Tuple(elems) if elems.is_empty() => {
             TirExpr::new(TirExprKind::Unit, TypeTable::UNIT, synth_span())
         }
@@ -597,11 +623,15 @@ fn synthesize_lift_list(
 
     // Resolve TypeIds for the element type and Array<ElemType>.
     // These are needed by the monomorphizer to instantiate Array::with_capacity and .push().
-    let (elem_type_id, array_type_id) = {
+    let (elem_type_id, array_type_id, array_struct_name) = {
         let mut tt = ctx.type_table.borrow_mut();
         let elem_tid = wasi_type_to_type_id(elem_ty, &mut tt, ctx.wasi_registry, ctx.cm_package);
         let array_tid = tt.make_array(elem_tid);
-        (elem_tid, array_tid)
+        let array_name = tt
+            .compiler_items()
+            .struct_name(crate::compiler_item::CompilerItem::Array)
+            .to_string();
+        (elem_tid, array_tid, array_name)
     };
 
     let base_local = alloc_local(next_local, locals, TypeTable::I32);
@@ -630,7 +660,7 @@ fn synthesize_lift_list(
         result_local,
         array_type_id,
         generic_static_call(
-            "Array",
+            &array_struct_name,
             "with_capacity",
             ModuleSource::prelude(),
             vec![elem_type_id],
@@ -689,7 +719,7 @@ fn synthesize_lift_list(
     // __result.push(lifted_elem)
     loop_stmts.push(expr_stmt(generic_method_call(
         local_ref(result_local, "__result", array_type_id),
-        "Array",
+        &array_struct_name,
         "push",
         ModuleSource::prelude(),
         vec![lifted_elem],
@@ -700,6 +730,7 @@ fn synthesize_lift_list(
     loop_stmts.extend(synthesize_free_element(
         elem_ty,
         local_ref(elem_addr_local, "__elem_addr", TypeTable::I32),
+        &string_name_for_free(ctx),
     ));
 
     // __i = __i + 1
@@ -797,7 +828,11 @@ fn synthesize_lift_option_inner(
         local_ref(result_local, "__option_result", option_type_id),
         option_some(lifted, option_type_id),
     )));
-    then_stmts.extend(synthesize_free_element(inner_ty, payload_addr));
+    then_stmts.extend(synthesize_free_element(
+        inner_ty,
+        payload_addr,
+        &string_name_for_free(ctx),
+    ));
 
     stmts.push(if_stmt(
         binary(
@@ -983,9 +1018,21 @@ fn synthesize_lift_tuple(
 ///
 /// For primitives: no-op.
 /// For String: frees the string data buffer.
-fn synthesize_free_element(ty: &Type, addr: TirExpr) -> Vec<TirStmt> {
+/// Look up the canonical stdlib `String` struct name via the
+/// compiler-item registry attached to `ctx`'s type table. Used to
+/// drive [`synthesize_free_element`]'s string match without
+/// hard-coding the literal `"String"`.
+fn string_name_for_free(ctx: &LiftContext<'_>) -> String {
+    ctx.type_table
+        .borrow()
+        .compiler_items()
+        .struct_name(crate::compiler_item::CompilerItem::String)
+        .to_string()
+}
+
+fn synthesize_free_element(ty: &Type, addr: TirExpr, string_name: &str) -> Vec<TirStmt> {
     match ty {
-        Type::Named(named) if named.name == "String" => {
+        Type::Named(named) if named.name == string_name => {
             let ptr = builtin_call("i32_load", vec![addr.clone()], TypeTable::I32);
             let len = builtin_call(
                 "i32_load",
@@ -1003,7 +1050,7 @@ fn synthesize_free_element(ty: &Type, addr: TirExpr) -> Vec<TirStmt> {
             let mut free_stmts = Vec::new();
             for (i, elem_ty) in elems.iter().enumerate() {
                 let elem_addr = binary_add(addr.clone(), i32_const(layout.offsets[i] as i32));
-                free_stmts.extend(synthesize_free_element(elem_ty, elem_addr));
+                free_stmts.extend(synthesize_free_element(elem_ty, elem_addr, string_name));
             }
             free_stmts
         }

--- a/wado-compiler/src/synthesis/cm_binding/lower.rs
+++ b/wado-compiler/src/synthesis/cm_binding/lower.rs
@@ -41,8 +41,46 @@ pub fn synthesize_lower(
     addr: TirExpr,
     next_local: &mut u32,
     locals: &mut Vec<TirLocal>,
+    names: &super::types::CmStdlibNames,
 ) -> Vec<TirStmt> {
     match ty {
+        Type::Named(named) if named.name == names.string => {
+            // cm_lower_string(value) returns packed i64: (ptr | (len << 32))
+            let packed_local = *next_local;
+            locals.push(TirLocal::synth(*next_local, TypeTable::I64, false));
+            *next_local += 1;
+            let packed = internal_call("cm_lower_string", vec![value], TypeTable::I64);
+            let mut stmts = vec![let_stmt("__packed", packed_local, TypeTable::I64, packed)];
+
+            // Store ptr (low 32 bits) at addr
+            let ptr = cast(
+                local_ref(packed_local, "__packed", TypeTable::I64),
+                TypeTable::I32,
+            );
+            stmts.push(expr_stmt(builtin_call(
+                "i32_store",
+                vec![addr.clone(), ptr],
+                TypeTable::UNIT,
+            )));
+
+            // Store len (high 32 bits) at addr + 4
+            let shifted = binary(
+                TirBinaryOp::Shr,
+                local_ref(packed_local, "__packed", TypeTable::I64),
+                i64_const(32),
+                TypeTable::I64,
+            );
+            let len = cast(shifted, TypeTable::I32);
+            stmts.push(expr_stmt(builtin_call(
+                "i32_store",
+                vec![
+                    binary(TirBinaryOp::Add, addr, i32_const(4), TypeTable::I32),
+                    len,
+                ],
+                TypeTable::UNIT,
+            )));
+            stmts
+        }
         Type::Named(named) => match named.name.as_str() {
             "i32" | "u32" => vec![expr_stmt(builtin_call(
                 "i32_store",
@@ -90,43 +128,6 @@ pub fn synthesize_lower(
                     TypeTable::UNIT,
                 ))]
             }
-            "String" => {
-                // cm_lower_string(value) returns packed i64: (ptr | (len << 32))
-                let packed_local = *next_local;
-                locals.push(TirLocal::synth(*next_local, TypeTable::I64, false));
-                *next_local += 1;
-                let packed = internal_call("cm_lower_string", vec![value], TypeTable::I64);
-                let mut stmts = vec![let_stmt("__packed", packed_local, TypeTable::I64, packed)];
-
-                // Store ptr (low 32 bits) at addr
-                let ptr = cast(
-                    local_ref(packed_local, "__packed", TypeTable::I64),
-                    TypeTable::I32,
-                );
-                stmts.push(expr_stmt(builtin_call(
-                    "i32_store",
-                    vec![addr.clone(), ptr],
-                    TypeTable::UNIT,
-                )));
-
-                // Store len (high 32 bits) at addr + 4
-                let shifted = binary(
-                    TirBinaryOp::Shr,
-                    local_ref(packed_local, "__packed", TypeTable::I64),
-                    i64_const(32),
-                    TypeTable::I64,
-                );
-                let len = cast(shifted, TypeTable::I32);
-                stmts.push(expr_stmt(builtin_call(
-                    "i32_store",
-                    vec![
-                        binary(TirBinaryOp::Add, addr, i32_const(4), TypeTable::I32),
-                        len,
-                    ],
-                    TypeTable::UNIT,
-                )));
-                stmts
-            }
             // Unknown named types: treat as i32 handles (enums, resources)
             _ => vec![expr_stmt(builtin_call(
                 "i32_store",
@@ -136,8 +137,9 @@ pub fn synthesize_lower(
         },
         Type::Generic(g) => match g.name.as_str() {
             // list<T>: lowered as (ptr, len) pair stored at addr
-            "Array"
-                if g.args.len() == 1 && matches!(&g.args[0], Type::Named(n) if n.name == "u8") =>
+            name if name == names.array
+                && g.args.len() == 1
+                && matches!(&g.args[0], Type::Named(n) if n.name == "u8") =>
             {
                 // list<u8>: use cm_lower_array_u8 → packed i64, store (ptr, len)
                 let packed_local = *next_local;
@@ -178,7 +180,7 @@ pub fn synthesize_lower(
                 )));
                 stmts
             }
-            "Array" => {
+            name if name == names.array => {
                 // General list<T>: treat as opaque i32 for now
                 vec![expr_stmt(builtin_call(
                     "i32_store",
@@ -222,6 +224,7 @@ pub(super) fn synthesize_lower_tuple(
     wasi_package: &str,
     type_table: &RefCell<TypeTable>,
 ) -> Vec<TirStmt> {
+    let names = super::types::CmStdlibNames::from_type_table(&type_table.borrow());
     let layout = cm_abi::layout_tuple(elems);
     let mut stmts = Vec::new();
 
@@ -273,7 +276,7 @@ pub(super) fn synthesize_lower_tuple(
                 type_table,
             )
         } else {
-            synthesize_lower(elem_ty, field_expr, field_addr, next_local, locals)
+            synthesize_lower(elem_ty, field_expr, field_addr, next_local, locals, &names)
         };
         stmts.extend(field_stmts);
     }
@@ -484,10 +487,11 @@ pub(super) fn synthesize_flatten_value_to_flat_args(
     wasi_package: &str,
     type_table: &RefCell<TypeTable>,
 ) {
+    let names = super::types::CmStdlibNames::from_type_table(&type_table.borrow());
     let resolved = wasi_registry.resolve_type(ty);
     match &resolved {
         // String → cm_lower_string → packed i64 → (ptr, len)
-        Type::Named(n) if n.name == "String" => {
+        Type::Named(n) if n.name == names.string => {
             let packed_local = alloc_local(next_local, locals, TypeTable::I64);
             stmts.push(let_stmt(
                 &format!("{prefix}_packed"),
@@ -555,7 +559,7 @@ pub(super) fn synthesize_flatten_value_to_flat_args(
                 .map(|c| {
                     c.payload
                         .as_ref()
-                        .map(|t| flatten_param_type(t, wasi_registry).len())
+                        .map(|t| flatten_param_type(t, wasi_registry, &names).len())
                         .unwrap_or(0)
                 })
                 .max()
@@ -654,6 +658,7 @@ pub(super) fn synthesize_flatten_option_to_flat_args(
     wasi_package: &str,
     type_table: &RefCell<TypeTable>,
 ) {
+    let names = super::types::CmStdlibNames::from_type_table(&type_table.borrow());
     let vt = value.type_id;
     let val_local = alloc_local(next_local, locals, vt);
     stmts.push(let_stmt(&format!("{prefix}_optval"), val_local, vt, value));
@@ -679,7 +684,7 @@ pub(super) fn synthesize_flatten_option_to_flat_args(
     ));
 
     // Compute inner flat types
-    let inner_flat_types = flatten_param_type(inner_type, wasi_registry);
+    let inner_flat_types = flatten_param_type(inner_type, wasi_registry, &names);
     if inner_flat_types.is_empty() {
         return;
     }
@@ -758,6 +763,7 @@ pub(super) fn synthesize_lower_wasi_type_to_memory(
     wasi_package: &str,
     type_table: &RefCell<TypeTable>,
 ) -> Vec<TirStmt> {
+    let names = super::types::CmStdlibNames::from_type_table(&type_table.borrow());
     let resolved = wasi_registry.resolve_type(ty);
     match &resolved {
         Type::Named(n) => {
@@ -823,7 +829,7 @@ pub(super) fn synthesize_lower_wasi_type_to_memory(
                 return stmts;
             }
             // Fall through to synthesize_lower for primitives and simple types
-            synthesize_lower(&resolved, value, addr, next_local, locals)
+            synthesize_lower(&resolved, value, addr, next_local, locals, &names)
         }
         Type::Tuple(elems) if !elems.is_empty() => synthesize_lower_tuple(
             elems,
@@ -835,6 +841,6 @@ pub(super) fn synthesize_lower_wasi_type_to_memory(
             wasi_package,
             type_table,
         ),
-        _ => synthesize_lower(&resolved, value, addr, next_local, locals),
+        _ => synthesize_lower(&resolved, value, addr, next_local, locals, &names),
     }
 }

--- a/wado-compiler/src/synthesis/cm_binding/resource_rewrite.rs
+++ b/wado-compiler/src/synthesis/cm_binding/resource_rewrite.rs
@@ -233,6 +233,9 @@ fn synthesize_stream_read_func(
     type_table: &RefCell<TypeTable>,
     interner: &RefCell<ModuleSourceInterner>,
 ) -> TirFunction {
+    let array_struct_name = super::types::CmStdlibNames::from_type_table(&type_table.borrow())
+        .array
+        .clone();
     let func_name = format!("__cm_stream_read_{elem_name}");
     let _tuple_type_id = type_table
         .borrow_mut()
@@ -358,7 +361,7 @@ fn synthesize_stream_read_func(
         TirExprKind::Call {
             func: FunctionRef {
                 module_source: ModuleSource::array(),
-                name: format!("Array<{elem_name}>::with_capacity"),
+                name: format!("{array_struct_name}<{elem_name}>::with_capacity"),
                 monomorph_info: Some(MonomorphInfo {
                     generic_name: "Array::with_capacity".to_string(),
                     impl_type_args: vec![elem_type_id],
@@ -366,8 +369,8 @@ fn synthesize_stream_read_func(
                     is_blanket: false,
                 }),
                 method_info: Some(LocalMethodName {
-                    struct_name: format!("Array<{elem_name}>"),
-                    base_struct_name: "Array".to_string(),
+                    struct_name: format!("{array_struct_name}<{elem_name}>"),
+                    base_struct_name: array_struct_name.clone(),
                     trait_name: None,
                     base_trait_name: None,
                     trait_type_args: vec![],
@@ -461,7 +464,7 @@ fn synthesize_stream_read_func(
             Box::new(local_ref(arr_idx, "arr", array_type_id)),
             FunctionRef {
                 module_source: ModuleSource::array(),
-                name: format!("Array<{elem_name}>::push"),
+                name: format!("{array_struct_name}<{elem_name}>::push"),
                 monomorph_info: Some(MonomorphInfo {
                     generic_name: "Array::push".to_string(),
                     impl_type_args: vec![elem_type_id],
@@ -469,8 +472,8 @@ fn synthesize_stream_read_func(
                     is_blanket: false,
                 }),
                 method_info: Some(LocalMethodName {
-                    struct_name: format!("Array<{elem_name}>"),
-                    base_struct_name: "Array".to_string(),
+                    struct_name: format!("{array_struct_name}<{elem_name}>"),
+                    base_struct_name: array_struct_name.clone(),
                     trait_name: None,
                     base_trait_name: None,
                     trait_type_args: vec![],

--- a/wado-compiler/src/synthesis/cm_binding/resource_rewrite.rs
+++ b/wado-compiler/src/synthesis/cm_binding/resource_rewrite.rs
@@ -233,9 +233,8 @@ fn synthesize_stream_read_func(
     type_table: &RefCell<TypeTable>,
     interner: &RefCell<ModuleSourceInterner>,
 ) -> TirFunction {
-    let array_struct_name = super::types::CmStdlibNames::from_type_table(&type_table.borrow())
-        .array
-        .clone();
+    let array_struct_name =
+        super::types::CmStdlibNames::from_type_table(&type_table.borrow()).array;
     let func_name = format!("__cm_stream_read_{elem_name}");
     let _tuple_type_id = type_table
         .borrow_mut()
@@ -473,7 +472,7 @@ fn synthesize_stream_read_func(
                 }),
                 method_info: Some(LocalMethodName {
                     struct_name: format!("{array_struct_name}<{elem_name}>"),
-                    base_struct_name: array_struct_name.clone(),
+                    base_struct_name: array_struct_name,
                     trait_name: None,
                     base_trait_name: None,
                     trait_type_args: vec![],

--- a/wado-compiler/src/synthesis/cm_binding/type_fixup.rs
+++ b/wado-compiler/src/synthesis/cm_binding/type_fixup.rs
@@ -39,6 +39,7 @@ fn replace_wasi_derived_type_recursive(
     wasi_package: &str,
     type_table: &RefCell<TypeTable>,
 ) {
+    let names = super::types::CmStdlibNames::from_type_table(&type_table.borrow());
     let old_type = {
         let mut tt = type_table.borrow_mut();
         wasi_type_to_type_id(wasi_type, &mut tt, wasi_registry, wasi_package)
@@ -67,7 +68,7 @@ fn replace_wasi_derived_type_recursive(
         }
     }
     match wasi_type {
-        Type::Generic(g) if g.name == "Array" && g.args.len() == 1 => {
+        Type::Generic(g) if g.name == names.array && g.args.len() == 1 => {
             let tt = type_table.borrow();
             if let Some(new_elem_args) = tt.generic_type_args(user_type)
                 && new_elem_args.len() == 1
@@ -880,6 +881,7 @@ fn rewrite_calls_in_expr(
     wasi_registry: &WasiRegistry,
     type_table: &Rc<RefCell<TypeTable>>,
 ) {
+    let names = super::types::CmStdlibNames::from_type_table(&type_table.borrow());
     // Check if this is an effect-like Call that should be rewritten
     let is_effect_call = matches!(&expr.kind, TirExprKind::Call { func, .. }
         if func.module_source.clone().is_effect_like() && func.module_source.clone().interface_name().is_some());
@@ -923,7 +925,7 @@ fn rewrite_calls_in_expr(
                     if i < adapter.params.len() && adapter.params[i].type_id != arg.expr.type_id {
                         let is_gc_passthrough = wasi_func.is_some_and(|f| {
                             i < f.params.len()
-                                && is_gc_passthrough_param(&f.params[i].2, wasi_registry)
+                                && is_gc_passthrough_param(&f.params[i].2, wasi_registry, &names)
                         });
                         if is_streaming && adapter.params[i].type_id == TypeTable::I32 {
                             // Streaming: keep adapter param as i32, cast the arg instead
@@ -1070,6 +1072,7 @@ fn rewrite_calls_in_expr(
                                 && is_gc_passthrough_param(
                                     &f.params[wasi_param_idx].2,
                                     wasi_registry,
+                                    &names,
                                 )
                         });
                         if is_streaming && adapter.params[param_idx].type_id == TypeTable::I32 {
@@ -1140,11 +1143,11 @@ fn rewrite_calls_in_expr(
                         continue;
                     }
                     let param_type = &func_info.params[wasi_param_idx].2;
-                    let flat_tys = flatten_param_type(param_type, wasi_registry);
+                    let flat_tys = flatten_param_type(param_type, wasi_registry, &names);
                     if flat_tys.is_empty() {
                         continue;
                     }
-                    if is_gc_passthrough_param(param_type, wasi_registry) {
+                    if is_gc_passthrough_param(param_type, wasi_registry, &names) {
                         if matches!(arg.expr.kind, TirExprKind::Null) {
                             let option_type_id = {
                                 let mut tt = type_table.borrow_mut();
@@ -1236,10 +1239,10 @@ fn rewrite_calls_in_expr(
                     for (i, (_name, _, param_type)) in func_info.params.iter().enumerate() {
                         let is_gc_passthrough = matches!(
                             param_type,
-                            Type::Named(n) if n.name == "String"
+                            Type::Named(n) if n.name == names.string
                         ) || matches!(
                             param_type,
-                            Type::Generic(g) if g.name == "Array" && g.args.len() == 1
+                            Type::Generic(g) if g.name == names.array && g.args.len() == 1
                         );
                         if is_gc_passthrough {
                             if flat_idx < adapter.params.len()
@@ -1254,7 +1257,7 @@ fn rewrite_calls_in_expr(
                             }
                             flat_idx += 1;
                         } else {
-                            let flat_tys = flatten_param_type(param_type, wasi_registry);
+                            let flat_tys = flatten_param_type(param_type, wasi_registry, &names);
                             flat_idx += flat_tys.len().max(1);
                         }
                     }
@@ -1283,11 +1286,11 @@ fn rewrite_calls_in_expr(
             let flat_call_args = if let Some(func_info) = &wasi_func_info {
                 let mut flat = Vec::new();
                 for (i, (_param_name, _, param_type)) in func_info.params.iter().enumerate() {
-                    let flat_tys = flatten_param_type(param_type, wasi_registry);
+                    let flat_tys = flatten_param_type(param_type, wasi_registry, &names);
                     if flat_tys.is_empty() || i >= taken_args.len() {
                         continue;
                     }
-                    if is_gc_passthrough_param(param_type, wasi_registry) {
+                    if is_gc_passthrough_param(param_type, wasi_registry, &names) {
                         let arg = &taken_args[i];
                         // Convert bare Null to VariantConstruct None.
                         // Use the binding's param type (from the WASI registry)

--- a/wado-compiler/src/synthesis/cm_binding/types.rs
+++ b/wado-compiler/src/synthesis/cm_binding/types.rs
@@ -71,7 +71,14 @@ pub fn wasi_type_to_type_id(
     registry: &WasiRegistry,
     wasi_package: &str,
 ) -> TypeId {
+    let string_struct_name = type_table
+        .compiler_items()
+        .struct_name(crate::compiler_item::CompilerItem::String)
+        .to_string();
     match ty {
+        Type::Named(named) if named.name.as_str() == string_struct_name => {
+            type_table.make_compiler_struct(crate::compiler_item::CompilerItem::String)
+        }
         Type::Named(named) => match named.name.as_str() {
             "i8" => TypeTable::I8,
             "i16" => TypeTable::I16,
@@ -87,7 +94,6 @@ pub fn wasi_type_to_type_id(
             "char" => TypeTable::CHAR,
             // Unit type written as a named type "()"
             "()" => TypeTable::UNIT,
-            "String" => type_table.make_struct("String".to_string(), ModuleSource::string()),
             // Resource/enum/variant types - look up the already-resolved TypeId.
             // Lookups are strictly scoped by `(name, wasi_package)`. If the
             // primary scope misses, we consult the registry for the canonical
@@ -103,37 +109,51 @@ pub fn wasi_type_to_type_id(
                 })
                 .unwrap_or(TypeTable::I32),
         },
-        Type::Generic(g) => match g.name.as_str() {
-            "Array" if g.args.len() == 1 => {
+        Type::Generic(g) => {
+            let array_name = type_table
+                .compiler_items()
+                .struct_name(crate::compiler_item::CompilerItem::Array)
+                .to_string();
+            if g.name.as_str() == array_name && g.args.len() == 1 {
                 let elem_type =
                     wasi_type_to_type_id(&g.args[0], type_table, registry, wasi_package);
-                type_table.make_array(elem_type)
+                return type_table.make_array(elem_type);
             }
-            "Option" if g.args.len() == 1 => {
+            let option_name = type_table
+                .compiler_items()
+                .variant_name(crate::compiler_item::CompilerItem::Option)
+                .to_string();
+            let result_name = type_table
+                .compiler_items()
+                .variant_name(crate::compiler_item::CompilerItem::Result)
+                .to_string();
+            if g.name.as_str() == option_name && g.args.len() == 1 {
                 let inner_type =
                     wasi_type_to_type_id(&g.args[0], type_table, registry, wasi_package);
-                type_table.make_option(inner_type)
+                return type_table.make_option(inner_type);
             }
-            "Result" if g.args.len() == 2 => {
+            if g.name.as_str() == result_name && g.args.len() == 2 {
                 let ok_type = wasi_type_to_type_id(&g.args[0], type_table, registry, wasi_package);
                 let err_type = wasi_type_to_type_id(&g.args[1], type_table, registry, wasi_package);
-                type_table.make_result(ok_type, err_type)
+                return type_table.make_result(ok_type, err_type);
             }
-            "Stream" if g.args.len() == 1 => {
-                let inner = wasi_type_to_type_id(&g.args[0], type_table, registry, wasi_package);
-                type_table.make_stream(inner)
+            match g.name.as_str() {
+                "Stream" if g.args.len() == 1 => {
+                    let inner = wasi_type_to_type_id(&g.args[0], type_table, registry, wasi_package);
+                    type_table.make_stream(inner)
+                }
+                "Future" if g.args.len() == 1 => {
+                    let inner = wasi_type_to_type_id(&g.args[0], type_table, registry, wasi_package);
+                    type_table.make_future(inner)
+                }
+                "AsyncCall" if g.args.len() == 1 => {
+                    let inner = wasi_type_to_type_id(&g.args[0], type_table, registry, wasi_package);
+                    type_table.make_async_call(inner)
+                }
+                // Own/Borrow are handle types represented as i32
+                "Own" | "Borrow" => TypeTable::I32,
+                _ => TypeTable::UNIT,
             }
-            "Future" if g.args.len() == 1 => {
-                let inner = wasi_type_to_type_id(&g.args[0], type_table, registry, wasi_package);
-                type_table.make_future(inner)
-            }
-            "AsyncCall" if g.args.len() == 1 => {
-                let inner = wasi_type_to_type_id(&g.args[0], type_table, registry, wasi_package);
-                type_table.make_async_call(inner)
-            }
-            // Own/Borrow are handle types represented as i32
-            "Own" | "Borrow" => TypeTable::I32,
-            _ => TypeTable::UNIT,
         },
         Type::Tuple(types) if types.is_empty() => TypeTable::UNIT,
         Type::Tuple(types) => {

--- a/wado-compiler/src/synthesis/cm_binding/types.rs
+++ b/wado-compiler/src/synthesis/cm_binding/types.rs
@@ -139,22 +139,25 @@ pub fn wasi_type_to_type_id(
             }
             match g.name.as_str() {
                 "Stream" if g.args.len() == 1 => {
-                    let inner = wasi_type_to_type_id(&g.args[0], type_table, registry, wasi_package);
+                    let inner =
+                        wasi_type_to_type_id(&g.args[0], type_table, registry, wasi_package);
                     type_table.make_stream(inner)
                 }
                 "Future" if g.args.len() == 1 => {
-                    let inner = wasi_type_to_type_id(&g.args[0], type_table, registry, wasi_package);
+                    let inner =
+                        wasi_type_to_type_id(&g.args[0], type_table, registry, wasi_package);
                     type_table.make_future(inner)
                 }
                 "AsyncCall" if g.args.len() == 1 => {
-                    let inner = wasi_type_to_type_id(&g.args[0], type_table, registry, wasi_package);
+                    let inner =
+                        wasi_type_to_type_id(&g.args[0], type_table, registry, wasi_package);
                     type_table.make_async_call(inner)
                 }
                 // Own/Borrow are handle types represented as i32
                 "Own" | "Borrow" => TypeTable::I32,
                 _ => TypeTable::UNIT,
             }
-        },
+        }
         Type::Tuple(types) if types.is_empty() => TypeTable::UNIT,
         Type::Tuple(types) => {
             let resolved: Vec<TypeId> = types

--- a/wado-compiler/src/synthesis/cm_binding/types.rs
+++ b/wado-compiler/src/synthesis/cm_binding/types.rs
@@ -8,6 +8,7 @@ use std::cell::RefCell;
 
 use crate::ast::{AstId, GenericType, NamedType, Type};
 use crate::cm_abi;
+use crate::compiler_item::CompilerItem;
 use crate::component_model::WasiRegistry;
 use crate::hashmap::IndexMap;
 use crate::module_source::{ModuleSource, ModuleSourceInterner};
@@ -17,6 +18,56 @@ use crate::tir::{
 };
 
 use crate::synthesis::common::{binary, i32_const, i64_const, synth_span};
+
+/// Snapshot of the stdlib type / variant names the CM binding code
+/// matches against — `String`, `Array`, `Option`, `Result` — resolved
+/// once through the `CompilerItem` registry so a stdlib rename of any
+/// of these flows through every CM lift / lower / adapter site
+/// without hard-coded literals scattered across `synthesis::cm_binding`.
+///
+/// `result` is kept for downstream callers that match against the
+/// `Result` variant name even when the current consumer set does not
+/// need it; populating it costs one registry hit + clone and keeps
+/// the snapshot's shape complete for the next CM-binding site that
+/// wants to read it.
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+pub struct CmStdlibNames {
+    pub string: String,
+    pub array: String,
+    pub option: String,
+    pub result: String,
+}
+
+impl CmStdlibNames {
+    /// Look up every name through the compiler-item registry attached
+    /// to `tt`. Cheap (four registry hits + four clones); callers
+    /// should keep the value around for the duration of a CM-binding
+    /// synthesis pass rather than rebuilding it per match arm.
+    pub fn from_type_table(tt: &TypeTable) -> Self {
+        let items = tt.compiler_items();
+        Self {
+            string: items.struct_name(CompilerItem::String).to_string(),
+            array: items.struct_name(CompilerItem::Array).to_string(),
+            option: items.variant_name(CompilerItem::Option).to_string(),
+            result: items.variant_name(CompilerItem::Result).to_string(),
+        }
+    }
+
+    /// Canonical-name snapshot for unit tests that do not bootstrap a
+    /// full `TypeTable` with the stdlib registered. The names are the
+    /// production stdlib defaults; tests that want to exercise rename
+    /// behaviour must construct a [`Self`] explicitly.
+    #[cfg(test)]
+    pub fn for_tests() -> Self {
+        Self {
+            string: "String".to_string(),
+            array: "Array".to_string(),
+            option: "Option".to_string(),
+            result: "Result".to_string(),
+        }
+    }
+}
 
 /// Context for lifting CM values to GC types, providing access to
 /// the WASI registry (for variant/enum case info) and type table (for `TypeIds`).
@@ -278,17 +329,21 @@ pub(super) fn is_unit_type(ty: &Type) -> bool {
         || matches!(ty, Type::Named(n) if n.name == "()")
 }
 
-pub(super) fn is_gc_passthrough_param(ty: &Type, wasi_registry: &WasiRegistry) -> bool {
+pub(super) fn is_gc_passthrough_param(
+    ty: &Type,
+    wasi_registry: &WasiRegistry,
+    names: &CmStdlibNames,
+) -> bool {
     match ty {
-        Type::Named(n) if n.name == "String" => true,
+        Type::Named(n) if n.name == names.string => true,
         Type::Named(n) => n.source_interface.as_deref().is_some_and(|s| {
             s.starts_with("wasi:")
                 && wasi_registry
                     .get_variant_cases_by_source(s, &n.name)
                     .is_some()
         }),
-        Type::Generic(g) if g.name == "Array" && g.args.len() == 1 => true,
-        Type::Generic(g) if g.name == "Option" && g.args.len() == 1 => true,
+        Type::Generic(g) if g.name == names.array && g.args.len() == 1 => true,
+        Type::Generic(g) if g.name == names.option && g.args.len() == 1 => true,
         _ => false,
     }
 }
@@ -304,6 +359,7 @@ pub(super) fn is_wasm_flat_type(type_id: TypeId) -> bool {
 pub fn flatten_param_type(
     ty: &Type,
     wasi_registry: &crate::component_model::WasiRegistry,
+    names: &CmStdlibNames,
 ) -> Vec<TypeId> {
     fn cm_val_to_type_id(v: &cm_abi::CmValType) -> TypeId {
         match v {
@@ -316,62 +372,66 @@ pub fn flatten_param_type(
 
     let resolved = wasi_registry.resolve_type(ty);
     match &resolved {
-        Type::Named(named) => match named.name.as_str() {
-            "i32" | "u32" | "bool" | "char" | "i8" | "u8" | "i16" | "u16" => {
-                vec![TypeTable::I32]
+        Type::Named(named) => {
+            if named.name == names.string {
+                return vec![TypeTable::I32, TypeTable::I32];
             }
-            "i64" | "u64" => vec![TypeTable::I64],
-            "f32" => vec![TypeTable::F32],
-            "f64" => vec![TypeTable::F64],
-            "String" => vec![TypeTable::I32, TypeTable::I32],
-            name => {
-                // Without a resolved WASI source the reference is not a WASI
-                // variant/struct — flatten to a single i32 handle.
-                let Some(source) = named
-                    .source_interface
-                    .as_deref()
-                    .filter(|s| s.starts_with("wasi:"))
-                else {
-                    return vec![TypeTable::I32];
-                };
-                // WASI variant: discriminant + join of all case payload flat types.
-                if let Some(cases) = wasi_registry.get_variant_cases_by_source(source, name) {
-                    let mut result = vec![TypeTable::I32]; // discriminant
-                    let case_flats: Vec<Vec<TypeId>> = cases
-                        .iter()
-                        .map(|c| {
-                            c.payload
-                                .as_ref()
-                                .map(|t| flatten_param_type(t, wasi_registry))
-                                .unwrap_or_default()
-                        })
-                        .collect();
-                    let max_len = case_flats.iter().map(Vec::len).max().unwrap_or(0);
-                    for i in 0..max_len {
-                        // Join: if all non-empty cases at position i agree on a type,
-                        // use that type; otherwise use i32 (per CM spec join).
-                        let joined = case_flats
+            match named.name.as_str() {
+                "i32" | "u32" | "bool" | "char" | "i8" | "u8" | "i16" | "u16" => {
+                    vec![TypeTable::I32]
+                }
+                "i64" | "u64" => vec![TypeTable::I64],
+                "f32" => vec![TypeTable::F32],
+                "f64" => vec![TypeTable::F64],
+                name => {
+                    // Without a resolved WASI source the reference is not a WASI
+                    // variant/struct — flatten to a single i32 handle.
+                    let Some(source) = named
+                        .source_interface
+                        .as_deref()
+                        .filter(|s| s.starts_with("wasi:"))
+                    else {
+                        return vec![TypeTable::I32];
+                    };
+                    // WASI variant: discriminant + join of all case payload flat types.
+                    if let Some(cases) = wasi_registry.get_variant_cases_by_source(source, name) {
+                        let mut result = vec![TypeTable::I32]; // discriminant
+                        let case_flats: Vec<Vec<TypeId>> = cases
                             .iter()
-                            .filter_map(|f| f.get(i).copied())
-                            .reduce(|a, b| if a == b { a } else { TypeTable::I32 })
-                            .unwrap_or(TypeTable::I32);
-                        result.push(joined);
+                            .map(|c| {
+                                c.payload
+                                    .as_ref()
+                                    .map(|t| flatten_param_type(t, wasi_registry, names))
+                                    .unwrap_or_default()
+                            })
+                            .collect();
+                        let max_len = case_flats.iter().map(Vec::len).max().unwrap_or(0);
+                        for i in 0..max_len {
+                            // Join: if all non-empty cases at position i agree on a type,
+                            // use that type; otherwise use i32 (per CM spec join).
+                            let joined = case_flats
+                                .iter()
+                                .filter_map(|f| f.get(i).copied())
+                                .reduce(|a, b| if a == b { a } else { TypeTable::I32 })
+                                .unwrap_or(TypeTable::I32);
+                            result.push(joined);
+                        }
+                        return result;
                     }
-                    return result;
+                    // WASI struct (record): concatenation of all field flat types.
+                    if let Some(fields) =
+                        wasi_registry.get_struct_fields_with_wado_names_by_source(source, name)
+                    {
+                        return fields
+                            .iter()
+                            .flat_map(|(_, _, ft)| flatten_param_type(ft, wasi_registry, names))
+                            .collect();
+                    }
+                    // Resource handles, enums, flags, etc.: single i32
+                    vec![TypeTable::I32]
                 }
-                // WASI struct (record): concatenation of all field flat types.
-                if let Some(fields) =
-                    wasi_registry.get_struct_fields_with_wado_names_by_source(source, name)
-                {
-                    return fields
-                        .iter()
-                        .flat_map(|(_, _, ft)| flatten_param_type(ft, wasi_registry))
-                        .collect();
-                }
-                // Resource handles, enums, flags, etc.: single i32
-                vec![TypeTable::I32]
             }
-        },
+        }
         Type::Generic(g) if g.name == "Stream" => vec![TypeTable::I32],
         Type::Reference(_) | Type::MutReference(_) => vec![TypeTable::I32],
         Type::Tuple(elems) if elems.is_empty() => vec![],
@@ -438,8 +498,12 @@ pub(super) fn cm_param_align(
 pub(super) fn cm_param_store_plan(
     ty: &Type,
     wasi_registry: &crate::component_model::WasiRegistry,
+    names: &CmStdlibNames,
 ) -> Vec<(u32, &'static str)> {
     if let Type::Named(named) = ty {
+        if named.name == names.string {
+            return vec![(0, "i32_store"), (4, "i32_store")];
+        }
         let source = named
             .source_interface
             .as_deref()
@@ -474,21 +538,20 @@ pub(super) fn cm_param_store_plan(
             "i64" | "u64" => vec![(0, "i64_store")],
             "f32" => vec![(0, "f32_store")],
             "f64" => vec![(0, "f64_store")],
-            "String" => vec![(0, "i32_store"), (4, "i32_store")],
             // i32, u32, char, resource handles
             _ => vec![(0, "i32_store")],
         };
     }
     match ty {
         Type::Reference(_) | Type::MutReference(_) => vec![(0, "i32_store")],
+        Type::Generic(g) if g.name == names.array => vec![(0, "i32_store"), (4, "i32_store")],
         Type::Generic(g) => match g.name.as_str() {
-            "Array" => vec![(0, "i32_store"), (4, "i32_store")],
             "Option" if g.args.len() == 1 => {
                 // option<T>: disc (u8) at offset 0, payload at align_to(1, align(T))
                 let inner_align =
                     crate::component_model::cm_align_with_registry(&g.args[0], wasi_registry);
                 let payload_offset = crate::cm_abi::align_to(1, inner_align);
-                let inner_store = cm_param_store_plan(&g.args[0], wasi_registry);
+                let inner_store = cm_param_store_plan(&g.args[0], wasi_registry, names);
                 let mut stores = vec![(0, "i32_store8")]; // discriminant
                 for (sub_offset, store_name) in inner_store {
                     stores.push((payload_offset + sub_offset, store_name));
@@ -525,7 +588,12 @@ pub(super) fn flatten_export_type(
     tir_modules: &IndexMap<ModuleSource, TirModule>,
     type_table: &TypeTable,
 ) {
+    let names = CmStdlibNames::from_type_table(type_table);
     match ty {
+        Type::Named(named) if named.name == names.string => {
+            out.push(cm_abi::CmValType::I32); // ptr
+            out.push(cm_abi::CmValType::I32); // len
+        }
         Type::Named(named) => match named.name.as_str() {
             "bool" | "u8" | "i8" | "u16" | "i16" | "i32" | "u32" | "char" => {
                 out.push(cm_abi::CmValType::I32);
@@ -533,10 +601,6 @@ pub(super) fn flatten_export_type(
             "i64" | "u64" => out.push(cm_abi::CmValType::I64),
             "f32" => out.push(cm_abi::CmValType::F32),
             "f64" => out.push(cm_abi::CmValType::F64),
-            "String" => {
-                out.push(cm_abi::CmValType::I32); // ptr
-                out.push(cm_abi::CmValType::I32); // len
-            }
             "()" => {} // unit — no values
             _ => {
                 // Check if it's a variant type defined in TIR modules
@@ -550,11 +614,11 @@ pub(super) fn flatten_export_type(
                 }
             }
         },
+        Type::Generic(generic) if generic.name == names.array => {
+            out.push(cm_abi::CmValType::I32); // ptr
+            out.push(cm_abi::CmValType::I32); // len
+        }
         Type::Generic(generic) => match generic.name.as_str() {
-            "Array" => {
-                out.push(cm_abi::CmValType::I32); // ptr
-                out.push(cm_abi::CmValType::I32); // len
-            }
             "Stream" | "Future" | "Own" | "Borrow" => out.push(cm_abi::CmValType::I32),
             "Option" if generic.args.len() == 1 => {
                 out.push(cm_abi::CmValType::I32); // discriminant
@@ -638,6 +702,7 @@ pub(super) fn flat_types_from_type_id_into(
     tir_modules: &IndexMap<ModuleSource, TirModule>,
     type_table: &TypeTable,
 ) {
+    let names = CmStdlibNames::from_type_table(type_table);
     match type_table.get(type_id) {
         ResolvedType::Primitive(p) => match p {
             PrimitiveType::I8
@@ -660,7 +725,7 @@ pub(super) fn flat_types_from_type_id_into(
         },
         ResolvedType::Unit => {} // no flat values
         ResolvedType::Struct { name, .. } => {
-            if name == "String" {
+            if name == &names.string {
                 out.push(cm_abi::CmValType::I32); // ptr
                 out.push(cm_abi::CmValType::I32); // len
             } else if let Some(struct_decl) = find_struct_decl(name, tir_modules) {
@@ -687,41 +752,26 @@ pub(super) fn flat_types_from_type_id_into(
                 for &elem in type_args {
                     flat_types_from_type_id_into(elem, out, tir_modules, type_table);
                 }
-            } else {
-                match name.as_str() {
-                    "Option" if type_args.len() == 1 => {
-                        out.push(cm_abi::CmValType::I32); // discriminant
-                        flat_types_from_type_id_into(type_args[0], out, tir_modules, type_table);
-                    }
-                    "Result" if type_args.len() == 2 => {
-                        out.push(cm_abi::CmValType::I32); // discriminant
-                        let mut ok_flat = Vec::new();
-                        let mut err_flat = Vec::new();
-                        flat_types_from_type_id_into(
-                            type_args[0],
-                            &mut ok_flat,
-                            tir_modules,
-                            type_table,
-                        );
-                        flat_types_from_type_id_into(
-                            type_args[1],
-                            &mut err_flat,
-                            tir_modules,
-                            type_table,
-                        );
-                        let max_len = ok_flat.len().max(err_flat.len());
-                        for i in 0..max_len {
-                            let ok_val = ok_flat.get(i).copied();
-                            let err_val = err_flat.get(i).copied();
-                            out.push(cm_abi::CmValType::join(ok_val, err_val));
-                        }
-                    }
-                    "Array" => {
-                        out.push(cm_abi::CmValType::I32); // ptr
-                        out.push(cm_abi::CmValType::I32); // len
-                    }
-                    _ => out.push(cm_abi::CmValType::I32),
+            } else if name == &names.option && type_args.len() == 1 {
+                out.push(cm_abi::CmValType::I32); // discriminant
+                flat_types_from_type_id_into(type_args[0], out, tir_modules, type_table);
+            } else if name == &names.result && type_args.len() == 2 {
+                out.push(cm_abi::CmValType::I32); // discriminant
+                let mut ok_flat = Vec::new();
+                let mut err_flat = Vec::new();
+                flat_types_from_type_id_into(type_args[0], &mut ok_flat, tir_modules, type_table);
+                flat_types_from_type_id_into(type_args[1], &mut err_flat, tir_modules, type_table);
+                let max_len = ok_flat.len().max(err_flat.len());
+                for i in 0..max_len {
+                    let ok_val = ok_flat.get(i).copied();
+                    let err_val = err_flat.get(i).copied();
+                    out.push(cm_abi::CmValType::join(ok_val, err_val));
                 }
+            } else if name == &names.array {
+                out.push(cm_abi::CmValType::I32); // ptr
+                out.push(cm_abi::CmValType::I32); // len
+            } else {
+                out.push(cm_abi::CmValType::I32);
             }
         }
         ResolvedType::Newtype { base_type, .. } => {

--- a/wado-compiler/src/synthesis/effect_dispatch.rs
+++ b/wado-compiler/src/synthesis/effect_dispatch.rs
@@ -781,9 +781,16 @@ fn build_dispatch_wrapper_function(
         // here anyway, panic with a diagnostic identifying the operation
         // — useful when a future refactor introduces a path that bypasses
         // effect-check.
+        let (string_struct_name, string_module) = {
+            let tt = type_table.borrow();
+            let (m, n) = tt
+                .compiler_items()
+                .require_struct(crate::compiler_item::CompilerItem::String);
+            (n.to_string(), m.clone())
+        };
         let string_type_id = type_table
             .borrow()
-            .find_struct_type("String", &ModuleSource::string())
+            .find_struct_type(&string_struct_name, &string_module)
             .unwrap_or_else(|| {
                 panic!(
                     "core:prelude/string.wado String type missing from \

--- a/wado-compiler/src/synthesis/from_synth.rs
+++ b/wado-compiler/src/synthesis/from_synth.rs
@@ -7,6 +7,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use crate::compiler_item::CompilerItem;
 use crate::name::{LocalMethodName, MethodName};
 use crate::synthesis::common::{
     block, local_ref, make_synthetic_method, param_local, return_stmt, synth_span,
@@ -16,20 +17,34 @@ use crate::tir::{
 };
 
 pub fn synthesize_from(module: &mut TirModule) {
+    // Resolve the canonical `From` trait name via the compiler-item registry
+    // so a stdlib rename of the trait still routes synthesis through the
+    // same anchor. The `From<T>` mangled form keeps the registered name as
+    // its prefix.
+    let from_prefix = {
+        let trait_name = module
+            .type_table
+            .borrow()
+            .compiler_items()
+            .trait_name(CompilerItem::From)
+            .to_string();
+        format!("{trait_name}<")
+    };
     let requests: Vec<SynthesisRequest> = module
         .synthesis_requests
-        .extract_if(.., |r| r.trait_name.starts_with("From<"))
+        .extract_if(.., |r| r.trait_name.starts_with(from_prefix.as_str()))
         .collect();
     if requests.is_empty() {
         return;
     }
 
-    let existing = collect_existing_from_methods(module);
+    let existing = collect_existing_from_methods(module, &from_prefix);
     let mut generated = Vec::new();
+    let from_trait_name = from_prefix.trim_end_matches('<');
 
     for req in &requests {
-        let from_type_name = extract_from_type_name(&req.trait_name);
-        let from_trait = format!("From<{from_type_name}>");
+        let from_type_name = extract_from_type_name(&req.trait_name, &from_prefix);
+        let from_trait = format!("{from_trait_name}<{from_type_name}>");
         let key = MethodName::format_local(&req.target_type_name, Some(&from_trait), "from");
         if existing.contains(&key) {
             continue;
@@ -42,15 +57,19 @@ pub fn synthesize_from(module: &mut TirModule) {
     module.functions.extend(generated);
 }
 
-fn extract_from_type_name(trait_name: &str) -> String {
+fn extract_from_type_name(trait_name: &str, from_prefix: &str) -> String {
     trait_name
-        .strip_prefix("From<")
+        .strip_prefix(from_prefix)
         .and_then(|s| s.strip_suffix('>'))
         .unwrap_or(trait_name)
         .to_string()
 }
 
-fn collect_existing_from_methods(module: &TirModule) -> crate::hashmap::IndexSet<String> {
+fn collect_existing_from_methods(
+    module: &TirModule,
+    from_prefix: &str,
+) -> crate::hashmap::IndexSet<String> {
+    let from_bare = from_prefix.trim_end_matches('<');
     module
         .functions
         .iter()
@@ -58,7 +77,7 @@ fn collect_existing_from_methods(module: &TirModule) -> crate::hashmap::IndexSet
             let func = f.borrow();
             func.method_info.as_ref().and_then(|info| {
                 info.trait_name.as_ref().and_then(|trait_name| {
-                    if trait_name == "From" || trait_name.starts_with("From<") {
+                    if trait_name == from_bare || trait_name.starts_with(from_prefix) {
                         Some(MethodName::format_local(
                             &info.base_struct_name,
                             Some(trait_name),

--- a/wado-compiler/src/synthesis/from_synth.rs
+++ b/wado-compiler/src/synthesis/from_synth.rs
@@ -17,19 +17,18 @@ use crate::tir::{
 };
 
 pub fn synthesize_from(module: &mut TirModule) {
-    // Resolve the canonical `From` trait name via the compiler-item registry
-    // so a stdlib rename of the trait still routes synthesis through the
-    // same anchor. The `From<T>` mangled form keeps the registered name as
-    // its prefix.
-    let from_prefix = {
-        let trait_name = module
-            .type_table
-            .borrow()
-            .compiler_items()
-            .trait_name(CompilerItem::From)
-            .to_string();
-        format!("{trait_name}<")
-    };
+    // Resolve the canonical `From` trait name via the compiler-item
+    // registry so a stdlib rename of the trait still routes synthesis
+    // through the same anchor. The `From<T>` mangled form keeps the
+    // registered name as its prefix; build the prefix from the
+    // registry-driven name and drain matching requests in one pass.
+    let from_trait_name = module
+        .type_table
+        .borrow()
+        .compiler_items()
+        .trait_name(CompilerItem::From)
+        .to_string();
+    let from_prefix = format!("{from_trait_name}<");
     let requests: Vec<SynthesisRequest> = module
         .synthesis_requests
         .extract_if(.., |r| r.trait_name.starts_with(from_prefix.as_str()))
@@ -38,9 +37,8 @@ pub fn synthesize_from(module: &mut TirModule) {
         return;
     }
 
-    let existing = collect_existing_from_methods(module, &from_prefix);
+    let existing = collect_existing_from_methods(module, &from_trait_name);
     let mut generated = Vec::new();
-    let from_trait_name = from_prefix.trim_end_matches('<');
 
     for req in &requests {
         let from_type_name = extract_from_type_name(&req.trait_name, &from_prefix);
@@ -67,9 +65,9 @@ fn extract_from_type_name(trait_name: &str, from_prefix: &str) -> String {
 
 fn collect_existing_from_methods(
     module: &TirModule,
-    from_prefix: &str,
+    from_trait_name: &str,
 ) -> crate::hashmap::IndexSet<String> {
-    let from_bare = from_prefix.trim_end_matches('<');
+    let from_prefix = format!("{from_trait_name}<");
     module
         .functions
         .iter()
@@ -77,7 +75,8 @@ fn collect_existing_from_methods(
             let func = f.borrow();
             func.method_info.as_ref().and_then(|info| {
                 info.trait_name.as_ref().and_then(|trait_name| {
-                    if trait_name == from_bare || trait_name.starts_with(from_prefix) {
+                    if trait_name == from_trait_name || trait_name.starts_with(from_prefix.as_str())
+                    {
                         Some(MethodName::format_local(
                             &info.base_struct_name,
                             Some(trait_name),

--- a/wado-compiler/src/synthesis/kiln_synth.rs
+++ b/wado-compiler/src/synthesis/kiln_synth.rs
@@ -12,6 +12,7 @@
 //!
 //! See WEP 2026-04-12 (Kiln) §"Options schema".
 
+use crate::compiler_item::CompilerItem;
 use crate::package::Package;
 use crate::tir::SynthesisRequest;
 
@@ -40,10 +41,16 @@ pub fn prepare_kiln(project: &mut Package) {
         return;
     };
 
+    let deserialize_trait_name = entry_module
+        .type_table
+        .borrow()
+        .compiler_items()
+        .trait_name(CompilerItem::Deserialize)
+        .to_string();
     let already_requested = entry_module
         .synthesis_requests
         .iter()
-        .any(|req| req.trait_name == "Deserialize" && req.target_type_name == "Options");
+        .any(|req| req.trait_name == deserialize_trait_name && req.target_type_name == "Options");
     if already_requested {
         return;
     }
@@ -55,7 +62,7 @@ pub fn prepare_kiln(project: &mut Package) {
         .unwrap_or(crate::tir::TypeTable::UNIT);
 
     entry_module.synthesis_requests.push(SynthesisRequest {
-        trait_name: "Deserialize".to_string(),
+        trait_name: deserialize_trait_name,
         target_type_name: "Options".to_string(),
         target_type_id,
         type_params: Vec::new(),

--- a/wado-compiler/src/synthesis/serde_synth.rs
+++ b/wado-compiler/src/synthesis/serde_synth.rs
@@ -76,57 +76,66 @@ pub fn synthesize_serde(project: &mut Package) {
         if requests.is_empty() {
             continue;
         }
+        let (serialize_trait_name, deserialize_trait_name) = {
+            let tt = module.type_table.borrow();
+            let items = tt.compiler_items();
+            (
+                items
+                    .trait_name(crate::compiler_item::CompilerItem::Serialize)
+                    .to_string(),
+                items
+                    .trait_name(crate::compiler_item::CompilerItem::Deserialize)
+                    .to_string(),
+            )
+        };
         let existing = collect_existing_trait_methods(module);
         let mut generated = Vec::new();
 
         for req in &requests {
-            match req.trait_name.as_str() {
-                "Serialize" => {
-                    let key = MethodName::format_local(
-                        &req.target_type_name,
-                        Some("Serialize"),
-                        "serialize",
-                    );
+            let trait_name = req.trait_name.as_str();
+            if trait_name == serialize_trait_name {
+                let key = MethodName::format_local(
+                    &req.target_type_name,
+                    Some(&serialize_trait_name),
+                    "serialize",
+                );
+                if existing.contains(&key) {
+                    continue;
+                }
+                let func = generate_struct_serialize(module, req)
+                    .or_else(|| generate_enum_serialize(module, req))
+                    .or_else(|| generate_variant_serialize(module, req))
+                    .or_else(|| generate_flags_serialize(module, req));
+                if let Some(f) = func {
+                    generated.push(Rc::new(RefCell::new(f)));
+                }
+            } else if trait_name == deserialize_trait_name {
+                let key = MethodName::format_local(
+                    &req.target_type_name,
+                    Some(&deserialize_trait_name),
+                    "deserialize",
+                );
                     if existing.contains(&key) {
                         continue;
                     }
-                    let func = generate_struct_serialize(module, req)
-                        .or_else(|| generate_enum_serialize(module, req))
-                        .or_else(|| generate_variant_serialize(module, req))
-                        .or_else(|| generate_flags_serialize(module, req));
+                if let Some((lookup_func, deser_func)) =
+                    generate_struct_deserialize(module, req)
+                {
+                    generated.push(Rc::new(RefCell::new(lookup_func)));
+                    generated.push(Rc::new(RefCell::new(deser_func)));
+                } else {
+                    let func = generate_enum_deserialize(module, req)
+                        .or_else(|| generate_variant_deserialize(module, req))
+                        .or_else(|| generate_flags_deserialize(module, req));
                     if let Some(f) = func {
                         generated.push(Rc::new(RefCell::new(f)));
                     }
                 }
-                "Deserialize" => {
-                    let key = MethodName::format_local(
-                        &req.target_type_name,
-                        Some("Deserialize"),
-                        "deserialize",
-                    );
-                    if existing.contains(&key) {
-                        continue;
-                    }
-                    if let Some((lookup_func, deser_func)) =
-                        generate_struct_deserialize(module, req)
-                    {
-                        generated.push(Rc::new(RefCell::new(lookup_func)));
-                        generated.push(Rc::new(RefCell::new(deser_func)));
-                    } else {
-                        let func = generate_enum_deserialize(module, req)
-                            .or_else(|| generate_variant_deserialize(module, req))
-                            .or_else(|| generate_flags_deserialize(module, req));
-                        if let Some(f) = func {
-                            generated.push(Rc::new(RefCell::new(f)));
-                        }
-                    }
-                }
-                other => {
-                    panic!(
-                        "unsupported synthesis trait `{other}` for `{}`",
-                        req.target_type_name
-                    );
-                }
+            } else {
+                panic!(
+                    "unsupported synthesis trait `{trait_name}` for `{}`",
+                    req.target_type_name
+                );
             }
         }
 
@@ -711,6 +720,12 @@ fn generate_struct_deserialize(
     let module_source = module.module_source.clone();
     let serde_module = ModuleSource::serde();
 
+    let deserialize_trait_name = module
+        .type_table
+        .borrow()
+        .compiler_items()
+        .trait_name(crate::compiler_item::CompilerItem::Deserialize)
+        .to_string();
     let mut tt = module.type_table.borrow_mut();
 
     let struct_type = req.target_type_id;
@@ -1187,11 +1202,14 @@ fn generate_struct_deserialize(
 
     let method_info = LocalMethodName::new(
         req.target_type_name.clone(),
-        Some("Deserialize".to_string()),
+        Some(deserialize_trait_name.clone()),
         "deserialize".to_string(),
     );
-    let qualified_name =
-        MethodName::format_local(&req.target_type_name, Some("Deserialize"), "deserialize");
+    let qualified_name = MethodName::format_local(
+        &req.target_type_name,
+        Some(&deserialize_trait_name),
+        "deserialize",
+    );
 
     let deser_func = TirFunction {
         module_source: ModuleSource::default(),
@@ -1619,6 +1637,18 @@ fn generate_enum_deserialize(
     let span = synth_span();
     let serde_module = ModuleSource::serde();
 
+    let (eq_trait_name, deserialize_trait_name) = {
+        let tt = module.type_table.borrow();
+        let items = tt.compiler_items();
+        (
+            items
+                .trait_name(crate::compiler_item::CompilerItem::Eq)
+                .to_string(),
+            items
+                .trait_name(crate::compiler_item::CompilerItem::Deserialize)
+                .to_string(),
+        )
+    };
     let mut tt = module.type_table.borrow_mut();
 
     let enum_type = req.target_type_id;
@@ -1818,7 +1848,7 @@ fn generate_enum_deserialize(
         );
         let eq_method = LocalMethodName::new(
             "String".to_string(),
-            Some("Eq".to_string()),
+            Some(eq_trait_name.clone()),
             "eq".to_string(),
         );
         let condition = TirExpr::new(
@@ -1934,11 +1964,14 @@ fn generate_enum_deserialize(
 
     let method_info = LocalMethodName::new(
         req.target_type_name.clone(),
-        Some("Deserialize".to_string()),
+        Some(deserialize_trait_name.clone()),
         "deserialize".to_string(),
     );
-    let qualified_name =
-        MethodName::format_local(&req.target_type_name, Some("Deserialize"), "deserialize");
+    let qualified_name = MethodName::format_local(
+        &req.target_type_name,
+        Some(&deserialize_trait_name),
+        "deserialize",
+    );
 
     Some(TirFunction {
         module_source: ModuleSource::default(),
@@ -2284,6 +2317,18 @@ fn generate_variant_deserialize(
     let span = synth_span();
     let serde_module = ModuleSource::serde();
 
+    let (eq_trait_name, deserialize_trait_name) = {
+        let tt = module.type_table.borrow();
+        let items = tt.compiler_items();
+        (
+            items
+                .trait_name(crate::compiler_item::CompilerItem::Eq)
+                .to_string(),
+            items
+                .trait_name(crate::compiler_item::CompilerItem::Deserialize)
+                .to_string(),
+        )
+    };
     let mut tt = module.type_table.borrow_mut();
 
     let variant_type = req.target_type_id;
@@ -2563,7 +2608,7 @@ fn generate_variant_deserialize(
         );
         let eq_method = LocalMethodName::new(
             "String".to_string(),
-            Some("Eq".to_string()),
+            Some(eq_trait_name.clone()),
             "eq".to_string(),
         );
         let condition = TirExpr::new(
@@ -2757,11 +2802,14 @@ fn generate_variant_deserialize(
 
     let method_info = LocalMethodName::new(
         req.target_type_name.clone(),
-        Some("Deserialize".to_string()),
+        Some(deserialize_trait_name.clone()),
         "deserialize".to_string(),
     );
-    let qualified_name =
-        MethodName::format_local(&req.target_type_name, Some("Deserialize"), "deserialize");
+    let qualified_name = MethodName::format_local(
+        &req.target_type_name,
+        Some(&deserialize_trait_name),
+        "deserialize",
+    );
 
     Some(TirFunction {
         module_source: ModuleSource::default(),
@@ -3098,6 +3146,18 @@ fn generate_flags_deserialize(
     let span = synth_span();
     let serde_module = ModuleSource::serde();
 
+    let (eq_trait_name, deserialize_trait_name) = {
+        let tt = module.type_table.borrow();
+        let items = tt.compiler_items();
+        (
+            items
+                .trait_name(crate::compiler_item::CompilerItem::Eq)
+                .to_string(),
+            items
+                .trait_name(crate::compiler_item::CompilerItem::Deserialize)
+                .to_string(),
+        )
+    };
     let mut tt = module.type_table.borrow_mut();
 
     let flags_type = req.target_type_id;
@@ -3217,7 +3277,7 @@ fn generate_flags_deserialize(
         );
         let eq_method = LocalMethodName::new(
             "String".to_string(),
-            Some("Eq".to_string()),
+            Some(eq_trait_name.clone()),
             "eq".to_string(),
         );
         let condition = TirExpr::new(
@@ -3382,11 +3442,14 @@ fn generate_flags_deserialize(
 
     let method_info = LocalMethodName::new(
         req.target_type_name.clone(),
-        Some("Deserialize".to_string()),
+        Some(deserialize_trait_name.clone()),
         "deserialize".to_string(),
     );
-    let qualified_name =
-        MethodName::format_local(&req.target_type_name, Some("Deserialize"), "deserialize");
+    let qualified_name = MethodName::format_local(
+        &req.target_type_name,
+        Some(&deserialize_trait_name),
+        "deserialize",
+    );
 
     Some(TirFunction {
         module_source: ModuleSource::default(),

--- a/wado-compiler/src/synthesis/serde_synth.rs
+++ b/wado-compiler/src/synthesis/serde_synth.rs
@@ -506,7 +506,7 @@ fn generate_struct_serialize(
     let ref_self_type = tt.make_ref(struct_type);
     let s_type_param = tt.make_type_param("S".to_string(), 0);
     let mut_ref_s = tt.make_mut_ref(s_type_param);
-    let string_type = tt.make_struct("String".to_string(), ModuleSource::string());
+    let string_type = tt.make_compiler_struct(crate::compiler_item::CompilerItem::String);
     let ref_string_type = tt.make_ref(string_type);
     let ser_error_type = tt.make_struct("SerializeError".to_string(), serde_module.clone());
     let result_unit_err = tt.make_result(TypeTable::UNIT, ser_error_type);
@@ -729,7 +729,7 @@ fn generate_struct_deserialize(
     let mut tt = module.type_table.borrow_mut();
 
     let struct_type = req.target_type_id;
-    let string_type = tt.make_struct("String".to_string(), ModuleSource::string());
+    let string_type = tt.make_compiler_struct(crate::compiler_item::CompilerItem::String);
     let ref_string_type = tt.make_ref(string_type);
     let option_i32 = tt.make_option(TypeTable::I32);
     let deser_error_type = tt.make_struct("DeserializeError".to_string(), serde_module.clone());
@@ -1492,7 +1492,7 @@ fn generate_enum_serialize(
     let ref_self_type = tt.make_ref(enum_type);
     let s_type_param = tt.make_type_param("S".to_string(), 0);
     let mut_ref_s = tt.make_mut_ref(s_type_param);
-    let string_type = tt.make_struct("String".to_string(), ModuleSource::string());
+    let string_type = tt.make_compiler_struct(crate::compiler_item::CompilerItem::String);
     let ref_string_type = tt.make_ref(string_type);
     let ser_error_type = tt.make_struct("SerializeError".to_string(), serde_module.clone());
     let result_unit_err = tt.make_result(TypeTable::UNIT, ser_error_type);
@@ -1637,7 +1637,7 @@ fn generate_enum_deserialize(
     let span = synth_span();
     let serde_module = ModuleSource::serde();
 
-    let (eq_trait_name, deserialize_trait_name) = {
+    let (eq_trait_name, deserialize_trait_name, string_struct_name) = {
         let tt = module.type_table.borrow();
         let items = tt.compiler_items();
         (
@@ -1647,12 +1647,15 @@ fn generate_enum_deserialize(
             items
                 .trait_name(crate::compiler_item::CompilerItem::Deserialize)
                 .to_string(),
+            items
+                .struct_name(crate::compiler_item::CompilerItem::String)
+                .to_string(),
         )
     };
     let mut tt = module.type_table.borrow_mut();
 
     let enum_type = req.target_type_id;
-    let string_type = tt.make_struct("String".to_string(), ModuleSource::string());
+    let string_type = tt.make_compiler_struct(crate::compiler_item::CompilerItem::String);
     let ref_string_type = tt.make_ref(string_type);
     let deser_error_type = tt.make_struct("DeserializeError".to_string(), serde_module.clone());
     let deser_error_kind_type = tt
@@ -1847,7 +1850,7 @@ fn generate_enum_deserialize(
             span,
         );
         let eq_method = LocalMethodName::new(
-            "String".to_string(),
+            string_struct_name.clone(),
             Some(eq_trait_name.clone()),
             "eq".to_string(),
         );
@@ -2036,7 +2039,7 @@ fn generate_variant_serialize(
     let ref_self_type = tt.make_ref(variant_type);
     let s_type_param = tt.make_type_param("S".to_string(), 0);
     let mut_ref_s = tt.make_mut_ref(s_type_param);
-    let string_type = tt.make_struct("String".to_string(), ModuleSource::string());
+    let string_type = tt.make_compiler_struct(crate::compiler_item::CompilerItem::String);
     let ref_string_type = tt.make_ref(string_type);
     let ser_error_type = tt.make_struct("SerializeError".to_string(), serde_module.clone());
     let ser_error_kind_type = tt
@@ -2317,7 +2320,7 @@ fn generate_variant_deserialize(
     let span = synth_span();
     let serde_module = ModuleSource::serde();
 
-    let (eq_trait_name, deserialize_trait_name) = {
+    let (eq_trait_name, deserialize_trait_name, string_struct_name) = {
         let tt = module.type_table.borrow();
         let items = tt.compiler_items();
         (
@@ -2327,12 +2330,15 @@ fn generate_variant_deserialize(
             items
                 .trait_name(crate::compiler_item::CompilerItem::Deserialize)
                 .to_string(),
+            items
+                .struct_name(crate::compiler_item::CompilerItem::String)
+                .to_string(),
         )
     };
     let mut tt = module.type_table.borrow_mut();
 
     let variant_type = req.target_type_id;
-    let string_type = tt.make_struct("String".to_string(), ModuleSource::string());
+    let string_type = tt.make_compiler_struct(crate::compiler_item::CompilerItem::String);
     let ref_string_type = tt.make_ref(string_type);
     let deser_error_type = tt.make_struct("DeserializeError".to_string(), serde_module.clone());
     let deser_error_kind_type = tt
@@ -2607,7 +2613,7 @@ fn generate_variant_deserialize(
             span,
         );
         let eq_method = LocalMethodName::new(
-            "String".to_string(),
+            string_struct_name.clone(),
             Some(eq_trait_name.clone()),
             "eq".to_string(),
         );
@@ -2911,13 +2917,19 @@ fn generate_flags_serialize(
     let span = synth_span();
     let serde_module = ModuleSource::serde();
 
+    let string_struct_name = module
+        .type_table
+        .borrow()
+        .compiler_items()
+        .struct_name(crate::compiler_item::CompilerItem::String)
+        .to_string();
     let mut tt = module.type_table.borrow_mut();
 
     let flags_type = req.target_type_id;
     let ref_self_type = tt.make_ref(flags_type);
     let s_type_param = tt.make_type_param("S".to_string(), 0);
     let mut_ref_s = tt.make_mut_ref(s_type_param);
-    let string_type = tt.make_struct("String".to_string(), ModuleSource::string());
+    let string_type = tt.make_compiler_struct(crate::compiler_item::CompilerItem::String);
     let ref_string_type = tt.make_ref(string_type);
     let ser_error_type = tt.make_struct("SerializeError".to_string(), serde_module.clone());
     let ser_error_kind_type = tt
@@ -3013,7 +3025,7 @@ fn generate_flags_serialize(
             "SerializeSeq",
             "element",
             serde_module.clone(),
-            vec!["String".to_string()],
+            vec![string_struct_name.clone()],
             vec![string_type],
             vec![ref_expr(
                 string_lit(member_name, string_type, span),
@@ -3146,7 +3158,7 @@ fn generate_flags_deserialize(
     let span = synth_span();
     let serde_module = ModuleSource::serde();
 
-    let (eq_trait_name, deserialize_trait_name) = {
+    let (eq_trait_name, deserialize_trait_name, string_struct_name) = {
         let tt = module.type_table.borrow();
         let items = tt.compiler_items();
         (
@@ -3156,6 +3168,9 @@ fn generate_flags_deserialize(
             items
                 .trait_name(crate::compiler_item::CompilerItem::Deserialize)
                 .to_string(),
+            items
+                .struct_name(crate::compiler_item::CompilerItem::String)
+                .to_string(),
         )
     };
     let mut tt = module.type_table.borrow_mut();
@@ -3163,7 +3178,7 @@ fn generate_flags_deserialize(
     let flags_type = req.target_type_id;
     let d_type_param = tt.make_type_param("D".to_string(), 0);
     let mut_ref_d = tt.make_mut_ref(d_type_param);
-    let string_type = tt.make_struct("String".to_string(), ModuleSource::string());
+    let string_type = tt.make_compiler_struct(crate::compiler_item::CompilerItem::String);
     let ref_string_type = tt.make_ref(string_type);
     let deser_error_type = tt.make_struct("DeserializeError".to_string(), serde_module.clone());
     let deser_error_kind_type = tt
@@ -3246,7 +3261,7 @@ fn generate_flags_deserialize(
         "DeserializeSeq",
         "next_element",
         serde_module.clone(),
-        vec!["String".to_string()],
+        vec![string_struct_name.clone()],
         vec![string_type],
         vec![],
         result_option_string_err,
@@ -3276,7 +3291,7 @@ fn generate_flags_deserialize(
             span,
         );
         let eq_method = LocalMethodName::new(
-            "String".to_string(),
+            string_struct_name.clone(),
             Some(eq_trait_name.clone()),
             "eq".to_string(),
         );

--- a/wado-compiler/src/synthesis/serde_synth.rs
+++ b/wado-compiler/src/synthesis/serde_synth.rs
@@ -115,12 +115,10 @@ pub fn synthesize_serde(project: &mut Package) {
                     Some(&deserialize_trait_name),
                     "deserialize",
                 );
-                    if existing.contains(&key) {
-                        continue;
-                    }
-                if let Some((lookup_func, deser_func)) =
-                    generate_struct_deserialize(module, req)
-                {
+                if existing.contains(&key) {
+                    continue;
+                }
+                if let Some((lookup_func, deser_func)) = generate_struct_deserialize(module, req) {
                     generated.push(Rc::new(RefCell::new(lookup_func)));
                     generated.push(Rc::new(RefCell::new(deser_func)));
                 } else {

--- a/wado-compiler/src/synthesis/serde_synth.rs
+++ b/wado-compiler/src/synthesis/serde_synth.rs
@@ -451,11 +451,12 @@ fn default_value_for_type(type_id: TypeId, type_table: &TypeTable, span: Span) -
         } => (name.clone(), module_source.clone(), vec![]),
         _ => return null_expr(type_id),
     };
-    let mut method_info = LocalMethodName::new(
-        base_name,
-        Some("Default".to_string()),
-        "default".to_string(),
-    );
+    let default_trait_name = type_table
+        .compiler_items()
+        .trait_name(crate::compiler_item::CompilerItem::Default)
+        .to_string();
+    let mut method_info =
+        LocalMethodName::new(base_name, Some(default_trait_name), "default".to_string());
     if !type_args.is_empty() {
         let arg_names: Vec<String> = type_args.iter().map(|t| type_table.type_name(*t)).collect();
         method_info = method_info.with_type_args(&arg_names, &[]);

--- a/wado-compiler/src/synthesis/template.rs
+++ b/wado-compiler/src/synthesis/template.rs
@@ -318,6 +318,13 @@ fn build_template_block(
     ctx: &TemplateCtx,
 ) -> TirExpr {
     let tt = ctx.tt;
+    let string_struct_name = tt
+        .borrow()
+        .compiler_items()
+        .struct_name(crate::compiler_item::CompilerItem::String)
+        .to_string();
+    let with_capacity_qualified =
+        crate::name::MethodName::format_local(&string_struct_name, None, "with_capacity");
     let label = "__tmpl".to_string();
 
     // Estimate capacity: sum of literal lengths + 16 per interpolation
@@ -336,10 +343,10 @@ fn build_template_block(
         TirExprKind::Call {
             func: FunctionRef {
                 module_source: ModuleSource::string(),
-                name: "String::with_capacity".to_string(),
+                name: with_capacity_qualified.clone(),
                 monomorph_info: None,
                 method_info: Some(LocalMethodName::new(
-                    "String".to_string(),
+                    string_struct_name.clone(),
                     None,
                     "with_capacity".to_string(),
                 )),
@@ -390,15 +397,17 @@ fn build_template_block(
                     string_type,
                     span,
                 );
+                let push_str_qualified =
+                    crate::name::MethodName::format_local(&string_struct_name, None, "push_str");
                 let push_str_call = TirExpr::new(
                     TirExprKind::method_call(
                         Box::new(buf_ref),
                         FunctionRef {
                             module_source: ModuleSource::string(),
-                            name: "String::push_str".to_string(),
+                            name: push_str_qualified,
                             monomorph_info: None,
                             method_info: Some(LocalMethodName::new(
-                                "String".to_string(),
+                                string_struct_name.clone(),
                                 None,
                                 "push_str".to_string(),
                             )),
@@ -433,15 +442,20 @@ fn build_template_block(
                     );
                     // Deref if needed (&String → String)
                     let derefed = deref_to_inner(*resolved, string_type, span);
+                    let push_str_qualified = crate::name::MethodName::format_local(
+                        &string_struct_name,
+                        None,
+                        "push_str",
+                    );
                     let push_str_call = TirExpr::new(
                         TirExprKind::method_call(
                             Box::new(buf_ref),
                             FunctionRef {
                                 module_source: ModuleSource::string(),
-                                name: "String::push_str".to_string(),
+                                name: push_str_qualified,
                                 monomorph_info: None,
                                 method_info: Some(LocalMethodName::new(
-                                    "String".to_string(),
+                                    string_struct_name.clone(),
                                     None,
                                     "push_str".to_string(),
                                 )),

--- a/wado-compiler/src/synthesis/template.rs
+++ b/wado-compiler/src/synthesis/template.rs
@@ -343,7 +343,7 @@ fn build_template_block(
         TirExprKind::Call {
             func: FunctionRef {
                 module_source: ModuleSource::string(),
-                name: with_capacity_qualified.clone(),
+                name: with_capacity_qualified,
                 monomorph_info: None,
                 method_info: Some(LocalMethodName::new(
                     string_struct_name.clone(),

--- a/wado-compiler/src/synthesis/traits.rs
+++ b/wado-compiler/src/synthesis/traits.rs
@@ -419,12 +419,18 @@ fn generate_enum_trait_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, 
     }
 
     let module_source = module.module_source.clone();
-    let eq_trait_name = module
-        .type_table
-        .borrow()
-        .compiler_items()
-        .trait_name(crate::compiler_item::CompilerItem::Eq)
-        .to_string();
+    let (eq_trait_name, ord_trait_name) = {
+        let tt = module.type_table.borrow();
+        let items = tt.compiler_items();
+        (
+            items
+                .trait_name(crate::compiler_item::CompilerItem::Eq)
+                .to_string(),
+            items
+                .trait_name(crate::compiler_item::CompilerItem::Ord)
+                .to_string(),
+        )
+    };
 
     let enum_infos: Vec<_> = module
         .enums
@@ -446,13 +452,19 @@ fn generate_enum_trait_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, 
             ctx.record_impl(enum_name, &eq_trait_name);
         }
 
-        if !ctx.has_impl(enum_name, "Ord") {
+        if !ctx.has_impl(enum_name, &ord_trait_name) {
             let ordering_type =
-                type_table.make_enum("Ordering".to_string(), ModuleSource::traits());
-            let func =
-                generate_enum_ord_fn(enum_name, enum_type, ref_enum_type, ordering_type, *span);
+                type_table.make_compiler_enum(crate::compiler_item::CompilerItem::Ordering);
+            let func = generate_enum_ord_fn(
+                enum_name,
+                enum_type,
+                ref_enum_type,
+                ordering_type,
+                &ord_trait_name,
+                *span,
+            );
             generated_functions.push(Rc::new(RefCell::new(func)));
-            ctx.record_impl(enum_name, "Ord");
+            ctx.record_impl(enum_name, &ord_trait_name);
         }
     }
 
@@ -474,12 +486,18 @@ fn generate_struct_eq_ord_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'
     let module_source = module.module_source.clone();
     let mut generated = Vec::new();
 
-    let eq_trait_name = module
-        .type_table
-        .borrow()
-        .compiler_items()
-        .trait_name(crate::compiler_item::CompilerItem::Eq)
-        .to_string();
+    let (eq_trait_name, ord_trait_name) = {
+        let tt = module.type_table.borrow();
+        let items = tt.compiler_items();
+        (
+            items
+                .trait_name(crate::compiler_item::CompilerItem::Eq)
+                .to_string(),
+            items
+                .trait_name(crate::compiler_item::CompilerItem::Ord)
+                .to_string(),
+        )
+    };
     let mut tt = module.type_table.borrow_mut();
 
     let struct_infos = collect_struct_fields(module);
@@ -502,8 +520,8 @@ fn generate_struct_eq_ord_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'
             ctx.record_impl(name, &eq_trait_name);
         }
 
-        if !ctx.has_impl(name, "Ord") {
-            let ordering_type = tt.make_enum("Ordering".to_string(), ModuleSource::traits());
+        if !ctx.has_impl(name, &ord_trait_name) {
+            let ordering_type = tt.make_compiler_enum(crate::compiler_item::CompilerItem::Ordering);
             let func = generate_struct_ord_fn(
                 name,
                 &[],
@@ -511,11 +529,12 @@ fn generate_struct_eq_ord_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'
                 ref_struct_type,
                 ordering_type,
                 &module_source,
+                &ord_trait_name,
                 &mut tt,
                 *span,
             );
             generated.push(Rc::new(RefCell::new(func)));
-            ctx.record_impl(name, "Ord");
+            ctx.record_impl(name, &ord_trait_name);
         }
     }
 
@@ -541,8 +560,8 @@ fn generate_struct_eq_ord_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'
             ctx.record_impl(name, &eq_trait_name);
         }
 
-        if !ctx.has_impl(name, "Ord") {
-            let ordering_type = tt.make_enum("Ordering".to_string(), ModuleSource::traits());
+        if !ctx.has_impl(name, &ord_trait_name) {
+            let ordering_type = tt.make_compiler_enum(crate::compiler_item::CompilerItem::Ordering);
             let func = generate_struct_ord_fn(
                 name,
                 type_params,
@@ -550,11 +569,12 @@ fn generate_struct_eq_ord_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'
                 ref_struct_type,
                 ordering_type,
                 &module_source,
+                &ord_trait_name,
                 &mut tt,
                 *span,
             );
             generated.push(Rc::new(RefCell::new(func)));
-            ctx.record_impl(name, "Ord");
+            ctx.record_impl(name, &ord_trait_name);
         }
     }
 
@@ -586,6 +606,12 @@ fn generate_struct_default_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<
     let module_source = module.module_source.clone();
     let mut generated = Vec::new();
 
+    let default_trait_name = module
+        .type_table
+        .borrow()
+        .compiler_items()
+        .trait_name(crate::compiler_item::CompilerItem::Default)
+        .to_string();
     let mut tt = module.type_table.borrow_mut();
 
     let infos: Vec<(String, Vec<(String, TypeId, u32, TirExpr)>, Span)> = module
@@ -607,13 +633,14 @@ fn generate_struct_default_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<
         .collect();
 
     for (name, fields, span) in &infos {
-        if ctx.has_impl(name, "Default") {
+        if ctx.has_impl(name, &default_trait_name) {
             continue;
         }
         let struct_type = tt.make_struct(name.clone(), module_source.clone());
-        let func = generate_struct_default_fn(name, fields, struct_type, *span);
+        let func =
+            generate_struct_default_fn(name, fields, struct_type, &default_trait_name, *span);
         generated.push(Rc::new(RefCell::new(func)));
-        ctx.record_impl(name, "Default");
+        ctx.record_impl(name, &default_trait_name);
     }
 
     drop(tt);
@@ -626,9 +653,10 @@ fn generate_struct_default_fn(
     struct_name: &str,
     fields: &[(String, TypeId, u32, TirExpr)],
     struct_type: TypeId,
+    default_trait_name: &str,
     span: Span,
 ) -> TirFunction {
-    let method_info = trait_method_info(struct_name, "Default", "default");
+    let method_info = trait_method_info(struct_name, default_trait_name, "default");
     let qualified_name = method_info.to_mangled_name();
 
     let struct_fields = fields
@@ -2834,9 +2862,10 @@ fn generate_enum_ord_fn(
     enum_type: TypeId,
     ref_enum_type: TypeId,
     ordering_type: TypeId,
+    ord_trait_name: &str,
     span: Span,
 ) -> TirFunction {
-    let method_info = trait_method_info(enum_name, "Ord", "cmp");
+    let method_info = trait_method_info(enum_name, ord_trait_name, "cmp");
     let qualified_name = method_info.to_mangled_name();
 
     let local_a = || local_expr(2, "a", enum_type, span);
@@ -3041,10 +3070,14 @@ fn cmp_call_expr(
 ) -> TirExpr {
     let ref_type = tt.make_ref(field_type);
     let arg = ref_expr(other_field, ref_type, span);
+    let ord_trait_name = tt
+        .compiler_items()
+        .trait_name(crate::compiler_item::CompilerItem::Ord)
+        .to_string();
     trait_call_on_type(
         self_field,
         field_type,
-        "Ord",
+        &ord_trait_name,
         "cmp",
         ordering_type,
         vec![arg],
@@ -3199,10 +3232,11 @@ fn generate_struct_ord_fn(
     ref_struct_type: TypeId,
     ordering_type: TypeId,
     module_source: &ModuleSource,
+    ord_trait_name: &str,
     tt: &mut TypeTable,
     span: Span,
 ) -> TirFunction {
-    let method_info = trait_method_info(struct_name, "Ord", "cmp");
+    let method_info = trait_method_info(struct_name, ord_trait_name, "cmp");
     let qualified_name = method_info.to_mangled_name();
 
     let (stmts, locals) = build_struct_ord_body(

--- a/wado-compiler/src/synthesis/traits.rs
+++ b/wado-compiler/src/synthesis/traits.rs
@@ -753,7 +753,7 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
     let mut tt = module.type_table.borrow_mut();
     let formatter_type = tt.make_struct("Formatter".to_string(), ModuleSource::format());
     let fmt_type = tt.make_mut_ref(formatter_type);
-    let string_type = tt.make_struct("String".to_string(), ModuleSource::string());
+    let string_type = tt.make_compiler_struct(crate::compiler_item::CompilerItem::String);
 
     // Enums
     let enum_infos: Vec<_> = module
@@ -787,7 +787,7 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
     let struct_infos = collect_struct_visible_fields(module);
 
     for (name, fields, has_hidden, sspan) in &struct_infos {
-        if name == "String" || name == "Formatter" {
+        if name == tt.compiler_items().struct_name(crate::compiler_item::CompilerItem::String) || name == "Formatter" {
             continue;
         }
         if ctx.has_impl(name, "Inspect") {
@@ -1672,7 +1672,7 @@ fn generate_inspect_alt_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_,
     let mut tt = module.type_table.borrow_mut();
     let formatter_type = tt.make_struct("Formatter".to_string(), ModuleSource::format());
     let fmt_type = tt.make_mut_ref(formatter_type);
-    let string_type = tt.make_struct("String".to_string(), ModuleSource::string());
+    let string_type = tt.make_compiler_struct(crate::compiler_item::CompilerItem::String);
     let span = synth_span();
 
     // `Inspect` may be provided either as a trait impl (via TraitEnv / the
@@ -1716,7 +1716,7 @@ fn generate_inspect_alt_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_,
     let struct_infos = collect_struct_visible_fields(module);
 
     for (name, fields, has_hidden, sspan) in &struct_infos {
-        if name == "String" || name == "Formatter" {
+        if name == tt.compiler_items().struct_name(crate::compiler_item::CompilerItem::String) || name == "Formatter" {
             continue;
         }
         if ctx.has_impl(name, "InspectAlt") {
@@ -2378,6 +2378,18 @@ fn generate_fallback_impls(
     let mut generated = Vec::new();
 
     let span = synth_span();
+    let (string_name, array_name) = {
+        let tt = module.type_table.borrow();
+        let items = tt.compiler_items();
+        (
+            items
+                .struct_name(crate::compiler_item::CompilerItem::String)
+                .to_string(),
+            items
+                .struct_name(crate::compiler_item::CompilerItem::Array)
+                .to_string(),
+        )
+    };
     let mut tt = module.type_table.borrow_mut();
     let formatter_type = tt.make_struct("Formatter".to_string(), ModuleSource::format());
     let fmt_type = tt.make_mut_ref(formatter_type);
@@ -2432,7 +2444,7 @@ fn generate_fallback_impls(
         .map(|s| s.name.clone())
         .collect();
     for name in &struct_names {
-        if name == "String" || name == "Formatter" {
+        if name == &string_name || name == "Formatter" {
             continue;
         }
         if !needs_fallback(name, ctx) {
@@ -2451,7 +2463,7 @@ fn generate_fallback_impls(
         .map(|s| (s.name.clone(), s.type_params.clone()))
         .collect();
     for (name, type_params) in &generic_struct_infos {
-        if name == "Array" {
+        if name == &array_name {
             continue;
         }
         if !needs_fallback(name, ctx) {
@@ -2666,10 +2678,14 @@ fn trait_impl_module(
     ref_module: ModuleSource,
     string_module: ModuleSource,
 ) -> ModuleSource {
+    let string_struct_name = tt
+        .compiler_items()
+        .struct_name(crate::compiler_item::CompilerItem::String)
+        .to_string();
     match tt.get(type_id).clone() {
         ResolvedType::Primitive(_) => ModuleSource::primitive(),
         ResolvedType::Ref(_) | ResolvedType::MutRef(_) => ref_module,
-        ResolvedType::Struct { ref name, .. } if name == "String" => string_module,
+        ResolvedType::Struct { ref name, .. } if name == &string_struct_name => string_module,
         ResolvedType::Struct {
             ref module_source, ..
         }

--- a/wado-compiler/src/synthesis/traits.rs
+++ b/wado-compiler/src/synthesis/traits.rs
@@ -440,7 +440,8 @@ fn generate_enum_trait_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, 
         let ref_enum_type = type_table.make_ref(enum_type);
 
         if !ctx.has_impl(enum_name, &eq_trait_name) {
-            let func = generate_enum_eq_fn(enum_name, enum_type, ref_enum_type, &eq_trait_name, *span);
+            let func =
+                generate_enum_eq_fn(enum_name, enum_type, ref_enum_type, &eq_trait_name, *span);
             generated_functions.push(Rc::new(RefCell::new(func)));
             ctx.record_impl(enum_name, &eq_trait_name);
         }
@@ -787,7 +788,12 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
     let struct_infos = collect_struct_visible_fields(module);
 
     for (name, fields, has_hidden, sspan) in &struct_infos {
-        if name == tt.compiler_items().struct_name(crate::compiler_item::CompilerItem::String) || name == "Formatter" {
+        if name
+            == tt
+                .compiler_items()
+                .struct_name(crate::compiler_item::CompilerItem::String)
+            || name == "Formatter"
+        {
             continue;
         }
         if ctx.has_impl(name, "Inspect") {
@@ -1716,7 +1722,12 @@ fn generate_inspect_alt_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_,
     let struct_infos = collect_struct_visible_fields(module);
 
     for (name, fields, has_hidden, sspan) in &struct_infos {
-        if name == tt.compiler_items().struct_name(crate::compiler_item::CompilerItem::String) || name == "Formatter" {
+        if name
+            == tt
+                .compiler_items()
+                .struct_name(crate::compiler_item::CompilerItem::String)
+            || name == "Formatter"
+        {
             continue;
         }
         if ctx.has_impl(name, "InspectAlt") {

--- a/wado-compiler/src/synthesis/traits.rs
+++ b/wado-compiler/src/synthesis/traits.rs
@@ -419,6 +419,12 @@ fn generate_enum_trait_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, 
     }
 
     let module_source = module.module_source.clone();
+    let eq_trait_name = module
+        .type_table
+        .borrow()
+        .compiler_items()
+        .trait_name(crate::compiler_item::CompilerItem::Eq)
+        .to_string();
 
     let enum_infos: Vec<_> = module
         .enums
@@ -433,10 +439,10 @@ fn generate_enum_trait_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, 
         let enum_type = type_table.make_enum(enum_name.clone(), module_source.clone());
         let ref_enum_type = type_table.make_ref(enum_type);
 
-        if !ctx.has_impl(enum_name, "Eq") {
-            let func = generate_enum_eq_fn(enum_name, enum_type, ref_enum_type, *span);
+        if !ctx.has_impl(enum_name, &eq_trait_name) {
+            let func = generate_enum_eq_fn(enum_name, enum_type, ref_enum_type, &eq_trait_name, *span);
             generated_functions.push(Rc::new(RefCell::new(func)));
-            ctx.record_impl(enum_name, "Eq");
+            ctx.record_impl(enum_name, &eq_trait_name);
         }
 
         if !ctx.has_impl(enum_name, "Ord") {
@@ -467,6 +473,12 @@ fn generate_struct_eq_ord_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'
     let module_source = module.module_source.clone();
     let mut generated = Vec::new();
 
+    let eq_trait_name = module
+        .type_table
+        .borrow()
+        .compiler_items()
+        .trait_name(crate::compiler_item::CompilerItem::Eq)
+        .to_string();
     let mut tt = module.type_table.borrow_mut();
 
     let struct_infos = collect_struct_fields(module);
@@ -474,18 +486,19 @@ fn generate_struct_eq_ord_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'
         let struct_type = tt.make_struct(name.clone(), module_source.clone());
         let ref_struct_type = tt.make_ref(struct_type);
 
-        if !ctx.has_impl(name, "Eq") {
+        if !ctx.has_impl(name, &eq_trait_name) {
             let func = generate_struct_eq_fn(
                 name,
                 &[],
                 fields,
                 ref_struct_type,
                 &module_source,
+                &eq_trait_name,
                 &mut tt,
                 *span,
             );
             generated.push(Rc::new(RefCell::new(func)));
-            ctx.record_impl(name, "Eq");
+            ctx.record_impl(name, &eq_trait_name);
         }
 
         if !ctx.has_impl(name, "Ord") {
@@ -512,18 +525,19 @@ fn generate_struct_eq_ord_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'
             tt.make_generic_instance(name.clone(), module_source.clone(), type_param_ids);
         let ref_struct_type = tt.make_ref(struct_type);
 
-        if !ctx.has_impl(name, "Eq") {
+        if !ctx.has_impl(name, &eq_trait_name) {
             let func = generate_struct_eq_fn(
                 name,
                 type_params,
                 fields,
                 ref_struct_type,
                 &module_source,
+                &eq_trait_name,
                 &mut tt,
                 *span,
             );
             generated.push(Rc::new(RefCell::new(func)));
-            ctx.record_impl(name, "Eq");
+            ctx.record_impl(name, &eq_trait_name);
         }
 
         if !ctx.has_impl(name, "Ord") {
@@ -669,11 +683,17 @@ fn generate_variant_eq_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, 
     let module_source = module.module_source.clone();
     let mut generated = Vec::new();
 
+    let eq_trait_name = module
+        .type_table
+        .borrow()
+        .compiler_items()
+        .trait_name(crate::compiler_item::CompilerItem::Eq)
+        .to_string();
     let mut tt = module.type_table.borrow_mut();
 
     let variant_infos = collect_variant_cases(module);
     for (name, cases, span) in &variant_infos {
-        if ctx.has_impl(name, "Eq") {
+        if ctx.has_impl(name, &eq_trait_name) {
             continue;
         }
         let variant_type = tt.make_variant(name.clone(), module_source.clone());
@@ -689,12 +709,12 @@ fn generate_variant_eq_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, 
             *span,
         );
         generated.push(Rc::new(RefCell::new(func)));
-        ctx.record_impl(name, "Eq");
+        ctx.record_impl(name, &eq_trait_name);
     }
 
     let generic_variant_infos = collect_generic_variant_cases(module);
     for (name, type_params, cases, span) in &generic_variant_infos {
-        if ctx.has_impl(name, "Eq") {
+        if ctx.has_impl(name, &eq_trait_name) {
             continue;
         }
         let type_param_ids = make_type_param_ids(type_params, &mut tt);
@@ -712,7 +732,7 @@ fn generate_variant_eq_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, 
             *span,
         );
         generated.push(Rc::new(RefCell::new(func)));
-        ctx.record_impl(name, "Eq");
+        ctx.record_impl(name, &eq_trait_name);
     }
 
     drop(tt);
@@ -2737,9 +2757,10 @@ fn generate_enum_eq_fn(
     enum_name: &str,
     enum_type: TypeId,
     ref_enum_type: TypeId,
+    eq_trait_name: &str,
     span: Span,
 ) -> TirFunction {
-    let method_info = trait_method_info(enum_name, "Eq", "eq");
+    let method_info = trait_method_info(enum_name, eq_trait_name, "eq");
     let qualified_name = method_info.to_mangled_name();
 
     let comparison = TirExpr::new(
@@ -2962,10 +2983,14 @@ fn eq_call_expr(
 ) -> TirExpr {
     let ref_type = tt.make_ref(field_type);
     let arg = ref_expr(other_field, ref_type, span);
+    let eq_trait_name = tt
+        .compiler_items()
+        .trait_name(crate::compiler_item::CompilerItem::Eq)
+        .to_string();
     trait_call_on_type(
         self_field,
         field_type,
-        "Eq",
+        &eq_trait_name,
         "eq",
         TypeTable::BOOL,
         vec![arg],
@@ -3025,10 +3050,11 @@ fn generate_struct_eq_fn(
     fields: &[(String, TypeId, u32)],
     ref_struct_type: TypeId,
     module_source: &ModuleSource,
+    eq_trait_name: &str,
     tt: &mut TypeTable,
     span: Span,
 ) -> TirFunction {
-    let method_info = trait_method_info(struct_name, "Eq", "eq");
+    let method_info = trait_method_info(struct_name, eq_trait_name, "eq");
     let qualified_name = method_info.to_mangled_name();
 
     let result = build_struct_eq_chain(fields, ref_struct_type, module_source, tt, span);
@@ -3292,7 +3318,11 @@ fn generate_variant_eq_fn(
     tt: &mut TypeTable,
     span: Span,
 ) -> TirFunction {
-    let method_info = trait_method_info(variant_name, "Eq", "eq");
+    let eq_trait_name = tt
+        .compiler_items()
+        .trait_name(crate::compiler_item::CompilerItem::Eq)
+        .to_string();
+    let method_info = trait_method_info(variant_name, &eq_trait_name, "eq");
     let qualified_name = method_info.to_mangled_name();
 
     let deref_self = || deref_local(0, "self", ref_variant_type, variant_type, span);

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -865,6 +865,19 @@ impl TypeTable {
             .trait_module(crate::compiler_item::CompilerItem::Default)
     }
 
+    /// Make the struct type for a registered [`CompilerItem`] variant
+    /// of kind [`CompilerItemKind::Struct`]. Reads both the module
+    /// source and the struct name from the registry so the call site
+    /// does not hard-code either. Panics with a clear ICE message when
+    /// the item is not registered or has the wrong kind.
+    pub fn make_compiler_struct(&mut self, item: crate::compiler_item::CompilerItem) -> TypeId {
+        let (module_source, name) = {
+            let (m, n) = self.compiler_items.require_struct(item);
+            (m.clone(), n.to_string())
+        };
+        self.make_struct(name, module_source)
+    }
+
     /// Create an `Option<T>` type using the module source registered
     /// via `#[compiler_item("option")]`.
     pub fn make_option(&mut self, inner: TypeId) -> TypeId {

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -878,6 +878,18 @@ impl TypeTable {
         self.make_struct(name, module_source)
     }
 
+    /// Make the enum type for a registered [`CompilerItem`] variant
+    /// of kind [`CompilerItemKind::Enum`] (currently `Ordering`).
+    /// Same shape as [`Self::make_compiler_struct`]: routes both name
+    /// and module through the registry.
+    pub fn make_compiler_enum(&mut self, item: crate::compiler_item::CompilerItem) -> TypeId {
+        let (module_source, name) = {
+            let (m, n) = self.compiler_items.require_enum(item);
+            (m.clone(), n.to_string())
+        };
+        self.make_enum(name, module_source)
+    }
+
     /// Create an `Option<T>` type using the module source registered
     /// via `#[compiler_item("option")]`.
     pub fn make_option(&mut self, inner: TypeId) -> TypeId {

--- a/wado-compiler/tests/fixtures.golden/http_fields_get_and_delete.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/http_fields_get_and_delete.wir.wado
@@ -589,9 +589,9 @@ condition: fields.has(\"x-temp\" as FieldName)
     }
     result = "wado-compiler/tests/fixtures/http_fields_get_and_delete.wado/__cm_binding__Fields_get_and_delete"(fields, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("x-temp"), used: 6 });
     if ref.test "core:prelude/types.wado//Result<core:prelude/array.wado/Array<core:prelude/array.wado/Array<u8>>,wasi:http/types.wado/HeaderError>::Ok"(result) {
-        values = __inline__value_copy_T428_13: block -> ref "core:prelude//Array<core:prelude/array.wado/Array<u8>>" {
+        values = __inline__value_copy_T427_13: block -> ref "core:prelude//Array<core:prelude/array.wado/Array<u8>>" {
             v_193 = ref.cast "core:prelude/types.wado//Result<core:prelude/array.wado/Array<core:prelude/array.wado/Array<u8>>,wasi:http/types.wado/HeaderError>::Ok"(result).payload_0;
-            break __inline__value_copy_T428_13: struct.new "core:prelude//Array<core:prelude/array.wado/Array<u8>>" { repr: ref.as_non_null(builtin::array_clone_deep<ref "core:prelude//Array<u8>">(/*via $value_copy$T31*/ v_193.repr)), used: v_193.used };
+            break __inline__value_copy_T427_13: struct.new "core:prelude//Array<core:prelude/array.wado/Array<u8>>" { repr: ref.as_non_null(builtin::array_clone_deep<ref "core:prelude//Array<u8>">(/*via $value_copy$T31*/ v_193.repr)), used: v_193.used };
             unreachable;
         };
         __v0_7 = values.used;

--- a/wado-compiler/tests/fixtures.golden/httpbin_404.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/httpbin_404.wir.wado
@@ -5337,7 +5337,7 @@ fn "core:prelude/string.wado/String::substr_bytes"(self, start, end) {
             "core:prelude/string.wado/String::push"(__local_16, 58);
             __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
             f_23 = __local_17;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(695, f_23);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(696, f_23);
             "core:prelude/string.wado/String::push"(__local_16, 58);
             "core:prelude/string.wado/String::push"(__local_16, 32);
             "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range out of bounds"), used: 24 });
@@ -5450,7 +5450,7 @@ condition: 0 <= start && start <= end && end <= self.used
             "core:prelude/string.wado/String::push"(__local_18, 58);
             __local_19 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_18 };
             f_74 = __local_19;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(696, f_74);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(697, f_74);
             "core:prelude/string.wado/String::push"(__local_18, 58);
             "core:prelude/string.wado/String::push"(__local_18, 32);
             "core:prelude/string.wado/String::push_str"(__local_18, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range not on UTF-8 character boundaries"), used: 44 });

--- a/wado-compiler/tests/fixtures.golden/httpbin_405.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/httpbin_405.wir.wado
@@ -5337,7 +5337,7 @@ fn "core:prelude/string.wado/String::substr_bytes"(self, start, end) {
             "core:prelude/string.wado/String::push"(__local_16, 58);
             __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
             f_23 = __local_17;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(695, f_23);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(696, f_23);
             "core:prelude/string.wado/String::push"(__local_16, 58);
             "core:prelude/string.wado/String::push"(__local_16, 32);
             "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range out of bounds"), used: 24 });
@@ -5450,7 +5450,7 @@ condition: 0 <= start && start <= end && end <= self.used
             "core:prelude/string.wado/String::push"(__local_18, 58);
             __local_19 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_18 };
             f_74 = __local_19;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(696, f_74);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(697, f_74);
             "core:prelude/string.wado/String::push"(__local_18, 58);
             "core:prelude/string.wado/String::push"(__local_18, 32);
             "core:prelude/string.wado/String::push_str"(__local_18, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range not on UTF-8 character boundaries"), used: 44 });

--- a/wado-compiler/tests/fixtures.golden/httpbin_anything.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/httpbin_anything.wir.wado
@@ -5337,7 +5337,7 @@ fn "core:prelude/string.wado/String::substr_bytes"(self, start, end) {
             "core:prelude/string.wado/String::push"(__local_16, 58);
             __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
             f_23 = __local_17;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(695, f_23);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(696, f_23);
             "core:prelude/string.wado/String::push"(__local_16, 58);
             "core:prelude/string.wado/String::push"(__local_16, 32);
             "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range out of bounds"), used: 24 });
@@ -5450,7 +5450,7 @@ condition: 0 <= start && start <= end && end <= self.used
             "core:prelude/string.wado/String::push"(__local_18, 58);
             __local_19 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_18 };
             f_74 = __local_19;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(696, f_74);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(697, f_74);
             "core:prelude/string.wado/String::push"(__local_18, 58);
             "core:prelude/string.wado/String::push"(__local_18, 32);
             "core:prelude/string.wado/String::push_str"(__local_18, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range not on UTF-8 character boundaries"), used: 44 });

--- a/wado-compiler/tests/fixtures.golden/httpbin_get.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/httpbin_get.wir.wado
@@ -5337,7 +5337,7 @@ fn "core:prelude/string.wado/String::substr_bytes"(self, start, end) {
             "core:prelude/string.wado/String::push"(__local_16, 58);
             __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
             f_23 = __local_17;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(695, f_23);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(696, f_23);
             "core:prelude/string.wado/String::push"(__local_16, 58);
             "core:prelude/string.wado/String::push"(__local_16, 32);
             "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range out of bounds"), used: 24 });
@@ -5450,7 +5450,7 @@ condition: 0 <= start && start <= end && end <= self.used
             "core:prelude/string.wado/String::push"(__local_18, 58);
             __local_19 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_18 };
             f_74 = __local_19;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(696, f_74);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(697, f_74);
             "core:prelude/string.wado/String::push"(__local_18, 58);
             "core:prelude/string.wado/String::push"(__local_18, 32);
             "core:prelude/string.wado/String::push_str"(__local_18, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range not on UTF-8 character boundaries"), used: 44 });

--- a/wado-compiler/tests/fixtures.golden/httpbin_headers.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/httpbin_headers.wir.wado
@@ -5337,7 +5337,7 @@ fn "core:prelude/string.wado/String::substr_bytes"(self, start, end) {
             "core:prelude/string.wado/String::push"(__local_16, 58);
             __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
             f_23 = __local_17;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(695, f_23);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(696, f_23);
             "core:prelude/string.wado/String::push"(__local_16, 58);
             "core:prelude/string.wado/String::push"(__local_16, 32);
             "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range out of bounds"), used: 24 });
@@ -5450,7 +5450,7 @@ condition: 0 <= start && start <= end && end <= self.used
             "core:prelude/string.wado/String::push"(__local_18, 58);
             __local_19 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_18 };
             f_74 = __local_19;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(696, f_74);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(697, f_74);
             "core:prelude/string.wado/String::push"(__local_18, 58);
             "core:prelude/string.wado/String::push"(__local_18, 32);
             "core:prelude/string.wado/String::push_str"(__local_18, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range not on UTF-8 character boundaries"), used: 44 });

--- a/wado-compiler/tests/fixtures.golden/httpbin_post.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/httpbin_post.wir.wado
@@ -5337,7 +5337,7 @@ fn "core:prelude/string.wado/String::substr_bytes"(self, start, end) {
             "core:prelude/string.wado/String::push"(__local_16, 58);
             __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
             f_23 = __local_17;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(695, f_23);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(696, f_23);
             "core:prelude/string.wado/String::push"(__local_16, 58);
             "core:prelude/string.wado/String::push"(__local_16, 32);
             "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range out of bounds"), used: 24 });
@@ -5450,7 +5450,7 @@ condition: 0 <= start && start <= end && end <= self.used
             "core:prelude/string.wado/String::push"(__local_18, 58);
             __local_19 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_18 };
             f_74 = __local_19;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(696, f_74);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(697, f_74);
             "core:prelude/string.wado/String::push"(__local_18, 58);
             "core:prelude/string.wado/String::push"(__local_18, 32);
             "core:prelude/string.wado/String::push_str"(__local_18, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range not on UTF-8 character boundaries"), used: 44 });

--- a/wado-compiler/tests/fixtures.golden/httpbin_status.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/httpbin_status.wir.wado
@@ -5337,7 +5337,7 @@ fn "core:prelude/string.wado/String::substr_bytes"(self, start, end) {
             "core:prelude/string.wado/String::push"(__local_16, 58);
             __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
             f_23 = __local_17;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(695, f_23);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(696, f_23);
             "core:prelude/string.wado/String::push"(__local_16, 58);
             "core:prelude/string.wado/String::push"(__local_16, 32);
             "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range out of bounds"), used: 24 });
@@ -5450,7 +5450,7 @@ condition: 0 <= start && start <= end && end <= self.used
             "core:prelude/string.wado/String::push"(__local_18, 58);
             __local_19 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_18 };
             f_74 = __local_19;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(696, f_74);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(697, f_74);
             "core:prelude/string.wado/String::push"(__local_18, 58);
             "core:prelude/string.wado/String::push"(__local_18, 32);
             "core:prelude/string.wado/String::push_str"(__local_18, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range not on UTF-8 character boundaries"), used: 44 });

--- a/wado-compiler/tests/fixtures.golden/key_value_literal_conditional.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/key_value_literal_conditional.wir.wado
@@ -209,7 +209,7 @@ fn "wado-compiler/tests/fixtures/key_value_literal_conditional.wado/run"() with 
     let rx: i32;
     let tx: i32;
     let handle: i32;
-    m = __inline__value_copy_T824_2: block -> ref "core:collections//TreeMap<core:prelude/string.wado/String,i32>" {
+    m = __inline__value_copy_T823_2: block -> ref "core:collections//TreeMap<core:prelude/string.wado/String,i32>" {
         v_16 = __kv_lit: block -> ref "core:collections//TreeMap<core:prelude/string.wado/String,i32>" {
             __b_1 = struct.new "core:collections//TreeMap<core:prelude/string.wado/String,i32>" { root: struct.new "core:prelude/types.wado//Option<i32>" { 1 }, nodes: ref.as_non_null(__inline_TreeMap_core_prelude_string_wado_String_i32___new_4____seq_lit: block -> ref "core:prelude//Array<core:collections/TreeMapNode<core:prelude/string.wado/String>>" {
                 __b_18 = struct.new "core:prelude//Array<core:collections/TreeMapNode<core:prelude/string.wado/String>>" { repr: builtin::array_new<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(0), used: 0 };
@@ -225,7 +225,7 @@ fn "wado-compiler/tests/fixtures/key_value_literal_conditional.wado/run"() with 
             break __kv_lit: __b_1;
             unreachable;
         };
-        break __inline__value_copy_T824_2: v_16;
+        break __inline__value_copy_T823_2: v_16;
         unreachable;
     };
     __v0_4 = "core:collections/TreeMap<core:prelude/string.wado/String,i32>^IndexValue<K>::index_value"(m, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("a"), used: 1 });
@@ -266,7 +266,7 @@ condition: m[\"a\"] == 1
         });
         unreachable;
     }
-    m2 = __inline__value_copy_T824_18: block -> ref "core:collections//TreeMap<core:prelude/string.wado/String,i32>" {
+    m2 = __inline__value_copy_T823_18: block -> ref "core:collections//TreeMap<core:prelude/string.wado/String,i32>" {
         v_42 = __kv_lit: block -> ref "core:collections//TreeMap<core:prelude/string.wado/String,i32>" {
             __b_7 = struct.new "core:collections//TreeMap<core:prelude/string.wado/String,i32>" { root: struct.new "core:prelude/types.wado//Option<i32>" { 1 }, nodes: ref.as_non_null(__inline_TreeMap_core_prelude_string_wado_String_i32___new_24____seq_lit: block -> ref "core:prelude//Array<core:collections/TreeMapNode<core:prelude/string.wado/String>>" {
                 __b_51 = struct.new "core:prelude//Array<core:collections/TreeMapNode<core:prelude/string.wado/String>>" { repr: builtin::array_new<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(0), used: 0 };
@@ -282,7 +282,7 @@ condition: m[\"a\"] == 1
             break __kv_lit: __b_7;
             unreachable;
         };
-        break __inline__value_copy_T824_18: v_42;
+        break __inline__value_copy_T823_18: v_42;
         unreachable;
     };
     __v0_9 = "core:collections/TreeMap<core:prelude/string.wado/String,i32>^IndexValue<K>::index_value"(m2, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("b"), used: 1 });

--- a/wado-compiler/tests/fixtures.golden/nested_array.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/nested_array.wir.wado
@@ -116,7 +116,7 @@ type "functype//wado-compiler/tests/fixtures/nested_array.wado/__cm_binding__Std
 
 type "functype//wado-compiler/tests/fixtures/nested_array.wado/__cm_export__run" = fn();  // TypeId(33)
 
-type "functype//wado-compiler/tests/fixtures/nested_array.wado/$value_copy$T411" = fn(ref "core:prelude//Array<i32>") -> ref "core:prelude//Array<i32>";  // TypeId(34)
+type "functype//wado-compiler/tests/fixtures/nested_array.wado/$value_copy$T410" = fn(ref "core:prelude//Array<i32>") -> ref "core:prelude//Array<i32>";  // TypeId(34)
 
 type "functype//core:cli/write_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(35)
 
@@ -346,9 +346,9 @@ fn "wado-compiler/tests/fixtures/nested_array.wado/nested_array_3deep_iterate_te
         l7: loop {
             __pattern_temp_0_20 = "core:prelude/array.wado/ArrayIter<core:prelude/array.wado/Array<core:prelude/array.wado/Array<i32>>>^Iterator::next"(__iter_8);
             if ref.is_null(__pattern_temp_0_20) == 0 {
-                plane = __inline__value_copy_T412_48: block -> ref "core:prelude//Array<core:prelude/array.wado/Array<i32>>" {
+                plane = __inline__value_copy_T411_48: block -> ref "core:prelude//Array<core:prelude/array.wado/Array<i32>>" {
                     v_100 = ref.as_non_null(__pattern_temp_0_20);
-                    break __inline__value_copy_T412_48: struct.new "core:prelude//Array<core:prelude/array.wado/Array<i32>>" { repr: ref.as_non_null(builtin::array_clone_deep<ref "core:prelude//Array<i32>">(/*via $value_copy$T411*/ v_100.repr)), used: v_100.used };
+                    break __inline__value_copy_T411_48: struct.new "core:prelude//Array<core:prelude/array.wado/Array<i32>>" { repr: ref.as_non_null(builtin::array_clone_deep<ref "core:prelude//Array<i32>">(/*via $value_copy$T410*/ v_100.repr)), used: v_100.used };
                     unreachable;
                 };
                 __iter_10 = struct.new "core:prelude/array.wado//ArrayIter<core:prelude/array.wado/Array<i32>>" { repr: plane.repr, used: plane.used, index: 0 };
@@ -356,9 +356,9 @@ fn "wado-compiler/tests/fixtures/nested_array.wado/nested_array_3deep_iterate_te
                     l10: loop {
                         __pattern_temp_1 = "core:prelude/array.wado/ArrayIter<core:prelude/array.wado/Array<i32>>^Iterator::next"(__iter_10);
                         if ref.is_null(__pattern_temp_1) == 0 {
-                            row = __inline__value_copy_T411_50: block -> ref "core:prelude//Array<i32>" {
+                            row = __inline__value_copy_T410_50: block -> ref "core:prelude//Array<i32>" {
                                 v_102 = ref.as_non_null(__pattern_temp_1);
-                                break __inline__value_copy_T411_50: struct.new "core:prelude//Array<i32>" { repr: ref.as_non_null(builtin::array_clone<i32>(v_102.repr)), used: v_102.used };
+                                break __inline__value_copy_T410_50: struct.new "core:prelude//Array<i32>" { repr: ref.as_non_null(builtin::array_clone<i32>(v_102.repr)), used: v_102.used };
                                 unreachable;
                             };
                             __iter_12 = struct.new "core:prelude/array.wado//ArrayIter<i32>" { repr: row.repr, used: row.used, index: 0 };
@@ -495,9 +495,9 @@ fn "wado-compiler/tests/fixtures/nested_array.wado/nested_array_iterate_test"() 
         l18: loop {
             __pattern_temp_0_14 = "core:prelude/array.wado/ArrayIter<core:prelude/array.wado/Array<i32>>^Iterator::next"(__iter_6);
             if ref.is_null(__pattern_temp_0_14) == 0 {
-                row = __inline__value_copy_T411_24: block -> ref "core:prelude//Array<i32>" {
+                row = __inline__value_copy_T410_24: block -> ref "core:prelude//Array<i32>" {
                     v = ref.as_non_null(__pattern_temp_0_14);
-                    break __inline__value_copy_T411_24: struct.new "core:prelude//Array<i32>" { repr: ref.as_non_null(builtin::array_clone<i32>(v.repr)), used: v.used };
+                    break __inline__value_copy_T410_24: struct.new "core:prelude//Array<i32>" { repr: ref.as_non_null(builtin::array_clone<i32>(v.repr)), used: v.used };
                     unreachable;
                 };
                 __iter_8 = struct.new "core:prelude/array.wado//ArrayIter<i32>" { repr: row.repr, used: row.used, index: 0 };
@@ -921,7 +921,7 @@ fn "wado-compiler/tests/fixtures/nested_array.wado/__cm_export__run"() {
     "wasi/task-return"(0);
 }
 
-fn "wado-compiler/tests/fixtures/nested_array.wado/$value_copy$T411"(v) {
+fn "wado-compiler/tests/fixtures/nested_array.wado/$value_copy$T410"(v) {
     return struct.new "core:prelude//Array<i32>" { repr: ref.as_non_null(builtin::array_clone<i32>(v.repr)), used: v.used };
 }
 

--- a/wado-compiler/tests/fixtures.golden/newtype_generic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/newtype_generic.wir.wado
@@ -152,13 +152,13 @@ fn "wado-compiler/tests/fixtures/newtype_generic.wado/run"() with Stdout {
     let rx_82: i32;
     let tx_83: i32;
     let handle_84: i32;
-    arr = __inline__value_copy_T412_2: block -> ref "core:prelude//Array<i32>" {
+    arr = __inline__value_copy_T411_2: block -> ref "core:prelude//Array<i32>" {
         v_15 = __seq_lit: block -> ref "core:prelude//Array<i32>" {
             __b_0 = struct.new "core:prelude//Array<i32>" { repr: array.new_fixed<i32>(1, 2, 3), used: 3 };
             break __seq_lit: __b_0;
             unreachable;
         };
-        break __inline__value_copy_T412_2: struct.new "core:prelude//Array<i32>" { repr: ref.as_non_null(builtin::array_clone<i32>(v_15.repr)), used: 3 };
+        break __inline__value_copy_T411_2: struct.new "core:prelude//Array<i32>" { repr: ref.as_non_null(builtin::array_clone<i32>(v_15.repr)), used: 3 };
         unreachable;
     };
     message_25 = __tmpl: block -> ref "core:prelude/string.wado//String" {
@@ -214,13 +214,13 @@ fn "wado-compiler/tests/fixtures/newtype_generic.wado/run"() with Stdout {
     handle_41 = "wado-compiler/tests/fixtures/newtype_generic.wado/__cm_binding__Stdout_write_via_stream"(rx_39);
     "core:cli/write_to_stream"(tx_40, message_38, 1);
     "wasi/future-drop-readable:transmission-cli"(handle_41);
-    arr2 = __inline__value_copy_T412_23: block -> ref "core:prelude//Array<i32>" {
+    arr2 = __inline__value_copy_T411_23: block -> ref "core:prelude//Array<i32>" {
         v_52 = __seq_lit: block -> ref "core:prelude//Array<i32>" {
             __b_2 = struct.new "core:prelude//Array<i32>" { repr: array.new_fixed<i32>(10, 20), used: 2 };
             break __seq_lit: __b_2;
             unreachable;
         };
-        break __inline__value_copy_T412_23: struct.new "core:prelude//Array<i32>" { repr: ref.as_non_null(builtin::array_clone<i32>(v_52.repr)), used: 2 };
+        break __inline__value_copy_T411_23: struct.new "core:prelude//Array<i32>" { repr: ref.as_non_null(builtin::array_clone<i32>(v_52.repr)), used: 2 };
         unreachable;
     };
     "wado-compiler/tests/fixtures/newtype_generic.wado/Array<i32>::push"(arr2, 30);
@@ -242,13 +242,13 @@ fn "wado-compiler/tests/fixtures/newtype_generic.wado/run"() with Stdout {
     handle_63 = "wado-compiler/tests/fixtures/newtype_generic.wado/__cm_binding__Stdout_write_via_stream"(rx_61);
     "core:cli/write_to_stream"(tx_62, message_60, 1);
     "wasi/future-drop-readable:transmission-cli"(handle_63);
-    strs = __inline__value_copy_T416_36: block -> ref "core:prelude//Array<core:prelude/string.wado/String>" {
+    strs = __inline__value_copy_T415_36: block -> ref "core:prelude//Array<core:prelude/string.wado/String>" {
         v_73 = __seq_lit: block -> ref "core:prelude//Array<core:prelude/string.wado/String>" {
             __b_4 = struct.new "core:prelude//Array<core:prelude/string.wado/String>" { repr: array.new_fixed<ref "core:prelude/string.wado//String">(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("hello"), used: 5 }, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("world"), used: 5 }), used: 2 };
             break __seq_lit: __b_4;
             unreachable;
         };
-        break __inline__value_copy_T416_36: struct.new "core:prelude//Array<core:prelude/string.wado/String>" { repr: ref.as_non_null(builtin::array_clone_deep<ref "core:prelude/string.wado//String">(/*via $value_copy$T25*/ v_73.repr)), used: 2 };
+        break __inline__value_copy_T415_36: struct.new "core:prelude//Array<core:prelude/string.wado/String>" { repr: ref.as_non_null(builtin::array_clone_deep<ref "core:prelude/string.wado//String">(/*via $value_copy$T25*/ v_73.repr)), used: 2 };
         unreachable;
     };
     message_81 = __tmpl: block -> ref "core:prelude/string.wado//String" {

--- a/wado-compiler/tests/fixtures.golden/pattern_mut_binding.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/pattern_mut_binding.wir.wado
@@ -634,9 +634,9 @@ condition: orig == \"hello\"
         unreachable;
     });
     if ref.is_null(opt_arr) == 0 {
-        arr = __inline__value_copy_T412_88: block -> ref "core:prelude//Array<i32>" {
+        arr = __inline__value_copy_T411_88: block -> ref "core:prelude//Array<i32>" {
             v_213 = ref.as_non_null(opt_arr);
-            break __inline__value_copy_T412_88: struct.new "core:prelude//Array<i32>" { repr: ref.as_non_null(builtin::array_clone<i32>(v_213.repr)), used: v_213.used };
+            break __inline__value_copy_T411_88: struct.new "core:prelude//Array<i32>" { repr: ref.as_non_null(builtin::array_clone<i32>(v_213.repr)), used: v_213.used };
             unreachable;
         };
         "core:prelude/array.wado/Array<i32>::push"(arr, 4);
@@ -691,9 +691,9 @@ condition: arr.len() == 4
         "wasi/future-drop-readable:transmission-cli"(handle_229);
     }
     if ref.is_null(opt_arr) == 0 {
-        orig_27 = __inline__value_copy_T412_104: block -> ref "core:prelude//Array<i32>" {
+        orig_27 = __inline__value_copy_T411_104: block -> ref "core:prelude//Array<i32>" {
             v_239 = ref.as_non_null(opt_arr);
-            break __inline__value_copy_T412_104: struct.new "core:prelude//Array<i32>" { repr: ref.as_non_null(builtin::array_clone<i32>(v_239.repr)), used: v_239.used };
+            break __inline__value_copy_T411_104: struct.new "core:prelude//Array<i32>" { repr: ref.as_non_null(builtin::array_clone<i32>(v_239.repr)), used: v_239.used };
             unreachable;
         };
         __v0_28 = orig_27.used;

--- a/wado-compiler/tests/fixtures.golden/serde_json_roundtrip_complex.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_roundtrip_complex.wir.wado
@@ -2272,9 +2272,9 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_3_arra
         let __sroa_parsed_r_case1_payload_0: ref null "core:serde//DeserializeError";
         multivalue_bind [__sroa_parsed_r_discriminant, __sroa_parsed_r_case0_payload_0, __sroa_parsed_r_case1_payload_0] = "core:json/core/json/from_string<core:prelude/array.wado/Array<wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Inner>>"(json);
         if __sroa_parsed_r_discriminant == 0 {
-            arr = __inline__value_copy_T558_6: block -> ref "core:prelude//Array<wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Inner>" {
+            arr = __inline__value_copy_T557_6: block -> ref "core:prelude//Array<wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Inner>" {
                 v = ref.as_non_null(__sroa_parsed_r_case0_payload_0);
-                break __inline__value_copy_T558_6: struct.new "core:prelude//Array<wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Inner>" { repr: ref.as_non_null(builtin::array_clone_deep<ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner">(/*via $value_copy$T23*/ v.repr)), used: v.used };
+                break __inline__value_copy_T557_6: struct.new "core:prelude//Array<wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Inner>" { repr: ref.as_non_null(builtin::array_clone_deep<ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner">(/*via $value_copy$T23*/ v.repr)), used: v.used };
                 unreachable;
             };
             __v0_6 = arr.used;
@@ -2543,9 +2543,9 @@ condition: json == \"[]\"
         let __sroa_parsed_r_case1_payload_0: ref null "core:serde//DeserializeError";
         multivalue_bind [__sroa_parsed_r_discriminant, __sroa_parsed_r_case0_payload_0, __sroa_parsed_r_case1_payload_0] = "core:json/core/json/from_string<core:prelude/array.wado/Array<wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Inner>>"(json);
         if __sroa_parsed_r_discriminant == 0 {
-            arr = __inline__value_copy_T558_13: block -> ref "core:prelude//Array<wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Inner>" {
+            arr = __inline__value_copy_T557_13: block -> ref "core:prelude//Array<wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Inner>" {
                 v = ref.as_non_null(__sroa_parsed_r_case0_payload_0);
-                break __inline__value_copy_T558_13: struct.new "core:prelude//Array<wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Inner>" { repr: ref.as_non_null(builtin::array_clone_deep<ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner">(/*via $value_copy$T23*/ v.repr)), used: v.used };
+                break __inline__value_copy_T557_13: struct.new "core:prelude//Array<wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Inner>" { repr: ref.as_non_null(builtin::array_clone_deep<ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner">(/*via $value_copy$T23*/ v.repr)), used: v.used };
                 unreachable;
             };
             __v0_8 = arr.used;
@@ -2884,9 +2884,9 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/__test_7_tree
         let __sroa_parsed_r_case1_payload_0: ref null "core:serde//DeserializeError";
         multivalue_bind [__sroa_parsed_r_discriminant, __sroa_parsed_r_case0_payload_0, __sroa_parsed_r_case1_payload_0] = "core:json/core/json/from_string<core:collections/TreeMap<core:prelude/string.wado/String,core:prelude/string.wado/String>>"(json);
         if __sroa_parsed_r_discriminant == 0 {
-            m = __inline__value_copy_T565_9: block -> ref "core:collections//TreeMap<core:prelude/string.wado/String,core:prelude/string.wado/String>" {
+            m = __inline__value_copy_T564_9: block -> ref "core:collections//TreeMap<core:prelude/string.wado/String,core:prelude/string.wado/String>" {
                 v = ref.as_non_null(__sroa_parsed_r_case0_payload_0);
-                break __inline__value_copy_T565_9: v;
+                break __inline__value_copy_T564_9: v;
                 unreachable;
             };
             __v0_5 = "core:collections/TreeMap<core:prelude/string.wado/String,core:prelude/string.wado/String>^IndexValue<K>::index_value"(m, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("name"), used: 4 });
@@ -4204,9 +4204,9 @@ condition: json == \"[1,2,3]\"
         if __sroa_parsed_r_discriminant == 0 {
             p = __sroa_parsed_r_case0_payload_0;
             if ref.is_null(p) == 0 {
-                arr = __inline__value_copy_T582_16: block -> ref "core:prelude//Array<i32>" {
+                arr = __inline__value_copy_T581_16: block -> ref "core:prelude//Array<i32>" {
                     v_45 = ref.as_non_null(p);
-                    break __inline__value_copy_T582_16: struct.new "core:prelude//Array<i32>" { repr: ref.as_non_null(builtin::array_clone<i32>(v_45.repr)), used: v_45.used };
+                    break __inline__value_copy_T581_16: struct.new "core:prelude//Array<i32>" { repr: ref.as_non_null(builtin::array_clone<i32>(v_45.repr)), used: v_45.used };
                     unreachable;
                 };
                 __v0_9 = arr.used;
@@ -4464,9 +4464,9 @@ condition: json == \"[1,null,3]\"
         let __sroa_parsed_r_case1_payload_0: ref null "core:serde//DeserializeError";
         multivalue_bind [__sroa_parsed_r_discriminant, __sroa_parsed_r_case0_payload_0, __sroa_parsed_r_case1_payload_0] = "core:json/core/json/from_string<core:prelude/array.wado/Array<core:prelude/types.wado/Option<i32>>>"(json);
         if __sroa_parsed_r_discriminant == 0 {
-            arr = __inline__value_copy_T588_16: block -> ref "core:prelude//Array<core:prelude/types.wado/Option<i32>>" {
+            arr = __inline__value_copy_T587_16: block -> ref "core:prelude//Array<core:prelude/types.wado/Option<i32>>" {
                 v_52 = ref.as_non_null(__sroa_parsed_r_case0_payload_0);
-                break __inline__value_copy_T588_16: v_52;
+                break __inline__value_copy_T587_16: v_52;
                 unreachable;
             };
             __v0_8 = arr.used;

--- a/wado-compiler/tests/fixtures.golden/serde_json_treemap.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/serde_json_treemap.wir.wado
@@ -944,9 +944,9 @@ fn "wado-compiler/tests/fixtures/serde_json_treemap.wado/__test_1_treemap_roundt
         let __sroa_parsed_r_case1_payload_0: ref null "core:serde//DeserializeError";
         multivalue_bind [__sroa_parsed_r_discriminant, __sroa_parsed_r_case0_payload_0, __sroa_parsed_r_case1_payload_0] = "core:json/core/json/from_string<core:collections/TreeMap<core:prelude/string.wado/String,i32>>"(json);
         if __sroa_parsed_r_discriminant == 0 {
-            parsed = __inline__value_copy_T543_9: block -> ref "core:collections//TreeMap<core:prelude/string.wado/String,i32>" {
+            parsed = __inline__value_copy_T542_9: block -> ref "core:collections//TreeMap<core:prelude/string.wado/String,i32>" {
                 v = ref.as_non_null(__sroa_parsed_r_case0_payload_0);
-                break __inline__value_copy_T543_9: v;
+                break __inline__value_copy_T542_9: v;
                 unreachable;
             };
             __v0_5 = "core:collections/TreeMap<core:prelude/string.wado/String,i32>^IndexValue<K>::index_value"(parsed, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("x"), used: 1 });
@@ -1169,9 +1169,9 @@ condition: json == `{}`
         let __sroa_parsed_r_case1_payload_0: ref null "core:serde//DeserializeError";
         multivalue_bind [__sroa_parsed_r_discriminant, __sroa_parsed_r_case0_payload_0, __sroa_parsed_r_case1_payload_0] = "core:json/core/json/from_string<core:collections/TreeMap<core:prelude/string.wado/String,i32>>"(json);
         if __sroa_parsed_r_discriminant == 0 {
-            parsed = __inline__value_copy_T543_17: block -> ref "core:collections//TreeMap<core:prelude/string.wado/String,i32>" {
+            parsed = __inline__value_copy_T542_17: block -> ref "core:collections//TreeMap<core:prelude/string.wado/String,i32>" {
                 v = ref.as_non_null(__sroa_parsed_r_case0_payload_0);
-                break __inline__value_copy_T543_17: v;
+                break __inline__value_copy_T542_17: v;
                 unreachable;
             };
             __v0_7 = parsed.size;
@@ -1662,9 +1662,9 @@ fn "wado-compiler/tests/fixtures/serde_json_treemap.wado/__test_9_treemap_keys_w
         let __sroa_parsed_r_case1_payload_0: ref null "core:serde//DeserializeError";
         multivalue_bind [__sroa_parsed_r_discriminant, __sroa_parsed_r_case0_payload_0, __sroa_parsed_r_case1_payload_0] = "core:json/core/json/from_string<core:collections/TreeMap<core:prelude/string.wado/String,i32>>"(s);
         if __sroa_parsed_r_discriminant == 0 {
-            parsed = __inline__value_copy_T543_9: block -> ref "core:collections//TreeMap<core:prelude/string.wado/String,i32>" {
+            parsed = __inline__value_copy_T542_9: block -> ref "core:collections//TreeMap<core:prelude/string.wado/String,i32>" {
                 v = ref.as_non_null(__sroa_parsed_r_case0_payload_0);
-                break __inline__value_copy_T543_9: v;
+                break __inline__value_copy_T542_9: v;
                 unreachable;
             };
             __v0_5 = "core:collections/TreeMap<core:prelude/string.wado/String,i32>^IndexValue<K>::index_value"(parsed, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("key with spaces"), used: 15 });
@@ -1889,9 +1889,9 @@ fn "wado-compiler/tests/fixtures/serde_json_treemap.wado/__test_11_treemap_many_
         let __sroa_parsed_r_case1_payload_0: ref null "core:serde//DeserializeError";
         multivalue_bind [__sroa_parsed_r_discriminant, __sroa_parsed_r_case0_payload_0, __sroa_parsed_r_case1_payload_0] = "core:json/core/json/from_string<core:collections/TreeMap<core:prelude/string.wado/String,i32>>"(json);
         if __sroa_parsed_r_discriminant == 0 {
-            parsed = __inline__value_copy_T543_12: block -> ref "core:collections//TreeMap<core:prelude/string.wado/String,i32>" {
+            parsed = __inline__value_copy_T542_12: block -> ref "core:collections//TreeMap<core:prelude/string.wado/String,i32>" {
                 v = ref.as_non_null(__sroa_parsed_r_case0_payload_0);
-                break __inline__value_copy_T543_12: v;
+                break __inline__value_copy_T542_12: v;
                 unreachable;
             };
             __v0_6 = parsed.size;
@@ -2023,9 +2023,9 @@ fn "wado-compiler/tests/fixtures/serde_json_treemap.wado/__test_12_treemap_deser
     let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
     multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "core:json/core/json/from_string<core:collections/TreeMap<core:prelude/string.wado/String,i32>>"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("{\"b\":2,\"a\":1,\"c\":3}"), used: 19 });
     if __sroa_r_discriminant == 0 {
-        map = __inline__value_copy_T543_0: block -> ref "core:collections//TreeMap<core:prelude/string.wado/String,i32>" {
+        map = __inline__value_copy_T542_0: block -> ref "core:collections//TreeMap<core:prelude/string.wado/String,i32>" {
             v = ref.as_non_null(__sroa_r_case0_payload_0);
-            break __inline__value_copy_T543_0: v;
+            break __inline__value_copy_T542_0: v;
             unreachable;
         };
         __v0_2 = "core:collections/TreeMap<core:prelude/string.wado/String,i32>^IndexValue<K>::index_value"(map, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("a"), used: 1 });

--- a/wado-compiler/tests/fixtures.golden/string_insert_panic_boundary.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/string_insert_panic_boundary.wir.wado
@@ -404,7 +404,7 @@ fn "core:prelude/string.wado/String::insert"(self, byte_index, ch) {
             "core:prelude/string.wado/String::push"(__local_5, 58);
             __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_5 };
             f_10 = __local_6;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(833, f_10);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(834, f_10);
             "core:prelude/string.wado/String::push"(__local_5, 58);
             "core:prelude/string.wado/String::push"(__local_5, 32);
             "core:prelude/string.wado/String::push_str"(__local_5, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("insert index not on UTF-8 character boundary"), used: 44 });

--- a/wado-compiler/tests/fixtures.golden/string_insert_str_panic_boundary.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/string_insert_str_panic_boundary.wir.wado
@@ -387,7 +387,7 @@ fn "core:prelude/string.wado/String::insert_str"(self, byte_index, s) {
             "core:prelude/string.wado/String::push"(__local_5, 58);
             __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_5 };
             f_10 = __local_6;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(881, f_10);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(882, f_10);
             "core:prelude/string.wado/String::push"(__local_5, 58);
             "core:prelude/string.wado/String::push"(__local_5, 32);
             "core:prelude/string.wado/String::push_str"(__local_5, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("insert_str index not on UTF-8 character boundary"), used: 48 });

--- a/wado-compiler/tests/fixtures.golden/string_remove_panic_boundary.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/string_remove_panic_boundary.wir.wado
@@ -406,7 +406,7 @@ fn "core:prelude/string.wado/String::remove"(self, byte_index) {
             "core:prelude/string.wado/String::push"(__local_10, 58);
             __local_11 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_10 };
             f_17 = __local_11;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(916, f_17);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(917, f_17);
             "core:prelude/string.wado/String::push"(__local_10, 58);
             "core:prelude/string.wado/String::push"(__local_10, 32);
             "core:prelude/string.wado/String::push_str"(__local_10, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("index out of bounds"), used: 19 });
@@ -465,7 +465,7 @@ condition: byte_index >= 0 && byte_index < self.used
             "core:prelude/string.wado/String::push"(__local_12, 58);
             __local_13 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_12 };
             f_48 = __local_13;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(917, f_48);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(918, f_48);
             "core:prelude/string.wado/String::push"(__local_12, 58);
             "core:prelude/string.wado/String::push"(__local_12, 32);
             "core:prelude/string.wado/String::push_str"(__local_12, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("remove index not on UTF-8 character boundary"), used: 44 });

--- a/wado-compiler/tests/fixtures.golden/string_remove_panic_oob.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/string_remove_panic_oob.wir.wado
@@ -406,7 +406,7 @@ fn "core:prelude/string.wado/String::remove"(self, byte_index) {
             "core:prelude/string.wado/String::push"(__local_10, 58);
             __local_11 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_10 };
             f_17 = __local_11;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(916, f_17);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(917, f_17);
             "core:prelude/string.wado/String::push"(__local_10, 58);
             "core:prelude/string.wado/String::push"(__local_10, 32);
             "core:prelude/string.wado/String::push_str"(__local_10, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("index out of bounds"), used: 19 });
@@ -465,7 +465,7 @@ condition: byte_index >= 0 && byte_index < self.used
             "core:prelude/string.wado/String::push"(__local_12, 58);
             __local_13 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_12 };
             f_48 = __local_13;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(917, f_48);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(918, f_48);
             "core:prelude/string.wado/String::push"(__local_12, 58);
             "core:prelude/string.wado/String::push"(__local_12, 32);
             "core:prelude/string.wado/String::push_str"(__local_12, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("remove index not on UTF-8 character boundary"), used: 44 });

--- a/wado-compiler/tests/fixtures.golden/string_substr_bytes_panic_boundary.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/string_substr_bytes_panic_boundary.wir.wado
@@ -421,7 +421,7 @@ fn "core:prelude/string.wado/String::substr_bytes"(self, start, end) {
             "core:prelude/string.wado/String::push"(__local_16, 58);
             __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
             f_23 = __local_17;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(695, f_23);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(696, f_23);
             "core:prelude/string.wado/String::push"(__local_16, 58);
             "core:prelude/string.wado/String::push"(__local_16, 32);
             "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range out of bounds"), used: 24 });
@@ -534,7 +534,7 @@ condition: 0 <= start && start <= end && end <= self.used
             "core:prelude/string.wado/String::push"(__local_18, 58);
             __local_19 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_18 };
             f_74 = __local_19;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(696, f_74);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(697, f_74);
             "core:prelude/string.wado/String::push"(__local_18, 58);
             "core:prelude/string.wado/String::push"(__local_18, 32);
             "core:prelude/string.wado/String::push_str"(__local_18, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range not on UTF-8 character boundaries"), used: 44 });

--- a/wado-compiler/tests/fixtures.golden/string_substr_bytes_panic_oob.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/string_substr_bytes_panic_oob.wir.wado
@@ -421,7 +421,7 @@ fn "core:prelude/string.wado/String::substr_bytes"(self, start, end) {
             "core:prelude/string.wado/String::push"(__local_16, 58);
             __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
             f_23 = __local_17;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(695, f_23);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(696, f_23);
             "core:prelude/string.wado/String::push"(__local_16, 58);
             "core:prelude/string.wado/String::push"(__local_16, 32);
             "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range out of bounds"), used: 24 });
@@ -534,7 +534,7 @@ condition: 0 <= start && start <= end && end <= self.used
             "core:prelude/string.wado/String::push"(__local_18, 58);
             __local_19 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_18 };
             f_74 = __local_19;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(696, f_74);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(697, f_74);
             "core:prelude/string.wado/String::push"(__local_18, 58);
             "core:prelude/string.wado/String::push"(__local_18, 32);
             "core:prelude/string.wado/String::push_str"(__local_18, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range not on UTF-8 character boundaries"), used: 44 });

--- a/wado-compiler/tests/fixtures.golden/string_truncate_panic.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/string_truncate_panic.wir.wado
@@ -369,7 +369,7 @@ fn "core:prelude/string.wado/String::truncate"(self, byte_len) {
             "core:prelude/string.wado/String::push"(__local_6, 58);
             __local_7 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_6 };
             f_13 = __local_7;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(451, f_13);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(452, f_13);
             "core:prelude/string.wado/String::push"(__local_6, 58);
             "core:prelude/string.wado/String::push"(__local_6, 32);
             "core:prelude/string.wado/String::push_str"(__local_6, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("negative length"), used: 15 });
@@ -400,7 +400,7 @@ condition: byte_len >= 0
             "core:prelude/string.wado/String::push"(__local_8, 58);
             __local_9 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_8 };
             f_24 = __local_9;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(452, f_24);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(453, f_24);
             "core:prelude/string.wado/String::push"(__local_8, 58);
             "core:prelude/string.wado/String::push"(__local_8, 32);
             "core:prelude/string.wado/String::push_str"(__local_8, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("not on a UTF-8 character boundary"), used: 33 });

--- a/wado-compiler/tests/fixtures.golden/variant_construct.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/variant_construct.wir.wado
@@ -354,9 +354,9 @@ condition: arr[0] == 1 as u8
     let __sroa___pattern_temp_2_case1_payload_0: ref null "core:prelude/string.wado//String";
     multivalue_bind [__sroa___pattern_temp_2_discriminant, __sroa___pattern_temp_2_case0_payload_0, __sroa___pattern_temp_2_case1_payload_0] = "wado-compiler/tests/fixtures/variant_construct.wado/return_result_array"();
     if __sroa___pattern_temp_2_discriminant == 0 {
-        arr_8 = __inline__value_copy_T413_30: block -> ref "core:prelude//Array<i32>" {
+        arr_8 = __inline__value_copy_T412_30: block -> ref "core:prelude//Array<i32>" {
             v_86 = ref.as_non_null(__sroa___pattern_temp_2_case0_payload_0);
-            break __inline__value_copy_T413_30: struct.new "core:prelude//Array<i32>" { repr: ref.as_non_null(builtin::array_clone<i32>(v_86.repr)), used: v_86.used };
+            break __inline__value_copy_T412_30: struct.new "core:prelude//Array<i32>" { repr: ref.as_non_null(builtin::array_clone<i32>(v_86.repr)), used: v_86.used };
             unreachable;
         };
         __v0_9 = arr_8.used;
@@ -441,9 +441,9 @@ condition: arr[0] == 10
         unreachable;
     }) };
     if ref.test "core:prelude/types.wado//Result<core:prelude/array.wado/Array<i32>,core:prelude/string.wado/String>::Ok"(__pattern_temp_3) {
-        arr_13 = __inline__value_copy_T413_51: block -> ref "core:prelude//Array<i32>" {
+        arr_13 = __inline__value_copy_T412_51: block -> ref "core:prelude//Array<i32>" {
             v_116 = ref.cast "core:prelude/types.wado//Result<core:prelude/array.wado/Array<i32>,core:prelude/string.wado/String>::Ok"(__pattern_temp_3).payload_0;
-            break __inline__value_copy_T413_51: struct.new "core:prelude//Array<i32>" { repr: ref.as_non_null(builtin::array_clone<i32>(v_116.repr)), used: v_116.used };
+            break __inline__value_copy_T412_51: struct.new "core:prelude//Array<i32>" { repr: ref.as_non_null(builtin::array_clone<i32>(v_116.repr)), used: v_116.used };
             unreachable;
         };
         __v0_14 = arr_13.used;

--- a/wado-compiler/tests/fixtures.golden/wir_optimize_vcopy_deref_snapshot.wir.wado
+++ b/wado-compiler/tests/fixtures.golden/wir_optimize_vcopy_deref_snapshot.wir.wado
@@ -128,9 +128,9 @@ fn "wado-compiler/tests/fixtures/wir_optimize_vcopy_deref_snapshot.wado/run"() w
     };
     snap = __inline_snapshot_then_mutate_8: block -> ref "core:prelude//Array<i32>" {
         arr_15 = arr_1;
-        snapshot = __inline__value_copy_T411_9: block -> ref "core:prelude//Array<i32>" {
+        snapshot = __inline__value_copy_T410_9: block -> ref "core:prelude//Array<i32>" {
             v = arr_15;
-            break __inline__value_copy_T411_9: struct.new "core:prelude//Array<i32>" { repr: ref.as_non_null(builtin::array_clone<i32>(v.repr)), used: v.used };
+            break __inline__value_copy_T410_9: struct.new "core:prelude//Array<i32>" { repr: ref.as_non_null(builtin::array_clone<i32>(v.repr)), used: v.used };
             unreachable;
         };
         "core:prelude/array.wado/Array<i32>::push"(arr_15, 100);

--- a/wado-compiler/tests/fixtures/compiler_item_attr_unknown_name_rejected.wado
+++ b/wado-compiler/tests/fixtures/compiler_item_attr_unknown_name_rejected.wado
@@ -1,0 +1,12 @@
+// Error: `#[compiler_item("typo")]` with an unrecognized name must surface as a
+// diagnostic rather than being silently dropped. This locks in the contract that
+// stdlib typos fail loud — without it a renamed `CompilerItem` variant on the
+// Rust side would leave the corresponding stdlib annotation pointing at nothing.
+
+#[compiler_item("not_a_real_item")]
+pub struct Garbage {}
+
+export fn run() {}
+
+__DATA__
+{"compile_error": "unknown compiler item"}

--- a/wado-compiler/tests/fixtures/compiler_item_attr_user_module_rejected.wado
+++ b/wado-compiler/tests/fixtures/compiler_item_attr_user_module_rejected.wado
@@ -1,9 +1,15 @@
 // Error: `#[compiler_item("...")]` may only appear inside `core::*` modules.
 // User-level code that tries to claim a compiler item must be rejected so
 // the registry's invariants stay tied to the stdlib.
+//
+// The attribute below is placed on a trait (the kind `eq` expects) so the
+// scope-violation diagnostic is what the test is locking in — not a kind
+// mismatch that happens to fire first.
 
 #[compiler_item("eq")]
-pub struct MyEq {}
+pub trait MyEq {
+    fn eq(&self, other: &Self) -> bool;
+}
 
 export fn run() {}
 

--- a/wado-compiler/tests/fixtures/compiler_item_attr_user_module_rejected.wado
+++ b/wado-compiler/tests/fixtures/compiler_item_attr_user_module_rejected.wado
@@ -1,0 +1,11 @@
+// Error: `#[compiler_item("...")]` may only appear inside `core::*` modules.
+// User-level code that tries to claim a compiler item must be rejected so
+// the registry's invariants stay tied to the stdlib.
+
+#[compiler_item("eq")]
+pub struct MyEq {}
+
+export fn run() {}
+
+__DATA__
+{"compile_error": "only valid inside `core::*` modules"}

--- a/wado-compiler/tests/format.fixtures.golden/all.clean.wado
+++ b/wado-compiler/tests/format.fixtures.golden/all.clean.wado
@@ -67,7 +67,7 @@ trait Container {
 }
 
 /// Trait with attribute (attribute must be preserved)
-#[compiler_item("default")]
+#[hidden]
 pub trait HasDefault {
     fn default() -> Self;
 }

--- a/wado-compiler/tests/format.fixtures.golden/all.lower.wado
+++ b/wado-compiler/tests/format.fixtures.golden/all.lower.wado
@@ -13653,7 +13653,7 @@ pub fn String::truncate(self: &mut String, byte_len: i32) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 451 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 452 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("negative length");
                 __r.String::push_str("\ncondition: byte_len >= 0\n");
@@ -13677,7 +13677,7 @@ pub fn String::truncate(self: &mut String, byte_len: i32) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 452 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 453 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("not on a UTF-8 character boundary");
                 __r.String::push_str("\ncondition: self.is_char_boundary(byte_len)\n");
@@ -13959,7 +13959,7 @@ pub fn String::substr_bytes(self: &String, start: i32, end: i32) -> String {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 695 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 696 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("byte range out of bounds");
                 __r.String::push_str("\ncondition: 0 <= start && start <= end && end <= self.used\n");
@@ -14016,7 +14016,7 @@ pub fn String::substr_bytes(self: &String, start: i32, end: i32) -> String {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 696 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 697 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("byte range not on UTF-8 character boundaries");
                 __r.String::push_str("\ncondition: self.is_char_boundary(start) && self.is_char_boundary(end)\n");
@@ -14233,7 +14233,7 @@ pub fn String::insert(self: &mut String, byte_index: i32, ch: char) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 833 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 834 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("insert index not on UTF-8 character boundary");
                 __r.String::push_str("\ncondition: self.is_char_boundary(byte_index)\n");
@@ -14301,7 +14301,7 @@ pub fn String::insert_str(self: &mut String, byte_index: i32, s: String) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 881 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 882 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("insert_str index not on UTF-8 character boundary");
                 __r.String::push_str("\ncondition: self.is_char_boundary(byte_index)\n");
@@ -14357,7 +14357,7 @@ pub fn String::remove(self: &mut String, byte_index: i32) -> char {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 916 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 917 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("index out of bounds");
                 __r.String::push_str("\ncondition: byte_index >= 0 && byte_index < self.used\n");
@@ -14397,7 +14397,7 @@ pub fn String::remove(self: &mut String, byte_index: i32) -> char {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 917 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 918 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("remove index not on UTF-8 character boundary");
                 __r.String::push_str("\ncondition: self.is_char_boundary(byte_index)\n");

--- a/wado-compiler/tests/format.fixtures.golden/all.lower.wado
+++ b/wado-compiler/tests/format.fixtures.golden/all.lower.wado
@@ -7285,7 +7285,7 @@ pub fn i128::from_str_radix(s: &String, radix: u32) -> Result<i128, ParseIntErro
 
 pub fn i128::from_str_radix_range(s: &String, start: i32, end: i32, radix: u32) -> Result<i128, ParseIntError> {
     "core::prelude/intparse.wado::assert_radix"(radix);
-    let __pattern_temp_0: [bool, i32] = "$value_copy$T239"(match "core::prelude/intparse.wado::parse_signed_prefix_range"(s, start, end) {
+    let __pattern_temp_0: [bool, i32] = "$value_copy$T238"(match "core::prelude/intparse.wado::parse_signed_prefix_range"(s, start, end) {
         Ok(p) => p,
         Err(k) => {
             return Result<i128, ParseIntError>::Err("core::prelude/intparse.wado::ParseIntError::new"(k));
@@ -8443,7 +8443,7 @@ pub fn parse_unsigned_prefix(s: &String) -> Result<i32, IntErrorKind> {
 
 pub fn parse_i64_radix_range(s: &String, start: i32, end: i32, radix: u32, max: i64, min_abs: u64) -> Result<i64, ParseIntError> {
     "core::prelude/intparse.wado::assert_radix"(radix);
-    let __pattern_temp_0: [bool, i32] = "$value_copy$T239"(match "core::prelude/intparse.wado::parse_signed_prefix_range"(s, start, end) {
+    let __pattern_temp_0: [bool, i32] = "$value_copy$T238"(match "core::prelude/intparse.wado::parse_signed_prefix_range"(s, start, end) {
         Ok(p) => p,
         Err(k) => {
             return Result<i64, ParseIntError>::Err("core::prelude/intparse.wado::ParseIntError::new"(k));
@@ -15449,7 +15449,7 @@ pub fn "StrCharIndicesIter^Iterator::collect"(self: &mut StrCharIndicesIter) -> 
     loop {
         let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
         if __variant_test(__pattern_temp_0, case=0, name=Some) {
-            let item: [i32, char] = "$value_copy$T302"(__variant_payload(__pattern_temp_0, case=0));
+            let item: [i32, char] = "$value_copy$T301"(__variant_payload(__pattern_temp_0, case=0));
             result."Array<core:prelude/types.wado/Tuple<i32,char>>::push"(item);
         } else {
             break;
@@ -15475,8 +15475,8 @@ pub fn "StrCharIndicesIter^Iterator::for_each"(self: &mut StrCharIndicesIter, f:
     loop {
         let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
         if __variant_test(__pattern_temp_0, case=0, name=Some) {
-            let item: [i32, char] = "$value_copy$T302"(__variant_payload(__pattern_temp_0, case=0));
-            f("$value_copy$T302"(item));
+            let item: [i32, char] = "$value_copy$T301"(__variant_payload(__pattern_temp_0, case=0));
+            f("$value_copy$T301"(item));
         } else {
             break;
         }
@@ -15487,8 +15487,8 @@ pub fn "StrCharIndicesIter^Iterator::find"(self: &mut StrCharIndicesIter, pred: 
     loop {
         let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
         if __variant_test(__pattern_temp_0, case=0, name=Some) {
-            let item: [i32, char] = "$value_copy$T302"(__variant_payload(__pattern_temp_0, case=0));
-            if pred("$value_copy$T302"(item)) {
+            let item: [i32, char] = "$value_copy$T301"(__variant_payload(__pattern_temp_0, case=0));
+            if pred("$value_copy$T301"(item)) {
                 return Option<[i32, char]>::Some(item);
             }
         } else {
@@ -15502,8 +15502,8 @@ pub fn "StrCharIndicesIter^Iterator::any"(self: &mut StrCharIndicesIter, pred: f
     loop {
         let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
         if __variant_test(__pattern_temp_0, case=0, name=Some) {
-            let item: [i32, char] = "$value_copy$T302"(__variant_payload(__pattern_temp_0, case=0));
-            if pred("$value_copy$T302"(item)) {
+            let item: [i32, char] = "$value_copy$T301"(__variant_payload(__pattern_temp_0, case=0));
+            if pred("$value_copy$T301"(item)) {
                 return true;
             }
         } else {
@@ -15517,8 +15517,8 @@ pub fn "StrCharIndicesIter^Iterator::all"(self: &mut StrCharIndicesIter, pred: f
     loop {
         let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
         if __variant_test(__pattern_temp_0, case=0, name=Some) {
-            let item: [i32, char] = "$value_copy$T302"(__variant_payload(__pattern_temp_0, case=0));
-            if !pred("$value_copy$T302"(item)) {
+            let item: [i32, char] = "$value_copy$T301"(__variant_payload(__pattern_temp_0, case=0));
+            if !pred("$value_copy$T301"(item)) {
                 return false;
             }
         } else {
@@ -15533,7 +15533,7 @@ pub fn "StrCharIndicesIter^Iterator::last"(self: &mut StrCharIndicesIter) -> Opt
     loop {
         let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
         if __variant_test(__pattern_temp_0, case=0, name=Some) {
-            let item: [i32, char] = "$value_copy$T302"(__variant_payload(__pattern_temp_0, case=0));
+            let item: [i32, char] = "$value_copy$T301"(__variant_payload(__pattern_temp_0, case=0));
             result = Option<[i32, char]>::Some(item);
         } else {
             break;
@@ -15547,7 +15547,7 @@ pub fn "StrCharIndicesIter^Iterator::nth"(self: &mut StrCharIndicesIter, n: i32)
     loop {
         let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
         if __variant_test(__pattern_temp_0, case=0, name=Some) {
-            let item: [i32, char] = "$value_copy$T302"(__variant_payload(__pattern_temp_0, case=0));
+            let item: [i32, char] = "$value_copy$T301"(__variant_payload(__pattern_temp_0, case=0));
             if (remaining <= 0) {
                 return Option<[i32, char]>::Some(item);
             }
@@ -15564,8 +15564,8 @@ pub fn "StrCharIndicesIter^Iterator::position"(self: &mut StrCharIndicesIter, pr
     loop {
         let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
         if __variant_test(__pattern_temp_0, case=0, name=Some) {
-            let item: [i32, char] = "$value_copy$T302"(__variant_payload(__pattern_temp_0, case=0));
-            if pred("$value_copy$T302"(item)) {
+            let item: [i32, char] = "$value_copy$T301"(__variant_payload(__pattern_temp_0, case=0));
+            if pred("$value_copy$T301"(item)) {
                 return Option<i32>::Some(idx);
             }
             idx = (idx + 1);
@@ -15579,13 +15579,13 @@ pub fn "StrCharIndicesIter^Iterator::position"(self: &mut StrCharIndicesIter, pr
 pub fn "StrCharIndicesIter^Iterator::reduce"(self: &mut StrCharIndicesIter, f: fn mut([i32, char], [i32, char]) -> [i32, char]) -> Option<[i32, char]> {
     let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
     if __variant_test(__pattern_temp_0, case=0, name=Some) {
-        let first: [i32, char] = "$value_copy$T302"(__variant_payload(__pattern_temp_0, case=0));
-        let mut acc: [i32, char] = "$value_copy$T302"(first);
+        let first: [i32, char] = "$value_copy$T301"(__variant_payload(__pattern_temp_0, case=0));
+        let mut acc: [i32, char] = "$value_copy$T301"(first);
         loop {
             let __pattern_temp_1: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
             if __variant_test(__pattern_temp_1, case=0, name=Some) {
-                let item: [i32, char] = "$value_copy$T302"(__variant_payload(__pattern_temp_1, case=0));
-                acc = f("$value_copy$T302"(acc), "$value_copy$T302"(item));
+                let item: [i32, char] = "$value_copy$T301"(__variant_payload(__pattern_temp_1, case=0));
+                acc = f("$value_copy$T301"(acc), "$value_copy$T301"(item));
             } else {
                 break;
             }
@@ -27730,7 +27730,7 @@ fn "$value_copy$T26"(v: Point) -> Point {
     return Point { x: v.x, y: v.y };
 }
 
-fn "$value_copy$T302"(v: [i32, char]) -> [i32, char] {
+fn "$value_copy$T301"(v: [i32, char]) -> [i32, char] {
     return Tuple<i32,char> { 0: v.0, 1: v.1 };
 }
 
@@ -27738,7 +27738,7 @@ fn "$value_copy$T34"(v: String) -> String {
     return String { repr: core::builtin::array_clone::<u8>(v.repr), used: v.used };
 }
 
-fn "$value_copy$T239"(v: [bool, i32]) -> [bool, i32] {
+fn "$value_copy$T238"(v: [bool, i32]) -> [bool, i32] {
     return Tuple<bool,i32> { 0: v.0, 1: v.1 };
 }
 

--- a/wado-compiler/tests/format.fixtures.golden/mess.lower.wado
+++ b/wado-compiler/tests/format.fixtures.golden/mess.lower.wado
@@ -6762,7 +6762,7 @@ pub fn i128::from_str_radix(s: &String, radix: u32) -> Result<i128, ParseIntErro
 
 pub fn i128::from_str_radix_range(s: &String, start: i32, end: i32, radix: u32) -> Result<i128, ParseIntError> {
     "core::prelude/intparse.wado::assert_radix"(radix);
-    let __pattern_temp_0: [bool, i32] = "$value_copy$T235"(match "core::prelude/intparse.wado::parse_signed_prefix_range"(s, start, end) {
+    let __pattern_temp_0: [bool, i32] = "$value_copy$T234"(match "core::prelude/intparse.wado::parse_signed_prefix_range"(s, start, end) {
         Ok(p) => p,
         Err(k) => {
             return Result<i128, ParseIntError>::Err("core::prelude/intparse.wado::ParseIntError::new"(k));
@@ -7860,7 +7860,7 @@ pub fn parse_unsigned_prefix(s: &String) -> Result<i32, IntErrorKind> {
 
 pub fn parse_i64_radix_range(s: &String, start: i32, end: i32, radix: u32, max: i64, min_abs: u64) -> Result<i64, ParseIntError> {
     "core::prelude/intparse.wado::assert_radix"(radix);
-    let __pattern_temp_0: [bool, i32] = "$value_copy$T235"(match "core::prelude/intparse.wado::parse_signed_prefix_range"(s, start, end) {
+    let __pattern_temp_0: [bool, i32] = "$value_copy$T234"(match "core::prelude/intparse.wado::parse_signed_prefix_range"(s, start, end) {
         Ok(p) => p,
         Err(k) => {
             return Result<i64, ParseIntError>::Err("core::prelude/intparse.wado::ParseIntError::new"(k));
@@ -14686,7 +14686,7 @@ pub fn "StrCharIndicesIter^Iterator::collect"(self: &mut StrCharIndicesIter) -> 
     loop {
         let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
         if __variant_test(__pattern_temp_0, case=0, name=Some) {
-            let item: [i32, char] = "$value_copy$T298"(__variant_payload(__pattern_temp_0, case=0));
+            let item: [i32, char] = "$value_copy$T297"(__variant_payload(__pattern_temp_0, case=0));
             result."Array<core:prelude/types.wado/Tuple<i32,char>>::push"(item);
         } else {
             break;
@@ -14712,8 +14712,8 @@ pub fn "StrCharIndicesIter^Iterator::for_each"(self: &mut StrCharIndicesIter, f:
     loop {
         let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
         if __variant_test(__pattern_temp_0, case=0, name=Some) {
-            let item: [i32, char] = "$value_copy$T298"(__variant_payload(__pattern_temp_0, case=0));
-            f("$value_copy$T298"(item));
+            let item: [i32, char] = "$value_copy$T297"(__variant_payload(__pattern_temp_0, case=0));
+            f("$value_copy$T297"(item));
         } else {
             break;
         }
@@ -14724,8 +14724,8 @@ pub fn "StrCharIndicesIter^Iterator::find"(self: &mut StrCharIndicesIter, pred: 
     loop {
         let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
         if __variant_test(__pattern_temp_0, case=0, name=Some) {
-            let item: [i32, char] = "$value_copy$T298"(__variant_payload(__pattern_temp_0, case=0));
-            if pred("$value_copy$T298"(item)) {
+            let item: [i32, char] = "$value_copy$T297"(__variant_payload(__pattern_temp_0, case=0));
+            if pred("$value_copy$T297"(item)) {
                 return Option<[i32, char]>::Some(item);
             }
         } else {
@@ -14739,8 +14739,8 @@ pub fn "StrCharIndicesIter^Iterator::any"(self: &mut StrCharIndicesIter, pred: f
     loop {
         let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
         if __variant_test(__pattern_temp_0, case=0, name=Some) {
-            let item: [i32, char] = "$value_copy$T298"(__variant_payload(__pattern_temp_0, case=0));
-            if pred("$value_copy$T298"(item)) {
+            let item: [i32, char] = "$value_copy$T297"(__variant_payload(__pattern_temp_0, case=0));
+            if pred("$value_copy$T297"(item)) {
                 return true;
             }
         } else {
@@ -14754,8 +14754,8 @@ pub fn "StrCharIndicesIter^Iterator::all"(self: &mut StrCharIndicesIter, pred: f
     loop {
         let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
         if __variant_test(__pattern_temp_0, case=0, name=Some) {
-            let item: [i32, char] = "$value_copy$T298"(__variant_payload(__pattern_temp_0, case=0));
-            if !pred("$value_copy$T298"(item)) {
+            let item: [i32, char] = "$value_copy$T297"(__variant_payload(__pattern_temp_0, case=0));
+            if !pred("$value_copy$T297"(item)) {
                 return false;
             }
         } else {
@@ -14770,7 +14770,7 @@ pub fn "StrCharIndicesIter^Iterator::last"(self: &mut StrCharIndicesIter) -> Opt
     loop {
         let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
         if __variant_test(__pattern_temp_0, case=0, name=Some) {
-            let item: [i32, char] = "$value_copy$T298"(__variant_payload(__pattern_temp_0, case=0));
+            let item: [i32, char] = "$value_copy$T297"(__variant_payload(__pattern_temp_0, case=0));
             result = Option<[i32, char]>::Some(item);
         } else {
             break;
@@ -14784,7 +14784,7 @@ pub fn "StrCharIndicesIter^Iterator::nth"(self: &mut StrCharIndicesIter, n: i32)
     loop {
         let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
         if __variant_test(__pattern_temp_0, case=0, name=Some) {
-            let item: [i32, char] = "$value_copy$T298"(__variant_payload(__pattern_temp_0, case=0));
+            let item: [i32, char] = "$value_copy$T297"(__variant_payload(__pattern_temp_0, case=0));
             if (remaining <= 0) {
                 return Option<[i32, char]>::Some(item);
             }
@@ -14801,8 +14801,8 @@ pub fn "StrCharIndicesIter^Iterator::position"(self: &mut StrCharIndicesIter, pr
     loop {
         let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
         if __variant_test(__pattern_temp_0, case=0, name=Some) {
-            let item: [i32, char] = "$value_copy$T298"(__variant_payload(__pattern_temp_0, case=0));
-            if pred("$value_copy$T298"(item)) {
+            let item: [i32, char] = "$value_copy$T297"(__variant_payload(__pattern_temp_0, case=0));
+            if pred("$value_copy$T297"(item)) {
                 return Option<i32>::Some(idx);
             }
             idx = (idx + 1);
@@ -14816,13 +14816,13 @@ pub fn "StrCharIndicesIter^Iterator::position"(self: &mut StrCharIndicesIter, pr
 pub fn "StrCharIndicesIter^Iterator::reduce"(self: &mut StrCharIndicesIter, f: fn mut([i32, char], [i32, char]) -> [i32, char]) -> Option<[i32, char]> {
     let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
     if __variant_test(__pattern_temp_0, case=0, name=Some) {
-        let first: [i32, char] = "$value_copy$T298"(__variant_payload(__pattern_temp_0, case=0));
-        let mut acc: [i32, char] = "$value_copy$T298"(first);
+        let first: [i32, char] = "$value_copy$T297"(__variant_payload(__pattern_temp_0, case=0));
+        let mut acc: [i32, char] = "$value_copy$T297"(first);
         loop {
             let __pattern_temp_1: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
             if __variant_test(__pattern_temp_1, case=0, name=Some) {
-                let item: [i32, char] = "$value_copy$T298"(__variant_payload(__pattern_temp_1, case=0));
-                acc = f("$value_copy$T298"(acc), "$value_copy$T298"(item));
+                let item: [i32, char] = "$value_copy$T297"(__variant_payload(__pattern_temp_1, case=0));
+                acc = f("$value_copy$T297"(acc), "$value_copy$T297"(item));
             } else {
                 break;
             }
@@ -25222,7 +25222,7 @@ fn "$value_copy$T19"(v: [f64, f64]) -> [f64, f64] {
     return Tuple<f64,f64> { 0: v.0, 1: v.1 };
 }
 
-fn "$value_copy$T298"(v: [i32, char]) -> [i32, char] {
+fn "$value_copy$T297"(v: [i32, char]) -> [i32, char] {
     return Tuple<i32,char> { 0: v.0, 1: v.1 };
 }
 
@@ -25230,7 +25230,7 @@ fn "$value_copy$T21"(v: String) -> String {
     return String { repr: core::builtin::array_clone::<u8>(v.repr), used: v.used };
 }
 
-fn "$value_copy$T235"(v: [bool, i32]) -> [bool, i32] {
+fn "$value_copy$T234"(v: [bool, i32]) -> [bool, i32] {
     return Tuple<bool,i32> { 0: v.0, 1: v.1 };
 }
 

--- a/wado-compiler/tests/format.fixtures.golden/mess.lower.wado
+++ b/wado-compiler/tests/format.fixtures.golden/mess.lower.wado
@@ -12890,7 +12890,7 @@ pub fn String::truncate(self: &mut String, byte_len: i32) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 451 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 452 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("negative length");
                 __r.String::push_str("\ncondition: byte_len >= 0\n");
@@ -12914,7 +12914,7 @@ pub fn String::truncate(self: &mut String, byte_len: i32) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 452 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 453 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("not on a UTF-8 character boundary");
                 __r.String::push_str("\ncondition: self.is_char_boundary(byte_len)\n");
@@ -13196,7 +13196,7 @@ pub fn String::substr_bytes(self: &String, start: i32, end: i32) -> String {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 695 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 696 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("byte range out of bounds");
                 __r.String::push_str("\ncondition: 0 <= start && start <= end && end <= self.used\n");
@@ -13253,7 +13253,7 @@ pub fn String::substr_bytes(self: &String, start: i32, end: i32) -> String {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 696 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 697 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("byte range not on UTF-8 character boundaries");
                 __r.String::push_str("\ncondition: self.is_char_boundary(start) && self.is_char_boundary(end)\n");
@@ -13470,7 +13470,7 @@ pub fn String::insert(self: &mut String, byte_index: i32, ch: char) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 833 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 834 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("insert index not on UTF-8 character boundary");
                 __r.String::push_str("\ncondition: self.is_char_boundary(byte_index)\n");
@@ -13538,7 +13538,7 @@ pub fn String::insert_str(self: &mut String, byte_index: i32, s: String) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 881 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 882 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("insert_str index not on UTF-8 character boundary");
                 __r.String::push_str("\ncondition: self.is_char_boundary(byte_index)\n");
@@ -13594,7 +13594,7 @@ pub fn String::remove(self: &mut String, byte_index: i32) -> char {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 916 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 917 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("index out of bounds");
                 __r.String::push_str("\ncondition: byte_index >= 0 && byte_index < self.used\n");
@@ -13634,7 +13634,7 @@ pub fn String::remove(self: &mut String, byte_index: i32) -> char {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 917 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 918 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("remove index not on UTF-8 character boundary");
                 __r.String::push_str("\ncondition: self.is_char_boundary(byte_index)\n");

--- a/wado-compiler/tests/format.fixtures.golden/ops.all.lower.wado
+++ b/wado-compiler/tests/format.fixtures.golden/ops.all.lower.wado
@@ -6093,7 +6093,7 @@ pub fn i128::from_str_radix(s: &String, radix: u32) -> Result<i128, ParseIntErro
 
 pub fn i128::from_str_radix_range(s: &String, start: i32, end: i32, radix: u32) -> Result<i128, ParseIntError> {
     "core::prelude/intparse.wado::assert_radix"(radix);
-    let __pattern_temp_0: [bool, i32] = "$value_copy$T219"(match "core::prelude/intparse.wado::parse_signed_prefix_range"(s, start, end) {
+    let __pattern_temp_0: [bool, i32] = "$value_copy$T218"(match "core::prelude/intparse.wado::parse_signed_prefix_range"(s, start, end) {
         Ok(p) => p,
         Err(k) => {
             return Result<i128, ParseIntError>::Err("core::prelude/intparse.wado::ParseIntError::new"(k));
@@ -7179,7 +7179,7 @@ pub fn parse_unsigned_prefix(s: &String) -> Result<i32, IntErrorKind> {
 
 pub fn parse_i64_radix_range(s: &String, start: i32, end: i32, radix: u32, max: i64, min_abs: u64) -> Result<i64, ParseIntError> {
     "core::prelude/intparse.wado::assert_radix"(radix);
-    let __pattern_temp_0: [bool, i32] = "$value_copy$T219"(match "core::prelude/intparse.wado::parse_signed_prefix_range"(s, start, end) {
+    let __pattern_temp_0: [bool, i32] = "$value_copy$T218"(match "core::prelude/intparse.wado::parse_signed_prefix_range"(s, start, end) {
         Ok(p) => p,
         Err(k) => {
             return Result<i64, ParseIntError>::Err("core::prelude/intparse.wado::ParseIntError::new"(k));
@@ -13969,7 +13969,7 @@ pub fn "StrCharIndicesIter^Iterator::collect"(self: &mut StrCharIndicesIter) -> 
     loop {
         let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
         if __variant_test(__pattern_temp_0, case=0, name=Some) {
-            let item: [i32, char] = "$value_copy$T283"(__variant_payload(__pattern_temp_0, case=0));
+            let item: [i32, char] = "$value_copy$T282"(__variant_payload(__pattern_temp_0, case=0));
             result."Array<core:prelude/types.wado/Tuple<i32,char>>::push"(item);
         } else {
             break;
@@ -13995,8 +13995,8 @@ pub fn "StrCharIndicesIter^Iterator::for_each"(self: &mut StrCharIndicesIter, f:
     loop {
         let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
         if __variant_test(__pattern_temp_0, case=0, name=Some) {
-            let item: [i32, char] = "$value_copy$T283"(__variant_payload(__pattern_temp_0, case=0));
-            f("$value_copy$T283"(item));
+            let item: [i32, char] = "$value_copy$T282"(__variant_payload(__pattern_temp_0, case=0));
+            f("$value_copy$T282"(item));
         } else {
             break;
         }
@@ -14007,8 +14007,8 @@ pub fn "StrCharIndicesIter^Iterator::find"(self: &mut StrCharIndicesIter, pred: 
     loop {
         let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
         if __variant_test(__pattern_temp_0, case=0, name=Some) {
-            let item: [i32, char] = "$value_copy$T283"(__variant_payload(__pattern_temp_0, case=0));
-            if pred("$value_copy$T283"(item)) {
+            let item: [i32, char] = "$value_copy$T282"(__variant_payload(__pattern_temp_0, case=0));
+            if pred("$value_copy$T282"(item)) {
                 return Option<[i32, char]>::Some(item);
             }
         } else {
@@ -14022,8 +14022,8 @@ pub fn "StrCharIndicesIter^Iterator::any"(self: &mut StrCharIndicesIter, pred: f
     loop {
         let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
         if __variant_test(__pattern_temp_0, case=0, name=Some) {
-            let item: [i32, char] = "$value_copy$T283"(__variant_payload(__pattern_temp_0, case=0));
-            if pred("$value_copy$T283"(item)) {
+            let item: [i32, char] = "$value_copy$T282"(__variant_payload(__pattern_temp_0, case=0));
+            if pred("$value_copy$T282"(item)) {
                 return true;
             }
         } else {
@@ -14037,8 +14037,8 @@ pub fn "StrCharIndicesIter^Iterator::all"(self: &mut StrCharIndicesIter, pred: f
     loop {
         let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
         if __variant_test(__pattern_temp_0, case=0, name=Some) {
-            let item: [i32, char] = "$value_copy$T283"(__variant_payload(__pattern_temp_0, case=0));
-            if !pred("$value_copy$T283"(item)) {
+            let item: [i32, char] = "$value_copy$T282"(__variant_payload(__pattern_temp_0, case=0));
+            if !pred("$value_copy$T282"(item)) {
                 return false;
             }
         } else {
@@ -14053,7 +14053,7 @@ pub fn "StrCharIndicesIter^Iterator::last"(self: &mut StrCharIndicesIter) -> Opt
     loop {
         let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
         if __variant_test(__pattern_temp_0, case=0, name=Some) {
-            let item: [i32, char] = "$value_copy$T283"(__variant_payload(__pattern_temp_0, case=0));
+            let item: [i32, char] = "$value_copy$T282"(__variant_payload(__pattern_temp_0, case=0));
             result = Option<[i32, char]>::Some(item);
         } else {
             break;
@@ -14067,7 +14067,7 @@ pub fn "StrCharIndicesIter^Iterator::nth"(self: &mut StrCharIndicesIter, n: i32)
     loop {
         let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
         if __variant_test(__pattern_temp_0, case=0, name=Some) {
-            let item: [i32, char] = "$value_copy$T283"(__variant_payload(__pattern_temp_0, case=0));
+            let item: [i32, char] = "$value_copy$T282"(__variant_payload(__pattern_temp_0, case=0));
             if (remaining <= 0) {
                 return Option<[i32, char]>::Some(item);
             }
@@ -14084,8 +14084,8 @@ pub fn "StrCharIndicesIter^Iterator::position"(self: &mut StrCharIndicesIter, pr
     loop {
         let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
         if __variant_test(__pattern_temp_0, case=0, name=Some) {
-            let item: [i32, char] = "$value_copy$T283"(__variant_payload(__pattern_temp_0, case=0));
-            if pred("$value_copy$T283"(item)) {
+            let item: [i32, char] = "$value_copy$T282"(__variant_payload(__pattern_temp_0, case=0));
+            if pred("$value_copy$T282"(item)) {
                 return Option<i32>::Some(idx);
             }
             idx = (idx + 1);
@@ -14099,13 +14099,13 @@ pub fn "StrCharIndicesIter^Iterator::position"(self: &mut StrCharIndicesIter, pr
 pub fn "StrCharIndicesIter^Iterator::reduce"(self: &mut StrCharIndicesIter, f: fn mut([i32, char], [i32, char]) -> [i32, char]) -> Option<[i32, char]> {
     let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
     if __variant_test(__pattern_temp_0, case=0, name=Some) {
-        let first: [i32, char] = "$value_copy$T283"(__variant_payload(__pattern_temp_0, case=0));
-        let mut acc: [i32, char] = "$value_copy$T283"(first);
+        let first: [i32, char] = "$value_copy$T282"(__variant_payload(__pattern_temp_0, case=0));
+        let mut acc: [i32, char] = "$value_copy$T282"(first);
         loop {
             let __pattern_temp_1: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
             if __variant_test(__pattern_temp_1, case=0, name=Some) {
-                let item: [i32, char] = "$value_copy$T283"(__variant_payload(__pattern_temp_1, case=0));
-                acc = f("$value_copy$T283"(acc), "$value_copy$T283"(item));
+                let item: [i32, char] = "$value_copy$T282"(__variant_payload(__pattern_temp_1, case=0));
+                acc = f("$value_copy$T282"(acc), "$value_copy$T282"(item));
             } else {
                 break;
             }
@@ -19269,7 +19269,7 @@ fn __initialize_modules() {
     __modules_initialized = true;
 }
 
-fn "$value_copy$T283"(v: [i32, char]) -> [i32, char] {
+fn "$value_copy$T282"(v: [i32, char]) -> [i32, char] {
     return Tuple<i32,char> { 0: v.0, 1: v.1 };
 }
 
@@ -19277,7 +19277,7 @@ fn "$value_copy$T25"(v: String) -> String {
     return String { repr: core::builtin::array_clone::<u8>(v.repr), used: v.used };
 }
 
-fn "$value_copy$T219"(v: [bool, i32]) -> [bool, i32] {
+fn "$value_copy$T218"(v: [bool, i32]) -> [bool, i32] {
     return Tuple<bool,i32> { 0: v.0, 1: v.1 };
 }
 

--- a/wado-compiler/tests/format.fixtures.golden/ops.all.lower.wado
+++ b/wado-compiler/tests/format.fixtures.golden/ops.all.lower.wado
@@ -12173,7 +12173,7 @@ pub fn String::truncate(self: &mut String, byte_len: i32) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 451 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 452 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("negative length");
                 __r.String::push_str("\ncondition: byte_len >= 0\n");
@@ -12197,7 +12197,7 @@ pub fn String::truncate(self: &mut String, byte_len: i32) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 452 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 453 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("not on a UTF-8 character boundary");
                 __r.String::push_str("\ncondition: self.is_char_boundary(byte_len)\n");
@@ -12479,7 +12479,7 @@ pub fn String::substr_bytes(self: &String, start: i32, end: i32) -> String {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 695 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 696 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("byte range out of bounds");
                 __r.String::push_str("\ncondition: 0 <= start && start <= end && end <= self.used\n");
@@ -12536,7 +12536,7 @@ pub fn String::substr_bytes(self: &String, start: i32, end: i32) -> String {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 696 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 697 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("byte range not on UTF-8 character boundaries");
                 __r.String::push_str("\ncondition: self.is_char_boundary(start) && self.is_char_boundary(end)\n");
@@ -12753,7 +12753,7 @@ pub fn String::insert(self: &mut String, byte_index: i32, ch: char) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 833 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 834 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("insert index not on UTF-8 character boundary");
                 __r.String::push_str("\ncondition: self.is_char_boundary(byte_index)\n");
@@ -12821,7 +12821,7 @@ pub fn String::insert_str(self: &mut String, byte_index: i32, s: String) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 881 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 882 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("insert_str index not on UTF-8 character boundary");
                 __r.String::push_str("\ncondition: self.is_char_boundary(byte_index)\n");
@@ -12877,7 +12877,7 @@ pub fn String::remove(self: &mut String, byte_index: i32) -> char {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 916 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 917 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("index out of bounds");
                 __r.String::push_str("\ncondition: byte_index >= 0 && byte_index < self.used\n");
@@ -12917,7 +12917,7 @@ pub fn String::remove(self: &mut String, byte_index: i32) -> char {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 917 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 918 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("remove index not on UTF-8 character boundary");
                 __r.String::push_str("\ncondition: self.is_char_boundary(byte_index)\n");

--- a/wado-compiler/tests/format.fixtures.golden/ops.mess.lower.wado
+++ b/wado-compiler/tests/format.fixtures.golden/ops.mess.lower.wado
@@ -6093,7 +6093,7 @@ pub fn i128::from_str_radix(s: &String, radix: u32) -> Result<i128, ParseIntErro
 
 pub fn i128::from_str_radix_range(s: &String, start: i32, end: i32, radix: u32) -> Result<i128, ParseIntError> {
     "core::prelude/intparse.wado::assert_radix"(radix);
-    let __pattern_temp_0: [bool, i32] = "$value_copy$T219"(match "core::prelude/intparse.wado::parse_signed_prefix_range"(s, start, end) {
+    let __pattern_temp_0: [bool, i32] = "$value_copy$T218"(match "core::prelude/intparse.wado::parse_signed_prefix_range"(s, start, end) {
         Ok(p) => p,
         Err(k) => {
             return Result<i128, ParseIntError>::Err("core::prelude/intparse.wado::ParseIntError::new"(k));
@@ -7179,7 +7179,7 @@ pub fn parse_unsigned_prefix(s: &String) -> Result<i32, IntErrorKind> {
 
 pub fn parse_i64_radix_range(s: &String, start: i32, end: i32, radix: u32, max: i64, min_abs: u64) -> Result<i64, ParseIntError> {
     "core::prelude/intparse.wado::assert_radix"(radix);
-    let __pattern_temp_0: [bool, i32] = "$value_copy$T219"(match "core::prelude/intparse.wado::parse_signed_prefix_range"(s, start, end) {
+    let __pattern_temp_0: [bool, i32] = "$value_copy$T218"(match "core::prelude/intparse.wado::parse_signed_prefix_range"(s, start, end) {
         Ok(p) => p,
         Err(k) => {
             return Result<i64, ParseIntError>::Err("core::prelude/intparse.wado::ParseIntError::new"(k));
@@ -13969,7 +13969,7 @@ pub fn "StrCharIndicesIter^Iterator::collect"(self: &mut StrCharIndicesIter) -> 
     loop {
         let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
         if __variant_test(__pattern_temp_0, case=0, name=Some) {
-            let item: [i32, char] = "$value_copy$T283"(__variant_payload(__pattern_temp_0, case=0));
+            let item: [i32, char] = "$value_copy$T282"(__variant_payload(__pattern_temp_0, case=0));
             result."Array<core:prelude/types.wado/Tuple<i32,char>>::push"(item);
         } else {
             break;
@@ -13995,8 +13995,8 @@ pub fn "StrCharIndicesIter^Iterator::for_each"(self: &mut StrCharIndicesIter, f:
     loop {
         let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
         if __variant_test(__pattern_temp_0, case=0, name=Some) {
-            let item: [i32, char] = "$value_copy$T283"(__variant_payload(__pattern_temp_0, case=0));
-            f("$value_copy$T283"(item));
+            let item: [i32, char] = "$value_copy$T282"(__variant_payload(__pattern_temp_0, case=0));
+            f("$value_copy$T282"(item));
         } else {
             break;
         }
@@ -14007,8 +14007,8 @@ pub fn "StrCharIndicesIter^Iterator::find"(self: &mut StrCharIndicesIter, pred: 
     loop {
         let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
         if __variant_test(__pattern_temp_0, case=0, name=Some) {
-            let item: [i32, char] = "$value_copy$T283"(__variant_payload(__pattern_temp_0, case=0));
-            if pred("$value_copy$T283"(item)) {
+            let item: [i32, char] = "$value_copy$T282"(__variant_payload(__pattern_temp_0, case=0));
+            if pred("$value_copy$T282"(item)) {
                 return Option<[i32, char]>::Some(item);
             }
         } else {
@@ -14022,8 +14022,8 @@ pub fn "StrCharIndicesIter^Iterator::any"(self: &mut StrCharIndicesIter, pred: f
     loop {
         let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
         if __variant_test(__pattern_temp_0, case=0, name=Some) {
-            let item: [i32, char] = "$value_copy$T283"(__variant_payload(__pattern_temp_0, case=0));
-            if pred("$value_copy$T283"(item)) {
+            let item: [i32, char] = "$value_copy$T282"(__variant_payload(__pattern_temp_0, case=0));
+            if pred("$value_copy$T282"(item)) {
                 return true;
             }
         } else {
@@ -14037,8 +14037,8 @@ pub fn "StrCharIndicesIter^Iterator::all"(self: &mut StrCharIndicesIter, pred: f
     loop {
         let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
         if __variant_test(__pattern_temp_0, case=0, name=Some) {
-            let item: [i32, char] = "$value_copy$T283"(__variant_payload(__pattern_temp_0, case=0));
-            if !pred("$value_copy$T283"(item)) {
+            let item: [i32, char] = "$value_copy$T282"(__variant_payload(__pattern_temp_0, case=0));
+            if !pred("$value_copy$T282"(item)) {
                 return false;
             }
         } else {
@@ -14053,7 +14053,7 @@ pub fn "StrCharIndicesIter^Iterator::last"(self: &mut StrCharIndicesIter) -> Opt
     loop {
         let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
         if __variant_test(__pattern_temp_0, case=0, name=Some) {
-            let item: [i32, char] = "$value_copy$T283"(__variant_payload(__pattern_temp_0, case=0));
+            let item: [i32, char] = "$value_copy$T282"(__variant_payload(__pattern_temp_0, case=0));
             result = Option<[i32, char]>::Some(item);
         } else {
             break;
@@ -14067,7 +14067,7 @@ pub fn "StrCharIndicesIter^Iterator::nth"(self: &mut StrCharIndicesIter, n: i32)
     loop {
         let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
         if __variant_test(__pattern_temp_0, case=0, name=Some) {
-            let item: [i32, char] = "$value_copy$T283"(__variant_payload(__pattern_temp_0, case=0));
+            let item: [i32, char] = "$value_copy$T282"(__variant_payload(__pattern_temp_0, case=0));
             if (remaining <= 0) {
                 return Option<[i32, char]>::Some(item);
             }
@@ -14084,8 +14084,8 @@ pub fn "StrCharIndicesIter^Iterator::position"(self: &mut StrCharIndicesIter, pr
     loop {
         let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
         if __variant_test(__pattern_temp_0, case=0, name=Some) {
-            let item: [i32, char] = "$value_copy$T283"(__variant_payload(__pattern_temp_0, case=0));
-            if pred("$value_copy$T283"(item)) {
+            let item: [i32, char] = "$value_copy$T282"(__variant_payload(__pattern_temp_0, case=0));
+            if pred("$value_copy$T282"(item)) {
                 return Option<i32>::Some(idx);
             }
             idx = (idx + 1);
@@ -14099,13 +14099,13 @@ pub fn "StrCharIndicesIter^Iterator::position"(self: &mut StrCharIndicesIter, pr
 pub fn "StrCharIndicesIter^Iterator::reduce"(self: &mut StrCharIndicesIter, f: fn mut([i32, char], [i32, char]) -> [i32, char]) -> Option<[i32, char]> {
     let __pattern_temp_0: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
     if __variant_test(__pattern_temp_0, case=0, name=Some) {
-        let first: [i32, char] = "$value_copy$T283"(__variant_payload(__pattern_temp_0, case=0));
-        let mut acc: [i32, char] = "$value_copy$T283"(first);
+        let first: [i32, char] = "$value_copy$T282"(__variant_payload(__pattern_temp_0, case=0));
+        let mut acc: [i32, char] = "$value_copy$T282"(first);
         loop {
             let __pattern_temp_1: Option<[i32, char]> = self."StrCharIndicesIter^Iterator::next"();
             if __variant_test(__pattern_temp_1, case=0, name=Some) {
-                let item: [i32, char] = "$value_copy$T283"(__variant_payload(__pattern_temp_1, case=0));
-                acc = f("$value_copy$T283"(acc), "$value_copy$T283"(item));
+                let item: [i32, char] = "$value_copy$T282"(__variant_payload(__pattern_temp_1, case=0));
+                acc = f("$value_copy$T282"(acc), "$value_copy$T282"(item));
             } else {
                 break;
             }
@@ -19269,7 +19269,7 @@ fn __initialize_modules() {
     __modules_initialized = true;
 }
 
-fn "$value_copy$T283"(v: [i32, char]) -> [i32, char] {
+fn "$value_copy$T282"(v: [i32, char]) -> [i32, char] {
     return Tuple<i32,char> { 0: v.0, 1: v.1 };
 }
 
@@ -19277,7 +19277,7 @@ fn "$value_copy$T25"(v: String) -> String {
     return String { repr: core::builtin::array_clone::<u8>(v.repr), used: v.used };
 }
 
-fn "$value_copy$T219"(v: [bool, i32]) -> [bool, i32] {
+fn "$value_copy$T218"(v: [bool, i32]) -> [bool, i32] {
     return Tuple<bool,i32> { 0: v.0, 1: v.1 };
 }
 

--- a/wado-compiler/tests/format.fixtures.golden/ops.mess.lower.wado
+++ b/wado-compiler/tests/format.fixtures.golden/ops.mess.lower.wado
@@ -12173,7 +12173,7 @@ pub fn String::truncate(self: &mut String, byte_len: i32) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 451 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 452 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("negative length");
                 __r.String::push_str("\ncondition: byte_len >= 0\n");
@@ -12197,7 +12197,7 @@ pub fn String::truncate(self: &mut String, byte_len: i32) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 452 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 453 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("not on a UTF-8 character boundary");
                 __r.String::push_str("\ncondition: self.is_char_boundary(byte_len)\n");
@@ -12479,7 +12479,7 @@ pub fn String::substr_bytes(self: &String, start: i32, end: i32) -> String {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 695 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 696 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("byte range out of bounds");
                 __r.String::push_str("\ncondition: 0 <= start && start <= end && end <= self.used\n");
@@ -12536,7 +12536,7 @@ pub fn String::substr_bytes(self: &String, start: i32, end: i32) -> String {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 696 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 697 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("byte range not on UTF-8 character boundaries");
                 __r.String::push_str("\ncondition: self.is_char_boundary(start) && self.is_char_boundary(end)\n");
@@ -12753,7 +12753,7 @@ pub fn String::insert(self: &mut String, byte_index: i32, ch: char) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 833 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 834 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("insert index not on UTF-8 character boundary");
                 __r.String::push_str("\ncondition: self.is_char_boundary(byte_index)\n");
@@ -12821,7 +12821,7 @@ pub fn String::insert_str(self: &mut String, byte_index: i32, s: String) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 881 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 882 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("insert_str index not on UTF-8 character boundary");
                 __r.String::push_str("\ncondition: self.is_char_boundary(byte_index)\n");
@@ -12877,7 +12877,7 @@ pub fn String::remove(self: &mut String, byte_index: i32) -> char {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 916 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 917 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("index out of bounds");
                 __r.String::push_str("\ncondition: byte_index >= 0 && byte_index < self.used\n");
@@ -12917,7 +12917,7 @@ pub fn String::remove(self: &mut String, byte_index: i32) -> char {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 917 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 918 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("remove index not on UTF-8 character boundary");
                 __r.String::push_str("\ncondition: self.is_char_boundary(byte_index)\n");

--- a/wado-compiler/tests/format.fixtures/all.dirty.wado
+++ b/wado-compiler/tests/format.fixtures/all.dirty.wado
@@ -67,7 +67,7 @@ trait Container {
 }
 
 /// Trait with attribute (attribute must be preserved)
-#[compiler_item("default")]
+#[hidden]
 pub trait HasDefault {
     fn default() -> Self;
 }


### PR DESCRIPTION
Closes #1086. Follow-up scope tracked in #1091.

Follow-up to #1085: every Rust-side hard-coded reference to a stdlib symbol that the audit listed (and every natural derivative the reviewer chose) now routes through the `CompilerItem` registry. A stdlib rename on the Wado side flows through automatically as long as the `#[compiler_item("...")]` annotation stays put.

## Shape

Nine commits, sequenced so each lands as a self-contained step:

1. **Route trait identity through `CompilerItem` registry** — add `Eq` variant + stdlib annotation; switch `synthesis::from_synth`, `synthesis::kiln_synth`, `synthesis::serde_synth`, `synthesis::traits`, `lower::plan::pattern`, `lower::translate::wide_int`, `resolver::operators`, `resolver::method_lookup`, `resolver::method_call`, `resolver::call`, `resolver::expr`, `resolver::trait_query` to read `Eq` / `Default` / `From` / `Deserialize` names from the registry.
2. **Route type identity through `CompilerItem` registry** — add `Array` / `String` / `I128` / `U128` variants and annotations; add `TypeTable::make_compiler_struct` helper; switch the CM lift, value-copy synth, wide-int match rewrite, serde codegen, and the synthesis::traits / cm_binding derivative sites.
3. **Route wide-int constructor calls through `CompilerItem` registry** — add `I128FromI64` / `I128FromPair` / `U128FromU64` / `U128FromPair` method variants and annotations; thread the registry-resolved `(module, type, method)` triple through `lower::wide_int_literal`'s builders so the optimizer / `wir_build` pattern matches no longer hard-code `i128::from_*` shapes.
4. **Hoist closure `__call` / `__Closure_` literals into named constants** — `__call` has no Wado-side declaration, so a `CompilerItem` anchor has nothing to bind to. Defined `name::CLOSURE_CALL_METHOD` and `name::CLOSURE_STRUCT_PREFIX` instead and replaced the literals in `lower::plan::closure`, `lower::translate`, `optimize::dce`, `name::is_closure_call`.
5. **Diagnose, validate, and regression-test `CompilerItem` annotations** — three new resolver diagnostics (unknown attr name, kind mismatch, scope violation), `CompilerItem::is_required(world)` + `CompilerItems::missing_required(world)` validator wired into `compile_with_options`, four unit tests pinning the rename-safety contract (issue #1077), and two e2e fixtures (`compiler_item_attr_user_module_rejected.wado`, `compiler_item_attr_unknown_name_rejected.wado`).
6. **Regenerate goldens and fix doc / format-fixture fallout** — `doc.rs` trait-doc extraction now bridges over `#[compiler_item(...)]`; `format.fixtures/all.dirty.wado` switched from the now-invalid `#[compiler_item("default")]` to `#[hidden]`; goldens regenerated for the line-number shifts in annotated stdlib files.
7. **Push remaining derivative sites through `CmStdlibNames`** — introduce `synthesis::cm_binding::types::CmStdlibNames`, a four-string snapshot for `String` / `Array` / `Option` / `Result`, and thread it through `flatten_param_type`, `cm_param_store_plan`, `is_gc_passthrough_param`, `flatten_export_type`, `flat_types_from_type_id_into`, `synthesize_lower` (+ helpers), `synthesize_adapter`, `synthesize_lift_from_flat_params`, `replace_wasi_derived_type_recursive`, `rewrite_calls_in_expr`, `synthesize_stream_read_func`. Also clean up the `PhantomData::<Resolved>` dummy, simplify `from_synth.rs`'s `format!`+`trim_end_matches`, and make the user-module e2e fixture attach `eq` to a trait so the scope-violation diagnostic is what's actually pinned.
8. **Route `Default` / `Ord` / `Ordering` through the registry** — `Default` was already in the registry but its name still appeared as a literal at the synthesised call sites. `Ord` and `Ordering` were missing entirely: add `CompilerItem::Ord` (trait), `CompilerItem::Ordering` (enum) — which also introduces `CompilerItemKind::Enum`, `Resolved::Enum`, `require_enum`, `enum_name`, `TypeTable::make_compiler_enum`, and `register_enum_compiler_item` — then switch every `"Default"` / `"Ord"` / `"Ordering"` literal in `synthesis::traits`, `resolver::operators`, `resolver::trait_query`, `resolver::expr`, `resolver::method_call`, `resolver::method_lookup`, `synthesis::serde_synth` to read the name from the registry.
9. **Address Devin review: 3 registry-consistency fixes**
   - `lower::translate::wide_int::create_{i128,u128}_eq_call` now looks the `i128` / `u128` struct names up via the registry instead of using string literals, matching the pattern the wide-int literal builders already use.
   - `synthesis::cm_binding::tests::register_option_result_for_tests` registers `CompilerItem::Array` against `ModuleSource::array()` (was `prelude()`), agreeing with the production `TypeTable::make_array` module source.
   - `resolver::module::collect_type_declarations`'s `Item::Enum` arm now calls `register_enum_compiler_item`, mirroring the variant / trait paths and future-proofing a lazily-loaded enum compiler item.

## Acceptance check

The issue's gate is

```
grep -rn '"String"\|"Array"\|"Eq"\|"From"\|"Deserialize"' \
  wado-compiler/src/{synthesis,lower,resolver}/
```

After this PR the only matches are inside `#[cfg(test)] mod tests` blocks (mock AST in `cm_binding.rs` and `trait_env.rs`) and the canonical-name body of `CmStdlibNames::for_tests`. Same story for the extended grep including `"Default"`, `"Ord"`, `"Ordering"`.

The `synthesis::serde_synth` / `synthesis::template` layers still hard-code `core:serde` and `core:format` symbols (`Serializer`, `Deserializer`, `Formatter`, `Display`, `Inspect`, …) plus variant cases (`Some` / `None` / `Ok` / `Err` / `Less` / `Equal` / `Greater`) — these are out of scope for #1086 and tracked separately in #1091.

## Test plan

- [x] `cargo build -p wado-compiler` — clean
- [x] `cargo test -p wado-compiler --lib` — 489 / 0
- [x] `cargo test -p wado-compiler --test e2e` — 6117 / 0 (includes the two new compile-error fixtures)
- [x] `cargo test -p wado-compiler --test format` — 88 / 0
- [x] `mise run on-task-done` end-to-end — 382 compile ok, 2573 test pass
- [x] Rename-safety locked: `method_name_round_trips_through_registry_even_when_renamed`, `missing_registration_returns_none`, `require_panics_on_unregistered`, `missing_required_scopes_by_world` unit tests in `compiler_item.rs`
- [x] Scope violation diagnostic locked: `compiler_item_attr_user_module_rejected.wado` e2e fixture
- [x] Unknown name diagnostic locked: `compiler_item_attr_unknown_name_rejected.wado` e2e fixture