### PR TITLE
perf: cache stdlib `Annotated` snapshot across compiles

### DIFF
--- a/wado-cli/src/test.rs
+++ b/wado-cli/src/test.rs
@@ -1287,6 +1287,36 @@ async fn run_one_package(
     Ok(totals)
 }
 
+/// Build the thread-local stdlib snapshot on `parallelism` distinct
+/// blocking-pool worker threads in parallel, ahead of any compile work.
+///
+/// Each worker would otherwise build the snapshot lazily on its first
+/// `annotate_loaded` call (~120 ms), serialising the cost behind that
+/// task.  A `std::sync::Barrier` keeps every prewarm task running
+/// simultaneously so tokio's blocking pool allocates `parallelism`
+/// distinct threads; those same threads are then reused for the
+/// `spawn_blocking` compile tasks scheduled by [`collect_test_jobs`],
+/// turning each first-compile from a cold miss into a cache hit.
+async fn prewarm_stdlib_snapshot_on_workers(parallelism: usize) {
+    let parallelism = parallelism.max(1);
+    let barrier = Arc::new(std::sync::Barrier::new(parallelism));
+    let handles: Vec<_> = (0..parallelism)
+        .map(|_| {
+            let barrier = Arc::clone(&barrier);
+            tokio::task::spawn_blocking(move || {
+                wado_compiler::prewarm_stdlib_snapshot();
+                // Block until every prewarm task is concurrently
+                // running so the blocking pool cannot satisfy all
+                // tasks with a single thread.
+                barrier.wait();
+            })
+        })
+        .collect();
+    for handle in handles {
+        let _ = handle.await;
+    }
+}
+
 pub async fn run(opts: TestOptions) {
     let overall_start = Instant::now();
     let multi_pkg = opts.package_runs.len() > 1;
@@ -1294,6 +1324,15 @@ pub async fn run(opts: TestOptions) {
     let jobs = opts.jobs;
     let package_runs = opts.package_runs;
     let preopened_dirs = Arc::new(opts.preopened_dirs);
+
+    // Prewarm the stdlib snapshot on `jobs` distinct worker threads
+    // before Phase 1 starts.  Each worker would otherwise build the
+    // snapshot (~120 ms) on its first compile and steal that time
+    // from the first batch of compiles; running the builds in
+    // parallel up-front amortises the cost and leaves the tokio
+    // blocking-pool threads in the steady state that subsequent
+    // `spawn_blocking` compile tasks can re-use.
+    prewarm_stdlib_snapshot_on_workers(jobs).await;
 
     let mut grand = PackageTotals::default();
     for pkg_run in &package_runs {

--- a/wado-cli/src/test.rs
+++ b/wado-cli/src/test.rs
@@ -1304,11 +1304,26 @@ async fn prewarm_stdlib_snapshot_on_workers(parallelism: usize) {
         .map(|_| {
             let barrier = Arc::clone(&barrier);
             tokio::task::spawn_blocking(move || {
-                wado_compiler::prewarm_stdlib_snapshot();
+                // Catch any panic from the snapshot build (the only
+                // place this can fail is the `expect` in
+                // `build_snapshot`, which would indicate a stdlib bug)
+                // so that **every** task reaches the barrier.  If one
+                // task panicked before the barrier the remaining
+                // `parallelism - 1` tasks would block forever waiting
+                // for a party count that can never be met,
+                // deadlocking the test runner.  Re-raise after the
+                // barrier so the original panic still propagates
+                // through `handle.await`.
+                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    wado_compiler::prewarm_stdlib_snapshot();
+                }));
                 // Block until every prewarm task is concurrently
                 // running so the blocking pool cannot satisfy all
                 // tasks with a single thread.
                 barrier.wait();
+                if let Err(panic) = result {
+                    std::panic::resume_unwind(panic);
+                }
             })
         })
         .collect();

--- a/wado-compiler/src/annotate.rs
+++ b/wado-compiler/src/annotate.rs
@@ -405,6 +405,15 @@ pub(crate) fn annotate_loaded<H: CompilerHost>(
         analyzer.into_symbols()
     };
 
+    // Per-thread stdlib `Annotated` snapshot.  When present,
+    // `annotate_modules` seeds its `TypeTable` / decl maps / registries
+    // from this snapshot and `lower_tir_from_state` copies the
+    // pre-lowered stdlib `TirModule`s directly into its result, skipping
+    // the ~28 s of CPU otherwise duplicated across a typical `wado test`
+    // run.  Returns `None` when called from inside the snapshot builder
+    // itself (re-entry guard); a fresh full annotate runs in that case.
+    let snapshot = crate::stdlib_snapshot::get_or_init_snapshot();
+
     let state = {
         let _span = logger.span("resolve/annotate");
         Resolver::annotate_modules(
@@ -414,6 +423,7 @@ pub(crate) fn annotate_loaded<H: CompilerHost>(
             logger,
             load_result.invocations.clone(),
             interner.clone(),
+            snapshot.as_deref(),
         )?
     };
 
@@ -431,6 +441,7 @@ pub(crate) fn annotate_loaded<H: CompilerHost>(
             load_result.entry_module_source.clone(),
             logger,
             &load_result.included_files,
+            snapshot.as_deref(),
         )?
     };
 

--- a/wado-compiler/src/builtin_registry.rs
+++ b/wado-compiler/src/builtin_registry.rs
@@ -35,7 +35,7 @@ pub struct BuiltinFunctionInfo {
 /// Collects function signatures from core:builtin and provides:
 /// - Type lookup for `builtin::` calls
 /// - Parameter validation (future)
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct BuiltinRegistry {
     /// `function_name` -> function info
     functions: IndexMap<String, BuiltinFunctionInfo>,

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -35,6 +35,7 @@ pub mod parser;
 pub mod resolver;
 pub mod stdlib;
 pub(crate) mod stdlib_snapshot;
+pub use stdlib_snapshot::prewarm as prewarm_stdlib_snapshot;
 pub mod symbol;
 pub mod syntax;
 pub mod synthesis;

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -34,6 +34,7 @@ pub mod package;
 pub mod parser;
 pub mod resolver;
 pub mod stdlib;
+pub(crate) mod stdlib_snapshot;
 pub mod symbol;
 pub mod syntax;
 pub mod synthesis;

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -837,43 +837,13 @@ fn cached_stdlib() -> &'static IndexMap<String, Module> {
 
     static CACHE: OnceLock<IndexMap<String, Module>> = OnceLock::new();
     CACHE.get_or_init(|| {
-        let core_modules: &[(&str, &str)] = &[
-            ("allocator", stdlib::CORE_ALLOCATOR),
-            ("builtin", stdlib::CORE_BUILTIN),
-            ("cli", stdlib::CORE_CLI),
-            ("collections", stdlib::CORE_COLLECTIONS),
-            ("internal", stdlib::CORE_INTERNAL),
-            ("prelude", stdlib::CORE_PRELUDE),
-            ("prelude/array.wado", stdlib::CORE_PRELUDE_ARRAY),
-            ("prelude/format.wado", stdlib::CORE_PRELUDE_FORMAT),
-            ("prelude/fpfmt.wado", stdlib::CORE_PRELUDE_FPFMT),
-            ("prelude/int128.wado", stdlib::CORE_PRELUDE_INT128),
-            ("prelude/intparse.wado", stdlib::CORE_PRELUDE_INTPARSE),
-            ("prelude/primitive.wado", stdlib::CORE_PRELUDE_PRIMITIVE),
-            ("prelude/range.wado", stdlib::CORE_PRELUDE_RANGE),
-            ("prelude/string.wado", stdlib::CORE_PRELUDE_STRING),
-            ("prelude/traits.wado", stdlib::CORE_PRELUDE_TRAITS),
-            ("prelude/tuple.wado", stdlib::CORE_PRELUDE_TUPLE),
-            ("prelude/types.wado", stdlib::CORE_PRELUDE_TYPES),
-            ("zlib", stdlib::CORE_ZLIB),
-            ("base64", stdlib::CORE_BASE64),
-            ("serde", stdlib::CORE_SERDE),
-            ("json", stdlib::CORE_JSON),
-            ("json_nsd", stdlib::CORE_JSON_NSD),
-            ("json_value", stdlib::CORE_JSON_VALUE),
-            ("simd", stdlib::CORE_SIMD),
-        ];
-
-        let total_count = core_modules.len() + stdlib::ALL_WASI_MODULES.len();
+        let total_count = stdlib::ALL_CORE_MODULES.len() + stdlib::ALL_WASI_MODULES.len();
         let mut cache = IndexMap::with_capacity_and_hasher(total_count, FxBuildHasher);
 
-        for &(name, source) in core_modules {
-            let import_path = format!("core:{name}");
-            let module = parse_bind_desugar_stdlib(&import_path, source);
-            cache.insert(import_path, module);
-        }
-
-        for &(import_path, source) in stdlib::ALL_WASI_MODULES {
+        for &(import_path, source) in stdlib::ALL_CORE_MODULES
+            .iter()
+            .chain(stdlib::ALL_WASI_MODULES.iter())
+        {
             cache.insert(
                 import_path.to_string(),
                 parse_bind_desugar_stdlib(import_path, source),

--- a/wado-compiler/src/module_source.rs
+++ b/wado-compiler/src/module_source.rs
@@ -68,7 +68,7 @@ static ENTRY_FILENAME_UNINITIALIZED: LazyLock<Arc<str>> =
     LazyLock::new(|| Arc::<str>::from("<uninitialized>"));
 
 fn well_known_arcs() -> Vec<Arc<str>> {
-    vec![
+    let mut arcs: Vec<Arc<str>> = vec![
         PLACEHOLDER_NAME.clone(),
         CORE_PRELUDE.clone(),
         CORE_BUILTIN.clone(),
@@ -90,8 +90,55 @@ fn well_known_arcs() -> Vec<Arc<str>> {
         ENTRY_FILENAME_ENTRY.clone(),
         ENTRY_FILENAME_STDIN.clone(),
         ENTRY_FILENAME_UNINITIALIZED.clone(),
-    ]
+    ];
+    arcs.extend(STDLIB_NAME_ARCS.iter().cloned());
+    arcs
 }
+
+/// Canonical `Arc<str>` values for every stdlib module's `ModuleSource`
+/// payload (the `name` for `core:*` or `interface` for `wasi:*` variant).
+///
+/// Built once from [`crate::stdlib::ALL_WASI_MODULES`] and the fixed set
+/// of core module names; every [`ModuleSourceInterner`] adopts these so
+/// that interning a stdlib name returns the canonical arc and
+/// `ModuleSource` values for stdlib modules compare pointer-equal across
+/// independently constructed interners. This is the foundation that
+/// lets the stdlib TIR cache key its IndexMaps by `ModuleSource`.
+static STDLIB_NAME_ARCS: LazyLock<Vec<Arc<str>>> = LazyLock::new(|| {
+    let core_names: &[&str] = &[
+        // Core modules without a dedicated static above. The names listed
+        // in `well_known_arcs()` (prelude, builtin, …) are intentionally
+        // omitted; including them here would duplicate the arc.
+        "collections",
+        "prelude/fpfmt.wado",
+        "prelude/intparse.wado",
+        "prelude/range.wado",
+        "prelude/tuple.wado",
+        "zlib",
+        "base64",
+        "benchmark",
+        "json",
+        "json_nsd",
+        "json_value",
+        "simd",
+        "url",
+        "router",
+        "kiln",
+        "kiln/kiln_host.wado",
+        "kiln/types.wado",
+        "kiln/worlds.wado",
+        // Wasm asset bundled by the stdlib (referenced as `core:libm.wat`).
+        "libm.wat",
+    ];
+    let mut arcs: Vec<Arc<str>> = core_names.iter().map(|n| Arc::<str>::from(*n)).collect();
+    for (path, _src) in crate::stdlib::ALL_WASI_MODULES {
+        // ModuleSource::Wasi's InternedStr is the part after the
+        // `wasi:` prefix; that is what the interner sees.
+        let interface = path.strip_prefix("wasi:").unwrap_or(path);
+        arcs.push(Arc::<str>::from(interface));
+    }
+    arcs
+});
 
 /// Interner for `ModuleSource` payloads. Wraps a generic
 /// [`StringInterner`] and adopts every well-known

--- a/wado-compiler/src/module_source.rs
+++ b/wado-compiler/src/module_source.rs
@@ -104,7 +104,7 @@ fn well_known_arcs() -> Vec<Arc<str>> {
 /// for the stdlib module set.  Every [`ModuleSourceInterner`] adopts
 /// these, so `ModuleSource` values for stdlib modules compare
 /// pointer-equal across independently constructed interners. This is
-/// the foundation that lets the stdlib TIR cache key its IndexMaps by
+/// the foundation that lets the stdlib TIR cache key its `IndexMaps` by
 /// `ModuleSource`.
 ///
 /// For each variant, the interned payload is the portion of the

--- a/wado-compiler/src/module_source.rs
+++ b/wado-compiler/src/module_source.rs
@@ -96,46 +96,41 @@ fn well_known_arcs() -> Vec<Arc<str>> {
 }
 
 /// Canonical `Arc<str>` values for every stdlib module's `ModuleSource`
-/// payload (the `name` for `core:*` or `interface` for `wasi:*` variant).
+/// payload.
 ///
-/// Built once from [`crate::stdlib::ALL_WASI_MODULES`] and the fixed set
-/// of core module names; every [`ModuleSourceInterner`] adopts these so
-/// that interning a stdlib name returns the canonical arc and
-/// `ModuleSource` values for stdlib modules compare pointer-equal across
-/// independently constructed interners. This is the foundation that
-/// lets the stdlib TIR cache key its IndexMaps by `ModuleSource`.
+/// Derived from [`crate::stdlib::ALL_CORE_MODULES`],
+/// [`crate::stdlib::ALL_WASI_MODULES`] and
+/// [`crate::stdlib::ALL_CORE_WASM_ASSETS`] — the single source of truth
+/// for the stdlib module set.  Every [`ModuleSourceInterner`] adopts
+/// these, so `ModuleSource` values for stdlib modules compare
+/// pointer-equal across independently constructed interners. This is
+/// the foundation that lets the stdlib TIR cache key its IndexMaps by
+/// `ModuleSource`.
+///
+/// For each variant, the interned payload is the portion of the
+/// import path that lands inside the `ModuleSource` variant:
+///
+/// * [`ModuleSource::Core`] holds the path stripped of its `core:`
+///   prefix (e.g. `"prelude"`, `"prelude/types.wado"`).
+/// * [`ModuleSource::Wasi`] holds the path stripped of its `wasi:`
+///   prefix.
+/// * [`ModuleSource::Wasm`] holds the full canonical path including
+///   the `core:` prefix (matching what the loader passes to
+///   [`ModuleSourceInterner::wasm`]).
 static STDLIB_NAME_ARCS: LazyLock<Vec<Arc<str>>> = LazyLock::new(|| {
-    let core_names: &[&str] = &[
-        // Core modules without a dedicated static above. The names listed
-        // in `well_known_arcs()` (prelude, builtin, …) are intentionally
-        // omitted; including them here would duplicate the arc.
-        "collections",
-        "prelude/fpfmt.wado",
-        "prelude/intparse.wado",
-        "prelude/range.wado",
-        "prelude/tuple.wado",
-        "zlib",
-        "base64",
-        "benchmark",
-        "json",
-        "json_nsd",
-        "json_value",
-        "simd",
-        "url",
-        "router",
-        "kiln",
-        "kiln/kiln_host.wado",
-        "kiln/types.wado",
-        "kiln/worlds.wado",
-        // Wasm asset bundled by the stdlib (referenced as `core:libm.wat`).
-        "libm.wat",
-    ];
-    let mut arcs: Vec<Arc<str>> = core_names.iter().map(|n| Arc::<str>::from(*n)).collect();
+    let mut arcs: Vec<Arc<str>> = Vec::new();
+    for (path, _src) in crate::stdlib::ALL_CORE_MODULES {
+        let name = path.strip_prefix("core:").unwrap_or(path);
+        arcs.push(Arc::<str>::from(name));
+    }
     for (path, _src) in crate::stdlib::ALL_WASI_MODULES {
-        // ModuleSource::Wasi's InternedStr is the part after the
-        // `wasi:` prefix; that is what the interner sees.
         let interface = path.strip_prefix("wasi:").unwrap_or(path);
         arcs.push(Arc::<str>::from(interface));
+    }
+    for (path, _bytes) in crate::stdlib::ALL_CORE_WASM_ASSETS {
+        // The loader interns the full canonical path for `Wasm`
+        // variants (no prefix stripping); see `ModuleLoader::handle_wasm_import`.
+        arcs.push(Arc::<str>::from(*path));
     }
     arcs
 });

--- a/wado-compiler/src/resolver/orchestration.rs
+++ b/wado-compiler/src/resolver/orchestration.rs
@@ -760,40 +760,46 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         snapshot: Option<&crate::annotate::Annotated>,
     ) -> Result<IndexMap<ModuleSource, TirModule>, Bail> {
         let mut result = IndexMap::default();
-        let stdlib_set: IndexSet<ModuleSource> = snapshot
-            .map(crate::stdlib_snapshot::stdlib_sources)
-            .unwrap_or_default();
+        // Per-rehydration memo: maps each cached function `Rc`'s pointer
+        // identity to its per-compile clone, so that aliasing between
+        // `functions` and `generic_functions` within a single stdlib
+        // module is preserved.  Lives across the whole loop so aliases
+        // between distinct stdlib modules (e.g. a generic helper shared
+        // between two `core:prelude/*` modules) are preserved too.
+        let mut fn_remap: IndexMap<
+            *const RefCell<crate::tir::TirFunction>,
+            Rc<RefCell<crate::tir::TirFunction>>,
+        > = IndexMap::default();
 
-        // Insert deep-cloned cached stdlib `TirModule`s first so their
-        // entries appear before per-compile user modules in the result —
-        // matching the iteration order downstream phases relied on
-        // historically (stdlib first, user after).
-        if let Some(snap) = snapshot {
-            let mut fn_remap: IndexMap<
-                *const RefCell<crate::tir::TirFunction>,
-                Rc<RefCell<crate::tir::TirFunction>>,
-            > = IndexMap::default();
-            for (ms, snap_module) in &snap.tir_modules {
-                if stdlib_set.contains(ms) {
-                    result.insert(
-                        ms.clone(),
-                        crate::stdlib_snapshot::rehydrate_tir_module(
-                            snap_module,
-                            &state.type_table,
-                            &mut fn_remap,
-                        ),
-                    );
-                }
-            }
-        }
-
-        // Per-module resolution: build each TirModule using the shared type
-        // table and the annotate-phase decl maps. Errors are emitted to the
-        // logger; we keep going so one broken module doesn't mask others.
+        // Per-module resolution: walk modules in the per-compile
+        // topological order so a `TirModule`'s position in the result map
+        // matches the dependency order downstream phases expect.  For
+        // each module either rehydrate from the snapshot cache (stdlib)
+        // or run the full body-level resolve pass (user code).  Errors
+        // are emitted to the logger; we keep going so one broken module
+        // doesn't mask others.
         let _span = logger.span("resolve/modules");
         for module_source in &state.sorted_sources {
-            if stdlib_set.contains(module_source) {
-                // Served from the snapshot cache above.
+            // Cache hit: deep-clone the cached `TirModule` into the
+            // per-compile shared type table.  Only `Core` / `Wasi` /
+            // `Wasm` variants are eligible — `ModuleSource::EntryPoint`
+            // values compare equal regardless of filename (one entry
+            // per compile), so `snap.tir_modules.get` would otherwise
+            // match the snapshot's synthetic empty entry against the
+            // user's real entry and silently substitute it.
+            if matches!(
+                module_source,
+                ModuleSource::Core { .. } | ModuleSource::Wasi { .. } | ModuleSource::Wasm { .. }
+            ) && let Some(snap_module) = snapshot.and_then(|s| s.tir_modules.get(module_source))
+            {
+                result.insert(
+                    module_source.clone(),
+                    crate::stdlib_snapshot::rehydrate_tir_module(
+                        snap_module,
+                        &state.type_table,
+                        &mut fn_remap,
+                    ),
+                );
                 continue;
             }
             let module = modules.get(module_source).expect("module should exist");

--- a/wado-compiler/src/resolver/orchestration.rs
+++ b/wado-compiler/src/resolver/orchestration.rs
@@ -109,6 +109,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             logger,
             invocations,
             interner,
+            None,
         )?;
         let trait_env = state.trait_env.clone();
         let tir_modules = Self::lower_tir_from_state(
@@ -118,6 +119,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             entry_module_source,
             logger,
             included_files,
+            None,
         )?;
         Ok((tir_modules, trait_env))
     }
@@ -133,27 +135,51 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         logger: &'a Logger<'a, H>,
         invocations: crate::kiln::InvocationIndex,
         interner: Rc<RefCell<ModuleSourceInterner>>,
+        snapshot: Option<&crate::annotate::Annotated>,
     ) -> Result<AnnotateState, Bail> {
         let invocations = Rc::new(invocations);
-        // Create a shared type table wrapped in Rc<RefCell<>> for cross-module sharing
-        let type_table = Rc::new(RefCell::new(TypeTable::new()));
-        let mut all_newtypes: IndexMap<ModuleSource, IndexMap<String, TypeId>> =
-            IndexMap::default();
+        // Set of stdlib module sources covered by the snapshot.  When non-empty,
+        // the per-module passes below skip these — their decl info is already
+        // present in the seeded maps.
+        let stdlib_set: IndexSet<ModuleSource> = snapshot
+            .map(crate::stdlib_snapshot::stdlib_sources)
+            .unwrap_or_default();
+        // Seed the shared type table from the snapshot when available so
+        // stdlib `TypeId`s occupy the same indices as in cached `TirModule`s.
+        let type_table = Rc::new(RefCell::new(
+            snapshot.map_or_else(TypeTable::new, |s| s.types.clone()),
+        ));
+        let mut all_newtypes: IndexMap<ModuleSource, IndexMap<String, TypeId>> = snapshot
+            .map(|s| (*s.state.all_newtypes).clone())
+            .unwrap_or_default();
         let mut all_generic_newtypes: IndexMap<ModuleSource, IndexMap<String, GenericNewtypeInfo>> =
-            IndexMap::default();
+            snapshot
+                .map(|s| (*s.state.all_generic_newtypes).clone())
+                .unwrap_or_default();
         let mut all_struct_fields: IndexMap<ModuleSource, IndexMap<String, StructFieldInfo>> =
-            IndexMap::default();
-        let mut all_variant_cases: IndexMap<ModuleSource, IndexMap<String, VariantInfo>> =
-            IndexMap::default();
-        let mut all_enum_cases: IndexMap<ModuleSource, IndexMap<String, EnumInfo>> =
-            IndexMap::default();
-        let mut all_flags_cases: IndexMap<ModuleSource, IndexMap<String, FlagsInfo>> =
-            IndexMap::default();
+            snapshot
+                .map(|s| (*s.state.all_struct_fields).clone())
+                .unwrap_or_default();
+        let mut all_variant_cases: IndexMap<ModuleSource, IndexMap<String, VariantInfo>> = snapshot
+            .map(|s| (*s.state.all_variant_cases).clone())
+            .unwrap_or_default();
+        let mut all_enum_cases: IndexMap<ModuleSource, IndexMap<String, EnumInfo>> = snapshot
+            .map(|s| (*s.state.all_enum_cases).clone())
+            .unwrap_or_default();
+        let mut all_flags_cases: IndexMap<ModuleSource, IndexMap<String, FlagsInfo>> = snapshot
+            .map(|s| (*s.state.all_flags_cases).clone())
+            .unwrap_or_default();
         let mut all_resource_types: IndexMap<ModuleSource, IndexMap<String, ResourceInfo>> =
-            IndexMap::default();
+            snapshot
+                .map(|s| (*s.state.all_resource_types).clone())
+                .unwrap_or_default();
 
         // First pass: collect struct, variant, enum, and resource names from all modules (for forward references)
         for (module_source, module) in modules {
+            if stdlib_set.contains(module_source) {
+                // Already covered by the snapshot seed above.
+                continue;
+            }
             for item in &module.items {
                 match item {
                     Item::Struct(struct_decl) => {
@@ -273,6 +299,10 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         // Each module's lookup goes directly through the in-progress shared
         // tables (`all_*`) via [`TypeLookup`] — no per-module flat-map cloning.
         for (module_source, module) in modules {
+            if stdlib_set.contains(module_source) {
+                // Stdlib fields are already resolved in the seeded maps.
+                continue;
+            }
             let (imported_type_sources, import_original_names) = Self::build_imported_type_sources(
                 &mut interner.borrow_mut(),
                 module,
@@ -544,13 +574,21 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         };
         let builtin_registry = {
             let _span = logger.span("resolve/builtin_registry");
-            let mut registry = BuiltinRegistry::build_from_stdlib(&type_table);
+            let mut registry = if let Some(snap) = snapshot {
+                // The snapshot's registry is bound to the snapshot's
+                // `TypeTable`, whose entries we cloned into `type_table`
+                // above — so the registered `TypeId`s remain valid.
+                snap.state.builtin_registry.clone()
+            } else {
+                BuiltinRegistry::build_from_stdlib(&type_table)
+            };
             // Fold in `#[canonical(...)]` no-body declarations from
             // loader-synthesised wasm-asset modules so calls into a
             // wat/wasm asset's exports lower through the same TirImport
-            // path as `core:builtin` declarations.
+            // path as `core:builtin` declarations.  Stdlib wasm assets
+            // (e.g. `core:libm.wat`) are already in `snap.state.builtin_registry`.
             for (ms, module) in modules {
-                if matches!(ms, ModuleSource::Wasm { .. }) {
+                if matches!(ms, ModuleSource::Wasm { .. }) && !stdlib_set.contains(ms) {
                     registry.register_wasm_module(module, &type_table);
                 }
             }
@@ -573,7 +611,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         // is resolved. This ensures that when resolving module X, it can look up associated
         // types from module Y's impl blocks even if Y hasn't been processed yet in the main
         // second pass (e.g., user module is sorted before prelude modules).
-        Self::register_all_generic_assoc_type_defs(modules, &type_table);
+        Self::register_all_generic_assoc_type_defs(modules, &type_table, &stdlib_set);
 
         // Wrap all_* maps in Rc for cheap sharing across per-module resolvers
         let all_newtypes = Rc::new(all_newtypes);
@@ -639,13 +677,23 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             &global_known_type_names,
             &resource_type_names,
             logger,
+            &stdlib_set,
         )?;
 
         // Pre-build function name → index maps for all loaded modules (O(1) lookup)
-        let all_module_func_indices: IndexMap<ModuleSource, IndexMap<String, usize>> = modules
-            .iter()
-            .map(|(src, module)| (src.clone(), Self::build_func_index(&module.items)))
-            .collect();
+        let all_module_func_indices: IndexMap<ModuleSource, IndexMap<String, usize>> = {
+            let mut indices: IndexMap<ModuleSource, IndexMap<String, usize>> = snapshot
+                .map(|s| s.state.all_module_func_indices.clone())
+                .unwrap_or_default();
+            for (src, module) in modules {
+                if stdlib_set.contains(src) {
+                    // Pre-populated from snapshot.
+                    continue;
+                }
+                indices.insert(src.clone(), Self::build_func_index(&module.items));
+            }
+            indices
+        };
 
         // Intern every declaration in the TypeTable so `find_decl_type_by_name`
         // (used by `register_symbol_key_type_indices` below) resolves for every
@@ -658,12 +706,23 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             &all_struct_fields,
             &all_resource_types,
             &type_table,
+            &stdlib_set,
         );
 
         // Populate `TypeTable::type_by_symbol` / `symbol_by_type` so LSP queries
         // can resolve a `SymbolKey` to a decl-backed type without running the
         // lower phase.
         Self::register_symbol_key_type_indices(symbols, &type_table);
+
+        // Seed the use→def reference map and the local-symbol map with the
+        // snapshot's pre-resolved stdlib entries so the LSP edges remain
+        // consistent and user-module body resolution can extend on top.
+        let references = Rc::new(RefCell::new(
+            snapshot.map(|s| s.references.clone()).unwrap_or_default(),
+        ));
+        let local_symbols = Rc::new(RefCell::new(
+            snapshot.map(|s| s.locals.clone()).unwrap_or_default(),
+        ));
 
         Ok(AnnotateState {
             type_table,
@@ -681,8 +740,8 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             builtin_registry,
             global_known_type_names,
             all_module_func_indices,
-            references: Rc::new(RefCell::new(IndexMap::default())),
-            local_symbols: Rc::new(RefCell::new(IndexMap::default())),
+            references,
+            local_symbols,
             invocations,
             interner,
         })
@@ -698,14 +757,45 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         entry_module_source: ModuleSource,
         logger: &'a Logger<'a, H>,
         included_files: &'a IndexMap<[String; 2], Vec<u8>>,
+        snapshot: Option<&crate::annotate::Annotated>,
     ) -> Result<IndexMap<ModuleSource, TirModule>, Bail> {
         let mut result = IndexMap::default();
+        let stdlib_set: IndexSet<ModuleSource> = snapshot
+            .map(crate::stdlib_snapshot::stdlib_sources)
+            .unwrap_or_default();
+
+        // Insert deep-cloned cached stdlib `TirModule`s first so their
+        // entries appear before per-compile user modules in the result —
+        // matching the iteration order downstream phases relied on
+        // historically (stdlib first, user after).
+        if let Some(snap) = snapshot {
+            let mut fn_remap: IndexMap<
+                *const RefCell<crate::tir::TirFunction>,
+                Rc<RefCell<crate::tir::TirFunction>>,
+            > = IndexMap::default();
+            for (ms, snap_module) in &snap.tir_modules {
+                if stdlib_set.contains(ms) {
+                    result.insert(
+                        ms.clone(),
+                        crate::stdlib_snapshot::rehydrate_tir_module(
+                            snap_module,
+                            &state.type_table,
+                            &mut fn_remap,
+                        ),
+                    );
+                }
+            }
+        }
 
         // Per-module resolution: build each TirModule using the shared type
         // table and the annotate-phase decl maps. Errors are emitted to the
         // logger; we keep going so one broken module doesn't mask others.
         let _span = logger.span("resolve/modules");
         for module_source in &state.sorted_sources {
+            if stdlib_set.contains(module_source) {
+                // Served from the snapshot cache above.
+                continue;
+            }
             let module = modules.get(module_source).expect("module should exist");
 
             // Build imported type sources and module-specific flat maps for this module
@@ -894,8 +984,13 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         all_struct_fields: &IndexMap<ModuleSource, IndexMap<String, StructFieldInfo>>,
         all_resource_types: &IndexMap<ModuleSource, IndexMap<String, ResourceInfo>>,
         type_table: &Rc<RefCell<TypeTable>>,
+        stdlib_set: &IndexSet<ModuleSource>,
     ) {
         for (module_source, module) in modules {
+            if stdlib_set.contains(module_source) {
+                // Stdlib decls were interned when the snapshot was built.
+                continue;
+            }
             let mut tt = type_table.borrow_mut();
             for item in &module.items {
                 match item {
@@ -1174,8 +1269,12 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         known_type_names: &IndexSet<String>,
         resource_type_names: &IndexSet<String>,
         logger: &Logger<'_, H>,
+        stdlib_set: &IndexSet<ModuleSource>,
     ) -> Result<(), Bail> {
         for (module_source, module) in modules {
+            if stdlib_set.contains(module_source) {
+                continue;
+            }
             logger.set_file(module_source.diagnostic_filename());
 
             // Build per-module known names: global names + import aliases + trait names
@@ -2472,8 +2571,14 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
     fn register_all_generic_assoc_type_defs(
         modules: &IndexMap<ModuleSource, Module>,
         type_table: &Rc<RefCell<TypeTable>>,
+        stdlib_set: &IndexSet<ModuleSource>,
     ) {
-        for module in modules.values() {
+        for (module_source, module) in modules {
+            if stdlib_set.contains(module_source) {
+                // Stdlib generic-assoc defs are baked into the seeded
+                // `TypeTable` via the snapshot.
+                continue;
+            }
             for item in &module.items {
                 let Item::Impl(impl_block) = item else {
                     continue;

--- a/wado-compiler/src/stdlib.rs
+++ b/wado-compiler/src/stdlib.rs
@@ -111,6 +111,54 @@ pub const WASI_TLS_TYPES: &str = include_str!("../lib/wasi/tls/types.wado");
 pub const WASI_TLS_CLIENT: &str = include_str!("../lib/wasi/tls/client.wado");
 pub const WASI_TLS_WORLDS: &str = include_str!("../lib/wasi/tls/worlds.wado");
 
+/// All core stdlib statics.
+///
+/// Each entry is `(import_path, source)` where `import_path` matches
+/// what users write in `from "core:..."` expressions. This is the
+/// single source of truth for the set of core stdlib modules: the
+/// loader's `cached_stdlib`, `get_stdlib_module`, and the
+/// `ModuleSourceInterner` well-known arc set all derive from it.
+pub const ALL_CORE_MODULES: &[(&str, &str)] = &[
+    ("core:allocator", CORE_ALLOCATOR),
+    ("core:builtin", CORE_BUILTIN),
+    ("core:cli", CORE_CLI),
+    ("core:collections", CORE_COLLECTIONS),
+    ("core:internal", CORE_INTERNAL),
+    ("core:prelude", CORE_PRELUDE),
+    ("core:prelude/array.wado", CORE_PRELUDE_ARRAY),
+    ("core:prelude/format.wado", CORE_PRELUDE_FORMAT),
+    ("core:prelude/fpfmt.wado", CORE_PRELUDE_FPFMT),
+    ("core:prelude/int128.wado", CORE_PRELUDE_INT128),
+    ("core:prelude/intparse.wado", CORE_PRELUDE_INTPARSE),
+    ("core:prelude/primitive.wado", CORE_PRELUDE_PRIMITIVE),
+    ("core:prelude/range.wado", CORE_PRELUDE_RANGE),
+    ("core:prelude/string.wado", CORE_PRELUDE_STRING),
+    ("core:prelude/traits.wado", CORE_PRELUDE_TRAITS),
+    ("core:prelude/tuple.wado", CORE_PRELUDE_TUPLE),
+    ("core:prelude/types.wado", CORE_PRELUDE_TYPES),
+    ("core:zlib", CORE_ZLIB),
+    ("core:base64", CORE_BASE64),
+    ("core:benchmark", CORE_BENCHMARK),
+    ("core:serde", CORE_SERDE),
+    ("core:json", CORE_JSON),
+    ("core:json_nsd", CORE_JSON_NSD),
+    ("core:json_value", CORE_JSON_VALUE),
+    ("core:simd", CORE_SIMD),
+    ("core:url", CORE_URL),
+    ("core:router", CORE_ROUTER),
+    ("core:kiln", CORE_KILN),
+    ("core:kiln/kiln_host.wado", CORE_KILN_KILN_HOST),
+    ("core:kiln/types.wado", CORE_KILN_TYPES),
+    ("core:kiln/worlds.wado", CORE_KILN_WORLDS),
+];
+
+/// All bundled wasm assets, used for registry building.
+///
+/// Each entry is `(canonical_path, bytes)` matching the canonical
+/// `wasm:`-style path that the loader assigns to
+/// [`ModuleSource::Wasm`].
+pub const ALL_CORE_WASM_ASSETS: &[(&str, &[u8])] = &[("core:libm.wat", CORE_LIBM_WAT)];
+
 /// All WASI interface statics, used for registry building.
 ///
 /// Each entry is `(import_path, source)` where `import_path` matches
@@ -175,10 +223,10 @@ pub const ALL_WASI_MODULES: &[(&str, &str)] = &[
 /// (`./foo.wat`) are loaded through `CompilerHost::load_source` instead.
 #[must_use]
 pub fn get_stdlib_wasm_asset(import_path: &str) -> Option<&'static [u8]> {
-    match import_path {
-        "core:libm.wat" => Some(CORE_LIBM_WAT),
-        _ => None,
-    }
+    ALL_CORE_WASM_ASSETS
+        .iter()
+        .find(|(path, _)| *path == import_path)
+        .map(|(_, bytes)| *bytes)
 }
 
 /// Get embedded module source by import path.
@@ -189,46 +237,11 @@ pub fn get_stdlib_wasm_asset(import_path: &str) -> Option<&'static [u8]> {
 /// # Returns
 /// The source code of the module if found, or `None` if not a standard library module.
 pub fn get_stdlib_module(import_path: &str) -> Option<&'static str> {
-    match import_path {
-        // Core library
-        "core:prelude" => Some(CORE_PRELUDE),
-        "core:prelude/traits.wado" => Some(CORE_PRELUDE_TRAITS),
-        "core:prelude/int128.wado" => Some(CORE_PRELUDE_INT128),
-        "core:prelude/types.wado" => Some(CORE_PRELUDE_TYPES),
-        "core:prelude/primitive.wado" => Some(CORE_PRELUDE_PRIMITIVE),
-        "core:prelude/string.wado" => Some(CORE_PRELUDE_STRING),
-        "core:prelude/format.wado" => Some(CORE_PRELUDE_FORMAT),
-        "core:prelude/array.wado" => Some(CORE_PRELUDE_ARRAY),
-        "core:prelude/fpfmt.wado" => Some(CORE_PRELUDE_FPFMT),
-        "core:prelude/intparse.wado" => Some(CORE_PRELUDE_INTPARSE),
-        "core:prelude/tuple.wado" => Some(CORE_PRELUDE_TUPLE),
-        "core:prelude/range.wado" => Some(CORE_PRELUDE_RANGE),
-        "core:collections" => Some(CORE_COLLECTIONS),
-        "core:cli" => Some(CORE_CLI),
-        "core:internal" => Some(CORE_INTERNAL),
-        "core:allocator" => Some(CORE_ALLOCATOR),
-        "core:builtin" => Some(CORE_BUILTIN),
-        "core:zlib" => Some(CORE_ZLIB),
-        "core:base64" => Some(CORE_BASE64),
-        "core:benchmark" => Some(CORE_BENCHMARK),
-        "core:serde" => Some(CORE_SERDE),
-        "core:json" => Some(CORE_JSON),
-        "core:json_nsd" => Some(CORE_JSON_NSD),
-        "core:json_value" => Some(CORE_JSON_VALUE),
-        "core:simd" => Some(CORE_SIMD),
-        "core:url" => Some(CORE_URL),
-        "core:router" => Some(CORE_ROUTER),
-        "core:kiln" => Some(CORE_KILN),
-        "core:kiln/kiln_host.wado" => Some(CORE_KILN_KILN_HOST),
-        "core:kiln/types.wado" => Some(CORE_KILN_TYPES),
-        "core:kiln/worlds.wado" => Some(CORE_KILN_WORLDS),
-
-        // WASI interfaces
-        _ => ALL_WASI_MODULES
-            .iter()
-            .find(|(path, _)| *path == import_path)
-            .map(|(_, src)| *src),
-    }
+    ALL_CORE_MODULES
+        .iter()
+        .chain(ALL_WASI_MODULES.iter())
+        .find(|(path, _)| *path == import_path)
+        .map(|(_, src)| *src)
 }
 
 #[cfg(test)]

--- a/wado-compiler/src/stdlib_snapshot.rs
+++ b/wado-compiler/src/stdlib_snapshot.rs
@@ -98,6 +98,18 @@ pub(crate) fn get_or_init_snapshot() -> Option<Rc<Annotated>> {
     }))
 }
 
+/// Build the current thread's snapshot now, ahead of the first
+/// `annotate_loaded` call.  Intended for parallel batch drivers (e.g.
+/// `wado test`) to amortise the ~120 ms snapshot build across worker
+/// threads before any compile work is scheduled, instead of paying
+/// the cost on each worker's first compile.
+///
+/// No-op if the snapshot is already built on this thread, or if
+/// called re-entrantly from inside [`build_snapshot`].
+pub fn prewarm() {
+    let _ = get_or_init_snapshot();
+}
+
 /// Drive the full loader + `annotate_loaded` pipeline on an empty
 /// entry source.  The loader's implicit-modules pass pulls in
 /// `core:prelude` and its transitive closure, matching the stdlib

--- a/wado-compiler/src/stdlib_snapshot.rs
+++ b/wado-compiler/src/stdlib_snapshot.rs
@@ -89,10 +89,20 @@ pub(crate) fn get_or_init_snapshot() -> Option<Rc<Annotated>> {
     }
     Some(SNAPSHOT.with(|cell| {
         cell.get_or_init(|| {
+            // Drop guard so the flag is cleared even if `build_snapshot`
+            // panics — otherwise an upstream `catch_unwind` (test
+            // harness, fuzzer) would leave `BUILDING` stuck at `true`
+            // for the rest of the thread's lifetime, permanently
+            // disabling the cache on that thread.
+            struct ResetGuard;
+            impl Drop for ResetGuard {
+                fn drop(&mut self) {
+                    BUILDING.with(|c| c.set(false));
+                }
+            }
             BUILDING.with(|c| c.set(true));
-            let result = Rc::new(build_snapshot());
-            BUILDING.with(|c| c.set(false));
-            result
+            let _guard = ResetGuard;
+            Rc::new(build_snapshot())
         })
         .clone()
     }))

--- a/wado-compiler/src/stdlib_snapshot.rs
+++ b/wado-compiler/src/stdlib_snapshot.rs
@@ -1,0 +1,213 @@
+//! Per-thread snapshot of the stdlib closure's post-`annotate_loaded`
+//! state.
+//!
+//! Every `compile_with_options` invocation that targets non-stdlib user
+//! code re-runs the loader → analyze → annotate → lower_tir pipeline
+//! over the same stdlib AST closure (`core:prelude` and its transitive
+//! imports plus `core:libm.wat`). Measurements on
+//! `package-gale` (257 compiles, see WEP comments in
+//! `wado-cli/src/test.rs`) put the per-compile stdlib portion of
+//! `resolve/lower_tir` at ~112 ms — adding up to ~28 s of CPU duplicated
+//! across one `wado test` run.
+//!
+//! [`get_or_init_snapshot`] returns a thread-local [`Annotated`] that
+//! has been driven through the same pipeline on a synthetic empty
+//! entry source, so the loader's implicit-modules pass produces the
+//! exact same closure as a real compile. Per-compile consumers can
+//! clone the snapshot's [`TypeTable`], decl maps, [`BuiltinRegistry`],
+//! [`TraitEnv`] and pre-lowered [`TirModule`]s as the seed for their
+//! own [`AnnotateState`] / `resolve/lower_tir` work and run those
+//! passes only over the user modules that come on top.
+//!
+//! ## Why thread-local
+//!
+//! [`Annotated`] holds `Rc<RefCell<…>>` for the type table and
+//! per-function bodies, so it is `!Send + !Sync`. A process-global
+//! `OnceLock<Annotated>` would not type-check. The thread-local
+//! `OnceCell` strategy matches how `wado test` schedules compile work
+//! (one current-thread tokio runtime per blocking worker thread, with
+//! the same worker thread typically handling many sequential compiles
+//! from `buffer_unordered`), so each worker pays the snapshot build
+//! cost once and amortises it across every subsequent compile on that
+//! thread.
+//!
+//! ## Why an empty entry source
+//!
+//! Constructing the snapshot via the real `ModuleLoader::load_all`
+//! avoids reimplementing the loader's implicit-modules pass and Wasm
+//! asset synthesis (notably the `core:libm.wat` `ModuleSource::Wasm`
+//! that `core:prelude/primitive.wado` imports). The entry source is
+//! empty, so the resulting closure is exactly the stdlib subset every
+//! real compile transitively loads.
+
+use std::cell::OnceCell;
+use std::future::Future;
+use std::pin::pin;
+use std::rc::Rc;
+use std::task::{Context, Poll, Waker};
+
+use crate::annotate::{Annotated, annotate_loaded};
+use crate::compiler_host::{
+    CompilerHost, Diagnostic, GeneratorRequest, GeneratorResponse, GeneratorRunnerError, LogLevel,
+    SourceError,
+};
+use crate::loader::ModuleLoader;
+use crate::logger::Logger;
+
+thread_local! {
+    static SNAPSHOT: OnceCell<Rc<Annotated>> = const { OnceCell::new() };
+}
+
+/// Return the current thread's stdlib [`Annotated`] snapshot, building
+/// it on first call.  Subsequent calls on the same thread are O(1)
+/// (an `Rc::clone` of the cached pointer).
+///
+/// # Panics
+///
+/// Panics if the stdlib closure fails to load or annotate.  The stdlib
+/// is shipped with the compiler and must always compile cleanly; a
+/// failure here indicates a build-time inconsistency in the stdlib
+/// itself, which is a non-recoverable bug.
+#[allow(dead_code)] // Wired up by the resolver in a follow-up change.
+pub(crate) fn get_or_init_snapshot() -> Rc<Annotated> {
+    SNAPSHOT.with(|cell| cell.get_or_init(|| Rc::new(build_snapshot())).clone())
+}
+
+/// Drive the full loader + `annotate_loaded` pipeline on an empty
+/// entry source.  The loader's implicit-modules pass pulls in
+/// `core:prelude` and its transitive closure, matching the stdlib
+/// subset every real compile loads.
+fn build_snapshot() -> Annotated {
+    let host = SnapshotHost;
+    let logger = Logger::new(&host, LogLevel::Off);
+
+    // `wado-compiler` has no async runtime dependency (it must compile
+    // to `wasm32-unknown-unknown`, see crate-level `CLAUDE.md`).  The
+    // loader future is driven by hand with a no-op waker: every `await`
+    // inside it bottoms out either at a `cached_stdlib()` lookup or at
+    // `SnapshotHost::load_source` (which returns immediately), so a
+    // single poll completes the whole pipeline.  No actual suspension
+    // can occur — if `Poll::Pending` ever surfaces it means an
+    // unexpected I/O point was introduced into the loader, which is a
+    // regression worth catching loudly.
+    let load_result = poll_to_completion(async {
+        ModuleLoader::new(&host, LogLevel::Off)
+            .load_all("", Some("<stdlib-snapshot>"))
+            .await
+    })
+    .expect("stdlib snapshot loader should succeed");
+
+    annotate_loaded(load_result, &logger).expect("stdlib snapshot should annotate cleanly")
+}
+
+/// Drive a future to completion under the assumption that it never
+/// truly suspends.  Used to obtain a synchronous result from the
+/// loader/annotate pipeline without introducing an async-runtime
+/// dependency in `wado-compiler` (which would break the crate's
+/// `wasm32-unknown-unknown` build).
+///
+/// Panics on `Poll::Pending`: the snapshot's loader/host pair never
+/// awaits real I/O, so a pending result indicates a regression in the
+/// pipeline (e.g. a tokio-specific await snuck into the loader).
+fn poll_to_completion<F: Future>(fut: F) -> F::Output {
+    let mut fut = pin!(fut);
+    let waker = Waker::noop();
+    let mut cx = Context::from_waker(waker);
+    match fut.as_mut().poll(&mut cx) {
+        Poll::Ready(value) => value,
+        Poll::Pending => panic!(
+            "stdlib snapshot future yielded Pending; the snapshot pipeline must not perform real I/O"
+        ),
+    }
+}
+
+/// In-memory [`CompilerHost`] used solely for building the stdlib
+/// snapshot.  The entry source is empty and every transitively-loaded
+/// module is a stdlib module served from `cached_stdlib()`, so
+/// `load_source` is unreachable in steady state.
+struct SnapshotHost;
+
+impl CompilerHost for SnapshotHost {
+    async fn load_source(&self, path: &str) -> Result<Vec<u8>, SourceError> {
+        // The snapshot's closure is the stdlib only; the loader resolves
+        // those via `cached_stdlib()` without touching this method. A
+        // call here would mean the loader tried to pull in a non-stdlib
+        // module, which is a regression we want surfaced clearly.
+        Err(SourceError::NotFound {
+            path: path.to_string(),
+        })
+    }
+
+    fn emit_diagnostic(&self, _diagnostic: Diagnostic) {
+        // Stdlib should be diagnostic-free.  Suppress anything that
+        // does fire so a stray warning during snapshot construction
+        // does not pollute the user's build output; a fatal Bail
+        // surfaces through the `expect` in `build_snapshot` instead.
+    }
+
+    async fn run_generator(
+        &self,
+        _component_wasm: &[u8],
+        _request: GeneratorRequest,
+    ) -> Result<GeneratorResponse, GeneratorRunnerError> {
+        // Stdlib has no Kiln invocations.
+        Err(GeneratorRunnerError::Unsupported)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::module_source::ModuleSource;
+
+    #[test]
+    fn snapshot_builds_and_contains_stdlib_closure() {
+        let snap = get_or_init_snapshot();
+
+        // The implicit-modules pass always pulls in `core:prelude` and
+        // its closure.  Verify the snapshot covers them so downstream
+        // consumers can rely on the cache hitting for these names.
+        let must_have = ["core:prelude", "core:builtin", "core:internal"];
+        for name in must_have {
+            let found = snap
+                .tir_modules
+                .keys()
+                .any(|ms| ms.to_string() == name);
+            assert!(
+                found,
+                "snapshot missing stdlib module {name}: have {:?}",
+                snap.tir_modules.keys().map(ToString::to_string).collect::<Vec<_>>()
+            );
+        }
+
+        // The snapshot is constructed from an empty synthetic entry,
+        // so we expect at most one `EntryPoint` module (carrying no
+        // items); every other entry must come from a stdlib variant.
+        // Consumers in later phases filter by these variants when
+        // deciding which modules can be served from the cache.
+        let mut entry_count = 0;
+        for ms in snap.tir_modules.keys() {
+            match ms {
+                ModuleSource::Core { .. }
+                | ModuleSource::Wasi { .. }
+                | ModuleSource::Wasm { .. } => {}
+                ModuleSource::EntryPoint { .. } => entry_count += 1,
+                _ => panic!("snapshot contains non-stdlib module: {ms:?}"),
+            }
+        }
+        assert!(
+            entry_count <= 1,
+            "expected at most one EntryPoint module, got {entry_count}"
+        );
+    }
+
+    #[test]
+    fn snapshot_is_cached_per_thread() {
+        let a = get_or_init_snapshot();
+        let b = get_or_init_snapshot();
+        assert!(
+            Rc::ptr_eq(&a, &b),
+            "second call on same thread must return the cached Rc"
+        );
+    }
+}

--- a/wado-compiler/src/stdlib_snapshot.rs
+++ b/wado-compiler/src/stdlib_snapshot.rs
@@ -40,7 +40,7 @@
 //! empty, so the resulting closure is exactly the stdlib subset every
 //! real compile transitively loads.
 
-use std::cell::OnceCell;
+use std::cell::{Cell, OnceCell, RefCell};
 use std::future::Future;
 use std::pin::pin;
 use std::rc::Rc;
@@ -51,16 +51,31 @@ use crate::compiler_host::{
     CompilerHost, Diagnostic, GeneratorRequest, GeneratorResponse, GeneratorRunnerError, LogLevel,
     SourceError,
 };
+use crate::hashmap::{IndexMap, IndexSet};
 use crate::loader::ModuleLoader;
 use crate::logger::Logger;
+use crate::module_source::ModuleSource;
+use crate::tir::{TirFunction, TirModule, TypeTable};
 
 thread_local! {
     static SNAPSHOT: OnceCell<Rc<Annotated>> = const { OnceCell::new() };
+    /// Re-entry guard for [`get_or_init_snapshot`].  Set to `true`
+    /// while [`build_snapshot`] is running.  The synthetic snapshot
+    /// build calls through `annotate_loaded` (which itself looks up
+    /// the snapshot) so we must report "no snapshot yet" to the inner
+    /// invocation rather than try to enter the `OnceCell` initialiser
+    /// recursively — `OnceCell::get_or_init` panics on re-entry.
+    static BUILDING: Cell<bool> = const { Cell::new(false) };
 }
 
-/// Return the current thread's stdlib [`Annotated`] snapshot, building
-/// it on first call.  Subsequent calls on the same thread are O(1)
-/// (an `Rc::clone` of the cached pointer).
+/// Return the current thread's stdlib [`Annotated`] snapshot.
+///
+/// On first call the snapshot is built by driving the full loader +
+/// [`annotate_loaded`] pipeline over an empty entry source. Returns
+/// [`None`] if the current call is itself running underneath
+/// [`build_snapshot`] — that is the call path the snapshot builder
+/// takes through `annotate_loaded`, and trying to satisfy it from the
+/// (still-being-built) cache would re-enter the `OnceCell` initialiser.
 ///
 /// # Panics
 ///
@@ -68,9 +83,19 @@ thread_local! {
 /// is shipped with the compiler and must always compile cleanly; a
 /// failure here indicates a build-time inconsistency in the stdlib
 /// itself, which is a non-recoverable bug.
-#[allow(dead_code)] // Wired up by the resolver in a follow-up change.
-pub(crate) fn get_or_init_snapshot() -> Rc<Annotated> {
-    SNAPSHOT.with(|cell| cell.get_or_init(|| Rc::new(build_snapshot())).clone())
+pub(crate) fn get_or_init_snapshot() -> Option<Rc<Annotated>> {
+    if BUILDING.with(Cell::get) {
+        return None;
+    }
+    Some(SNAPSHOT.with(|cell| {
+        cell.get_or_init(|| {
+            BUILDING.with(|c| c.set(true));
+            let result = Rc::new(build_snapshot());
+            BUILDING.with(|c| c.set(false));
+            result
+        })
+        .clone()
+    }))
 }
 
 /// Drive the full loader + `annotate_loaded` pipeline on an empty
@@ -121,6 +146,77 @@ fn poll_to_completion<F: Future>(fut: F) -> F::Output {
     }
 }
 
+/// `ModuleSource` variants whose state is captured by a snapshot.
+///
+/// Only modules with names that are stable across compiles in the same
+/// process can be served from the cache — that is exactly the set of
+/// stdlib modules served from `cached_stdlib()` plus the `core:libm.wat`
+/// Wasm asset module. Returns the subset of `snap.tir_modules` whose
+/// keys match.
+pub(crate) fn stdlib_sources(snap: &Annotated) -> IndexSet<ModuleSource> {
+    snap.tir_modules
+        .keys()
+        .filter(|ms| {
+            matches!(
+                ms,
+                ModuleSource::Core { .. }
+                    | ModuleSource::Wasi { .. }
+                    | ModuleSource::Wasm { .. }
+            )
+        })
+        .cloned()
+        .collect()
+}
+
+/// Deep-clone a cached [`TirModule`] for use in a per-compile pipeline.
+///
+/// The snapshot holds [`TirModule`]s whose `Rc<RefCell<TirFunction>>`
+/// values are shared across all stdlib modules in the snapshot, and
+/// whose `type_table` `Rc<RefCell<TypeTable>>` points at the snapshot's
+/// frozen table.  A naïve `Clone` would only bump those `Rc` refcounts,
+/// so a per-compile optimiser pass mutating a function body would
+/// corrupt the cached snapshot.
+///
+/// This helper rebuilds the function `Rc`s into fresh allocations,
+/// memoising by the source `Rc`'s pointer identity so aliasing within
+/// the module (e.g. between `functions` and `generic_functions`) is
+/// preserved.  The `type_table` field is repointed to the per-compile
+/// shared table; `TypeIds` embedded in function bodies remain valid
+/// because the per-compile table is seeded from a clone of the
+/// snapshot's table and stdlib entries occupy the same indices.
+pub(crate) fn rehydrate_tir_module(
+    snap_module: &TirModule,
+    fresh_type_table: &Rc<RefCell<TypeTable>>,
+    fn_remap: &mut IndexMap<*const RefCell<TirFunction>, Rc<RefCell<TirFunction>>>,
+) -> TirModule {
+    let mut new_module = snap_module.clone();
+    new_module.type_table = Rc::clone(fresh_type_table);
+    new_module.functions = snap_module
+        .functions
+        .iter()
+        .map(|rc| clone_fn_rc(rc, fn_remap))
+        .collect();
+    new_module.generic_functions = snap_module
+        .generic_functions
+        .iter()
+        .map(|(k, v)| (k.clone(), clone_fn_rc(v, fn_remap)))
+        .collect();
+    new_module
+}
+
+fn clone_fn_rc(
+    rc: &Rc<RefCell<TirFunction>>,
+    remap: &mut IndexMap<*const RefCell<TirFunction>, Rc<RefCell<TirFunction>>>,
+) -> Rc<RefCell<TirFunction>> {
+    let key: *const RefCell<TirFunction> = Rc::as_ptr(rc);
+    if let Some(existing) = remap.get(&key) {
+        return existing.clone();
+    }
+    let fresh = Rc::new(RefCell::new(rc.borrow().clone()));
+    remap.insert(key, fresh.clone());
+    fresh
+}
+
 /// In-memory [`CompilerHost`] used solely for building the stdlib
 /// snapshot.  The entry source is empty and every transitively-loaded
 /// module is a stdlib module served from `cached_stdlib()`, so
@@ -162,7 +258,7 @@ mod tests {
 
     #[test]
     fn snapshot_builds_and_contains_stdlib_closure() {
-        let snap = get_or_init_snapshot();
+        let snap = get_or_init_snapshot().expect("not re-entering the builder");
 
         // The implicit-modules pass always pulls in `core:prelude` and
         // its closure.  Verify the snapshot covers them so downstream
@@ -203,8 +299,8 @@ mod tests {
 
     #[test]
     fn snapshot_is_cached_per_thread() {
-        let a = get_or_init_snapshot();
-        let b = get_or_init_snapshot();
+        let a = get_or_init_snapshot().expect("not building");
+        let b = get_or_init_snapshot().expect("not building");
         assert!(
             Rc::ptr_eq(&a, &b),
             "second call on same thread must return the cached Rc"

--- a/wado-compiler/src/stdlib_snapshot.rs
+++ b/wado-compiler/src/stdlib_snapshot.rs
@@ -2,7 +2,7 @@
 //! state.
 //!
 //! Every `compile_with_options` invocation that targets non-stdlib user
-//! code re-runs the loader → analyze → annotate → lower_tir pipeline
+//! code re-runs the loader → analyze → annotate → `lower_tir` pipeline
 //! over the same stdlib AST closure (`core:prelude` and its transitive
 //! imports plus `core:libm.wat`). Measurements on
 //! `package-gale` (257 compiles, see WEP comments in
@@ -181,9 +181,7 @@ pub(crate) fn stdlib_sources(snap: &Annotated) -> IndexSet<ModuleSource> {
         .filter(|ms| {
             matches!(
                 ms,
-                ModuleSource::Core { .. }
-                    | ModuleSource::Wasi { .. }
-                    | ModuleSource::Wasm { .. }
+                ModuleSource::Core { .. } | ModuleSource::Wasi { .. } | ModuleSource::Wasm { .. }
             )
         })
         .cloned()
@@ -287,14 +285,14 @@ mod tests {
         // consumers can rely on the cache hitting for these names.
         let must_have = ["core:prelude", "core:builtin", "core:internal"];
         for name in must_have {
-            let found = snap
-                .tir_modules
-                .keys()
-                .any(|ms| ms.to_string() == name);
+            let found = snap.tir_modules.keys().any(|ms| ms.to_string() == name);
             assert!(
                 found,
                 "snapshot missing stdlib module {name}: have {:?}",
-                snap.tir_modules.keys().map(ToString::to_string).collect::<Vec<_>>()
+                snap.tir_modules
+                    .keys()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
             );
         }
 

--- a/wado-compiler/tests/annotate.rs
+++ b/wado-compiler/tests/annotate.rs
@@ -6,6 +6,7 @@ mod common;
 
 use common::InMemoryHost;
 use wado_compiler::annotate;
+use wado_compiler::module_source::ModuleSource;
 use wado_compiler::symbol::{SymbolKey, SymbolKind};
 
 fn block_on<F: std::future::Future>(future: F) -> F::Output {
@@ -72,4 +73,143 @@ fn annotate_resolves_position_to_ast_id() {
         .lookup_in_module(&entry, "run")
         .expect("run symbol should be defined");
     assert_eq!(run_symbol.defined_at.ast_id, id);
+}
+
+/// Verify that calls into stdlib resolve via the same `referenced_symbol`
+/// edge whether or not the stdlib snapshot cache served the stdlib
+/// module.  The annotate pipeline seeds `state.references` from the
+/// snapshot's drained `references` map and the per-compile resolver
+/// walks the entry module's body to add the user-side use→def edges on
+/// top — both halves are needed for the cross-module jump-to-def to
+/// work.
+#[test]
+fn annotate_resolves_stdlib_call_to_stdlib_def() {
+    let source = r#"
+use { println, Stdout } from "core:cli";
+
+export fn run() with Stdout {
+    println("hello");
+}
+"#;
+    let host = InMemoryHost::new();
+    let annotated = block_on(annotate(source, &host, Some("entry.wado"))).unwrap();
+
+    let entry = annotated.interner.borrow_mut().entry_point("entry.wado");
+
+    // The `println` call site lives on line 5 ("    println(...)") at the
+    // start of `println`.  Column 5 is the first character of the
+    // identifier.
+    let call_id = annotated
+        .ast_id_at(&entry, 5, 5)
+        .expect("position inside `println` call should resolve to an AstId");
+    let call_key = SymbolKey::new(entry.clone(), call_id);
+
+    let def_key = annotated
+        .referenced_symbol(&call_key)
+        .expect("`println` call site must record a use→def edge to the stdlib decl");
+    // The defining symbol lives in a stdlib module — either `core:cli`
+    // (where the user imports from) or a re-exported origin.
+    assert!(
+        matches!(
+            &def_key.module,
+            ModuleSource::Core { .. } | ModuleSource::Wasi { .. }
+        ),
+        "println def should live in stdlib, got {:?}",
+        def_key.module,
+    );
+
+    let def_symbol = annotated
+        .symbol_at(&def_key)
+        .expect("stdlib def must resolve to a Symbol via `symbol_at`");
+    assert_eq!(def_symbol.name, "println");
+}
+
+/// Verify that the snapshot's locals don't leak into per-compile `Annotated::symbol_at`
+/// lookups — the seeded `local_symbols` map only contributes stdlib-internal
+/// keys, and resolving a user-defined `let` must hit the per-compile entry,
+/// not anything carried over from the snapshot's empty entry source.
+#[test]
+fn annotate_resolves_user_let_binding_independently_of_snapshot() {
+    let source = r"
+export fn run() {
+    let x = 1;
+    let _y = x;
+}
+";
+    let host = InMemoryHost::new();
+    let annotated = block_on(annotate(source, &host, Some("entry.wado"))).unwrap();
+
+    let entry = annotated.interner.borrow_mut().entry_point("entry.wado");
+
+    // `let _y = x;` is on line 4.  Column 14 lands on the identifier `x`.
+    let use_id = annotated
+        .ast_id_at(&entry, 4, 14)
+        .expect("position inside `x` use should resolve to an AstId");
+    let use_key = SymbolKey::new(entry.clone(), use_id);
+
+    let def_key = annotated
+        .referenced_symbol(&use_key)
+        .expect("`x` use site must record a use→def edge to the let binding");
+    assert_eq!(
+        def_key.module, entry,
+        "user let binding must resolve to the per-compile entry, got {:?}",
+        def_key.module,
+    );
+    let def_symbol = annotated
+        .symbol_at(&def_key)
+        .expect("user let binding must resolve via `symbol_at` (locals table)");
+    assert_eq!(def_symbol.name, "x");
+}
+
+/// Compile the same source twice on the same thread to force a snapshot
+/// cache hit on the second call, then verify the user→stdlib edge
+/// resolves to the same definition both times.  Divergence here would
+/// mean the seeded `references` map drifts when a stdlib module is
+/// served from the snapshot rather than freshly resolved.
+#[test]
+fn annotate_references_are_stable_across_cached_compiles() {
+    let source = r#"
+use { println, Stdout } from "core:cli";
+
+export fn run() with Stdout {
+    let msg = "hi";
+    println(msg);
+}
+"#;
+    let host = InMemoryHost::new();
+
+    // Resolve the same use→def edge under both a cold and a (potentially
+    // cached) compile and require they agree exactly.  We compare both
+    // the resolved `SymbolKey` and the underlying `Symbol::name`, since
+    // a stale snapshot could in principle yield a different key with
+    // the same name.
+    let resolve_println_def = |a: &wado_compiler::annotate::Annotated| -> (SymbolKey, String) {
+        let entry = a.interner.borrow_mut().entry_point("entry.wado");
+        // Line 6: `    println(msg);` — column 5 lands on `println`.
+        let call_id = a
+            .ast_id_at(&entry, 6, 5)
+            .expect("println call should resolve to an AstId");
+        let use_key = SymbolKey::new(entry, call_id);
+        let def_key = a
+            .referenced_symbol(&use_key)
+            .expect("println call must record a use→def edge");
+        let name = a
+            .symbol_at(&def_key)
+            .expect("def must resolve to a Symbol")
+            .name
+            .clone();
+        (def_key, name)
+    };
+
+    let a1 = block_on(annotate(source, &host, Some("entry.wado"))).unwrap();
+    let r1 = resolve_println_def(&a1);
+
+    let a2 = block_on(annotate(source, &host, Some("entry.wado"))).unwrap();
+    let r2 = resolve_println_def(&a2);
+
+    assert_eq!(
+        r1, r2,
+        "println use→def edge must be identical between cold and cached compiles"
+    );
+    assert_eq!(r1.1, "println");
 }

--- a/wado-compiler/tests/annotate.rs
+++ b/wado-compiler/tests/annotate.rs
@@ -102,7 +102,7 @@ export fn run() with Stdout {
     let call_id = annotated
         .ast_id_at(&entry, 5, 5)
         .expect("position inside `println` call should resolve to an AstId");
-    let call_key = SymbolKey::new(entry.clone(), call_id);
+    let call_key = SymbolKey::new(entry, call_id);
 
     let def_key = annotated
         .referenced_symbol(&call_key)


### PR DESCRIPTION
## Summary

`wado test package-gale` re-runs the `loader → analyze → annotate → lower_tir` pipeline over the same stdlib AST closure (`core:prelude` and its transitive imports plus `core:libm.wat`) on every compile.  Per-compile measurements put the stdlib portion of `resolve/lower_tir` at ~112 ms — adding up to ~28 s of duplicated CPU across one 257-file `wado test` run.

This branch caches that work in a per-thread `Annotated` snapshot and threads it through `Resolver::annotate_modules` / `Resolver::lower_tir_from_state`, so every compile after the first on a given worker thread reuses the stdlib's `TypeTable`, decl maps, `BuiltinRegistry`, `references`, `local_symbols`, and pre-lowered `TirModule`s instead of rebuilding them.

### Performance (`wado test package-gale`, release, 4 cores)

| parallelism | before  | after   | delta |
| ----------- | ------- | ------- | ----- |
| `-p 4` (default) | 80.2 s | 55.9 s | **−30%** |
| `-p 8`           | 49.2 s | 37.6 s | **−24%** |

Per-compile wall time on tiny test files (`tests/antlr4-compat/**/Declarations_*`) drops from ~400 ms to ~180 ms.

### How it works

* **`stdlib::ALL_CORE_MODULES`** is a new const that becomes the single source of truth for the core stdlib module set.  `loader::cached_stdlib`, `get_stdlib_module`, and the well-known-arc set in `module_source` all derive from it; the equivalent `ALL_CORE_WASM_ASSETS` covers `core:libm.wat`.  Every stdlib `ModuleSource` payload (the `name` / `interface` / `path` `InternedStr`) is adopted into the well-known arc pool so two independently constructed `ModuleSourceInterner`s produce pointer-equal `ModuleSource` values for any stdlib module — the foundation that lets the snapshot's `IndexMap`s key by `ModuleSource` and still hit on per-compile lookups.

* **`wado_compiler::stdlib_snapshot`** holds a `thread_local!` `OnceCell<Rc<Annotated>>` built by driving the real `ModuleLoader::load_all` + `annotate_loaded` over an empty entry source (so the implicit-modules pass produces the same closure every real compile loads).  A `Cell<bool>` re-entry guard returns `None` while the builder is itself running, since the build path goes through `annotate_loaded` and `OnceCell::get_or_init` panics on re-entry.  `wado-compiler` has no async runtime dependency (it must build for `wasm32-unknown-unknown`), so the loader future is driven by hand with `Waker::noop`; the host returns immediately for every `load_source` call, so a single poll completes the pipeline.

* **`Resolver::annotate_modules`** seeds its `TypeTable`, `all_newtypes` / `all_struct_fields` / etc., `BuiltinRegistry`, `references`, `local_symbols`, and `all_module_func_indices` from the snapshot when one is supplied, and every per-module pass (`collect names`, `resolve fields`, `register wasm modules`, `intern decl types`, `validate type definitions`, `register generic-assoc defs`) skips modules already covered by the seed.  `TraitEnv::build` still iterates every loaded module because its inserts are idempotent (~4 ms accepted); the cost/benefit of seeding it was judged not worth the surgery against its `!Clone` design contract.

* **`Resolver::lower_tir_from_state`** walks `state.sorted_sources` in dependency order and dispatches each entry to either a cache rehydration or the full `resolve_module` path.  The cache lookup is variant-gated to `Core` / `Wasi` / `Wasm` because `ModuleSource::EntryPoint` values compare equal regardless of `filename`; without the gate the snapshot's synthetic empty entry would silently substitute the user's real entry module.  `rehydrate_tir_module` deep-clones the function `Rc<RefCell<TirFunction>>` graph into fresh allocations — memoising on the source `Rc`'s pointer identity so intra-module aliasing (functions vs. generic_functions, and aliases shared between distinct stdlib modules) is preserved — and repoints `type_table` to the per-compile shared cell.

* **`wado test` prewarm** submits one `spawn_blocking` task per `--parallel` slot at the very start of `run`, each calling `prewarm_stdlib_snapshot` and then blocking on a `std::sync::Barrier`.  The barrier forces tokio's blocking pool to allocate `parallelism` distinct worker threads concurrently; those same threads are then reused for the compile tasks scheduled by `collect_test_jobs`, turning each worker's first compile from a cold cache miss into a cache hit.

### Tested

* Full `wado-compiler` suite (~7000 tests across `unittests`, `e2e`, `annotate`, `compile_errors`, `format`, `kiln_*`, `string_templates`, `tiri`, `trait_query`, `wasm_import_dce`, `wat`, `zlib_interop`) passes.
* `wado test package-gale` (257 fixtures, 1162 tests) passes with the measured speedups above.
* New `tests/annotate.rs` regressions cover the cached-snapshot LSP path: user→stdlib `referenced_symbol` edges resolve to stdlib `Symbol`s, user `let` bindings resolve to the per-compile entry (not anything leaked from the seeded `local_symbols`), and the `println` use→def edge is identical between cold and cached compiles.

https://claude.ai/code/session_01PWikR9hw3THpZWze4BqHi4

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWikR9hw3THpZWze4BqHi4)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wado-lang/wado/pull/1094" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->