### PR TITLE
feat(stdlib): add `String::new()`

### DIFF
--- a/docs/stdlib-core-prelude.md
+++ b/docs/stdlib-core-prelude.md
@@ -3003,6 +3003,10 @@ UTF-8 encoded string type with O(1) amortized push_str
 
 _Fields are private._
 
+#### `pub fn new() -> String`
+
+Create a new empty string with no allocated capacity.
+
 #### `pub fn with_capacity(capacity: i32) -> String`
 
 Create a new empty string with the specified capacity

--- a/wado-compiler/lib/core/prelude/string.wado
+++ b/wado-compiler/lib/core/prelude/string.wado
@@ -25,6 +25,11 @@ pub struct String {
 }
 
 impl String {
+    /// Create a new empty string with no allocated capacity.
+    pub fn new() -> String {
+        return String::with_capacity(0);
+    }
+
     /// Create a new empty string with the specified capacity
     /// The string starts empty but has space for `capacity` bytes
     pub fn with_capacity(capacity: i32) -> String {

--- a/wado-compiler/lib/core/prelude/string_test.wado
+++ b/wado-compiler/lib/core/prelude/string_test.wado
@@ -480,6 +480,22 @@ test "String::with_capacity starts empty" {
     assert s.is_empty();
 }
 
+test "String::new starts empty" {
+    let s = String::new();
+    assert s.len() == 0;
+    assert s.is_empty();
+    assert s.capacity() == 0;
+}
+
+test "String::new is usable as a growable buffer" {
+    let mut s = String::new();
+    s.push_str("Hello");
+    s.push(',');
+    s.push(' ');
+    s.push_str("World!");
+    assert s == "Hello, World!";
+}
+
 test "push_str updates len" {
     let mut s = String::with_capacity(10);
     assert s.len() == 0;

--- a/wado-compiler/tests/generated/fixtures/httpbin_404.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/httpbin_404.wir.wado
@@ -5331,7 +5331,7 @@ fn "core:prelude/string.wado/String::substr_bytes"(self, start, end) {
             "core:prelude/string.wado/String::push"(__local_16, 58);
             __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
             f_23 = __local_17;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(696, f_23);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(701, f_23);
             "core:prelude/string.wado/String::push"(__local_16, 58);
             "core:prelude/string.wado/String::push"(__local_16, 32);
             "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range out of bounds"), used: 24 });
@@ -5444,7 +5444,7 @@ condition: 0 <= start && start <= end && end <= self.used
             "core:prelude/string.wado/String::push"(__local_18, 58);
             __local_19 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_18 };
             f_74 = __local_19;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(697, f_74);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(702, f_74);
             "core:prelude/string.wado/String::push"(__local_18, 58);
             "core:prelude/string.wado/String::push"(__local_18, 32);
             "core:prelude/string.wado/String::push_str"(__local_18, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range not on UTF-8 character boundaries"), used: 44 });

--- a/wado-compiler/tests/generated/fixtures/httpbin_405.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/httpbin_405.wir.wado
@@ -5331,7 +5331,7 @@ fn "core:prelude/string.wado/String::substr_bytes"(self, start, end) {
             "core:prelude/string.wado/String::push"(__local_16, 58);
             __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
             f_23 = __local_17;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(696, f_23);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(701, f_23);
             "core:prelude/string.wado/String::push"(__local_16, 58);
             "core:prelude/string.wado/String::push"(__local_16, 32);
             "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range out of bounds"), used: 24 });
@@ -5444,7 +5444,7 @@ condition: 0 <= start && start <= end && end <= self.used
             "core:prelude/string.wado/String::push"(__local_18, 58);
             __local_19 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_18 };
             f_74 = __local_19;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(697, f_74);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(702, f_74);
             "core:prelude/string.wado/String::push"(__local_18, 58);
             "core:prelude/string.wado/String::push"(__local_18, 32);
             "core:prelude/string.wado/String::push_str"(__local_18, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range not on UTF-8 character boundaries"), used: 44 });

--- a/wado-compiler/tests/generated/fixtures/httpbin_anything.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/httpbin_anything.wir.wado
@@ -5331,7 +5331,7 @@ fn "core:prelude/string.wado/String::substr_bytes"(self, start, end) {
             "core:prelude/string.wado/String::push"(__local_16, 58);
             __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
             f_23 = __local_17;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(696, f_23);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(701, f_23);
             "core:prelude/string.wado/String::push"(__local_16, 58);
             "core:prelude/string.wado/String::push"(__local_16, 32);
             "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range out of bounds"), used: 24 });
@@ -5444,7 +5444,7 @@ condition: 0 <= start && start <= end && end <= self.used
             "core:prelude/string.wado/String::push"(__local_18, 58);
             __local_19 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_18 };
             f_74 = __local_19;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(697, f_74);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(702, f_74);
             "core:prelude/string.wado/String::push"(__local_18, 58);
             "core:prelude/string.wado/String::push"(__local_18, 32);
             "core:prelude/string.wado/String::push_str"(__local_18, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range not on UTF-8 character boundaries"), used: 44 });

--- a/wado-compiler/tests/generated/fixtures/httpbin_get.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/httpbin_get.wir.wado
@@ -5331,7 +5331,7 @@ fn "core:prelude/string.wado/String::substr_bytes"(self, start, end) {
             "core:prelude/string.wado/String::push"(__local_16, 58);
             __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
             f_23 = __local_17;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(696, f_23);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(701, f_23);
             "core:prelude/string.wado/String::push"(__local_16, 58);
             "core:prelude/string.wado/String::push"(__local_16, 32);
             "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range out of bounds"), used: 24 });
@@ -5444,7 +5444,7 @@ condition: 0 <= start && start <= end && end <= self.used
             "core:prelude/string.wado/String::push"(__local_18, 58);
             __local_19 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_18 };
             f_74 = __local_19;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(697, f_74);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(702, f_74);
             "core:prelude/string.wado/String::push"(__local_18, 58);
             "core:prelude/string.wado/String::push"(__local_18, 32);
             "core:prelude/string.wado/String::push_str"(__local_18, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range not on UTF-8 character boundaries"), used: 44 });

--- a/wado-compiler/tests/generated/fixtures/httpbin_headers.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/httpbin_headers.wir.wado
@@ -5331,7 +5331,7 @@ fn "core:prelude/string.wado/String::substr_bytes"(self, start, end) {
             "core:prelude/string.wado/String::push"(__local_16, 58);
             __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
             f_23 = __local_17;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(696, f_23);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(701, f_23);
             "core:prelude/string.wado/String::push"(__local_16, 58);
             "core:prelude/string.wado/String::push"(__local_16, 32);
             "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range out of bounds"), used: 24 });
@@ -5444,7 +5444,7 @@ condition: 0 <= start && start <= end && end <= self.used
             "core:prelude/string.wado/String::push"(__local_18, 58);
             __local_19 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_18 };
             f_74 = __local_19;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(697, f_74);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(702, f_74);
             "core:prelude/string.wado/String::push"(__local_18, 58);
             "core:prelude/string.wado/String::push"(__local_18, 32);
             "core:prelude/string.wado/String::push_str"(__local_18, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range not on UTF-8 character boundaries"), used: 44 });

--- a/wado-compiler/tests/generated/fixtures/httpbin_post.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/httpbin_post.wir.wado
@@ -5331,7 +5331,7 @@ fn "core:prelude/string.wado/String::substr_bytes"(self, start, end) {
             "core:prelude/string.wado/String::push"(__local_16, 58);
             __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
             f_23 = __local_17;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(696, f_23);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(701, f_23);
             "core:prelude/string.wado/String::push"(__local_16, 58);
             "core:prelude/string.wado/String::push"(__local_16, 32);
             "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range out of bounds"), used: 24 });
@@ -5444,7 +5444,7 @@ condition: 0 <= start && start <= end && end <= self.used
             "core:prelude/string.wado/String::push"(__local_18, 58);
             __local_19 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_18 };
             f_74 = __local_19;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(697, f_74);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(702, f_74);
             "core:prelude/string.wado/String::push"(__local_18, 58);
             "core:prelude/string.wado/String::push"(__local_18, 32);
             "core:prelude/string.wado/String::push_str"(__local_18, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range not on UTF-8 character boundaries"), used: 44 });

--- a/wado-compiler/tests/generated/fixtures/httpbin_status.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/httpbin_status.wir.wado
@@ -5331,7 +5331,7 @@ fn "core:prelude/string.wado/String::substr_bytes"(self, start, end) {
             "core:prelude/string.wado/String::push"(__local_16, 58);
             __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
             f_23 = __local_17;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(696, f_23);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(701, f_23);
             "core:prelude/string.wado/String::push"(__local_16, 58);
             "core:prelude/string.wado/String::push"(__local_16, 32);
             "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range out of bounds"), used: 24 });
@@ -5444,7 +5444,7 @@ condition: 0 <= start && start <= end && end <= self.used
             "core:prelude/string.wado/String::push"(__local_18, 58);
             __local_19 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_18 };
             f_74 = __local_19;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(697, f_74);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(702, f_74);
             "core:prelude/string.wado/String::push"(__local_18, 58);
             "core:prelude/string.wado/String::push"(__local_18, 32);
             "core:prelude/string.wado/String::push_str"(__local_18, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range not on UTF-8 character boundaries"), used: 44 });

--- a/wado-compiler/tests/generated/fixtures/string_insert_panic_boundary.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/string_insert_panic_boundary.wir.wado
@@ -404,7 +404,7 @@ fn "core:prelude/string.wado/String::insert"(self, byte_index, ch) {
             "core:prelude/string.wado/String::push"(__local_5, 58);
             __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_5 };
             f_10 = __local_6;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(834, f_10);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(839, f_10);
             "core:prelude/string.wado/String::push"(__local_5, 58);
             "core:prelude/string.wado/String::push"(__local_5, 32);
             "core:prelude/string.wado/String::push_str"(__local_5, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("insert index not on UTF-8 character boundary"), used: 44 });

--- a/wado-compiler/tests/generated/fixtures/string_insert_str_panic_boundary.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/string_insert_str_panic_boundary.wir.wado
@@ -387,7 +387,7 @@ fn "core:prelude/string.wado/String::insert_str"(self, byte_index, s) {
             "core:prelude/string.wado/String::push"(__local_5, 58);
             __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_5 };
             f_10 = __local_6;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(882, f_10);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(887, f_10);
             "core:prelude/string.wado/String::push"(__local_5, 58);
             "core:prelude/string.wado/String::push"(__local_5, 32);
             "core:prelude/string.wado/String::push_str"(__local_5, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("insert_str index not on UTF-8 character boundary"), used: 48 });

--- a/wado-compiler/tests/generated/fixtures/string_remove_panic_boundary.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/string_remove_panic_boundary.wir.wado
@@ -406,7 +406,7 @@ fn "core:prelude/string.wado/String::remove"(self, byte_index) {
             "core:prelude/string.wado/String::push"(__local_10, 58);
             __local_11 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_10 };
             f_17 = __local_11;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(917, f_17);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(922, f_17);
             "core:prelude/string.wado/String::push"(__local_10, 58);
             "core:prelude/string.wado/String::push"(__local_10, 32);
             "core:prelude/string.wado/String::push_str"(__local_10, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("index out of bounds"), used: 19 });
@@ -465,7 +465,7 @@ condition: byte_index >= 0 && byte_index < self.used
             "core:prelude/string.wado/String::push"(__local_12, 58);
             __local_13 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_12 };
             f_48 = __local_13;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(918, f_48);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(923, f_48);
             "core:prelude/string.wado/String::push"(__local_12, 58);
             "core:prelude/string.wado/String::push"(__local_12, 32);
             "core:prelude/string.wado/String::push_str"(__local_12, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("remove index not on UTF-8 character boundary"), used: 44 });

--- a/wado-compiler/tests/generated/fixtures/string_remove_panic_oob.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/string_remove_panic_oob.wir.wado
@@ -406,7 +406,7 @@ fn "core:prelude/string.wado/String::remove"(self, byte_index) {
             "core:prelude/string.wado/String::push"(__local_10, 58);
             __local_11 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_10 };
             f_17 = __local_11;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(917, f_17);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(922, f_17);
             "core:prelude/string.wado/String::push"(__local_10, 58);
             "core:prelude/string.wado/String::push"(__local_10, 32);
             "core:prelude/string.wado/String::push_str"(__local_10, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("index out of bounds"), used: 19 });
@@ -465,7 +465,7 @@ condition: byte_index >= 0 && byte_index < self.used
             "core:prelude/string.wado/String::push"(__local_12, 58);
             __local_13 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_12 };
             f_48 = __local_13;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(918, f_48);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(923, f_48);
             "core:prelude/string.wado/String::push"(__local_12, 58);
             "core:prelude/string.wado/String::push"(__local_12, 32);
             "core:prelude/string.wado/String::push_str"(__local_12, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("remove index not on UTF-8 character boundary"), used: 44 });

--- a/wado-compiler/tests/generated/fixtures/string_substr_bytes_panic_boundary.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/string_substr_bytes_panic_boundary.wir.wado
@@ -421,7 +421,7 @@ fn "core:prelude/string.wado/String::substr_bytes"(self, start, end) {
             "core:prelude/string.wado/String::push"(__local_16, 58);
             __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
             f_23 = __local_17;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(696, f_23);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(701, f_23);
             "core:prelude/string.wado/String::push"(__local_16, 58);
             "core:prelude/string.wado/String::push"(__local_16, 32);
             "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range out of bounds"), used: 24 });
@@ -534,7 +534,7 @@ condition: 0 <= start && start <= end && end <= self.used
             "core:prelude/string.wado/String::push"(__local_18, 58);
             __local_19 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_18 };
             f_74 = __local_19;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(697, f_74);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(702, f_74);
             "core:prelude/string.wado/String::push"(__local_18, 58);
             "core:prelude/string.wado/String::push"(__local_18, 32);
             "core:prelude/string.wado/String::push_str"(__local_18, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range not on UTF-8 character boundaries"), used: 44 });

--- a/wado-compiler/tests/generated/fixtures/string_substr_bytes_panic_oob.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/string_substr_bytes_panic_oob.wir.wado
@@ -421,7 +421,7 @@ fn "core:prelude/string.wado/String::substr_bytes"(self, start, end) {
             "core:prelude/string.wado/String::push"(__local_16, 58);
             __local_17 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_16 };
             f_23 = __local_17;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(696, f_23);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(701, f_23);
             "core:prelude/string.wado/String::push"(__local_16, 58);
             "core:prelude/string.wado/String::push"(__local_16, 32);
             "core:prelude/string.wado/String::push_str"(__local_16, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range out of bounds"), used: 24 });
@@ -534,7 +534,7 @@ condition: 0 <= start && start <= end && end <= self.used
             "core:prelude/string.wado/String::push"(__local_18, 58);
             __local_19 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_18 };
             f_74 = __local_19;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(697, f_74);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(702, f_74);
             "core:prelude/string.wado/String::push"(__local_18, 58);
             "core:prelude/string.wado/String::push"(__local_18, 32);
             "core:prelude/string.wado/String::push_str"(__local_18, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("byte range not on UTF-8 character boundaries"), used: 44 });

--- a/wado-compiler/tests/generated/fixtures/string_truncate_panic.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/string_truncate_panic.wir.wado
@@ -369,7 +369,7 @@ fn "core:prelude/string.wado/String::truncate"(self, byte_len) {
             "core:prelude/string.wado/String::push"(__local_6, 58);
             __local_7 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_6 };
             f_13 = __local_7;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(452, f_13);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(457, f_13);
             "core:prelude/string.wado/String::push"(__local_6, 58);
             "core:prelude/string.wado/String::push"(__local_6, 32);
             "core:prelude/string.wado/String::push_str"(__local_6, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("negative length"), used: 15 });
@@ -400,7 +400,7 @@ condition: byte_len >= 0
             "core:prelude/string.wado/String::push"(__local_8, 58);
             __local_9 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_8 };
             f_24 = __local_9;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(453, f_24);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(458, f_24);
             "core:prelude/string.wado/String::push"(__local_8, 58);
             "core:prelude/string.wado/String::push"(__local_8, 32);
             "core:prelude/string.wado/String::push_str"(__local_8, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("not on a UTF-8 character boundary"), used: 33 });

--- a/wado-compiler/tests/generated/format.fixtures/all.lower.wado
+++ b/wado-compiler/tests/generated/format.fixtures/all.lower.wado
@@ -10102,6 +10102,10 @@ fn byte_to_ascii_lowercase(b: u8) -> u8 {
     return (b | (((b >= 'A' as u8) && (b <= 'Z' as u8)) as u8 * ('A' as u8 ^ 'a' as u8)));
 }
 
+pub fn String::new() -> String {
+    return "core::prelude/string.wado::String::with_capacity"(0);
+}
+
 pub fn String::with_capacity(capacity: i32) -> String {
     return String { repr: "core::builtin::core/builtin/array_new<u8>"(capacity), used: 0 };
 }
@@ -10773,7 +10777,7 @@ pub fn String::truncate(self: &mut String, byte_len: i32) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 452 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 457 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("negative length");
                 __r.String::push_str("\ncondition: byte_len >= 0\n");
@@ -10797,7 +10801,7 @@ pub fn String::truncate(self: &mut String, byte_len: i32) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 453 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 458 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("not on a UTF-8 character boundary");
                 __r.String::push_str("\ncondition: self.is_char_boundary(byte_len)\n");
@@ -11079,7 +11083,7 @@ pub fn String::substr_bytes(self: &String, start: i32, end: i32) -> String {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 696 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 701 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("byte range out of bounds");
                 __r.String::push_str("\ncondition: 0 <= start && start <= end && end <= self.used\n");
@@ -11136,7 +11140,7 @@ pub fn String::substr_bytes(self: &String, start: i32, end: i32) -> String {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 697 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 702 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("byte range not on UTF-8 character boundaries");
                 __r.String::push_str("\ncondition: self.is_char_boundary(start) && self.is_char_boundary(end)\n");
@@ -11353,7 +11357,7 @@ pub fn String::insert(self: &mut String, byte_index: i32, ch: char) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 834 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 839 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("insert index not on UTF-8 character boundary");
                 __r.String::push_str("\ncondition: self.is_char_boundary(byte_index)\n");
@@ -11421,7 +11425,7 @@ pub fn String::insert_str(self: &mut String, byte_index: i32, s: String) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 882 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 887 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("insert_str index not on UTF-8 character boundary");
                 __r.String::push_str("\ncondition: self.is_char_boundary(byte_index)\n");
@@ -11477,7 +11481,7 @@ pub fn String::remove(self: &mut String, byte_index: i32) -> char {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 917 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 922 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("index out of bounds");
                 __r.String::push_str("\ncondition: byte_index >= 0 && byte_index < self.used\n");
@@ -11517,7 +11521,7 @@ pub fn String::remove(self: &mut String, byte_index: i32) -> char {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 918 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 923 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("remove index not on UTF-8 character boundary");
                 __r.String::push_str("\ncondition: self.is_char_boundary(byte_index)\n");

--- a/wado-compiler/tests/generated/format.fixtures/mess.lower.wado
+++ b/wado-compiler/tests/generated/format.fixtures/mess.lower.wado
@@ -9627,6 +9627,10 @@ fn byte_to_ascii_lowercase(b: u8) -> u8 {
     return (b | (((b >= 'A' as u8) && (b <= 'Z' as u8)) as u8 * ('A' as u8 ^ 'a' as u8)));
 }
 
+pub fn String::new() -> String {
+    return "core::prelude/string.wado::String::with_capacity"(0);
+}
+
 pub fn String::with_capacity(capacity: i32) -> String {
     return String { repr: "core::builtin::core/builtin/array_new<u8>"(capacity), used: 0 };
 }
@@ -10298,7 +10302,7 @@ pub fn String::truncate(self: &mut String, byte_len: i32) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 452 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 457 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("negative length");
                 __r.String::push_str("\ncondition: byte_len >= 0\n");
@@ -10322,7 +10326,7 @@ pub fn String::truncate(self: &mut String, byte_len: i32) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 453 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 458 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("not on a UTF-8 character boundary");
                 __r.String::push_str("\ncondition: self.is_char_boundary(byte_len)\n");
@@ -10604,7 +10608,7 @@ pub fn String::substr_bytes(self: &String, start: i32, end: i32) -> String {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 696 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 701 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("byte range out of bounds");
                 __r.String::push_str("\ncondition: 0 <= start && start <= end && end <= self.used\n");
@@ -10661,7 +10665,7 @@ pub fn String::substr_bytes(self: &String, start: i32, end: i32) -> String {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 697 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 702 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("byte range not on UTF-8 character boundaries");
                 __r.String::push_str("\ncondition: self.is_char_boundary(start) && self.is_char_boundary(end)\n");
@@ -10878,7 +10882,7 @@ pub fn String::insert(self: &mut String, byte_index: i32, ch: char) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 834 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 839 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("insert index not on UTF-8 character boundary");
                 __r.String::push_str("\ncondition: self.is_char_boundary(byte_index)\n");
@@ -10946,7 +10950,7 @@ pub fn String::insert_str(self: &mut String, byte_index: i32, s: String) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 882 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 887 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("insert_str index not on UTF-8 character boundary");
                 __r.String::push_str("\ncondition: self.is_char_boundary(byte_index)\n");
@@ -11002,7 +11006,7 @@ pub fn String::remove(self: &mut String, byte_index: i32) -> char {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 917 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 922 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("index out of bounds");
                 __r.String::push_str("\ncondition: byte_index >= 0 && byte_index < self.used\n");
@@ -11042,7 +11046,7 @@ pub fn String::remove(self: &mut String, byte_index: i32) -> char {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 918 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 923 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("remove index not on UTF-8 character boundary");
                 __r.String::push_str("\ncondition: self.is_char_boundary(byte_index)\n");

--- a/wado-compiler/tests/generated/format.fixtures/ops.all.lower.wado
+++ b/wado-compiler/tests/generated/format.fixtures/ops.all.lower.wado
@@ -9126,6 +9126,10 @@ fn byte_to_ascii_lowercase(b: u8) -> u8 {
     return (b | (((b >= 'A' as u8) && (b <= 'Z' as u8)) as u8 * ('A' as u8 ^ 'a' as u8)));
 }
 
+pub fn String::new() -> String {
+    return "core::prelude/string.wado::String::with_capacity"(0);
+}
+
 pub fn String::with_capacity(capacity: i32) -> String {
     return String { repr: "core::builtin::core/builtin/array_new<u8>"(capacity), used: 0 };
 }
@@ -9797,7 +9801,7 @@ pub fn String::truncate(self: &mut String, byte_len: i32) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 452 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 457 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("negative length");
                 __r.String::push_str("\ncondition: byte_len >= 0\n");
@@ -9821,7 +9825,7 @@ pub fn String::truncate(self: &mut String, byte_len: i32) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 453 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 458 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("not on a UTF-8 character boundary");
                 __r.String::push_str("\ncondition: self.is_char_boundary(byte_len)\n");
@@ -10103,7 +10107,7 @@ pub fn String::substr_bytes(self: &String, start: i32, end: i32) -> String {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 696 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 701 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("byte range out of bounds");
                 __r.String::push_str("\ncondition: 0 <= start && start <= end && end <= self.used\n");
@@ -10160,7 +10164,7 @@ pub fn String::substr_bytes(self: &String, start: i32, end: i32) -> String {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 697 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 702 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("byte range not on UTF-8 character boundaries");
                 __r.String::push_str("\ncondition: self.is_char_boundary(start) && self.is_char_boundary(end)\n");
@@ -10377,7 +10381,7 @@ pub fn String::insert(self: &mut String, byte_index: i32, ch: char) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 834 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 839 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("insert index not on UTF-8 character boundary");
                 __r.String::push_str("\ncondition: self.is_char_boundary(byte_index)\n");
@@ -10445,7 +10449,7 @@ pub fn String::insert_str(self: &mut String, byte_index: i32, s: String) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 882 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 887 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("insert_str index not on UTF-8 character boundary");
                 __r.String::push_str("\ncondition: self.is_char_boundary(byte_index)\n");
@@ -10501,7 +10505,7 @@ pub fn String::remove(self: &mut String, byte_index: i32) -> char {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 917 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 922 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("index out of bounds");
                 __r.String::push_str("\ncondition: byte_index >= 0 && byte_index < self.used\n");
@@ -10541,7 +10545,7 @@ pub fn String::remove(self: &mut String, byte_index: i32) -> char {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 918 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 923 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("remove index not on UTF-8 character boundary");
                 __r.String::push_str("\ncondition: self.is_char_boundary(byte_index)\n");

--- a/wado-compiler/tests/generated/format.fixtures/ops.mess.lower.wado
+++ b/wado-compiler/tests/generated/format.fixtures/ops.mess.lower.wado
@@ -9126,6 +9126,10 @@ fn byte_to_ascii_lowercase(b: u8) -> u8 {
     return (b | (((b >= 'A' as u8) && (b <= 'Z' as u8)) as u8 * ('A' as u8 ^ 'a' as u8)));
 }
 
+pub fn String::new() -> String {
+    return "core::prelude/string.wado::String::with_capacity"(0);
+}
+
 pub fn String::with_capacity(capacity: i32) -> String {
     return String { repr: "core::builtin::core/builtin/array_new<u8>"(capacity), used: 0 };
 }
@@ -9797,7 +9801,7 @@ pub fn String::truncate(self: &mut String, byte_len: i32) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 452 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 457 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("negative length");
                 __r.String::push_str("\ncondition: byte_len >= 0\n");
@@ -9821,7 +9825,7 @@ pub fn String::truncate(self: &mut String, byte_len: i32) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 453 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 458 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("not on a UTF-8 character boundary");
                 __r.String::push_str("\ncondition: self.is_char_boundary(byte_len)\n");
@@ -10103,7 +10107,7 @@ pub fn String::substr_bytes(self: &String, start: i32, end: i32) -> String {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 696 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 701 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("byte range out of bounds");
                 __r.String::push_str("\ncondition: 0 <= start && start <= end && end <= self.used\n");
@@ -10160,7 +10164,7 @@ pub fn String::substr_bytes(self: &String, start: i32, end: i32) -> String {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 697 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 702 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("byte range not on UTF-8 character boundaries");
                 __r.String::push_str("\ncondition: self.is_char_boundary(start) && self.is_char_boundary(end)\n");
@@ -10377,7 +10381,7 @@ pub fn String::insert(self: &mut String, byte_index: i32, ch: char) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 834 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 839 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("insert index not on UTF-8 character boundary");
                 __r.String::push_str("\ncondition: self.is_char_boundary(byte_index)\n");
@@ -10445,7 +10449,7 @@ pub fn String::insert_str(self: &mut String, byte_index: i32, s: String) {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 882 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 887 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("insert_str index not on UTF-8 character boundary");
                 __r.String::push_str("\ncondition: self.is_char_boundary(byte_index)\n");
@@ -10501,7 +10505,7 @@ pub fn String::remove(self: &mut String, byte_index: i32) -> char {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 917 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 922 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("index out of bounds");
                 __r.String::push_str("\ncondition: byte_index >= 0 && byte_index < self.used\n");
@@ -10541,7 +10545,7 @@ pub fn String::remove(self: &mut String, byte_index: i32) -> char {
                 __r.String::push_str("core:prelude/string.wado");
                 __r.String::push_str(":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 918 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 923 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(": ");
                 __r.String::push_str("remove index not on UTF-8 character boundary");
                 __r.String::push_str("\ncondition: self.is_char_boundary(byte_index)\n");


### PR DESCRIPTION
## Summary

Adds `String::new()` to the core prelude as a thin wrapper around `String::with_capacity(0)`, mirroring Rust's `String::new`. Users coming from Rust naturally reach for it when they need an empty growable string.

Closes #1103.

## Changes

- `wado-compiler/lib/core/prelude/string.wado`: define `pub fn new() -> String` on `impl String`.
- `wado-compiler/lib/core/prelude/string_test.wado`: add tests covering the empty state (`len`, `is_empty`, `capacity`) and use as a growable buffer.
- `docs/stdlib-core-prelude.md`: regenerated via `mise run doc-stdlib`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NYSjexEEUpHuC4637j2Rmp)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wado-lang/wado/pull/1107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->