### PR TITLE
fix(tagpr): sync Cargo.lock via postVersionCommand to fix --locked CI

### DIFF
--- a/.tagpr
+++ b/.tagpr
@@ -9,28 +9,28 @@
 #
 # Default bump is patch. Override per-PR with labels:
 #   tagpr:patch | tagpr:minor | tagpr:major
+#
+# File format is git-config; entries outside the [tagpr] section are
+# silently ignored by `git config --get tagpr.<key>`.
 
-# tagpr has no native Cargo.toml handler but its generic version-file
-# regex is line-anchored, matching `version = "..."` only at the start
-# of a line. Our root Cargo.toml has exactly one such line — the
-# [workspace.package].version — because every member crate inherits its
-# version from the workspace via `version = { workspace = true }`. The
-# `version = "..."` entries inside [workspace.dependencies] inline tables
-# are not at the start of a line, so the bump is unambiguous.
-versionFile = Cargo.toml
-
-# After tagpr writes the new version, sync Cargo.lock so the release PR
-# is in a buildable state. Must be `postVersionCommand`, not `command`:
-# `command` runs *before* the version bump, when Cargo.toml/Cargo.lock
-# still match, so `cargo update` would be a no-op and Cargo.lock would
-# stay stale — breaking `cargo --locked` in CI.
-# We don't pass --offline: tagpr.yml runs on a fresh GitHub-hosted runner
-# without a warmed Cargo registry index, and --offline would fail there.
-postVersionCommand = cargo update --workspace
-
-# Default bump kind when no `tagpr:major`/`tagpr:minor` label is present.
-release = patch
 [tagpr]
 	vPrefix = true
 	releaseBranch = main
+
+	# tagpr has no native Cargo.toml handler but its generic version-file
+	# regex is line-anchored, matching `version = "..."` only at the start
+	# of a line. Our root Cargo.toml has exactly one such line — the
+	# [workspace.package].version — because every member crate inherits its
+	# version from the workspace via `version = { workspace = true }`. The
+	# `version = "..."` entries inside [workspace.dependencies] inline tables
+	# are not at the start of a line, so the bump is unambiguous.
 	versionFile = Cargo.toml
+
+	# After tagpr writes the new version, sync Cargo.lock so the release PR
+	# is in a buildable state. Must be `postVersionCommand`, not `command`:
+	# `command` runs *before* the version bump, when Cargo.toml/Cargo.lock
+	# still match, so `cargo update` would be a no-op and Cargo.lock would
+	# stay stale — breaking `cargo --locked` in CI.
+	# We don't pass --offline: tagpr.yml runs on a fresh GitHub-hosted runner
+	# without a warmed Cargo registry index, and --offline would fail there.
+	postVersionCommand = cargo update --workspace

--- a/.tagpr
+++ b/.tagpr
@@ -20,10 +20,13 @@
 versionFile = Cargo.toml
 
 # After tagpr writes the new version, sync Cargo.lock so the release PR
-# is in a buildable state. We don't pass --offline: tagpr.yml runs on a
-# fresh GitHub-hosted runner without a warmed Cargo registry index, and
-# --offline would fail there.
-command = cargo update --workspace
+# is in a buildable state. Must be `postVersionCommand`, not `command`:
+# `command` runs *before* the version bump, when Cargo.toml/Cargo.lock
+# still match, so `cargo update` would be a no-op and Cargo.lock would
+# stay stale — breaking `cargo --locked` in CI.
+# We don't pass --offline: tagpr.yml runs on a fresh GitHub-hosted runner
+# without a warmed Cargo registry index, and --offline would fail there.
+postVersionCommand = cargo update --workspace
 
 # Default bump kind when no `tagpr:major`/`tagpr:minor` label is present.
 release = patch


### PR DESCRIPTION
## Summary

`tagpr` left `Cargo.lock` stale after every workspace version bump, breaking `cargo --locked` on the release PR until an unrelated `chore: tidy` job happened to regenerate the lockfile.

## Root cause

`tagpr.go:490` runs `tagpr.command` **before** `bumpVersionFile`. With `command = cargo update --workspace`, the update ran while `Cargo.toml` and `Cargo.lock` still matched the previous version — a no-op. tagpr then bumped `[workspace.package].version` in `Cargo.toml` in the same `[tagpr] prepare for the next release` commit without touching `Cargo.lock`, leaving the workspace member entries (`wado-cli`, `wado-compiler`, `wado-manifest`, `wado-lsp`, `wado-bundled-libm`, `wado-from-idl`, `wado-dev-tools`) at the old version.

`cargo --locked` correctly rejected the resulting tree with `cannot update the lock file because --locked was passed`, failing every CI job that uses `--locked` (Test Core, all E2E O*, Check wasm32).

Observed in [run 26004338554](https://github.com/wado-lang/wado/actions/runs/26004338554) on `tagpr-from-v0.0.2` (PR #1046).

## Fix

Switch the directive to `postVersionCommand`, which `tagpr.go:503` runs **after** `bumpVersionFile`. `cargo update --workspace` then produces the matching 7-entry `Cargo.lock` delta, which tagpr's `git diff --raw HEAD` (`tagpr.go:524`) picks up into the same release-prep commit.

`--workspace` is the correct scope — it only re-syncs workspace member entries, leaving transitive dependencies untouched (verified locally: simulating the version bump produced exactly 7 updates, and `generic-array v0.14.7` remained `Unchanged` despite a newer `v0.14.9` being available).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmavCLvS6C2g2pmSec9SYe)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wado-lang/wado/pull/1112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->