### PR TITLE
Route remaining hard-coded stdlib refs through `CompilerItem` (issue #1091)

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4444,9 +4444,13 @@ fn stream_new() -> i64;
 fn realloc(oldptr: i32, oldsize: i32, align: i32, newsize: i32) -> i32;
 ```
 
-#### `#[comp_feature("name")]`
+#### `#[compiler_item("name")]`
 
-Marks a function as providing a compiler feature. The compiler uses these flags to enable optimizations and synthesis passes (e.g., `array_append`, `string_append`, `option`, `result`, `default`). Used in `core:prelude` method implementations.
+Marks a stdlib declaration as the resolution for a compiler-recognized item. The compiler uses these annotations to bind specific stdlib symbols (types, traits, methods, variant/enum cases) to the Rust-side enum `CompilerItem` so downstream passes (synthesis, lowering, codegen) can look them up by key instead of by hard-coded name. Renaming a stdlib item on the Wado side stays transparent as long as the `#[compiler_item("...")]` argument is unchanged.
+
+Examples: `#[compiler_item("option")]` on `variant Option`, `#[compiler_item("option_some")]` on the `Some` case, `#[compiler_item("display")]` on the `Display` trait, `#[compiler_item("string_push_str")]` on the `String::push_str` method.
+
+The attribute is only valid inside `core::*` modules; the resolver rejects it on user code.
 
 #### `#[cm("namespace:pkg/interface@version")]` / `#[cm_params(...)]`
 

--- a/wado-compiler/lib/core/prelude/format.wado
+++ b/wado-compiler/lib/core/prelude/format.wado
@@ -10,12 +10,16 @@
 
 use { Display, DisplayAlt, Inspect, InspectAlt } from "core:prelude/traits.wado";
 /// Text alignment for padding.
+#[compiler_item("alignment")]
 pub enum Alignment {
     /// Left-aligned: `{x:<5}` -> "42   "
+    #[compiler_item("alignment_left")]
     Left,
     /// Center-aligned: `{x:^5}` -> " 42  "
+    #[compiler_item("alignment_center")]
     Center,
     /// Right-aligned (default for numbers): `{x:>5}` -> "   42"
+    #[compiler_item("alignment_right")]
     Right,
 }
 /// Formatter that writes directly into a referenced output buffer.
@@ -26,6 +30,7 @@ pub enum Alignment {
 /// `[[fill]align][sign][#][0][width][.precision]type`
 ///
 /// Width and precision use -1 as sentinel for "not specified".
+#[compiler_item("formatter")]
 pub struct Formatter {
     /// Fill character for padding (default: ' ')
     pub fill: char,

--- a/wado-compiler/lib/core/prelude/traits.wado
+++ b/wado-compiler/lib/core/prelude/traits.wado
@@ -7,10 +7,13 @@
 #[compiler_item("ordering")]
 pub enum Ordering {
     /// The first value is less than the second.
+    #[compiler_item("ordering_less")]
     Less,
     /// The two values are equal.
+    #[compiler_item("ordering_equal")]
     Equal,
     /// The first value is greater than the second.
+    #[compiler_item("ordering_greater")]
     Greater,
 }
 
@@ -192,6 +195,7 @@ pub trait Shr {
 /// Trait for user-facing display formatting.
 /// Types implementing this trait can be formatted with `{x}` in template strings.
 /// All format traits write to a `Formatter` that wraps `&mut String`.
+#[compiler_item("display")]
 pub trait Display {
     /// Formats the value and writes to the given formatter.
     fn fmt(&self, f: &mut Formatter);
@@ -204,6 +208,7 @@ pub trait Display {
 /// - Chars are quoted: `'A'`
 /// - Structs show field names: `Point { x: 10, y: 20 }`
 /// - Enums/Variants show type-qualified names: `Color::Red`
+#[compiler_item("inspect")]
 pub trait Inspect {
     /// Formats the value as a debug representation and writes to the given formatter.
     fn inspect(&self, f: &mut Formatter);
@@ -211,6 +216,7 @@ pub trait Inspect {
 
 /// Trait for formatting values as binary integers.
 /// Used with the `{x:b}` format specifier.
+#[compiler_item("binary")]
 pub trait Binary {
     /// Formats the value as binary and writes to the given formatter.
     fn fmt(&self, f: &mut Formatter);
@@ -218,6 +224,7 @@ pub trait Binary {
 
 /// Trait for formatting values as octal integers.
 /// Used with the `{x:o}` format specifier.
+#[compiler_item("octal")]
 pub trait Octal {
     /// Formats the value as octal and writes to the given formatter.
     fn fmt(&self, f: &mut Formatter);
@@ -225,6 +232,7 @@ pub trait Octal {
 
 /// Trait for formatting values as lowercase hexadecimal.
 /// Used with the `{x:x}` format specifier.
+#[compiler_item("lower_hex")]
 pub trait LowerHex {
     /// Formats the value as lowercase hex and writes to the given formatter.
     fn fmt(&self, f: &mut Formatter);
@@ -232,6 +240,7 @@ pub trait LowerHex {
 
 /// Trait for formatting values as uppercase hexadecimal.
 /// Used with the `{x:X}` format specifier.
+#[compiler_item("upper_hex")]
 pub trait UpperHex {
     /// Formats the value as uppercase hex and writes to the given formatter.
     fn fmt(&self, f: &mut Formatter);
@@ -239,6 +248,7 @@ pub trait UpperHex {
 
 /// Trait for formatting values in lowercase exponential notation.
 /// Used with the `{x:e}` format specifier.
+#[compiler_item("lower_exp")]
 pub trait LowerExp {
     /// Formats the value in lowercase exponential notation and writes to the given formatter.
     fn fmt(&self, f: &mut Formatter);
@@ -246,6 +256,7 @@ pub trait LowerExp {
 
 /// Trait for formatting values in uppercase exponential notation.
 /// Used with the `{x:E}` format specifier.
+#[compiler_item("upper_exp")]
 pub trait UpperExp {
     /// Formats the value in uppercase exponential notation and writes to the given formatter.
     fn fmt(&self, f: &mut Formatter);
@@ -255,6 +266,7 @@ pub trait UpperExp {
 /// Used with the `{x:#?}` format specifier.
 /// Produces multi-line indented output for composite types.
 /// Primitive types delegate to `Inspect::inspect`.
+#[compiler_item("inspect_alt")]
 pub trait InspectAlt {
     fn inspect_alt(&self, f: &mut Formatter);
 }
@@ -262,30 +274,35 @@ pub trait InspectAlt {
 /// Trait for alternate display formatting.
 /// Used with the `{x:#}` format specifier.
 /// If not explicitly implemented, auto-generated to delegate to `InspectAlt::inspect_alt`.
+#[compiler_item("display_alt")]
 pub trait DisplayAlt {
     fn fmt_alt(&self, f: &mut Formatter);
 }
 
 /// Trait for alternate binary formatting (with `0b` prefix).
 /// Used with the `{x:#b}` format specifier.
+#[compiler_item("binary_alt")]
 pub trait BinaryAlt {
     fn fmt_alt(&self, f: &mut Formatter);
 }
 
 /// Trait for alternate octal formatting (with `0o` prefix).
 /// Used with the `{x:#o}` format specifier.
+#[compiler_item("octal_alt")]
 pub trait OctalAlt {
     fn fmt_alt(&self, f: &mut Formatter);
 }
 
 /// Trait for alternate lowercase hex formatting (with `0x` prefix).
 /// Used with the `{x:#x}` format specifier.
+#[compiler_item("lower_hex_alt")]
 pub trait LowerHexAlt {
     fn fmt_alt(&self, f: &mut Formatter);
 }
 
 /// Trait for alternate uppercase hex formatting (with `0X` prefix).
 /// Used with the `{x:#X}` format specifier.
+#[compiler_item("upper_hex_alt")]
 pub trait UpperHexAlt {
     fn fmt_alt(&self, f: &mut Formatter);
 }

--- a/wado-compiler/lib/core/prelude/types.wado
+++ b/wado-compiler/lib/core/prelude/types.wado
@@ -17,14 +17,18 @@ pub struct Box<T> {
 /// Optional value - either Some(T) or None
 #[compiler_item("option")]
 pub variant Option<T> {
+    #[compiler_item("option_some")]
     Some(T),
+    #[compiler_item("option_none")]
     None,
 }
 
 /// Result type - either Ok(T) or Err(E)
 #[compiler_item("result")]
 pub variant Result<T, E> {
+    #[compiler_item("result_ok")]
     Ok(T),
+    #[compiler_item("result_err")]
     Err(E),
 }
 impl<T: Eq> Eq for Option<T> {

--- a/wado-compiler/lib/core/serde.wado
+++ b/wado-compiler/lib/core/serde.wado
@@ -66,21 +66,28 @@
 #![stdlib("core:serde")]
 
 
+#[compiler_item("serialize_error_kind")]
 pub enum SerializeErrorKind {
     UnsupportedValue,
+    #[compiler_item("serialize_error_kind_custom")]
     Custom,
 }
 
+#[compiler_item("serialize_error")]
 pub struct SerializeError {
     pub kind: SerializeErrorKind,
     pub message: String,
 }
 
+#[compiler_item("deserialize_error_kind")]
 pub enum DeserializeErrorKind {
     UnexpectedType,
+    #[compiler_item("deserialize_error_kind_missing_field")]
     MissingField,
+    #[compiler_item("deserialize_error_kind_unknown_variant")]
     UnknownVariant,
     DuplicateField,
+    #[compiler_item("deserialize_error_kind_invalid_value")]
     InvalidValue,
     Overflow,
     MalformedInput,
@@ -89,6 +96,7 @@ pub enum DeserializeErrorKind {
     Custom,
 }
 
+#[compiler_item("deserialize_error")]
 pub struct DeserializeError {
     pub kind: DeserializeErrorKind,
     pub message: String,
@@ -129,6 +137,7 @@ impl DeserializeError {
     }
 }
 
+#[compiler_item("serialize_seq")]
 pub trait SerializeSeq {
     fn element<T: Serialize>(&mut self, value: &T) -> Result<(), SerializeError>;
     fn end(&mut self) -> Result<(), SerializeError>;
@@ -140,17 +149,20 @@ pub trait SerializeMap {
     fn end(&mut self) -> Result<(), SerializeError>;
 }
 
+#[compiler_item("serialize_struct")]
 pub trait SerializeStruct {
     fn field<T: Serialize>(&mut self, name: &String, value: &T) -> Result<(), SerializeError>;
     fn end(&mut self) -> Result<(), SerializeError>;
 }
 
+#[compiler_item("serialize_variant")]
 pub trait SerializeVariant {
     fn payload<T: Serialize>(&mut self, value: &T) -> Result<(), SerializeError>;
     fn end(&mut self) -> Result<(), SerializeError>;
 }
 
 
+#[compiler_item("serializer")]
 pub trait Serializer {
     type SeqSerializer: SerializeSeq;
     type MapSerializer: SerializeMap;
@@ -183,6 +195,7 @@ pub trait Serialize {
 }
 
 
+#[compiler_item("deserialize_seq")]
 pub trait DeserializeSeq {
     fn next_element<T: Deserialize>(&mut self) -> Result<Option<T>, DeserializeError>;
     fn end(&mut self) -> Result<(), DeserializeError>;
@@ -194,6 +207,7 @@ pub trait DeserializeMap {
     fn end(&mut self) -> Result<(), DeserializeError>;
 }
 
+#[compiler_item("deserialize_struct")]
 pub trait DeserializeStruct {
     fn next_field(&mut self) -> Result<Option<i32>, DeserializeError>;
     fn value<T: Deserialize>(&mut self) -> Result<T, DeserializeError>;
@@ -201,6 +215,7 @@ pub trait DeserializeStruct {
     fn end(&mut self) -> Result<(), DeserializeError>;
 }
 
+#[compiler_item("deserialize_variant")]
 pub trait DeserializeVariant {
     fn variant_name(&mut self) -> Result<String, DeserializeError>;
     fn disc(&mut self) -> Result<i32, DeserializeError>;
@@ -221,6 +236,7 @@ pub trait Visitor {
     fn visit_map<A: DeserializeMap>(&mut self, map: &mut A) -> Result<Self::Value, DeserializeError>;
 }
 
+#[compiler_item("deserializer")]
 pub trait Deserializer {
     type SeqAccess: DeserializeSeq;
     type MapAccess: DeserializeMap;

--- a/wado-compiler/src/compiler_item.rs
+++ b/wado-compiler/src/compiler_item.rs
@@ -572,10 +572,9 @@ impl CompilerItem {
             | Self::U128FromU64
             | Self::U128FromPair => CompilerItemKind::Method,
             Self::Tuple => CompilerItemKind::TupleFamily,
-            Self::OptionSome
-            | Self::OptionNone
-            | Self::ResultOk
-            | Self::ResultErr => CompilerItemKind::VariantCase,
+            Self::OptionSome | Self::OptionNone | Self::ResultOk | Self::ResultErr => {
+                CompilerItemKind::VariantCase
+            }
             Self::OrderingLess
             | Self::OrderingEqual
             | Self::OrderingGreater
@@ -962,17 +961,19 @@ impl CompilerItems {
 
     /// Module + parent-type name + case name + case index of a
     /// [`CompilerItemKind::VariantCase`] item.
-    pub fn require_variant_case(
-        &self,
-        item: CompilerItem,
-    ) -> (&ModuleSource, &str, &str, u32) {
+    pub fn require_variant_case(&self, item: CompilerItem) -> (&ModuleSource, &str, &str, u32) {
         match self.require(item) {
             Resolved::VariantCase {
                 module_source,
                 parent_type,
                 name,
                 case_index,
-            } => (module_source, parent_type.as_str(), name.as_str(), *case_index),
+            } => (
+                module_source,
+                parent_type.as_str(),
+                name.as_str(),
+                *case_index,
+            ),
             other => kind_mismatch_ice(item, "VariantCase", other),
         }
     }
@@ -986,7 +987,12 @@ impl CompilerItems {
                 parent_type,
                 name,
                 case_index,
-            } => (module_source, parent_type.as_str(), name.as_str(), *case_index),
+            } => (
+                module_source,
+                parent_type.as_str(),
+                name.as_str(),
+                *case_index,
+            ),
             other => kind_mismatch_ice(item, "EnumCase", other),
         }
     }

--- a/wado-compiler/src/compiler_item.rs
+++ b/wado-compiler/src/compiler_item.rs
@@ -678,6 +678,17 @@ pub enum Resolved {
         ///
         /// Reading: [`CompilerItems::trait_method_name`].
         method_name: Option<String>,
+        /// Associated type names declared on the trait, in source
+        /// order. Auto-captured by the resolver when registering the
+        /// trait's `#[compiler_item("...")]` annotation. Empty for
+        /// traits without associated types.
+        ///
+        /// The serde synthesiser uses these to construct `S::SeqSerializer`
+        /// / `D::StructAccess` projections without hard-coding the
+        /// source-side associated type spellings.
+        ///
+        /// Reading: [`CompilerItems::trait_assoc_type_names`].
+        assoc_type_names: Vec<String>,
     },
     Method {
         module_source: ModuleSource,
@@ -942,6 +953,40 @@ impl CompilerItems {
         }
     }
 
+    /// Associated type names declared on a trait, in source order.
+    /// Auto-captured when the trait's `#[compiler_item("...")]` is
+    /// registered, so the synthesiser can build `S::SeqSerializer`-style
+    /// projections without hard-coding the source-side associated type
+    /// spellings.
+    pub fn trait_assoc_type_names(&self, item: CompilerItem) -> &[String] {
+        match self.require(item) {
+            Resolved::Trait {
+                assoc_type_names, ..
+            } => assoc_type_names.as_slice(),
+            other => kind_mismatch_ice(item, "Trait", other),
+        }
+    }
+
+    /// Single associated type name on a trait, looked up by source-side
+    /// name. Panics if the trait has no such associated type — callers
+    /// must spell the name exactly as it appears in the trait
+    /// declaration. The accessor exists purely as a guard against
+    /// silently typoing the lookup name; the registry edge that catches
+    /// stdlib renames is [`Self::trait_assoc_type_names`].
+    pub fn trait_assoc_type_name(&self, item: CompilerItem, source_name: &str) -> &str {
+        self.trait_assoc_type_names(item)
+            .iter()
+            .find(|n| n.as_str() == source_name)
+            .unwrap_or_else(|| {
+                panic!(
+                    "compiler item `{item}` has no associated type named `{source_name}`; \
+                     declared associated types: {:?}",
+                    self.trait_assoc_type_names(item)
+                )
+            })
+            .as_str()
+    }
+
     /// Name-only convenience for a [`CompilerItemKind::Struct`] item.
     pub fn struct_name(&self, item: CompilerItem) -> &str {
         self.require_struct(item).1
@@ -1200,6 +1245,7 @@ mod tests {
                     module_source: ModuleSource::types(),
                     name: "Option".into(),
                     method_name: None,
+                    assoc_type_names: Vec::new(),
                 },
             )
             .unwrap_err();
@@ -1243,6 +1289,7 @@ mod tests {
                 module_source: ModuleSource::traits(),
                 name: "Default".into(),
                 method_name: Some("default".into()),
+                assoc_type_names: Vec::new(),
             },
         )
         .unwrap();
@@ -1286,6 +1333,43 @@ mod tests {
         assert_eq!(module, &ModuleSource::string());
         assert_eq!(owner, "String");
         assert_eq!(name, "push_str_v2");
+    }
+
+    /// Trait associated type names round-trip through the registry —
+    /// if the stdlib renamed `Serializer::SeqSerializer` to
+    /// `Serializer::SeqWriter`, the resolver would auto-capture the
+    /// new name and the synthesiser would pick it up via
+    /// [`CompilerItems::trait_assoc_type_name`] without touching any
+    /// hard-coded string in synthesis code.
+    #[test]
+    fn assoc_type_names_round_trip_through_registry_even_when_renamed() {
+        let mut reg = CompilerItems::new();
+        reg.register(
+            CompilerItem::Serializer,
+            Resolved::Trait {
+                module_source: ModuleSource::serde(),
+                name: "Serializer".to_string(),
+                method_name: None,
+                assoc_type_names: vec![
+                    "SeqWriter".to_string(),
+                    "StructWriter".to_string(),
+                    "VariantWriter".to_string(),
+                ],
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            reg.trait_assoc_type_names(CompilerItem::Serializer),
+            &[
+                "SeqWriter".to_string(),
+                "StructWriter".to_string(),
+                "VariantWriter".to_string()
+            ]
+        );
+        assert_eq!(
+            reg.trait_assoc_type_name(CompilerItem::Serializer, "StructWriter"),
+            "StructWriter"
+        );
     }
 
     /// Counterpart to the rename-rewrite test: omitting the

--- a/wado-compiler/src/compiler_item.rs
+++ b/wado-compiler/src/compiler_item.rs
@@ -663,6 +663,21 @@ pub enum Resolved {
     Trait {
         module_source: ModuleSource,
         name: String,
+        /// Primary method name for **single-method** traits, captured
+        /// automatically by the resolver when registering the trait's
+        /// `#[compiler_item("...")]` annotation. `None` for
+        /// multi-method traits (`Serializer`, `Deserializer`, …).
+        ///
+        /// The format-family traits (`Display` / `DisplayAlt` /
+        /// `Inspect` / `InspectAlt` / `Binary` / `BinaryAlt` / `Octal`
+        /// / `OctalAlt` / `LowerHex` / `LowerHexAlt` / `UpperHex` /
+        /// `UpperHexAlt` / `LowerExp` / `UpperExp`) all have exactly
+        /// one method by design, so the synthesiser can look up the
+        /// method name from the trait registration alone instead of
+        /// hard-coding `"fmt"` / `"inspect"` at every call site.
+        ///
+        /// Reading: [`CompilerItems::trait_method_name`].
+        method_name: Option<String>,
     },
     Method {
         module_source: ModuleSource,
@@ -888,6 +903,7 @@ impl CompilerItems {
             Resolved::Trait {
                 module_source,
                 name,
+                ..
             } => (module_source, name.as_str()),
             other => kind_mismatch_ice(item, "Trait", other),
         }
@@ -899,6 +915,31 @@ impl CompilerItems {
     /// (e.g. when constructing a synthesised `LocalMethodName`).
     pub fn trait_name(&self, item: CompilerItem) -> &str {
         self.require_trait(item).1
+    }
+
+    /// Resolved method name of a **single-method** trait — `"fmt"` for
+    /// `Display`, `"inspect"` for `Inspect`, and so on across the
+    /// format-family traits. Panics for multi-method traits where
+    /// `method_name` was not captured during registration; callers
+    /// that need such method names must reach for a dedicated method
+    /// `CompilerItem` instead.
+    ///
+    /// Routing the synthesiser's `Display::fmt` / `Inspect::inspect`
+    /// call construction through this method removes the last hard
+    /// dependency on the conventional source-side method spelling.
+    pub fn trait_method_name(&self, item: CompilerItem) -> &str {
+        match self.require(item) {
+            Resolved::Trait {
+                method_name: Some(name),
+                ..
+            } => name.as_str(),
+            Resolved::Trait { name, .. } => panic!(
+                "compiler item `{item}` (trait `{name}`) has no captured \
+                 method name; `trait_method_name` is only valid for \
+                 single-method traits"
+            ),
+            other => kind_mismatch_ice(item, "Trait", other),
+        }
     }
 
     /// Name-only convenience for a [`CompilerItemKind::Struct`] item.
@@ -1158,6 +1199,7 @@ mod tests {
                 Resolved::Trait {
                     module_source: ModuleSource::types(),
                     name: "Option".into(),
+                    method_name: None,
                 },
             )
             .unwrap_err();
@@ -1200,6 +1242,7 @@ mod tests {
             Resolved::Trait {
                 module_source: ModuleSource::traits(),
                 name: "Default".into(),
+                method_name: Some("default".into()),
             },
         )
         .unwrap();

--- a/wado-compiler/src/compiler_item.rs
+++ b/wado-compiler/src/compiler_item.rs
@@ -97,6 +97,122 @@ pub enum CompilerItem {
     /// `core:serde::Deserialize` — anchor for `Deserialize` impl
     /// synthesis and for the Kiln CM adapter's options decoding.
     Deserialize,
+    /// `core:serde::Serializer` — supertrait bound on synthesised
+    /// `serialize<S: Serializer>` methods.
+    Serializer,
+    /// `core:serde::Deserializer` — supertrait bound on synthesised
+    /// `deserialize<D: Deserializer>` methods.
+    Deserializer,
+    /// `core:serde::SerializeStruct` — associated-type bound used when
+    /// the synthesised struct serializer projects `S::StructSerializer`.
+    SerializeStruct,
+    /// `core:serde::SerializeSeq` — associated-type bound used when the
+    /// synthesised array / tuple serializer projects `S::SeqSerializer`.
+    SerializeSeq,
+    /// `core:serde::SerializeVariant` — associated-type bound used when
+    /// the synthesised variant serializer projects `S::VariantSerializer`.
+    SerializeVariant,
+    /// `core:serde::DeserializeStruct` — associated-type bound used when
+    /// the synthesised struct deserializer projects `D::StructAccess`.
+    DeserializeStruct,
+    /// `core:serde::DeserializeSeq` — associated-type bound used when
+    /// the synthesised array / tuple deserializer projects `D::SeqAccess`.
+    DeserializeSeq,
+    /// `core:serde::DeserializeVariant` — associated-type bound used when
+    /// the synthesised variant deserializer projects `D::VariantAccess`.
+    DeserializeVariant,
+    /// `core:prelude/traits::Display` — anchor for `{x}` template-string
+    /// dispatch and the auto-derive Display→Inspect fallback.
+    Display,
+    /// `core:prelude/traits::DisplayAlt` — `{x:#}` dispatch.
+    DisplayAlt,
+    /// `core:prelude/traits::Inspect` — `{x:?}` dispatch.
+    Inspect,
+    /// `core:prelude/traits::InspectAlt` — `{x:#?}` dispatch.
+    InspectAlt,
+    /// `core:prelude/traits::Binary` — `{x:b}` dispatch.
+    Binary,
+    /// `core:prelude/traits::BinaryAlt` — `{x:#b}` dispatch.
+    BinaryAlt,
+    /// `core:prelude/traits::Octal` — `{x:o}` dispatch.
+    Octal,
+    /// `core:prelude/traits::OctalAlt` — `{x:#o}` dispatch.
+    OctalAlt,
+    /// `core:prelude/traits::LowerHex` — `{x:x}` dispatch.
+    LowerHex,
+    /// `core:prelude/traits::LowerHexAlt` — `{x:#x}` dispatch.
+    LowerHexAlt,
+    /// `core:prelude/traits::UpperHex` — `{x:X}` dispatch.
+    UpperHex,
+    /// `core:prelude/traits::UpperHexAlt` — `{x:#X}` dispatch.
+    UpperHexAlt,
+    /// `core:prelude/traits::LowerExp` — `{x:e}` dispatch.
+    LowerExp,
+    /// `core:prelude/traits::UpperExp` — `{x:E}` dispatch.
+    UpperExp,
+
+    // ── Format types (structs / enums) ─────────────────────────────────
+    /// `core:prelude/format::Formatter` — the format target struct.
+    Formatter,
+    /// `core:prelude/format::Alignment` — alignment enum used by the
+    /// formatter's pad path.
+    Alignment,
+    /// `core:serde::SerializeError` — error struct returned from every
+    /// synthesised `Serializer` method.
+    SerializeError,
+    /// `core:serde::SerializeErrorKind` — error kind enum used by the
+    /// synthesised error-literal helpers.
+    SerializeErrorKind,
+    /// `core:serde::DeserializeError` — error struct returned from every
+    /// synthesised `Deserializer` method.
+    DeserializeError,
+    /// `core:serde::DeserializeErrorKind` — error kind enum used by the
+    /// synthesised error-literal helpers.
+    DeserializeErrorKind,
+
+    // ── Variant cases ─────────────────────────────────────────────────
+    /// `Option::Some` — anchors the case-name / case-index pair used by
+    /// every site that constructs or matches `Some(_)`.
+    OptionSome,
+    /// `Option::None` — anchors the case-name / case-index pair used by
+    /// every site that constructs or matches `None`.
+    OptionNone,
+    /// `Result::Ok` — anchors the case-name / case-index pair used by
+    /// every site that constructs or matches `Ok(_)`.
+    ResultOk,
+    /// `Result::Err` — anchors the case-name / case-index pair used by
+    /// every site that constructs or matches `Err(_)`.
+    ResultErr,
+    /// `Ordering::Less` — anchors the case-name / case-index pair used
+    /// by operator dispatch lowering for `<` / `<=`.
+    OrderingLess,
+    /// `Ordering::Equal` — anchors the case-name / case-index pair used
+    /// by operator dispatch lowering for `==` / `!=`.
+    OrderingEqual,
+    /// `Ordering::Greater` — anchors the case-name / case-index pair
+    /// used by operator dispatch lowering for `>` / `>=`.
+    OrderingGreater,
+    /// `SerializeErrorKind::Custom` — anchors the case-name / case-index
+    /// pair used by `serialize_error_literal`.
+    SerializeErrorKindCustom,
+    /// `DeserializeErrorKind::MissingField` — anchors the case-name /
+    /// case-index pair used by `deserialize_error_literal`.
+    DeserializeErrorKindMissingField,
+    /// `DeserializeErrorKind::UnknownVariant` — anchors the case-name /
+    /// case-index pair used by `deserialize_error_literal`.
+    DeserializeErrorKindUnknownVariant,
+    /// `DeserializeErrorKind::InvalidValue` — anchors the case-name /
+    /// case-index pair used by `deserialize_error_literal`.
+    DeserializeErrorKindInvalidValue,
+    /// `Alignment::Left` — anchors the case-name / case-index pair used
+    /// by template-string padding lowering.
+    AlignmentLeft,
+    /// `Alignment::Center` — anchors the case-name / case-index pair
+    /// used by template-string padding lowering.
+    AlignmentCenter,
+    /// `Alignment::Right` — anchors the case-name / case-index pair used
+    /// by template-string padding lowering.
+    AlignmentRight,
 
     // ── Methods (impl-block functions) ────────────────────────────────
     /// `Array<T>::push` — recognised by the WIR optimiser to collapse
@@ -155,6 +271,48 @@ impl CompilerItem {
         Self::From,
         Self::Serialize,
         Self::Deserialize,
+        Self::Serializer,
+        Self::Deserializer,
+        Self::SerializeStruct,
+        Self::SerializeSeq,
+        Self::SerializeVariant,
+        Self::DeserializeStruct,
+        Self::DeserializeSeq,
+        Self::DeserializeVariant,
+        Self::Display,
+        Self::DisplayAlt,
+        Self::Inspect,
+        Self::InspectAlt,
+        Self::Binary,
+        Self::BinaryAlt,
+        Self::Octal,
+        Self::OctalAlt,
+        Self::LowerHex,
+        Self::LowerHexAlt,
+        Self::UpperHex,
+        Self::UpperHexAlt,
+        Self::LowerExp,
+        Self::UpperExp,
+        Self::Formatter,
+        Self::Alignment,
+        Self::SerializeError,
+        Self::SerializeErrorKind,
+        Self::DeserializeError,
+        Self::DeserializeErrorKind,
+        Self::OptionSome,
+        Self::OptionNone,
+        Self::ResultOk,
+        Self::ResultErr,
+        Self::OrderingLess,
+        Self::OrderingEqual,
+        Self::OrderingGreater,
+        Self::SerializeErrorKindCustom,
+        Self::DeserializeErrorKindMissingField,
+        Self::DeserializeErrorKindUnknownVariant,
+        Self::DeserializeErrorKindInvalidValue,
+        Self::AlignmentLeft,
+        Self::AlignmentCenter,
+        Self::AlignmentRight,
         Self::ArrayPush,
         Self::StringPushStr,
         Self::StringPushChar,
@@ -194,6 +352,48 @@ impl CompilerItem {
             Self::From => "from",
             Self::Serialize => "serialize",
             Self::Deserialize => "deserialize",
+            Self::Serializer => "serializer",
+            Self::Deserializer => "deserializer",
+            Self::SerializeStruct => "serialize_struct",
+            Self::SerializeSeq => "serialize_seq",
+            Self::SerializeVariant => "serialize_variant",
+            Self::DeserializeStruct => "deserialize_struct",
+            Self::DeserializeSeq => "deserialize_seq",
+            Self::DeserializeVariant => "deserialize_variant",
+            Self::Display => "display",
+            Self::DisplayAlt => "display_alt",
+            Self::Inspect => "inspect",
+            Self::InspectAlt => "inspect_alt",
+            Self::Binary => "binary",
+            Self::BinaryAlt => "binary_alt",
+            Self::Octal => "octal",
+            Self::OctalAlt => "octal_alt",
+            Self::LowerHex => "lower_hex",
+            Self::LowerHexAlt => "lower_hex_alt",
+            Self::UpperHex => "upper_hex",
+            Self::UpperHexAlt => "upper_hex_alt",
+            Self::LowerExp => "lower_exp",
+            Self::UpperExp => "upper_exp",
+            Self::Formatter => "formatter",
+            Self::Alignment => "alignment",
+            Self::SerializeError => "serialize_error",
+            Self::SerializeErrorKind => "serialize_error_kind",
+            Self::DeserializeError => "deserialize_error",
+            Self::DeserializeErrorKind => "deserialize_error_kind",
+            Self::OptionSome => "option_some",
+            Self::OptionNone => "option_none",
+            Self::ResultOk => "result_ok",
+            Self::ResultErr => "result_err",
+            Self::OrderingLess => "ordering_less",
+            Self::OrderingEqual => "ordering_equal",
+            Self::OrderingGreater => "ordering_greater",
+            Self::SerializeErrorKindCustom => "serialize_error_kind_custom",
+            Self::DeserializeErrorKindMissingField => "deserialize_error_kind_missing_field",
+            Self::DeserializeErrorKindUnknownVariant => "deserialize_error_kind_unknown_variant",
+            Self::DeserializeErrorKindInvalidValue => "deserialize_error_kind_invalid_value",
+            Self::AlignmentLeft => "alignment_left",
+            Self::AlignmentCenter => "alignment_center",
+            Self::AlignmentRight => "alignment_right",
             Self::ArrayPush => "array_push",
             Self::StringPushStr => "string_push_str",
             Self::StringPushChar => "string_push_char",
@@ -256,7 +456,39 @@ impl CompilerItem {
             | Self::I128FromPair
             | Self::U128FromU64
             | Self::U128FromPair
-            | Self::Tuple => true,
+            | Self::Tuple
+            // Variant cases of always-loaded variants/enums travel with
+            // their parents — Option, Result, and Ordering are all in
+            // the auto-loaded prelude, so their cases are always
+            // required too.
+            | Self::OptionSome
+            | Self::OptionNone
+            | Self::ResultOk
+            | Self::ResultErr
+            | Self::OrderingLess
+            | Self::OrderingEqual
+            | Self::OrderingGreater
+            // The format module is part of `core:prelude` so its
+            // structs / enums / traits / cases are always required.
+            | Self::Formatter
+            | Self::Alignment
+            | Self::AlignmentLeft
+            | Self::AlignmentCenter
+            | Self::AlignmentRight
+            | Self::Display
+            | Self::DisplayAlt
+            | Self::Inspect
+            | Self::InspectAlt
+            | Self::Binary
+            | Self::BinaryAlt
+            | Self::Octal
+            | Self::OctalAlt
+            | Self::LowerHex
+            | Self::LowerHexAlt
+            | Self::UpperHex
+            | Self::UpperHexAlt
+            | Self::LowerExp
+            | Self::UpperExp => true,
             // Kiln generator world only.
             Self::KilnRequest => world == "core:kiln/generator",
             // Loaded only when the user imports `core:serde` (which
@@ -264,7 +496,24 @@ impl CompilerItem {
             // validator skips the check; downstream synthesis ICEs
             // with a clear message if the items are reached for
             // without being registered.
-            Self::Serialize | Self::Deserialize => false,
+            Self::Serialize
+            | Self::Deserialize
+            | Self::Serializer
+            | Self::Deserializer
+            | Self::SerializeStruct
+            | Self::SerializeSeq
+            | Self::SerializeVariant
+            | Self::DeserializeStruct
+            | Self::DeserializeSeq
+            | Self::DeserializeVariant
+            | Self::SerializeError
+            | Self::SerializeErrorKind
+            | Self::DeserializeError
+            | Self::DeserializeErrorKind
+            | Self::SerializeErrorKindCustom
+            | Self::DeserializeErrorKindMissingField
+            | Self::DeserializeErrorKindUnknownVariant
+            | Self::DeserializeErrorKindInvalidValue => false,
         }
     }
 
@@ -282,13 +531,38 @@ impl CompilerItem {
             | Self::KilnRequest
             | Self::String => CompilerItemKind::Struct,
             Self::Option | Self::Result => CompilerItemKind::Variant,
-            Self::Ordering => CompilerItemKind::Enum,
+            Self::Ordering | Self::Alignment => CompilerItemKind::Enum,
+            Self::SerializeError | Self::DeserializeError => CompilerItemKind::Struct,
+            Self::SerializeErrorKind | Self::DeserializeErrorKind => CompilerItemKind::Enum,
+            Self::Formatter => CompilerItemKind::Struct,
             Self::Default
             | Self::Eq
             | Self::Ord
             | Self::From
             | Self::Serialize
-            | Self::Deserialize => CompilerItemKind::Trait,
+            | Self::Deserialize
+            | Self::Serializer
+            | Self::Deserializer
+            | Self::SerializeStruct
+            | Self::SerializeSeq
+            | Self::SerializeVariant
+            | Self::DeserializeStruct
+            | Self::DeserializeSeq
+            | Self::DeserializeVariant
+            | Self::Display
+            | Self::DisplayAlt
+            | Self::Inspect
+            | Self::InspectAlt
+            | Self::Binary
+            | Self::BinaryAlt
+            | Self::Octal
+            | Self::OctalAlt
+            | Self::LowerHex
+            | Self::LowerHexAlt
+            | Self::UpperHex
+            | Self::UpperHexAlt
+            | Self::LowerExp
+            | Self::UpperExp => CompilerItemKind::Trait,
             Self::ArrayPush
             | Self::StringPushStr
             | Self::StringPushChar
@@ -298,6 +572,20 @@ impl CompilerItem {
             | Self::U128FromU64
             | Self::U128FromPair => CompilerItemKind::Method,
             Self::Tuple => CompilerItemKind::TupleFamily,
+            Self::OptionSome
+            | Self::OptionNone
+            | Self::ResultOk
+            | Self::ResultErr => CompilerItemKind::VariantCase,
+            Self::OrderingLess
+            | Self::OrderingEqual
+            | Self::OrderingGreater
+            | Self::AlignmentLeft
+            | Self::AlignmentCenter
+            | Self::AlignmentRight
+            | Self::SerializeErrorKindCustom
+            | Self::DeserializeErrorKindMissingField
+            | Self::DeserializeErrorKindUnknownVariant
+            | Self::DeserializeErrorKindInvalidValue => CompilerItemKind::EnumCase,
         }
     }
 }
@@ -328,6 +616,10 @@ pub enum CompilerItemKind {
     Method,
     /// The `pub type [..T];` declaration that owns the tuple family.
     TupleFamily,
+    /// One case of a `variant` declaration (e.g. `Option::Some`).
+    VariantCase,
+    /// One case of an `enum` declaration (e.g. `Ordering::Less`).
+    EnumCase,
 }
 
 impl fmt::Display for CompilerItemKind {
@@ -339,6 +631,8 @@ impl fmt::Display for CompilerItemKind {
             Self::Trait => "trait",
             Self::Method => "method",
             Self::TupleFamily => "tuple type family",
+            Self::VariantCase => "variant case",
+            Self::EnumCase => "enum case",
         })
     }
 }
@@ -381,6 +675,31 @@ pub enum Resolved {
     /// user-visible declared name on the Wado side, only an owning
     /// module; the [`ModuleSource`] is therefore the only payload.
     TupleFamily { module_source: ModuleSource },
+    /// One case of a `variant` declaration. Carries the owning
+    /// variant's name (`Option`, `Result`) so downstream consumers can
+    /// reconstruct the `TirPattern::Variant.enum_type` / lookup keys,
+    /// plus the case's own name and zero-based index.
+    VariantCase {
+        module_source: ModuleSource,
+        /// The variant type the case belongs to (e.g. `"Option"`).
+        parent_type: String,
+        /// The case name (e.g. `"Some"`).
+        name: String,
+        /// Zero-based index of the case in declaration order.
+        case_index: u32,
+    },
+    /// One case of an `enum` declaration. Same shape as
+    /// [`Self::VariantCase`] but for payload-less `enum` cases
+    /// (`Ordering::Less`, `Alignment::Right`, …).
+    EnumCase {
+        module_source: ModuleSource,
+        /// The enum type the case belongs to (e.g. `"Ordering"`).
+        parent_type: String,
+        /// The case name (e.g. `"Less"`).
+        name: String,
+        /// Zero-based index of the case in declaration order.
+        case_index: u32,
+    },
 }
 
 impl Resolved {
@@ -394,6 +713,8 @@ impl Resolved {
             Self::Trait { .. } => CompilerItemKind::Trait,
             Self::Method { .. } => CompilerItemKind::Method,
             Self::TupleFamily { .. } => CompilerItemKind::TupleFamily,
+            Self::VariantCase { .. } => CompilerItemKind::VariantCase,
+            Self::EnumCase { .. } => CompilerItemKind::EnumCase,
         }
     }
 
@@ -406,7 +727,9 @@ impl Resolved {
             | Self::Enum { module_source, .. }
             | Self::Trait { module_source, .. }
             | Self::Method { module_source, .. }
-            | Self::TupleFamily { module_source } => module_source,
+            | Self::TupleFamily { module_source }
+            | Self::VariantCase { module_source, .. }
+            | Self::EnumCase { module_source, .. } => module_source,
         }
     }
 }
@@ -635,6 +958,57 @@ impl CompilerItems {
             Resolved::TupleFamily { module_source } => Some(module_source),
             _ => None,
         }
+    }
+
+    /// Module + parent-type name + case name + case index of a
+    /// [`CompilerItemKind::VariantCase`] item.
+    pub fn require_variant_case(
+        &self,
+        item: CompilerItem,
+    ) -> (&ModuleSource, &str, &str, u32) {
+        match self.require(item) {
+            Resolved::VariantCase {
+                module_source,
+                parent_type,
+                name,
+                case_index,
+            } => (module_source, parent_type.as_str(), name.as_str(), *case_index),
+            other => kind_mismatch_ice(item, "VariantCase", other),
+        }
+    }
+
+    /// Module + parent-type name + case name + case index of a
+    /// [`CompilerItemKind::EnumCase`] item.
+    pub fn require_enum_case(&self, item: CompilerItem) -> (&ModuleSource, &str, &str, u32) {
+        match self.require(item) {
+            Resolved::EnumCase {
+                module_source,
+                parent_type,
+                name,
+                case_index,
+            } => (module_source, parent_type.as_str(), name.as_str(), *case_index),
+            other => kind_mismatch_ice(item, "EnumCase", other),
+        }
+    }
+
+    /// Case name of a [`CompilerItemKind::VariantCase`] item.
+    pub fn variant_case_name(&self, item: CompilerItem) -> &str {
+        self.require_variant_case(item).2
+    }
+
+    /// Zero-based case index of a [`CompilerItemKind::VariantCase`] item.
+    pub fn variant_case_index(&self, item: CompilerItem) -> u32 {
+        self.require_variant_case(item).3
+    }
+
+    /// Case name of a [`CompilerItemKind::EnumCase`] item.
+    pub fn enum_case_name(&self, item: CompilerItem) -> &str {
+        self.require_enum_case(item).2
+    }
+
+    /// Zero-based case index of a [`CompilerItemKind::EnumCase`] item.
+    pub fn enum_case_index(&self, item: CompilerItem) -> u32 {
+        self.require_enum_case(item).3
     }
 
     /// List every required-but-missing [`CompilerItem`] for the given
@@ -887,6 +1261,77 @@ mod tests {
     fn require_panics_on_unregistered() {
         let reg = CompilerItems::new();
         let _ = reg.require_method(CompilerItem::StringPushStr);
+    }
+
+    /// Variant case round-trip: register a `VariantCase` item under a
+    /// non-default case name and confirm the registry hands the same
+    /// `(parent, name, index)` triple back. Pins the contract that
+    /// stdlib renames of variant cases flow through the registry the
+    /// same way method / trait renames already do (issues #1086 /
+    /// #1090 / #1091).
+    #[test]
+    fn variant_case_round_trips_through_registry_even_when_renamed() {
+        let mut reg = CompilerItems::new();
+        reg.register(
+            CompilerItem::OptionSome,
+            Resolved::VariantCase {
+                module_source: ModuleSource::types(),
+                parent_type: "Option".to_string(),
+                name: "SomeV2".to_string(),
+                case_index: 0,
+            },
+        )
+        .unwrap();
+        let (module, parent, name, index) = reg.require_variant_case(CompilerItem::OptionSome);
+        assert_eq!(module, &ModuleSource::types());
+        assert_eq!(parent, "Option");
+        assert_eq!(name, "SomeV2");
+        assert_eq!(index, 0);
+    }
+
+    /// Mirror of [`variant_case_round_trips_through_registry_even_when_renamed`]
+    /// for `EnumCase` items. Locks in that `Ordering::Less` /
+    /// `Alignment::Left` and friends — payload-less enum cases — are
+    /// just as renameable as their variant-with-payload counterparts.
+    #[test]
+    fn enum_case_round_trips_through_registry_even_when_renamed() {
+        let mut reg = CompilerItems::new();
+        reg.register(
+            CompilerItem::OrderingLess,
+            Resolved::EnumCase {
+                module_source: ModuleSource::traits(),
+                parent_type: "Ordering".to_string(),
+                name: "LessV2".to_string(),
+                case_index: 0,
+            },
+        )
+        .unwrap();
+        let (module, parent, name, index) = reg.require_enum_case(CompilerItem::OrderingLess);
+        assert_eq!(module, &ModuleSource::traits());
+        assert_eq!(parent, "Ordering");
+        assert_eq!(name, "LessV2");
+        assert_eq!(index, 0);
+    }
+
+    /// `VariantCase` items must reject being attached to an `EnumCase`
+    /// resolved value — the kind mismatch surface that protected the
+    /// earlier kinds (`Variant` vs `Trait`) needs to extend to the new
+    /// case kinds too.
+    #[test]
+    fn register_rejects_variant_case_with_enum_case_resolved() {
+        let mut reg = CompilerItems::new();
+        let err = reg
+            .register(
+                CompilerItem::OptionSome,
+                Resolved::EnumCase {
+                    module_source: ModuleSource::types(),
+                    parent_type: "Option".to_string(),
+                    name: "Some".to_string(),
+                    case_index: 0,
+                },
+            )
+            .unwrap_err();
+        assert!(matches!(err, RegisterError::KindMismatch { .. }));
     }
 
     /// Validator covers every required item in `ALL`. With an empty

--- a/wado-compiler/src/compiler_item.rs
+++ b/wado-compiler/src/compiler_item.rs
@@ -999,14 +999,11 @@ impl CompilerItems {
     /// the only legitimate way to hit that is to break the structural
     /// shape of the trait, which the synthesiser does not silently
     /// handle anywhere else either.
-    pub fn trait_assoc_type_by_bound(
-        &self,
-        item: CompilerItem,
-        bound_trait_name: &str,
-    ) -> &str {
-        let assoc = self.trait_assoc_types(item).iter().find(|a| {
-            a.bound_names.iter().any(|b| b == bound_trait_name)
-        });
+    pub fn trait_assoc_type_by_bound(&self, item: CompilerItem, bound_trait_name: &str) -> &str {
+        let assoc = self
+            .trait_assoc_types(item)
+            .iter()
+            .find(|a| a.bound_names.iter().any(|b| b == bound_trait_name));
         match assoc {
             Some(a) => a.name.as_str(),
             None => panic!(

--- a/wado-compiler/src/compiler_item.rs
+++ b/wado-compiler/src/compiler_item.rs
@@ -637,6 +637,23 @@ impl fmt::Display for CompilerItemKind {
 }
 
 /// The resolved data for a registered [`CompilerItem`].
+/// One associated type declaration captured from a trait registered
+/// via `#[compiler_item("...")]`. Carries the source-side name plus
+/// the source-side names of all trait bounds (e.g.
+/// `type SeqSerializer: SerializeSeq;` →
+/// `{ name: "SeqSerializer", bound_names: ["SerializeSeq"] }`).
+///
+/// The bound list is what makes
+/// [`CompilerItems::trait_assoc_type_by_bound`] stable across stdlib
+/// renames: the synthesiser asks "which assoc type is bound by
+/// `SerializeSeq`?" instead of "is there an assoc type named
+/// `SeqSerializer`?".
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TraitAssocType {
+    pub name: String,
+    pub bound_names: Vec<String>,
+}
+
 ///
 /// One enum with a variant per [`CompilerItemKind`]. Each variant
 /// carries enough information for downstream consumers to reconstruct
@@ -678,17 +695,26 @@ pub enum Resolved {
         ///
         /// Reading: [`CompilerItems::trait_method_name`].
         method_name: Option<String>,
-        /// Associated type names declared on the trait, in source
-        /// order. Auto-captured by the resolver when registering the
-        /// trait's `#[compiler_item("...")]` annotation. Empty for
-        /// traits without associated types.
+        /// Associated types declared on the trait, in source order.
+        /// Each entry pairs the assoc type's source-side name with the
+        /// source-side names of its trait bounds (e.g. for
+        /// `type SeqSerializer: SerializeSeq;` the entry is
+        /// `TraitAssocType { name: "SeqSerializer", bound_names: ["SerializeSeq"] }`).
+        /// Auto-captured by the resolver when registering the trait's
+        /// `#[compiler_item("...")]` annotation; empty for traits
+        /// without associated types.
         ///
-        /// The serde synthesiser uses these to construct `S::SeqSerializer`
-        /// / `D::StructAccess` projections without hard-coding the
-        /// source-side associated type spellings.
+        /// The serde synthesiser identifies each assoc type by its
+        /// **bound trait** (itself a `#[compiler_item("...")]`-
+        /// registered trait whose current spelling comes from the
+        /// registry), not by its source-side spelling. That makes both
+        /// ends rename-stable: renaming `SeqSerializer` to `SeqWriter`
+        /// or renaming the bound `SerializeSeq` to `SeqWriterTrait`
+        /// both keep flowing through the registry instead of panicking
+        /// on a missing source-side name.
         ///
-        /// Reading: [`CompilerItems::trait_assoc_type_names`].
-        assoc_type_names: Vec<String>,
+        /// Reading: [`CompilerItems::trait_assoc_type_by_bound`].
+        assoc_types: Vec<TraitAssocType>,
     },
     Method {
         module_source: ModuleSource,
@@ -953,38 +979,42 @@ impl CompilerItems {
         }
     }
 
-    /// Associated type names declared on a trait, in source order.
-    /// Auto-captured when the trait's `#[compiler_item("...")]` is
-    /// registered, so the synthesiser can build `S::SeqSerializer`-style
-    /// projections without hard-coding the source-side associated type
-    /// spellings.
-    pub fn trait_assoc_type_names(&self, item: CompilerItem) -> &[String] {
+    /// All associated types declared on a trait, in source order, with
+    /// their names and trait bounds. Auto-captured when the trait's
+    /// `#[compiler_item("...")]` is registered.
+    pub fn trait_assoc_types(&self, item: CompilerItem) -> &[TraitAssocType] {
         match self.require(item) {
-            Resolved::Trait {
-                assoc_type_names, ..
-            } => assoc_type_names.as_slice(),
+            Resolved::Trait { assoc_types, .. } => assoc_types.as_slice(),
             other => kind_mismatch_ice(item, "Trait", other),
         }
     }
 
-    /// Single associated type name on a trait, looked up by source-side
-    /// name. Panics if the trait has no such associated type — callers
-    /// must spell the name exactly as it appears in the trait
-    /// declaration. The accessor exists purely as a guard against
-    /// silently typoing the lookup name; the registry edge that catches
-    /// stdlib renames is [`Self::trait_assoc_type_names`].
-    pub fn trait_assoc_type_name(&self, item: CompilerItem, source_name: &str) -> &str {
-        self.trait_assoc_type_names(item)
-            .iter()
-            .find(|n| n.as_str() == source_name)
-            .unwrap_or_else(|| {
-                panic!(
-                    "compiler item `{item}` has no associated type named `{source_name}`; \
-                     declared associated types: {:?}",
-                    self.trait_assoc_type_names(item)
-                )
-            })
-            .as_str()
+    /// Single associated type name on a trait, identified by the
+    /// source-side name of its trait bound. Both the bound trait's
+    /// spelling (passed in by the caller) and the associated type's
+    /// spelling (returned) come from the registry, so renaming either
+    /// end in the stdlib flows through without hand-edits.
+    ///
+    /// Panics if no associated type with the given bound is found —
+    /// the only legitimate way to hit that is to break the structural
+    /// shape of the trait, which the synthesiser does not silently
+    /// handle anywhere else either.
+    pub fn trait_assoc_type_by_bound(
+        &self,
+        item: CompilerItem,
+        bound_trait_name: &str,
+    ) -> &str {
+        let assoc = self.trait_assoc_types(item).iter().find(|a| {
+            a.bound_names.iter().any(|b| b == bound_trait_name)
+        });
+        match assoc {
+            Some(a) => a.name.as_str(),
+            None => panic!(
+                "compiler item `{item}` has no associated type bound by `{bound_trait_name}`; \
+                 declared associated types: {:?}",
+                self.trait_assoc_types(item)
+            ),
+        }
     }
 
     /// Name-only convenience for a [`CompilerItemKind::Struct`] item.
@@ -1245,7 +1275,7 @@ mod tests {
                     module_source: ModuleSource::types(),
                     name: "Option".into(),
                     method_name: None,
-                    assoc_type_names: Vec::new(),
+                    assoc_types: Vec::new(),
                 },
             )
             .unwrap_err();
@@ -1289,7 +1319,7 @@ mod tests {
                 module_source: ModuleSource::traits(),
                 name: "Default".into(),
                 method_name: Some("default".into()),
-                assoc_type_names: Vec::new(),
+                assoc_types: Vec::new(),
             },
         )
         .unwrap();
@@ -1335,14 +1365,16 @@ mod tests {
         assert_eq!(name, "push_str_v2");
     }
 
-    /// Trait associated type names round-trip through the registry —
-    /// if the stdlib renamed `Serializer::SeqSerializer` to
-    /// `Serializer::SeqWriter`, the resolver would auto-capture the
-    /// new name and the synthesiser would pick it up via
-    /// [`CompilerItems::trait_assoc_type_name`] without touching any
-    /// hard-coded string in synthesis code.
+    /// Trait associated type names round-trip through the registry by
+    /// **bound trait**: if the stdlib renamed
+    /// `Serializer::SeqSerializer` to `Serializer::SeqWriter` (bound
+    /// unchanged), or renamed the bound itself from `SerializeSeq` to
+    /// `SeqWriterTrait`, the synthesiser still resolves the correct
+    /// associated type by asking
+    /// [`CompilerItems::trait_assoc_type_by_bound`] with the bound
+    /// trait's current spelling (also looked up from the registry).
     #[test]
-    fn assoc_type_names_round_trip_through_registry_even_when_renamed() {
+    fn assoc_types_round_trip_by_bound_even_when_renamed() {
         let mut reg = CompilerItems::new();
         reg.register(
             CompilerItem::Serializer,
@@ -1350,26 +1382,34 @@ mod tests {
                 module_source: ModuleSource::serde(),
                 name: "Serializer".to_string(),
                 method_name: None,
-                assoc_type_names: vec![
-                    "SeqWriter".to_string(),
-                    "StructWriter".to_string(),
-                    "VariantWriter".to_string(),
+                assoc_types: vec![
+                    TraitAssocType {
+                        name: "SeqWriter".to_string(),
+                        bound_names: vec!["SerializeSeq".to_string()],
+                    },
+                    TraitAssocType {
+                        name: "StructWriter".to_string(),
+                        bound_names: vec!["SerializeStruct".to_string()],
+                    },
+                    TraitAssocType {
+                        name: "VariantWriter".to_string(),
+                        bound_names: vec!["SerializeVariant".to_string()],
+                    },
                 ],
             },
         )
         .unwrap();
+        // Bound-based lookup finds the renamed assoc type:
         assert_eq!(
-            reg.trait_assoc_type_names(CompilerItem::Serializer),
-            &[
-                "SeqWriter".to_string(),
-                "StructWriter".to_string(),
-                "VariantWriter".to_string()
-            ]
+            reg.trait_assoc_type_by_bound(CompilerItem::Serializer, "SerializeSeq"),
+            "SeqWriter"
         );
         assert_eq!(
-            reg.trait_assoc_type_name(CompilerItem::Serializer, "StructWriter"),
+            reg.trait_assoc_type_by_bound(CompilerItem::Serializer, "SerializeStruct"),
             "StructWriter"
         );
+        // The captured `assoc_types` are also inspectable.
+        assert_eq!(reg.trait_assoc_types(CompilerItem::Serializer).len(), 3);
     }
 
     /// Counterpart to the rename-rewrite test: omitting the

--- a/wado-compiler/src/lower/plan/closure.rs
+++ b/wado-compiler/src/lower/plan/closure.rs
@@ -710,15 +710,32 @@ impl ClosureLowerer {
         type_table: &mut TypeTable,
         span: Span,
     ) {
-        let formatter_type =
-            type_table.make_struct("Formatter".to_string(), ModuleSource::format());
+        // Resolve Formatter / Inspect / InspectAlt through the
+        // `CompilerItem` registry. The struct name flows into the inner
+        // `Formatter::write_str` call below, so capture it once instead
+        // of looking it up per method.
+        let (formatter_name, inspect_trait, inspect_alt_trait) = {
+            let items = type_table.compiler_items();
+            (
+                items
+                    .struct_name(crate::compiler_item::CompilerItem::Formatter)
+                    .to_string(),
+                items
+                    .trait_name(crate::compiler_item::CompilerItem::Inspect)
+                    .to_string(),
+                items
+                    .trait_name(crate::compiler_item::CompilerItem::InspectAlt)
+                    .to_string(),
+            )
+        };
+        let formatter_type = type_table.make_struct(formatter_name.clone(), ModuleSource::format());
         let formatter_mut_ref = type_table.make_mut_ref(formatter_type);
         let string_type =
             type_table.make_compiler_struct(crate::compiler_item::CompilerItem::String);
 
         for (trait_name, method_name, payload) in [
-            ("Inspect", "inspect", signature),
-            ("InspectAlt", "inspect_alt", source),
+            (inspect_trait.as_str(), "inspect", signature),
+            (inspect_alt_trait.as_str(), "inspect_alt", source),
         ] {
             let func = self.build_functor_format_method(
                 struct_name,
@@ -728,6 +745,7 @@ impl ClosureLowerer {
                 self_ref_type,
                 formatter_mut_ref,
                 string_type,
+                &formatter_name,
                 span,
             );
             self.generated_functions.push(Rc::new(RefCell::new(func)));
@@ -747,6 +765,7 @@ impl ClosureLowerer {
         self_ref_type: TypeId,
         formatter_mut_ref: TypeId,
         string_type: TypeId,
+        formatter_name: &str,
         span: Span,
     ) -> TirFunction {
         let method_info = LocalMethodName::new(
@@ -769,10 +788,10 @@ impl ClosureLowerer {
                 Box::new(fmt_local),
                 FunctionRef {
                     module_source: ModuleSource::format(),
-                    name: "Formatter::write_str".to_string(),
+                    name: format!("{formatter_name}::write_str"),
                     monomorph_info: None,
                     method_info: Some(LocalMethodName::new(
-                        "Formatter".to_string(),
+                        formatter_name.to_string(),
                         None,
                         "write_str".to_string(),
                     )),
@@ -1460,7 +1479,7 @@ impl ClosureCallSiteLowerer<'_> {
             Some(info) => info,
             None => return,
         };
-        if info.base_struct_name != "Fn" {
+        if info.base_struct_name != crate::name::CLOSURE_FN_TRAIT {
             return;
         }
         let Some(base_trait) = info.base_trait_name.as_deref() else {
@@ -1469,12 +1488,22 @@ impl ClosureCallSiteLowerer<'_> {
         // Map each formatting trait to the per-functor impl that
         // produces the right output. `Display`/`DisplayAlt` fall back
         // to `Inspect`/`InspectAlt` so the redirect targets are the
-        // same per-functor method either way.
-        let (target_trait, target_method) = match base_trait {
-            "Inspect" | "Display" => ("Inspect", "inspect"),
-            "InspectAlt" | "DisplayAlt" => ("InspectAlt", "inspect_alt"),
-            _ => return,
-        };
+        // same per-functor method either way. All four trait names
+        // flow through the `CompilerItem` registry so a stdlib rename
+        // of any of them does not silently bypass this redirect.
+        let items = self.type_table.compiler_items();
+        let inspect = items.trait_name(crate::compiler_item::CompilerItem::Inspect);
+        let inspect_alt = items.trait_name(crate::compiler_item::CompilerItem::InspectAlt);
+        let display = items.trait_name(crate::compiler_item::CompilerItem::Display);
+        let display_alt = items.trait_name(crate::compiler_item::CompilerItem::DisplayAlt);
+        let (target_trait, target_method): (String, &str) =
+            if base_trait == inspect || base_trait == display {
+                (inspect.to_string(), "inspect")
+            } else if base_trait == inspect_alt || base_trait == display_alt {
+                (inspect_alt.to_string(), "inspect_alt")
+            } else {
+                return;
+            };
 
         let local_idx = match peel_ref_to_local(receiver) {
             Some(idx) => idx,
@@ -1501,7 +1530,7 @@ impl ClosureCallSiteLowerer<'_> {
 
         let new_method_info = LocalMethodName::new(
             functor.struct_name.clone(),
-            Some(target_trait.to_string()),
+            Some(target_trait),
             target_method.to_string(),
         );
         let new_name = new_method_info.to_mangled_name();

--- a/wado-compiler/src/lower/plan/closure.rs
+++ b/wado-compiler/src/lower/plan/closure.rs
@@ -713,8 +713,11 @@ impl ClosureLowerer {
         // Resolve Formatter / Inspect / InspectAlt through the
         // `CompilerItem` registry. The struct name flows into the inner
         // `Formatter::write_str` call below, so capture it once instead
-        // of looking it up per method.
-        let (formatter_name, inspect_trait, inspect_alt_trait) = {
+        // of looking it up per method. Method names come from the
+        // single-method trait's `trait_method_name` so a rename of
+        // `Inspect::inspect` → `Inspect::dump` (or similar) is picked
+        // up here without touching this site.
+        let (formatter_name, inspect_trait, inspect_method, inspect_alt_trait, inspect_alt_method) = {
             let items = type_table.compiler_items();
             (
                 items
@@ -724,7 +727,13 @@ impl ClosureLowerer {
                     .trait_name(crate::compiler_item::CompilerItem::Inspect)
                     .to_string(),
                 items
+                    .trait_method_name(crate::compiler_item::CompilerItem::Inspect)
+                    .to_string(),
+                items
                     .trait_name(crate::compiler_item::CompilerItem::InspectAlt)
+                    .to_string(),
+                items
+                    .trait_method_name(crate::compiler_item::CompilerItem::InspectAlt)
                     .to_string(),
             )
         };
@@ -734,8 +743,12 @@ impl ClosureLowerer {
             type_table.make_compiler_struct(crate::compiler_item::CompilerItem::String);
 
         for (trait_name, method_name, payload) in [
-            (inspect_trait.as_str(), "inspect", signature),
-            (inspect_alt_trait.as_str(), "inspect_alt", source),
+            (inspect_trait.as_str(), inspect_method.as_str(), signature),
+            (
+                inspect_alt_trait.as_str(),
+                inspect_alt_method.as_str(),
+                source,
+            ),
         ] {
             let func = self.build_functor_format_method(
                 struct_name,
@@ -1493,14 +1506,17 @@ impl ClosureCallSiteLowerer<'_> {
         // of any of them does not silently bypass this redirect.
         let items = self.type_table.compiler_items();
         let inspect = items.trait_name(crate::compiler_item::CompilerItem::Inspect);
+        let inspect_method = items.trait_method_name(crate::compiler_item::CompilerItem::Inspect);
         let inspect_alt = items.trait_name(crate::compiler_item::CompilerItem::InspectAlt);
+        let inspect_alt_method =
+            items.trait_method_name(crate::compiler_item::CompilerItem::InspectAlt);
         let display = items.trait_name(crate::compiler_item::CompilerItem::Display);
         let display_alt = items.trait_name(crate::compiler_item::CompilerItem::DisplayAlt);
-        let (target_trait, target_method): (String, &str) =
+        let (target_trait, target_method): (String, String) =
             if base_trait == inspect || base_trait == display {
-                (inspect.to_string(), "inspect")
+                (inspect.to_string(), inspect_method.to_string())
             } else if base_trait == inspect_alt || base_trait == display_alt {
-                (inspect_alt.to_string(), "inspect_alt")
+                (inspect_alt.to_string(), inspect_alt_method.to_string())
             } else {
                 return;
             };
@@ -1531,7 +1547,7 @@ impl ClosureCallSiteLowerer<'_> {
         let new_method_info = LocalMethodName::new(
             functor.struct_name.clone(),
             Some(target_trait),
-            target_method.to_string(),
+            target_method,
         );
         let new_name = new_method_info.to_mangled_name();
 

--- a/wado-compiler/src/monomorphize/func_inst.rs
+++ b/wado-compiler/src/monomorphize/func_inst.rs
@@ -3681,14 +3681,15 @@ fn try_lower_comparison(
         // flows through this primitive-ord-dispatch path without touching
         // the literal-case mapping table.
         let items = type_table.compiler_items();
-        let (_, _, less_n, less_i) = items.require_enum_case(crate::compiler_item::CompilerItem::OrderingLess);
+        let (_, _, less_n, less_i) =
+            items.require_enum_case(crate::compiler_item::CompilerItem::OrderingLess);
         let (_, _, greater_n, greater_i) =
             items.require_enum_case(crate::compiler_item::CompilerItem::OrderingGreater);
         let less_n = less_n.to_string();
         let greater_n = greater_n.to_string();
         let (compare_op, case_name, case_index): (TirBinaryOp, String, u32) = match op {
-            TirBinaryOp::Lt => (TirBinaryOp::Eq, less_n.clone(), less_i),
-            TirBinaryOp::Gt => (TirBinaryOp::Eq, greater_n.clone(), greater_i),
+            TirBinaryOp::Lt => (TirBinaryOp::Eq, less_n, less_i),
+            TirBinaryOp::Gt => (TirBinaryOp::Eq, greater_n, greater_i),
             TirBinaryOp::LtEq => (TirBinaryOp::NotEq, greater_n, greater_i),
             TirBinaryOp::GtEq => (TirBinaryOp::NotEq, less_n, less_i),
             _ => unreachable!(),

--- a/wado-compiler/src/monomorphize/func_inst.rs
+++ b/wado-compiler/src/monomorphize/func_inst.rs
@@ -3676,18 +3676,28 @@ fn try_lower_comparison(
             span,
         );
 
-        let (compare_op, case_name, case_index): (TirBinaryOp, &str, u32) = match op {
-            TirBinaryOp::Lt => (TirBinaryOp::Eq, "Less", 0),
-            TirBinaryOp::Gt => (TirBinaryOp::Eq, "Greater", 2),
-            TirBinaryOp::LtEq => (TirBinaryOp::NotEq, "Greater", 2),
-            TirBinaryOp::GtEq => (TirBinaryOp::NotEq, "Less", 0),
+        // Look up Ordering's `Less` / `Greater` cases through the
+        // `CompilerItem` registry so a stdlib rename of either case
+        // flows through this primitive-ord-dispatch path without touching
+        // the literal-case mapping table.
+        let items = type_table.compiler_items();
+        let (_, _, less_n, less_i) = items.require_enum_case(crate::compiler_item::CompilerItem::OrderingLess);
+        let (_, _, greater_n, greater_i) =
+            items.require_enum_case(crate::compiler_item::CompilerItem::OrderingGreater);
+        let less_n = less_n.to_string();
+        let greater_n = greater_n.to_string();
+        let (compare_op, case_name, case_index): (TirBinaryOp, String, u32) = match op {
+            TirBinaryOp::Lt => (TirBinaryOp::Eq, less_n.clone(), less_i),
+            TirBinaryOp::Gt => (TirBinaryOp::Eq, greater_n.clone(), greater_i),
+            TirBinaryOp::LtEq => (TirBinaryOp::NotEq, greater_n, greater_i),
+            TirBinaryOp::GtEq => (TirBinaryOp::NotEq, less_n, less_i),
             _ => unreachable!(),
         };
 
         let ordering_variant = TirExpr::new(
             TirExprKind::EnumConstruct {
                 enum_type: ordering_type_id,
-                case_name: case_name.to_string(),
+                case_name,
                 case_index,
             },
             ordering_type_id,

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -52,6 +52,13 @@ pub const CLOSURE_CALL_METHOD: &str = "__call";
 /// convention — there is no Wado-side declaration to anchor it to.
 pub const CLOSURE_STRUCT_PREFIX: &str = "__Closure_";
 
+/// Canonical name of the synthesised closure-trait family (`Fn<N, Ret>`).
+/// Like [`CLOSURE_CALL_METHOD`] / [`CLOSURE_STRUCT_PREFIX`], the trait is
+/// compiler-internal — there is no Wado-side `trait Fn { ... }` declaration
+/// to attach a `#[compiler_item("...")]` to — so a `const` is the right
+/// anchor shape.
+pub const CLOSURE_FN_TRAIT: &str = "Fn";
+
 /// A free function name (not a method on a struct).
 ///
 /// Format: `{module_source}/{name}`

--- a/wado-compiler/src/resolver/call.rs
+++ b/wado-compiler/src/resolver/call.rs
@@ -789,10 +789,25 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     }
                 }
                 // Check if it's a local function (defined in this module) or
-                // a built-in type constructor (Ok, Err, Some, None)
-                else if self.function_return_types.contains_key(&ident.name)
-                    || matches!(ident.name.as_str(), "Ok" | "Err" | "Some" | "None")
-                {
+                // a built-in type constructor (Ok, Err, Some, None).
+                // The four constructor names flow through the
+                // `CompilerItem` registry so a stdlib rename of any of
+                // them is picked up here without re-editing the literal set.
+                else if self.function_return_types.contains_key(&ident.name) || {
+                    let tt = self.type_table.borrow();
+                    let items = tt.compiler_items();
+                    let name = ident.name.as_str();
+                    name == items.variant_case_name(crate::compiler_item::CompilerItem::ResultOk)
+                        || name
+                            == items
+                                .variant_case_name(crate::compiler_item::CompilerItem::ResultErr)
+                        || name
+                            == items
+                                .variant_case_name(crate::compiler_item::CompilerItem::OptionSome)
+                        || name
+                            == items
+                                .variant_case_name(crate::compiler_item::CompilerItem::OptionNone)
+                } {
                     self.record_item_reference_by_name(ident.id, &ident.name);
                     (
                         Some(CalleeRef::local(

--- a/wado-compiler/src/resolver/expr.rs
+++ b/wado-compiler/src/resolver/expr.rs
@@ -2874,6 +2874,17 @@ impl<H: CompilerHost> Resolver<'_, H> {
         let inner_type = inner.type_id;
         let tt = self.type_table.borrow();
         let some_type = tt.as_option(inner_type).unwrap();
+        // Look up the `Some` / `None` case names through the
+        // `CompilerItem` registry so a stdlib rename of either case
+        // flows through the `?` lowering for `Option` without touching
+        // this site.
+        let items = tt.compiler_items();
+        let some_name = items
+            .variant_case_name(crate::compiler_item::CompilerItem::OptionSome)
+            .to_string();
+        let none_name = items
+            .variant_case_name(crate::compiler_item::CompilerItem::OptionNone)
+            .to_string();
         drop(tt);
 
         // Allocate a local for the Some payload binding
@@ -2884,7 +2895,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         let some_arm = TirMatchArm {
             pattern: TirPattern::Variant {
                 enum_type: inner_type,
-                variant_name: "Some".to_string(),
+                variant_name: some_name,
                 bindings: vec![TirPattern::Binding {
                     name: "__qm_v".to_string(),
                     local_index: v_local,
@@ -2908,7 +2919,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         let none_arm = TirMatchArm {
             pattern: TirPattern::Variant {
                 enum_type: inner_type,
-                variant_name: "None".to_string(),
+                variant_name: none_name,
                 bindings: vec![],
                 payload_type: TypeTable::UNIT,
             },

--- a/wado-compiler/src/resolver/expr.rs
+++ b/wado-compiler/src/resolver/expr.rs
@@ -2969,11 +2969,24 @@ impl<H: CompilerHost> Resolver<'_, H> {
         let v_local = ctx.add_local("__qm_v".to_string(), ok_type, false, None);
         let e_local = ctx.add_local("__qm_e".to_string(), inner_err_type, false, None);
 
+        // Look up the `Ok` / `Err` case names + indexes through the
+        // `CompilerItem` registry so a stdlib rename of either case
+        // flows through the `?` lowering path without touching this site.
+        let (ok_name, _ok_index, err_name, err_index) = {
+            let tt = self.type_table.borrow();
+            let items = tt.compiler_items();
+            let (_, _, ok_n, ok_i) =
+                items.require_variant_case(crate::compiler_item::CompilerItem::ResultOk);
+            let (_, _, err_n, err_i) =
+                items.require_variant_case(crate::compiler_item::CompilerItem::ResultErr);
+            (ok_n.to_string(), ok_i, err_n.to_string(), err_i)
+        };
+
         // Arm 0: Ok(v) => v
         let ok_arm = TirMatchArm {
             pattern: TirPattern::Variant {
                 enum_type: inner_type,
-                variant_name: "Ok".to_string(),
+                variant_name: ok_name,
                 bindings: vec![TirPattern::Binding {
                     name: "__qm_v".to_string(),
                     local_index: v_local,
@@ -3014,8 +3027,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
         let err_variant = TirExpr::new(
             TirExprKind::VariantConstruct {
                 variant_type: return_type,
-                case_index: 1, // Err is case 1 in Result<T, E>
-                case_name: "Err".to_string(),
+                case_index: err_index,
+                case_name: err_name.clone(),
                 payload: Some(Box::new(converted_err)),
             },
             return_type,
@@ -3026,7 +3039,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         let err_arm = TirMatchArm {
             pattern: TirPattern::Variant {
                 enum_type: inner_type,
-                variant_name: "Err".to_string(),
+                variant_name: err_name,
                 bindings: vec![TirPattern::Binding {
                     name: "__qm_e".to_string(),
                     local_index: e_local,

--- a/wado-compiler/src/resolver/item.rs
+++ b/wado-compiler/src/resolver/item.rs
@@ -189,6 +189,7 @@ pub(super) fn register_trait_compiler_item<H: CompilerHost>(
     attrs: &[crate::ast::Attribute],
     name: &str,
     methods: &[crate::ast::Function],
+    assoc_types: &[crate::ast::AssociatedTypeDecl],
     module_source: &ModuleSource,
     span: Span,
     logger: &Logger<'_, H>,
@@ -207,10 +208,12 @@ pub(super) fn register_trait_compiler_item<H: CompilerHost>(
     } else {
         None
     };
+    let assoc_type_names = assoc_types.iter().map(|a| a.name.clone()).collect();
     let resolved = Resolved::Trait {
         module_source: module_source.clone(),
         name: name.to_string(),
         method_name,
+        assoc_type_names,
     };
     if let Err(err) = type_table
         .borrow_mut()

--- a/wado-compiler/src/resolver/item.rs
+++ b/wado-compiler/src/resolver/item.rs
@@ -208,12 +208,23 @@ pub(super) fn register_trait_compiler_item<H: CompilerHost>(
     } else {
         None
     };
-    let assoc_type_names = assoc_types.iter().map(|a| a.name.clone()).collect();
+    // For each associated type, capture both its source-side name and the
+    // source-side names of all its trait bounds. The synthesiser identifies
+    // assoc types by their bound (a `#[compiler_item("...")]`-registered
+    // trait whose current spelling also comes from the registry), so both
+    // ends stay rename-stable.
+    let assoc_types = assoc_types
+        .iter()
+        .map(|a| crate::compiler_item::TraitAssocType {
+            name: a.name.clone(),
+            bound_names: a.bounds.iter().map(|b| b.name.clone()).collect(),
+        })
+        .collect();
     let resolved = Resolved::Trait {
         module_source: module_source.clone(),
         name: name.to_string(),
         method_name,
-        assoc_type_names,
+        assoc_types,
     };
     if let Err(err) = type_table
         .borrow_mut()

--- a/wado-compiler/src/resolver/item.rs
+++ b/wado-compiler/src/resolver/item.rs
@@ -178,10 +178,17 @@ pub(super) fn register_enum_compiler_item<H: CompilerHost>(
 }
 
 /// Register a trait declaration's `#[compiler_item(...)]` annotation, if any.
+///
+/// `methods` is the trait's full method list; the resolver inspects it
+/// to cache the single-method trait's primary method name into the
+/// registry (see [`Resolved::Trait::method_name`]). For multi-method
+/// traits the cache stays `None` and downstream consumers that need a
+/// method name must reach for a dedicated method [`CompilerItem`].
 pub(super) fn register_trait_compiler_item<H: CompilerHost>(
     type_table: &RefCell<TypeTable>,
     attrs: &[crate::ast::Attribute],
     name: &str,
+    methods: &[crate::ast::Function],
     module_source: &ModuleSource,
     span: Span,
     logger: &Logger<'_, H>,
@@ -192,9 +199,18 @@ pub(super) fn register_trait_compiler_item<H: CompilerHost>(
     if !check_compiler_item_placement(item, CompilerItemKind::Trait, module_source, span, logger) {
         return;
     }
+    // Single-method traits cache the method's name so the synthesiser
+    // can construct `<Trait>::<method>` calls without hard-coding the
+    // source-side spelling. Multi-method traits leave it unset.
+    let method_name = if methods.len() == 1 {
+        Some(methods[0].name.clone())
+    } else {
+        None
+    };
     let resolved = Resolved::Trait {
         module_source: module_source.clone(),
         name: name.to_string(),
+        method_name,
     };
     if let Err(err) = type_table
         .borrow_mut()

--- a/wado-compiler/src/resolver/item.rs
+++ b/wado-compiler/src/resolver/item.rs
@@ -235,6 +235,89 @@ pub(super) fn register_method_compiler_item<H: CompilerHost>(
     }
 }
 
+/// Register a single variant case's `#[compiler_item("...")]` annotation.
+///
+/// `parent_type` is the variant the case belongs to (e.g. `"Option"`).
+/// `case_index` is the zero-based position of the case in its declared
+/// order, which downstream consumers (pattern matching, variant
+/// construction) need in addition to the case name.
+pub(super) fn register_variant_case_compiler_item<H: CompilerHost>(
+    type_table: &RefCell<TypeTable>,
+    attrs: &[crate::ast::Attribute],
+    parent_type: &str,
+    case_name: &str,
+    case_index: u32,
+    module_source: &ModuleSource,
+    span: Span,
+    logger: &Logger<'_, H>,
+) {
+    let Some(item) = extract_compiler_item(attrs, span, logger) else {
+        return;
+    };
+    if !check_compiler_item_placement(
+        item,
+        CompilerItemKind::VariantCase,
+        module_source,
+        span,
+        logger,
+    ) {
+        return;
+    }
+    let resolved = Resolved::VariantCase {
+        module_source: module_source.clone(),
+        parent_type: parent_type.to_string(),
+        name: case_name.to_string(),
+        case_index,
+    };
+    if let Err(err) = type_table
+        .borrow_mut()
+        .compiler_items_mut()
+        .register(item, resolved)
+    {
+        report_register_error(err, span, logger);
+    }
+}
+
+/// Register a single enum case's `#[compiler_item("...")]` annotation.
+/// See [`register_variant_case_compiler_item`] for the shape — same
+/// payload, different parent kind.
+pub(super) fn register_enum_case_compiler_item<H: CompilerHost>(
+    type_table: &RefCell<TypeTable>,
+    attrs: &[crate::ast::Attribute],
+    parent_type: &str,
+    case_name: &str,
+    case_index: u32,
+    module_source: &ModuleSource,
+    span: Span,
+    logger: &Logger<'_, H>,
+) {
+    let Some(item) = extract_compiler_item(attrs, span, logger) else {
+        return;
+    };
+    if !check_compiler_item_placement(
+        item,
+        CompilerItemKind::EnumCase,
+        module_source,
+        span,
+        logger,
+    ) {
+        return;
+    }
+    let resolved = Resolved::EnumCase {
+        module_source: module_source.clone(),
+        parent_type: parent_type.to_string(),
+        name: case_name.to_string(),
+        case_index,
+    };
+    if let Err(err) = type_table
+        .borrow_mut()
+        .compiler_items_mut()
+        .register(item, resolved)
+    {
+        report_register_error(err, span, logger);
+    }
+}
+
 /// Register a `pub type [..T];` declaration's `#[compiler_item("tuple")]` annotation.
 pub(super) fn register_tuple_compiler_item<H: CompilerHost>(
     type_table: &RefCell<TypeTable>,

--- a/wado-compiler/src/resolver/module.rs
+++ b/wado-compiler/src/resolver/module.rs
@@ -315,6 +315,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         &trait_decl.attrs,
                         &trait_decl.name,
                         &trait_decl.methods,
+                        &trait_decl.associated_types,
                         &self.current_module_source,
                         trait_decl.span,
                         self.logger,

--- a/wado-compiler/src/resolver/module.rs
+++ b/wado-compiler/src/resolver/module.rs
@@ -314,6 +314,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         &self.type_table,
                         &trait_decl.attrs,
                         &trait_decl.name,
+                        &trait_decl.methods,
                         &self.current_module_source,
                         trait_decl.span,
                         self.logger,

--- a/wado-compiler/src/resolver/module.rs
+++ b/wado-compiler/src/resolver/module.rs
@@ -218,6 +218,19 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         scope.logger,
                     );
 
+                    for (case_index, case) in variant_decl.cases.iter().enumerate() {
+                        super::item::register_variant_case_compiler_item(
+                            &scope.type_table,
+                            &case.attrs,
+                            &variant_decl.name,
+                            &case.name,
+                            case_index as u32,
+                            &module_source,
+                            case.span,
+                            scope.logger,
+                        );
+                    }
+
                     drop(scope);
                 }
                 Item::Enum(enum_decl) => {
@@ -254,6 +267,18 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         enum_decl.span,
                         self.logger,
                     );
+                    for (case_index, case) in enum_decl.cases.iter().enumerate() {
+                        super::item::register_enum_case_compiler_item(
+                            &self.type_table,
+                            &case.attrs,
+                            &enum_decl.name,
+                            &case.name,
+                            case_index as u32,
+                            &self.current_module_source,
+                            case.span,
+                            self.logger,
+                        );
+                    }
                 }
                 Item::Flags(flags_decl) => {
                     // Create a distinct Flags type (not a newtype over u32)

--- a/wado-compiler/src/resolver/operators.rs
+++ b/wado-compiler/src/resolver/operators.rs
@@ -1324,8 +1324,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         let (less_name, less_index, greater_name, greater_index) = {
             let tt = self.type_table.borrow();
             let items = tt.compiler_items();
-            let (_, _, less_name, less_index) =
-                items.require_enum_case(CompilerItem::OrderingLess);
+            let (_, _, less_name, less_index) = items.require_enum_case(CompilerItem::OrderingLess);
             let (_, _, greater_name, greater_index) =
                 items.require_enum_case(CompilerItem::OrderingGreater);
             (
@@ -1336,8 +1335,8 @@ impl<H: CompilerHost> Resolver<'_, H> {
             )
         };
         let (compare_op, case_name, case_index): (TirBinaryOp, String, u32) = match op {
-            BinaryOp::Lt => (TirBinaryOp::Eq, less_name.clone(), less_index),
-            BinaryOp::Gt => (TirBinaryOp::Eq, greater_name.clone(), greater_index),
+            BinaryOp::Lt => (TirBinaryOp::Eq, less_name, less_index),
+            BinaryOp::Gt => (TirBinaryOp::Eq, greater_name, greater_index),
             BinaryOp::LtEq => (TirBinaryOp::NotEq, greater_name, greater_index),
             BinaryOp::GtEq => (TirBinaryOp::NotEq, less_name, less_index),
             _ => unreachable!(),

--- a/wado-compiler/src/resolver/operators.rs
+++ b/wado-compiler/src/resolver/operators.rs
@@ -1318,17 +1318,34 @@ impl<H: CompilerHost> Resolver<'_, H> {
             .type_table
             .borrow_mut()
             .make_compiler_enum(CompilerItem::Ordering);
-        let (compare_op, case_name, case_index): (TirBinaryOp, &str, u32) = match op {
-            BinaryOp::Lt => (TirBinaryOp::Eq, "Less", 0),
-            BinaryOp::Gt => (TirBinaryOp::Eq, "Greater", 2),
-            BinaryOp::LtEq => (TirBinaryOp::NotEq, "Greater", 2),
-            BinaryOp::GtEq => (TirBinaryOp::NotEq, "Less", 0),
+        // Look up Ordering's `Less` / `Greater` cases through the
+        // `CompilerItem` registry so a stdlib rename of either case
+        // flows here without touching the operator-lowering path.
+        let (less_name, less_index, greater_name, greater_index) = {
+            let tt = self.type_table.borrow();
+            let items = tt.compiler_items();
+            let (_, _, less_name, less_index) =
+                items.require_enum_case(CompilerItem::OrderingLess);
+            let (_, _, greater_name, greater_index) =
+                items.require_enum_case(CompilerItem::OrderingGreater);
+            (
+                less_name.to_string(),
+                less_index,
+                greater_name.to_string(),
+                greater_index,
+            )
+        };
+        let (compare_op, case_name, case_index): (TirBinaryOp, String, u32) = match op {
+            BinaryOp::Lt => (TirBinaryOp::Eq, less_name.clone(), less_index),
+            BinaryOp::Gt => (TirBinaryOp::Eq, greater_name.clone(), greater_index),
+            BinaryOp::LtEq => (TirBinaryOp::NotEq, greater_name, greater_index),
+            BinaryOp::GtEq => (TirBinaryOp::NotEq, less_name, less_index),
             _ => unreachable!(),
         };
         let ordering_variant = TirExpr::new(
             TirExprKind::EnumConstruct {
                 enum_type: ordering_type_id,
-                case_name: case_name.to_string(),
+                case_name,
                 case_index,
             },
             ordering_type_id,

--- a/wado-compiler/src/resolver/orchestration.rs
+++ b/wado-compiler/src/resolver/orchestration.rs
@@ -317,6 +317,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                             &trait_decl.attrs,
                             &trait_decl.name,
                             &trait_decl.methods,
+                            &trait_decl.associated_types,
                             module_source,
                             trait_decl.span,
                             logger,

--- a/wado-compiler/src/resolver/orchestration.rs
+++ b/wado-compiler/src/resolver/orchestration.rs
@@ -316,6 +316,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                             &type_table,
                             &trait_decl.attrs,
                             &trait_decl.name,
+                            &trait_decl.methods,
                             module_source,
                             trait_decl.span,
                             logger,

--- a/wado-compiler/src/resolver/orchestration.rs
+++ b/wado-compiler/src/resolver/orchestration.rs
@@ -247,6 +247,18 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                             variant_decl.span,
                             logger,
                         );
+                        for (case_index, case) in variant_decl.cases.iter().enumerate() {
+                            super::item::register_variant_case_compiler_item(
+                                &type_table,
+                                &case.attrs,
+                                &variant_decl.name,
+                                &case.name,
+                                case_index as u32,
+                                module_source,
+                                case.span,
+                                logger,
+                            );
+                        }
                     }
                     Item::Enum(enum_decl) => {
                         // Insert with empty cases first - will be populated in second sub-pass
@@ -269,6 +281,18 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                             enum_decl.span,
                             logger,
                         );
+                        for (case_index, case) in enum_decl.cases.iter().enumerate() {
+                            super::item::register_enum_case_compiler_item(
+                                &type_table,
+                                &case.attrs,
+                                &enum_decl.name,
+                                &case.name,
+                                case_index as u32,
+                                module_source,
+                                case.span,
+                                logger,
+                            );
+                        }
                     }
                     Item::Resource(resource_decl) => {
                         all_resource_types

--- a/wado-compiler/src/resolver/stmt.rs
+++ b/wado-compiler/src/resolver/stmt.rs
@@ -2548,7 +2548,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
             .to_string();
         let (some_pattern, then_block) = if ref_mode == RefBinding::None {
             let pattern = Pattern::Variant {
-                variant_name: some_case_name.clone(),
+                variant_name: some_case_name,
                 variant_qualifier: None,
                 name_id: None,
                 name_span: span,
@@ -2573,7 +2573,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 }
             };
             let pattern = Pattern::Variant {
-                variant_name: some_case_name.clone(),
+                variant_name: some_case_name,
                 variant_qualifier: None,
                 name_id: None,
                 name_span: span,

--- a/wado-compiler/src/resolver/stmt.rs
+++ b/wado-compiler/src/resolver/stmt.rs
@@ -1818,10 +1818,16 @@ impl<H: CompilerHost> Resolver<'_, H> {
             _ => None,
         }?;
         let variant_info = self.lookup_variant_case(&variant_name)?;
-        if variant_info.cases.iter().any(|c| c.name == "None") {
+        let none_case_name = self
+            .type_table
+            .borrow()
+            .compiler_items()
+            .variant_case_name(crate::compiler_item::CompilerItem::OptionNone)
+            .to_string();
+        if variant_info.cases.iter().any(|c| c.name == none_case_name) {
             Some(TirPattern::Variant {
                 enum_type: scrutinee_type,
-                variant_name: "None".to_string(),
+                variant_name: none_case_name,
                 bindings: vec![],
                 payload_type: TypeTable::UNIT,
             })
@@ -2534,9 +2540,15 @@ impl<H: CompilerHost> Resolver<'_, H> {
         //   if let Some(__elem_N) = iter.next() { let binding = &__elem_N; body }
         // For value iterables:
         //   if let Some(binding) = iter.next() { body }
+        let some_case_name = self
+            .type_table
+            .borrow()
+            .compiler_items()
+            .variant_case_name(crate::compiler_item::CompilerItem::OptionSome)
+            .to_string();
         let (some_pattern, then_block) = if ref_mode == RefBinding::None {
             let pattern = Pattern::Variant {
-                variant_name: "Some".to_string(),
+                variant_name: some_case_name.clone(),
                 variant_qualifier: None,
                 name_id: None,
                 name_span: span,
@@ -2561,7 +2573,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 }
             };
             let pattern = Pattern::Variant {
-                variant_name: "Some".to_string(),
+                variant_name: some_case_name.clone(),
                 variant_qualifier: None,
                 name_id: None,
                 name_span: span,

--- a/wado-compiler/src/synthesis/cm_binding.rs
+++ b/wado-compiler/src/synthesis/cm_binding.rs
@@ -538,10 +538,46 @@ mod tests {
             },
         );
         let _ = tt.compiler_items_mut().register(
+            CompilerItem::OptionSome,
+            Resolved::VariantCase {
+                module_source: ModuleSource::prelude(),
+                parent_type: "Option".to_string(),
+                name: "Some".to_string(),
+                case_index: 0,
+            },
+        );
+        let _ = tt.compiler_items_mut().register(
+            CompilerItem::OptionNone,
+            Resolved::VariantCase {
+                module_source: ModuleSource::prelude(),
+                parent_type: "Option".to_string(),
+                name: "None".to_string(),
+                case_index: 1,
+            },
+        );
+        let _ = tt.compiler_items_mut().register(
             CompilerItem::Result,
             Resolved::Variant {
                 module_source: ModuleSource::prelude(),
                 name: "Result".to_string(),
+            },
+        );
+        let _ = tt.compiler_items_mut().register(
+            CompilerItem::ResultOk,
+            Resolved::VariantCase {
+                module_source: ModuleSource::prelude(),
+                parent_type: "Result".to_string(),
+                name: "Ok".to_string(),
+                case_index: 0,
+            },
+        );
+        let _ = tt.compiler_items_mut().register(
+            CompilerItem::ResultErr,
+            Resolved::VariantCase {
+                module_source: ModuleSource::prelude(),
+                parent_type: "Result".to_string(),
+                name: "Err".to_string(),
+                case_index: 1,
             },
         );
         let _ = tt.compiler_items_mut().register(

--- a/wado-compiler/src/synthesis/cm_binding/export_adapter.rs
+++ b/wado-compiler/src/synthesis/cm_binding/export_adapter.rs
@@ -368,8 +368,8 @@ fn lower_to_flat_inner(
                 TirExprKind::Cast {
                     expr: Box::new(variant_test(
                         local_ref(opt_local, "__opt_val", type_id),
-                        0,
-                        "Some",
+                        names.some_index,
+                        &names.some_name,
                     )),
                     target_type: TypeTable::I32,
                 },
@@ -723,12 +723,16 @@ pub(super) fn synthesize_lift_from_flat_params(
 
                 // if disc == 0 { None } else { Some(lift(inner_flat)) }
                 let result_local = alloc_local(next_local, locals, target_type_id);
+                let opt_none_expr = {
+                    let tt = type_table_cell.borrow();
+                    option_none(target_type_id, tt.compiler_items())
+                };
                 // Default: None
                 stmts.push(let_mut_stmt(
                     "__opt_result",
                     result_local,
                     target_type_id,
-                    option_none(target_type_id),
+                    opt_none_expr,
                 ));
 
                 // if disc != 0
@@ -736,9 +740,13 @@ pub(super) fn synthesize_lift_from_flat_params(
                 if inner_flat.is_empty() {
                     // Inner is unit — Some(())
                     let unit = TirExpr::new(TirExprKind::Unit, TypeTable::UNIT, synth_span());
+                    let opt_some_unit = {
+                        let tt = type_table_cell.borrow();
+                        option_some(unit, target_type_id, tt.compiler_items())
+                    };
                     then_stmts.push(expr_stmt(assign(
                         local_ref(result_local, "__opt_result", target_type_id),
-                        option_some(unit, target_type_id),
+                        opt_some_unit,
                     )));
                 } else {
                     let (inner_lifted, _) = synthesize_lift_from_flat_params(
@@ -753,9 +761,13 @@ pub(super) fn synthesize_lift_from_flat_params(
                         type_table_cell,
                         lift_ctx,
                     );
+                    let opt_some_inner = {
+                        let tt = type_table_cell.borrow();
+                        option_some(inner_lifted, target_type_id, tt.compiler_items())
+                    };
                     then_stmts.push(expr_stmt(assign(
                         local_ref(result_local, "__opt_result", target_type_id),
-                        option_some(inner_lifted, target_type_id),
+                        opt_some_inner,
                     )));
                 }
 
@@ -1176,11 +1188,18 @@ pub(super) fn synthesize_result_export_binding(
     err_stmts.push(return_stmt(None));
 
     // === Combine Ok/Err into if-else ===
+    let (ok_name_for_test, ok_index_for_test) = {
+        let tt = type_table.borrow();
+        let (_, _, n, i) = tt
+            .compiler_items()
+            .require_variant_case(crate::compiler_item::CompilerItem::ResultOk);
+        (n.to_string(), i)
+    };
     body_stmts.push(if_stmt(
         variant_test(
             local_ref(result_local, "__result", user_return_type),
-            0,
-            "Ok",
+            ok_index_for_test,
+            &ok_name_for_test,
         ),
         block(ok_stmts),
         Some(block(err_stmts)),

--- a/wado-compiler/src/synthesis/cm_binding/export_adapter.rs
+++ b/wado-compiler/src/synthesis/cm_binding/export_adapter.rs
@@ -96,7 +96,8 @@ fn lower_to_flat_inner(
     tir_modules: &IndexMap<ModuleSource, TirModule>,
     ctx: LiftContext<'_>,
 ) -> Vec<FlatLocal> {
-    let names = super::types::CmStdlibNames::from_type_table(&ctx.type_table.borrow());
+    let names =
+        super::types::CmStdlibNames::from_compiler_items(ctx.type_table.borrow().compiler_items());
     match resolved {
         ResolvedType::Primitive(p) => {
             let (flat_type_id, cm_type) = match p {
@@ -529,7 +530,8 @@ pub(super) fn synthesize_lift_from_flat_params(
     type_table_cell: &RefCell<TypeTable>,
     lift_ctx: LiftContext<'_>,
 ) -> (TirExpr, usize) {
-    let names = super::types::CmStdlibNames::from_type_table(&type_table_cell.borrow());
+    let names =
+        super::types::CmStdlibNames::from_compiler_items(type_table_cell.borrow().compiler_items());
     match ty {
         Type::Named(named) if named.name == names.string => {
             // String flat ABI: (ptr: i32, len: i32) pointing to linear memory

--- a/wado-compiler/src/synthesis/cm_binding/export_adapter.rs
+++ b/wado-compiler/src/synthesis/cm_binding/export_adapter.rs
@@ -410,8 +410,11 @@ fn lower_to_flat_inner(
 
                 // if disc != 0 { lower(variant_payload(value)) → inner_locals }
                 let mut then_stmts: Vec<TirStmt> = Vec::new();
-                let unwrapped =
-                    variant_payload(local_ref(opt_local, "__opt_val", type_id), 0, inner_type_id);
+                let unwrapped = variant_payload(
+                    local_ref(opt_local, "__opt_val", type_id),
+                    names.some_index,
+                    inner_type_id,
+                );
                 let inner_lowered = synthesize_lower_to_flat(
                     unwrapped,
                     inner_type_id,
@@ -1006,6 +1009,13 @@ pub(super) fn synthesize_result_export_binding(
             );
         }
     };
+    let (_, _, ok_case_name, ok_case_index) = tt
+        .compiler_items()
+        .require_variant_case(crate::compiler_item::CompilerItem::ResultOk);
+    let ok_case_name = ok_case_name.to_string();
+    let (_, _, _err_case_name, err_case_index) = tt
+        .compiler_items()
+        .require_variant_case(crate::compiler_item::CompilerItem::ResultErr);
     drop(tt);
 
     // Allocate mutable flat value locals (initialized to zero)
@@ -1038,7 +1048,7 @@ pub(super) fn synthesize_result_export_binding(
     // Extract Ok payload
     let ok_value = variant_payload(
         local_ref(result_local, "__result", user_return_type),
-        0, // Ok case index
+        ok_case_index,
         ok_type_id,
     );
 
@@ -1109,7 +1119,7 @@ pub(super) fn synthesize_result_export_binding(
     // Extract Err payload
     let err_value = variant_payload(
         local_ref(result_local, "__result", user_return_type),
-        1, // Err case index
+        err_case_index,
         err_type_id,
     );
     let err_local = alloc_local(&mut next_local, &mut locals, err_type_id);
@@ -1190,18 +1200,11 @@ pub(super) fn synthesize_result_export_binding(
     err_stmts.push(return_stmt(None));
 
     // === Combine Ok/Err into if-else ===
-    let (ok_name_for_test, ok_index_for_test) = {
-        let tt = type_table.borrow();
-        let (_, _, n, i) = tt
-            .compiler_items()
-            .require_variant_case(crate::compiler_item::CompilerItem::ResultOk);
-        (n.to_string(), i)
-    };
     body_stmts.push(if_stmt(
         variant_test(
             local_ref(result_local, "__result", user_return_type),
-            ok_index_for_test,
-            &ok_name_for_test,
+            ok_case_index,
+            &ok_case_name,
         ),
         block(ok_stmts),
         Some(block(err_stmts)),

--- a/wado-compiler/src/synthesis/cm_binding/import_adapter.rs
+++ b/wado-compiler/src/synthesis/cm_binding/import_adapter.rs
@@ -95,12 +95,22 @@ fn synthesize_lift_flat_result(
         let err_is_unit = matches!(err_ty, Type::Named(n) if n.name == "()")
             || matches!(err_ty, Type::Tuple(elems) if elems.is_empty());
 
+        let (ok_name, ok_index, err_name, err_index) = {
+            let tt = ctx.type_table.borrow();
+            let items = tt.compiler_items();
+            let (_, _, ok_n, ok_i) =
+                items.require_variant_case(crate::compiler_item::CompilerItem::ResultOk);
+            let (_, _, err_n, err_i) =
+                items.require_variant_case(crate::compiler_item::CompilerItem::ResultErr);
+            (ok_n.to_string(), ok_i, err_n.to_string(), err_i)
+        };
+
         let ok_construct = if ok_is_unit {
             TirExpr::new(
                 TirExprKind::VariantConstruct {
                     variant_type: result_type_id,
-                    case_index: 0,
-                    case_name: "Ok".to_string(),
+                    case_index: ok_index,
+                    case_name: ok_name.clone(),
                     payload: None,
                 },
                 result_type_id,
@@ -112,8 +122,8 @@ fn synthesize_lift_flat_result(
             TirExpr::new(
                 TirExprKind::VariantConstruct {
                     variant_type: result_type_id,
-                    case_index: 0,
-                    case_name: "Ok".to_string(),
+                    case_index: ok_index,
+                    case_name: ok_name.clone(),
                     payload: None,
                 },
                 result_type_id,
@@ -125,8 +135,8 @@ fn synthesize_lift_flat_result(
             TirExpr::new(
                 TirExprKind::VariantConstruct {
                     variant_type: result_type_id,
-                    case_index: 1,
-                    case_name: "Err".to_string(),
+                    case_index: err_index,
+                    case_name: err_name.clone(),
                     payload: None,
                 },
                 result_type_id,
@@ -156,8 +166,8 @@ fn synthesize_lift_flat_result(
                 TirExpr::new(
                     TirExprKind::VariantConstruct {
                         variant_type: result_type_id,
-                        case_index: 1,
-                        case_name: "Err".to_string(),
+                        case_index: err_index,
+                        case_name: err_name.clone(),
                         payload: Some(Box::new(lifted)),
                     },
                     result_type_id,
@@ -167,8 +177,8 @@ fn synthesize_lift_flat_result(
                 TirExpr::new(
                     TirExprKind::VariantConstruct {
                         variant_type: result_type_id,
-                        case_index: 1,
-                        case_name: "Err".to_string(),
+                        case_index: err_index,
+                        case_name: err_name.clone(),
                         payload: None,
                     },
                     result_type_id,

--- a/wado-compiler/src/synthesis/cm_binding/import_adapter.rs
+++ b/wado-compiler/src/synthesis/cm_binding/import_adapter.rs
@@ -371,7 +371,8 @@ pub(super) fn synthesize_adapter(
     owner_module: &ModuleSource,
     entry_source: &ModuleSource,
 ) -> AdapterArtifacts {
-    let names = super::types::CmStdlibNames::from_type_table(&type_table.borrow());
+    let names =
+        super::types::CmStdlibNames::from_compiler_items(type_table.borrow().compiler_items());
     let name = binding_func_name(&func_info.interface_name, &func_info.method_name);
     let local_name = func_info.local_alias_name();
 

--- a/wado-compiler/src/synthesis/cm_binding/import_adapter.rs
+++ b/wado-compiler/src/synthesis/cm_binding/import_adapter.rs
@@ -110,7 +110,7 @@ fn synthesize_lift_flat_result(
                 TirExprKind::VariantConstruct {
                     variant_type: result_type_id,
                     case_index: ok_index,
-                    case_name: ok_name.clone(),
+                    case_name: ok_name,
                     payload: None,
                 },
                 result_type_id,
@@ -123,7 +123,7 @@ fn synthesize_lift_flat_result(
                 TirExprKind::VariantConstruct {
                     variant_type: result_type_id,
                     case_index: ok_index,
-                    case_name: ok_name.clone(),
+                    case_name: ok_name,
                     payload: None,
                 },
                 result_type_id,
@@ -136,7 +136,7 @@ fn synthesize_lift_flat_result(
                 TirExprKind::VariantConstruct {
                     variant_type: result_type_id,
                     case_index: err_index,
-                    case_name: err_name.clone(),
+                    case_name: err_name,
                     payload: None,
                 },
                 result_type_id,
@@ -167,7 +167,7 @@ fn synthesize_lift_flat_result(
                     TirExprKind::VariantConstruct {
                         variant_type: result_type_id,
                         case_index: err_index,
-                        case_name: err_name.clone(),
+                        case_name: err_name,
                         payload: Some(Box::new(lifted)),
                     },
                     result_type_id,
@@ -178,7 +178,7 @@ fn synthesize_lift_flat_result(
                     TirExprKind::VariantConstruct {
                         variant_type: result_type_id,
                         case_index: err_index,
-                        case_name: err_name.clone(),
+                        case_name: err_name,
                         payload: None,
                     },
                     result_type_id,

--- a/wado-compiler/src/synthesis/cm_binding/lift.rs
+++ b/wado-compiler/src/synthesis/cm_binding/lift.rs
@@ -938,7 +938,7 @@ fn synthesize_lift_result_inner(
             TirExprKind::VariantConstruct {
                 variant_type: result_type_id,
                 case_index: ok_index,
-                case_name: ok_name.clone(),
+                case_name: ok_name,
                 payload: ok_payload,
             },
             result_type_id,
@@ -968,7 +968,7 @@ fn synthesize_lift_result_inner(
             TirExprKind::VariantConstruct {
                 variant_type: result_type_id,
                 case_index: err_index,
-                case_name: err_name.clone(),
+                case_name: err_name,
                 payload: err_payload,
             },
             result_type_id,

--- a/wado-compiler/src/synthesis/cm_binding/lift.rs
+++ b/wado-compiler/src/synthesis/cm_binding/lift.rs
@@ -806,11 +806,15 @@ fn synthesize_lift_option_inner(
     ));
 
     let result_local = alloc_local(next_local, locals, option_type_id);
+    let none_init = {
+        let tt = ctx.type_table.borrow();
+        option_none(option_type_id, tt.compiler_items())
+    };
     stmts.push(let_mut_stmt(
         "__option_result",
         result_local,
         option_type_id,
-        option_none(option_type_id),
+        none_init,
     ));
 
     // if __disc != 0 { __option_result = Some(lift(inner, addr + offset)); }
@@ -824,9 +828,13 @@ fn synthesize_lift_option_inner(
         locals,
         ctx,
     );
+    let some_expr = {
+        let tt = ctx.type_table.borrow();
+        option_some(lifted, option_type_id, tt.compiler_items())
+    };
     then_stmts.push(expr_stmt(assign(
         local_ref(result_local, "__option_result", option_type_id),
-        option_some(lifted, option_type_id),
+        some_expr,
     )));
     then_stmts.extend(synthesize_free_element(
         inner_ty,
@@ -879,11 +887,23 @@ fn synthesize_lift_result_inner(
 
     // Determine the proper variant TypeId for Result<ok_ty, err_ty> so that the
     // mutable local is typed as a GC reference (not i32).
-    let result_type_id = {
+    let (result_type_id, ok_name, ok_index, err_name, err_index) = {
         let mut tt = ctx.type_table.borrow_mut();
         let ok_type_id = wasi_type_to_type_id(ok_ty, &mut tt, ctx.wasi_registry, ctx.cm_package);
         let err_type_id = wasi_type_to_type_id(err_ty, &mut tt, ctx.wasi_registry, ctx.cm_package);
-        tt.make_result(ok_type_id, err_type_id)
+        let result_type_id = tt.make_result(ok_type_id, err_type_id);
+        let items = tt.compiler_items();
+        let (_, _, ok_n, ok_i) =
+            items.require_variant_case(crate::compiler_item::CompilerItem::ResultOk);
+        let (_, _, err_n, err_i) =
+            items.require_variant_case(crate::compiler_item::CompilerItem::ResultErr);
+        (
+            result_type_id,
+            ok_n.to_string(),
+            ok_i,
+            err_n.to_string(),
+            err_i,
+        )
     };
 
     let result_local = alloc_local(next_local, locals, result_type_id);
@@ -917,8 +937,8 @@ fn synthesize_lift_result_inner(
         TirExpr::new(
             TirExprKind::VariantConstruct {
                 variant_type: result_type_id,
-                case_index: 0,
-                case_name: "Ok".to_string(),
+                case_index: ok_index,
+                case_name: ok_name.clone(),
                 payload: ok_payload,
             },
             result_type_id,
@@ -947,8 +967,8 @@ fn synthesize_lift_result_inner(
         TirExpr::new(
             TirExprKind::VariantConstruct {
                 variant_type: result_type_id,
-                case_index: 1,
-                case_name: "Err".to_string(),
+                case_index: err_index,
+                case_name: err_name.clone(),
                 payload: err_payload,
             },
             result_type_id,

--- a/wado-compiler/src/synthesis/cm_binding/lower.rs
+++ b/wado-compiler/src/synthesis/cm_binding/lower.rs
@@ -406,6 +406,7 @@ pub(super) fn synthesize_lower_option_to_memory(
     type_table: &RefCell<TypeTable>,
 ) {
     let value_type_id = value.type_id;
+    let names = super::types::CmStdlibNames::from_type_table(&type_table.borrow());
 
     // Materialize value into a local so we can reference it multiple times
     let value_local = alloc_local(next_local, locals, value_type_id);
@@ -420,8 +421,8 @@ pub(super) fn synthesize_lower_option_to_memory(
             addr.clone(),
             variant_test(
                 local_ref(value_local, "__opt_val", value_type_id),
-                0,
-                "Some",
+                names.some_index,
+                &names.some_name,
             ),
         ],
         TypeTable::UNIT,
@@ -444,7 +445,7 @@ pub(super) fn synthesize_lower_option_to_memory(
     };
     let payload_expr = variant_payload(
         local_ref(value_local, "__opt_val", value_type_id),
-        0,
+        names.some_index,
         inner_type_id,
     );
 
@@ -462,8 +463,8 @@ pub(super) fn synthesize_lower_option_to_memory(
     stmts.push(if_stmt(
         variant_test(
             local_ref(value_local, "__opt_val", value_type_id),
-            0,
-            "Some",
+            names.some_index,
+            &names.some_name,
         ),
         block(case_stmts),
         None,
@@ -673,8 +674,8 @@ pub(super) fn synthesize_flatten_option_to_flat_args(
         TypeTable::I32,
         variant_test(
             local_ref(val_local, &format!("{prefix}_optval"), vt),
-            0,
-            "Some",
+            names.some_index,
+            &names.some_name,
         ),
     ));
     flat_args.push(local_ref(
@@ -708,7 +709,7 @@ pub(super) fn synthesize_flatten_option_to_flat_args(
     };
     let payload_expr = variant_payload(
         local_ref(val_local, &format!("{prefix}_optval"), vt),
-        0, // case_index 0 = Some
+        names.some_index,
         inner_type_id,
     );
 
@@ -739,8 +740,8 @@ pub(super) fn synthesize_flatten_option_to_flat_args(
     stmts.push(if_stmt(
         variant_test(
             local_ref(val_local, &format!("{prefix}_optval"), vt),
-            0,
-            "Some",
+            names.some_index,
+            &names.some_name,
         ),
         block(some_stmts),
         None,

--- a/wado-compiler/src/synthesis/cm_binding/lower.rs
+++ b/wado-compiler/src/synthesis/cm_binding/lower.rs
@@ -224,7 +224,8 @@ pub(super) fn synthesize_lower_tuple(
     wasi_package: &str,
     type_table: &RefCell<TypeTable>,
 ) -> Vec<TirStmt> {
-    let names = super::types::CmStdlibNames::from_type_table(&type_table.borrow());
+    let names =
+        super::types::CmStdlibNames::from_compiler_items(type_table.borrow().compiler_items());
     let layout = cm_abi::layout_tuple(elems);
     let mut stmts = Vec::new();
 
@@ -406,7 +407,8 @@ pub(super) fn synthesize_lower_option_to_memory(
     type_table: &RefCell<TypeTable>,
 ) {
     let value_type_id = value.type_id;
-    let names = super::types::CmStdlibNames::from_type_table(&type_table.borrow());
+    let names =
+        super::types::CmStdlibNames::from_compiler_items(type_table.borrow().compiler_items());
 
     // Materialize value into a local so we can reference it multiple times
     let value_local = alloc_local(next_local, locals, value_type_id);
@@ -488,7 +490,8 @@ pub(super) fn synthesize_flatten_value_to_flat_args(
     wasi_package: &str,
     type_table: &RefCell<TypeTable>,
 ) {
-    let names = super::types::CmStdlibNames::from_type_table(&type_table.borrow());
+    let names =
+        super::types::CmStdlibNames::from_compiler_items(type_table.borrow().compiler_items());
     let resolved = wasi_registry.resolve_type(ty);
     match &resolved {
         // String → cm_lower_string → packed i64 → (ptr, len)
@@ -659,7 +662,8 @@ pub(super) fn synthesize_flatten_option_to_flat_args(
     wasi_package: &str,
     type_table: &RefCell<TypeTable>,
 ) {
-    let names = super::types::CmStdlibNames::from_type_table(&type_table.borrow());
+    let names =
+        super::types::CmStdlibNames::from_compiler_items(type_table.borrow().compiler_items());
     let vt = value.type_id;
     let val_local = alloc_local(next_local, locals, vt);
     stmts.push(let_stmt(&format!("{prefix}_optval"), val_local, vt, value));
@@ -764,7 +768,8 @@ pub(super) fn synthesize_lower_wasi_type_to_memory(
     wasi_package: &str,
     type_table: &RefCell<TypeTable>,
 ) -> Vec<TirStmt> {
-    let names = super::types::CmStdlibNames::from_type_table(&type_table.borrow());
+    let names =
+        super::types::CmStdlibNames::from_compiler_items(type_table.borrow().compiler_items());
     let resolved = wasi_registry.resolve_type(ty);
     match &resolved {
         Type::Named(n) => {

--- a/wado-compiler/src/synthesis/cm_binding/resource_rewrite.rs
+++ b/wado-compiler/src/synthesis/cm_binding/resource_rewrite.rs
@@ -234,7 +234,8 @@ fn synthesize_stream_read_func(
     interner: &RefCell<ModuleSourceInterner>,
 ) -> TirFunction {
     let array_struct_name =
-        super::types::CmStdlibNames::from_type_table(&type_table.borrow()).array;
+        super::types::CmStdlibNames::from_compiler_items(type_table.borrow().compiler_items())
+            .array;
     let func_name = format!("__cm_stream_read_{elem_name}");
     let _tuple_type_id = type_table
         .borrow_mut()

--- a/wado-compiler/src/synthesis/cm_binding/task_return.rs
+++ b/wado-compiler/src/synthesis/cm_binding/task_return.rs
@@ -269,6 +269,10 @@ fn generate_inline_task_return(
             }
             _ => panic!("Expected Result<T, E> type"),
         };
+        let items = tt.compiler_items();
+        let (_, _, ok_case_name, ok_case_index) =
+            items.require_variant_case(crate::compiler_item::CompilerItem::ResultOk);
+        let ok_case_name = ok_case_name.to_string();
         drop(tt);
 
         // Store result in local
@@ -306,7 +310,7 @@ fn generate_inline_task_return(
         )));
         let ok_value = variant_payload(
             local_ref(result_local, "__task_ret", value_type_id),
-            0,
+            ok_case_index,
             ok_type_id,
         );
         let tt = type_table.borrow();
@@ -425,8 +429,8 @@ fn generate_inline_task_return(
         stmts.push(if_stmt(
             variant_test(
                 local_ref(result_local, "__task_ret", value_type_id),
-                0,
-                "Ok",
+                ok_case_index,
+                &ok_case_name,
             ),
             block(ok_stmts),
             Some(block(err_stmts)),

--- a/wado-compiler/src/synthesis/cm_binding/task_return.rs
+++ b/wado-compiler/src/synthesis/cm_binding/task_return.rs
@@ -273,6 +273,8 @@ fn generate_inline_task_return(
         let (_, _, ok_case_name, ok_case_index) =
             items.require_variant_case(crate::compiler_item::CompilerItem::ResultOk);
         let ok_case_name = ok_case_name.to_string();
+        let (_, _, _err_case_name, err_case_index) =
+            items.require_variant_case(crate::compiler_item::CompilerItem::ResultErr);
         drop(tt);
 
         // Store result in local
@@ -363,7 +365,7 @@ fn generate_inline_task_return(
         )));
         let err_value = variant_payload(
             local_ref(result_local, "__task_ret", value_type_id),
-            1,
+            err_case_index,
             err_type_id,
         );
         let err_local = alloc_local(next_local, locals, err_type_id);

--- a/wado-compiler/src/synthesis/cm_binding/type_fixup.rs
+++ b/wado-compiler/src/synthesis/cm_binding/type_fixup.rs
@@ -684,7 +684,12 @@ fn fixup_expr_type(expr: &mut TirExpr, old_type: TypeId, new_type: TypeId) {
 ///
 /// For multi-flat types like `Option<T>`, the Wado-level arg (e.g., `null`)
 /// is expanded into multiple i32 args (discriminant + payload).
-fn flatten_arg_for_call_site(arg: &TirExpr, flat_tys: &[TypeId], flat_args: &mut Vec<TirExpr>) {
+fn flatten_arg_for_call_site(
+    arg: &TirExpr,
+    flat_tys: &[TypeId],
+    flat_args: &mut Vec<TirExpr>,
+    names: &super::types::CmStdlibNames,
+) {
     // Unwrap Cast nodes transparently
     let inner = match &arg.kind {
         TirExprKind::Cast { expr, .. } => expr.as_ref(),
@@ -702,7 +707,7 @@ fn flatten_arg_for_call_site(arg: &TirExpr, flat_tys: &[TypeId], flat_args: &mut
             case_name,
             payload: None,
             ..
-        } if case_name == "None" => {
+        } if case_name == &names.none_name => {
             for _ in flat_tys {
                 flat_args.push(i32_const(0));
             }
@@ -712,12 +717,12 @@ fn flatten_arg_for_call_site(arg: &TirExpr, flat_tys: &[TypeId], flat_args: &mut
             case_name,
             payload: Some(value),
             ..
-        } if case_name == "Some" => {
+        } if case_name == &names.some_name => {
             flat_args.push(i32_const(1));
             let remaining = &flat_tys[1..];
             if remaining.len() == 1 {
                 // Single-value payload: pass through (e.g., enum discriminant)
-                flatten_arg_for_call_site(value, remaining, flat_args);
+                flatten_arg_for_call_site(value, remaining, flat_args, names);
             } else {
                 // Multi-value payload (e.g., String → ptr+len): pass through as-is
                 // The binding will lower it internally
@@ -1149,23 +1154,27 @@ fn rewrite_calls_in_expr(
                     }
                     if is_gc_passthrough_param(param_type, wasi_registry, &names) {
                         if matches!(arg.expr.kind, TirExprKind::Null) {
-                            let option_type_id = {
+                            let (option_type_id, none_expr) = {
                                 let mut tt = type_table.borrow_mut();
-                                wasi_type_to_type_id(
+                                let option_type_id = wasi_type_to_type_id(
                                     param_type,
                                     &mut tt,
                                     wasi_registry,
                                     &func_info.package,
-                                )
+                                );
+                                let none_expr =
+                                    option_none(option_type_id, tt.compiler_items());
+                                (option_type_id, none_expr)
                             };
-                            flat.push(option_none(option_type_id));
+                            let _ = option_type_id;
+                            flat.push(none_expr);
                         } else {
                             flat.push(arg.expr.clone());
                         }
                     } else if flat_tys.len() == 1 {
                         flat.push(arg.expr.clone());
                     } else {
-                        flatten_arg_for_call_site(&arg.expr, &flat_tys, &mut flat);
+                        flatten_arg_for_call_site(&arg.expr, &flat_tys, &mut flat, &names);
                     }
                 }
                 flat
@@ -1297,23 +1306,27 @@ fn rewrite_calls_in_expr(
                         // to get a properly-resolved type_id, since the
                         // source null's type_id may have unknown inner type.
                         if matches!(arg.kind, TirExprKind::Null) {
-                            let option_type_id = {
+                            let (option_type_id, none_expr) = {
                                 let mut tt = type_table.borrow_mut();
-                                wasi_type_to_type_id(
+                                let option_type_id = wasi_type_to_type_id(
                                     param_type,
                                     &mut tt,
                                     wasi_registry,
                                     &func_info.package,
-                                )
+                                );
+                                let none_expr =
+                                    option_none(option_type_id, tt.compiler_items());
+                                (option_type_id, none_expr)
                             };
-                            flat.push(option_none(option_type_id));
+                            let _ = option_type_id;
+                            flat.push(none_expr);
                         } else {
                             flat.push(arg.clone());
                         }
                     } else if flat_tys.len() == 1 {
                         flat.push(taken_args[i].clone());
                     } else {
-                        flatten_arg_for_call_site(&taken_args[i], &flat_tys, &mut flat);
+                        flatten_arg_for_call_site(&taken_args[i], &flat_tys, &mut flat, &names);
                     }
                 }
                 flat

--- a/wado-compiler/src/synthesis/cm_binding/type_fixup.rs
+++ b/wado-compiler/src/synthesis/cm_binding/type_fixup.rs
@@ -1162,8 +1162,7 @@ fn rewrite_calls_in_expr(
                                     wasi_registry,
                                     &func_info.package,
                                 );
-                                let none_expr =
-                                    option_none(option_type_id, tt.compiler_items());
+                                let none_expr = option_none(option_type_id, tt.compiler_items());
                                 (option_type_id, none_expr)
                             };
                             let _ = option_type_id;
@@ -1314,8 +1313,7 @@ fn rewrite_calls_in_expr(
                                     wasi_registry,
                                     &func_info.package,
                                 );
-                                let none_expr =
-                                    option_none(option_type_id, tt.compiler_items());
+                                let none_expr = option_none(option_type_id, tt.compiler_items());
                                 (option_type_id, none_expr)
                             };
                             let _ = option_type_id;

--- a/wado-compiler/src/synthesis/cm_binding/type_fixup.rs
+++ b/wado-compiler/src/synthesis/cm_binding/type_fixup.rs
@@ -39,7 +39,8 @@ fn replace_wasi_derived_type_recursive(
     wasi_package: &str,
     type_table: &RefCell<TypeTable>,
 ) {
-    let names = super::types::CmStdlibNames::from_type_table(&type_table.borrow());
+    let names =
+        super::types::CmStdlibNames::from_compiler_items(type_table.borrow().compiler_items());
     let old_type = {
         let mut tt = type_table.borrow_mut();
         wasi_type_to_type_id(wasi_type, &mut tt, wasi_registry, wasi_package)
@@ -886,7 +887,8 @@ fn rewrite_calls_in_expr(
     wasi_registry: &WasiRegistry,
     type_table: &Rc<RefCell<TypeTable>>,
 ) {
-    let names = super::types::CmStdlibNames::from_type_table(&type_table.borrow());
+    let names =
+        super::types::CmStdlibNames::from_compiler_items(type_table.borrow().compiler_items());
     // Check if this is an effect-like Call that should be rewritten
     let is_effect_call = matches!(&expr.kind, TirExprKind::Call { func, .. }
         if func.module_source.clone().is_effect_like() && func.module_source.clone().interface_name().is_some());

--- a/wado-compiler/src/synthesis/cm_binding/types.rs
+++ b/wado-compiler/src/synthesis/cm_binding/types.rs
@@ -37,20 +37,44 @@ pub struct CmStdlibNames {
     pub array: String,
     pub option: String,
     pub result: String,
+    /// `Option::Some` case name + zero-based index.
+    pub some_name: String,
+    pub some_index: u32,
+    /// `Option::None` case name + zero-based index.
+    pub none_name: String,
+    pub none_index: u32,
+    /// `Result::Ok` case name + zero-based index.
+    pub ok_name: String,
+    pub ok_index: u32,
+    /// `Result::Err` case name + zero-based index.
+    pub err_name: String,
+    pub err_index: u32,
 }
 
 impl CmStdlibNames {
     /// Look up every name through the compiler-item registry attached
-    /// to `tt`. Cheap (four registry hits + four clones); callers
+    /// to `tt`. Cheap (a handful of registry hits + clones); callers
     /// should keep the value around for the duration of a CM-binding
     /// synthesis pass rather than rebuilding it per match arm.
     pub fn from_type_table(tt: &TypeTable) -> Self {
         let items = tt.compiler_items();
+        let (_, _, some_name, some_index) = items.require_variant_case(CompilerItem::OptionSome);
+        let (_, _, none_name, none_index) = items.require_variant_case(CompilerItem::OptionNone);
+        let (_, _, ok_name, ok_index) = items.require_variant_case(CompilerItem::ResultOk);
+        let (_, _, err_name, err_index) = items.require_variant_case(CompilerItem::ResultErr);
         Self {
             string: items.struct_name(CompilerItem::String).to_string(),
             array: items.struct_name(CompilerItem::Array).to_string(),
             option: items.variant_name(CompilerItem::Option).to_string(),
             result: items.variant_name(CompilerItem::Result).to_string(),
+            some_name: some_name.to_string(),
+            some_index,
+            none_name: none_name.to_string(),
+            none_index,
+            ok_name: ok_name.to_string(),
+            ok_index,
+            err_name: err_name.to_string(),
+            err_index,
         }
     }
 
@@ -65,6 +89,14 @@ impl CmStdlibNames {
             array: "Array".to_string(),
             option: "Option".to_string(),
             result: "Result".to_string(),
+            some_name: "Some".to_string(),
+            some_index: 0,
+            none_name: "None".to_string(),
+            none_index: 1,
+            ok_name: "Ok".to_string(),
+            ok_index: 0,
+            err_name: "Err".to_string(),
+            err_index: 1,
         }
     }
 }

--- a/wado-compiler/src/synthesis/cm_binding/types.rs
+++ b/wado-compiler/src/synthesis/cm_binding/types.rs
@@ -53,9 +53,9 @@ pub struct CmStdlibNames {
 
 impl CmStdlibNames {
     /// Look up every name through the [`CompilerItems`] registry.
-    /// Cheap (a handful of registry hits + clones); cm_binding's
-    /// multi-entry-point shape (lift / lower / adapter / type_fixup /
-    /// task_return are all called independently from outside paths)
+    /// Cheap (a handful of registry hits + clones); `cm_binding`'s
+    /// multi-entry-point shape (lift / lower / adapter / `type_fixup` /
+    /// `task_return` are all called independently from outside paths)
     /// means each entry rebuilds the snapshot locally rather than
     /// threading a single one through a single context — mirrors the
     /// `from_compiler_items` constructor shape used by the other

--- a/wado-compiler/src/synthesis/cm_binding/types.rs
+++ b/wado-compiler/src/synthesis/cm_binding/types.rs
@@ -8,7 +8,7 @@ use std::cell::RefCell;
 
 use crate::ast::{AstId, GenericType, NamedType, Type};
 use crate::cm_abi;
-use crate::compiler_item::CompilerItem;
+use crate::compiler_item::{CompilerItem, CompilerItems};
 use crate::component_model::WasiRegistry;
 use crate::hashmap::IndexMap;
 use crate::module_source::{ModuleSource, ModuleSourceInterner};
@@ -52,12 +52,16 @@ pub struct CmStdlibNames {
 }
 
 impl CmStdlibNames {
-    /// Look up every name through the compiler-item registry attached
-    /// to `tt`. Cheap (a handful of registry hits + clones); callers
-    /// should keep the value around for the duration of a CM-binding
-    /// synthesis pass rather than rebuilding it per match arm.
-    pub fn from_type_table(tt: &TypeTable) -> Self {
-        let items = tt.compiler_items();
+    /// Look up every name through the [`CompilerItems`] registry.
+    /// Cheap (a handful of registry hits + clones); cm_binding's
+    /// multi-entry-point shape (lift / lower / adapter / type_fixup /
+    /// task_return are all called independently from outside paths)
+    /// means each entry rebuilds the snapshot locally rather than
+    /// threading a single one through a single context — mirrors the
+    /// `from_compiler_items` constructor shape used by the other
+    /// synthesis passes (`SerdeStdlibNames`, `FormatStdlibNames`,
+    /// `TraitsStdlibNames`).
+    pub fn from_compiler_items(items: &CompilerItems) -> Self {
         let (_, _, some_name, some_index) = items.require_variant_case(CompilerItem::OptionSome);
         let (_, _, none_name, none_index) = items.require_variant_case(CompilerItem::OptionNone);
         let (_, _, ok_name, ok_index) = items.require_variant_case(CompilerItem::ResultOk);
@@ -620,7 +624,7 @@ pub(super) fn flatten_export_type(
     tir_modules: &IndexMap<ModuleSource, TirModule>,
     type_table: &TypeTable,
 ) {
-    let names = CmStdlibNames::from_type_table(type_table);
+    let names = CmStdlibNames::from_compiler_items(type_table.compiler_items());
     match ty {
         Type::Named(named) if named.name == names.string => {
             out.push(cm_abi::CmValType::I32); // ptr
@@ -734,7 +738,7 @@ pub(super) fn flat_types_from_type_id_into(
     tir_modules: &IndexMap<ModuleSource, TirModule>,
     type_table: &TypeTable,
 ) {
-    let names = CmStdlibNames::from_type_table(type_table);
+    let names = CmStdlibNames::from_compiler_items(type_table.compiler_items());
     match type_table.get(type_id) {
         ResolvedType::Primitive(p) => match p {
             PrimitiveType::I8

--- a/wado-compiler/src/synthesis/common.rs
+++ b/wado-compiler/src/synthesis/common.rs
@@ -471,19 +471,19 @@ pub fn make_synthetic_method(
 /// wrapped in an explicit `Ref`; `ref_string_type` is the cached `&String`
 /// type id the caller already produced from `string_type`.
 ///
-/// The `Formatter` struct name is **not** taken as a parameter because
-/// `Formatter` is a [`CompilerItem`] anchor — the `LocalMethodName` /
-/// `FunctionRef` use the literal `"Formatter"` only because this helper
-/// is called from many sites and the struct is always referenced under
-/// the canonical name. Migrating the callers to thread a snapshot
-/// through is tracked alongside the rest of the
-/// `CompilerItem::Formatter` flow.
+/// `formatter_name` is the resolved [`CompilerItem::Formatter`] struct
+/// name. Every caller already snapshotted it (either via
+/// [`super::traits::TraitsStdlibNames`] on `SynthesisCtx`, or by reading
+/// it directly off `tt.compiler_items()`), so threading it through this
+/// helper avoids a fresh registry lookup per call without re-introducing
+/// the `"Formatter"` literal here.
 pub fn write_str_stmt(
     text: impl Into<String>,
     fmt: TirExpr,
     string_type: TypeId,
     ref_string_type: TypeId,
     span: Span,
+    formatter_name: &str,
 ) -> TirStmt {
     let literal = TirExpr::new(TirExprKind::StringLiteral(text.into()), string_type, span);
     let arg = TirExpr::new(
@@ -499,10 +499,10 @@ pub fn write_str_stmt(
             Box::new(fmt),
             FunctionRef {
                 module_source: ModuleSource::format(),
-                name: "Formatter::write_str".to_string(),
+                name: format!("{formatter_name}::write_str"),
                 monomorph_info: None,
                 method_info: Some(LocalMethodName::new(
-                    "Formatter".to_string(),
+                    formatter_name.to_string(),
                     None,
                     "write_str".to_string(),
                 )),

--- a/wado-compiler/src/synthesis/common.rs
+++ b/wado-compiler/src/synthesis/common.rs
@@ -476,6 +476,14 @@ pub fn make_synthetic_method(
 /// method. `Formatter::write_str` takes `&String`, so the literal is
 /// wrapped in an explicit `Ref`; `ref_string_type` is the cached `&String`
 /// type id the caller already produced from `string_type`.
+///
+/// The `Formatter` struct name is **not** taken as a parameter because
+/// `Formatter` is a [`CompilerItem`] anchor — the `LocalMethodName` /
+/// `FunctionRef` use the literal `"Formatter"` only because this helper
+/// is called from many sites and the struct is always referenced under
+/// the canonical name. Migrating the callers to thread a snapshot
+/// through is tracked alongside the rest of the
+/// `CompilerItem::Formatter` flow.
 pub fn write_str_stmt(
     text: impl Into<String>,
     fmt: TirExpr,

--- a/wado-compiler/src/synthesis/common.rs
+++ b/wado-compiler/src/synthesis/common.rs
@@ -5,6 +5,7 @@
 //! - TIR expression and statement builders
 //! - Synthetic function creation
 
+use crate::compiler_item::{CompilerItem, CompilerItems};
 use crate::hashmap::IndexSet;
 
 use crate::module_source::ModuleSource;
@@ -239,12 +240,23 @@ pub fn cm_raw_call(local_name: &str, args: Vec<TirExpr>, return_type: TypeId) ->
 }
 
 /// Create an `Option::Some(value)` expression.
-pub fn option_some(value: TirExpr, option_type_id: TypeId) -> TirExpr {
+///
+/// Looks up the `Some` case name + index through the
+/// [`CompilerItem::OptionSome`] anchor so stdlib renames flow through
+/// without touching synthesis sites. See `compiler_item.rs` for the
+/// design.
+pub fn option_some(
+    value: TirExpr,
+    option_type_id: TypeId,
+    items: &CompilerItems,
+) -> TirExpr {
+    let (_, _, case_name, case_index) =
+        items.require_variant_case(CompilerItem::OptionSome);
     TirExpr::new(
         TirExprKind::VariantConstruct {
             variant_type: option_type_id,
-            case_index: 0,
-            case_name: "Some".to_string(),
+            case_index,
+            case_name: case_name.to_string(),
             payload: Some(Box::new(value)),
         },
         option_type_id,
@@ -252,13 +264,16 @@ pub fn option_some(value: TirExpr, option_type_id: TypeId) -> TirExpr {
     )
 }
 
-/// Create a `null` (`Option::None`) expression.
-pub fn option_none(option_type_id: TypeId) -> TirExpr {
+/// Create a `null` (`Option::None`) expression. See [`option_some`] for
+/// the registry-lookup contract.
+pub fn option_none(option_type_id: TypeId, items: &CompilerItems) -> TirExpr {
+    let (_, _, case_name, case_index) =
+        items.require_variant_case(CompilerItem::OptionNone);
     TirExpr::new(
         TirExprKind::VariantConstruct {
             variant_type: option_type_id,
-            case_index: 1,
-            case_name: "None".to_string(),
+            case_index,
+            case_name: case_name.to_string(),
             payload: None,
         },
         option_type_id,

--- a/wado-compiler/src/synthesis/common.rs
+++ b/wado-compiler/src/synthesis/common.rs
@@ -245,13 +245,8 @@ pub fn cm_raw_call(local_name: &str, args: Vec<TirExpr>, return_type: TypeId) ->
 /// [`CompilerItem::OptionSome`] anchor so stdlib renames flow through
 /// without touching synthesis sites. See `compiler_item.rs` for the
 /// design.
-pub fn option_some(
-    value: TirExpr,
-    option_type_id: TypeId,
-    items: &CompilerItems,
-) -> TirExpr {
-    let (_, _, case_name, case_index) =
-        items.require_variant_case(CompilerItem::OptionSome);
+pub fn option_some(value: TirExpr, option_type_id: TypeId, items: &CompilerItems) -> TirExpr {
+    let (_, _, case_name, case_index) = items.require_variant_case(CompilerItem::OptionSome);
     TirExpr::new(
         TirExprKind::VariantConstruct {
             variant_type: option_type_id,
@@ -267,8 +262,7 @@ pub fn option_some(
 /// Create a `null` (`Option::None`) expression. See [`option_some`] for
 /// the registry-lookup contract.
 pub fn option_none(option_type_id: TypeId, items: &CompilerItems) -> TirExpr {
-    let (_, _, case_name, case_index) =
-        items.require_variant_case(CompilerItem::OptionNone);
+    let (_, _, case_name, case_index) = items.require_variant_case(CompilerItem::OptionNone);
     TirExpr::new(
         TirExprKind::VariantConstruct {
             variant_type: option_type_id,

--- a/wado-compiler/src/synthesis/effect_dispatch.rs
+++ b/wado-compiler/src/synthesis/effect_dispatch.rs
@@ -1730,7 +1730,10 @@ fn desugar_with_handler(expr: &mut TirExpr, env: &DispatchEnv, ctx: &mut LowerCt
             span,
         );
         let d_ref = ref_expr(d_local_expr, plan.inner_ref_type_id, span);
-        let some_d_ref = option_some(d_ref, plan.nullable_ref_type_id);
+        let some_d_ref = {
+            let tt = env.type_table.borrow();
+            option_some(d_ref, plan.nullable_ref_type_id, tt.compiler_items())
+        };
         prelude.push(TirStmt::new(
             TirStmtKind::Expr(TirExpr::new(
                 TirExprKind::GlobalVarSet {

--- a/wado-compiler/src/synthesis/effect_dispatch.rs
+++ b/wado-compiler/src/synthesis/effect_dispatch.rs
@@ -829,9 +829,15 @@ fn build_dispatch_wrapper_function(
         nullable_ref_type_id,
         span,
     );
+    let some_case_name = {
+        let tt = type_table.borrow();
+        tt.compiler_items()
+            .variant_case_name(crate::compiler_item::CompilerItem::OptionSome)
+            .to_string()
+    };
     let pattern = TirPattern::Variant {
         enum_type: nullable_ref_type_id,
-        variant_name: "Some".to_string(),
+        variant_name: some_case_name,
         bindings: vec![TirPattern::Binding {
             name: "__d".to_string(),
             local_index: d_local,

--- a/wado-compiler/src/synthesis/serde_synth.rs
+++ b/wado-compiler/src/synthesis/serde_synth.rs
@@ -65,6 +65,30 @@ pub(super) struct SerdeStdlibNames {
     pub deser_err_unknown_variant_index: u32,
     pub deser_err_invalid_value_name: String,
     pub deser_err_invalid_value_index: u32,
+    /// `Serializer` associated type spellings: `SeqSerializer`,
+    /// `StructSerializer`, `VariantSerializer`. Auto-captured from the
+    /// trait declaration so the synthesiser can build `S::SeqSerializer`
+    /// projections without hard-coding the source-side names.
+    pub seq_serializer_assoc: String,
+    pub struct_serializer_assoc: String,
+    pub variant_serializer_assoc: String,
+    /// `Deserializer` associated type spellings: `SeqAccess`,
+    /// `StructAccess`, `VariantAccess`.
+    pub seq_access_assoc: String,
+    pub struct_access_assoc: String,
+    pub variant_access_assoc: String,
+    /// Pre-formatted `S::<assoc>` / `D::<assoc>` projection labels used
+    /// by `type_param_method_call` as the receiver's struct-name slot
+    /// (`S` is the conventional `Serializer` type parameter; `D`, the
+    /// `Deserializer` one). Reading these from the snapshot keeps all
+    /// associated-type references in this file routed through
+    /// [`CompilerItems::trait_assoc_type_name`].
+    pub s_struct_serializer_proj: String,
+    pub s_seq_serializer_proj: String,
+    pub s_variant_serializer_proj: String,
+    pub d_struct_access_proj: String,
+    pub d_seq_access_proj: String,
+    pub d_variant_access_proj: String,
 }
 
 impl SerdeStdlibNames {
@@ -120,6 +144,48 @@ impl SerdeStdlibNames {
             deser_err_unknown_variant_index,
             deser_err_invalid_value_name: deser_err_invalid_value_name.to_string(),
             deser_err_invalid_value_index,
+            seq_serializer_assoc: items
+                .trait_assoc_type_name(CompilerItem::Serializer, "SeqSerializer")
+                .to_string(),
+            struct_serializer_assoc: items
+                .trait_assoc_type_name(CompilerItem::Serializer, "StructSerializer")
+                .to_string(),
+            variant_serializer_assoc: items
+                .trait_assoc_type_name(CompilerItem::Serializer, "VariantSerializer")
+                .to_string(),
+            seq_access_assoc: items
+                .trait_assoc_type_name(CompilerItem::Deserializer, "SeqAccess")
+                .to_string(),
+            struct_access_assoc: items
+                .trait_assoc_type_name(CompilerItem::Deserializer, "StructAccess")
+                .to_string(),
+            variant_access_assoc: items
+                .trait_assoc_type_name(CompilerItem::Deserializer, "VariantAccess")
+                .to_string(),
+            s_struct_serializer_proj: format!(
+                "S::{}",
+                items.trait_assoc_type_name(CompilerItem::Serializer, "StructSerializer")
+            ),
+            s_seq_serializer_proj: format!(
+                "S::{}",
+                items.trait_assoc_type_name(CompilerItem::Serializer, "SeqSerializer")
+            ),
+            s_variant_serializer_proj: format!(
+                "S::{}",
+                items.trait_assoc_type_name(CompilerItem::Serializer, "VariantSerializer")
+            ),
+            d_struct_access_proj: format!(
+                "D::{}",
+                items.trait_assoc_type_name(CompilerItem::Deserializer, "StructAccess")
+            ),
+            d_seq_access_proj: format!(
+                "D::{}",
+                items.trait_assoc_type_name(CompilerItem::Deserializer, "SeqAccess")
+            ),
+            d_variant_access_proj: format!(
+                "D::{}",
+                items.trait_assoc_type_name(CompilerItem::Deserializer, "VariantAccess")
+            ),
         }
     }
 }
@@ -628,7 +694,7 @@ fn generate_struct_serialize(
     let result_unit_err = tt.make_result(TypeTable::UNIT, ser_error_type);
     let struct_ser_type = tt.make_assoc_type_projection(
         s_type_param,
-        "StructSerializer".to_string(),
+        names.struct_serializer_assoc.clone(),
         vec![names.serialize_struct.clone()],
         vec![],
     );
@@ -706,7 +772,7 @@ fn generate_struct_serialize(
 
         let field_call = type_param_method_call(
             local_ref(st_local, "st", mut_ref_ss),
-            "S::StructSerializer",
+            &names.s_struct_serializer_proj,
             &names.serialize_struct,
             "field",
             serde_module.clone(),
@@ -728,7 +794,7 @@ fn generate_struct_serialize(
 
     let end_call = type_param_method_call(
         local_ref(st_local, "st", mut_ref_ss),
-        "S::StructSerializer",
+        &names.s_struct_serializer_proj,
         &names.serialize_struct,
         "end",
         serde_module,
@@ -860,7 +926,7 @@ fn generate_struct_deserialize(
     let mut_ref_d = tt.make_mut_ref(d_type_param);
     let struct_access_type = tt.make_assoc_type_projection(
         d_type_param,
-        "StructAccess".to_string(),
+        names.struct_access_assoc.clone(),
         vec![names.deserialize_struct.clone()],
         vec![],
     );
@@ -1029,7 +1095,7 @@ fn generate_struct_deserialize(
 
     let next_field_call = type_param_method_call(
         local_ref(sd_local, "sd", mut_ref_sa),
-        "D::StructAccess",
+        &names.d_struct_access_proj,
         &names.deserialize_struct,
         "next_field",
         serde_module.clone(),
@@ -1052,7 +1118,7 @@ fn generate_struct_deserialize(
         let bit = 1u32 << i;
         let value_call = type_param_method_call(
             local_ref(sd_local, "sd", mut_ref_sa),
-            "D::StructAccess",
+            &names.d_struct_access_proj,
             &names.deserialize_struct,
             "value",
             serde_module.clone(),
@@ -1132,7 +1198,7 @@ fn generate_struct_deserialize(
 
     let skip_call = type_param_method_call(
         local_ref(sd_local, "sd", mut_ref_sa),
-        "D::StructAccess",
+        &names.d_struct_access_proj,
         &names.deserialize_struct,
         "skip",
         serde_module.clone(),
@@ -1263,7 +1329,7 @@ fn generate_struct_deserialize(
     // sd.end()
     let end_call = type_param_method_call(
         local_ref(sd_local, "sd", mut_ref_sa),
-        "D::StructAccess",
+        &names.d_struct_access_proj,
         &names.deserialize_struct,
         "end",
         serde_module,
@@ -1789,7 +1855,7 @@ fn generate_enum_deserialize(
     let mut_ref_d = tt.make_mut_ref(d_type_param);
     let variant_access_type = tt.make_assoc_type_projection(
         d_type_param,
-        "VariantAccess".to_string(),
+        names.variant_access_assoc.clone(),
         vec![names.deserialize_variant.clone()],
         vec![],
     );
@@ -1857,7 +1923,7 @@ fn generate_enum_deserialize(
     // let __disc_r = va.disc()
     let disc_call = type_param_method_call(
         local_ref(va_local, "va", mut_ref_va),
-        "D::VariantAccess",
+        &names.d_variant_access_proj,
         &names.deserialize_variant,
         "disc",
         serde_module.clone(),
@@ -1889,7 +1955,7 @@ fn generate_enum_deserialize(
 
         let end_call = type_param_method_call(
             local_ref(va_local, "va", mut_ref_va),
-            "D::VariantAccess",
+            &names.d_variant_access_proj,
             &names.deserialize_variant,
             "end",
             serde_module.clone(),
@@ -1948,7 +2014,7 @@ fn generate_enum_deserialize(
     // let __name_r = va.variant_name()
     let name_call = type_param_method_call(
         local_ref(va_local, "va", mut_ref_va),
-        "D::VariantAccess",
+        &names.d_variant_access_proj,
         &names.deserialize_variant,
         "variant_name",
         serde_module.clone(),
@@ -2002,7 +2068,7 @@ fn generate_enum_deserialize(
 
         let end_call = type_param_method_call(
             local_ref(va_local, "va", mut_ref_va),
-            "D::VariantAccess",
+            &names.d_variant_access_proj,
             &names.deserialize_variant,
             "end",
             serde_module.clone(),
@@ -2191,7 +2257,7 @@ fn generate_variant_serialize(
     let result_unit_err = tt.make_result(TypeTable::UNIT, ser_error_type);
     let variant_ser_type = tt.make_assoc_type_projection(
         s_type_param,
-        "VariantSerializer".to_string(),
+        names.variant_serializer_assoc.clone(),
         vec![names.serialize_variant.clone()],
         vec![],
     );
@@ -2305,7 +2371,7 @@ fn generate_variant_serialize(
             );
             let payload_call = type_param_method_call(
                 local_ref(vs_local, "__vs", mut_ref_vs),
-                "S::VariantSerializer",
+                &names.s_variant_serializer_proj,
                 &names.serialize_variant,
                 "payload",
                 serde_module.clone(),
@@ -2318,7 +2384,7 @@ fn generate_variant_serialize(
 
             let end_call = type_param_method_call(
                 local_ref(vs_local, "__vs", mut_ref_vs),
-                "S::VariantSerializer",
+                &names.s_variant_serializer_proj,
                 &names.serialize_variant,
                 "end",
                 serde_module.clone(),
@@ -2493,7 +2559,7 @@ fn generate_variant_deserialize(
     let mut_ref_d = tt.make_mut_ref(d_type_param);
     let variant_access_type = tt.make_assoc_type_projection(
         d_type_param,
-        "VariantAccess".to_string(),
+        names.variant_access_assoc.clone(),
         vec![names.deserialize_variant.clone()],
         vec![],
     );
@@ -2564,7 +2630,7 @@ fn generate_variant_deserialize(
     // --- disc-based path (tried first) ---
     let disc_call = type_param_method_call(
         local_ref(va_local, "va", mut_ref_va),
-        "D::VariantAccess",
+        &names.d_variant_access_proj,
         &names.deserialize_variant,
         "disc",
         serde_module.clone(),
@@ -2598,7 +2664,7 @@ fn generate_variant_deserialize(
         if is_unit {
             let end_call = type_param_method_call(
                 local_ref(va_local, "va", mut_ref_va),
-                "D::VariantAccess",
+                &names.d_variant_access_proj,
                 &names.deserialize_variant,
                 "end",
                 serde_module.clone(),
@@ -2631,7 +2697,7 @@ fn generate_variant_deserialize(
 
             let payload_call = type_param_method_call(
                 local_ref(va_local, "va", mut_ref_va),
-                "D::VariantAccess",
+                &names.d_variant_access_proj,
                 &names.deserialize_variant,
                 "payload",
                 serde_module.clone(),
@@ -2644,7 +2710,7 @@ fn generate_variant_deserialize(
 
             let end_call = type_param_method_call(
                 local_ref(va_local, "va", mut_ref_va),
-                "D::VariantAccess",
+                &names.d_variant_access_proj,
                 &names.deserialize_variant,
                 "end",
                 serde_module.clone(),
@@ -2728,7 +2794,7 @@ fn generate_variant_deserialize(
 
     let name_call = type_param_method_call(
         local_ref(va_local, "va", mut_ref_va),
-        "D::VariantAccess",
+        &names.d_variant_access_proj,
         &names.deserialize_variant,
         "variant_name",
         serde_module.clone(),
@@ -2784,7 +2850,7 @@ fn generate_variant_deserialize(
         if is_unit {
             let end_call = type_param_method_call(
                 local_ref(va_local, "va", mut_ref_va),
-                "D::VariantAccess",
+                &names.d_variant_access_proj,
                 &names.deserialize_variant,
                 "end",
                 serde_module.clone(),
@@ -2817,7 +2883,7 @@ fn generate_variant_deserialize(
 
             let payload_call = type_param_method_call(
                 local_ref(va_local, "va", mut_ref_va),
-                "D::VariantAccess",
+                &names.d_variant_access_proj,
                 &names.deserialize_variant,
                 "payload",
                 serde_module.clone(),
@@ -2830,7 +2896,7 @@ fn generate_variant_deserialize(
 
             let end_call = type_param_method_call(
                 local_ref(va_local, "va", mut_ref_va),
-                "D::VariantAccess",
+                &names.d_variant_access_proj,
                 &names.deserialize_variant,
                 "end",
                 serde_module.clone(),
@@ -3096,7 +3162,7 @@ fn generate_flags_serialize(
     let result_unit_err = tt.make_result(TypeTable::UNIT, ser_error_type);
     let seq_ser_type = tt.make_assoc_type_projection(
         s_type_param,
-        "SeqSerializer".to_string(),
+        names.seq_serializer_assoc.clone(),
         vec![names.serialize_seq.clone()],
         vec![],
     );
@@ -3179,7 +3245,7 @@ fn generate_flags_serialize(
         let bit_check = flags_bit_check(ref_self_type, flags_type, *bitmask, span);
         let element_call = type_param_method_call(
             local_ref(seq_local, "seq", mut_ref_seq),
-            "S::SeqSerializer",
+            &names.s_seq_serializer_proj,
             &names.serialize_seq,
             "element",
             serde_module.clone(),
@@ -3203,7 +3269,7 @@ fn generate_flags_serialize(
     // return seq.end();
     let end_call = type_param_method_call(
         local_ref(seq_local, "seq", mut_ref_seq),
-        "S::SeqSerializer",
+        &names.s_seq_serializer_proj,
         &names.serialize_seq,
         "end",
         serde_module,
@@ -3347,7 +3413,7 @@ fn generate_flags_deserialize(
     let result_unit_err = tt.make_result(TypeTable::UNIT, deser_error_type);
     let seq_access_type = tt.make_assoc_type_projection(
         d_type_param,
-        "SeqAccess".to_string(),
+        names.seq_access_assoc.clone(),
         vec![names.deserialize_seq.clone()],
         vec![],
     );
@@ -3416,7 +3482,7 @@ fn generate_flags_deserialize(
     // loop { let __elem_r = seq.next_element::<String>(); ... }
     let next_call = type_param_method_call(
         local_ref(seq_local, "seq", mut_ref_seq),
-        "D::SeqAccess",
+        &names.d_seq_access_proj,
         &names.deserialize_seq,
         "next_element",
         serde_module.clone(),
@@ -3580,7 +3646,7 @@ fn generate_flags_deserialize(
     // seq.end()?
     let end_call = type_param_method_call(
         local_ref(seq_local, "seq", mut_ref_seq),
-        "D::SeqAccess",
+        &names.d_seq_access_proj,
         &names.deserialize_seq,
         "end",
         serde_module,

--- a/wado-compiler/src/synthesis/serde_synth.rs
+++ b/wado-compiler/src/synthesis/serde_synth.rs
@@ -6,6 +6,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use crate::compiler_item::{CompilerItem, CompilerItems};
 use crate::hashmap::IndexSet;
 
 use crate::module_source::ModuleSource;
@@ -17,6 +18,113 @@ use crate::tir::{
     TirStructField, TirTemplatePart, TirTypeParam, TypeId, TypeTable,
 };
 use crate::token::Span;
+
+/// Snapshot of every `core:serde` symbol name + case index this
+/// synthesiser needs, resolved once through the `CompilerItem`
+/// registry. Mirrors [`super::cm_binding::types::CmStdlibNames`]: built
+/// per-call, cheap (a handful of registry hits + clones), and threaded
+/// through the synthesis helpers so a stdlib rename of any of these
+/// items flows through every call site without touching Rust code.
+///
+/// All trait / struct / enum / case names live here together because
+/// every synthesised `Serialize` / `Deserialize` impl reaches for the
+/// full set; splitting the snapshot per-item would just multiply the
+/// borrow points without making any one site cleaner.
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+pub(super) struct SerdeStdlibNames {
+    pub serialize: String,
+    pub deserialize: String,
+    pub serializer: String,
+    pub deserializer: String,
+    pub serialize_struct: String,
+    pub serialize_seq: String,
+    pub serialize_variant: String,
+    pub deserialize_struct: String,
+    pub deserialize_seq: String,
+    pub deserialize_variant: String,
+    pub serialize_error: String,
+    pub serialize_error_kind: String,
+    pub deserialize_error: String,
+    pub deserialize_error_kind: String,
+    pub ok_name: String,
+    pub ok_index: u32,
+    pub err_name: String,
+    pub err_index: u32,
+    pub some_name: String,
+    pub some_index: u32,
+    pub none_name: String,
+    pub none_index: u32,
+    pub ser_err_custom_name: String,
+    pub ser_err_custom_index: u32,
+    pub deser_err_missing_field_name: String,
+    pub deser_err_missing_field_index: u32,
+    pub deser_err_unknown_variant_name: String,
+    pub deser_err_unknown_variant_index: u32,
+    pub deser_err_invalid_value_name: String,
+    pub deser_err_invalid_value_index: u32,
+}
+
+impl SerdeStdlibNames {
+    pub fn from_compiler_items(items: &CompilerItems) -> Self {
+        let (_, _, ok_name, ok_index) = items.require_variant_case(CompilerItem::ResultOk);
+        let (_, _, err_name, err_index) = items.require_variant_case(CompilerItem::ResultErr);
+        let (_, _, some_name, some_index) =
+            items.require_variant_case(CompilerItem::OptionSome);
+        let (_, _, none_name, none_index) =
+            items.require_variant_case(CompilerItem::OptionNone);
+        let (_, _, ser_err_custom_name, ser_err_custom_index) =
+            items.require_enum_case(CompilerItem::SerializeErrorKindCustom);
+        let (_, _, deser_err_missing_field_name, deser_err_missing_field_index) =
+            items.require_enum_case(CompilerItem::DeserializeErrorKindMissingField);
+        let (_, _, deser_err_unknown_variant_name, deser_err_unknown_variant_index) =
+            items.require_enum_case(CompilerItem::DeserializeErrorKindUnknownVariant);
+        let (_, _, deser_err_invalid_value_name, deser_err_invalid_value_index) =
+            items.require_enum_case(CompilerItem::DeserializeErrorKindInvalidValue);
+        Self {
+            serialize: items.trait_name(CompilerItem::Serialize).to_string(),
+            deserialize: items.trait_name(CompilerItem::Deserialize).to_string(),
+            serializer: items.trait_name(CompilerItem::Serializer).to_string(),
+            deserializer: items.trait_name(CompilerItem::Deserializer).to_string(),
+            serialize_struct: items.trait_name(CompilerItem::SerializeStruct).to_string(),
+            serialize_seq: items.trait_name(CompilerItem::SerializeSeq).to_string(),
+            serialize_variant: items
+                .trait_name(CompilerItem::SerializeVariant)
+                .to_string(),
+            deserialize_struct: items
+                .trait_name(CompilerItem::DeserializeStruct)
+                .to_string(),
+            deserialize_seq: items.trait_name(CompilerItem::DeserializeSeq).to_string(),
+            deserialize_variant: items
+                .trait_name(CompilerItem::DeserializeVariant)
+                .to_string(),
+            serialize_error: items.struct_name(CompilerItem::SerializeError).to_string(),
+            serialize_error_kind: items.enum_name(CompilerItem::SerializeErrorKind).to_string(),
+            deserialize_error: items
+                .struct_name(CompilerItem::DeserializeError)
+                .to_string(),
+            deserialize_error_kind: items
+                .enum_name(CompilerItem::DeserializeErrorKind)
+                .to_string(),
+            ok_name: ok_name.to_string(),
+            ok_index,
+            err_name: err_name.to_string(),
+            err_index,
+            some_name: some_name.to_string(),
+            some_index,
+            none_name: none_name.to_string(),
+            none_index,
+            ser_err_custom_name: ser_err_custom_name.to_string(),
+            ser_err_custom_index,
+            deser_err_missing_field_name: deser_err_missing_field_name.to_string(),
+            deser_err_missing_field_index,
+            deser_err_unknown_variant_name: deser_err_unknown_variant_name.to_string(),
+            deser_err_unknown_variant_index,
+            deser_err_invalid_value_name: deser_err_invalid_value_name.to_string(),
+            deser_err_invalid_value_index,
+        }
+    }
+}
 
 use super::common::{
     alloc_local, block, break_stmt, cast, deref_expr, expr_stmt, field_access, i32_const, if_stmt,
@@ -76,55 +184,49 @@ pub fn synthesize_serde(project: &mut Package) {
         if requests.is_empty() {
             continue;
         }
-        let (serialize_trait_name, deserialize_trait_name) = {
+        let names = {
             let tt = module.type_table.borrow();
-            let items = tt.compiler_items();
-            (
-                items
-                    .trait_name(crate::compiler_item::CompilerItem::Serialize)
-                    .to_string(),
-                items
-                    .trait_name(crate::compiler_item::CompilerItem::Deserialize)
-                    .to_string(),
-            )
+            SerdeStdlibNames::from_compiler_items(tt.compiler_items())
         };
         let existing = collect_existing_trait_methods(module);
         let mut generated = Vec::new();
 
         for req in &requests {
             let trait_name = req.trait_name.as_str();
-            if trait_name == serialize_trait_name {
+            if trait_name == names.serialize {
                 let key = MethodName::format_local(
                     &req.target_type_name,
-                    Some(&serialize_trait_name),
+                    Some(&names.serialize),
                     "serialize",
                 );
                 if existing.contains(&key) {
                     continue;
                 }
-                let func = generate_struct_serialize(module, req)
-                    .or_else(|| generate_enum_serialize(module, req))
-                    .or_else(|| generate_variant_serialize(module, req))
-                    .or_else(|| generate_flags_serialize(module, req));
+                let func = generate_struct_serialize(module, req, &names)
+                    .or_else(|| generate_enum_serialize(module, req, &names))
+                    .or_else(|| generate_variant_serialize(module, req, &names))
+                    .or_else(|| generate_flags_serialize(module, req, &names));
                 if let Some(f) = func {
                     generated.push(Rc::new(RefCell::new(f)));
                 }
-            } else if trait_name == deserialize_trait_name {
+            } else if trait_name == names.deserialize {
                 let key = MethodName::format_local(
                     &req.target_type_name,
-                    Some(&deserialize_trait_name),
+                    Some(&names.deserialize),
                     "deserialize",
                 );
                 if existing.contains(&key) {
                     continue;
                 }
-                if let Some((lookup_func, deser_func)) = generate_struct_deserialize(module, req) {
+                if let Some((lookup_func, deser_func)) =
+                    generate_struct_deserialize(module, req, &names)
+                {
                     generated.push(Rc::new(RefCell::new(lookup_func)));
                     generated.push(Rc::new(RefCell::new(deser_func)));
                 } else {
-                    let func = generate_enum_deserialize(module, req)
-                        .or_else(|| generate_variant_deserialize(module, req))
-                        .or_else(|| generate_flags_deserialize(module, req));
+                    let func = generate_enum_deserialize(module, req, &names)
+                        .or_else(|| generate_variant_deserialize(module, req, &names))
+                        .or_else(|| generate_flags_deserialize(module, req, &names));
                     if let Some(f) = func {
                         generated.push(Rc::new(RefCell::new(f)));
                     }
@@ -217,11 +319,12 @@ fn propagate_err_block(
     err_type: TypeId,
     outer_result_type: TypeId,
     span: Span,
+    names: &SerdeStdlibNames,
 ) -> TirBlock {
     let extract_err = TirExpr::new(
         TirExprKind::VariantPayload {
             expr: Box::new(local_ref(result_local, result_local_name, result_type)),
-            case_index: 1, // Err
+            case_index: names.err_index,
             payload_type: err_type,
         },
         err_type,
@@ -231,15 +334,16 @@ fn propagate_err_block(
         extract_err,
         outer_result_type,
         span,
+        names,
     )))])
 }
 
-fn variant_ok(value: TirExpr, result_type: TypeId, span: Span) -> TirExpr {
+fn variant_ok(value: TirExpr, result_type: TypeId, span: Span, names: &SerdeStdlibNames) -> TirExpr {
     TirExpr::new(
         TirExprKind::VariantConstruct {
             variant_type: result_type,
-            case_index: 0,
-            case_name: "Ok".to_string(),
+            case_index: names.ok_index,
+            case_name: names.ok_name.clone(),
             payload: Some(Box::new(value)),
         },
         result_type,
@@ -247,12 +351,12 @@ fn variant_ok(value: TirExpr, result_type: TypeId, span: Span) -> TirExpr {
     )
 }
 
-fn variant_err(value: TirExpr, result_type: TypeId, span: Span) -> TirExpr {
+fn variant_err(value: TirExpr, result_type: TypeId, span: Span, names: &SerdeStdlibNames) -> TirExpr {
     TirExpr::new(
         TirExprKind::VariantConstruct {
             variant_type: result_type,
-            case_index: 1,
-            case_name: "Err".to_string(),
+            case_index: names.err_index,
+            case_name: names.err_name.clone(),
             payload: Some(Box::new(value)),
         },
         result_type,
@@ -269,13 +373,14 @@ fn if_let_ok(
     then_block: TirBlock,
     else_block: TirBlock,
     span: Span,
+    names: &SerdeStdlibNames,
 ) -> TirStmt {
     TirStmt::new(
         TirStmtKind::IfLet {
             scrutinee,
             pattern: TirPattern::Variant {
                 enum_type: result_type,
-                variant_name: "Ok".to_string(),
+                variant_name: names.ok_name.clone(),
                 bindings: vec![TirPattern::Binding {
                     name: ok_name.to_string(),
                     local_index: ok_local,
@@ -299,13 +404,14 @@ fn if_let_some(
     then_block: TirBlock,
     else_block: TirBlock,
     span: Span,
+    names: &SerdeStdlibNames,
 ) -> TirStmt {
     TirStmt::new(
         TirStmtKind::IfLet {
             scrutinee,
             pattern: TirPattern::Variant {
                 enum_type: option_type,
-                variant_name: "Some".to_string(),
+                variant_name: names.some_name.clone(),
                 bindings: vec![TirPattern::Binding {
                     name: inner_name.to_string(),
                     local_index: inner_local,
@@ -326,19 +432,20 @@ fn serialize_error_literal(
     message: &str,
     string_type: TypeId,
     span: Span,
+    names: &SerdeStdlibNames,
 ) -> TirExpr {
     TirExpr::new(
         TirExprKind::StructLiteral {
             struct_type: error_type,
-            struct_name: "SerializeError".to_string(),
+            struct_name: names.serialize_error.clone(),
             fields: vec![
                 TirStructField {
                     name: "kind".to_string(),
                     value: TirExpr::new(
                         TirExprKind::EnumConstruct {
                             enum_type: error_kind_type,
-                            case_index: 1,
-                            case_name: "Custom".to_string(),
+                            case_index: names.ser_err_custom_index,
+                            case_name: names.ser_err_custom_name.clone(),
                         },
                         error_kind_type,
                         span,
@@ -365,11 +472,12 @@ fn deserialize_error_literal(
     message: &str,
     string_type: TypeId,
     span: Span,
+    names: &SerdeStdlibNames,
 ) -> TirExpr {
     TirExpr::new(
         TirExprKind::StructLiteral {
             struct_type: error_type,
-            struct_name: "DeserializeError".to_string(),
+            struct_name: names.deserialize_error.clone(),
             fields: vec![
                 TirStructField {
                     name: "kind".to_string(),
@@ -494,6 +602,7 @@ fn default_value_for_type(type_id: TypeId, type_table: &TypeTable, span: Span) -
 fn generate_struct_serialize(
     module: &TirModule,
     req: &crate::tir::SynthesisRequest,
+    names: &SerdeStdlibNames,
 ) -> Option<TirFunction> {
     let struct_def = find_struct(module, &req.target_type_name)?;
     let span = synth_span();
@@ -507,12 +616,12 @@ fn generate_struct_serialize(
     let mut_ref_s = tt.make_mut_ref(s_type_param);
     let string_type = tt.make_compiler_struct(crate::compiler_item::CompilerItem::String);
     let ref_string_type = tt.make_ref(string_type);
-    let ser_error_type = tt.make_struct("SerializeError".to_string(), serde_module.clone());
+    let ser_error_type = tt.make_struct(names.serialize_error.clone(), serde_module.clone());
     let result_unit_err = tt.make_result(TypeTable::UNIT, ser_error_type);
     let struct_ser_type = tt.make_assoc_type_projection(
         s_type_param,
         "StructSerializer".to_string(),
-        vec!["SerializeStruct".to_string()],
+        vec![names.serialize_struct.clone()],
         vec![],
     );
     let result_ss_err = tt.make_result(struct_ser_type, ser_error_type);
@@ -557,7 +666,7 @@ fn generate_struct_serialize(
     let begin_call = type_param_method_call(
         local_ref(1, "s", mut_ref_s),
         "S",
-        "Serializer",
+        &names.serializer,
         "begin_struct",
         serde_module.clone(),
         vec![],
@@ -590,7 +699,7 @@ fn generate_struct_serialize(
         let field_call = type_param_method_call(
             local_ref(st_local, "st", mut_ref_ss),
             "S::StructSerializer",
-            "SerializeStruct",
+            &names.serialize_struct,
             "field",
             serde_module.clone(),
             vec![field_type_names[i].clone()],
@@ -612,7 +721,7 @@ fn generate_struct_serialize(
     let end_call = type_param_method_call(
         local_ref(st_local, "st", mut_ref_ss),
         "S::StructSerializer",
-        "SerializeStruct",
+        &names.serialize_struct,
         "end",
         serde_module,
         vec![],
@@ -630,6 +739,7 @@ fn generate_struct_serialize(
         ser_error_type,
         result_unit_err,
         span,
+        names,
     );
 
     stmts.push(if_let_ok(
@@ -641,15 +751,16 @@ fn generate_struct_serialize(
         block(then_stmts),
         else_block,
         span,
+        names,
     ));
 
     let method_info = LocalMethodName::new(
         req.target_type_name.clone(),
-        Some("Serialize".to_string()),
+        Some(names.serialize.clone()),
         "serialize".to_string(),
     );
     let qualified_name =
-        MethodName::format_local(&req.target_type_name, Some("Serialize"), "serialize");
+        MethodName::format_local(&req.target_type_name, Some(&names.serialize), "serialize");
 
     Some(TirFunction {
         module_source: ModuleSource::default(),
@@ -663,7 +774,7 @@ fn generate_struct_serialize(
             name: "S".to_string(),
             is_effect: false,
             is_pack: false,
-            bounds: vec!["Serializer".to_string()],
+            bounds: vec![names.serializer.clone()],
             default: None,
             index: 0,
         }],
@@ -713,27 +824,22 @@ fn generate_struct_serialize(
 fn generate_struct_deserialize(
     module: &TirModule,
     req: &crate::tir::SynthesisRequest,
+    names: &SerdeStdlibNames,
 ) -> Option<(TirFunction, TirFunction)> {
     let struct_def = find_struct(module, &req.target_type_name)?;
     let span = synth_span();
     let module_source = module.module_source.clone();
     let serde_module = ModuleSource::serde();
 
-    let deserialize_trait_name = module
-        .type_table
-        .borrow()
-        .compiler_items()
-        .trait_name(crate::compiler_item::CompilerItem::Deserialize)
-        .to_string();
     let mut tt = module.type_table.borrow_mut();
 
     let struct_type = req.target_type_id;
     let string_type = tt.make_compiler_struct(crate::compiler_item::CompilerItem::String);
     let ref_string_type = tt.make_ref(string_type);
     let option_i32 = tt.make_option(TypeTable::I32);
-    let deser_error_type = tt.make_struct("DeserializeError".to_string(), serde_module.clone());
+    let deser_error_type = tt.make_struct(names.deserialize_error.clone(), serde_module.clone());
     let deser_error_kind_type = tt
-        .find_enum_type("DeserializeErrorKind", &serde_module)
+        .find_enum_type(&names.deserialize_error_kind, &serde_module)
         .unwrap_or(TypeTable::I32);
     let result_struct_err = tt.make_result(struct_type, deser_error_type);
     let lookup_fn_type = tt.make_function(
@@ -747,7 +853,7 @@ fn generate_struct_deserialize(
     let struct_access_type = tt.make_assoc_type_projection(
         d_type_param,
         "StructAccess".to_string(),
-        vec!["DeserializeStruct".to_string()],
+        vec![names.deserialize_struct.clone()],
         vec![],
     );
     let result_sa_err = tt.make_result(struct_access_type, deser_error_type);
@@ -845,7 +951,7 @@ fn generate_struct_deserialize(
     let begin_call = type_param_method_call(
         local_ref(0, "d", mut_ref_d),
         "D",
-        "Deserializer",
+        &names.deserializer,
         "begin_struct",
         serde_module.clone(),
         vec![],
@@ -916,7 +1022,7 @@ fn generate_struct_deserialize(
     let next_field_call = type_param_method_call(
         local_ref(sd_local, "sd", mut_ref_sa),
         "D::StructAccess",
-        "DeserializeStruct",
+        &names.deserialize_struct,
         "next_field",
         serde_module.clone(),
         vec![],
@@ -939,7 +1045,7 @@ fn generate_struct_deserialize(
         let value_call = type_param_method_call(
             local_ref(sd_local, "sd", mut_ref_sa),
             "D::StructAccess",
-            "DeserializeStruct",
+            &names.deserialize_struct,
             "value",
             serde_module.clone(),
             vec![field_type_names[i].clone()],
@@ -1001,8 +1107,10 @@ fn generate_struct_deserialize(
                     deser_error_type,
                     result_struct_err,
                     span,
+                    names,
                 ),
                 span,
+                names,
             ),
         ];
 
@@ -1017,7 +1125,7 @@ fn generate_struct_deserialize(
     let skip_call = type_param_method_call(
         local_ref(sd_local, "sd", mut_ref_sa),
         "D::StructAccess",
-        "DeserializeStruct",
+        &names.deserialize_struct,
         "skip",
         serde_module.clone(),
         vec![],
@@ -1055,6 +1163,7 @@ fn generate_struct_deserialize(
         block(vec![expr_stmt(match_expr)]),
         block(vec![break_stmt()]),
         span,
+        names,
     );
 
     let if_ok = if_let_ok(
@@ -1071,8 +1180,10 @@ fn generate_struct_deserialize(
             deser_error_type,
             result_struct_err,
             span,
+            names,
         ),
         span,
+        names,
     );
     loop_stmts.push(if_ok);
 
@@ -1121,11 +1232,12 @@ fn generate_struct_deserialize(
             let missing_err = deserialize_error_literal(
                 deser_error_type,
                 deser_error_kind_type,
-                "MissingField",
-                1,
+                &names.deser_err_missing_field_name,
+                names.deser_err_missing_field_index,
                 "required field missing",
                 string_type,
                 span,
+                names,
             );
             then_stmts.push(if_stmt(
                 ne_check,
@@ -1133,6 +1245,7 @@ fn generate_struct_deserialize(
                     missing_err,
                     result_struct_err,
                     span,
+                    names,
                 )))]),
                 None,
             ));
@@ -1143,7 +1256,7 @@ fn generate_struct_deserialize(
     let end_call = type_param_method_call(
         local_ref(sd_local, "sd", mut_ref_sa),
         "D::StructAccess",
-        "DeserializeStruct",
+        &names.deserialize_struct,
         "end",
         serde_module,
         vec![],
@@ -1177,6 +1290,7 @@ fn generate_struct_deserialize(
         struct_lit,
         result_struct_err,
         span,
+        names,
     ))));
 
     let else_block = propagate_err_block(
@@ -1186,6 +1300,7 @@ fn generate_struct_deserialize(
         deser_error_type,
         result_struct_err,
         span,
+        names,
     );
 
     stmts.push(if_let_ok(
@@ -1197,16 +1312,17 @@ fn generate_struct_deserialize(
         block(then_stmts),
         else_block,
         span,
+        names,
     ));
 
     let method_info = LocalMethodName::new(
         req.target_type_name.clone(),
-        Some(deserialize_trait_name.clone()),
+        Some(names.deserialize.clone()),
         "deserialize".to_string(),
     );
     let qualified_name = MethodName::format_local(
         &req.target_type_name,
-        Some(&deserialize_trait_name),
+        Some(&names.deserialize),
         "deserialize",
     );
 
@@ -1222,7 +1338,7 @@ fn generate_struct_deserialize(
             name: "D".to_string(),
             is_effect: false,
             is_pack: false,
-            bounds: vec!["Deserializer".to_string()],
+            bounds: vec![names.deserializer.clone()],
             default: None,
             index: 0,
         }],
@@ -1403,11 +1519,12 @@ fn generate_lookup_function(
             block(vec![return_stmt(Some(option_some(
                 i32_const(i as i32),
                 option_i32,
+                compiler_items,
             )))]),
             None,
         ));
     }
-    stmts.push(return_stmt(Some(option_none(option_i32))));
+    stmts.push(return_stmt(Some(option_none(option_i32, compiler_items))));
 
     TirFunction {
         module_source: ModuleSource::default(),
@@ -1480,6 +1597,7 @@ fn find_variant<'a>(module: &'a TirModule, name: &str) -> Option<&'a crate::tir:
 fn generate_enum_serialize(
     module: &TirModule,
     req: &crate::tir::SynthesisRequest,
+    names: &SerdeStdlibNames,
 ) -> Option<TirFunction> {
     let enum_def = find_enum(module, &req.target_type_name)?;
     let span = synth_span();
@@ -1493,7 +1611,7 @@ fn generate_enum_serialize(
     let mut_ref_s = tt.make_mut_ref(s_type_param);
     let string_type = tt.make_compiler_struct(crate::compiler_item::CompilerItem::String);
     let ref_string_type = tt.make_ref(string_type);
-    let ser_error_type = tt.make_struct("SerializeError".to_string(), serde_module.clone());
+    let ser_error_type = tt.make_struct(names.serialize_error.clone(), serde_module.clone());
     let result_unit_err = tt.make_result(TypeTable::UNIT, ser_error_type);
 
     let cases: Vec<(String, u32)> = enum_def
@@ -1516,7 +1634,7 @@ fn generate_enum_serialize(
         let call = type_param_method_call(
             local_ref(1, "s", mut_ref_s),
             "S",
-            "Serializer",
+            &names.serializer,
             "serialize_unit_variant",
             serde_module.clone(),
             vec![],
@@ -1563,11 +1681,11 @@ fn generate_enum_serialize(
 
     let method_info = LocalMethodName::new(
         req.target_type_name.clone(),
-        Some("Serialize".to_string()),
+        Some(names.serialize.clone()),
         "serialize".to_string(),
     );
     let qualified_name =
-        MethodName::format_local(&req.target_type_name, Some("Serialize"), "serialize");
+        MethodName::format_local(&req.target_type_name, Some(&names.serialize), "serialize");
 
     Some(TirFunction {
         module_source: ModuleSource::default(),
@@ -1581,7 +1699,7 @@ fn generate_enum_serialize(
             name: "S".to_string(),
             is_effect: false,
             is_pack: false,
-            bounds: vec!["Serializer".to_string()],
+            bounds: vec![names.serializer.clone()],
             default: None,
             index: 0,
         }],
@@ -1631,20 +1749,18 @@ fn generate_enum_serialize(
 fn generate_enum_deserialize(
     module: &TirModule,
     req: &crate::tir::SynthesisRequest,
+    names: &SerdeStdlibNames,
 ) -> Option<TirFunction> {
     let enum_def = find_enum(module, &req.target_type_name)?;
     let span = synth_span();
     let serde_module = ModuleSource::serde();
 
-    let (eq_trait_name, deserialize_trait_name, string_struct_name) = {
+    let (eq_trait_name, string_struct_name) = {
         let tt = module.type_table.borrow();
         let items = tt.compiler_items();
         (
             items
                 .trait_name(crate::compiler_item::CompilerItem::Eq)
-                .to_string(),
-            items
-                .trait_name(crate::compiler_item::CompilerItem::Deserialize)
                 .to_string(),
             items
                 .struct_name(crate::compiler_item::CompilerItem::String)
@@ -1656,9 +1772,9 @@ fn generate_enum_deserialize(
     let enum_type = req.target_type_id;
     let string_type = tt.make_compiler_struct(crate::compiler_item::CompilerItem::String);
     let ref_string_type = tt.make_ref(string_type);
-    let deser_error_type = tt.make_struct("DeserializeError".to_string(), serde_module.clone());
+    let deser_error_type = tt.make_struct(names.deserialize_error.clone(), serde_module.clone());
     let deser_error_kind_type = tt
-        .find_enum_type("DeserializeErrorKind", &serde_module)
+        .find_enum_type(&names.deserialize_error_kind, &serde_module)
         .unwrap_or(TypeTable::I32);
     let result_enum_err = tt.make_result(enum_type, deser_error_type);
     let d_type_param = tt.make_type_param("D".to_string(), 0);
@@ -1666,7 +1782,7 @@ fn generate_enum_deserialize(
     let variant_access_type = tt.make_assoc_type_projection(
         d_type_param,
         "VariantAccess".to_string(),
-        vec!["DeserializeVariant".to_string()],
+        vec![names.deserialize_variant.clone()],
         vec![],
     );
     let result_va_err = tt.make_result(variant_access_type, deser_error_type);
@@ -1703,7 +1819,7 @@ fn generate_enum_deserialize(
     let begin_call = type_param_method_call(
         local_ref(0, "d", mut_ref_d),
         "D",
-        "Deserializer",
+        &names.deserializer,
         "begin_variant",
         serde_module.clone(),
         vec![],
@@ -1734,7 +1850,7 @@ fn generate_enum_deserialize(
     let disc_call = type_param_method_call(
         local_ref(va_local, "va", mut_ref_va),
         "D::VariantAccess",
-        "DeserializeVariant",
+        &names.deserialize_variant,
         "disc",
         serde_module.clone(),
         vec![],
@@ -1766,7 +1882,7 @@ fn generate_enum_deserialize(
         let end_call = type_param_method_call(
             local_ref(va_local, "va", mut_ref_va),
             "D::VariantAccess",
-            "DeserializeVariant",
+            &names.deserialize_variant,
             "end",
             serde_module.clone(),
             vec![],
@@ -1788,7 +1904,7 @@ fn generate_enum_deserialize(
 
         let if_body = block(vec![
             expr_stmt(end_call),
-            return_stmt(Some(variant_ok(enum_construct, result_enum_err, span))),
+            return_stmt(Some(variant_ok(enum_construct, result_enum_err, span, names))),
         ]);
         disc_then_stmts.push(if_stmt(condition, if_body, None));
     }
@@ -1797,16 +1913,18 @@ fn generate_enum_deserialize(
     let disc_unknown_err = deserialize_error_literal(
         deser_error_type,
         deser_error_kind_type,
-        "UnknownVariant",
-        2,
+        &names.deser_err_unknown_variant_name,
+        names.deser_err_unknown_variant_index,
         "unknown variant discriminant",
         string_type,
         span,
+        names,
     );
     disc_then_stmts.push(return_stmt(Some(variant_err(
         disc_unknown_err,
         result_enum_err,
         span,
+        names,
     ))));
 
     // if let Ok(__disc) = __disc_r { disc_matching } else { name fallback }
@@ -1818,7 +1936,7 @@ fn generate_enum_deserialize(
     let name_call = type_param_method_call(
         local_ref(va_local, "va", mut_ref_va),
         "D::VariantAccess",
-        "DeserializeVariant",
+        &names.deserialize_variant,
         "variant_name",
         serde_module.clone(),
         vec![],
@@ -1872,7 +1990,7 @@ fn generate_enum_deserialize(
         let end_call = type_param_method_call(
             local_ref(va_local, "va", mut_ref_va),
             "D::VariantAccess",
-            "DeserializeVariant",
+            &names.deserialize_variant,
             "end",
             serde_module.clone(),
             vec![],
@@ -1894,7 +2012,7 @@ fn generate_enum_deserialize(
 
         let if_body = block(vec![
             expr_stmt(end_call),
-            return_stmt(Some(variant_ok(enum_construct, result_enum_err, span))),
+            return_stmt(Some(variant_ok(enum_construct, result_enum_err, span, names))),
         ]);
         name_then_stmts.push(if_stmt(condition, if_body, None));
     }
@@ -1903,16 +2021,18 @@ fn generate_enum_deserialize(
     let unknown_err = deserialize_error_literal(
         deser_error_type,
         deser_error_kind_type,
-        "UnknownVariant",
-        2,
+        &names.deser_err_unknown_variant_name,
+        names.deser_err_unknown_variant_index,
         "unknown variant",
         string_type,
         span,
+        names,
     );
     name_then_stmts.push(return_stmt(Some(variant_err(
         unknown_err,
         result_enum_err,
         span,
+        names,
     ))));
 
     name_fallback_stmts.push(if_let_ok(
@@ -1929,8 +2049,10 @@ fn generate_enum_deserialize(
             deser_error_type,
             result_enum_err,
             span,
+            names,
         ),
         span,
+        names,
     ));
 
     // Wire up disc path with name fallback in else
@@ -1943,6 +2065,7 @@ fn generate_enum_deserialize(
         block(disc_then_stmts),
         block(name_fallback_stmts),
         span,
+        names,
     ));
 
     // Wire up: if let Ok(mut va) = __va_r { then_stmts } else { propagate err }
@@ -1960,18 +2083,20 @@ fn generate_enum_deserialize(
             deser_error_type,
             result_enum_err,
             span,
+            names,
         ),
         span,
+        names,
     ));
 
     let method_info = LocalMethodName::new(
         req.target_type_name.clone(),
-        Some(deserialize_trait_name.clone()),
+        Some(names.deserialize.clone()),
         "deserialize".to_string(),
     );
     let qualified_name = MethodName::format_local(
         &req.target_type_name,
-        Some(&deserialize_trait_name),
+        Some(&names.deserialize),
         "deserialize",
     );
 
@@ -1987,7 +2112,7 @@ fn generate_enum_deserialize(
             name: "D".to_string(),
             is_effect: false,
             is_pack: false,
-            bounds: vec!["Deserializer".to_string()],
+            bounds: vec![names.deserializer.clone()],
             default: None,
             index: 0,
         }],
@@ -2027,6 +2152,7 @@ fn generate_enum_deserialize(
 fn generate_variant_serialize(
     module: &TirModule,
     req: &crate::tir::SynthesisRequest,
+    names: &SerdeStdlibNames,
 ) -> Option<TirFunction> {
     let variant_def = find_variant(module, &req.target_type_name)?;
     let span = synth_span();
@@ -2040,15 +2166,15 @@ fn generate_variant_serialize(
     let mut_ref_s = tt.make_mut_ref(s_type_param);
     let string_type = tt.make_compiler_struct(crate::compiler_item::CompilerItem::String);
     let ref_string_type = tt.make_ref(string_type);
-    let ser_error_type = tt.make_struct("SerializeError".to_string(), serde_module.clone());
+    let ser_error_type = tt.make_struct(names.serialize_error.clone(), serde_module.clone());
     let ser_error_kind_type = tt
-        .find_enum_type("SerializeErrorKind", &serde_module)
+        .find_enum_type(&names.serialize_error_kind, &serde_module)
         .unwrap_or(TypeTable::I32);
     let result_unit_err = tt.make_result(TypeTable::UNIT, ser_error_type);
     let variant_ser_type = tt.make_assoc_type_projection(
         s_type_param,
         "VariantSerializer".to_string(),
-        vec!["SerializeVariant".to_string()],
+        vec![names.serialize_variant.clone()],
         vec![],
     );
     let result_vs_err = tt.make_result(variant_ser_type, ser_error_type);
@@ -2086,7 +2212,7 @@ fn generate_variant_serialize(
             let call = type_param_method_call(
                 local_ref(1, "s", mut_ref_s),
                 "S",
-                "Serializer",
+                &names.serializer,
                 "serialize_unit_variant",
                 serde_module.clone(),
                 vec![],
@@ -2132,7 +2258,7 @@ fn generate_variant_serialize(
             let begin_call = type_param_method_call(
                 local_ref(1, "s", mut_ref_s),
                 "S",
-                "Serializer",
+                &names.serializer,
                 "begin_variant",
                 serde_module.clone(),
                 vec![],
@@ -2162,7 +2288,7 @@ fn generate_variant_serialize(
             let payload_call = type_param_method_call(
                 local_ref(vs_local, "__vs", mut_ref_vs),
                 "S::VariantSerializer",
-                "SerializeVariant",
+                &names.serialize_variant,
                 "payload",
                 serde_module.clone(),
                 vec![payload_type_names[i].clone()],
@@ -2175,7 +2301,7 @@ fn generate_variant_serialize(
             let end_call = type_param_method_call(
                 local_ref(vs_local, "__vs", mut_ref_vs),
                 "S::VariantSerializer",
-                "SerializeVariant",
+                &names.serialize_variant,
                 "end",
                 serde_module.clone(),
                 vec![],
@@ -2191,6 +2317,7 @@ fn generate_variant_serialize(
                 "begin_variant failed",
                 string_type,
                 span,
+                names,
             );
 
             let then_block = block(vec![expr_stmt(payload_call), return_stmt(Some(end_call))]);
@@ -2198,6 +2325,7 @@ fn generate_variant_serialize(
                 err_val,
                 result_unit_err,
                 span,
+                names,
             )))]);
 
             let body_stmts = vec![
@@ -2211,6 +2339,7 @@ fn generate_variant_serialize(
                     then_block,
                     else_block,
                     span,
+                    names,
                 ),
             ];
 
@@ -2246,11 +2375,11 @@ fn generate_variant_serialize(
 
     let method_info = LocalMethodName::new(
         req.target_type_name.clone(),
-        Some("Serialize".to_string()),
+        Some(names.serialize.clone()),
         "serialize".to_string(),
     );
     let qualified_name =
-        MethodName::format_local(&req.target_type_name, Some("Serialize"), "serialize");
+        MethodName::format_local(&req.target_type_name, Some(&names.serialize), "serialize");
 
     Some(TirFunction {
         module_source: ModuleSource::default(),
@@ -2264,7 +2393,7 @@ fn generate_variant_serialize(
             name: "S".to_string(),
             is_effect: false,
             is_pack: false,
-            bounds: vec!["Serializer".to_string()],
+            bounds: vec![names.serializer.clone()],
             default: None,
             index: 0,
         }],
@@ -2314,20 +2443,18 @@ fn generate_variant_serialize(
 fn generate_variant_deserialize(
     module: &TirModule,
     req: &crate::tir::SynthesisRequest,
+    names: &SerdeStdlibNames,
 ) -> Option<TirFunction> {
     let variant_def = find_variant(module, &req.target_type_name)?;
     let span = synth_span();
     let serde_module = ModuleSource::serde();
 
-    let (eq_trait_name, deserialize_trait_name, string_struct_name) = {
+    let (eq_trait_name, string_struct_name) = {
         let tt = module.type_table.borrow();
         let items = tt.compiler_items();
         (
             items
                 .trait_name(crate::compiler_item::CompilerItem::Eq)
-                .to_string(),
-            items
-                .trait_name(crate::compiler_item::CompilerItem::Deserialize)
                 .to_string(),
             items
                 .struct_name(crate::compiler_item::CompilerItem::String)
@@ -2339,9 +2466,9 @@ fn generate_variant_deserialize(
     let variant_type = req.target_type_id;
     let string_type = tt.make_compiler_struct(crate::compiler_item::CompilerItem::String);
     let ref_string_type = tt.make_ref(string_type);
-    let deser_error_type = tt.make_struct("DeserializeError".to_string(), serde_module.clone());
+    let deser_error_type = tt.make_struct(names.deserialize_error.clone(), serde_module.clone());
     let deser_error_kind_type = tt
-        .find_enum_type("DeserializeErrorKind", &serde_module)
+        .find_enum_type(&names.deserialize_error_kind, &serde_module)
         .unwrap_or(TypeTable::I32);
     let result_variant_err = tt.make_result(variant_type, deser_error_type);
     let d_type_param = tt.make_type_param("D".to_string(), 0);
@@ -2349,7 +2476,7 @@ fn generate_variant_deserialize(
     let variant_access_type = tt.make_assoc_type_projection(
         d_type_param,
         "VariantAccess".to_string(),
-        vec!["DeserializeVariant".to_string()],
+        vec![names.deserialize_variant.clone()],
         vec![],
     );
     let result_va_err = tt.make_result(variant_access_type, deser_error_type);
@@ -2391,7 +2518,7 @@ fn generate_variant_deserialize(
     let begin_call = type_param_method_call(
         local_ref(0, "d", mut_ref_d),
         "D",
-        "Deserializer",
+        &names.deserializer,
         "begin_variant",
         serde_module.clone(),
         vec![],
@@ -2420,7 +2547,7 @@ fn generate_variant_deserialize(
     let disc_call = type_param_method_call(
         local_ref(va_local, "va", mut_ref_va),
         "D::VariantAccess",
-        "DeserializeVariant",
+        &names.deserialize_variant,
         "disc",
         serde_module.clone(),
         vec![],
@@ -2454,7 +2581,7 @@ fn generate_variant_deserialize(
             let end_call = type_param_method_call(
                 local_ref(va_local, "va", mut_ref_va),
                 "D::VariantAccess",
-                "DeserializeVariant",
+                &names.deserialize_variant,
                 "end",
                 serde_module.clone(),
                 vec![],
@@ -2477,7 +2604,7 @@ fn generate_variant_deserialize(
 
             let if_body = block(vec![
                 expr_stmt(end_call),
-                return_stmt(Some(variant_ok(construct, result_variant_err, span))),
+                return_stmt(Some(variant_ok(construct, result_variant_err, span, names))),
             ]);
             disc_then_stmts.push(if_stmt(condition, if_body, None));
         } else {
@@ -2487,7 +2614,7 @@ fn generate_variant_deserialize(
             let payload_call = type_param_method_call(
                 local_ref(va_local, "va", mut_ref_va),
                 "D::VariantAccess",
-                "DeserializeVariant",
+                &names.deserialize_variant,
                 "payload",
                 serde_module.clone(),
                 vec![payload_type_names[i].clone()],
@@ -2500,7 +2627,7 @@ fn generate_variant_deserialize(
             let end_call = type_param_method_call(
                 local_ref(va_local, "va", mut_ref_va),
                 "D::VariantAccess",
-                "DeserializeVariant",
+                &names.deserialize_variant,
                 "end",
                 serde_module.clone(),
                 vec![],
@@ -2527,7 +2654,7 @@ fn generate_variant_deserialize(
 
             let ok_block = block(vec![
                 expr_stmt(end_call),
-                return_stmt(Some(variant_ok(construct, result_variant_err, span))),
+                return_stmt(Some(variant_ok(construct, result_variant_err, span, names))),
             ]);
 
             let if_body = block(vec![
@@ -2551,8 +2678,10 @@ fn generate_variant_deserialize(
                         deser_error_type,
                         result_variant_err,
                         span,
+                        names,
                     ),
                     span,
+                    names,
                 ),
             ]);
             disc_then_stmts.push(if_stmt(condition, if_body, None));
@@ -2562,16 +2691,18 @@ fn generate_variant_deserialize(
     let disc_unknown_err = deserialize_error_literal(
         deser_error_type,
         deser_error_kind_type,
-        "UnknownVariant",
-        2,
+        &names.deser_err_unknown_variant_name,
+        names.deser_err_unknown_variant_index,
         "unknown variant discriminant",
         string_type,
         span,
+        names,
     );
     disc_then_stmts.push(return_stmt(Some(variant_err(
         disc_unknown_err,
         result_variant_err,
         span,
+        names,
     ))));
 
     // --- name-based fallback ---
@@ -2580,7 +2711,7 @@ fn generate_variant_deserialize(
     let name_call = type_param_method_call(
         local_ref(va_local, "va", mut_ref_va),
         "D::VariantAccess",
-        "DeserializeVariant",
+        &names.deserialize_variant,
         "variant_name",
         serde_module.clone(),
         vec![],
@@ -2636,7 +2767,7 @@ fn generate_variant_deserialize(
             let end_call = type_param_method_call(
                 local_ref(va_local, "va", mut_ref_va),
                 "D::VariantAccess",
-                "DeserializeVariant",
+                &names.deserialize_variant,
                 "end",
                 serde_module.clone(),
                 vec![],
@@ -2659,7 +2790,7 @@ fn generate_variant_deserialize(
 
             let if_body = block(vec![
                 expr_stmt(end_call),
-                return_stmt(Some(variant_ok(construct, result_variant_err, span))),
+                return_stmt(Some(variant_ok(construct, result_variant_err, span, names))),
             ]);
             name_then_stmts.push(if_stmt(condition, if_body, None));
         } else {
@@ -2669,7 +2800,7 @@ fn generate_variant_deserialize(
             let payload_call = type_param_method_call(
                 local_ref(va_local, "va", mut_ref_va),
                 "D::VariantAccess",
-                "DeserializeVariant",
+                &names.deserialize_variant,
                 "payload",
                 serde_module.clone(),
                 vec![payload_type_names[i].clone()],
@@ -2682,7 +2813,7 @@ fn generate_variant_deserialize(
             let end_call = type_param_method_call(
                 local_ref(va_local, "va", mut_ref_va),
                 "D::VariantAccess",
-                "DeserializeVariant",
+                &names.deserialize_variant,
                 "end",
                 serde_module.clone(),
                 vec![],
@@ -2709,7 +2840,7 @@ fn generate_variant_deserialize(
 
             let ok_block = block(vec![
                 expr_stmt(end_call),
-                return_stmt(Some(variant_ok(construct, result_variant_err, span))),
+                return_stmt(Some(variant_ok(construct, result_variant_err, span, names))),
             ]);
 
             let if_body = block(vec![
@@ -2733,8 +2864,10 @@ fn generate_variant_deserialize(
                         deser_error_type,
                         result_variant_err,
                         span,
+                        names,
                     ),
                     span,
+                    names,
                 ),
             ]);
             name_then_stmts.push(if_stmt(condition, if_body, None));
@@ -2745,16 +2878,18 @@ fn generate_variant_deserialize(
     let unknown_err = deserialize_error_literal(
         deser_error_type,
         deser_error_kind_type,
-        "UnknownVariant",
-        2,
+        &names.deser_err_unknown_variant_name,
+        names.deser_err_unknown_variant_index,
         "unknown variant",
         string_type,
         span,
+        names,
     );
     name_then_stmts.push(return_stmt(Some(variant_err(
         unknown_err,
         result_variant_err,
         span,
+        names,
     ))));
 
     name_fallback_stmts.push(if_let_ok(
@@ -2771,8 +2906,10 @@ fn generate_variant_deserialize(
             deser_error_type,
             result_variant_err,
             span,
+            names,
         ),
         span,
+        names,
     ));
 
     // Wire up disc path with name fallback
@@ -2785,6 +2922,7 @@ fn generate_variant_deserialize(
         block(disc_then_stmts),
         block(name_fallback_stmts),
         span,
+        names,
     ));
 
     stmts.push(if_let_ok(
@@ -2801,18 +2939,20 @@ fn generate_variant_deserialize(
             deser_error_type,
             result_variant_err,
             span,
+            names,
         ),
         span,
+        names,
     ));
 
     let method_info = LocalMethodName::new(
         req.target_type_name.clone(),
-        Some(deserialize_trait_name.clone()),
+        Some(names.deserialize.clone()),
         "deserialize".to_string(),
     );
     let qualified_name = MethodName::format_local(
         &req.target_type_name,
-        Some(&deserialize_trait_name),
+        Some(&names.deserialize),
         "deserialize",
     );
 
@@ -2828,7 +2968,7 @@ fn generate_variant_deserialize(
             name: "D".to_string(),
             is_effect: false,
             is_pack: false,
-            bounds: vec!["Deserializer".to_string()],
+            bounds: vec![names.deserializer.clone()],
             default: None,
             index: 0,
         }],
@@ -2911,6 +3051,7 @@ fn flags_bit_check(ref_self_type: TypeId, flags_type: TypeId, bitmask: u32, span
 fn generate_flags_serialize(
     module: &TirModule,
     req: &crate::tir::SynthesisRequest,
+    names: &SerdeStdlibNames,
 ) -> Option<TirFunction> {
     let flags_def = find_flags(module, &req.target_type_name)?;
     let span = synth_span();
@@ -2930,15 +3071,15 @@ fn generate_flags_serialize(
     let mut_ref_s = tt.make_mut_ref(s_type_param);
     let string_type = tt.make_compiler_struct(crate::compiler_item::CompilerItem::String);
     let ref_string_type = tt.make_ref(string_type);
-    let ser_error_type = tt.make_struct("SerializeError".to_string(), serde_module.clone());
+    let ser_error_type = tt.make_struct(names.serialize_error.clone(), serde_module.clone());
     let ser_error_kind_type = tt
-        .find_enum_type("SerializeErrorKind", &serde_module)
+        .find_enum_type(&names.serialize_error_kind, &serde_module)
         .unwrap_or(TypeTable::I32);
     let result_unit_err = tt.make_result(TypeTable::UNIT, ser_error_type);
     let seq_ser_type = tt.make_assoc_type_projection(
         s_type_param,
         "SeqSerializer".to_string(),
-        vec!["SerializeSeq".to_string()],
+        vec![names.serialize_seq.clone()],
         vec![],
     );
     let result_seq_err = tt.make_result(seq_ser_type, ser_error_type);
@@ -2998,7 +3139,7 @@ fn generate_flags_serialize(
     let begin_call = type_param_method_call(
         local_ref(1, "s", mut_ref_s),
         "S",
-        "Serializer",
+        &names.serializer,
         "begin_seq",
         serde_module.clone(),
         vec![],
@@ -3021,7 +3162,7 @@ fn generate_flags_serialize(
         let element_call = type_param_method_call(
             local_ref(seq_local, "seq", mut_ref_seq),
             "S::SeqSerializer",
-            "SerializeSeq",
+            &names.serialize_seq,
             "element",
             serde_module.clone(),
             vec![string_struct_name.clone()],
@@ -3045,7 +3186,7 @@ fn generate_flags_serialize(
     let end_call = type_param_method_call(
         local_ref(seq_local, "seq", mut_ref_seq),
         "S::SeqSerializer",
-        "SerializeSeq",
+        &names.serialize_seq,
         "end",
         serde_module,
         vec![],
@@ -3063,11 +3204,13 @@ fn generate_flags_serialize(
         "begin_seq failed",
         string_type,
         span,
+        names,
     );
     let else_stmts = vec![return_stmt(Some(variant_err(
         err_val,
         result_unit_err,
         span,
+        names,
     )))];
 
     stmts.push(if_let_ok(
@@ -3079,15 +3222,16 @@ fn generate_flags_serialize(
         block(then_stmts),
         block(else_stmts),
         span,
+        names,
     ));
 
     let method_info = LocalMethodName::new(
         req.target_type_name.clone(),
-        Some("Serialize".to_string()),
+        Some(names.serialize.clone()),
         "serialize".to_string(),
     );
     let qualified_name =
-        MethodName::format_local(&req.target_type_name, Some("Serialize"), "serialize");
+        MethodName::format_local(&req.target_type_name, Some(&names.serialize), "serialize");
 
     Some(TirFunction {
         module_source: ModuleSource::default(),
@@ -3101,7 +3245,7 @@ fn generate_flags_serialize(
             name: "S".to_string(),
             is_effect: false,
             is_pack: false,
-            bounds: vec!["Serializer".to_string()],
+            bounds: vec![names.serializer.clone()],
             default: None,
             index: 0,
         }],
@@ -3152,20 +3296,18 @@ fn generate_flags_serialize(
 fn generate_flags_deserialize(
     module: &TirModule,
     req: &crate::tir::SynthesisRequest,
+    names: &SerdeStdlibNames,
 ) -> Option<TirFunction> {
     let flags_def = find_flags(module, &req.target_type_name)?;
     let span = synth_span();
     let serde_module = ModuleSource::serde();
 
-    let (eq_trait_name, deserialize_trait_name, string_struct_name) = {
+    let (eq_trait_name, string_struct_name) = {
         let tt = module.type_table.borrow();
         let items = tt.compiler_items();
         (
             items
                 .trait_name(crate::compiler_item::CompilerItem::Eq)
-                .to_string(),
-            items
-                .trait_name(crate::compiler_item::CompilerItem::Deserialize)
                 .to_string(),
             items
                 .struct_name(crate::compiler_item::CompilerItem::String)
@@ -3179,16 +3321,16 @@ fn generate_flags_deserialize(
     let mut_ref_d = tt.make_mut_ref(d_type_param);
     let string_type = tt.make_compiler_struct(crate::compiler_item::CompilerItem::String);
     let ref_string_type = tt.make_ref(string_type);
-    let deser_error_type = tt.make_struct("DeserializeError".to_string(), serde_module.clone());
+    let deser_error_type = tt.make_struct(names.deserialize_error.clone(), serde_module.clone());
     let deser_error_kind_type = tt
-        .find_enum_type("DeserializeErrorKind", &serde_module)
+        .find_enum_type(&names.deserialize_error_kind, &serde_module)
         .unwrap_or(TypeTable::I32);
     let result_flags_err = tt.make_result(flags_type, deser_error_type);
     let result_unit_err = tt.make_result(TypeTable::UNIT, deser_error_type);
     let seq_access_type = tt.make_assoc_type_projection(
         d_type_param,
         "SeqAccess".to_string(),
-        vec!["DeserializeSeq".to_string()],
+        vec![names.deserialize_seq.clone()],
         vec![],
     );
     let result_seq_err = tt.make_result(seq_access_type, deser_error_type);
@@ -3219,7 +3361,7 @@ fn generate_flags_deserialize(
     let begin_call = type_param_method_call(
         local_ref(0, "d", mut_ref_d),
         "D",
-        "Deserializer",
+        &names.deserializer,
         "begin_seq",
         serde_module.clone(),
         vec![],
@@ -3257,7 +3399,7 @@ fn generate_flags_deserialize(
     let next_call = type_param_method_call(
         local_ref(seq_local, "seq", mut_ref_seq),
         "D::SeqAccess",
-        "DeserializeSeq",
+        &names.deserialize_seq,
         "next_element",
         serde_module.clone(),
         vec![string_struct_name.clone()],
@@ -3364,15 +3506,17 @@ fn generate_flags_deserialize(
     let unknown_err = deserialize_error_literal_with_expr(
         deser_error_type,
         deser_error_kind_type,
-        "InvalidValue",
-        4,
+        &names.deser_err_invalid_value_name,
+        names.deser_err_invalid_value_index,
         unknown_msg,
         span,
+        names,
     );
     name_match_stmts.push(return_stmt(Some(variant_err(
         unknown_err,
         result_flags_err,
         span,
+        names,
     ))));
 
     // if let Some(name) = elem { match... } else { break }
@@ -3387,6 +3531,7 @@ fn generate_flags_deserialize(
         some_then,
         none_else,
         span,
+        names,
     );
 
     // if let Ok(elem) = __elem_r { if let Some... } else { propagate err }
@@ -3398,6 +3543,7 @@ fn generate_flags_deserialize(
         deser_error_type,
         result_flags_err,
         span,
+        names,
     );
     loop_body_stmts.push(if_let_ok(
         local_ref(elem_result_local, "__elem_r", result_option_string_err),
@@ -3408,6 +3554,7 @@ fn generate_flags_deserialize(
         ok_elem_then,
         ok_elem_else,
         span,
+        names,
     ));
 
     ok_stmts.push(loop_stmt(block(loop_body_stmts)));
@@ -3416,7 +3563,7 @@ fn generate_flags_deserialize(
     let end_call = type_param_method_call(
         local_ref(seq_local, "seq", mut_ref_seq),
         "D::SeqAccess",
-        "DeserializeSeq",
+        &names.deserialize_seq,
         "end",
         serde_module,
         vec![],
@@ -3433,6 +3580,7 @@ fn generate_flags_deserialize(
         bits_as_flags,
         result_flags_err,
         span,
+        names,
     ))));
 
     // if let Ok(mut seq) = __seq_r { ... } else { propagate err }
@@ -3450,18 +3598,20 @@ fn generate_flags_deserialize(
             deser_error_type,
             result_flags_err,
             span,
+            names,
         ),
         span,
+        names,
     ));
 
     let method_info = LocalMethodName::new(
         req.target_type_name.clone(),
-        Some(deserialize_trait_name.clone()),
+        Some(names.deserialize.clone()),
         "deserialize".to_string(),
     );
     let qualified_name = MethodName::format_local(
         &req.target_type_name,
-        Some(&deserialize_trait_name),
+        Some(&names.deserialize),
         "deserialize",
     );
 
@@ -3477,7 +3627,7 @@ fn generate_flags_deserialize(
             name: "D".to_string(),
             is_effect: false,
             is_pack: false,
-            bounds: vec!["Deserializer".to_string()],
+            bounds: vec![names.deserializer.clone()],
             default: None,
             index: 0,
         }],
@@ -3522,6 +3672,7 @@ fn deserialize_error_literal_with_expr(
     kind_index: u32,
     message_expr: TirExpr,
     span: Span,
+    names: &SerdeStdlibNames,
 ) -> TirExpr {
     let kind = TirExpr::new(
         TirExprKind::EnumConstruct {
@@ -3543,7 +3694,7 @@ fn deserialize_error_literal_with_expr(
     TirExpr::new(
         TirExprKind::StructLiteral {
             struct_type: deser_error_type,
-            struct_name: "DeserializeError".to_string(),
+            struct_name: names.deserialize_error.clone(),
             fields: vec![
                 TirStructField {
                     name: "kind".to_string(),

--- a/wado-compiler/src/synthesis/serde_synth.rs
+++ b/wado-compiler/src/synthesis/serde_synth.rs
@@ -69,10 +69,8 @@ impl SerdeStdlibNames {
     pub fn from_compiler_items(items: &CompilerItems) -> Self {
         let (_, _, ok_name, ok_index) = items.require_variant_case(CompilerItem::ResultOk);
         let (_, _, err_name, err_index) = items.require_variant_case(CompilerItem::ResultErr);
-        let (_, _, some_name, some_index) =
-            items.require_variant_case(CompilerItem::OptionSome);
-        let (_, _, none_name, none_index) =
-            items.require_variant_case(CompilerItem::OptionNone);
+        let (_, _, some_name, some_index) = items.require_variant_case(CompilerItem::OptionSome);
+        let (_, _, none_name, none_index) = items.require_variant_case(CompilerItem::OptionNone);
         let (_, _, ser_err_custom_name, ser_err_custom_index) =
             items.require_enum_case(CompilerItem::SerializeErrorKindCustom);
         let (_, _, deser_err_missing_field_name, deser_err_missing_field_index) =
@@ -88,9 +86,7 @@ impl SerdeStdlibNames {
             deserializer: items.trait_name(CompilerItem::Deserializer).to_string(),
             serialize_struct: items.trait_name(CompilerItem::SerializeStruct).to_string(),
             serialize_seq: items.trait_name(CompilerItem::SerializeSeq).to_string(),
-            serialize_variant: items
-                .trait_name(CompilerItem::SerializeVariant)
-                .to_string(),
+            serialize_variant: items.trait_name(CompilerItem::SerializeVariant).to_string(),
             deserialize_struct: items
                 .trait_name(CompilerItem::DeserializeStruct)
                 .to_string(),
@@ -99,7 +95,9 @@ impl SerdeStdlibNames {
                 .trait_name(CompilerItem::DeserializeVariant)
                 .to_string(),
             serialize_error: items.struct_name(CompilerItem::SerializeError).to_string(),
-            serialize_error_kind: items.enum_name(CompilerItem::SerializeErrorKind).to_string(),
+            serialize_error_kind: items
+                .enum_name(CompilerItem::SerializeErrorKind)
+                .to_string(),
             deserialize_error: items
                 .struct_name(CompilerItem::DeserializeError)
                 .to_string(),
@@ -338,7 +336,12 @@ fn propagate_err_block(
     )))])
 }
 
-fn variant_ok(value: TirExpr, result_type: TypeId, span: Span, names: &SerdeStdlibNames) -> TirExpr {
+fn variant_ok(
+    value: TirExpr,
+    result_type: TypeId,
+    span: Span,
+    names: &SerdeStdlibNames,
+) -> TirExpr {
     TirExpr::new(
         TirExprKind::VariantConstruct {
             variant_type: result_type,
@@ -351,7 +354,12 @@ fn variant_ok(value: TirExpr, result_type: TypeId, span: Span, names: &SerdeStdl
     )
 }
 
-fn variant_err(value: TirExpr, result_type: TypeId, span: Span, names: &SerdeStdlibNames) -> TirExpr {
+fn variant_err(
+    value: TirExpr,
+    result_type: TypeId,
+    span: Span,
+    names: &SerdeStdlibNames,
+) -> TirExpr {
     TirExpr::new(
         TirExprKind::VariantConstruct {
             variant_type: result_type,
@@ -1904,7 +1912,12 @@ fn generate_enum_deserialize(
 
         let if_body = block(vec![
             expr_stmt(end_call),
-            return_stmt(Some(variant_ok(enum_construct, result_enum_err, span, names))),
+            return_stmt(Some(variant_ok(
+                enum_construct,
+                result_enum_err,
+                span,
+                names,
+            ))),
         ]);
         disc_then_stmts.push(if_stmt(condition, if_body, None));
     }
@@ -2012,7 +2025,12 @@ fn generate_enum_deserialize(
 
         let if_body = block(vec![
             expr_stmt(end_call),
-            return_stmt(Some(variant_ok(enum_construct, result_enum_err, span, names))),
+            return_stmt(Some(variant_ok(
+                enum_construct,
+                result_enum_err,
+                span,
+                names,
+            ))),
         ]);
         name_then_stmts.push(if_stmt(condition, if_body, None));
     }

--- a/wado-compiler/src/synthesis/serde_synth.rs
+++ b/wado-compiler/src/synthesis/serde_synth.rs
@@ -65,15 +65,15 @@ pub(super) struct SerdeStdlibNames {
     pub deser_err_unknown_variant_index: u32,
     pub deser_err_invalid_value_name: String,
     pub deser_err_invalid_value_index: u32,
-    /// `Serializer` associated type spellings: `SeqSerializer`,
-    /// `StructSerializer`, `VariantSerializer`. Auto-captured from the
-    /// trait declaration so the synthesiser can build `S::SeqSerializer`
-    /// projections without hard-coding the source-side names.
+    /// `Serializer` / `Deserializer` associated-type spellings,
+    /// resolved by their **trait bound** (also looked up from the
+    /// registry) rather than by source-side name. Renaming
+    /// `Serializer::SeqSerializer` to `SeqWriter` — or renaming the
+    /// bound `SerializeSeq` to `SeqWriterTrait` — both flow through
+    /// the registry without panicking on a stale lookup key.
     pub seq_serializer_assoc: String,
     pub struct_serializer_assoc: String,
     pub variant_serializer_assoc: String,
-    /// `Deserializer` associated type spellings: `SeqAccess`,
-    /// `StructAccess`, `VariantAccess`.
     pub seq_access_assoc: String,
     pub struct_access_assoc: String,
     pub variant_access_assoc: String,
@@ -145,46 +145,82 @@ impl SerdeStdlibNames {
             deser_err_invalid_value_name: deser_err_invalid_value_name.to_string(),
             deser_err_invalid_value_index,
             seq_serializer_assoc: items
-                .trait_assoc_type_name(CompilerItem::Serializer, "SeqSerializer")
+                .trait_assoc_type_by_bound(
+                    CompilerItem::Serializer,
+                    items.trait_name(CompilerItem::SerializeSeq),
+                )
                 .to_string(),
             struct_serializer_assoc: items
-                .trait_assoc_type_name(CompilerItem::Serializer, "StructSerializer")
+                .trait_assoc_type_by_bound(
+                    CompilerItem::Serializer,
+                    items.trait_name(CompilerItem::SerializeStruct),
+                )
                 .to_string(),
             variant_serializer_assoc: items
-                .trait_assoc_type_name(CompilerItem::Serializer, "VariantSerializer")
+                .trait_assoc_type_by_bound(
+                    CompilerItem::Serializer,
+                    items.trait_name(CompilerItem::SerializeVariant),
+                )
                 .to_string(),
             seq_access_assoc: items
-                .trait_assoc_type_name(CompilerItem::Deserializer, "SeqAccess")
+                .trait_assoc_type_by_bound(
+                    CompilerItem::Deserializer,
+                    items.trait_name(CompilerItem::DeserializeSeq),
+                )
                 .to_string(),
             struct_access_assoc: items
-                .trait_assoc_type_name(CompilerItem::Deserializer, "StructAccess")
+                .trait_assoc_type_by_bound(
+                    CompilerItem::Deserializer,
+                    items.trait_name(CompilerItem::DeserializeStruct),
+                )
                 .to_string(),
             variant_access_assoc: items
-                .trait_assoc_type_name(CompilerItem::Deserializer, "VariantAccess")
+                .trait_assoc_type_by_bound(
+                    CompilerItem::Deserializer,
+                    items.trait_name(CompilerItem::DeserializeVariant),
+                )
                 .to_string(),
             s_struct_serializer_proj: format!(
                 "S::{}",
-                items.trait_assoc_type_name(CompilerItem::Serializer, "StructSerializer")
+                items.trait_assoc_type_by_bound(
+                    CompilerItem::Serializer,
+                    items.trait_name(CompilerItem::SerializeStruct),
+                )
             ),
             s_seq_serializer_proj: format!(
                 "S::{}",
-                items.trait_assoc_type_name(CompilerItem::Serializer, "SeqSerializer")
+                items.trait_assoc_type_by_bound(
+                    CompilerItem::Serializer,
+                    items.trait_name(CompilerItem::SerializeSeq),
+                )
             ),
             s_variant_serializer_proj: format!(
                 "S::{}",
-                items.trait_assoc_type_name(CompilerItem::Serializer, "VariantSerializer")
+                items.trait_assoc_type_by_bound(
+                    CompilerItem::Serializer,
+                    items.trait_name(CompilerItem::SerializeVariant),
+                )
             ),
             d_struct_access_proj: format!(
                 "D::{}",
-                items.trait_assoc_type_name(CompilerItem::Deserializer, "StructAccess")
+                items.trait_assoc_type_by_bound(
+                    CompilerItem::Deserializer,
+                    items.trait_name(CompilerItem::DeserializeStruct),
+                )
             ),
             d_seq_access_proj: format!(
                 "D::{}",
-                items.trait_assoc_type_name(CompilerItem::Deserializer, "SeqAccess")
+                items.trait_assoc_type_by_bound(
+                    CompilerItem::Deserializer,
+                    items.trait_name(CompilerItem::DeserializeSeq),
+                )
             ),
             d_variant_access_proj: format!(
                 "D::{}",
-                items.trait_assoc_type_name(CompilerItem::Deserializer, "VariantAccess")
+                items.trait_assoc_type_by_bound(
+                    CompilerItem::Deserializer,
+                    items.trait_name(CompilerItem::DeserializeVariant),
+                )
             ),
         }
     }

--- a/wado-compiler/src/synthesis/serde_synth.rs
+++ b/wado-compiler/src/synthesis/serde_synth.rs
@@ -26,12 +26,13 @@ use crate::token::Span;
 /// through the synthesis helpers so a stdlib rename of any of these
 /// items flows through every call site without touching Rust code.
 ///
-/// All trait / struct / enum / case names live here together because
-/// every synthesised `Serialize` / `Deserialize` impl reaches for the
-/// full set; splitting the snapshot per-item would just multiply the
-/// borrow points without making any one site cleaner.
+/// Field set is **minimal**: only the symbols this synthesiser actually
+/// reads end up here. `Option::Some`'s case name is needed by
+/// `if_let_some` (the pattern carries the name); `Option::None` is
+/// **not** included because the only place serde constructs `None`
+/// (`generate_lookup_function`) calls `option_none` directly with
+/// `&CompilerItems`, never through this snapshot.
 #[derive(Clone, Debug)]
-#[allow(dead_code)]
 pub(super) struct SerdeStdlibNames {
     pub serialize: String,
     pub deserialize: String,
@@ -51,10 +52,11 @@ pub(super) struct SerdeStdlibNames {
     pub ok_index: u32,
     pub err_name: String,
     pub err_index: u32,
+    /// `Some` case name. The index is intentionally omitted —
+    /// `if_let_some` only needs the name on the pattern; `option_some`
+    /// / `option_none` constructors take `&CompilerItems` and look up
+    /// the index themselves.
     pub some_name: String,
-    pub some_index: u32,
-    pub none_name: String,
-    pub none_index: u32,
     pub ser_err_custom_name: String,
     pub ser_err_custom_index: u32,
     pub deser_err_missing_field_name: String,
@@ -69,8 +71,9 @@ impl SerdeStdlibNames {
     pub fn from_compiler_items(items: &CompilerItems) -> Self {
         let (_, _, ok_name, ok_index) = items.require_variant_case(CompilerItem::ResultOk);
         let (_, _, err_name, err_index) = items.require_variant_case(CompilerItem::ResultErr);
-        let (_, _, some_name, some_index) = items.require_variant_case(CompilerItem::OptionSome);
-        let (_, _, none_name, none_index) = items.require_variant_case(CompilerItem::OptionNone);
+        let some_name = items
+            .variant_case_name(CompilerItem::OptionSome)
+            .to_string();
         let (_, _, ser_err_custom_name, ser_err_custom_index) =
             items.require_enum_case(CompilerItem::SerializeErrorKindCustom);
         let (_, _, deser_err_missing_field_name, deser_err_missing_field_index) =
@@ -108,10 +111,7 @@ impl SerdeStdlibNames {
             ok_index,
             err_name: err_name.to_string(),
             err_index,
-            some_name: some_name.to_string(),
-            some_index,
-            none_name: none_name.to_string(),
-            none_index,
+            some_name,
             ser_err_custom_name: ser_err_custom_name.to_string(),
             ser_err_custom_index,
             deser_err_missing_field_name: deser_err_missing_field_name.to_string(),

--- a/wado-compiler/src/synthesis/template.rs
+++ b/wado-compiler/src/synthesis/template.rs
@@ -63,8 +63,7 @@ impl FormatStdlibNames {
         let (_, _, left_name, left_index) = items.require_enum_case(CompilerItem::AlignmentLeft);
         let (_, _, center_name, center_index) =
             items.require_enum_case(CompilerItem::AlignmentCenter);
-        let (_, _, right_name, right_index) =
-            items.require_enum_case(CompilerItem::AlignmentRight);
+        let (_, _, right_name, right_index) = items.require_enum_case(CompilerItem::AlignmentRight);
         Self {
             formatter: items.struct_name(CompilerItem::Formatter).to_string(),
             alignment: items.enum_name(CompilerItem::Alignment).to_string(),

--- a/wado-compiler/src/synthesis/template.rs
+++ b/wado-compiler/src/synthesis/template.rs
@@ -14,6 +14,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
 
+use crate::compiler_item::{CompilerItem, CompilerItems};
 use crate::module_source::ModuleSource;
 use crate::name::LocalMethodName;
 use crate::resolver::trait_env::TraitEnv;
@@ -23,6 +24,73 @@ use crate::tir::{
     TirUnaryOp, TypeId, TypeTable,
 };
 use crate::token::Span;
+
+/// Snapshot of every `core:prelude/format` symbol name + case index the
+/// template-expansion synthesiser needs. Resolved once through the
+/// [`CompilerItem`] registry per template-string expansion, then threaded
+/// through the helpers so stdlib renames flow without touching synthesis
+/// sites — same shape as
+/// [`super::cm_binding::types::CmStdlibNames`].
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+pub(super) struct FormatStdlibNames {
+    pub formatter: String,
+    pub alignment: String,
+    pub left_name: String,
+    pub left_index: u32,
+    pub center_name: String,
+    pub center_index: u32,
+    pub right_name: String,
+    pub right_index: u32,
+    pub display: String,
+    pub display_alt: String,
+    pub inspect: String,
+    pub inspect_alt: String,
+    pub binary: String,
+    pub binary_alt: String,
+    pub octal: String,
+    pub octal_alt: String,
+    pub lower_hex: String,
+    pub lower_hex_alt: String,
+    pub upper_hex: String,
+    pub upper_hex_alt: String,
+    pub lower_exp: String,
+    pub upper_exp: String,
+}
+
+impl FormatStdlibNames {
+    pub fn from_compiler_items(items: &CompilerItems) -> Self {
+        let (_, _, left_name, left_index) = items.require_enum_case(CompilerItem::AlignmentLeft);
+        let (_, _, center_name, center_index) =
+            items.require_enum_case(CompilerItem::AlignmentCenter);
+        let (_, _, right_name, right_index) =
+            items.require_enum_case(CompilerItem::AlignmentRight);
+        Self {
+            formatter: items.struct_name(CompilerItem::Formatter).to_string(),
+            alignment: items.enum_name(CompilerItem::Alignment).to_string(),
+            left_name: left_name.to_string(),
+            left_index,
+            center_name: center_name.to_string(),
+            center_index,
+            right_name: right_name.to_string(),
+            right_index,
+            display: items.trait_name(CompilerItem::Display).to_string(),
+            display_alt: items.trait_name(CompilerItem::DisplayAlt).to_string(),
+            inspect: items.trait_name(CompilerItem::Inspect).to_string(),
+            inspect_alt: items.trait_name(CompilerItem::InspectAlt).to_string(),
+            binary: items.trait_name(CompilerItem::Binary).to_string(),
+            binary_alt: items.trait_name(CompilerItem::BinaryAlt).to_string(),
+            octal: items.trait_name(CompilerItem::Octal).to_string(),
+            octal_alt: items.trait_name(CompilerItem::OctalAlt).to_string(),
+            lower_hex: items.trait_name(CompilerItem::LowerHex).to_string(),
+            lower_hex_alt: items.trait_name(CompilerItem::LowerHexAlt).to_string(),
+            upper_hex: items.trait_name(CompilerItem::UpperHex).to_string(),
+            upper_hex_alt: items.trait_name(CompilerItem::UpperHexAlt).to_string(),
+            lower_exp: items.trait_name(CompilerItem::LowerExp).to_string(),
+            upper_exp: items.trait_name(CompilerItem::UpperExp).to_string(),
+        }
+    }
+}
 
 /// Expand all `TemplateString` nodes in a module.
 ///
@@ -34,10 +102,12 @@ pub fn expand_templates(
     tt: &Rc<RefCell<TypeTable>>,
     trait_env: &Arc<TraitEnv>,
 ) {
+    let names = FormatStdlibNames::from_compiler_items(tt.borrow().compiler_items());
     let ctx = TemplateCtx {
         tt,
         module_src: module.module_source.clone(),
         trait_env,
+        names: &names,
     };
     for func_rc in &module.functions {
         let mut func = func_rc.borrow_mut();
@@ -79,6 +149,7 @@ struct TemplateCtx<'a> {
     tt: &'a Rc<RefCell<TypeTable>>,
     module_src: ModuleSource,
     trait_env: &'a Arc<TraitEnv>,
+    names: &'a FormatStdlibNames,
 }
 
 struct FuncLocalAlloc {
@@ -382,7 +453,7 @@ fn build_template_block(
 
     let formatter_type = tt
         .borrow_mut()
-        .make_struct("Formatter".to_string(), ModuleSource::format());
+        .make_struct(ctx.names.formatter.clone(), ModuleSource::format());
     let mut_ref_formatter = tt.borrow_mut().make_mut_ref(formatter_type);
     let ref_string_type = tt.borrow_mut().make_ref(string_type);
     let mut fmt_local_index: Option<u32> = None;
@@ -493,22 +564,22 @@ fn build_template_block(
                     .is_some_and(|fs| fs.type_char == Some('?'));
                 let is_alternate = format_spec.as_ref().is_some_and(|fs| fs.alternate);
 
-                let (trait_name, method_name) = match &format_spec {
+                let (trait_name, method_name): (&str, &str) = match &format_spec {
                     Some(fs) => match (fs.type_char, fs.alternate) {
-                        (Some('b'), true) => ("BinaryAlt", "fmt_alt"),
-                        (Some('b'), false) => ("Binary", "fmt"),
-                        (Some('o'), true) => ("OctalAlt", "fmt_alt"),
-                        (Some('o'), false) => ("Octal", "fmt"),
-                        (Some('x'), true) => ("LowerHexAlt", "fmt_alt"),
-                        (Some('x'), false) => ("LowerHex", "fmt"),
-                        (Some('X'), true) => ("UpperHexAlt", "fmt_alt"),
-                        (Some('X'), false) => ("UpperHex", "fmt"),
-                        (Some('e'), _) => ("LowerExp", "fmt"),
-                        (Some('E'), _) => ("UpperExp", "fmt"),
-                        (_, true) => ("DisplayAlt", "fmt_alt"),
-                        _ => ("Display", "fmt"),
+                        (Some('b'), true) => (ctx.names.binary_alt.as_str(), "fmt_alt"),
+                        (Some('b'), false) => (ctx.names.binary.as_str(), "fmt"),
+                        (Some('o'), true) => (ctx.names.octal_alt.as_str(), "fmt_alt"),
+                        (Some('o'), false) => (ctx.names.octal.as_str(), "fmt"),
+                        (Some('x'), true) => (ctx.names.lower_hex_alt.as_str(), "fmt_alt"),
+                        (Some('x'), false) => (ctx.names.lower_hex.as_str(), "fmt"),
+                        (Some('X'), true) => (ctx.names.upper_hex_alt.as_str(), "fmt_alt"),
+                        (Some('X'), false) => (ctx.names.upper_hex.as_str(), "fmt"),
+                        (Some('e'), _) => (ctx.names.lower_exp.as_str(), "fmt"),
+                        (Some('E'), _) => (ctx.names.upper_exp.as_str(), "fmt"),
+                        (_, true) => (ctx.names.display_alt.as_str(), "fmt_alt"),
+                        _ => (ctx.names.display.as_str(), "fmt"),
                     },
-                    None => ("Display", "fmt"),
+                    None => (ctx.names.display.as_str(), "fmt"),
                 };
 
                 // Create or reassign Formatter local
@@ -520,6 +591,7 @@ fn build_template_block(
                         &format_spec,
                         span,
                         tt,
+                        ctx.names,
                     );
                     let assign = TirExpr::new(
                         TirExprKind::Assign {
@@ -548,6 +620,7 @@ fn build_template_block(
                         &format_spec,
                         span,
                         tt,
+                        ctx.names,
                     );
                     stmts.push(TirStmt::new(
                         TirStmtKind::Let {
@@ -581,10 +654,10 @@ fn build_template_block(
                 );
 
                 if is_inspect {
-                    let (it_name, im_name) = if is_alternate {
-                        ("InspectAlt", "inspect_alt")
+                    let (it_name, im_name): (&str, &str) = if is_alternate {
+                        (ctx.names.inspect_alt.as_str(), "inspect_alt")
                     } else {
-                        ("Inspect", "inspect")
+                        (ctx.names.inspect.as_str(), "inspect")
                     };
                     let call_stmts = trait_fmt_call(
                         resolved.type_id,
@@ -649,6 +722,7 @@ fn build_formatter_expr(
     parsed: &Option<TemplateFormatSpec>,
     span: Span,
     tt: &Rc<RefCell<TypeTable>>,
+    names: &FormatStdlibNames,
 ) -> TirExpr {
     let mut_ref_string = tt.borrow_mut().make_mut_ref(string_type);
     let buf_mut_ref = TirExpr::new(
@@ -681,10 +755,10 @@ fn build_formatter_expr(
             TirExprKind::Call {
                 func: FunctionRef {
                     module_source: ModuleSource::format(),
-                    name: "Formatter::new".to_string(),
+                    name: format!("{}::new", names.formatter),
                     monomorph_info: None,
                     method_info: Some(LocalMethodName::new(
-                        "Formatter".to_string(),
+                        names.formatter.clone(),
                         None,
                         "new".to_string(),
                     )),
@@ -700,23 +774,18 @@ fn build_formatter_expr(
     let pf = parsed.as_ref().unwrap();
     let alignment_type = tt
         .borrow_mut()
-        .make_enum("Alignment".to_string(), ModuleSource::format());
+        .make_enum(names.alignment.clone(), ModuleSource::format());
     let fill_char = pf.fill.unwrap_or(if pf.zero_pad { '0' } else { ' ' });
-    let align_index: u32 = match pf.align {
-        Some('<') => 0,
-        Some('^') => 1,
-        _ => 2,
-    };
-    let align_name = match align_index {
-        0 => "Left",
-        1 => "Center",
-        _ => "Right",
+    let (align_index, align_name): (u32, &str) = match pf.align {
+        Some('<') => (names.left_index, names.left_name.as_str()),
+        Some('^') => (names.center_index, names.center_name.as_str()),
+        _ => (names.right_index, names.right_name.as_str()),
     };
 
     TirExpr::new(
         TirExprKind::StructLiteral {
             struct_type: formatter_type,
-            struct_name: "Formatter".to_string(),
+            struct_name: names.formatter.clone(),
             fields: vec![
                 TirStructField {
                     name: "fill".to_string(),
@@ -987,7 +1056,7 @@ fn method_name_for_type(
             let arity = params.len().to_string();
             let ret_name = tt_ref.mangle_type_name(return_type);
             LocalMethodName::new(
-                "Fn".to_string(),
+                crate::name::CLOSURE_FN_TRAIT.to_string(),
                 Some(trait_name.to_string()),
                 method_name.to_string(),
             )

--- a/wado-compiler/src/synthesis/template.rs
+++ b/wado-compiler/src/synthesis/template.rs
@@ -31,6 +31,12 @@ use crate::token::Span;
 /// through the helpers so stdlib renames flow without touching synthesis
 /// sites — same shape as
 /// [`super::cm_binding::types::CmStdlibNames`].
+///
+/// Every format-family trait is single-method, so each `<trait>` field
+/// is paired with a `<trait>_method` field carrying the trait's
+/// resolved method name (e.g. `"fmt"` for `Display`, `"inspect"` for
+/// `Inspect`). Both values come from
+/// [`CompilerItems::trait_method_name`].
 #[derive(Clone, Debug)]
 #[allow(dead_code)]
 pub(super) struct FormatStdlibNames {
@@ -43,19 +49,33 @@ pub(super) struct FormatStdlibNames {
     pub right_name: String,
     pub right_index: u32,
     pub display: String,
+    pub display_method: String,
     pub display_alt: String,
+    pub display_alt_method: String,
     pub inspect: String,
+    pub inspect_method: String,
     pub inspect_alt: String,
+    pub inspect_alt_method: String,
     pub binary: String,
+    pub binary_method: String,
     pub binary_alt: String,
+    pub binary_alt_method: String,
     pub octal: String,
+    pub octal_method: String,
     pub octal_alt: String,
+    pub octal_alt_method: String,
     pub lower_hex: String,
+    pub lower_hex_method: String,
     pub lower_hex_alt: String,
+    pub lower_hex_alt_method: String,
     pub upper_hex: String,
+    pub upper_hex_method: String,
     pub upper_hex_alt: String,
+    pub upper_hex_alt_method: String,
     pub lower_exp: String,
+    pub lower_exp_method: String,
     pub upper_exp: String,
+    pub upper_exp_method: String,
 }
 
 impl FormatStdlibNames {
@@ -74,19 +94,41 @@ impl FormatStdlibNames {
             right_name: right_name.to_string(),
             right_index,
             display: items.trait_name(CompilerItem::Display).to_string(),
+            display_method: items.trait_method_name(CompilerItem::Display).to_string(),
             display_alt: items.trait_name(CompilerItem::DisplayAlt).to_string(),
+            display_alt_method: items
+                .trait_method_name(CompilerItem::DisplayAlt)
+                .to_string(),
             inspect: items.trait_name(CompilerItem::Inspect).to_string(),
+            inspect_method: items.trait_method_name(CompilerItem::Inspect).to_string(),
             inspect_alt: items.trait_name(CompilerItem::InspectAlt).to_string(),
+            inspect_alt_method: items
+                .trait_method_name(CompilerItem::InspectAlt)
+                .to_string(),
             binary: items.trait_name(CompilerItem::Binary).to_string(),
+            binary_method: items.trait_method_name(CompilerItem::Binary).to_string(),
             binary_alt: items.trait_name(CompilerItem::BinaryAlt).to_string(),
+            binary_alt_method: items.trait_method_name(CompilerItem::BinaryAlt).to_string(),
             octal: items.trait_name(CompilerItem::Octal).to_string(),
+            octal_method: items.trait_method_name(CompilerItem::Octal).to_string(),
             octal_alt: items.trait_name(CompilerItem::OctalAlt).to_string(),
+            octal_alt_method: items.trait_method_name(CompilerItem::OctalAlt).to_string(),
             lower_hex: items.trait_name(CompilerItem::LowerHex).to_string(),
+            lower_hex_method: items.trait_method_name(CompilerItem::LowerHex).to_string(),
             lower_hex_alt: items.trait_name(CompilerItem::LowerHexAlt).to_string(),
+            lower_hex_alt_method: items
+                .trait_method_name(CompilerItem::LowerHexAlt)
+                .to_string(),
             upper_hex: items.trait_name(CompilerItem::UpperHex).to_string(),
+            upper_hex_method: items.trait_method_name(CompilerItem::UpperHex).to_string(),
             upper_hex_alt: items.trait_name(CompilerItem::UpperHexAlt).to_string(),
+            upper_hex_alt_method: items
+                .trait_method_name(CompilerItem::UpperHexAlt)
+                .to_string(),
             lower_exp: items.trait_name(CompilerItem::LowerExp).to_string(),
+            lower_exp_method: items.trait_method_name(CompilerItem::LowerExp).to_string(),
             upper_exp: items.trait_name(CompilerItem::UpperExp).to_string(),
+            upper_exp_method: items.trait_method_name(CompilerItem::UpperExp).to_string(),
         }
     }
 }
@@ -565,20 +607,57 @@ fn build_template_block(
 
                 let (trait_name, method_name): (&str, &str) = match &format_spec {
                     Some(fs) => match (fs.type_char, fs.alternate) {
-                        (Some('b'), true) => (ctx.names.binary_alt.as_str(), "fmt_alt"),
-                        (Some('b'), false) => (ctx.names.binary.as_str(), "fmt"),
-                        (Some('o'), true) => (ctx.names.octal_alt.as_str(), "fmt_alt"),
-                        (Some('o'), false) => (ctx.names.octal.as_str(), "fmt"),
-                        (Some('x'), true) => (ctx.names.lower_hex_alt.as_str(), "fmt_alt"),
-                        (Some('x'), false) => (ctx.names.lower_hex.as_str(), "fmt"),
-                        (Some('X'), true) => (ctx.names.upper_hex_alt.as_str(), "fmt_alt"),
-                        (Some('X'), false) => (ctx.names.upper_hex.as_str(), "fmt"),
-                        (Some('e'), _) => (ctx.names.lower_exp.as_str(), "fmt"),
-                        (Some('E'), _) => (ctx.names.upper_exp.as_str(), "fmt"),
-                        (_, true) => (ctx.names.display_alt.as_str(), "fmt_alt"),
-                        _ => (ctx.names.display.as_str(), "fmt"),
+                        (Some('b'), true) => (
+                            ctx.names.binary_alt.as_str(),
+                            ctx.names.binary_alt_method.as_str(),
+                        ),
+                        (Some('b'), false) => {
+                            (ctx.names.binary.as_str(), ctx.names.binary_method.as_str())
+                        }
+                        (Some('o'), true) => (
+                            ctx.names.octal_alt.as_str(),
+                            ctx.names.octal_alt_method.as_str(),
+                        ),
+                        (Some('o'), false) => {
+                            (ctx.names.octal.as_str(), ctx.names.octal_method.as_str())
+                        }
+                        (Some('x'), true) => (
+                            ctx.names.lower_hex_alt.as_str(),
+                            ctx.names.lower_hex_alt_method.as_str(),
+                        ),
+                        (Some('x'), false) => (
+                            ctx.names.lower_hex.as_str(),
+                            ctx.names.lower_hex_method.as_str(),
+                        ),
+                        (Some('X'), true) => (
+                            ctx.names.upper_hex_alt.as_str(),
+                            ctx.names.upper_hex_alt_method.as_str(),
+                        ),
+                        (Some('X'), false) => (
+                            ctx.names.upper_hex.as_str(),
+                            ctx.names.upper_hex_method.as_str(),
+                        ),
+                        (Some('e'), _) => (
+                            ctx.names.lower_exp.as_str(),
+                            ctx.names.lower_exp_method.as_str(),
+                        ),
+                        (Some('E'), _) => (
+                            ctx.names.upper_exp.as_str(),
+                            ctx.names.upper_exp_method.as_str(),
+                        ),
+                        (_, true) => (
+                            ctx.names.display_alt.as_str(),
+                            ctx.names.display_alt_method.as_str(),
+                        ),
+                        _ => (
+                            ctx.names.display.as_str(),
+                            ctx.names.display_method.as_str(),
+                        ),
                     },
-                    None => (ctx.names.display.as_str(), "fmt"),
+                    None => (
+                        ctx.names.display.as_str(),
+                        ctx.names.display_method.as_str(),
+                    ),
                 };
 
                 // Create or reassign Formatter local
@@ -654,9 +733,15 @@ fn build_template_block(
 
                 if is_inspect {
                     let (it_name, im_name): (&str, &str) = if is_alternate {
-                        (ctx.names.inspect_alt.as_str(), "inspect_alt")
+                        (
+                            ctx.names.inspect_alt.as_str(),
+                            ctx.names.inspect_alt_method.as_str(),
+                        )
                     } else {
-                        (ctx.names.inspect.as_str(), "inspect")
+                        (
+                            ctx.names.inspect.as_str(),
+                            ctx.names.inspect_method.as_str(),
+                        )
                     };
                     let call_stmts = trait_fmt_call(
                         resolved.type_id,

--- a/wado-compiler/src/synthesis/traits.rs
+++ b/wado-compiler/src/synthesis/traits.rs
@@ -925,6 +925,7 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
             ref_string_type,
             *espan,
             &inspect_name,
+            &formatter_name,
         ))));
         ctx.record_impl(name, &inspect_name);
     }
@@ -959,6 +960,7 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
             &mut tt,
             *sspan,
             &inspect_name,
+            &formatter_name,
         ))));
         ctx.record_impl(name, &inspect_name);
     }
@@ -985,6 +987,7 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
             &mut tt,
             *sspan,
             &inspect_name,
+            &formatter_name,
         ))));
         ctx.record_impl(name, &inspect_name);
     }
@@ -1009,6 +1012,7 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
             &mut tt,
             *vspan,
             &inspect_name,
+            &formatter_name,
         ))));
         ctx.record_impl(name, &inspect_name);
     }
@@ -1035,6 +1039,7 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
             &mut tt,
             *vspan,
             &inspect_name,
+            &formatter_name,
         ))));
         ctx.record_impl(name, &inspect_name);
     }
@@ -1068,6 +1073,7 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
             ref_string_type,
             fspan,
             &inspect_name,
+            &formatter_name,
         ))));
         ctx.record_impl(name, &inspect_name);
     }
@@ -1098,6 +1104,7 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
             &mut tt,
             synth_span(),
             &inspect_name,
+            &formatter_name,
         ))));
         ctx.record_impl(&nt.name, &inspect_name);
     }
@@ -1134,6 +1141,7 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
                     ref_string_type,
                     span,
                     &inspect_name,
+                    &formatter_name,
                 ))));
                 // Intentionally do NOT `ctx.record_impl` — these per-module
                 // stubs are emitted into every module that uses the shape,
@@ -1183,6 +1191,7 @@ fn generate_enum_inspect_fn(
     ref_string_type: TypeId,
     span: Span,
     inspect_trait: &str,
+    formatter_name: &str,
 ) -> TirFunction {
     let method_info = trait_method_info(enum_name, inspect_trait, "inspect");
     let qualified_name = method_info.to_mangled_name();
@@ -1199,6 +1208,7 @@ fn generate_enum_inspect_fn(
                 string_type,
                 ref_string_type,
                 span,
+                formatter_name,
             )],
             span,
         );
@@ -1268,6 +1278,7 @@ fn generate_struct_inspect_fn(
     tt: &mut TypeTable,
     span: Span,
     inspect_trait: &str,
+    formatter_name: &str,
 ) -> TirFunction {
     let method_info = trait_method_info(struct_name, inspect_trait, "inspect");
     let qualified_name = method_info.to_mangled_name();
@@ -1284,6 +1295,7 @@ fn generate_struct_inspect_fn(
         tt,
         span,
         inspect_trait,
+        formatter_name,
     );
     let body = TirBlock::new(stmts, span);
 
@@ -1313,9 +1325,11 @@ fn build_struct_inspect_body(
     tt: &mut TypeTable,
     span: Span,
     inspect_trait: &str,
+    formatter_name: &str,
 ) -> Vec<TirStmt> {
     let fmt = || local_expr(1, "f", fmt_type, span);
-    let write = |s: String| write_str_stmt(s, fmt(), string_type, ref_string_type, span);
+    let write =
+        |s: String| write_str_stmt(s, fmt(), string_type, ref_string_type, span, formatter_name);
     let mut stmts = Vec::new();
 
     if fields.is_empty() {
@@ -1379,6 +1393,7 @@ fn generate_variant_inspect_fn(
     tt: &mut TypeTable,
     span: Span,
     inspect_trait: &str,
+    formatter_name: &str,
 ) -> TirFunction {
     let method_info = trait_method_info(variant_name, inspect_trait, "inspect");
     let qualified_name = method_info.to_mangled_name();
@@ -1395,6 +1410,7 @@ fn generate_variant_inspect_fn(
         tt,
         span,
         inspect_trait,
+        formatter_name,
     );
     let body = TirBlock::new(stmts, span);
 
@@ -1424,10 +1440,12 @@ fn build_variant_inspect_body(
     tt: &mut TypeTable,
     span: Span,
     inspect_trait: &str,
+    formatter_name: &str,
 ) -> Vec<TirStmt> {
     let deref_self = || deref_local(0, "self", ref_variant_type, variant_type, span);
     let fmt = || local_expr(1, "f", fmt_type, span);
-    let write = |s: String| write_str_stmt(s, fmt(), string_type, ref_string_type, span);
+    let write =
+        |s: String| write_str_stmt(s, fmt(), string_type, ref_string_type, span, formatter_name);
 
     let mut chain: Option<TirExpr> = None;
     for (case_name, case_index, payload_type) in cases.iter().rev() {
@@ -1498,6 +1516,7 @@ fn generate_newtype_inspect_fn(
     tt: &mut TypeTable,
     span: Span,
     inspect_trait: &str,
+    formatter_name: &str,
 ) -> TirFunction {
     let method_info = trait_method_info(newtype_name, inspect_trait, "inspect");
     let qualified_name = method_info.to_mangled_name();
@@ -1530,6 +1549,7 @@ fn generate_newtype_inspect_fn(
             string_type,
             ref_string_type,
             span,
+            formatter_name,
         ),
     ];
 
@@ -1557,6 +1577,7 @@ fn generate_flags_inspect_fn(
     ref_string_type: TypeId,
     span: &Span,
     inspect_trait: &str,
+    formatter_name: &str,
 ) -> TirFunction {
     let method_info = trait_method_info(flags_name, inspect_trait, "inspect");
     let qualified_name = method_info.to_mangled_name();
@@ -1603,6 +1624,7 @@ fn generate_flags_inspect_fn(
                     string_type,
                     ref_string_type,
                     *span,
+                    formatter_name,
                 )],
                 *span,
             ),
@@ -1694,6 +1716,7 @@ fn generate_flags_inspect_fn(
                             string_type,
                             ref_string_type,
                             *span,
+                            formatter_name,
                         )],
                         *span,
                     ),
@@ -1711,6 +1734,7 @@ fn generate_flags_inspect_fn(
             string_type,
             ref_string_type,
             *span,
+            formatter_name,
         ));
 
         let member_if = TirExpr::new(
@@ -1846,6 +1870,7 @@ fn generate_opaque_inspect_fn(
     ref_string_type: TypeId,
     span: Span,
     inspect_trait: &str,
+    formatter_name: &str,
 ) -> TirFunction {
     let method_info = trait_method_info(base_name, inspect_trait, "inspect")
         .with_struct_type_args(type_arg_names);
@@ -1859,6 +1884,7 @@ fn generate_opaque_inspect_fn(
             string_type,
             ref_string_type,
             span,
+            formatter_name,
         )],
         span,
     );
@@ -2224,7 +2250,16 @@ fn build_struct_inspect_alt_body(
     inspect_alt_trait: &str,
 ) -> Vec<TirStmt> {
     let fmt = || local_expr(1, "f", fmt_type, span);
-    let write = |s: &str| write_str_stmt(s.to_string(), fmt(), string_type, ref_string_type, span);
+    let write = |s: &str| {
+        write_str_stmt(
+            s.to_string(),
+            fmt(),
+            string_type,
+            ref_string_type,
+            span,
+            formatter_name,
+        )
+    };
     let newline_indent = || {
         formatter_call(
             "write_newline_indent",
@@ -2245,6 +2280,7 @@ fn build_struct_inspect_alt_body(
             string_type,
             ref_string_type,
             span,
+            formatter_name,
         ));
         return stmts;
     }
@@ -2264,6 +2300,7 @@ fn build_struct_inspect_alt_body(
             string_type,
             ref_string_type,
             span,
+            formatter_name,
         ));
         let field_access = field_access_local(
             0,
@@ -2384,6 +2421,7 @@ fn build_variant_inspect_alt_body(
                 string_type,
                 ref_string_type,
                 span,
+                formatter_name,
             ));
         } else {
             // f.open_brace("VariantName::CaseName(")
@@ -2426,6 +2464,7 @@ fn build_variant_inspect_alt_body(
                 string_type,
                 ref_string_type,
                 span,
+                formatter_name,
             ));
             // f.close_brace(")")
             then_stmts.push(formatter_call(

--- a/wado-compiler/src/synthesis/traits.rs
+++ b/wado-compiler/src/synthesis/traits.rs
@@ -332,7 +332,7 @@ pub(crate) struct SynthesisCtx<'env, 'pend> {
     /// Snapshot of every `core:prelude/{traits,format}` symbol this pass
     /// touches, resolved once through the [`CompilerItem`] registry.
     /// Threaded through `SynthesisCtx` so every sub-pass (Inspect /
-    /// InspectAlt / Display / DisplayAlt fallbacks, plus the helpers that
+    /// `InspectAlt` / Display / `DisplayAlt` fallbacks, plus the helpers that
     /// build trait method names) reads the registered trait / struct names
     /// instead of hard-coding `"Inspect"` / `"Formatter"` / etc.
     pub(crate) names: &'env TraitsStdlibNames,
@@ -2885,10 +2885,18 @@ fn generate_fallback_impls(
             continue;
         }
         let ref_type = tt.make_ref(sig.repr_type_id);
-        let target_info = trait_method_info(crate::name::CLOSURE_FN_TRAIT, &pair.target_trait, pair.target_method)
-            .with_struct_type_args(&sig.type_arg_names);
-        let delegate_info = trait_method_info(crate::name::CLOSURE_FN_TRAIT, &pair.delegate_trait, pair.delegate_method)
-            .with_struct_type_args(&sig.type_arg_names);
+        let target_info = trait_method_info(
+            crate::name::CLOSURE_FN_TRAIT,
+            &pair.target_trait,
+            pair.target_method,
+        )
+        .with_struct_type_args(&sig.type_arg_names);
+        let delegate_info = trait_method_info(
+            crate::name::CLOSURE_FN_TRAIT,
+            &pair.delegate_trait,
+            pair.delegate_method,
+        )
+        .with_struct_type_args(&sig.type_arg_names);
         generated.push(Rc::new(RefCell::new(generate_display_fallback(
             target_info,
             delegate_info,

--- a/wado-compiler/src/synthesis/traits.rs
+++ b/wado-compiler/src/synthesis/traits.rs
@@ -41,9 +41,17 @@ use super::common::{
 pub(crate) struct TraitsStdlibNames {
     pub formatter: String,
     pub display: String,
+    /// `Display::fmt` method name, resolved via [`Resolved::Trait::method_name`].
+    pub display_method: String,
     pub display_alt: String,
+    /// `DisplayAlt::fmt_alt` method name, resolved via the registry.
+    pub display_alt_method: String,
     pub inspect: String,
+    /// `Inspect::inspect` method name, resolved via the registry.
+    pub inspect_method: String,
     pub inspect_alt: String,
+    /// `InspectAlt::inspect_alt` method name, resolved via the registry.
+    pub inspect_alt_method: String,
     pub less_name: String,
     pub less_index: u32,
     pub equal_name: String,
@@ -61,9 +69,17 @@ impl TraitsStdlibNames {
         Self {
             formatter: items.struct_name(CompilerItem::Formatter).to_string(),
             display: items.trait_name(CompilerItem::Display).to_string(),
+            display_method: items.trait_method_name(CompilerItem::Display).to_string(),
             display_alt: items.trait_name(CompilerItem::DisplayAlt).to_string(),
+            display_alt_method: items
+                .trait_method_name(CompilerItem::DisplayAlt)
+                .to_string(),
             inspect: items.trait_name(CompilerItem::Inspect).to_string(),
+            inspect_method: items.trait_method_name(CompilerItem::Inspect).to_string(),
             inspect_alt: items.trait_name(CompilerItem::InspectAlt).to_string(),
+            inspect_alt_method: items
+                .trait_method_name(CompilerItem::InspectAlt)
+                .to_string(),
             less_name: less_name.to_string(),
             less_index,
             equal_name: equal_name.to_string(),
@@ -78,35 +94,38 @@ impl TraitsStdlibNames {
 /// fallback machinery is parameterised over which trait to emit and which trait
 /// to delegate to.
 ///
-/// Trait names are owned `String`s rather than `&'static str` because the
-/// values come from the [`CompilerItem`] registry — they reflect whatever
-/// the stdlib's `#[compiler_item("...")]` annotation says, not a literal.
+/// Every name in this struct — both trait names and their method names —
+/// flows from the `CompilerItem` registry. The stdlib's
+/// `#[compiler_item("...")]` annotations control the spelling on both
+/// halves, so renaming `Display::fmt` to `Display::display_value` flows
+/// to the synthesised fallback's emitted call without touching this
+/// code.
 struct TraitPair {
     /// e.g. `"Display"` or `"DisplayAlt"`.
     target_trait: String,
     /// e.g. `"fmt"` or `"fmt_alt"`.
-    target_method: &'static str,
+    target_method: String,
     /// Trait the fallback delegates to (`"Inspect"` or `"InspectAlt"`).
     delegate_trait: String,
     /// Method on the delegate trait (`"inspect"` or `"inspect_alt"`).
-    delegate_method: &'static str,
+    delegate_method: String,
 }
 
 impl TraitPair {
     fn display(names: &TraitsStdlibNames) -> Self {
         Self {
             target_trait: names.display.clone(),
-            target_method: "fmt",
+            target_method: names.display_method.clone(),
             delegate_trait: names.inspect.clone(),
-            delegate_method: "inspect",
+            delegate_method: names.inspect_method.clone(),
         }
     }
     fn display_alt(names: &TraitsStdlibNames) -> Self {
         Self {
             target_trait: names.display_alt.clone(),
-            target_method: "fmt_alt",
+            target_method: names.display_alt_method.clone(),
             delegate_trait: names.inspect_alt.clone(),
-            delegate_method: "inspect_alt",
+            delegate_method: names.inspect_alt_method.clone(),
         }
     }
 }
@@ -892,6 +911,7 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
     let mut generated = Vec::new();
     let formatter_name = ctx.names.formatter.clone();
     let inspect_name = ctx.names.inspect.clone();
+    let inspect_method = ctx.names.inspect_method.clone();
 
     let mut tt = module.type_table.borrow_mut();
     let formatter_type = tt.make_struct(formatter_name.clone(), ModuleSource::format());
@@ -925,6 +945,7 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
             ref_string_type,
             *espan,
             &inspect_name,
+            &inspect_method,
             &formatter_name,
         ))));
         ctx.record_impl(name, &inspect_name);
@@ -960,6 +981,7 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
             &mut tt,
             *sspan,
             &inspect_name,
+            &inspect_method,
             &formatter_name,
         ))));
         ctx.record_impl(name, &inspect_name);
@@ -987,6 +1009,7 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
             &mut tt,
             *sspan,
             &inspect_name,
+            &inspect_method,
             &formatter_name,
         ))));
         ctx.record_impl(name, &inspect_name);
@@ -1012,6 +1035,7 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
             &mut tt,
             *vspan,
             &inspect_name,
+            &inspect_method,
             &formatter_name,
         ))));
         ctx.record_impl(name, &inspect_name);
@@ -1039,6 +1063,7 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
             &mut tt,
             *vspan,
             &inspect_name,
+            &inspect_method,
             &formatter_name,
         ))));
         ctx.record_impl(name, &inspect_name);
@@ -1073,6 +1098,7 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
             ref_string_type,
             fspan,
             &inspect_name,
+            &inspect_method,
             &formatter_name,
         ))));
         ctx.record_impl(name, &inspect_name);
@@ -1104,6 +1130,7 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
             &mut tt,
             synth_span(),
             &inspect_name,
+            &inspect_method,
             &formatter_name,
         ))));
         ctx.record_impl(&nt.name, &inspect_name);
@@ -1141,6 +1168,7 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
                     ref_string_type,
                     span,
                     &inspect_name,
+                    &inspect_method,
                     &formatter_name,
                 ))));
                 // Intentionally do NOT `ctx.record_impl` — these per-module
@@ -1165,6 +1193,7 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
             fmt_type,
             span,
             &inspect_name,
+            &inspect_method,
         ))));
         // Per-module: do not `ctx.record_impl`.
     }
@@ -1191,9 +1220,10 @@ fn generate_enum_inspect_fn(
     ref_string_type: TypeId,
     span: Span,
     inspect_trait: &str,
+    inspect_method: &str,
     formatter_name: &str,
 ) -> TirFunction {
-    let method_info = trait_method_info(enum_name, inspect_trait, "inspect");
+    let method_info = trait_method_info(enum_name, inspect_trait, inspect_method);
     let qualified_name = method_info.to_mangled_name();
 
     let deref_self = || deref_local(0, "self", ref_enum_type, enum_type, span);
@@ -1278,9 +1308,10 @@ fn generate_struct_inspect_fn(
     tt: &mut TypeTable,
     span: Span,
     inspect_trait: &str,
+    inspect_method: &str,
     formatter_name: &str,
 ) -> TirFunction {
-    let method_info = trait_method_info(struct_name, inspect_trait, "inspect");
+    let method_info = trait_method_info(struct_name, inspect_trait, inspect_method);
     let qualified_name = method_info.to_mangled_name();
 
     let stmts = build_struct_inspect_body(
@@ -1295,6 +1326,7 @@ fn generate_struct_inspect_fn(
         tt,
         span,
         inspect_trait,
+        inspect_method,
         formatter_name,
     );
     let body = TirBlock::new(stmts, span);
@@ -1325,6 +1357,7 @@ fn build_struct_inspect_body(
     tt: &mut TypeTable,
     span: Span,
     inspect_trait: &str,
+    inspect_method: &str,
     formatter_name: &str,
 ) -> Vec<TirStmt> {
     let fmt = || local_expr(1, "f", fmt_type, span);
@@ -1361,6 +1394,7 @@ fn build_struct_inspect_body(
             tt,
             span,
             inspect_trait,
+            inspect_method,
         ));
     }
     if has_hidden {
@@ -1393,9 +1427,10 @@ fn generate_variant_inspect_fn(
     tt: &mut TypeTable,
     span: Span,
     inspect_trait: &str,
+    inspect_method: &str,
     formatter_name: &str,
 ) -> TirFunction {
-    let method_info = trait_method_info(variant_name, inspect_trait, "inspect");
+    let method_info = trait_method_info(variant_name, inspect_trait, inspect_method);
     let qualified_name = method_info.to_mangled_name();
 
     let stmts = build_variant_inspect_body(
@@ -1410,6 +1445,7 @@ fn generate_variant_inspect_fn(
         tt,
         span,
         inspect_trait,
+        inspect_method,
         formatter_name,
     );
     let body = TirBlock::new(stmts, span);
@@ -1440,6 +1476,7 @@ fn build_variant_inspect_body(
     tt: &mut TypeTable,
     span: Span,
     inspect_trait: &str,
+    inspect_method: &str,
     formatter_name: &str,
 ) -> Vec<TirStmt> {
     let deref_self = || deref_local(0, "self", ref_variant_type, variant_type, span);
@@ -1471,6 +1508,7 @@ fn build_variant_inspect_body(
                 tt,
                 span,
                 inspect_trait,
+                inspect_method,
             ));
             then_stmts.push(write(")".to_string()));
         }
@@ -1516,9 +1554,10 @@ fn generate_newtype_inspect_fn(
     tt: &mut TypeTable,
     span: Span,
     inspect_trait: &str,
+    inspect_method: &str,
     formatter_name: &str,
 ) -> TirFunction {
-    let method_info = trait_method_info(newtype_name, inspect_trait, "inspect");
+    let method_info = trait_method_info(newtype_name, inspect_trait, inspect_method);
     let qualified_name = method_info.to_mangled_name();
 
     let deref_self = deref_local(0, "self", ref_newtype_type, newtype_type, span);
@@ -1542,6 +1581,7 @@ fn generate_newtype_inspect_fn(
             tt,
             span,
             inspect_trait,
+            inspect_method,
         ),
         write_str_stmt(
             format!(" as {newtype_name}"),
@@ -1577,9 +1617,10 @@ fn generate_flags_inspect_fn(
     ref_string_type: TypeId,
     span: &Span,
     inspect_trait: &str,
+    inspect_method: &str,
     formatter_name: &str,
 ) -> TirFunction {
-    let method_info = trait_method_info(flags_name, inspect_trait, "inspect");
+    let method_info = trait_method_info(flags_name, inspect_trait, inspect_method);
     let qualified_name = method_info.to_mangled_name();
 
     // Cast deref'd flags value to u32 for bit operations.
@@ -1780,11 +1821,12 @@ fn generate_fn_inspect_fn(
     fmt_type: TypeId,
     span: Span,
     inspect_trait: &str,
+    inspect_method: &str,
 ) -> TirFunction {
     generate_fn_canonical_dispatch_stub(
         FnDispatchTrait::Inspect,
         inspect_trait,
-        "inspect",
+        inspect_method,
         type_arg_names,
         arity,
         return_type,
@@ -1803,11 +1845,12 @@ fn generate_fn_inspect_alt_fn(
     fmt_type: TypeId,
     span: Span,
     inspect_alt_trait: &str,
+    inspect_alt_method: &str,
 ) -> TirFunction {
     generate_fn_canonical_dispatch_stub(
         FnDispatchTrait::InspectAlt,
         inspect_alt_trait,
-        "inspect_alt",
+        inspect_alt_method,
         type_arg_names,
         arity,
         return_type,
@@ -1870,9 +1913,10 @@ fn generate_opaque_inspect_fn(
     ref_string_type: TypeId,
     span: Span,
     inspect_trait: &str,
+    inspect_method: &str,
     formatter_name: &str,
 ) -> TirFunction {
-    let method_info = trait_method_info(base_name, inspect_trait, "inspect")
+    let method_info = trait_method_info(base_name, inspect_trait, inspect_method)
         .with_struct_type_args(type_arg_names);
     let qualified_name = method_info.to_mangled_name();
 
@@ -1908,7 +1952,9 @@ fn generate_inspect_alt_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_,
     let module_source = module.module_source.clone();
     let formatter_name = ctx.names.formatter.clone();
     let inspect_name = ctx.names.inspect.clone();
+    let inspect_method = ctx.names.inspect_method.clone();
     let inspect_alt_name = ctx.names.inspect_alt.clone();
+    let inspect_alt_method = ctx.names.inspect_alt_method.clone();
     let all_fn_names: IndexSet<String> = module
         .functions
         .iter()
@@ -1932,7 +1978,7 @@ fn generate_inspect_alt_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_,
         if ctx.has_impl(type_name, &inspect_name) {
             return true;
         }
-        let mangled = MethodName::format_local(type_name, Some(&inspect_name), "inspect");
+        let mangled = MethodName::format_local(type_name, Some(&inspect_name), &inspect_method);
         all_fn_names.contains(&mangled)
     };
 
@@ -1949,8 +1995,8 @@ fn generate_inspect_alt_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_,
         let enum_type = tt.make_enum(name.clone(), module_source.clone());
         let ref_type = tt.make_ref(enum_type);
         generated.push(Rc::new(RefCell::new(generate_display_fallback(
-            trait_method_info(&name, &inspect_alt_name, "inspect_alt"),
-            trait_method_info(&name, &inspect_name, "inspect"),
+            trait_method_info(&name, &inspect_alt_name, &inspect_alt_method),
+            trait_method_info(&name, &inspect_name, &inspect_method),
             ref_type,
             fmt_type,
             &module_source,
@@ -1990,6 +2036,7 @@ fn generate_inspect_alt_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_,
             &mut tt,
             *sspan,
             &inspect_alt_name,
+            &inspect_alt_method,
             &formatter_name,
         ))));
         ctx.record_impl(name, &inspect_alt_name);
@@ -2017,6 +2064,7 @@ fn generate_inspect_alt_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_,
             &mut tt,
             *sspan,
             &inspect_alt_name,
+            &inspect_alt_method,
             &formatter_name,
         ))));
         ctx.record_impl(name, &inspect_alt_name);
@@ -2042,6 +2090,7 @@ fn generate_inspect_alt_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_,
             &mut tt,
             *vspan,
             &inspect_alt_name,
+            &inspect_alt_method,
             &formatter_name,
         ))));
         ctx.record_impl(name, &inspect_alt_name);
@@ -2069,6 +2118,7 @@ fn generate_inspect_alt_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_,
             &mut tt,
             *vspan,
             &inspect_alt_name,
+            &inspect_alt_method,
             &formatter_name,
         ))));
         ctx.record_impl(name, &inspect_alt_name);
@@ -2087,8 +2137,8 @@ fn generate_inspect_alt_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_,
         }
         let ref_type = tt.make_ref(*flags_type_id);
         generated.push(Rc::new(RefCell::new(generate_display_fallback(
-            trait_method_info(name, &inspect_alt_name, "inspect_alt"),
-            trait_method_info(name, &inspect_name, "inspect"),
+            trait_method_info(name, &inspect_alt_name, &inspect_alt_method),
+            trait_method_info(name, &inspect_name, &inspect_method),
             ref_type,
             fmt_type,
             &module_source,
@@ -2107,8 +2157,8 @@ fn generate_inspect_alt_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_,
         }
         let ref_type = tt.make_ref(nt.type_id);
         generated.push(Rc::new(RefCell::new(generate_display_fallback(
-            trait_method_info(&nt.name, &inspect_alt_name, "inspect_alt"),
-            trait_method_info(&nt.name, &inspect_name, "inspect"),
+            trait_method_info(&nt.name, &inspect_alt_name, &inspect_alt_method),
+            trait_method_info(&nt.name, &inspect_name, &inspect_method),
             ref_type,
             fmt_type,
             &module_source,
@@ -2136,9 +2186,9 @@ fn generate_inspect_alt_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_,
         // Opaque resource types (Future, Stream, etc.): delegate to
         // Inspect via the stock `display_fallback`.
         generated.push(Rc::new(RefCell::new(generate_display_fallback(
-            trait_method_info(&base_name, &inspect_alt_name, "inspect_alt")
+            trait_method_info(&base_name, &inspect_alt_name, &inspect_alt_method)
                 .with_struct_type_args(&type_arg_names),
-            trait_method_info(&base_name, &inspect_name, "inspect")
+            trait_method_info(&base_name, &inspect_name, &inspect_method)
                 .with_struct_type_args(&type_arg_names),
             ref_type,
             fmt_type,
@@ -2169,6 +2219,7 @@ fn generate_inspect_alt_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_,
             fmt_type,
             span,
             &inspect_alt_name,
+            &inspect_alt_method,
         ))));
         // Per-module: do not `ctx.record_impl`.
     }
@@ -2200,9 +2251,10 @@ fn generate_struct_inspect_alt_fn(
     tt: &mut TypeTable,
     span: Span,
     inspect_alt_trait: &str,
+    inspect_alt_method: &str,
     formatter_name: &str,
 ) -> TirFunction {
-    let method_info = trait_method_info(struct_name, inspect_alt_trait, "inspect_alt");
+    let method_info = trait_method_info(struct_name, inspect_alt_trait, inspect_alt_method);
     let qualified_name = method_info.to_mangled_name();
 
     let stmts = build_struct_inspect_alt_body(
@@ -2218,6 +2270,7 @@ fn generate_struct_inspect_alt_fn(
         span,
         formatter_name,
         inspect_alt_trait,
+        inspect_alt_method,
     );
     let body = TirBlock::new(stmts, span);
 
@@ -2248,6 +2301,7 @@ fn build_struct_inspect_alt_body(
     span: Span,
     formatter_name: &str,
     inspect_alt_trait: &str,
+    inspect_alt_method: &str,
 ) -> Vec<TirStmt> {
     let fmt = || local_expr(1, "f", fmt_type, span);
     let write = |s: &str| {
@@ -2319,6 +2373,7 @@ fn build_struct_inspect_alt_body(
             tt,
             span,
             inspect_alt_trait,
+            inspect_alt_method,
         ));
         stmts.push(write(","));
     }
@@ -2352,9 +2407,10 @@ fn generate_variant_inspect_alt_fn(
     tt: &mut TypeTable,
     span: Span,
     inspect_alt_trait: &str,
+    inspect_alt_method: &str,
     formatter_name: &str,
 ) -> TirFunction {
-    let method_info = trait_method_info(variant_name, inspect_alt_trait, "inspect_alt");
+    let method_info = trait_method_info(variant_name, inspect_alt_trait, inspect_alt_method);
     let qualified_name = method_info.to_mangled_name();
 
     let stmts = build_variant_inspect_alt_body(
@@ -2370,6 +2426,7 @@ fn generate_variant_inspect_alt_fn(
         span,
         formatter_name,
         inspect_alt_trait,
+        inspect_alt_method,
     );
     let body = TirBlock::new(stmts, span);
 
@@ -2399,6 +2456,7 @@ fn build_variant_inspect_alt_body(
     span: Span,
     formatter_name: &str,
     inspect_alt_trait: &str,
+    inspect_alt_method: &str,
 ) -> Vec<TirStmt> {
     let deref_self = || {
         deref_expr(
@@ -2457,6 +2515,7 @@ fn build_variant_inspect_alt_body(
                 tt,
                 span,
                 inspect_alt_trait,
+                inspect_alt_method,
             ));
             then_stmts.push(write_str_stmt(
                 ",",
@@ -2510,12 +2569,13 @@ fn inspect_alt_call(
     tt: &mut TypeTable,
     span: Span,
     inspect_alt_trait: &str,
+    inspect_alt_method: &str,
 ) -> TirStmt {
     let call = trait_call_on_type(
         value,
         value_type,
         inspect_alt_trait,
-        "inspect_alt",
+        inspect_alt_method,
         TypeTable::UNIT,
         vec![fmt],
         true,
@@ -2729,7 +2789,7 @@ fn generate_fallback_impls(
             return true;
         }
         let delegate_key =
-            MethodName::format_local(name, Some(&pair.delegate_trait), pair.delegate_method);
+            MethodName::format_local(name, Some(&pair.delegate_trait), &pair.delegate_method);
         all_fn_names.contains(&delegate_key)
     };
 
@@ -2740,8 +2800,8 @@ fn generate_fallback_impls(
                          ref_type: TypeId,
                          impl_type_params: Vec<TirTypeParam>|
      -> Rc<RefCell<TirFunction>> {
-        let target_info = trait_method_info(name, &pair.target_trait, pair.target_method);
-        let delegate_info = trait_method_info(name, &pair.delegate_trait, pair.delegate_method);
+        let target_info = trait_method_info(name, &pair.target_trait, &pair.target_method);
+        let delegate_info = trait_method_info(name, &pair.delegate_trait, &pair.delegate_method);
         Rc::new(RefCell::new(generate_display_fallback(
             target_info,
             delegate_info,
@@ -2890,10 +2950,10 @@ fn generate_fallback_impls(
             continue;
         }
         let ref_type = tt.make_ref(type_id);
-        let target_info = trait_method_info(&base_name, &pair.target_trait, pair.target_method)
+        let target_info = trait_method_info(&base_name, &pair.target_trait, &pair.target_method)
             .with_struct_type_args(&type_arg_names);
         let delegate_info =
-            trait_method_info(&base_name, &pair.delegate_trait, pair.delegate_method)
+            trait_method_info(&base_name, &pair.delegate_trait, &pair.delegate_method)
                 .with_struct_type_args(&type_arg_names);
         generated.push(Rc::new(RefCell::new(generate_display_fallback(
             target_info,
@@ -2927,13 +2987,13 @@ fn generate_fallback_impls(
         let target_info = trait_method_info(
             crate::name::CLOSURE_FN_TRAIT,
             &pair.target_trait,
-            pair.target_method,
+            &pair.target_method,
         )
         .with_struct_type_args(&sig.type_arg_names);
         let delegate_info = trait_method_info(
             crate::name::CLOSURE_FN_TRAIT,
             &pair.delegate_trait,
-            pair.delegate_method,
+            &pair.delegate_method,
         )
         .with_struct_type_args(&sig.type_arg_names);
         generated.push(Rc::new(RefCell::new(generate_display_fallback(
@@ -2961,12 +3021,13 @@ fn inspect_call(
     tt: &mut TypeTable,
     span: Span,
     inspect_trait: &str,
+    inspect_method: &str,
 ) -> TirStmt {
     let call = trait_call_on_type(
         value,
         value_type,
         inspect_trait,
-        "inspect",
+        inspect_method,
         TypeTable::UNIT,
         vec![fmt],
         true,

--- a/wado-compiler/src/synthesis/traits.rs
+++ b/wado-compiler/src/synthesis/traits.rs
@@ -12,6 +12,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use crate::compiler_item::{CompilerItem, CompilerItems};
 use crate::hashmap::IndexSet;
 
 use crate::module_source::ModuleSource;
@@ -30,33 +31,85 @@ use super::common::{
     write_str_stmt,
 };
 
+/// Snapshot of every `core:prelude/{traits,format}` symbol name that the
+/// trait-synthesis phase reaches for. Built once per pass through the
+/// [`CompilerItem`] registry and threaded through the helpers so a
+/// stdlib rename flows without touching synthesis sites — same shape
+/// as [`super::cm_binding::types::CmStdlibNames`] and
+/// [`super::template::FormatStdlibNames`].
+#[derive(Clone, Debug)]
+pub(crate) struct TraitsStdlibNames {
+    pub formatter: String,
+    pub display: String,
+    pub display_alt: String,
+    pub inspect: String,
+    pub inspect_alt: String,
+    pub less_name: String,
+    pub less_index: u32,
+    pub equal_name: String,
+    pub equal_index: u32,
+    pub greater_name: String,
+    pub greater_index: u32,
+}
+
+impl TraitsStdlibNames {
+    pub(crate) fn from_compiler_items(items: &CompilerItems) -> Self {
+        let (_, _, less_name, less_index) = items.require_enum_case(CompilerItem::OrderingLess);
+        let (_, _, equal_name, equal_index) = items.require_enum_case(CompilerItem::OrderingEqual);
+        let (_, _, greater_name, greater_index) =
+            items.require_enum_case(CompilerItem::OrderingGreater);
+        Self {
+            formatter: items.struct_name(CompilerItem::Formatter).to_string(),
+            display: items.trait_name(CompilerItem::Display).to_string(),
+            display_alt: items.trait_name(CompilerItem::DisplayAlt).to_string(),
+            inspect: items.trait_name(CompilerItem::Inspect).to_string(),
+            inspect_alt: items.trait_name(CompilerItem::InspectAlt).to_string(),
+            less_name: less_name.to_string(),
+            less_index,
+            equal_name: equal_name.to_string(),
+            equal_index,
+            greater_name: greater_name.to_string(),
+            greater_index,
+        }
+    }
+}
+
 /// One half of an auto-derived trait pair: the `Display`/`DisplayAlt`/`InspectAlt`
 /// fallback machinery is parameterised over which trait to emit and which trait
 /// to delegate to.
+///
+/// Trait names are owned `String`s rather than `&'static str` because the
+/// values come from the [`CompilerItem`] registry — they reflect whatever
+/// the stdlib's `#[compiler_item("...")]` annotation says, not a literal.
 struct TraitPair {
     /// e.g. `"Display"` or `"DisplayAlt"`.
-    target_trait: &'static str,
+    target_trait: String,
     /// e.g. `"fmt"` or `"fmt_alt"`.
     target_method: &'static str,
     /// Trait the fallback delegates to (`"Inspect"` or `"InspectAlt"`).
-    delegate_trait: &'static str,
+    delegate_trait: String,
     /// Method on the delegate trait (`"inspect"` or `"inspect_alt"`).
     delegate_method: &'static str,
 }
 
-const DISPLAY_PAIR: TraitPair = TraitPair {
-    target_trait: "Display",
-    target_method: "fmt",
-    delegate_trait: "Inspect",
-    delegate_method: "inspect",
-};
-
-const DISPLAY_ALT_PAIR: TraitPair = TraitPair {
-    target_trait: "DisplayAlt",
-    target_method: "fmt_alt",
-    delegate_trait: "InspectAlt",
-    delegate_method: "inspect_alt",
-};
+impl TraitPair {
+    fn display(names: &TraitsStdlibNames) -> Self {
+        Self {
+            target_trait: names.display.clone(),
+            target_method: "fmt",
+            delegate_trait: names.inspect.clone(),
+            delegate_method: "inspect",
+        }
+    }
+    fn display_alt(names: &TraitsStdlibNames) -> Self {
+        Self {
+            target_trait: names.display_alt.clone(),
+            target_method: "fmt_alt",
+            delegate_trait: names.inspect_alt.clone(),
+            delegate_method: "inspect_alt",
+        }
+    }
+}
 
 /// Shorthand for `LocalMethodName::new(struct.into(), Some(trait.into()), method.into())`.
 fn trait_method_info(struct_name: &str, trait_name: &str, method: &str) -> LocalMethodName {
@@ -235,10 +288,15 @@ pub fn synthesize_traits(project: Package) -> Package {
     let mut pending: IndexSet<(String, ModuleSource, String)> = IndexSet::default();
     for module in project.tir_modules.values_mut() {
         let module_source = module.module_source.clone();
+        let names = {
+            let tt = module.type_table.borrow();
+            TraitsStdlibNames::from_compiler_items(tt.compiler_items())
+        };
         let mut ctx = SynthesisCtx {
             trait_env: &trait_env,
             pending: &mut pending,
             module: module_source,
+            names: &names,
         };
         generate_enum_trait_impls(module, &mut ctx);
         generate_struct_eq_ord_impls(module, &mut ctx);
@@ -271,6 +329,13 @@ pub(crate) struct SynthesisCtx<'env, 'pend> {
     /// Module currently being synthesised. Auto-derived impls live in this
     /// module by convention.
     pub(crate) module: ModuleSource,
+    /// Snapshot of every `core:prelude/{traits,format}` symbol this pass
+    /// touches, resolved once through the [`CompilerItem`] registry.
+    /// Threaded through `SynthesisCtx` so every sub-pass (Inspect /
+    /// InspectAlt / Display / DisplayAlt fallbacks, plus the helpers that
+    /// build trait method names) reads the registered trait / struct names
+    /// instead of hard-coding `"Inspect"` / `"Formatter"` / etc.
+    pub(crate) names: &'env TraitsStdlibNames,
 }
 
 impl SynthesisCtx<'_, '_> {
@@ -506,6 +571,7 @@ fn generate_enum_trait_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, 
                 ordering_type,
                 &ord_trait_name,
                 *span,
+                ctx.names,
             );
             generated_functions.push(Rc::new(RefCell::new(func)));
             ctx.record_impl(enum_name, &ord_trait_name);
@@ -576,6 +642,7 @@ fn generate_struct_eq_ord_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'
                 &ord_trait_name,
                 &mut tt,
                 *span,
+                ctx.names,
             );
             generated.push(Rc::new(RefCell::new(func)));
             ctx.record_impl(name, &ord_trait_name);
@@ -616,6 +683,7 @@ fn generate_struct_eq_ord_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'
                 &ord_trait_name,
                 &mut tt,
                 *span,
+                ctx.names,
             );
             generated.push(Rc::new(RefCell::new(func)));
             ctx.record_impl(name, &ord_trait_name);
@@ -822,9 +890,11 @@ fn generate_variant_eq_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, 
 fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>) {
     let module_source = module.module_source.clone();
     let mut generated = Vec::new();
+    let formatter_name = ctx.names.formatter.clone();
+    let inspect_name = ctx.names.inspect.clone();
 
     let mut tt = module.type_table.borrow_mut();
-    let formatter_type = tt.make_struct("Formatter".to_string(), ModuleSource::format());
+    let formatter_type = tt.make_struct(formatter_name.clone(), ModuleSource::format());
     let fmt_type = tt.make_mut_ref(formatter_type);
     let string_type = tt.make_compiler_struct(crate::compiler_item::CompilerItem::String);
     let ref_string_type = tt.make_ref(string_type);
@@ -840,7 +910,7 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
         .collect();
 
     for (name, cases, espan) in &enum_infos {
-        if ctx.has_impl(name, "Inspect") {
+        if ctx.has_impl(name, &inspect_name) {
             continue;
         }
         let enum_type = tt.make_enum(name.clone(), module_source.clone());
@@ -854,8 +924,9 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
             string_type,
             ref_string_type,
             *espan,
+            &inspect_name,
         ))));
-        ctx.record_impl(name, "Inspect");
+        ctx.record_impl(name, &inspect_name);
     }
 
     // Non-generic structs
@@ -866,11 +937,11 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
             == tt
                 .compiler_items()
                 .struct_name(crate::compiler_item::CompilerItem::String)
-            || name == "Formatter"
+            || name == &formatter_name
         {
             continue;
         }
-        if ctx.has_impl(name, "Inspect") {
+        if ctx.has_impl(name, &inspect_name) {
             continue;
         }
         let struct_type = tt.make_struct(name.clone(), module_source.clone());
@@ -887,13 +958,14 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
             &module_source,
             &mut tt,
             *sspan,
+            &inspect_name,
         ))));
-        ctx.record_impl(name, "Inspect");
+        ctx.record_impl(name, &inspect_name);
     }
 
     let generic_struct_infos = collect_generic_struct_visible_fields(module);
     for (name, type_params, fields, has_hidden, sspan) in &generic_struct_infos {
-        if ctx.has_impl(name, "Inspect") {
+        if ctx.has_impl(name, &inspect_name) {
             continue;
         }
         let type_param_ids = make_type_param_ids(type_params, &mut tt);
@@ -912,13 +984,14 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
             &module_source,
             &mut tt,
             *sspan,
+            &inspect_name,
         ))));
-        ctx.record_impl(name, "Inspect");
+        ctx.record_impl(name, &inspect_name);
     }
 
     let variant_infos = collect_variant_cases(module);
     for (name, cases, vspan) in &variant_infos {
-        if ctx.has_impl(name, "Inspect") {
+        if ctx.has_impl(name, &inspect_name) {
             continue;
         }
         let variant_type = tt.make_variant(name.clone(), module_source.clone());
@@ -935,13 +1008,14 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
             &module_source,
             &mut tt,
             *vspan,
+            &inspect_name,
         ))));
-        ctx.record_impl(name, "Inspect");
+        ctx.record_impl(name, &inspect_name);
     }
 
     let generic_variant_infos = collect_generic_variant_cases(module);
     for (name, type_params, cases, vspan) in &generic_variant_infos {
-        if ctx.has_impl(name, "Inspect") {
+        if ctx.has_impl(name, &inspect_name) {
             continue;
         }
         let type_param_ids = make_type_param_ids(type_params, &mut tt);
@@ -960,8 +1034,9 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
             &module_source,
             &mut tt,
             *vspan,
+            &inspect_name,
         ))));
-        ctx.record_impl(name, "Inspect");
+        ctx.record_impl(name, &inspect_name);
     }
 
     // Flags types (newtypes over u32)
@@ -979,7 +1054,7 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
         .collect();
 
     for (name, flags_type_id, members, fspan) in &flags_infos {
-        if ctx.has_impl(name, "Inspect") {
+        if ctx.has_impl(name, &inspect_name) {
             continue;
         }
         let ref_type = tt.make_ref(*flags_type_id);
@@ -992,8 +1067,9 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
             string_type,
             ref_string_type,
             fspan,
+            &inspect_name,
         ))));
-        ctx.record_impl(name, "Inspect");
+        ctx.record_impl(name, &inspect_name);
     }
 
     // Newtypes (e.g., `type Meters = f64`)
@@ -1002,7 +1078,7 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
         if module.flags.iter().any(|f| f.type_id == nt.type_id) {
             continue;
         }
-        if ctx.has_impl(&nt.name, "Inspect") {
+        if ctx.has_impl(&nt.name, &inspect_name) {
             continue;
         }
         let base_type = match tt.get(nt.type_id) {
@@ -1021,8 +1097,9 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
             &module_source,
             &mut tt,
             synth_span(),
+            &inspect_name,
         ))));
-        ctx.record_impl(&nt.name, "Inspect");
+        ctx.record_impl(&nt.name, &inspect_name);
     }
 
     // Parameterized types (tuples, generic resources). `Fn` signatures are
@@ -1031,7 +1108,7 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
     let span = synth_span();
     for (type_id, base_name, type_arg_names) in collect_parameterized_types(&tt) {
         let mangled = format_parameterized_name(&base_name, &type_arg_names);
-        if ctx.has_impl(&mangled, "Inspect") {
+        if ctx.has_impl(&mangled, &inspect_name) {
             continue;
         }
         let ref_type = tt.make_ref(type_id);
@@ -1056,6 +1133,7 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
                     string_type,
                     ref_string_type,
                     span,
+                    &inspect_name,
                 ))));
                 // Intentionally do NOT `ctx.record_impl` — these per-module
                 // stubs are emitted into every module that uses the shape,
@@ -1066,8 +1144,8 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
 
     // `Fn` dispatch stubs — one per canonical `(arity, return_type)`.
     for sig in collect_canonical_fn_signatures(&tt) {
-        let mangled = format_parameterized_name("Fn", &sig.type_arg_names);
-        if ctx.has_impl(&mangled, "Inspect") {
+        let mangled = format_parameterized_name(crate::name::CLOSURE_FN_TRAIT, &sig.type_arg_names);
+        if ctx.has_impl(&mangled, &inspect_name) {
             continue;
         }
         let ref_type = tt.make_ref(sig.repr_type_id);
@@ -1078,6 +1156,7 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
             ref_type,
             fmt_type,
             span,
+            &inspect_name,
         ))));
         // Per-module: do not `ctx.record_impl`.
     }
@@ -1103,8 +1182,9 @@ fn generate_enum_inspect_fn(
     string_type: TypeId,
     ref_string_type: TypeId,
     span: Span,
+    inspect_trait: &str,
 ) -> TirFunction {
-    let method_info = trait_method_info(enum_name, "Inspect", "inspect");
+    let method_info = trait_method_info(enum_name, inspect_trait, "inspect");
     let qualified_name = method_info.to_mangled_name();
 
     let deref_self = || deref_local(0, "self", ref_enum_type, enum_type, span);
@@ -1187,8 +1267,9 @@ fn generate_struct_inspect_fn(
     module_source: &ModuleSource,
     tt: &mut TypeTable,
     span: Span,
+    inspect_trait: &str,
 ) -> TirFunction {
-    let method_info = trait_method_info(struct_name, "Inspect", "inspect");
+    let method_info = trait_method_info(struct_name, inspect_trait, "inspect");
     let qualified_name = method_info.to_mangled_name();
 
     let stmts = build_struct_inspect_body(
@@ -1202,6 +1283,7 @@ fn generate_struct_inspect_fn(
         module_source,
         tt,
         span,
+        inspect_trait,
     );
     let body = TirBlock::new(stmts, span);
 
@@ -1230,6 +1312,7 @@ fn build_struct_inspect_body(
     module_source: &ModuleSource,
     tt: &mut TypeTable,
     span: Span,
+    inspect_trait: &str,
 ) -> Vec<TirStmt> {
     let fmt = || local_expr(1, "f", fmt_type, span);
     let write = |s: String| write_str_stmt(s, fmt(), string_type, ref_string_type, span);
@@ -1263,6 +1346,7 @@ fn build_struct_inspect_body(
             module_source,
             tt,
             span,
+            inspect_trait,
         ));
     }
     if has_hidden {
@@ -1294,8 +1378,9 @@ fn generate_variant_inspect_fn(
     module_source: &ModuleSource,
     tt: &mut TypeTable,
     span: Span,
+    inspect_trait: &str,
 ) -> TirFunction {
-    let method_info = trait_method_info(variant_name, "Inspect", "inspect");
+    let method_info = trait_method_info(variant_name, inspect_trait, "inspect");
     let qualified_name = method_info.to_mangled_name();
 
     let stmts = build_variant_inspect_body(
@@ -1309,6 +1394,7 @@ fn generate_variant_inspect_fn(
         module_source,
         tt,
         span,
+        inspect_trait,
     );
     let body = TirBlock::new(stmts, span);
 
@@ -1337,6 +1423,7 @@ fn build_variant_inspect_body(
     module_source: &ModuleSource,
     tt: &mut TypeTable,
     span: Span,
+    inspect_trait: &str,
 ) -> Vec<TirStmt> {
     let deref_self = || deref_local(0, "self", ref_variant_type, variant_type, span);
     let fmt = || local_expr(1, "f", fmt_type, span);
@@ -1365,6 +1452,7 @@ fn build_variant_inspect_body(
                 module_source,
                 tt,
                 span,
+                inspect_trait,
             ));
             then_stmts.push(write(")".to_string()));
         }
@@ -1409,8 +1497,9 @@ fn generate_newtype_inspect_fn(
     module_source: &ModuleSource,
     tt: &mut TypeTable,
     span: Span,
+    inspect_trait: &str,
 ) -> TirFunction {
-    let method_info = trait_method_info(newtype_name, "Inspect", "inspect");
+    let method_info = trait_method_info(newtype_name, inspect_trait, "inspect");
     let qualified_name = method_info.to_mangled_name();
 
     let deref_self = deref_local(0, "self", ref_newtype_type, newtype_type, span);
@@ -1426,7 +1515,15 @@ fn generate_newtype_inspect_fn(
     );
 
     let stmts = vec![
-        inspect_call(cast_to_base, base_type, fmt(), module_source, tt, span),
+        inspect_call(
+            cast_to_base,
+            base_type,
+            fmt(),
+            module_source,
+            tt,
+            span,
+            inspect_trait,
+        ),
         write_str_stmt(
             format!(" as {newtype_name}"),
             fmt(),
@@ -1459,8 +1556,9 @@ fn generate_flags_inspect_fn(
     string_type: TypeId,
     ref_string_type: TypeId,
     span: &Span,
+    inspect_trait: &str,
 ) -> TirFunction {
-    let method_info = trait_method_info(flags_name, "Inspect", "inspect");
+    let method_info = trait_method_info(flags_name, inspect_trait, "inspect");
     let qualified_name = method_info.to_mangled_name();
 
     // Cast deref'd flags value to u32 for bit operations.
@@ -1657,10 +1755,11 @@ fn generate_fn_inspect_fn(
     ref_fn_type: TypeId,
     fmt_type: TypeId,
     span: Span,
+    inspect_trait: &str,
 ) -> TirFunction {
     generate_fn_canonical_dispatch_stub(
         FnDispatchTrait::Inspect,
-        "Inspect",
+        inspect_trait,
         "inspect",
         type_arg_names,
         arity,
@@ -1679,10 +1778,11 @@ fn generate_fn_inspect_alt_fn(
     ref_fn_type: TypeId,
     fmt_type: TypeId,
     span: Span,
+    inspect_alt_trait: &str,
 ) -> TirFunction {
     generate_fn_canonical_dispatch_stub(
         FnDispatchTrait::InspectAlt,
-        "InspectAlt",
+        inspect_alt_trait,
         "inspect_alt",
         type_arg_names,
         arity,
@@ -1708,8 +1808,8 @@ fn generate_fn_canonical_dispatch_stub(
     fmt_type: TypeId,
     span: Span,
 ) -> TirFunction {
-    let method_info =
-        trait_method_info("Fn", trait_name, method_name).with_struct_type_args(type_arg_names);
+    let method_info = trait_method_info(crate::name::CLOSURE_FN_TRAIT, trait_name, method_name)
+        .with_struct_type_args(type_arg_names);
     let qualified_name = method_info.to_mangled_name();
 
     let mut func = make_synthetic_method(
@@ -1745,9 +1845,10 @@ fn generate_opaque_inspect_fn(
     string_type: TypeId,
     ref_string_type: TypeId,
     span: Span,
+    inspect_trait: &str,
 ) -> TirFunction {
-    let method_info =
-        trait_method_info(base_name, "Inspect", "inspect").with_struct_type_args(type_arg_names);
+    let method_info = trait_method_info(base_name, inspect_trait, "inspect")
+        .with_struct_type_args(type_arg_names);
     let qualified_name = method_info.to_mangled_name();
 
     let fmt = local_expr(1, "f", fmt_type, span);
@@ -1779,6 +1880,9 @@ fn generate_opaque_inspect_fn(
 /// For simple types (enums, flags, newtypes, primitives, functions), delegates to Inspect.
 fn generate_inspect_alt_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>) {
     let module_source = module.module_source.clone();
+    let formatter_name = ctx.names.formatter.clone();
+    let inspect_name = ctx.names.inspect.clone();
+    let inspect_alt_name = ctx.names.inspect_alt.clone();
     let all_fn_names: IndexSet<String> = module
         .functions
         .iter()
@@ -1787,7 +1891,7 @@ fn generate_inspect_alt_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_,
     let mut generated = Vec::new();
 
     let mut tt = module.type_table.borrow_mut();
-    let formatter_type = tt.make_struct("Formatter".to_string(), ModuleSource::format());
+    let formatter_type = tt.make_struct(formatter_name.clone(), ModuleSource::format());
     let fmt_type = tt.make_mut_ref(formatter_type);
     let string_type = tt.make_compiler_struct(crate::compiler_item::CompilerItem::String);
     let ref_string_type = tt.make_ref(string_type);
@@ -1799,10 +1903,10 @@ fn generate_inspect_alt_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_,
     // trait synthesis. Both shapes need to qualify a type for an
     // `InspectAlt` Display-delegate.
     let has_inspect = |type_name: &str, ctx: &SynthesisCtx<'_, '_>| -> bool {
-        if ctx.has_impl(type_name, "Inspect") {
+        if ctx.has_impl(type_name, &inspect_name) {
             return true;
         }
-        let mangled = MethodName::format_local(type_name, Some("Inspect"), "inspect");
+        let mangled = MethodName::format_local(type_name, Some(&inspect_name), "inspect");
         all_fn_names.contains(&mangled)
     };
 
@@ -1813,21 +1917,21 @@ fn generate_inspect_alt_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_,
         .map(|e| e.name.clone())
         .collect::<Vec<_>>()
     {
-        if ctx.has_impl(&name, "InspectAlt") || !has_inspect(&name, ctx) {
+        if ctx.has_impl(&name, &inspect_alt_name) || !has_inspect(&name, ctx) {
             continue;
         }
         let enum_type = tt.make_enum(name.clone(), module_source.clone());
         let ref_type = tt.make_ref(enum_type);
         generated.push(Rc::new(RefCell::new(generate_display_fallback(
-            trait_method_info(&name, "InspectAlt", "inspect_alt"),
-            trait_method_info(&name, "Inspect", "inspect"),
+            trait_method_info(&name, &inspect_alt_name, "inspect_alt"),
+            trait_method_info(&name, &inspect_name, "inspect"),
             ref_type,
             fmt_type,
             &module_source,
             vec![],
             span,
         ))));
-        ctx.record_impl(&name, "InspectAlt");
+        ctx.record_impl(&name, &inspect_alt_name);
     }
 
     // Non-generic structs — pretty-print with begin_block/end_block
@@ -1838,11 +1942,11 @@ fn generate_inspect_alt_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_,
             == tt
                 .compiler_items()
                 .struct_name(crate::compiler_item::CompilerItem::String)
-            || name == "Formatter"
+            || name == &formatter_name
         {
             continue;
         }
-        if ctx.has_impl(name, "InspectAlt") {
+        if ctx.has_impl(name, &inspect_alt_name) {
             continue;
         }
         let struct_type = tt.make_struct(name.clone(), module_source.clone());
@@ -1859,13 +1963,15 @@ fn generate_inspect_alt_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_,
             &module_source,
             &mut tt,
             *sspan,
+            &inspect_alt_name,
+            &formatter_name,
         ))));
-        ctx.record_impl(name, "InspectAlt");
+        ctx.record_impl(name, &inspect_alt_name);
     }
 
     let generic_struct_infos = collect_generic_struct_visible_fields(module);
     for (name, type_params, fields, has_hidden, sspan) in &generic_struct_infos {
-        if ctx.has_impl(name, "InspectAlt") {
+        if ctx.has_impl(name, &inspect_alt_name) {
             continue;
         }
         let type_param_ids = make_type_param_ids(type_params, &mut tt);
@@ -1884,13 +1990,15 @@ fn generate_inspect_alt_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_,
             &module_source,
             &mut tt,
             *sspan,
+            &inspect_alt_name,
+            &formatter_name,
         ))));
-        ctx.record_impl(name, "InspectAlt");
+        ctx.record_impl(name, &inspect_alt_name);
     }
 
     let variant_infos = collect_variant_cases(module);
     for (name, cases, vspan) in &variant_infos {
-        if ctx.has_impl(name, "InspectAlt") {
+        if ctx.has_impl(name, &inspect_alt_name) {
             continue;
         }
         let variant_type = tt.make_variant(name.clone(), module_source.clone());
@@ -1907,13 +2015,15 @@ fn generate_inspect_alt_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_,
             &module_source,
             &mut tt,
             *vspan,
+            &inspect_alt_name,
+            &formatter_name,
         ))));
-        ctx.record_impl(name, "InspectAlt");
+        ctx.record_impl(name, &inspect_alt_name);
     }
 
     let generic_variant_infos = collect_generic_variant_cases(module);
     for (name, type_params, cases, vspan) in &generic_variant_infos {
-        if ctx.has_impl(name, "InspectAlt") {
+        if ctx.has_impl(name, &inspect_alt_name) {
             continue;
         }
         let type_param_ids = make_type_param_ids(type_params, &mut tt);
@@ -1932,8 +2042,10 @@ fn generate_inspect_alt_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_,
             &module_source,
             &mut tt,
             *vspan,
+            &inspect_alt_name,
+            &formatter_name,
         ))));
-        ctx.record_impl(name, "InspectAlt");
+        ctx.record_impl(name, &inspect_alt_name);
     }
 
     // Flags — delegate to Inspect (bit flags don't need pretty print)
@@ -1944,40 +2056,40 @@ fn generate_inspect_alt_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_,
         .collect();
 
     for (name, flags_type_id) in &flags_infos {
-        if ctx.has_impl(name, "InspectAlt") || !has_inspect(name, ctx) {
+        if ctx.has_impl(name, &inspect_alt_name) || !has_inspect(name, ctx) {
             continue;
         }
         let ref_type = tt.make_ref(*flags_type_id);
         generated.push(Rc::new(RefCell::new(generate_display_fallback(
-            trait_method_info(name, "InspectAlt", "inspect_alt"),
-            trait_method_info(name, "Inspect", "inspect"),
+            trait_method_info(name, &inspect_alt_name, "inspect_alt"),
+            trait_method_info(name, &inspect_name, "inspect"),
             ref_type,
             fmt_type,
             &module_source,
             vec![],
             span,
         ))));
-        ctx.record_impl(name, "InspectAlt");
+        ctx.record_impl(name, &inspect_alt_name);
     }
 
     for nt in &module.newtypes {
         if module.flags.iter().any(|f| f.type_id == nt.type_id) {
             continue;
         }
-        if ctx.has_impl(&nt.name, "InspectAlt") || !has_inspect(&nt.name, ctx) {
+        if ctx.has_impl(&nt.name, &inspect_alt_name) || !has_inspect(&nt.name, ctx) {
             continue;
         }
         let ref_type = tt.make_ref(nt.type_id);
         generated.push(Rc::new(RefCell::new(generate_display_fallback(
-            trait_method_info(&nt.name, "InspectAlt", "inspect_alt"),
-            trait_method_info(&nt.name, "Inspect", "inspect"),
+            trait_method_info(&nt.name, &inspect_alt_name, "inspect_alt"),
+            trait_method_info(&nt.name, &inspect_name, "inspect"),
             ref_type,
             fmt_type,
             &module_source,
             vec![],
             span,
         ))));
-        ctx.record_impl(&nt.name, "InspectAlt");
+        ctx.record_impl(&nt.name, &inspect_alt_name);
     }
 
     // Tuples are skipped — their `InspectAlt` is provided by the variadic impl
@@ -1985,7 +2097,7 @@ fn generate_inspect_alt_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_,
     // `Inspect` counterpart. `Fn` signatures are handled separately below.
     for (type_id, base_name, type_arg_names) in collect_parameterized_types(&tt) {
         let mangled = format_parameterized_name(&base_name, &type_arg_names);
-        if ctx.has_impl(&mangled, "InspectAlt") || !has_inspect(&mangled, ctx) {
+        if ctx.has_impl(&mangled, &inspect_alt_name) || !has_inspect(&mangled, ctx) {
             continue;
         }
         let resolved = tt.get(type_id).clone();
@@ -1998,9 +2110,9 @@ fn generate_inspect_alt_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_,
         // Opaque resource types (Future, Stream, etc.): delegate to
         // Inspect via the stock `display_fallback`.
         generated.push(Rc::new(RefCell::new(generate_display_fallback(
-            trait_method_info(&base_name, "InspectAlt", "inspect_alt")
+            trait_method_info(&base_name, &inspect_alt_name, "inspect_alt")
                 .with_struct_type_args(&type_arg_names),
-            trait_method_info(&base_name, "Inspect", "inspect")
+            trait_method_info(&base_name, &inspect_name, "inspect")
                 .with_struct_type_args(&type_arg_names),
             ref_type,
             fmt_type,
@@ -2018,8 +2130,8 @@ fn generate_inspect_alt_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_,
     // delegate would let the optimizer collapse InspectAlt to Inspect
     // before WIR build runs, defeating the per-literal source dispatch.
     for sig in collect_canonical_fn_signatures(&tt) {
-        let mangled = format_parameterized_name("Fn", &sig.type_arg_names);
-        if ctx.has_impl(&mangled, "InspectAlt") || !has_inspect(&mangled, ctx) {
+        let mangled = format_parameterized_name(crate::name::CLOSURE_FN_TRAIT, &sig.type_arg_names);
+        if ctx.has_impl(&mangled, &inspect_alt_name) || !has_inspect(&mangled, ctx) {
             continue;
         }
         let ref_type = tt.make_ref(sig.repr_type_id);
@@ -2030,6 +2142,7 @@ fn generate_inspect_alt_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_,
             ref_type,
             fmt_type,
             span,
+            &inspect_alt_name,
         ))));
         // Per-module: do not `ctx.record_impl`.
     }
@@ -2060,8 +2173,10 @@ fn generate_struct_inspect_alt_fn(
     module_source: &ModuleSource,
     tt: &mut TypeTable,
     span: Span,
+    inspect_alt_trait: &str,
+    formatter_name: &str,
 ) -> TirFunction {
-    let method_info = trait_method_info(struct_name, "InspectAlt", "inspect_alt");
+    let method_info = trait_method_info(struct_name, inspect_alt_trait, "inspect_alt");
     let qualified_name = method_info.to_mangled_name();
 
     let stmts = build_struct_inspect_alt_body(
@@ -2075,6 +2190,8 @@ fn generate_struct_inspect_alt_fn(
         module_source,
         tt,
         span,
+        formatter_name,
+        inspect_alt_trait,
     );
     let body = TirBlock::new(stmts, span);
 
@@ -2103,11 +2220,20 @@ fn build_struct_inspect_alt_body(
     module_source: &ModuleSource,
     tt: &mut TypeTable,
     span: Span,
+    formatter_name: &str,
+    inspect_alt_trait: &str,
 ) -> Vec<TirStmt> {
     let fmt = || local_expr(1, "f", fmt_type, span);
     let write = |s: &str| write_str_stmt(s.to_string(), fmt(), string_type, ref_string_type, span);
-    let newline_indent =
-        || formatter_call("write_newline_indent", fmt(), None::<(&str, TypeId)>, span);
+    let newline_indent = || {
+        formatter_call(
+            "write_newline_indent",
+            fmt(),
+            None::<(&str, TypeId)>,
+            span,
+            formatter_name,
+        )
+    };
 
     let mut stmts = Vec::new();
 
@@ -2128,6 +2254,7 @@ fn build_struct_inspect_alt_body(
         fmt(),
         Some((format!("{struct_name} {{"), string_type)),
         span,
+        formatter_name,
     ));
     for (field_name, field_type, field_index) in fields {
         stmts.push(newline_indent());
@@ -2154,6 +2281,7 @@ fn build_struct_inspect_alt_body(
             module_source,
             tt,
             span,
+            inspect_alt_trait,
         ));
         stmts.push(write(","));
     }
@@ -2166,6 +2294,7 @@ fn build_struct_inspect_alt_body(
         fmt(),
         Some(("}", string_type)),
         span,
+        formatter_name,
     ));
     stmts
 }
@@ -2185,8 +2314,10 @@ fn generate_variant_inspect_alt_fn(
     module_source: &ModuleSource,
     tt: &mut TypeTable,
     span: Span,
+    inspect_alt_trait: &str,
+    formatter_name: &str,
 ) -> TirFunction {
-    let method_info = trait_method_info(variant_name, "InspectAlt", "inspect_alt");
+    let method_info = trait_method_info(variant_name, inspect_alt_trait, "inspect_alt");
     let qualified_name = method_info.to_mangled_name();
 
     let stmts = build_variant_inspect_alt_body(
@@ -2200,6 +2331,8 @@ fn generate_variant_inspect_alt_fn(
         module_source,
         tt,
         span,
+        formatter_name,
+        inspect_alt_trait,
     );
     let body = TirBlock::new(stmts, span);
 
@@ -2227,6 +2360,8 @@ fn build_variant_inspect_alt_body(
     module_source: &ModuleSource,
     tt: &mut TypeTable,
     span: Span,
+    formatter_name: &str,
+    inspect_alt_trait: &str,
 ) -> Vec<TirStmt> {
     let deref_self = || {
         deref_expr(
@@ -2257,6 +2392,7 @@ fn build_variant_inspect_alt_body(
                 fmt_local(),
                 Some((format!("{variant_name}::{case_name}("), string_type)),
                 span,
+                formatter_name,
             ));
             // f.write_newline_indent()
             then_stmts.push(formatter_call(
@@ -2264,6 +2400,7 @@ fn build_variant_inspect_alt_body(
                 fmt_local(),
                 None::<(&str, TypeId)>,
                 span,
+                formatter_name,
             ));
             let payload = TirExpr::new(
                 TirExprKind::VariantPayload {
@@ -2281,6 +2418,7 @@ fn build_variant_inspect_alt_body(
                 module_source,
                 tt,
                 span,
+                inspect_alt_trait,
             ));
             then_stmts.push(write_str_stmt(
                 ",",
@@ -2295,6 +2433,7 @@ fn build_variant_inspect_alt_body(
                 fmt_local(),
                 Some((")", string_type)),
                 span,
+                formatter_name,
             ));
         }
 
@@ -2331,11 +2470,12 @@ fn inspect_alt_call(
     module_source: &ModuleSource,
     tt: &mut TypeTable,
     span: Span,
+    inspect_alt_trait: &str,
 ) -> TirStmt {
     let call = trait_call_on_type(
         value,
         value_type,
-        "InspectAlt",
+        inspect_alt_trait,
         "inspect_alt",
         TypeTable::UNIT,
         vec![fmt],
@@ -2354,6 +2494,7 @@ fn formatter_call(
     fmt: TirExpr,
     text_arg: Option<(impl Into<String>, TypeId)>,
     span: Span,
+    formatter_name: &str,
 ) -> TirStmt {
     let args = match text_arg {
         Some((text, string_type)) => vec![CallArg::new(
@@ -2367,10 +2508,10 @@ fn formatter_call(
             Box::new(fmt),
             FunctionRef {
                 module_source: ModuleSource::format(),
-                name: format!("Formatter::{method_name}"),
+                name: format!("{formatter_name}::{method_name}"),
                 monomorph_info: None,
                 method_info: Some(LocalMethodName::new(
-                    "Formatter".to_string(),
+                    formatter_name.to_string(),
                     None,
                     method_name.to_string(),
                 )),
@@ -2391,7 +2532,8 @@ fn formatter_call(
 /// fn fmt(&self, f: &mut Formatter) { self.inspect(f); }
 /// ```
 fn generate_display_fallback_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>) {
-    generate_fallback_impls(module, ctx, &DISPLAY_PAIR);
+    let pair = TraitPair::display(ctx.names);
+    generate_fallback_impls(module, ctx, &pair);
 }
 
 /// Generate a `Display::fmt` function that delegates to `self.inspect(f)`.
@@ -2497,7 +2639,8 @@ fn generate_display_fallback(
 
 /// Generate `DisplayAlt::fmt_alt` fallback implementations that delegate to `InspectAlt::inspect_alt`.
 fn generate_display_alt_fallback_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>) {
-    generate_fallback_impls(module, ctx, &DISPLAY_ALT_PAIR);
+    let pair = TraitPair::display_alt(ctx.names);
+    generate_fallback_impls(module, ctx, &pair);
 }
 
 /// Walk every type kind in a module and emit a delegating fallback method
@@ -2529,19 +2672,25 @@ fn generate_fallback_impls(
                 .to_string(),
         )
     };
+    let formatter_struct_name = {
+        let tt = module.type_table.borrow();
+        tt.compiler_items()
+            .struct_name(CompilerItem::Formatter)
+            .to_string()
+    };
     let mut tt = module.type_table.borrow_mut();
-    let formatter_type = tt.make_struct("Formatter".to_string(), ModuleSource::format());
+    let formatter_type = tt.make_struct(formatter_struct_name.clone(), ModuleSource::format());
     let fmt_type = tt.make_mut_ref(formatter_type);
 
     let needs_fallback = |name: &str, ctx: &SynthesisCtx<'_, '_>| -> bool {
-        if ctx.has_impl(name, pair.target_trait) {
+        if ctx.has_impl(name, &pair.target_trait) {
             return false;
         }
-        if ctx.has_impl(name, pair.delegate_trait) {
+        if ctx.has_impl(name, &pair.delegate_trait) {
             return true;
         }
         let delegate_key =
-            MethodName::format_local(name, Some(pair.delegate_trait), pair.delegate_method);
+            MethodName::format_local(name, Some(&pair.delegate_trait), pair.delegate_method);
         all_fn_names.contains(&delegate_key)
     };
 
@@ -2552,8 +2701,8 @@ fn generate_fallback_impls(
                          ref_type: TypeId,
                          impl_type_params: Vec<TirTypeParam>|
      -> Rc<RefCell<TirFunction>> {
-        let target_info = trait_method_info(name, pair.target_trait, pair.target_method);
-        let delegate_info = trait_method_info(name, pair.delegate_trait, pair.delegate_method);
+        let target_info = trait_method_info(name, &pair.target_trait, pair.target_method);
+        let delegate_info = trait_method_info(name, &pair.delegate_trait, pair.delegate_method);
         Rc::new(RefCell::new(generate_display_fallback(
             target_info,
             delegate_info,
@@ -2573,7 +2722,7 @@ fn generate_fallback_impls(
         let enum_type = tt.make_enum(name.clone(), module_source.clone());
         let ref_type = tt.make_ref(enum_type);
         generated.push(make_fallback(name, ref_type, vec![]));
-        ctx.record_impl(name, pair.target_trait);
+        ctx.record_impl(name, &pair.target_trait);
     }
 
     let struct_names: Vec<_> = module
@@ -2583,7 +2732,7 @@ fn generate_fallback_impls(
         .map(|s| s.name.clone())
         .collect();
     for name in &struct_names {
-        if name == &string_name || name == "Formatter" {
+        if name == &string_name || name == &formatter_struct_name {
             continue;
         }
         if !needs_fallback(name, ctx) {
@@ -2592,7 +2741,7 @@ fn generate_fallback_impls(
         let struct_type = tt.make_struct(name.clone(), module_source.clone());
         let ref_type = tt.make_ref(struct_type);
         generated.push(make_fallback(name, ref_type, vec![]));
-        ctx.record_impl(name, pair.target_trait);
+        ctx.record_impl(name, &pair.target_trait);
     }
 
     let generic_struct_infos: Vec<_> = module
@@ -2613,7 +2762,7 @@ fn generate_fallback_impls(
             tt.make_generic_instance(name.clone(), module_source.clone(), type_param_ids);
         let ref_type = tt.make_ref(struct_type);
         generated.push(make_fallback(name, ref_type, type_params.clone()));
-        ctx.record_impl(name, pair.target_trait);
+        ctx.record_impl(name, &pair.target_trait);
     }
 
     let variant_names: Vec<_> = module
@@ -2629,7 +2778,7 @@ fn generate_fallback_impls(
         let variant_type = tt.make_variant(name.clone(), module_source.clone());
         let ref_type = tt.make_ref(variant_type);
         generated.push(make_fallback(name, ref_type, vec![]));
-        ctx.record_impl(name, pair.target_trait);
+        ctx.record_impl(name, &pair.target_trait);
     }
 
     let generic_variant_infos: Vec<_> = module
@@ -2647,7 +2796,7 @@ fn generate_fallback_impls(
             tt.make_generic_instance(name.clone(), module_source.clone(), type_param_ids);
         let ref_type = tt.make_ref(variant_type);
         generated.push(make_fallback(name, ref_type, type_params.clone()));
-        ctx.record_impl(name, pair.target_trait);
+        ctx.record_impl(name, &pair.target_trait);
     }
 
     let flags_infos: Vec<_> = module
@@ -2661,7 +2810,7 @@ fn generate_fallback_impls(
         }
         let ref_type = tt.make_ref(*flags_type_id);
         generated.push(make_fallback(name, ref_type, vec![]));
-        ctx.record_impl(name, pair.target_trait);
+        ctx.record_impl(name, &pair.target_trait);
     }
 
     for nt in &module.newtypes {
@@ -2673,7 +2822,7 @@ fn generate_fallback_impls(
         }
         let ref_type = tt.make_ref(nt.type_id);
         generated.push(make_fallback(&nt.name, ref_type, vec![]));
-        ctx.record_impl(&nt.name, pair.target_trait);
+        ctx.record_impl(&nt.name, &pair.target_trait);
     }
 
     // Parameterized types (opaque types). Tuples are skipped because their
@@ -2688,10 +2837,10 @@ fn generate_fallback_impls(
             continue;
         }
         let mangled = format_parameterized_name(&base_name, &type_arg_names);
-        if ctx.has_impl(&mangled, pair.target_trait) {
+        if ctx.has_impl(&mangled, &pair.target_trait) {
             continue;
         }
-        let delegate_present = ctx.has_impl(&mangled, pair.delegate_trait) || {
+        let delegate_present = ctx.has_impl(&mangled, &pair.delegate_trait) || {
             let delegate_key = format!(
                 "{mangled}^{}::{}",
                 pair.delegate_trait, pair.delegate_method
@@ -2702,10 +2851,10 @@ fn generate_fallback_impls(
             continue;
         }
         let ref_type = tt.make_ref(type_id);
-        let target_info = trait_method_info(&base_name, pair.target_trait, pair.target_method)
+        let target_info = trait_method_info(&base_name, &pair.target_trait, pair.target_method)
             .with_struct_type_args(&type_arg_names);
         let delegate_info =
-            trait_method_info(&base_name, pair.delegate_trait, pair.delegate_method)
+            trait_method_info(&base_name, &pair.delegate_trait, pair.delegate_method)
                 .with_struct_type_args(&type_arg_names);
         generated.push(Rc::new(RefCell::new(generate_display_fallback(
             target_info,
@@ -2721,11 +2870,11 @@ fn generate_fallback_impls(
 
     // `Fn` dispatch-stub fallbacks — one per canonical `(arity, return_type)`.
     for sig in collect_canonical_fn_signatures(&tt) {
-        let mangled = format_parameterized_name("Fn", &sig.type_arg_names);
-        if ctx.has_impl(&mangled, pair.target_trait) {
+        let mangled = format_parameterized_name(crate::name::CLOSURE_FN_TRAIT, &sig.type_arg_names);
+        if ctx.has_impl(&mangled, &pair.target_trait) {
             continue;
         }
-        let delegate_present = ctx.has_impl(&mangled, pair.delegate_trait) || {
+        let delegate_present = ctx.has_impl(&mangled, &pair.delegate_trait) || {
             let delegate_key = format!(
                 "{mangled}^{}::{}",
                 pair.delegate_trait, pair.delegate_method
@@ -2736,9 +2885,9 @@ fn generate_fallback_impls(
             continue;
         }
         let ref_type = tt.make_ref(sig.repr_type_id);
-        let target_info = trait_method_info("Fn", pair.target_trait, pair.target_method)
+        let target_info = trait_method_info(crate::name::CLOSURE_FN_TRAIT, &pair.target_trait, pair.target_method)
             .with_struct_type_args(&sig.type_arg_names);
-        let delegate_info = trait_method_info("Fn", pair.delegate_trait, pair.delegate_method)
+        let delegate_info = trait_method_info(crate::name::CLOSURE_FN_TRAIT, &pair.delegate_trait, pair.delegate_method)
             .with_struct_type_args(&sig.type_arg_names);
         generated.push(Rc::new(RefCell::new(generate_display_fallback(
             target_info,
@@ -2764,11 +2913,12 @@ fn inspect_call(
     module_source: &ModuleSource,
     tt: &mut TypeTable,
     span: Span,
+    inspect_trait: &str,
 ) -> TirStmt {
     let call = trait_call_on_type(
         value,
         value_type,
-        "Inspect",
+        inspect_trait,
         "inspect",
         TypeTable::UNIT,
         vec![fmt],
@@ -3048,6 +3198,7 @@ fn generate_enum_ord_fn(
     ordering_type: TypeId,
     ord_trait_name: &str,
     span: Span,
+    names: &TraitsStdlibNames,
 ) -> TirFunction {
     let method_info = trait_method_info(enum_name, ord_trait_name, "cmp");
     let qualified_name = method_info.to_mangled_name();
@@ -3055,7 +3206,7 @@ fn generate_enum_ord_fn(
     let local_a = || local_expr(2, "a", enum_type, span);
     let local_b = || local_expr(3, "b", enum_type, span);
 
-    let cmp_branch = |op, ordering_case_index, ordering_case_name| {
+    let cmp_branch = |op, ordering_case_index, ordering_case_name: &str| {
         let cond = TirExpr::new(
             TirExprKind::Binary {
                 left: Box::new(local_a()),
@@ -3115,11 +3266,16 @@ fn generate_enum_ord_fn(
                 3,
                 deref_local(1, "other", ref_enum_type, enum_type, span),
             ),
-            cmp_branch(TirBinaryOp::Lt, 0, "Less"),
-            cmp_branch(TirBinaryOp::Gt, 2, "Greater"),
+            cmp_branch(TirBinaryOp::Lt, names.less_index, &names.less_name),
+            cmp_branch(TirBinaryOp::Gt, names.greater_index, &names.greater_name),
             TirStmt::new(
                 TirStmtKind::Return {
-                    value: Some(ordering_construct(ordering_type, 1, "Equal", span)),
+                    value: Some(ordering_construct(
+                        ordering_type,
+                        names.equal_index,
+                        &names.equal_name,
+                        span,
+                    )),
                 },
                 span,
             ),
@@ -3419,6 +3575,7 @@ fn generate_struct_ord_fn(
     ord_trait_name: &str,
     tt: &mut TypeTable,
     span: Span,
+    names: &TraitsStdlibNames,
 ) -> TirFunction {
     let method_info = trait_method_info(struct_name, ord_trait_name, "cmp");
     let qualified_name = method_info.to_mangled_name();
@@ -3430,6 +3587,7 @@ fn generate_struct_ord_fn(
         module_source,
         tt,
         span,
+        names,
     );
     let body = TirBlock::new(stmts, span);
 
@@ -3459,6 +3617,7 @@ fn build_struct_ord_body(
     module_source: &ModuleSource,
     tt: &mut TypeTable,
     span: Span,
+    names: &TraitsStdlibNames,
 ) -> (Vec<TirStmt>, Vec<TirLocal>) {
     let mut stmts = Vec::new();
     let mut locals = binary_method_locals(ref_struct_type);
@@ -3516,7 +3675,12 @@ fn build_struct_ord_body(
             TirExprKind::Binary {
                 op: TirBinaryOp::NotEq,
                 left: Box::new(local_c.clone()),
-                right: Box::new(ordering_construct(ordering_type, 1, "Equal", span)),
+                right: Box::new(ordering_construct(
+                    ordering_type,
+                    names.equal_index,
+                    &names.equal_name,
+                    span,
+                )),
             },
             TypeTable::BOOL,
             span,
@@ -3541,7 +3705,12 @@ fn build_struct_ord_body(
 
     stmts.push(TirStmt::new(
         TirStmtKind::Return {
-            value: Some(ordering_construct(ordering_type, 1, "Equal", span)),
+            value: Some(ordering_construct(
+                ordering_type,
+                names.equal_index,
+                &names.equal_name,
+                span,
+            )),
         },
         span,
     ));


### PR DESCRIPTION
Closes #1091.

Follow-up to #1086 / #1090. Routes every remaining hard-coded `core:serde` / `core:format` / variant-case / method-name stdlib literal in `wado-compiler/src/{synthesis,lower,resolver}/` through the `CompilerItem` registry. A stdlib rename of any of these now flows through compilation without touching Rust code.

## Summary

- **+48 new `CompilerItem` variants** across three groups (serde core, format core, variant/enum cases) plus the `Method` items for trait methods captured via `Resolved::Trait::method_name`.
- **+2 new `CompilerItemKind`s** — `VariantCase` and `EnumCase` — plus matching `Resolved` carriers that record `(module, parent_type, case_name, case_index)`.
- **+`method_name: Option<String>` on `Resolved::Trait`**, auto-captured by the resolver for single-method traits (the format family — `Display` / `Inspect` / `Binary` / `Octal` / `LowerHex` / `UpperHex` / `LowerExp` / their `*Alt` variants). `CompilerItems::trait_method_name(item)` exposes it.
- **stdlib annotations**: `serde.wado` (traits + error structs/enums + error-kind cases), `prelude/format.wado` (Formatter, Alignment + cases), `prelude/traits.wado` (Display/Inspect family), `prelude/types.wado` (Option / Result cases).
- **synthesis migration**: four snapshot helpers (`CmStdlibNames` / `SerdeStdlibNames` / `FormatStdlibNames` / `TraitsStdlibNames`) capture the registry contents once per pass and thread through every helper. All four now share a uniform `from_compiler_items(&CompilerItems) -> Self` constructor.
- **`Fn` closure trait** ← `name::CLOSURE_FN_TRAIT` const (compiler-internal anchor, matches the existing `CLOSURE_CALL_METHOD` / `CLOSURE_STRUCT_PREFIX` pattern).
- **2 new `compiler_item` round-trip tests** pin the contract: variant cases and enum cases under the registry survive being renamed in stdlib without any Rust-side updates.

## Sites covered

| Audit category | Sites |
|---|---|
| serde traits / assoc types / error structs / error-kind cases | ~70 |
| format traits + `Formatter` / `Alignment` cases | ~80 |
| Option / Result / Ordering / Alignment variant cases | ~30 |
| Method names (`fmt` / `fmt_alt` / `inspect` / `inspect_alt`) | 40 |
| Closure `Fn` trait + closure formatter redirect | 5 |
| **Total** | **~225** |

Issue's strict acceptance grep:
```
grep -rn '"Serializer"\|"Deserializer"\|"SerializeStruct"\|"DeserializeStruct"\|"Formatter"\|"Display"\|"Inspect"\|"Some"\|"None"\|"Ok"\|"Err"\|"Less"\|"Equal"\|"Greater"' wado-compiler/src/{synthesis,lower,resolver}/
```
returns zero production-code matches; the only remaining literals are inside `#[cfg(test)]` test fixtures (`register_option_result_for_tests`, `CmStdlibNames::for_tests`).

## Tests

- `cargo test --lib -p wado-compiler` → **500 passed, 0 failed**
- `cargo test -p wado-compiler --test e2e` → **6177 passed, 0 failed** (covers O0 / O2; full O0+O1+O2+O3+Os pass under `WADO_FULL_TEST=1`)
- `cargo test -p wado-compiler --test format` → **89 passed, 0 failed**
- `mise run test-wado` (stdlib logic tests) → **2602 passed, 0 failed**, 387 compile ok

Refs #1086, #1090.

## Test plan

- [x] Unit tests pass
- [x] e2e fixtures pass at every `-O` level
- [x] Format-fixture tests pass
- [x] wado-stdlib tests pass
- [ ] CI green on PR

https://claude.ai/code/session_01BgmbMHvsn3Fw5scsKauTPR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BgmbMHvsn3Fw5scsKauTPR)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wado-lang/wado/pull/1113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->