### PR TITLE
test(vscode): de-flake LSP suite tmpDir cleanup on Windows

### DIFF
--- a/wado-vscode/src/test/suite/lsp-hover.test.ts
+++ b/wado-vscode/src/test/suite/lsp-hover.test.ts
@@ -1,8 +1,8 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
-import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { cleanupTmpDir, createTmpDir } from './tmp-workspace';
 
 const SOURCE = `fn answer() -> i32 {
     return 42;
@@ -50,7 +50,7 @@ suite('Wado LSP (hover)', () => {
     test('returns hover information for a function reference', async function () {
         this.timeout(60_000);
 
-        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wado-lsp-hover-'));
+        const tmpDir = createTmpDir('wado-lsp-hover-');
         const filePath = path.join(tmpDir, 'hover.wado');
         fs.writeFileSync(filePath, SOURCE, 'utf8');
 
@@ -89,7 +89,7 @@ suite('Wado LSP (hover)', () => {
                 `Hover should reference the symbol or its signature, got: ${rendered}`,
             );
         } finally {
-            fs.rmSync(tmpDir, { recursive: true, force: true });
+            await cleanupTmpDir(tmpDir);
         }
     });
 });

--- a/wado-vscode/src/test/suite/lsp-restart.test.ts
+++ b/wado-vscode/src/test/suite/lsp-restart.test.ts
@@ -1,8 +1,8 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
-import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { cleanupTmpDir, createTmpDir } from './tmp-workspace';
 
 const BROKEN_SOURCE = `fn main() -> i32 {
     let x: i32 = "not an integer";
@@ -61,7 +61,7 @@ suite('Wado LSP (restart command)', () => {
     test('restart command re-publishes diagnostics from a fresh client', async function () {
         this.timeout(90_000);
 
-        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wado-lsp-restart-'));
+        const tmpDir = createTmpDir('wado-lsp-restart-');
         const filePath = path.join(tmpDir, 'broken.wado');
         fs.writeFileSync(filePath, BROKEN_SOURCE, 'utf8');
 
@@ -114,7 +114,7 @@ suite('Wado LSP (restart command)', () => {
                 'Post-restart diagnostics should include an error',
             );
         } finally {
-            fs.rmSync(tmpDir, { recursive: true, force: true });
+            await cleanupTmpDir(tmpDir);
         }
     });
 });

--- a/wado-vscode/src/test/suite/lsp-subprocess.test.ts
+++ b/wado-vscode/src/test/suite/lsp-subprocess.test.ts
@@ -1,8 +1,8 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
-import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { cleanupTmpDir, createTmpDir } from './tmp-workspace';
 
 const BROKEN_WADO_SOURCE = `fn main() -> i32 {
     let x: i32 = "not an integer";
@@ -92,7 +92,7 @@ suite('Wado LSP (native subprocess)', () => {
     test('publishes diagnostics when using the native subprocess server', async function () {
         this.timeout(60_000);
 
-        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wado-lsp-subproc-'));
+        const tmpDir = createTmpDir('wado-lsp-subproc-');
         const filePath = path.join(tmpDir, 'broken.wado');
         fs.writeFileSync(filePath, BROKEN_WADO_SOURCE, 'utf8');
 
@@ -114,7 +114,7 @@ suite('Wado LSP (native subprocess)', () => {
                 )}`,
             );
         } finally {
-            fs.rmSync(tmpDir, { recursive: true, force: true });
+            await cleanupTmpDir(tmpDir);
         }
     });
 });

--- a/wado-vscode/src/test/suite/lsp.test.ts
+++ b/wado-vscode/src/test/suite/lsp.test.ts
@@ -1,8 +1,8 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
-import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { cleanupTmpDir, createTmpDir } from './tmp-workspace';
 
 const BROKEN_WADO_SOURCE = `fn main() -> i32 {
     let x: i32 = "not an integer";
@@ -59,7 +59,7 @@ suite('Wado LSP', () => {
     test('publishes diagnostics for a broken .wado file', async function () {
         this.timeout(120_000);
 
-        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wado-lsp-test-'));
+        const tmpDir = createTmpDir('wado-lsp-test-');
         const filePath = path.join(tmpDir, 'broken.wado');
         fs.writeFileSync(filePath, BROKEN_WADO_SOURCE, 'utf8');
 
@@ -82,7 +82,7 @@ suite('Wado LSP', () => {
                 )}`,
             );
         } finally {
-            fs.rmSync(tmpDir, { recursive: true, force: true });
+            await cleanupTmpDir(tmpDir);
         }
     });
 });

--- a/wado-vscode/src/test/suite/tmp-workspace.ts
+++ b/wado-vscode/src/test/suite/tmp-workspace.ts
@@ -1,0 +1,35 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+/**
+ * Create a unique temp directory for a test.
+ */
+export function createTmpDir(prefix: string): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+/**
+ * Tear down a temp directory created for a test.
+ *
+ * On Windows, VS Code's file watcher and the LSP client may still hold
+ * handles to files under `tmpDir` for a brief moment after the test body
+ * resolves, which makes a naive `rmSync` race with `EBUSY` / `EPERM`.
+ * Closing the editors first releases VS Code's references, and the retry
+ * options on `rmSync` cover the remaining window where the LSP server is
+ * still flushing.
+ */
+export async function cleanupTmpDir(tmpDir: string): Promise<void> {
+    try {
+        await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+    } catch {
+        /* ignore — best-effort cleanup */
+    }
+    fs.rmSync(tmpDir, {
+        recursive: true,
+        force: true,
+        maxRetries: 10,
+        retryDelay: 100,
+    });
+}


### PR DESCRIPTION
## Summary

The Windows CI job for `wado-vscode` was flaking on the LSP tests with:

```
Error: EBUSY: resource busy or locked, rmdir 'C:\Users\RUNNER~1\AppData\Local\Temp\wado-lsp-hover-3vqcvA'
```

and a matching `[File Watcher (node.js)] Watcher shutdown because watched path got deleted` line just before. VS Code's file watcher and the LSP client were still holding handles to files under `tmpDir` for a brief moment after the test body resolved, so the immediate `fs.rmSync` raced with Windows' "can't unlink an open file" semantics.

Four LSP tests duplicated the same `mkdtempSync` + naive `rmSync` pattern. This PR centralizes it:

- New `wado-vscode/src/test/suite/tmp-workspace.ts` helper:
  - `createTmpDir(prefix)` wraps `mkdtempSync`.
  - `cleanupTmpDir(tmpDir)` first issues `workbench.action.closeAllEditors` to release VS Code's references, then calls `fs.rmSync` with `maxRetries: 10, retryDelay: 100` to ride out the remaining window where the LSP server is still detaching.
- `lsp.test.ts`, `lsp-hover.test.ts`, `lsp-restart.test.ts`, `lsp-subprocess.test.ts` switch to the helper; the now-unused `os` import is dropped from each.

## Test plan

- [x] `npx tsc -p .` in `wado-vscode/` passes
- [ ] Windows CI for the `wado-vscode` extension test job passes
- [ ] No regression on macOS / Linux CI

---
_Generated by [Claude Code](https://claude.ai/code/session_018PVUiL3FwWXX9vWj39NEDh)_