### PR TITLE
fix(analyze): store actual aliased type on Newtype symbol

### DIFF
--- a/wado-compiler/src/analyze.rs
+++ b/wado-compiler/src/analyze.rs
@@ -415,9 +415,9 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
                 }
 
                 Item::Newtype(newtype) => {
-                    let kind = SymbolKind::Newtype(NewtypeSymbol {
-                        aliased_type: "unknown".to_string(), // TODO: store actual type
-                    });
+                    let mut aliased_type = String::new();
+                    crate::unparse::unparse_type_into(&newtype.ty, &mut aliased_type);
+                    let kind = SymbolKind::Newtype(NewtypeSymbol { aliased_type });
 
                     self.define_unique(
                         module_source,

--- a/wado-compiler/tests/annotate.rs
+++ b/wado-compiler/tests/annotate.rs
@@ -9,6 +9,34 @@ use wado_compiler::annotate;
 use wado_compiler::module_source::ModuleSource;
 use wado_compiler::symbol::{SymbolKey, SymbolKind};
 
+#[test]
+fn annotate_newtype_records_aliased_type() {
+    let source = r"
+type Meters = f64;
+type Pair = [i32, i32];
+type Maybe = Option<i32>;
+";
+    let host = InMemoryHost::new();
+    let annotated = block_on(annotate(source, &host, Some("entry.wado"))).unwrap();
+
+    let entry = annotated.interner.borrow_mut().entry_point("entry.wado");
+
+    let expect_aliased = |name: &str, expected: &str| {
+        let sym = annotated
+            .symbols
+            .lookup_in_module(&entry, name)
+            .unwrap_or_else(|| panic!("{name} symbol should be defined"));
+        match &sym.kind {
+            SymbolKind::Newtype(n) => assert_eq!(n.aliased_type, expected, "newtype {name}"),
+            other => panic!("expected Newtype for {name}, got {other:?}"),
+        }
+    };
+
+    expect_aliased("Meters", "f64");
+    expect_aliased("Pair", "[i32, i32]");
+    expect_aliased("Maybe", "Option<i32>");
+}
+
 fn block_on<F: std::future::Future>(future: F) -> F::Output {
     tokio::runtime::Runtime::new().unwrap().block_on(future)
 }


### PR DESCRIPTION
The analyzer was recording the literal string `"unknown"` as the `aliased_type` for every `Newtype` symbol (the `TODO: store actual type` at `wado-compiler/src/analyze.rs:419`). This surfaced through `wado dump --symbols`, where every newtype rendered as `type = unknown`.

Now we unparse the newtype's `Type` AST via `unparse::unparse_type_into`, so the symbol table carries the real alias — e.g. `f64`, `[i32, i32]`, `Option<i32>`.

A new `annotate_newtype_records_aliased_type` test covers named, tuple, and generic alias targets.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPtuYNsD5MdoANASp7AXoH)_