### PR TITLE
fix: unify break value types in labeled block expressions

### DIFF
--- a/wado-compiler/src/resolver/expr.rs
+++ b/wado-compiler/src/resolver/expr.rs
@@ -195,6 +195,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 ctx.labeled_block_targets.push(LabeledBlockTarget {
                     label: lb.label.clone(),
                     break_types: Vec::new(),
+                    expected_type,
                 });
                 ctx.active_labels.push(lb.label.clone());
 
@@ -205,14 +206,28 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 ctx.active_labels.pop();
                 let target = ctx.labeled_block_targets.pop().unwrap();
 
-                let result_type = if !target.break_types.is_empty() {
-                    // TODO: type unification for multiple breaks
-                    target.break_types[0]
-                } else if let Some(ty) = expected_type {
+                // Unify the types of every `break label: expr`. The use-site
+                // expected type wins when present; otherwise pick a
+                // representative break type, skipping `never` (the bottom
+                // type) so a diverging break does not mask the real type.
+                let result_type = if let Some(ty) = expected_type {
                     ty
+                } else if !target.break_types.is_empty() {
+                    target
+                        .break_types
+                        .iter()
+                        .copied()
+                        .find(|&t| t != TypeTable::NEVER)
+                        .unwrap_or(target.break_types[0])
                 } else {
                     TypeTable::UNIT
                 };
+
+                // Report any break whose value type disagrees with the
+                // unified result type.
+                for &break_type in &target.break_types {
+                    self.check_branch_type(break_type, result_type, lb.span);
+                }
 
                 TirExpr::new(
                     TirExprKind::LabeledBlock {
@@ -1947,7 +1962,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
     /// else branches when an outer type annotation pinned the
     /// expected result type; the same rule lives inline in
     /// `resolve_match_expr` for arm bodies.
-    fn check_branch_type(&mut self, actual: TypeId, expected: TypeId, span: Span) {
+    pub(super) fn check_branch_type(&mut self, actual: TypeId, expected: TypeId, span: Span) {
         let result = {
             let tt = self.type_table.borrow();
             check_assignable(actual, expected, &tt)

--- a/wado-compiler/src/resolver/stmt.rs
+++ b/wado-compiler/src/resolver/stmt.rs
@@ -2712,10 +2712,20 @@ impl<H: CompilerHost> Resolver<'_, H> {
         break_stmt: &BreakStmt,
         ctx: &mut FunctionContext,
     ) -> TirStmt {
+        // Resolve the break value against the target block's expected type
+        // so that literals coerce correctly (e.g. `break label: 10` when the
+        // block is used as `let x: i64 = label: { ... }`).
+        let expected = break_stmt.label.as_ref().and_then(|label| {
+            ctx.labeled_block_targets
+                .iter()
+                .rev()
+                .find(|t| &t.label == label)
+                .and_then(|t| t.expected_type)
+        });
         let value = break_stmt
             .value
             .as_ref()
-            .map(|v| self.resolve_expr(v, ctx, None));
+            .map(|v| self.resolve_expr(v, ctx, expected));
 
         // Validate that the target label exists
         if let Some(label) = &break_stmt.label

--- a/wado-compiler/src/resolver/types.rs
+++ b/wado-compiler/src/resolver/types.rs
@@ -1111,6 +1111,10 @@ pub(super) struct LabeledBlockTarget {
     pub(super) label: String,
     /// Types collected from `break label: expr;` statements
     pub(super) break_types: Vec<TypeId>,
+    /// Expected type propagated from the labeled block's use site, if any.
+    /// `break label: expr` values are resolved against this so a literal
+    /// (e.g. `break label: 10` with `let x: i64 = ...`) coerces correctly.
+    pub(super) expected_type: Option<TypeId>,
 }
 
 /// Function context during resolution with scope tracking

--- a/wado-compiler/tests/e2e.rs
+++ b/wado-compiler/tests/e2e.rs
@@ -1035,3 +1035,4 @@ test "passes unexpectedly" {
 // fn-ref fixtures added (generic ref / alias / arity / cross-module alias)
 // fn-ref fixture added (self-recursive generic)
 // touched
+// labeled-block break type unification fixtures added

--- a/wado-compiler/tests/fixtures/labeled_block_break_coercion.wado
+++ b/wado-compiler/tests/fixtures/labeled_block_break_coercion.wado
@@ -1,0 +1,29 @@
+// A labeled block used as a value expression unifies its `break` values
+// against the use-site expected type, so integer literals coerce to the
+// annotated type instead of defaulting to i32.
+
+use { println, Stdout } from "core:cli";
+
+export fn run() with Stdout {
+    let wide: i64 = compute: {
+        if true {
+            break compute: 10;
+        }
+        break compute: 20;
+    };
+    assert wide == 10;
+
+    // Without an annotation, multiple breaks of the same type still unify.
+    let same = pick: {
+        if false {
+            break pick: 1;
+        }
+        break pick: 2;
+    };
+    assert same == 2;
+
+    println(`wide={wide} same={same}`);
+}
+
+__DATA__
+{"stdout": "wide=10 same=2\n"}

--- a/wado-compiler/tests/fixtures/labeled_block_error_break_type_mismatch.wado
+++ b/wado-compiler/tests/fixtures/labeled_block_error_break_type_mismatch.wado
@@ -1,0 +1,17 @@
+// Test error: a labeled block whose `break` values have incompatible
+// types is rejected instead of silently taking the first break's type.
+
+use { println, Stdout } from "core:cli";
+
+export fn run() with Stdout {
+    let result = compute: {
+        if true {
+            break compute: 10;
+        }
+        break compute: "hello"; // Error: i32 vs String
+    };
+    println(`{result}`);
+}
+
+__DATA__
+{"compile_error": "type mismatch"}


### PR DESCRIPTION
## Summary

Implements the `// TODO: type unification for multiple breaks` in `wado-compiler/src/resolver/expr.rs`.

A labeled block used as a value expression (`let x = label: { break label: ... }`) previously:

- took the **first** `break` value's type as its result type;
- resolved every `break` value with **no expected type**, so `let x: i64 = label: { break label: 10 }` failed (`expected 'i64', found 'i32'`) because the integer literal defaulted to `i32`;
- silently accepted `break` values of mutually incompatible types, risking a WIR type-mismatch ICE.

Now:

- `break` values are resolved against the block's use-site expected type, so literals coerce correctly;
- the result type prefers that expected type, falling back to a representative non-`never` break type (mirroring `match` result-type selection);
- every `break` value is checked against the unified result type and mismatches are reported.

## Changes

- `resolver/types.rs`: `LabeledBlockTarget` gains an `expected_type` field.
- `resolver/expr.rs`: `Expr::LabeledBlock` propagates the expected type, unifies break types, and reports mismatches. `check_branch_type` is now `pub(super)`.
- `resolver/stmt.rs`: `resolve_break` resolves the break value against the target block's expected type.
- New e2e fixtures: `labeled_block_break_coercion.wado` (positive), `labeled_block_error_break_type_mismatch.wado` (negative).

## Test plan

- [x] `labeled_block_break_coercion.wado` — `let wide: i64 = compute: { break compute: 10; }` coerces correctly
- [x] `labeled_block_error_break_type_mismatch.wado` — mixed break types produce a `compile_error`
- [x] `cargo test -p wado-compiler` — full suite passes (e2e 6377 + unit suites, 0 failed)

https://claude.ai/code/session_01CnPqoFGx1r9Q5TnPsPRwd6

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnPqoFGx1r9Q5TnPsPRwd6)_