### PR TITLE
fix: report uninferable method type parameters instead of ICE

### DIFF
--- a/wado-compiler/lib/core/json_value.wado
+++ b/wado-compiler/lib/core/json_value.wado
@@ -127,7 +127,7 @@ impl Visitor for ValueVisitor {
     fn visit_seq<A: DeserializeSeq>(&mut self, seq: &mut A) -> Result<Value, DeserializeError> {
         let mut items: Array<Value> = [];
         loop {
-            let next_opt = seq.next_element::<Value>()?;  // FIXME: removing turbofish causes ICE
+            let next_opt = seq.next_element::<Value>()?;
             match next_opt {
                 Some(item) => {
                     items.push(item);

--- a/wado-compiler/src/resolver/method_call.rs
+++ b/wado-compiler/src/resolver/method_call.rs
@@ -512,6 +512,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 raw_args: &method_call.args,
                 decl_return_type: return_type,
                 expected_return_type: expected_type,
+                span: method_call.span,
             })
         } else {
             type_args

--- a/wado-compiler/src/resolver/method_lookup.rs
+++ b/wado-compiler/src/resolver/method_lookup.rs
@@ -16,7 +16,7 @@ use super::Resolver;
 use super::infer::InferCtx;
 use super::types::{
     ArithmeticTraitInfo, FunctionContext, IndexAssignTraitInfo, IndexMutTraitInfo, IndexTraitInfo,
-    IndexValueTraitInfo, KeyValueLiteralTraitInfo, MethodInfo, SequenceLiteralTraitInfo,
+    IndexValueTraitInfo, KeyValueLiteralTraitInfo, MethodInfo, SequenceLiteralTraitInfo, TypeError,
 };
 
 /// Lightweight reference to an impl block, avoiding deep clones.
@@ -59,6 +59,9 @@ pub(super) struct MethodInferenceInput<'a> {
     /// Expected return type at the call site (from a type annotation or
     /// surrounding call), used for back-inference.
     pub expected_return_type: Option<TypeId>,
+    /// Call-site span, used to anchor a "cannot infer type parameter"
+    /// diagnostic when inference leaves a method type parameter dangling.
+    pub span: Span,
 }
 
 impl<H: CompilerHost> Resolver<'_, H> {
@@ -1312,6 +1315,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
             raw_args,
             decl_return_type,
             expected_return_type,
+            span,
         } = input;
 
         let base_type_id = self.get_base_type(receiver_type);
@@ -1355,9 +1359,9 @@ impl<H: CompilerHost> Resolver<'_, H> {
         let method_type_param_ids: Vec<TypeId> = {
             let mut tt = self.type_table.borrow_mut();
             method_type_param_names
-                .into_iter()
+                .iter()
                 .enumerate()
-                .map(|(i, name)| tt.make_type_param(name, impl_offset + i as u32))
+                .map(|(i, (name, _))| tt.make_type_param(name.clone(), impl_offset + i as u32))
                 .collect()
         };
 
@@ -1391,6 +1395,44 @@ impl<H: CompilerHost> Resolver<'_, H> {
         if !all_concrete {
             let all_outer = inferred.iter().all(|tid| scope_params.contains(tid));
             if !all_outer {
+                // A method type parameter resolved to neither a concrete type
+                // nor an outer-scope parameter — it stayed a fresh, dangling
+                // `TypeParam`. Without an explicit turbofish or an LHS type
+                // annotation there is nothing left to pin it, so report a
+                // clean diagnostic here instead of letting the dangling id
+                // reach a later phase and panic.
+                //
+                // `fn`-bound parameters (`<F: fn(...) -> ...>`) are excluded:
+                // they are constrained structurally from the bound's function
+                // type, not by call-site inference, so an empty result for
+                // them is expected and handled downstream.
+                let unresolved: Vec<&str> = method_type_param_names
+                    .iter()
+                    .zip(inferred.iter())
+                    .filter(|&((_, has_fn_bound), &tid)| {
+                        !has_fn_bound
+                            && matches!(
+                                self.type_table.borrow().get(tid),
+                                ResolvedType::TypeParam { .. } | ResolvedType::TypePack { .. }
+                            )
+                            && !scope_params.contains(&tid)
+                    })
+                    .map(|((name, _), _)| name.as_str())
+                    .collect();
+                if !unresolved.is_empty() {
+                    let params = unresolved
+                        .iter()
+                        .map(|n| format!("`{n}`"))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    let _ = self.logger.error(TypeError::CannotInferType {
+                        message: format!(
+                            "cannot infer type parameter {params} of method `{method_name}`; \
+                             add a turbofish (`{method_name}::<...>()`) or a type annotation"
+                        ),
+                        span,
+                    });
+                }
                 return vec![];
             }
         }
@@ -1405,13 +1447,16 @@ impl<H: CompilerHost> Resolver<'_, H> {
         &self,
         trait_names: &[String],
         method_name: &str,
-    ) -> Option<Vec<String>> {
-        let extract_names = |method: &ast::Function| -> Option<Vec<String>> {
-            let names: Vec<String> = method
+    ) -> Option<Vec<(String, bool)>> {
+        let extract_names = |method: &ast::Function| -> Option<Vec<(String, bool)>> {
+            let names: Vec<(String, bool)> = method
                 .type_params
                 .iter()
                 .filter(|p| !p.is_effect)
-                .map(|tp| tp.name.clone())
+                .map(|tp| {
+                    let has_fn_bound = tp.bounds.iter().any(|b| b.fn_signature.is_some());
+                    (tp.name.clone(), has_fn_bound)
+                })
                 .collect();
             if names.is_empty() { None } else { Some(names) }
         };
@@ -1467,13 +1512,16 @@ impl<H: CompilerHost> Resolver<'_, H> {
         struct_name: &str,
         struct_module_source: Option<&ModuleSource>,
         method_name: &str,
-    ) -> Option<Vec<String>> {
-        let extract_names = |method: &ast::Function| -> Option<Vec<String>> {
-            let names: Vec<String> = method
+    ) -> Option<Vec<(String, bool)>> {
+        let extract_names = |method: &ast::Function| -> Option<Vec<(String, bool)>> {
+            let names: Vec<(String, bool)> = method
                 .type_params
                 .iter()
                 .filter(|p| !p.is_effect)
-                .map(|tp| tp.name.clone())
+                .map(|tp| {
+                    let has_fn_bound = tp.bounds.iter().any(|b| b.fn_signature.is_some());
+                    (tp.name.clone(), has_fn_bound)
+                })
                 .collect();
             if names.is_empty() { None } else { Some(names) }
         };
@@ -1487,7 +1535,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
             impl_type_name == struct_name || impl_base_name == struct_name
         };
 
-        let search_items = |items: &[Item], include_trait: bool| -> Option<Vec<String>> {
+        let search_items = |items: &[Item], include_trait: bool| -> Option<Vec<(String, bool)>> {
             for item in items {
                 if let Item::Impl(impl_block) = item
                     && impl_matches_struct(impl_block, include_trait)

--- a/wado-compiler/tests/e2e.rs
+++ b/wado-compiler/tests/e2e.rs
@@ -1039,3 +1039,4 @@ test "passes unexpectedly" {
 // labeled-block break null-coercion / shadowed-label fixtures added
 // labeled-block break null-inference error fixtures added
 // match / if all-null inference error fixtures added
+// uninferable method type parameter error fixture added

--- a/wado-compiler/tests/fixtures/infer_method_type_arg_uninferable_error.wado
+++ b/wado-compiler/tests/fixtures/infer_method_type_arg_uninferable_error.wado
@@ -1,0 +1,38 @@
+// Test: when a method's type parameter appears only in the return type and
+// the call site provides neither a turbofish nor an LHS type annotation, the
+// type parameter cannot be inferred. This must surface as a clean compile
+// error rather than reaching a later phase and panicking.
+//
+// Regression test for the `json_value.wado` FIXME: `seq.next_element()`
+// (a `fn next_element<T>(&mut self) -> Result<Option<T>, _>`) called without
+// `::<Value>` used to ICE in WIR lowering with "unresolved MethodCall".
+
+trait Producer {
+    fn produce<T>(&self) -> Option<T>;
+}
+
+fn consume<P: Producer>(p: &P) {
+    // `T` of `produce` only appears in the return type and nothing here
+    // constrains it, so it is genuinely uninferable.
+    let opt = p.produce();
+    match opt {
+        Some(_v) => {},
+        None => {},
+    }
+}
+
+struct Gen {}
+
+impl Producer for Gen {
+    fn produce<T>(&self) -> Option<T> {
+        return Option::None;
+    }
+}
+
+export fn run() {
+    let g = Gen {};
+    consume(&g);
+}
+
+__DATA__
+{"compile_error": "cannot infer"}

--- a/wado-compiler/tests/generated/fixtures/labeled_block_break_coercion.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/labeled_block_break_coercion.wir.wado
@@ -206,18 +206,14 @@ fn "core:cli/write_to_stream"(tx, message, add_newline) {
 }
 
 fn "core:cli/println"(message) with Stdout {
-    let rx: i32;
-    let tx: i32;
     let handle: i32;
     let __pair_temp_1: i64;
     __pair_temp_1 = "wasi/stream-new"();
     let __mv_lo_1: i32;
     let __mv_hi_1: i32;
     multivalue_bind [__mv_lo_1, __mv_hi_1] = (builtin::i32_wrap_i64(__pair_temp_1); builtin::i32_wrap_i64(__pair_temp_1 >>u 32_i64));
-    rx = __mv_lo_1;
-    tx = __mv_hi_1;
-    handle = "wado-compiler/tests/fixtures/labeled_block_break_coercion.wado/__cm_binding__Stdout_write_via_stream"(rx);
-    "core:cli/write_to_stream"(tx, message, 1);
+    handle = "wado-compiler/tests/fixtures/labeled_block_break_coercion.wado/__cm_binding__Stdout_write_via_stream"(__mv_lo_1);
+    "core:cli/write_to_stream"(__mv_hi_1, message, 1);
     "wasi/future-drop-readable:transmission-cli"(handle);
 }
 
@@ -256,21 +252,15 @@ fn "core:internal/write_string_to_stream"(tx, message, add_newline) {
 }
 
 fn "core:internal/log_stderr"(message) {
-    let rx: i32;
-    let tx: i32;
     let future_handle: i32;
-    let future: i32;
     let __pair_temp_1: i64;
     __pair_temp_1 = "wasi/stream-new"();
     let __mv_lo_1: i32;
     let __mv_hi_1: i32;
     multivalue_bind [__mv_lo_1, __mv_hi_1] = (builtin::i32_wrap_i64(__pair_temp_1); builtin::i32_wrap_i64(__pair_temp_1 >>u 32_i64));
-    rx = __mv_lo_1;
-    tx = __mv_hi_1;
-    future_handle = "wasi/wasi:cli/Stderr::write_via_stream"(rx);
-    "core:internal/write_string_to_stream"(tx, message, 1);
-    future = future_handle;
-    "wasi/future-drop-readable:transmission-cli"(future);
+    future_handle = "wasi/wasi:cli/Stderr::write_via_stream"(__mv_lo_1);
+    "core:internal/write_string_to_stream"(__mv_hi_1, message, 1);
+    "wasi/future-drop-readable:transmission-cli"(future_handle);
 }
 
 fn "core:internal/panic"(message) {
@@ -383,7 +373,6 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
 }
 
 fn "core:prelude/primitive.wado/i64::fmt_decimal"(self, f) {
-    let value: i64;
     let is_negative: bool;
     let remaining_digits: i32;
     let digit_count_6: i32;
@@ -394,9 +383,8 @@ fn "core:prelude/primitive.wado/i64::fmt_decimal"(self, f) {
     let offset_11: i32;
     let self_12: ref "core:prelude/string.wado//String";
     let self_13: ref "core:prelude/string.wado//String";
-    value = self;
-    is_negative = value < 0_i64;
-    if value == -9223372036854775808_i64 {
+    is_negative = self < 0_i64;
+    if self == -9223372036854775808_i64 {
         remaining_digits = "core:prelude/primitive.wado/count_digits_i64"(922337203685477580_i64);
         digit_count_6 = remaining_digits + 1;
         offset_7 = "core:prelude/format.wado/Formatter::prepare_int_write"(f, 1, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_6);
@@ -409,9 +397,9 @@ fn "core:prelude/primitive.wado/i64::fmt_decimal"(self, f) {
         builtin::array_set_u8(repr, offset_7 + remaining_digits, 56);
     } else {
         abs_val = (if is_negative -> i64 {
-            0_i64 - value;
+            0_i64 - self;
         } else {
-            value;
+            self;
         });
         digit_count_10 = "core:prelude/primitive.wado/count_digits_i64"(abs_val);
         offset_11 = "core:prelude/format.wado/Formatter::prepare_int_write"(f, is_negative, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 }, digit_count_10);
@@ -475,28 +463,26 @@ fn "core:prelude/string.wado/String::push_str"(self, other) {
 }
 
 fn "core:prelude/string.wado/String::push"(self, c) {
-    let code: u32;
-    code = c;
     if builtin::unlikely((self.used + 4) > builtin::array_len(self.repr)) {
         "core:prelude/string.wado/String::grow"(self, self.used + 4);
     }
-    if code <u 128 {
-        builtin::array_set_u8(self.repr, self.used, code & 255);
+    if c <u 128 {
+        builtin::array_set_u8(self.repr, self.used, c & 255);
         self.used = self.used + 1;
-    } else if code <u 2048 {
-        builtin::array_set_u8(self.repr, self.used, (192 | (code >>u 6)) & 255);
-        builtin::array_set_u8(self.repr, self.used + 1, (128 | (code & 63)) & 255);
+    } else if c <u 2048 {
+        builtin::array_set_u8(self.repr, self.used, (192 | (c >>u 6)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 1, (128 | (c & 63)) & 255);
         self.used = self.used + 2;
-    } else if code <u 65536 {
-        builtin::array_set_u8(self.repr, self.used, (224 | (code >>u 12)) & 255);
-        builtin::array_set_u8(self.repr, self.used + 1, (128 | ((code >>u 6) & 63)) & 255);
-        builtin::array_set_u8(self.repr, self.used + 2, (128 | (code & 63)) & 255);
+    } else if c <u 65536 {
+        builtin::array_set_u8(self.repr, self.used, (224 | (c >>u 12)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 1, (128 | ((c >>u 6) & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 2, (128 | (c & 63)) & 255);
         self.used = self.used + 3;
     } else {
-        builtin::array_set_u8(self.repr, self.used, (240 | (code >>u 18)) & 255);
-        builtin::array_set_u8(self.repr, self.used + 1, (128 | ((code >>u 12) & 63)) & 255);
-        builtin::array_set_u8(self.repr, self.used + 2, (128 | ((code >>u 6) & 63)) & 255);
-        builtin::array_set_u8(self.repr, self.used + 3, (128 | (code & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used, (240 | (c >>u 18)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 1, (128 | ((c >>u 12) & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 2, (128 | ((c >>u 6) & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 3, (128 | (c & 63)) & 255);
         self.used = self.used + 4;
     }
 }
@@ -565,9 +551,7 @@ fn "core:prelude/format.wado/Formatter::prepare_int_write"(self, is_negative, pr
         return "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
     }
     align = self.align;
-    let __match_scrut_0: "core:prelude/format.wado//enum:Alignment";
-    __match_scrut_0 = align;
-    if __match_scrut_0 == 0 {
+    if align == 0 {
         if sign_len > 0 {
             "core:prelude/string.wado/String::push_str"(self.buf, sign);
         }

--- a/wado-compiler/tests/generated/fixtures/labeled_block_break_null_coercion.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/labeled_block_break_null_coercion.wir.wado
@@ -191,18 +191,14 @@ fn "core:cli/write_to_stream"(tx, message, add_newline) {
 }
 
 fn "core:cli/println"(message) with Stdout {
-    let rx: i32;
-    let tx: i32;
     let handle: i32;
     let __pair_temp_1: i64;
     __pair_temp_1 = "wasi/stream-new"();
     let __mv_lo_1: i32;
     let __mv_hi_1: i32;
     multivalue_bind [__mv_lo_1, __mv_hi_1] = (builtin::i32_wrap_i64(__pair_temp_1); builtin::i32_wrap_i64(__pair_temp_1 >>u 32_i64));
-    rx = __mv_lo_1;
-    tx = __mv_hi_1;
-    handle = "wado-compiler/tests/fixtures/labeled_block_break_null_coercion.wado/__cm_binding__Stdout_write_via_stream"(rx);
-    "core:cli/write_to_stream"(tx, message, 1);
+    handle = "wado-compiler/tests/fixtures/labeled_block_break_null_coercion.wado/__cm_binding__Stdout_write_via_stream"(__mv_lo_1);
+    "core:cli/write_to_stream"(__mv_hi_1, message, 1);
     "wasi/future-drop-readable:transmission-cli"(handle);
 }
 
@@ -379,28 +375,26 @@ fn "core:prelude/string.wado/String::push_str"(self, other) {
 }
 
 fn "core:prelude/string.wado/String::push"(self, c) {
-    let code: u32;
-    code = c;
     if builtin::unlikely((self.used + 4) > builtin::array_len(self.repr)) {
         "core:prelude/string.wado/String::grow"(self, self.used + 4);
     }
-    if code <u 128 {
-        builtin::array_set_u8(self.repr, self.used, code & 255);
+    if c <u 128 {
+        builtin::array_set_u8(self.repr, self.used, c & 255);
         self.used = self.used + 1;
-    } else if code <u 2048 {
-        builtin::array_set_u8(self.repr, self.used, (192 | (code >>u 6)) & 255);
-        builtin::array_set_u8(self.repr, self.used + 1, (128 | (code & 63)) & 255);
+    } else if c <u 2048 {
+        builtin::array_set_u8(self.repr, self.used, (192 | (c >>u 6)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 1, (128 | (c & 63)) & 255);
         self.used = self.used + 2;
-    } else if code <u 65536 {
-        builtin::array_set_u8(self.repr, self.used, (224 | (code >>u 12)) & 255);
-        builtin::array_set_u8(self.repr, self.used + 1, (128 | ((code >>u 6) & 63)) & 255);
-        builtin::array_set_u8(self.repr, self.used + 2, (128 | (code & 63)) & 255);
+    } else if c <u 65536 {
+        builtin::array_set_u8(self.repr, self.used, (224 | (c >>u 12)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 1, (128 | ((c >>u 6) & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 2, (128 | (c & 63)) & 255);
         self.used = self.used + 3;
     } else {
-        builtin::array_set_u8(self.repr, self.used, (240 | (code >>u 18)) & 255);
-        builtin::array_set_u8(self.repr, self.used + 1, (128 | ((code >>u 12) & 63)) & 255);
-        builtin::array_set_u8(self.repr, self.used + 2, (128 | ((code >>u 6) & 63)) & 255);
-        builtin::array_set_u8(self.repr, self.used + 3, (128 | (code & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used, (240 | (c >>u 18)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 1, (128 | ((c >>u 12) & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 2, (128 | ((c >>u 6) & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 3, (128 | (c & 63)) & 255);
         self.used = self.used + 4;
     }
 }
@@ -469,9 +463,7 @@ fn "core:prelude/format.wado/Formatter::prepare_int_write"(self, is_negative, pr
         return "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
     }
     align = self.align;
-    let __match_scrut_0: "core:prelude/format.wado//enum:Alignment";
-    __match_scrut_0 = align;
-    if __match_scrut_0 == 0 {
+    if align == 0 {
         if sign_len > 0 {
             "core:prelude/string.wado/String::push_str"(self.buf, sign);
         }

--- a/wado-compiler/tests/generated/fixtures/labeled_block_break_shadowed_label.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/labeled_block_break_shadowed_label.wir.wado
@@ -134,18 +134,14 @@ fn "core:cli/write_to_stream"(tx, message, add_newline) {
 }
 
 fn "core:cli/println"(message) with Stdout {
-    let rx: i32;
-    let tx: i32;
     let handle: i32;
     let __pair_temp_1: i64;
     __pair_temp_1 = "wasi/stream-new"();
     let __mv_lo_1: i32;
     let __mv_hi_1: i32;
     multivalue_bind [__mv_lo_1, __mv_hi_1] = (builtin::i32_wrap_i64(__pair_temp_1); builtin::i32_wrap_i64(__pair_temp_1 >>u 32_i64));
-    rx = __mv_lo_1;
-    tx = __mv_hi_1;
-    handle = "wado-compiler/tests/fixtures/labeled_block_break_shadowed_label.wado/__cm_binding__Stdout_write_via_stream"(rx);
-    "core:cli/write_to_stream"(tx, message, 1);
+    handle = "wado-compiler/tests/fixtures/labeled_block_break_shadowed_label.wado/__cm_binding__Stdout_write_via_stream"(__mv_lo_1);
+    "core:cli/write_to_stream"(__mv_hi_1, message, 1);
     "wasi/future-drop-readable:transmission-cli"(handle);
 }
 
@@ -322,28 +318,26 @@ fn "core:prelude/string.wado/String::push_str"(self, other) {
 }
 
 fn "core:prelude/string.wado/String::push"(self, c) {
-    let code: u32;
-    code = c;
     if builtin::unlikely((self.used + 4) > builtin::array_len(self.repr)) {
         "core:prelude/string.wado/String::grow"(self, self.used + 4);
     }
-    if code <u 128 {
-        builtin::array_set_u8(self.repr, self.used, code & 255);
+    if c <u 128 {
+        builtin::array_set_u8(self.repr, self.used, c & 255);
         self.used = self.used + 1;
-    } else if code <u 2048 {
-        builtin::array_set_u8(self.repr, self.used, (192 | (code >>u 6)) & 255);
-        builtin::array_set_u8(self.repr, self.used + 1, (128 | (code & 63)) & 255);
+    } else if c <u 2048 {
+        builtin::array_set_u8(self.repr, self.used, (192 | (c >>u 6)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 1, (128 | (c & 63)) & 255);
         self.used = self.used + 2;
-    } else if code <u 65536 {
-        builtin::array_set_u8(self.repr, self.used, (224 | (code >>u 12)) & 255);
-        builtin::array_set_u8(self.repr, self.used + 1, (128 | ((code >>u 6) & 63)) & 255);
-        builtin::array_set_u8(self.repr, self.used + 2, (128 | (code & 63)) & 255);
+    } else if c <u 65536 {
+        builtin::array_set_u8(self.repr, self.used, (224 | (c >>u 12)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 1, (128 | ((c >>u 6) & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 2, (128 | (c & 63)) & 255);
         self.used = self.used + 3;
     } else {
-        builtin::array_set_u8(self.repr, self.used, (240 | (code >>u 18)) & 255);
-        builtin::array_set_u8(self.repr, self.used + 1, (128 | ((code >>u 12) & 63)) & 255);
-        builtin::array_set_u8(self.repr, self.used + 2, (128 | ((code >>u 6) & 63)) & 255);
-        builtin::array_set_u8(self.repr, self.used + 3, (128 | (code & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used, (240 | (c >>u 18)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 1, (128 | ((c >>u 12) & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 2, (128 | ((c >>u 6) & 63)) & 255);
+        builtin::array_set_u8(self.repr, self.used + 3, (128 | (c & 63)) & 255);
         self.used = self.used + 4;
     }
 }
@@ -412,9 +406,7 @@ fn "core:prelude/format.wado/Formatter::prepare_int_write"(self, is_negative, pr
         return "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
     }
     align = self.align;
-    let __match_scrut_0: "core:prelude/format.wado//enum:Alignment";
-    __match_scrut_0 = align;
-    if __match_scrut_0 == 0 {
+    if align == 0 {
         if sign_len > 0 {
             "core:prelude/string.wado/String::push_str"(self.buf, sign);
         }


### PR DESCRIPTION
## Summary

Resolves the `json_value.wado` FIXME on `seq.next_element::<Value>()` —
"removing turbofish causes ICE".

A method whose type parameter appears only in the return type (e.g.
`fn next_element<T>(&mut self) -> Result<Option<T>, _>`) used to panic
in WIR lowering when called without a turbofish or LHS type annotation:

```
[WIR] unresolved MethodCall: name="JsonSeqAccess^DeserializeSeq::next_element"
      ... method_type_args: []
```

The resolver returned an empty type-arg vector for the unresolved
parameter and let the dangling `TypeParam` id slip all the way through
to `wir_build`, where `resolve_function_ref` failed and `panic!`'d.

This was not specific to `json_value` — any call that leaves a method
type parameter uninferred hit the same crash.

## Changes

- `infer_method_type_args` now emits a clean `CannotInferType`
  diagnostic at the call site when a method type parameter resolves to
  neither a concrete type nor an outer-scope parameter. Compilation
  bails after the resolve phase, so the dangling id never reaches WIR.
- `fn`-bound parameters (`<F: fn(...) -> ...>`) are excluded from the
  check: they are constrained structurally from the bound's function
  type, not by call-site inference, so an empty inference result for
  them is expected (regression-guarded by `closure_method_fn_bound`).
- `json_value.wado`: the turbofish is now genuinely required syntax
  rather than an ICE workaround, so the misleading FIXME comment is
  removed.
- New e2e fixture `infer_method_type_arg_uninferable_error.wado`
  mirrors the `visit_seq` pattern (a `<P: Producer>` receiver calling
  `p.produce()`) and asserts the clean compile error.
- Regenerates three labeled-block golden WIR fixtures that had drifted
  from current copy-propagation output (via `update-golden-fixtures`,
  unrelated to this fix).

Error message example:

```
error: cannot infer type parameter `T` of method `produce`;
       add a turbofish (`produce::<...>()`) or a type annotation
```

## Scope note

This makes the ICE a clean diagnostic. It does **not** add whole-body
backward type inference (inferring `T` from a later use such as
`items.push(item)`), so the turbofish / annotation remains required —
that would be a separate, larger inference change.

## Test plan

- [x] `mise run on-task-done` — full suite green (e2e 6427 passed,
      test-wado 2820 passed, 0 failures)
- [x] new fixture passes at -O0/-O1/-O2/-O3/-Os
- [x] `closure_method_fn_bound` (the `fn`-bound regression) passes

https://claude.ai/code/session_013X6HYjYV2RBu6ehJCRA8kt

---
_Generated by [Claude Code](https://claude.ai/code/session_013X6HYjYV2RBu6ehJCRA8kt)_