### PR TITLE
fix: run the epoch ticker on a dedicated OS thread

### DIFF
--- a/wado-cli/src/serve.rs
+++ b/wado-cli/src/serve.rs
@@ -4,8 +4,8 @@ use std::future::Future;
 use std::net::SocketAddr;
 use std::pin::{Pin, pin};
 use std::process;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
 use std::task::{Context, Poll};
 use std::time::Duration;
 
@@ -44,7 +44,7 @@ use wado_compiler::LogLevel;
 /// trapped by the epoch deadline (see `worker_loop`).
 const DEFAULT_TIMEOUT_SECS: u64 = 30;
 
-/// Epoch ticker interval. A background task bumps the engine epoch every
+/// Epoch ticker interval. A background thread bumps the engine epoch every
 /// tick; a worker store's deadline counts these ticks, giving
 /// second-granularity runaway-guest detection.
 const EPOCH_TICK_MS: u64 = 1000;
@@ -829,14 +829,28 @@ async fn run_http_server(
     // Background ticker that advances the engine epoch. Each worker store
     // arms an epoch deadline counted in these ticks; without the ticker
     // the deadline would never be reached and runaway guests never trap.
+    //
+    // It runs on a dedicated OS thread, never a tokio task: a guest that
+    // runs away in pure wasm blocks the tokio worker thread polling it,
+    // and on a single-core host that is the only worker thread. A
+    // tokio-task ticker would then be starved by the very guest it exists
+    // to trap — the epoch would never advance and the server would
+    // deadlock. A kernel-scheduled OS thread keeps ticking regardless.
+    let epoch_stop = Arc::new((Mutex::new(false), Condvar::new()));
     let epoch_ticker = {
         let engine = engine.clone();
-        tokio::spawn(async move {
-            let mut interval = tokio::time::interval(Duration::from_millis(EPOCH_TICK_MS));
-            interval.tick().await; // the first tick fires immediately; skip it
-            loop {
-                interval.tick().await;
-                engine.increment_epoch();
+        let epoch_stop = Arc::clone(&epoch_stop);
+        std::thread::spawn(move || {
+            let (lock, cvar) = &*epoch_stop;
+            let mut stop = lock.lock().unwrap();
+            while !*stop {
+                let (next, wait) = cvar
+                    .wait_timeout(stop, Duration::from_millis(EPOCH_TICK_MS))
+                    .unwrap();
+                stop = next;
+                if wait.timed_out() {
+                    engine.increment_epoch();
+                }
             }
         })
     };
@@ -944,7 +958,12 @@ async fn run_http_server(
     for engine_task in engine_tasks {
         let _ = tokio::time::timeout(drain_deadline, engine_task).await;
     }
-    epoch_ticker.abort();
+    {
+        let (lock, cvar) = &*epoch_stop;
+        *lock.lock().unwrap() = true;
+        cvar.notify_all();
+    }
+    let _ = epoch_ticker.join();
 
     if fatal_shutdown {
         anyhow::bail!("a worker failed to instantiate the component");

--- a/wado-cli/tests/serve.rs
+++ b/wado-cli/tests/serve.rs
@@ -170,10 +170,10 @@ fn timeout_returns_504_for_runaway_guest() {
     let start = Instant::now();
     // The client read timeout must be a generous *upper bound on the worst
     // case CI run*, not the test's actual deadline — that lives in the
-    // `elapsed <= 8s` assertion below. A tight client timeout (we used 15s
-    // here originally) panics on `read_to_string` as `WouldBlock` whenever
-    // CI is slower than the 8s assertion would have allowed, hiding the
-    // useful "elapsed was Xs" signal behind an opaque socket-level error.
+    // `elapsed` assertions below. A tight client timeout panics on
+    // `read_to_string` as `WouldBlock` whenever CI is slower than the
+    // assertion would have allowed, hiding the useful "elapsed was Xs"
+    // signal behind an opaque socket-level error.
     let (status, body) = http_get(port, "/", Duration::from_mins(1));
     let elapsed = start.elapsed();
 
@@ -182,16 +182,28 @@ fn timeout_returns_504_for_runaway_guest() {
         body.contains("timed out"),
         "504 body should mention the timeout; got: {body:?}",
     );
-    // The 504 should fire near the configured 2s deadline. Allow a generous
-    // window: epoch ticker granularity is 1s, and CI machines can be slow.
+    // The 504 reaches the client via one of two paths, and which one wins
+    // depends on how CPU-starved the host is:
+    //   * graceful: the first-byte timeout in `dispatch_request` fires at
+    //     ~`--timeout` (2s) — this needs a free tokio worker thread;
+    //   * backstop: when a runaway guest monopolises every tokio worker
+    //     thread (e.g. a single-core CI runner), the first-byte timeout is
+    //     itself starved, so the 504 only resolves once the epoch deadline
+    //     (`--timeout` + 5s grace) traps the guest and frees the runtime.
+    // So the legitimate window is wide. The lower bound proves the timeout
+    // is actually enforced (CPU starvation only ever *delays* the 504, so
+    // it cannot make this bound flaky); the upper bound is generous enough
+    // that only a genuine "timeout never fires" regression — which would
+    // instead hit the 1-minute client read timeout — trips it.
     assert!(
         elapsed >= Duration::from_millis(1500),
         "504 returned in {elapsed:?} — earlier than the configured 2s timeout, \
          which suggests the timeout isn't actually being enforced",
     );
     assert!(
-        elapsed <= Duration::from_secs(8),
-        "504 returned in {elapsed:?} — later than expected for a 2s timeout",
+        elapsed <= Duration::from_secs(20),
+        "504 returned in {elapsed:?} — far later than the 2s timeout or its \
+         epoch-deadline backstop, which suggests the timeout isn't enforced",
     );
 }
 


### PR DESCRIPTION
## Summary

- Fixes a deadlock in `wado serve`: the epoch ticker ran as a tokio task, so a guest that runs away in pure wasm — which blocks the tokio worker thread polling it — could starve the very ticker meant to trap it. On a single-core host (the only worker thread) the server froze and the client connection was reset instead of receiving a 504.
- Moves the ticker to a kernel-scheduled OS thread so the epoch advances regardless of tokio worker starvation; shutdown stops it cleanly via a `Condvar`.
- Widens the runaway-guest test's upper time bound (8s → 20s): on a CPU-starved host the 504 now arrives via the epoch-deadline backstop (~`timeout` + 5s) rather than the graceful first-byte timeout.

## Root cause

`timeout_returns_504_for_runaway_guest` was flaky (intermittent `ConnectionReset`). Pinning the test to one CPU (`taskset -c 0`) reproduced it 100% of the time: the runaway guest monopolises the sole tokio worker thread, the `tokio::spawn`'d epoch ticker never gets scheduled, `increment_epoch()` is never called, and the guest is never trapped — a deadlock. This is also a real server bug: a runaway guest on a CPU-constrained deployment would never be stopped.

## Test plan

- [x] `timeout_returns_504_for_runaway_guest` pinned to 1 CPU: 0/4 before → 10/10 after (deterministic, ~8s)
- [x] `cargo test -p wado-cli --test serve` (4/4 pass) unpinned
- [x] `cargo clippy --locked -p wado-cli --all-features --all-targets -- -D warnings` clean

https://claude.ai/code/session_01DPkBS2abY6a19wnnNdguKK

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPkBS2abY6a19wnnNdguKK)_