### PR TITLE
perf: reduce wado serve native host overhead

### DIFF
--- a/.claude/skills/profile-compiler/SKILL.md
+++ b/.claude/skills/profile-compiler/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: profile-compiler
+description: Profile the native Rust `wado` binary (compile/serve/run) with a sampling profiler to find host-side bottlenecks. Use for native CPU profiling, not guest wasm (see profiling-wado for that).
+---
+
+# Profiling the native `wado` binary
+
+Host-side Rust profiling (the compiler, `wado serve`, `wado run`, …
+including wasmtime/cranelift). For the **guest** wasm program, use
+`profiling-wado` instead.
+
+## Workflow
+
+```sh
+# 1. Build with symbols (release is stripped; `profiling` inherits it + keeps DWARF)
+cargo build --profile profiling --bin wado
+
+# 2. Record under load with samply (brew install samply)
+samply record --save-only --rate 1000 -o /tmp/prof.json -- \
+  target/profiling/wado serve --addr 127.0.0.1:8080 app.wado &
+SAMPLY_PID=$!
+# ... drive load (e.g. oha against benchmark/http_routing) ...
+
+# 3. Stop: SIGTERM the CHILD, not samply. samply finalizes on child exit;
+#    signalling samply leaves the child running and the recording hangs.
+kill -TERM "$(pgrep -P "$SAMPLY_PID" | head -1)"; wait "$SAMPLY_PID"
+
+# 4. Analyze
+python3 .claude/skills/profile-compiler/scripts/analyze_native_profile.py /tmp/prof.json
+```
+
+Interactive call tree (and correct kernel symbols): `samply load /tmp/prof.json`.
+
+## Non-obvious points
+
+- **Read CPU, not wall-clock.** The script weights by `threadCPUDelta`;
+  otherwise parked tokio/rayon worker threads bury everything.
+- **Kernel syscall names from `atos` are wrong** (shared-cache base
+  offset). Read syscall cost via the script's "nearest Rust caller"
+  attribution, not the syscall name.
+- **macOS only** (`atos`). On Linux use `perf` or `samply load`; the
+  weighting/attribution logic ports, the `atos` symbolication does not.

--- a/.claude/skills/profile-compiler/SKILL.md
+++ b/.claude/skills/profile-compiler/SKILL.md
@@ -38,5 +38,14 @@ Interactive call tree (and correct kernel symbols): `samply load /tmp/prof.json`
 - **Kernel syscall names from `atos` are wrong** (shared-cache base
   offset). Read syscall cost via the script's "nearest Rust caller"
   attribution, not the syscall name.
+- **Symbolication needs the matching binary.** A saved profile holds only
+  addresses; the script resolves them against the binary at the recorded
+  path, so rebuilding `target/profiling/wado` makes earlier profiles
+  re-symbolicate to garbage. Analyze before rebuilding, or keep the
+  matching binary.
+- **Validate with the profile, not req/s.** The CPU breakdown is
+  reproducible run to run; throughput on a busy dev machine swings by tens
+  of percent. Use the profile to confirm a change landed (e.g. a hot
+  function shrank); measure absolute throughput on a quiet/target host.
 - **macOS only** (`atos`). On Linux use `perf` or `samply load`; the
   weighting/attribution logic ports, the `atos` symbolication does not.

--- a/.claude/skills/profile-compiler/scripts/analyze_native_profile.py
+++ b/.claude/skills/profile-compiler/scripts/analyze_native_profile.py
@@ -23,6 +23,7 @@ Usage:
 """
 import argparse
 import json
+import platform
 import re
 import subprocess
 from collections import defaultdict
@@ -68,7 +69,7 @@ def thread_func_keys(thread):
     return keys
 
 
-def symbolicate(profile, binary, main_base):
+def symbolicate(profile, binary, main_base, arch):
     """(lib_index, rva) -> cleaned symbol, via atos batched per lib."""
     libs = profile["libs"]
     all_keys = set()
@@ -92,7 +93,7 @@ def symbolicate(profile, binary, main_base):
         addrs = [hex(base + r) for r in rvas]
         try:
             lines = subprocess.run(
-                ["atos", "-o", path, "-arch", "arm64", "-l", hex(base), *addrs],
+                ["atos", "-o", path, "-arch", arch, "-l", hex(base), *addrs],
                 capture_output=True, text=True, timeout=180,
             ).stdout.splitlines()
         except (OSError, subprocess.SubprocessError):
@@ -113,11 +114,13 @@ def main():
     ap.add_argument("--binary", default="wado", help="main executable lib name")
     ap.add_argument("--main-base", default="0x100000000",
                     help="__TEXT vmaddr of the main executable")
+    ap.add_argument("--arch", default=platform.machine(),
+                    help="atos -arch (defaults to the host arch, e.g. arm64 / x86_64)")
     args = ap.parse_args()
 
     profile = json.load(open(args.profile))
     libs = profile["libs"]
-    keyname = symbolicate(profile, args.binary, int(args.main_base, 16))
+    keyname = symbolicate(profile, args.binary, int(args.main_base, 16), args.arch)
 
     self_by = defaultdict(float)
     incl_by = defaultdict(float)

--- a/.claude/skills/profile-compiler/scripts/analyze_native_profile.py
+++ b/.claude/skills/profile-compiler/scripts/analyze_native_profile.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Aggregate a samply profile of the native `wado` binary into Rust-level
+bottlenecks.
+
+samply's `--save-only` profile is **unsymbolicated** (funcTable.name holds a
+hex relative-virtual-address). This script:
+
+  1. keys every frame by (lib_index, rva) so identical raw addresses in
+     different libraries are never merged;
+  2. symbolicates each lib with `atos` (macOS) — the main executable's
+     __TEXT base is 0x100000000, shared dylibs use base 0;
+  3. weights samples by **threadCPUDelta** (real CPU), not wall-clock
+     `weight` — otherwise parked tokio/rayon worker threads bury everything;
+  4. reports a library breakdown, top self functions (all + main-binary
+     only), and the syscall/alloc CPU attributed to its nearest Rust caller.
+
+macOS-specific (uses `atos`). On Linux, `samply load` symbolicates natively;
+the weighting/attribution logic here is the platform-agnostic part.
+
+Usage:
+  analyze_native_profile.py PROFILE.json [--top N] [--binary wado]
+                            [--main-base 0x100000000]
+"""
+import argparse
+import json
+import re
+import subprocess
+from collections import defaultdict
+
+HEXNAME = re.compile(r"^0x([0-9a-fA-F]+)$")
+HASH_SUFFIX = re.compile(r"::h[0-9a-f]{16}\b")
+OFFSET_SUFFIX = re.compile(r"\s*\+\s*\d+\s*$")
+LINE_SUFFIX = re.compile(r"\s*\([^()]*:\d+\)\s*$")
+# Common Rust v0/legacy mangling fragments atos leaves in place.
+DEMANGLE = [
+    ("$u20$", " "), ("$u7b$", "{"), ("$u7d$", "}"), ("$u5b$", "["),
+    ("$u5d$", "]"), ("$LT$", "<"), ("$GT$", ">"), ("$C$", ","),
+    ("$RF$", "&"), ("$LP$", "("), ("$RP$", ")"), ("..", "::"),
+]
+
+
+def demangle(name: str) -> str:
+    for a, b in DEMANGLE:
+        name = name.replace(a, b)
+    return name.replace("_<", "<").strip()
+
+
+def clean(name: str) -> str:
+    """Collapse a symbol to its function identity (drop line/offset/hash)."""
+    name = LINE_SUFFIX.sub("", name)
+    name = OFFSET_SUFFIX.sub("", name)
+    name = HASH_SUFFIX.sub("", name)
+    return demangle(name)
+
+
+def thread_func_keys(thread):
+    """funcTable index -> (lib_index, rva) for one thread."""
+    strings = thread["stringArray"]
+    ftab = thread["funcTable"]
+    rtab = thread["resourceTable"]
+    keys = []
+    for i in range(ftab["length"]):
+        res = ftab["resource"][i]
+        lib = (rtab["lib"][res] if res is not None and 0 <= res < rtab["length"]
+               and rtab["lib"][res] is not None else -1)
+        m = HEXNAME.match(strings[ftab["name"][i]])
+        keys.append((lib, int(m.group(1), 16) if m else -1))
+    return keys
+
+
+def symbolicate(profile, binary, main_base):
+    """(lib_index, rva) -> cleaned symbol, via atos batched per lib."""
+    libs = profile["libs"]
+    all_keys = set()
+    for thread in profile["threads"]:
+        all_keys.update(thread_func_keys(thread))
+
+    by_lib = defaultdict(list)
+    for lib, rva in all_keys:
+        by_lib[lib].append(rva)
+
+    out = {}
+    for lib, rvas in by_lib.items():
+        rvas = sorted(set(rvas))
+        if lib < 0 or lib >= len(libs):
+            for r in rvas:
+                out[(lib, r)] = "[unknown]"
+            continue
+        meta = libs[lib]
+        path = meta.get("path") or meta["name"]
+        base = main_base if meta["name"] == binary else 0
+        addrs = [hex(base + r) for r in rvas]
+        try:
+            lines = subprocess.run(
+                ["atos", "-o", path, "-arch", "arm64", "-l", hex(base), *addrs],
+                capture_output=True, text=True, timeout=180,
+            ).stdout.splitlines()
+        except (OSError, subprocess.SubprocessError):
+            lines = []
+        lines += [""] * (len(rvas) - len(lines))
+        for r, line in zip(rvas, lines):
+            s = line.strip()
+            if not s or s.startswith("0x"):
+                s = f"[{meta['name']}]+{hex(r)}"
+            out[(lib, r)] = clean(s)
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("profile")
+    ap.add_argument("--top", type=int, default=30)
+    ap.add_argument("--binary", default="wado", help="main executable lib name")
+    ap.add_argument("--main-base", default="0x100000000",
+                    help="__TEXT vmaddr of the main executable")
+    args = ap.parse_args()
+
+    profile = json.load(open(args.profile))
+    libs = profile["libs"]
+    keyname = symbolicate(profile, args.binary, int(args.main_base, 16))
+
+    self_by = defaultdict(float)
+    incl_by = defaultdict(float)
+    lib_self = defaultdict(float)
+    attr = defaultdict(float)        # syscall/alloc leaf -> nearest Rust caller
+    total = 0.0
+    used_wallclock = False
+
+    for thread in profile["threads"]:
+        keys = thread_func_keys(thread)
+        fr_func = thread["frameTable"]["func"]
+        st_frame = thread["stackTable"]["frame"]
+        st_prefix = thread["stackTable"]["prefix"]
+        samples = thread["samples"]
+        stacks = samples["stack"]
+        weights = samples.get("threadCPUDelta")
+        if weights is None:
+            weights = samples.get("weight")
+            used_wallclock = True
+
+        def key(stack_idx):
+            return keys[fr_func[st_frame[stack_idx]]]
+
+        def name(stack_idx):
+            return keyname[key(stack_idx)]
+
+        def lib_name(stack_idx):
+            li = key(stack_idx)[0]
+            return libs[li]["name"] if 0 <= li < len(libs) else "[unknown]"
+
+        for i, leaf in enumerate(stacks):
+            if leaf is None:
+                continue
+            w = 1.0 if weights is None else (weights[i] or 0)
+            total += w
+            self_by[name(leaf)] += w
+            lib_self[lib_name(leaf)] += w
+            # inclusive: dedup by name per sample (avoids >100% on recursion)
+            seen = set()
+            cur = leaf
+            while cur is not None:
+                n = name(cur)
+                if n not in seen:
+                    seen.add(n)
+                    incl_by[n] += w
+                cur = st_prefix[cur]
+            # attribute non-main-binary leaf CPU to nearest main-binary caller
+            if lib_name(leaf) != args.binary:
+                cur = leaf
+                caller = None
+                while cur is not None:
+                    if lib_name(cur) == args.binary:
+                        caller = name(cur)
+                        break
+                    cur = st_prefix[cur]
+                attr[caller or "[no Rust ancestor]"] += w
+
+    if total == 0:
+        print("No samples found.")
+        return
+    if used_wallclock:
+        print("WARNING: no threadCPUDelta; weighting by wall-clock samples "
+              "(idle/parked threads will dominate).\n")
+
+    def show(title, table, pred=None):
+        print(f"\n=== {title} ===")
+        rows = [(k, v) for k, v in table.items() if pred is None or pred(k)]
+        for k, v in sorted(rows, key=lambda kv: kv[1], reverse=True)[: args.top]:
+            print(f"{v / total * 100:6.2f}%  {k}")
+
+    in_bin = f"(in {args.binary})"
+    print(f"total CPU weight = {total:.0f}")
+    print("\n=== CPU by library (self) ===")
+    for k, v in sorted(lib_self.items(), key=lambda kv: kv[1], reverse=True):
+        print(f"{v / total * 100:6.2f}%  {k}")
+    show("Top SELF — all", self_by)
+    show(f"Top SELF — {args.binary} (Rust) only", self_by, lambda n: in_bin in n)
+    show("Syscall/alloc CPU attributed to nearest Rust caller", attr,
+         lambda n: in_bin in n)
+
+
+if __name__ == "__main__":
+    main()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,6 +1592,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2892ae4ea6fa2cb7acb0e236a6880d39523239cd9089de71d220910ccc806790"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1668,6 +1677,15 @@ name = "micromap"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebca48a43116bc25f18a61360f1be98412f50cc218f5e52c823086b999a4a21a"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -2996,6 +3014,7 @@ dependencies = [
  "jsonschema",
  "lexopt",
  "libc",
+ "mimalloc",
  "predicates",
  "rustls",
  "rustls-pemfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ crc32fast = { version = "1" }
 adler = { version = "1" }
 toml = { version = "1", default-features = false, features = ["parse", "display", "serde", "preserve_order"] }
 libc = { version = "0.2" }
+mimalloc = { version = "0.1" }
 iana-time-zone = { version = "0.1" }
 sha2 = { version = "0.11", default-features = false }
 dprint-plugin-markdown = { version = "0.22" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,19 @@ lto = "thin"
 codegen-units = 1
 strip = "symbols"
 
+# `profiling` is `release` with debug info kept, for sampling profilers
+# (samply, perf, Instruments). It matches the production codegen
+# (`lto`/`codegen-units` are inherited) but keeps symbols and full
+# DWARF so inlined frames resolve. Build with
+# `cargo build --profile profiling --bin wado`. It lives in its own
+# `target/profiling/` dir, so it never invalidates the `release` cache
+# the way overriding release via `CARGO_PROFILE_RELEASE_*` would.
+# See the `profile-compiler` skill.
+[profile.profiling]
+inherits = "release"
+debug = 2
+strip = false
+
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }
 disallowed_types = "warn"

--- a/wado-cli/Cargo.toml
+++ b/wado-cli/Cargo.toml
@@ -44,6 +44,7 @@ wasmtime-wasi-http = { workspace = true }
 wasmtime-wasi-tls = { workspace = true }
 iana-time-zone = { workspace = true }
 libc = { workspace = true }
+mimalloc = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/wado-cli/src/main.rs
+++ b/wado-cli/src/main.rs
@@ -1,6 +1,14 @@
 use std::process;
 
 use lexopt::Arg::{Long, Value};
+use mimalloc::MiMalloc;
+
+// `wado serve` allocates and frees a burst of small per-request objects
+// (request/response buffers, header maps, resource tables) on every request.
+// The system allocator's cross-thread contention dominates the host CPU
+// profile under load, so route all allocation through mimalloc.
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 #[derive(Clone, Copy)]
 enum Cmd {

--- a/wado-cli/src/serve.rs
+++ b/wado-cli/src/serve.rs
@@ -910,6 +910,13 @@ async fn run_http_server(
                 tokio::time::sleep(Duration::from_millis(50)).await;
             }
             Either::Left((Ok((stream, remote_addr)), _shutdown)) => {
+                // Disable Nagle's algorithm. Responses are written head-first
+                // and body-second (the body streams in asynchronously from the
+                // guest), so with Nagle on the body write can stall waiting for
+                // the ACK of the head — a classic latency hit under load.
+                if let Err(e) = stream.set_nodelay(true) {
+                    eprintln!("warning: failed to set TCP_NODELAY for {remote_addr}: {e}");
+                }
                 let io = TokioIo::new(stream);
                 let dispatch = Arc::clone(&dispatch);
 

--- a/wado-cli/src/serve.rs
+++ b/wado-cli/src/serve.rs
@@ -7,7 +7,7 @@ use std::process;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::task::{Context, Poll};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use bytes::Bytes;
@@ -24,7 +24,7 @@ use hyper_util::rt::{TokioExecutor, TokioIo};
 use hyper_util::server::conn::auto;
 use lexopt::Arg::Value;
 use tokio::net::TcpListener;
-use tokio::sync::{Notify, mpsc, oneshot};
+use tokio::sync::{Notify, mpsc, oneshot, watch};
 use tokio::task::JoinSet;
 use wasmtime::component::{Accessor, AccessorTask, Component};
 use wasmtime::{AsContextMut, Engine, Store};
@@ -445,27 +445,35 @@ impl AccessorTask<WasiState> for HandlerTask {
                 // Pump frames until EOF, body error, hyper drops the body,
                 // or the consumer stalls past the idle timeout.
                 //
-                // `frame_tx.send().await` blocks on a full channel, so a
-                // slow consumer back-pressures into the guest. A client
-                // that stops draining entirely but keeps the connection
-                // open never drops `frame_rx`, so the send would otherwise
-                // block forever and pin this task's fiber stack (#1138).
-                // `tokio::time::timeout` bounds each send; it resets per
-                // frame, so a slow-but-progressing client is unaffected.
+                // When the bounded channel has room the send completes
+                // synchronously (`try_send`), so the common case arms no
+                // timer. Only a full channel needs to wait — a slow consumer
+                // back-pressures into the guest, and a client that stops
+                // draining entirely but keeps the connection open never drops
+                // `frame_rx`, so the send would otherwise block forever and
+                // pin this task's fiber stack (#1138). The idle timeout
+                // bounds that wait; it is re-armed per blocking send, so a
+                // slow-but-progressing client is unaffected.
                 let mut body = pin!(body);
                 while let Some(Ok(frame)) = poll_fn(|cx| body.as_mut().poll_frame(cx)).await {
-                    match tokio::time::timeout(idle_timeout, frame_tx.send(frame)).await {
-                        Ok(Ok(())) => {}
+                    match frame_tx.try_send(frame) {
+                        Ok(()) => {}
                         // hyper dropped the body — client disconnected.
-                        Ok(Err(_)) => break,
-                        // The consumer stalled: abort the pump so the fiber
-                        // stack is reclaimed.
-                        Err(_) => {
-                            eprintln!(
-                                "Request body pump aborted: response consumer \
-                                 stalled for more than {idle_timeout:?}"
-                            );
-                            break;
+                        Err(mpsc::error::TrySendError::Closed(_)) => break,
+                        // Channel full: back-pressure, bounded by the idle
+                        // timeout so a stalled consumer cannot pin the fiber.
+                        Err(mpsc::error::TrySendError::Full(frame)) => {
+                            match tokio::time::timeout(idle_timeout, frame_tx.send(frame)).await {
+                                Ok(Ok(())) => {}
+                                Ok(Err(_)) => break,
+                                Err(_) => {
+                                    eprintln!(
+                                        "Request body pump aborted: response consumer \
+                                         stalled for more than {idle_timeout:?}"
+                                    );
+                                    break;
+                                }
+                            }
                         }
                     }
                 }
@@ -506,6 +514,10 @@ impl AccessorTask<WasiState> for HandlerTask {
 struct Dispatch {
     txs: Vec<mpsc::Sender<RequestJob>>,
     next: AtomicUsize,
+    /// Coarse server-wide clock for the first-byte timeout. Each in-flight
+    /// request clones this and checks its own deadline on every tick (see
+    /// `await_first_byte`), so no request arms its own timer.
+    tick_rx: watch::Receiver<()>,
 }
 
 impl Dispatch {
@@ -517,11 +529,51 @@ impl Dispatch {
     }
 }
 
+/// Wait for the response head, bounding the wait by `timeout` without arming
+/// a per-request timer.
+///
+/// `tick_rx` is a server-wide coarse clock (see the ticker in
+/// `run_http_server`); every tick wakes in-flight waiters to re-check their
+/// own deadline. The 504 therefore fires within one tick *after* `timeout`,
+/// never before it — fine for a backstop that only guards against a guest
+/// that never produces a head, and the worker's epoch deadline
+/// (`timeout + 5s`) still trails it comfortably.
+async fn await_first_byte(
+    resp_rx: oneshot::Receiver<HandlerOutcome>,
+    timeout: Duration,
+    mut tick_rx: watch::Receiver<()>,
+) -> HandlerOutcome {
+    let aborted =
+        || HandlerOutcome::Trapped("Handler aborted without producing a response".to_string());
+    let deadline = Instant::now() + timeout;
+    let mut resp_rx = pin!(resp_rx);
+    loop {
+        match select(resp_rx.as_mut(), pin!(tick_rx.changed())).await {
+            Either::Left((Ok(outcome), _)) => return outcome,
+            Either::Left((Err(_recv), _)) => return aborted(),
+            Either::Right((Ok(()), _)) => {
+                if Instant::now() >= deadline {
+                    return HandlerOutcome::Timeout;
+                }
+            }
+            // Ticker gone (server shutting down). Break out so the borrow of
+            // `resp_rx` from `select` ends, then await the head directly:
+            // deliver it if it still lands; shutdown drains in-flight anyway.
+            Either::Right((Err(_closed), _)) => break,
+        }
+    }
+    match resp_rx.await {
+        Ok(outcome) => outcome,
+        Err(_recv) => aborted(),
+    }
+}
+
 /// Convert a hyper request into a job, submit it to a worker instance, and
 /// render the outcome as a hyper response.
 ///
-/// A first-byte `tokio::time::sleep(timeout)` is raced against the head
-/// oneshot, so a guest that never produces a response head yields a 504.
+/// The first-byte timeout is enforced against a shared coarse tick (see
+/// `await_first_byte`), so a guest that never produces a response head
+/// yields a 504 without each request arming its own timer.
 async fn dispatch_request(
     dispatch: &Dispatch,
     timeout: Duration,
@@ -544,15 +596,8 @@ async fn dispatch_request(
     }
 
     // First-byte timeout. After the head arrives, the body stream is bounded
-    // by the bounded frame channel rather than by this sleep.
-    let timeout_fut = pin!(tokio::time::sleep(timeout));
-    let outcome = match select(pin!(resp_rx), timeout_fut).await {
-        Either::Left((Ok(outcome), _)) => outcome,
-        Either::Left((Err(_recv), _)) => {
-            HandlerOutcome::Trapped("Handler aborted without producing a response".to_string())
-        }
-        Either::Right(((), _resp_rx)) => HandlerOutcome::Timeout,
-    };
+    // by the bounded frame channel rather than by this deadline.
+    let outcome = await_first_byte(resp_rx, timeout, dispatch.tick_rx.clone()).await;
 
     Ok(match outcome {
         HandlerOutcome::Streaming(parts, frame_rx) => {
@@ -638,10 +683,10 @@ enum Step {
 /// and resumes — self-healing rather than dying.
 ///
 /// The epoch deadline is `timeout_secs` plus a grace margin: the
-/// client-facing first-byte timeout (`dispatch_request`) fires at exactly
-/// `timeout_secs` and returns 504, so the epoch trap is only a later
-/// backstop that reclaims the runaway and the worker — the client has
-/// already had a clean 504 by then.
+/// client-facing first-byte timeout (`dispatch_request`) fires within a
+/// coarse tick after `timeout_secs` and returns 504, so the epoch trap is
+/// only a later backstop that reclaims the runaway and the worker — the
+/// client has already had a clean 504 by then.
 async fn worker_loop(
     engine: Engine,
     service_pre: Arc<ServicePre<WasiState>>,
@@ -821,9 +866,31 @@ async fn run_http_server(
             Arc::clone(&fatal),
         )));
     }
+    // Coarse server-wide clock for the first-byte timeout. One ticker
+    // replaces a per-request timer: each in-flight request races the
+    // response head against these ticks and checks its own deadline (see
+    // `await_first_byte`). The tick interval bounds how late the 504 fires,
+    // so keep it small relative to `timeout` but coarse enough to be cheap.
+    // Unlike the epoch ticker this need not run on an OS thread: it backs a
+    // client-facing 504, not the runaway-guest backstop, so it shares the
+    // same scheduling assumptions as the request tasks it wakes.
+    let (tick_tx, tick_rx) = watch::channel(());
+    let first_byte_tick = (timeout / 8).clamp(Duration::from_millis(100), Duration::from_secs(1));
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(first_byte_tick);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            interval.tick().await;
+            // Stops once every receiver (held via `Dispatch`) is gone.
+            if tick_tx.send(()).is_err() {
+                break;
+            }
+        }
+    });
     let dispatch = Arc::new(Dispatch {
         txs,
         next: AtomicUsize::new(0),
+        tick_rx,
     });
 
     // Background ticker that advances the engine epoch. Each worker store

--- a/wado-cli/src/serve.rs
+++ b/wado-cli/src/serve.rs
@@ -549,7 +549,17 @@ async fn await_first_byte(
     let mut resp_rx = pin!(resp_rx);
     loop {
         match select(resp_rx.as_mut(), pin!(tick_rx.changed())).await {
-            Either::Left((Ok(outcome), _)) => return outcome,
+            // The deadline is authoritative regardless of which branch wins:
+            // a head that lands past it (after the deadline but before the
+            // next tick) is still a timeout, matching the old sleep-vs-recv
+            // race rather than letting a late head slip through.
+            Either::Left((Ok(outcome), _)) => {
+                return if Instant::now() >= deadline {
+                    HandlerOutcome::Timeout
+                } else {
+                    outcome
+                };
+            }
             Either::Left((Err(_recv), _)) => return aborted(),
             Either::Right((Ok(()), _)) => {
                 if Instant::now() >= deadline {


### PR DESCRIPTION
Reduces native (host-side Rust) CPU overhead in `wado serve`, found by profiling the `wado` binary under load. The system allocator and per-request tokio timers were on the hot path; routing itself was not.

- **mimalloc as the global allocator** (`wado-cli`). Profiling showed the OS allocator's contention on the per-request hot path — its internals plus the free/realloc behind request/response buffers, header maps, and resource tables. Routing all allocation through mimalloc takes that off the hot path.
- **TCP_NODELAY on accepted connections.** Responses are written head-first then body-second (the body streams in asynchronously), so Nagle can stall the body write on the head's ACK. Throughput-neutral, improves tail latency; the low-level `serve_connection` path does not set it automatically.
- **Fewer per-request timers.** Two timers were armed on every request though neither normally fires. The body pump now uses a `try_send` fast path and arms its idle timeout only when the channel is full. The first-byte timeout uses one server-wide coarse ticker instead of a per-request `tokio::time::sleep`, removing timer-wheel arm/cancel churn. Behaviour is preserved: back-pressure and the stalled-consumer guard (#1138) are unchanged, and the first-byte 504 still fires within a tick of the deadline, ahead of the worker epoch backstop.

Tooling to find these (also included): a `profiling` build profile (`release` plus debug info, in its own target dir) and a `profile-compiler` skill for the host-side sampling-profiler workflow.

Throughput gains measured on a macOS desktop are too noisy to quote; the wins are validated by the CPU profile. Confirm absolute throughput on the amd64/Linux target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)