### PR TITLE
test: ignore O1/O3/Os via datatest-mini 0.4 ignore_unless_env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,9 +598,9 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "datatest-mini"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77d7de675b257484c8fd2589c75a733744e7f8a4c013d6a19bbc76a9b22890fd"
+checksum = "47c266895a3bda28121fee70a33a12374881a5db741b818cca1094de2bebe590"
 dependencies = [
  "regex",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 rust-version = "1.94"
 
 [workspace.dependencies]
-datatest-mini = { version = "0.3" }
+datatest-mini = { version = "0.4" }
 anyhow = { version = "1" }
 fluent-uri = { version = "0.4" }
 glob = { version = "0.3" }

--- a/wado-compiler/AGENTS.md
+++ b/wado-compiler/AGENTS.md
@@ -114,12 +114,21 @@ __DATA__
 
 ### Adding Test Fixtures
 
-After adding new `.wado` files to `tests/fixtures/`, run `touch tests/e2e.rs`
-so `datatest_mini` rediscovers test files.
+`datatest_mini` resolves everything when the `harness!` macro in `tests/e2e.rs`
+expands at compile time, and an incremental `cargo test` will not re-expand it
+unless that file changes. So run `touch tests/e2e.rs` (or `cargo clean`) whenever
+the macro's compile-time inputs change:
 
-`datatest_mini` discovers fixtures at compile time, so without rebuilding
-`tests/e2e.rs` an incremental `cargo test` will not pick up the new fixture.
-This only matters for local development — CI builds from scratch.
+- **After adding or removing `.wado` files under `tests/fixtures/`** — otherwise
+  the new/deleted fixtures are not discovered.
+- **When changing the env vars that gate optimization levels** — O1/O3/Os carry
+  `ignore_unless_env = ["CI", "WADO_FULL_TEST"]`, evaluated at expansion time. To
+  flip them between running and `#[ignore]` (e.g. set `WADO_FULL_TEST=1` to run
+  them locally), touch the file so the new env value is read.
+
+This only matters for local development — CI builds from scratch, so it always
+sees the current fixtures and env. Locally you can also run the ignored levels
+without touching or rebuilding via `cargo test -- --ignored`.
 
 `tests/fixtures` requires data-section test spec, so if you test cross-module features, place the loaded modules in `tests/fixtures/sub`.
 

--- a/wado-compiler/tests/e2e.rs
+++ b/wado-compiler/tests/e2e.rs
@@ -908,31 +908,25 @@ fn fixture_test_o2(path: &Path, content: &str) -> Result<(), Box<dyn std::error:
 }
 
 /// Test function for O1 (development optimization)
-/// Skipped by default locally. Runs in CI or when `WADO_FULL_TEST=1` is set.
+/// `#[ignore]`d unless `CI` or `WADO_FULL_TEST` is set at build time (see the
+/// `harness!` entry below). Run locally with `cargo test -- --ignored`.
 fn fixture_test_o1(path: &Path, content: &str) -> Result<(), Box<dyn std::error::Error>> {
-    if std::env::var("CI").is_err() && std::env::var("WADO_FULL_TEST").is_err() {
-        return Ok(()); // Skip locally by default
-    }
     run_fixture_test_with_opt(path, content, OptLevel::O1);
     Ok(())
 }
 
 /// Test function for O3 (aggressive optimization)
-/// Skipped by default locally. Runs in CI or when `WADO_FULL_TEST=1` is set.
+/// `#[ignore]`d unless `CI` or `WADO_FULL_TEST` is set at build time (see the
+/// `harness!` entry below). Run locally with `cargo test -- --ignored`.
 fn fixture_test_o3(path: &Path, content: &str) -> Result<(), Box<dyn std::error::Error>> {
-    if std::env::var("CI").is_err() && std::env::var("WADO_FULL_TEST").is_err() {
-        return Ok(()); // Skip locally by default
-    }
     run_fixture_test_with_opt(path, content, OptLevel::O3);
     Ok(())
 }
 
 /// Test function for Os (size optimization)
-/// Skipped by default locally. Runs in CI or when `WADO_FULL_TEST=1` is set.
+/// `#[ignore]`d unless `CI` or `WADO_FULL_TEST` is set at build time (see the
+/// `harness!` entry below). Run locally with `cargo test -- --ignored`.
 fn fixture_test_os(path: &Path, content: &str) -> Result<(), Box<dyn std::error::Error>> {
-    if std::env::var("CI").is_err() && std::env::var("WADO_FULL_TEST").is_err() {
-        return Ok(()); // Skip locally by default
-    }
     run_fixture_test_with_opt(path, content, OptLevel::Os);
     Ok(())
 }
@@ -974,12 +968,20 @@ fn keep_wasm_artifacts(dir: &str, fixture_name: &str, opt_name: &str, wasm: &[u8
 
 datatest_mini::harness! {
     // Pattern matches .wado files directly in fixtures/ but not in subdirectories
-    // (subdirectories contain helper modules that are imported, not run as tests)
+    // (subdirectories contain helper modules that are imported, not run as tests).
+    //
+    // O1/O3/Os are `#[ignore]`d unless CI or WADO_FULL_TEST is set at build time.
+    // The env is read at macro expansion, so toggling requires re-expanding the
+    // macro (touch this file or `cargo clean`); locally, run them on demand with
+    // `cargo test -- --ignored`.
     { test = fixture_test_o0, root = "tests/fixtures", pattern = r"^[^/]+\.wado$" },
-    { test = fixture_test_o1, root = "tests/fixtures", pattern = r"^[^/]+\.wado$" },
+    { test = fixture_test_o1, root = "tests/fixtures", pattern = r"^[^/]+\.wado$",
+      ignore_unless_env = ["CI", "WADO_FULL_TEST"] },
     { test = fixture_test_o2, root = "tests/fixtures", pattern = r"^[^/]+\.wado$" },
-    { test = fixture_test_o3, root = "tests/fixtures", pattern = r"^[^/]+\.wado$" },
-    { test = fixture_test_os, root = "tests/fixtures", pattern = r"^[^/]+\.wado$" },
+    { test = fixture_test_o3, root = "tests/fixtures", pattern = r"^[^/]+\.wado$",
+      ignore_unless_env = ["CI", "WADO_FULL_TEST"] },
+    { test = fixture_test_os, root = "tests/fixtures", pattern = r"^[^/]+\.wado$",
+      ignore_unless_env = ["CI", "WADO_FULL_TEST"] },
 }
 
 /// End-to-end check on the `#![TODO]` wrapper: a module-level `#![TODO]` whose


### PR DESCRIPTION
## What

- Bump `datatest-mini` to **0.4** (workspace dep).
- Replace the hand-written runtime skip in `fixture_test_o1/o3/os` with the new harness param `ignore_unless_env = ["CI", "WADO_FULL_TEST"]`.
- Rewrite the "Adding Test Fixtures" note in `wado-compiler/AGENTS.md`.

## Why

Previously O1/O3/Os returned `Ok(())` early when neither `CI` nor `WADO_FULL_TEST` was set. That reported as a **green pass** (misleading), and only *after* the fixture file had already been read.

With `ignore_unless_env`, datatest-mini emits a real `#[ignore = "..."]` at macro-expansion (compile) time, so:

- Locally those levels show as **`ignored`** (no more green lie) and do **no file I/O**.
- Run them on demand without rebuilding: `cargo test -- --ignored`.
- CI builds from scratch with `CI` set, so they run there exactly as before.

## Caveat

The decision is compile-time. Toggling the env requires re-expanding the macro — `touch tests/e2e.rs` (the same step already needed to pick up added/removed fixtures) or `cargo clean`. `proc_macro::tracked_env` (which would auto-rebuild) is nightly-only. The AGENTS.md note now documents both touch triggers.

## Verification

- `cargo test -p wado-compiler --test e2e --no-run` builds clean against `datatest-mini v0.4.0`.
- `cargo test -p wado-compiler --test e2e -- --list --ignored` shows **only** `fixture_test_o1/o3/os` ignored (1295 each = fixture count); `o0`/`o2` remain runnable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)