### PR TITLE
chore: export MISE_GITHUB_TOKEN in mise-setup hook

### DIFF
--- a/.claude/hooks/mise-setup.sh
+++ b/.claude/hooks/mise-setup.sh
@@ -102,6 +102,7 @@ if [ -n "$CLAUDE_ENV_FILE" ]; then
 export PATH="$HOME/.local/bin:$PATH"
 export MISE_YES=true
 export MISE_TRUSTED_CONFIG_PATHS="$HOME:$PWD"
+export MISE_GITHUB_TOKEN=$(gh auth token)
 eval "$(mise activate bash)"
 EOF
     log "Environment persisted to CLAUDE_ENV_FILE"


### PR DESCRIPTION
Mise downloads some tools from GitHub artifacts, and unauthenticated requests hit the GitHub API rate limit, causing setup failures in the web session environment.

Pass an authenticated token via `MISE_GITHUB_TOKEN` (sourced from `gh auth token`) so mise can fetch artifacts without being rate-limited.


---
_Generated by [Claude Code](https://claude.ai/code/session_014LdeX8M5MHxoDipouzgGNv)_