### PR TITLE
fix: create tagpr release as draft so release.yml can upload assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,11 @@ jobs:
           sha256sum wado-* > SHA256SUMS.txt
           cat SHA256SUMS.txt
 
+      # tagpr creates the release as a draft (see `.tagpr`). The repository
+      # has "Immutable releases" enabled, which forbids uploading assets to
+      # a published release — assets must go onto a draft. action-gh-release@v3
+      # uploads files before flipping draft=false, so leaving `draft` unset
+      # (default false) uploads to the existing draft and then publishes it.
       - uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.validate.outputs.tag }}

--- a/.tagpr
+++ b/.tagpr
@@ -4,8 +4,10 @@
 #   1. tagpr.yml runs on every push to main.
 #   2. tagpr maintains an open "Release v<next>" PR that bumps the version
 #      and updates CHANGELOG.md based on PRs merged since the previous tag.
-#   3. Merging that PR triggers tagpr to push tag `v<next>`.
-#   4. release.yml runs on the tag push and publishes the release.
+#   3. Merging that PR triggers tagpr to push tag `v<next>` and create a
+#      draft GitHub Release (see `release = draft` below).
+#   4. release.yml runs on the tag push, uploads build artifacts to that
+#      draft release, and publishes it.
 #
 # Default bump is patch. Override per-PR with labels:
 #   tagpr:patch | tagpr:minor | tagpr:major
@@ -16,6 +18,18 @@
 [tagpr]
 	vPrefix = true
 	releaseBranch = main
+
+	# Create the GitHub Release as a draft so release.yml can upload build
+	# artifacts to it. The repository has "Immutable releases" enabled, which
+	# forbids adding assets after a release is published — assets must be
+	# uploaded to a draft and the draft is then published.
+	#
+	# Flow:
+	#   tagpr        — pushes the tag and creates a draft release (with notes).
+	#   release.yml  — finds the draft, uploads artifacts, then publishes it
+	#                  (softprops/action-gh-release@v3 uploads assets before
+	#                  flipping draft=false).
+	release = draft
 
 	# tagpr has no native Cargo.toml handler but its generic version-file
 	# regex is line-anchored, matching `version = "..."` only at the start


### PR DESCRIPTION
The repository has "Immutable releases" enabled, which forbids adding
assets to a release after it has been published. tagpr was publishing
the release immediately on tag push, so the subsequent `release.yml`
upload step failed with:

```
Cannot upload asset wado-v0.0.3-x86_64-unknown-linux-gnu.tar.gz
to an immutable release. GitHub only allows asset uploads before
a release is published, so upload assets to a draft release before
you publish it.
```

## Changes

- `.tagpr`: set `release = draft` so tagpr creates the GitHub Release
  as a draft (with notes) rather than publishing it immediately.
- `.github/workflows/release.yml`: no behavioural change — added a
  comment documenting why the existing default `draft: false` is
  correct. `softprops/action-gh-release@v3` uploads assets first and
  then flips `draft=false`, so the existing call uploads to the draft
  tagpr created and publishes it once all assets are attached.

## Note on v0.0.3

The already-published `v0.0.3` release is immutable and missing its
assets. It will need to be deleted (and its tag re-pushed, or skipped
in favour of `v0.0.4`) for users to get binaries — this PR only fixes
the workflow for future releases.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XAcoWWUGUEvNDFRA58XYXo)_