### PR TITLE
refactor(stdlib): replace manual element-copy loops with builtin::array_copy

### DIFF
--- a/wado-compiler/lib/core/prelude/array.wado
+++ b/wado-compiler/lib/core/prelude/array.wado
@@ -42,11 +42,7 @@ impl Array<T> {
         let capacity = builtin::array_len(self.repr);
         let new_capacity = i32_max(capacity * 2, 4);
         let new_repr: builtin::array<T> = builtin::array_new(new_capacity);
-        let old_repr = self.repr;
-        let used = self.used;
-        for let mut i = 0; i < used; i += 1 {
-            builtin::array_set(new_repr, i, builtin::array_get(old_repr, i));
-        }
+        builtin::array_copy(new_repr, 0, self.repr, 0, self.used);
         self.repr = new_repr;
     }
 
@@ -57,11 +53,7 @@ impl Array<T> {
         }
         let new_capacity = i32_max(i32_max(capacity * 2, min_capacity), 4);
         let new_repr: builtin::array<T> = builtin::array_new(new_capacity);
-        let old_repr = self.repr;
-        let used = self.used;
-        for let mut i = 0; i < used; i += 1 {
-            builtin::array_set(new_repr, i, builtin::array_get(old_repr, i));
-        }
+        builtin::array_copy(new_repr, 0, self.repr, 0, self.used);
         self.repr = new_repr;
     }
 
@@ -141,11 +133,7 @@ impl Array<T> {
             self.grow();
         }
         // Shift elements right
-        let mut i = self.used;
-        while i > index {
-            builtin::array_set(self.repr, i, builtin::array_get(self.repr, i - 1));
-            i -= 1;
-        }
+        builtin::array_copy(self.repr, index + 1, self.repr, index, self.used - index);
         builtin::array_set(self.repr, index, value);
         self.used += 1;
     }
@@ -156,9 +144,7 @@ impl Array<T> {
         assert index >= 0 && index < self.used, "index out of bounds";
         let value = builtin::array_get(self.repr, index);
         // Shift elements left
-        for let mut i = index; i < self.used - 1; i += 1 {
-            builtin::array_set(self.repr, i, builtin::array_get(self.repr, i + 1));
-        }
+        builtin::array_copy(self.repr, index, self.repr, index + 1, self.used - 1 - index);
         self.used -= 1;
         return value;
     }
@@ -197,9 +183,7 @@ impl Array<T> {
         let capacity = builtin::array_len(self.repr);
         if capacity > self.used {
             let new_repr: builtin::array<T> = builtin::array_new(self.used);
-            for let mut i = 0; i < self.used; i += 1 {
-                builtin::array_set(new_repr, i, builtin::array_get(self.repr, i));
-            }
+            builtin::array_copy(new_repr, 0, self.repr, 0, self.used);
             self.repr = new_repr;
         }
     }
@@ -235,12 +219,8 @@ impl Array<T> {
     pub fn repeat(&self, n: i32) -> Array<T> {
         let total = self.used * n;
         let new_repr: builtin::array<T> = builtin::array_new(total);
-        let mut offset = 0;
         for let mut r = 0; r < n; r += 1 {
-            for let mut i = 0; i < self.used; i += 1 {
-                builtin::array_set(new_repr, offset, builtin::array_get(self.repr, i));
-                offset += 1;
-            }
+            builtin::array_copy(new_repr, r * self.used, self.repr, 0, self.used);
         }
         return Array { repr: new_repr, used: total };
     }
@@ -255,19 +235,15 @@ impl Array<T> {
         if builtin::unlikely(new_used > capacity) {
             let new_capacity = i32_max(new_used, capacity * 2);
             let new_repr: builtin::array<T> = builtin::array_new(new_capacity);
-            // Use element-by-element loop: Wasm array.copy is a libcall in wasmtime
-            // (~3μs/element), while a JIT-compiled loop runs at ~1ns/element.
-            let old_repr = self.repr;
-            let old_used = self.used;
-            for let mut i = 0; i < old_used; i += 1 {
-                builtin::array_set(new_repr, i, builtin::array_get(old_repr, i));
-            }
+            builtin::array_copy(new_repr, 0, self.repr, 0, self.used);
             self.repr = new_repr;
         }
         let raw = self.repr;
         let base = self.used;
-        // Forward copy is correct for non-overlapping (any order works) and for
-        // overlapping back-references where src < dst (DEFLATE run-length expansion).
+        // Forward element-by-element copy intentionally propagates just-written
+        // values for DEFLATE-style run-length back-references (src < dst, overlap).
+        // `builtin::array_copy` uses copy-as-if-buffered semantics, so it cannot
+        // replace this loop.
         for let mut i = 0; i < count; i += 1 {
             builtin::array_set(raw, base + i, builtin::array_get(raw, src_start + i));
         }

--- a/wado-compiler/lib/core/prelude/string.wado
+++ b/wado-compiler/lib/core/prelude/string.wado
@@ -856,14 +856,7 @@ impl String {
             self.grow(new_used);
         }
         // Shift bytes right
-        let mut i = self.used - 1;
-        while i >= byte_index {
-            builtin::array_set_u8(self.repr, i + char_len, builtin::array_get_u8(self.repr, i));
-            if i == 0 {
-                break;
-            }
-            i -= 1;
-        }
+        builtin::array_copy(self.repr, byte_index + char_len, self.repr, byte_index, self.used - byte_index);
         // Write encoded char
         if code < 0x80 {
             builtin::array_set_u8(self.repr, byte_index, code as u8);
@@ -905,14 +898,7 @@ impl String {
             self.grow(new_used);
         }
         // Shift bytes right
-        let mut i = self.used - 1;
-        while i >= byte_index {
-            builtin::array_set_u8(self.repr, i + s_len, builtin::array_get_u8(self.repr, i));
-            if i == 0 {
-                break;
-            }
-            i -= 1;
-        }
+        builtin::array_copy(self.repr, byte_index + s_len, self.repr, byte_index, self.used - byte_index);
         // Copy inserted string
         builtin::array_copy(self.repr, byte_index, s.internal_raw_bytes(), 0, s_len);
         self.used = new_used;
@@ -960,10 +946,7 @@ impl String {
             (b0 & 0x07) << 18 | (b1 & 0x3F) << 12 | (b2 & 0x3F) << 6 | b3 & 0x3F;
         };
         // Shift bytes left
-        let src = byte_index + char_len;
-        for let mut i = src; i < self.used; i += 1 {
-            builtin::array_set_u8(self.repr, i - char_len, builtin::array_get_u8(self.repr, i));
-        }
+        builtin::array_copy(self.repr, byte_index, self.repr, byte_index + char_len, self.used - byte_index - char_len);
         self.used -= char_len;
         return char::from_u32_unchecked(code);
     }

--- a/wado-compiler/tests/generated/fixtures/allocator_freelist_churn_mixed.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/allocator_freelist_churn_mixed.wir.wado
@@ -732,9 +732,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -743,21 +740,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l65: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l65;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/array_bounds_elim_oob_complex.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/array_bounds_elim_oob_complex.wir.wado
@@ -200,9 +200,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -211,21 +208,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l8: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l8;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/array_bounds_elim_oob_loop_dynamic.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/array_bounds_elim_oob_loop_dynamic.wir.wado
@@ -638,9 +638,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -649,21 +646,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l54: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l54;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/array_of_generic_struct.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/array_of_generic_struct.wir.wado
@@ -652,9 +652,6 @@ fn "core:prelude/array.wado/Array<wado-compiler/tests/fixtures/array_of_generic_
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<wado-compiler/tests/fixtures/array_of_generic_struct.wado/Wrapper<i32>>";
-    let old_repr: ref "builtin::array<wado-compiler/tests/fixtures/array_of_generic_struct.wado/Wrapper<i32>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -663,21 +660,7 @@ fn "core:prelude/array.wado/Array<wado-compiler/tests/fixtures/array_of_generic_
         unreachable;
     };
     new_repr = builtin::array_new<ref "wado-compiler/tests/fixtures/array_of_generic_struct.wado//Wrapper<i32>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l51: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "wado-compiler/tests/fixtures/array_of_generic_struct.wado//Wrapper<i32>">(new_repr, i, builtin::array_get<ref "wado-compiler/tests/fixtures/array_of_generic_struct.wado//Wrapper<i32>">(old_repr, i));
-                i = i + 1;
-                continue l51;
-            };
-        };
-    };
+    builtin::array_copy<ref "wado-compiler/tests/fixtures/array_of_generic_struct.wado//Wrapper<i32>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/array_specialized.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/array_specialized.wir.wado
@@ -3136,9 +3136,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -3147,21 +3144,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l291: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l291;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -3169,9 +3152,6 @@ fn "core:prelude/array.wado/Array<char>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<char>;
-    let old_repr: ref builtin::array<char>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -3180,21 +3160,7 @@ fn "core:prelude/array.wado/Array<char>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<char>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l294: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<char>(new_repr, i, builtin::array_get<char>(old_repr, i));
-                i = i + 1;
-                continue l294;
-            };
-        };
-    };
+    builtin::array_copy<char>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -3202,9 +3168,6 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let old_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -3213,21 +3176,7 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude/string.wado//String">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l297: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude/string.wado//String">(new_repr, i, builtin::array_get<ref "core:prelude/string.wado//String">(old_repr, i));
-                i = i + 1;
-                continue l297;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude/string.wado//String">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -3235,9 +3184,6 @@ fn "core:prelude/array.wado/Array<bool>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<bool>;
-    let old_repr: ref builtin::array<bool>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -3246,21 +3192,7 @@ fn "core:prelude/array.wado/Array<bool>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<bool>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l300: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<bool>(new_repr, i, builtin::array_get<bool>(old_repr, i));
-                i = i + 1;
-                continue l300;
-            };
-        };
-    };
+    builtin::array_copy<bool>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -3268,9 +3200,6 @@ fn "core:prelude/array.wado/Array<f32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<f32>;
-    let old_repr: ref builtin::array<f32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -3279,21 +3208,7 @@ fn "core:prelude/array.wado/Array<f32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<f32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l303: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<f32>(new_repr, i, builtin::array_get<f32>(old_repr, i));
-                i = i + 1;
-                continue l303;
-            };
-        };
-    };
+    builtin::array_copy<f32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -3301,9 +3216,6 @@ fn "core:prelude/array.wado/Array<f64>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<f64>;
-    let old_repr: ref builtin::array<f64>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -3312,21 +3224,7 @@ fn "core:prelude/array.wado/Array<f64>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<f64>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l306: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<f64>(new_repr, i, builtin::array_get<f64>(old_repr, i));
-                i = i + 1;
-                continue l306;
-            };
-        };
-    };
+    builtin::array_copy<f64>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -3334,9 +3232,6 @@ fn "core:prelude/array.wado/Array<i16>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i16>;
-    let old_repr: ref builtin::array<i16>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -3345,21 +3240,7 @@ fn "core:prelude/array.wado/Array<i16>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i16>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l309: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i16>(new_repr, i, builtin::array_get<i16>(old_repr, i));
-                i = i + 1;
-                continue l309;
-            };
-        };
-    };
+    builtin::array_copy<i16>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -3367,9 +3248,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -3378,21 +3256,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l312: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l312;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -3400,9 +3264,6 @@ fn "core:prelude/array.wado/Array<i64>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i64>;
-    let old_repr: ref builtin::array<i64>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -3411,21 +3272,7 @@ fn "core:prelude/array.wado/Array<i64>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i64>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l315: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i64>(new_repr, i, builtin::array_get<i64>(old_repr, i));
-                i = i + 1;
-                continue l315;
-            };
-        };
-    };
+    builtin::array_copy<i64>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -3433,9 +3280,6 @@ fn "core:prelude/array.wado/Array<i8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i8>;
-    let old_repr: ref builtin::array<i8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -3444,21 +3288,7 @@ fn "core:prelude/array.wado/Array<i8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l318: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i8>(new_repr, i, builtin::array_get<i8>(old_repr, i));
-                i = i + 1;
-                continue l318;
-            };
-        };
-    };
+    builtin::array_copy<i8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -3466,9 +3296,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<bool,i32,core:pr
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<bool,i32,core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<bool,i32,core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -3477,21 +3304,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<bool,i32,core:pr
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[bool, i32, String]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l321: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[bool, i32, String]">(new_repr, i, builtin::array_get<ref "tuple//[bool, i32, String]">(old_repr, i));
-                i = i + 1;
-                continue l321;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[bool, i32, String]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -3499,9 +3312,6 @@ fn "core:prelude/array.wado/Array<u16>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u16>;
-    let old_repr: ref builtin::array<u16>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -3510,21 +3320,7 @@ fn "core:prelude/array.wado/Array<u16>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u16>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l324: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<u16>(new_repr, i, builtin::array_get<u16>(old_repr, i));
-                i = i + 1;
-                continue l324;
-            };
-        };
-    };
+    builtin::array_copy<u16>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -3532,9 +3328,6 @@ fn "core:prelude/array.wado/Array<u32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u32>;
-    let old_repr: ref builtin::array<u32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -3543,21 +3336,7 @@ fn "core:prelude/array.wado/Array<u32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l327: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<u32>(new_repr, i, builtin::array_get<u32>(old_repr, i));
-                i = i + 1;
-                continue l327;
-            };
-        };
-    };
+    builtin::array_copy<u32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -3565,9 +3344,6 @@ fn "core:prelude/array.wado/Array<u64>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u64>;
-    let old_repr: ref builtin::array<u64>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -3576,21 +3352,7 @@ fn "core:prelude/array.wado/Array<u64>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u64>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l330: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<u64>(new_repr, i, builtin::array_get<u64>(old_repr, i));
-                i = i + 1;
-                continue l330;
-            };
-        };
-    };
+    builtin::array_copy<u64>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/cli_args.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/cli_args.wir.wado
@@ -535,9 +535,6 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let old_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -546,21 +543,7 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude/string.wado//String">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l51: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude/string.wado//String">(new_repr, i, builtin::array_get<ref "core:prelude/string.wado//String">(old_repr, i));
-                i = i + 1;
-                continue l51;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude/string.wado//String">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/closure_1.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/closure_1.wir.wado
@@ -1068,9 +1068,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1079,21 +1076,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l79: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l79;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/closure_2.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/closure_2.wir.wado
@@ -2182,9 +2182,6 @@ fn "core:prelude/array.wado/Array<Fn<1,i32>>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<Fn<1,i32>>;
-    let old_repr: ref builtin::array<Fn<1,i32>>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -2193,21 +2190,7 @@ fn "core:prelude/array.wado/Array<Fn<1,i32>>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<ref struct>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l129: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref struct>(new_repr, i, builtin::array_get<ref struct>(old_repr, i));
-                i = i + 1;
-                continue l129;
-            };
-        };
-    };
+    builtin::array_copy<ref struct>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -2270,13 +2253,13 @@ fn "wado-compiler/tests/fixtures/closure_2.wado/__Closure_24::__call"(n) {
     __for_0: block {
         i = 1;
         block {
-            l132: loop {
+            l129: loop {
                 if i > n {
                     break __for_0;
                 }
                 result = result * i;
                 i = i + 1;
-                continue l132;
+                continue l129;
             };
         };
     };
@@ -2288,14 +2271,14 @@ fn "wado-compiler/tests/fixtures/closure_2.wado/__Closure_28::__call"(n) {
     let i: i32;
     sum = 0;
     i = 1;
-    b134: block {
-        l135: loop {
+    b131: block {
+        l132: loop {
             if i > n {
-                break b134;
+                break b131;
             }
             sum = sum + i;
             i = i + 1;
-            continue l135;
+            continue l132;
         };
     };
     return sum;

--- a/wado-compiler/tests/generated/fixtures/closure_3.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/closure_3.wir.wado
@@ -2557,18 +2557,18 @@ fn "core:prelude/array.wado/Array<i32>::sort_by"(self, cmp) {
     src = self.repr;
     buf = builtin::array_new<i32>(n);
     width = 1;
-    __for_11: block {
+    __for_5: block {
         block {
             l130: loop {
                 if width >= n {
-                    break __for_11;
+                    break __for_5;
                 }
-                __for_12: block {
+                __for_6: block {
                     start = 0;
                     block {
                         l133: loop {
                             if start >= n {
-                                break __for_12;
+                                break __for_6;
                             }
                             mid = start + width;
                             if mid < n {
@@ -2579,12 +2579,12 @@ fn "core:prelude/array.wado/Array<i32>::sort_by"(self, cmp) {
                                 };
                                 i = start;
                                 j = mid;
-                                __for_13: block {
+                                __for_7: block {
                                     k = start;
                                     block {
                                         l137: loop {
                                             if k >= end {
-                                                break __for_13;
+                                                break __for_7;
                                             }
                                             if i < mid {
                                                 if j < end {
@@ -2784,9 +2784,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -2795,21 +2792,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l164: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l164;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -2886,18 +2869,18 @@ fn "wado-compiler/tests/fixtures/closure_3.wado/Array<i32>::sort_by$__Closure_18
     src = self.repr;
     buf = builtin::array_new<i32>(n);
     width = 1;
-    __for_11: block {
+    __for_5: block {
         block {
-            l170: loop {
+            l167: loop {
                 if width >= n {
-                    break __for_11;
+                    break __for_5;
                 }
-                __for_12: block {
+                __for_6: block {
                     start = 0;
                     block {
-                        l173: loop {
+                        l170: loop {
                             if start >= n {
-                                break __for_12;
+                                break __for_6;
                             }
                             mid = start + width;
                             if mid < n {
@@ -2908,12 +2891,12 @@ fn "wado-compiler/tests/fixtures/closure_3.wado/Array<i32>::sort_by$__Closure_18
                                 };
                                 i = start;
                                 j = mid;
-                                __for_13: block {
+                                __for_7: block {
                                     k = start;
                                     block {
-                                        l177: loop {
+                                        l174: loop {
                                             if k >= end {
-                                                break __for_13;
+                                                break __for_7;
                                             }
                                             if i < mid {
                                                 if j < end {
@@ -2945,19 +2928,19 @@ fn "wado-compiler/tests/fixtures/closure_3.wado/Array<i32>::sort_by$__Closure_18
                                                 j = j + 1;
                                             }
                                             k = k + 1;
-                                            continue l177;
+                                            continue l174;
                                         };
                                     };
                                 };
                                 builtin::array_copy<i32>(src, start, buf, start, end - start);
                             }
                             start = start + (width * 2);
-                            continue l173;
+                            continue l170;
                         };
                     };
                 };
                 width = width * 2;
-                continue l170;
+                continue l167;
             };
         };
     };
@@ -2985,18 +2968,18 @@ fn "wado-compiler/tests/fixtures/closure_3.wado/Array<i32>::sort_by$__Closure_19
     src = self.repr;
     buf = builtin::array_new<i32>(n);
     width = 1;
-    __for_11: block {
+    __for_5: block {
         block {
-            l186: loop {
+            l183: loop {
                 if width >= n {
-                    break __for_11;
+                    break __for_5;
                 }
-                __for_12: block {
+                __for_6: block {
                     start = 0;
                     block {
-                        l189: loop {
+                        l186: loop {
                             if start >= n {
-                                break __for_12;
+                                break __for_6;
                             }
                             mid = start + width;
                             if mid < n {
@@ -3007,12 +2990,12 @@ fn "wado-compiler/tests/fixtures/closure_3.wado/Array<i32>::sort_by$__Closure_19
                                 };
                                 i = start;
                                 j = mid;
-                                __for_13: block {
+                                __for_7: block {
                                     k = start;
                                     block {
-                                        l193: loop {
+                                        l190: loop {
                                             if k >= end {
-                                                break __for_13;
+                                                break __for_7;
                                             }
                                             if i < mid {
                                                 if j < end {
@@ -3044,19 +3027,19 @@ fn "wado-compiler/tests/fixtures/closure_3.wado/Array<i32>::sort_by$__Closure_19
                                                 j = j + 1;
                                             }
                                             k = k + 1;
-                                            continue l193;
+                                            continue l190;
                                         };
                                     };
                                 };
                                 builtin::array_copy<i32>(src, start, buf, start, end - start);
                             }
                             start = start + (width * 2);
-                            continue l189;
+                            continue l186;
                         };
                     };
                 };
                 width = width * 2;
-                continue l186;
+                continue l183;
             };
         };
     };

--- a/wado-compiler/tests/generated/fixtures/closure_iterator_fn_mut.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/closure_iterator_fn_mut.wir.wado
@@ -872,9 +872,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -883,21 +880,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l64: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l64;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/cross_module_struct_field_type.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/cross_module_struct_field_type.wir.wado
@@ -724,7 +724,7 @@ fn "core:prelude/array.wado/Array<./sub/cross_module_struct_field_type_lib.wado/
     if self.used != other.used {
         return 0;
     }
-    __for_9: block {
+    __for_3: block {
         i = 0;
         _licm_used_5 = self.used;
         _licm_repr_6 = self.repr;
@@ -732,7 +732,7 @@ fn "core:prelude/array.wado/Array<./sub/cross_module_struct_field_type_lib.wado/
         block {
             l67: loop {
                 if i >= _licm_used_5 {
-                    break __for_9;
+                    break __for_3;
                 }
                 if __inline_Inner_Eq__eq_0: block -> bool {
                     self_3 = builtin::array_get<ref "./sub/cross_module_struct_field_type_lib.wado//Inner">(_licm_repr_6, i);

--- a/wado-compiler/tests/generated/fixtures/cross_module_treemap_variant.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/cross_module_treemap_variant.wir.wado
@@ -793,9 +793,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,./sub/cross_module_treemap_variant_helper.wado/Value>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,./sub/cross_module_treemap_variant_helper.wado/Value>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -804,21 +801,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[String, Value]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l60: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[String, Value]">(new_repr, i, builtin::array_get<ref "tuple//[String, Value]">(old_repr, i));
-                i = i + 1;
-                continue l60;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[String, Value]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -826,9 +809,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,./sub/cross_module_treemap_variant_helper.wado/Value>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,./sub/cross_module_treemap_variant_helper.wado/Value>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -837,21 +817,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,./sub/cross_module_treemap_variant_helper.wado/Value>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l63: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,./sub/cross_module_treemap_variant_helper.wado/Value>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,./sub/cross_module_treemap_variant_helper.wado/Value>">(old_repr, i));
-                i = i + 1;
-                continue l63;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,./sub/cross_module_treemap_variant_helper.wado/Value>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1026,9 +992,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1037,21 +1000,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l89: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(old_repr, i));
-                i = i + 1;
-                continue l89;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/dict_mini.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/dict_mini.wir.wado
@@ -760,9 +760,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -771,21 +768,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[String, String]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l73: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[String, String]">(new_repr, i, builtin::array_get<ref "tuple//[String, String]">(old_repr, i));
-                i = i + 1;
-                continue l73;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[String, String]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/effect_handler_resource_stream.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/effect_handler_resource_stream.wir.wado
@@ -1018,9 +1018,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1029,21 +1026,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l67: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l67;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/effect_handler_resource_stream_self_delegation.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/effect_handler_resource_stream_self_delegation.wir.wado
@@ -1107,9 +1107,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1118,21 +1115,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l67: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l67;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/for_of_indexed_array_test.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/for_of_indexed_array_test.wir.wado
@@ -1210,9 +1210,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1221,21 +1218,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l86: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l86;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/from_literal_cast.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/from_literal_cast.wir.wado
@@ -900,9 +900,6 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let old_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -911,21 +908,7 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude/string.wado//String">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l74: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude/string.wado//String">(new_repr, i, builtin::array_get<ref "core:prelude/string.wado//String">(old_repr, i));
-                i = i + 1;
-                continue l74;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude/string.wado//String">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/from_literal_custom.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/from_literal_custom.wir.wado
@@ -991,9 +991,6 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let old_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1002,21 +999,7 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude/string.wado//String">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l77: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude/string.wado//String">(new_repr, i, builtin::array_get<ref "core:prelude/string.wado//String">(old_repr, i));
-                i = i + 1;
-                continue l77;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude/string.wado//String">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1034,9 +1017,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1045,21 +1025,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l81: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l81;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/from_literal_enum_concrete.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/from_literal_enum_concrete.wir.wado
@@ -621,9 +621,6 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let old_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -632,21 +629,7 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude/string.wado//String">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l48: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude/string.wado//String">(new_repr, i, builtin::array_get<ref "core:prelude/string.wado//String">(old_repr, i));
-                i = i + 1;
-                continue l48;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude/string.wado//String">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -664,9 +647,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -675,21 +655,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l52: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l52;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/from_literal_flags_concrete.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/from_literal_flags_concrete.wir.wado
@@ -621,9 +621,6 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let old_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -632,21 +629,7 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude/string.wado//String">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l48: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude/string.wado//String">(new_repr, i, builtin::array_get<ref "core:prelude/string.wado//String">(old_repr, i));
-                i = i + 1;
-                continue l48;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude/string.wado//String">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -664,9 +647,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -675,21 +655,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l52: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l52;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/from_literal_fn_arg.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/from_literal_fn_arg.wir.wado
@@ -689,9 +689,6 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let old_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -700,21 +697,7 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude/string.wado//String">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l51: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude/string.wado//String">(new_repr, i, builtin::array_get<ref "core:prelude/string.wado//String">(old_repr, i));
-                i = i + 1;
-                continue l51;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude/string.wado//String">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -732,9 +715,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -743,21 +723,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l55: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l55;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/from_literal_nested_generic.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/from_literal_nested_generic.wir.wado
@@ -577,9 +577,6 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let old_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -588,21 +585,7 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude/string.wado//String">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l46: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude/string.wado//String">(new_repr, i, builtin::array_get<ref "core:prelude/string.wado//String">(old_repr, i));
-                i = i + 1;
-                continue l46;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude/string.wado//String">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -620,9 +603,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -631,21 +611,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l50: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l50;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/from_literal_newtype_concrete.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/from_literal_newtype_concrete.wir.wado
@@ -621,9 +621,6 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let old_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -632,21 +629,7 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude/string.wado//String">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l48: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude/string.wado//String">(new_repr, i, builtin::array_get<ref "core:prelude/string.wado//String">(old_repr, i));
-                i = i + 1;
-                continue l48;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude/string.wado//String">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -664,9 +647,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -675,21 +655,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l52: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l52;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/from_literal_return.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/from_literal_return.wir.wado
@@ -733,9 +733,6 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let old_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -744,21 +741,7 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude/string.wado//String">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l61: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude/string.wado//String">(new_repr, i, builtin::array_get<ref "core:prelude/string.wado//String">(old_repr, i));
-                i = i + 1;
-                continue l61;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude/string.wado//String">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -917,8 +900,8 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,i32>::find_index"(s
     _licm_used_17 = _licm_entries_14.used;
     _licm_repr_18 = _licm_entries_14.repr;
     _licm_used_23 = key.used;
-    b78: block {
-        l79: loop {
+    b75: block {
+        l76: loop {
             let __match_scrut_0: ref "core:prelude/types.wado//Option<i32>";
             __match_scrut_0 = current;
             if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_0) {
@@ -958,9 +941,9 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,i32>::find_index"(s
                     current = n.right;
                 }
             } else {
-                break b78;
+                break b75;
             }
-            continue l79;
+            continue l76;
         };
     };
     return -1;
@@ -970,9 +953,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,i32>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,i32>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -981,21 +961,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l88: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(old_repr, i));
-                i = i + 1;
-                continue l88;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1170,9 +1136,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1181,21 +1144,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l114: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(old_repr, i));
-                i = i + 1;
-                continue l114;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/from_literal_variant_concrete.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/from_literal_variant_concrete.wir.wado
@@ -621,9 +621,6 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let old_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -632,21 +629,7 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude/string.wado//String">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l48: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude/string.wado//String">(new_repr, i, builtin::array_get<ref "core:prelude/string.wado//String">(old_repr, i));
-                i = i + 1;
-                continue l48;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude/string.wado//String">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -664,9 +647,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -675,21 +655,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l52: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l52;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/generic_advanced.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/generic_advanced.wir.wado
@@ -1059,9 +1059,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1070,21 +1067,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l79: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l79;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/generic_struct_1.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/generic_struct_1.wir.wado
@@ -1568,9 +1568,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1579,21 +1576,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l110: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l110;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1641,8 +1624,8 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,i32>::find_index"(s
     _licm_used_17 = _licm_entries_14.used;
     _licm_repr_18 = _licm_entries_14.repr;
     _licm_used_23 = key.used;
-    b114: block {
-        l115: loop {
+    b111: block {
+        l112: loop {
             let __match_scrut_0: ref "core:prelude/types.wado//Option<i32>";
             __match_scrut_0 = current;
             if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_0) {
@@ -1682,9 +1665,9 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,i32>::find_index"(s
                     current = n.right;
                 }
             } else {
-                break b114;
+                break b111;
             }
-            continue l115;
+            continue l112;
         };
     };
     return -1;
@@ -1795,9 +1778,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,i32>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,i32>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1806,21 +1786,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l136: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(old_repr, i));
-                i = i + 1;
-                continue l136;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1995,9 +1961,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -2006,21 +1969,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l162: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(old_repr, i));
-                i = i + 1;
-                continue l162;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/global_2.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/global_2.wir.wado
@@ -2157,9 +2157,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -2168,21 +2165,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l193: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l193;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/hfs_aliased_local_whole_read.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/hfs_aliased_local_whole_read.wir.wado
@@ -572,9 +572,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<bool,i32,core:pr
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<bool,i32,core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<bool,i32,core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -583,21 +580,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<bool,i32,core:pr
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[bool, i32, String]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l53: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[bool, i32, String]">(new_repr, i, builtin::array_get<ref "tuple//[bool, i32, String]">(old_repr, i));
-                i = i + 1;
-                continue l53;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[bool, i32, String]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/http_base64_decode.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/http_base64_decode.wir.wado
@@ -1929,9 +1929,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1940,21 +1937,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l208: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l208;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/http_client_advanced.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/http_client_advanced.wir.wado
@@ -2693,9 +2693,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -2704,21 +2701,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l256: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l256;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -2736,9 +2719,6 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<u8>>::grow"(self
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/array.wado/Array<u8>>";
-    let old_repr: ref "builtin::array<core:prelude/array.wado/Array<u8>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -2747,21 +2727,7 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<u8>>::grow"(self
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude//Array<u8>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l260: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude//Array<u8>">(new_repr, i, builtin::array_get<ref "core:prelude//Array<u8>">(old_repr, i));
-                i = i + 1;
-                continue l260;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude//Array<u8>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/http_client_request_full.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/http_client_request_full.wir.wado
@@ -3327,9 +3327,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -3338,21 +3335,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l323: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l323;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/http_client_send_body_read.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/http_client_send_body_read.wir.wado
@@ -2017,9 +2017,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -2028,21 +2025,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l201: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l201;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/http_client_send_with_body.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/http_client_send_with_body.wir.wado
@@ -1632,9 +1632,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1643,21 +1640,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l156: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l156;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/http_echo_headers.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/http_echo_headers.wir.wado
@@ -1137,9 +1137,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1148,21 +1145,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l91: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l91;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1170,9 +1153,6 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<u8>>::grow"(self
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/array.wado/Array<u8>>";
-    let old_repr: ref "builtin::array<core:prelude/array.wado/Array<u8>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1181,21 +1161,7 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<u8>>::grow"(self
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude//Array<u8>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l94: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude//Array<u8>">(new_repr, i, builtin::array_get<ref "core:prelude//Array<u8>">(old_repr, i));
-                i = i + 1;
-                continue l94;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude//Array<u8>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/http_error_code_comprehensive.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/http_error_code_comprehensive.wir.wado
@@ -3840,9 +3840,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -3851,21 +3848,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l271: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l271;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/http_fields_copy_all.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/http_fields_copy_all.wir.wado
@@ -1444,9 +1444,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1455,21 +1452,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l126: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l126;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1477,9 +1460,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:prelude/array.wado/Array<u8>>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:prelude/array.wado/Array<u8>>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1488,21 +1468,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[String, Array<u8>]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l129: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[String, Array<u8>]">(new_repr, i, builtin::array_get<ref "tuple//[String, Array<u8>]">(old_repr, i));
-                i = i + 1;
-                continue l129;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[String, Array<u8>]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/http_fields_from_list_error.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/http_fields_from_list_error.wir.wado
@@ -1695,9 +1695,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1706,21 +1703,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l164: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l164;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/http_fields_get_and_delete.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/http_fields_get_and_delete.wir.wado
@@ -1621,9 +1621,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1632,21 +1629,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l141: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l141;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1654,9 +1637,6 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<u8>>::grow"(self
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/array.wado/Array<u8>>";
-    let old_repr: ref "builtin::array<core:prelude/array.wado/Array<u8>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1665,21 +1645,7 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<u8>>::grow"(self
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude//Array<u8>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l144: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude//Array<u8>">(new_repr, i, builtin::array_get<ref "core:prelude//Array<u8>">(old_repr, i));
-                i = i + 1;
-                continue l144;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude//Array<u8>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/http_fields_immutable_errors.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/http_fields_immutable_errors.wir.wado
@@ -2058,9 +2058,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -2069,21 +2066,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l178: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l178;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -2091,9 +2074,6 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<u8>>::grow"(self
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/array.wado/Array<u8>>";
-    let old_repr: ref "builtin::array<core:prelude/array.wado/Array<u8>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -2102,21 +2082,7 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<u8>>::grow"(self
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude//Array<u8>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l181: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude//Array<u8>">(new_repr, i, builtin::array_get<ref "core:prelude//Array<u8>">(old_repr, i));
-                i = i + 1;
-                continue l181;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude//Array<u8>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -2124,9 +2090,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:prelude/array.wado/Array<u8>>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:prelude/array.wado/Array<u8>>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -2135,21 +2098,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[String, Array<u8>]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l184: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[String, Array<u8>]">(new_repr, i, builtin::array_get<ref "tuple//[String, Array<u8>]">(old_repr, i));
-                i = i + 1;
-                continue l184;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[String, Array<u8>]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/http_fields_set.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/http_fields_set.wir.wado
@@ -1631,9 +1631,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1642,21 +1639,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l143: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l143;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1674,9 +1657,6 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<u8>>::grow"(self
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/array.wado/Array<u8>>";
-    let old_repr: ref "builtin::array<core:prelude/array.wado/Array<u8>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1685,21 +1665,7 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<u8>>::grow"(self
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude//Array<u8>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l147: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude//Array<u8>">(new_repr, i, builtin::array_get<ref "core:prelude//Array<u8>">(old_repr, i));
-                i = i + 1;
-                continue l147;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude//Array<u8>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1707,9 +1673,6 @@ fn "core:prelude/array.wado/Array<wasi:http/types.wado/FieldValue>::grow"(self) 
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/array.wado/Array<u8>>";
-    let old_repr: ref "builtin::array<core:prelude/array.wado/Array<u8>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1718,21 +1681,7 @@ fn "core:prelude/array.wado/Array<wasi:http/types.wado/FieldValue>::grow"(self) 
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude//Array<u8>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l150: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude//Array<u8>">(new_repr, i, builtin::array_get<ref "core:prelude//Array<u8>">(old_repr, i));
-                i = i + 1;
-                continue l150;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude//Array<u8>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/http_method_and_scheme_variants.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/http_method_and_scheme_variants.wir.wado
@@ -2384,9 +2384,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -2395,21 +2392,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l239: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l239;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/http_request_headers.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/http_request_headers.wir.wado
@@ -1415,9 +1415,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1426,21 +1423,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l123: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l123;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1448,9 +1431,6 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<u8>>::grow"(self
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/array.wado/Array<u8>>";
-    let old_repr: ref "builtin::array<core:prelude/array.wado/Array<u8>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1459,21 +1439,7 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<u8>>::grow"(self
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude//Array<u8>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l126: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude//Array<u8>">(new_repr, i, builtin::array_get<ref "core:prelude//Array<u8>">(old_repr, i));
-                i = i + 1;
-                continue l126;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude//Array<u8>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/http_request_options_timeouts.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/http_request_options_timeouts.wir.wado
@@ -2257,9 +2257,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -2268,21 +2265,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l172: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l172;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/http_response_trailers.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/http_response_trailers.wir.wado
@@ -1517,9 +1517,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1528,21 +1525,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l128: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l128;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/http_uninit_string_conditional_trap.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/http_uninit_string_conditional_trap.wir.wado
@@ -1157,9 +1157,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1168,21 +1165,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l88: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l88;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/httpbin_404.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/httpbin_404.wir.wado
@@ -5424,16 +5424,16 @@ fn "core:prelude/string.wado/StrSplitIter^Iterator::next"(self) {
                 break b540;
             }
             matched = 1;
-            __for_13: block {
+            __for_12: block {
                 j = 0;
                 block {
                     l544: loop {
                         if j >= _licm_sep_len_13 {
-                            break __for_13;
+                            break __for_12;
                         }
                         if builtin::array_get_u8(_licm_repr_14, i + j) != builtin::array_get_u8(_licm_sep_repr_15, j) {
                             matched = 0;
-                            break __for_13;
+                            break __for_12;
                         }
                         j = j + 1;
                         continue l544;
@@ -6535,9 +6535,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6546,21 +6543,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l724: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l724;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6605,8 +6588,8 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,core:json_value/Val
     _licm_used_17 = _licm_entries_14.used;
     _licm_repr_18 = _licm_entries_14.repr;
     _licm_used_23 = key.used;
-    b728: block {
-        l729: loop {
+    b725: block {
+        l726: loop {
             let __match_scrut_0: ref "core:prelude/types.wado//Option<i32>";
             __match_scrut_0 = current;
             if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_0) {
@@ -6646,9 +6629,9 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,core:json_value/Val
                     current = n.right;
                 }
             } else {
-                break b728;
+                break b725;
             }
-            continue l729;
+            continue l726;
         };
     };
     return -1;
@@ -6658,9 +6641,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:prelude/array.wado/Array<u8>>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:prelude/array.wado/Array<u8>>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6669,21 +6649,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[String, Array<u8>]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l738: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[String, Array<u8>]">(new_repr, i, builtin::array_get<ref "tuple//[String, Array<u8>]">(old_repr, i));
-                i = i + 1;
-                continue l738;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[String, Array<u8>]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6691,9 +6657,6 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<u8>>::grow"(self
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/array.wado/Array<u8>>";
-    let old_repr: ref "builtin::array<core:prelude/array.wado/Array<u8>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6702,21 +6665,7 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<u8>>::grow"(self
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude//Array<u8>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l741: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude//Array<u8>">(new_repr, i, builtin::array_get<ref "core:prelude//Array<u8>">(old_repr, i));
-                i = i + 1;
-                continue l741;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude//Array<u8>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6724,9 +6673,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:json_value/Value>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:json_value/Value>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6735,21 +6681,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[String, Value]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l744: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[String, Value]">(new_repr, i, builtin::array_get<ref "tuple//[String, Value]">(old_repr, i));
-                i = i + 1;
-                continue l744;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[String, Value]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6910,9 +6842,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6921,21 +6850,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l762: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>">(old_repr, i));
-                i = i + 1;
-                continue l762;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -7110,9 +7025,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -7121,21 +7033,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l788: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(old_repr, i));
-                i = i + 1;
-                continue l788;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/httpbin_405.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/httpbin_405.wir.wado
@@ -5424,16 +5424,16 @@ fn "core:prelude/string.wado/StrSplitIter^Iterator::next"(self) {
                 break b540;
             }
             matched = 1;
-            __for_13: block {
+            __for_12: block {
                 j = 0;
                 block {
                     l544: loop {
                         if j >= _licm_sep_len_13 {
-                            break __for_13;
+                            break __for_12;
                         }
                         if builtin::array_get_u8(_licm_repr_14, i + j) != builtin::array_get_u8(_licm_sep_repr_15, j) {
                             matched = 0;
-                            break __for_13;
+                            break __for_12;
                         }
                         j = j + 1;
                         continue l544;
@@ -6535,9 +6535,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6546,21 +6543,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l724: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l724;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6605,8 +6588,8 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,core:json_value/Val
     _licm_used_17 = _licm_entries_14.used;
     _licm_repr_18 = _licm_entries_14.repr;
     _licm_used_23 = key.used;
-    b728: block {
-        l729: loop {
+    b725: block {
+        l726: loop {
             let __match_scrut_0: ref "core:prelude/types.wado//Option<i32>";
             __match_scrut_0 = current;
             if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_0) {
@@ -6646,9 +6629,9 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,core:json_value/Val
                     current = n.right;
                 }
             } else {
-                break b728;
+                break b725;
             }
-            continue l729;
+            continue l726;
         };
     };
     return -1;
@@ -6658,9 +6641,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:prelude/array.wado/Array<u8>>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:prelude/array.wado/Array<u8>>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6669,21 +6649,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[String, Array<u8>]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l738: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[String, Array<u8>]">(new_repr, i, builtin::array_get<ref "tuple//[String, Array<u8>]">(old_repr, i));
-                i = i + 1;
-                continue l738;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[String, Array<u8>]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6691,9 +6657,6 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<u8>>::grow"(self
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/array.wado/Array<u8>>";
-    let old_repr: ref "builtin::array<core:prelude/array.wado/Array<u8>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6702,21 +6665,7 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<u8>>::grow"(self
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude//Array<u8>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l741: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude//Array<u8>">(new_repr, i, builtin::array_get<ref "core:prelude//Array<u8>">(old_repr, i));
-                i = i + 1;
-                continue l741;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude//Array<u8>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6724,9 +6673,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:json_value/Value>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:json_value/Value>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6735,21 +6681,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[String, Value]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l744: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[String, Value]">(new_repr, i, builtin::array_get<ref "tuple//[String, Value]">(old_repr, i));
-                i = i + 1;
-                continue l744;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[String, Value]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6910,9 +6842,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6921,21 +6850,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l762: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>">(old_repr, i));
-                i = i + 1;
-                continue l762;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -7110,9 +7025,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -7121,21 +7033,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l788: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(old_repr, i));
-                i = i + 1;
-                continue l788;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/httpbin_anything.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/httpbin_anything.wir.wado
@@ -5424,16 +5424,16 @@ fn "core:prelude/string.wado/StrSplitIter^Iterator::next"(self) {
                 break b540;
             }
             matched = 1;
-            __for_13: block {
+            __for_12: block {
                 j = 0;
                 block {
                     l544: loop {
                         if j >= _licm_sep_len_13 {
-                            break __for_13;
+                            break __for_12;
                         }
                         if builtin::array_get_u8(_licm_repr_14, i + j) != builtin::array_get_u8(_licm_sep_repr_15, j) {
                             matched = 0;
-                            break __for_13;
+                            break __for_12;
                         }
                         j = j + 1;
                         continue l544;
@@ -6535,9 +6535,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6546,21 +6543,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l724: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l724;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6605,8 +6588,8 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,core:json_value/Val
     _licm_used_17 = _licm_entries_14.used;
     _licm_repr_18 = _licm_entries_14.repr;
     _licm_used_23 = key.used;
-    b728: block {
-        l729: loop {
+    b725: block {
+        l726: loop {
             let __match_scrut_0: ref "core:prelude/types.wado//Option<i32>";
             __match_scrut_0 = current;
             if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_0) {
@@ -6646,9 +6629,9 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,core:json_value/Val
                     current = n.right;
                 }
             } else {
-                break b728;
+                break b725;
             }
-            continue l729;
+            continue l726;
         };
     };
     return -1;
@@ -6658,9 +6641,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:prelude/array.wado/Array<u8>>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:prelude/array.wado/Array<u8>>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6669,21 +6649,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[String, Array<u8>]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l738: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[String, Array<u8>]">(new_repr, i, builtin::array_get<ref "tuple//[String, Array<u8>]">(old_repr, i));
-                i = i + 1;
-                continue l738;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[String, Array<u8>]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6691,9 +6657,6 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<u8>>::grow"(self
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/array.wado/Array<u8>>";
-    let old_repr: ref "builtin::array<core:prelude/array.wado/Array<u8>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6702,21 +6665,7 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<u8>>::grow"(self
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude//Array<u8>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l741: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude//Array<u8>">(new_repr, i, builtin::array_get<ref "core:prelude//Array<u8>">(old_repr, i));
-                i = i + 1;
-                continue l741;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude//Array<u8>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6724,9 +6673,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:json_value/Value>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:json_value/Value>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6735,21 +6681,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[String, Value]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l744: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[String, Value]">(new_repr, i, builtin::array_get<ref "tuple//[String, Value]">(old_repr, i));
-                i = i + 1;
-                continue l744;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[String, Value]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6910,9 +6842,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6921,21 +6850,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l762: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>">(old_repr, i));
-                i = i + 1;
-                continue l762;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -7110,9 +7025,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -7121,21 +7033,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l788: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(old_repr, i));
-                i = i + 1;
-                continue l788;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/httpbin_get.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/httpbin_get.wir.wado
@@ -5424,16 +5424,16 @@ fn "core:prelude/string.wado/StrSplitIter^Iterator::next"(self) {
                 break b540;
             }
             matched = 1;
-            __for_13: block {
+            __for_12: block {
                 j = 0;
                 block {
                     l544: loop {
                         if j >= _licm_sep_len_13 {
-                            break __for_13;
+                            break __for_12;
                         }
                         if builtin::array_get_u8(_licm_repr_14, i + j) != builtin::array_get_u8(_licm_sep_repr_15, j) {
                             matched = 0;
-                            break __for_13;
+                            break __for_12;
                         }
                         j = j + 1;
                         continue l544;
@@ -6535,9 +6535,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6546,21 +6543,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l724: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l724;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6605,8 +6588,8 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,core:json_value/Val
     _licm_used_17 = _licm_entries_14.used;
     _licm_repr_18 = _licm_entries_14.repr;
     _licm_used_23 = key.used;
-    b728: block {
-        l729: loop {
+    b725: block {
+        l726: loop {
             let __match_scrut_0: ref "core:prelude/types.wado//Option<i32>";
             __match_scrut_0 = current;
             if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_0) {
@@ -6646,9 +6629,9 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,core:json_value/Val
                     current = n.right;
                 }
             } else {
-                break b728;
+                break b725;
             }
-            continue l729;
+            continue l726;
         };
     };
     return -1;
@@ -6658,9 +6641,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:prelude/array.wado/Array<u8>>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:prelude/array.wado/Array<u8>>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6669,21 +6649,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[String, Array<u8>]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l738: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[String, Array<u8>]">(new_repr, i, builtin::array_get<ref "tuple//[String, Array<u8>]">(old_repr, i));
-                i = i + 1;
-                continue l738;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[String, Array<u8>]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6691,9 +6657,6 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<u8>>::grow"(self
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/array.wado/Array<u8>>";
-    let old_repr: ref "builtin::array<core:prelude/array.wado/Array<u8>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6702,21 +6665,7 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<u8>>::grow"(self
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude//Array<u8>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l741: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude//Array<u8>">(new_repr, i, builtin::array_get<ref "core:prelude//Array<u8>">(old_repr, i));
-                i = i + 1;
-                continue l741;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude//Array<u8>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6724,9 +6673,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:json_value/Value>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:json_value/Value>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6735,21 +6681,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[String, Value]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l744: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[String, Value]">(new_repr, i, builtin::array_get<ref "tuple//[String, Value]">(old_repr, i));
-                i = i + 1;
-                continue l744;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[String, Value]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6910,9 +6842,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6921,21 +6850,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l762: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>">(old_repr, i));
-                i = i + 1;
-                continue l762;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -7110,9 +7025,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -7121,21 +7033,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l788: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(old_repr, i));
-                i = i + 1;
-                continue l788;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/httpbin_headers.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/httpbin_headers.wir.wado
@@ -5424,16 +5424,16 @@ fn "core:prelude/string.wado/StrSplitIter^Iterator::next"(self) {
                 break b540;
             }
             matched = 1;
-            __for_13: block {
+            __for_12: block {
                 j = 0;
                 block {
                     l544: loop {
                         if j >= _licm_sep_len_13 {
-                            break __for_13;
+                            break __for_12;
                         }
                         if builtin::array_get_u8(_licm_repr_14, i + j) != builtin::array_get_u8(_licm_sep_repr_15, j) {
                             matched = 0;
-                            break __for_13;
+                            break __for_12;
                         }
                         j = j + 1;
                         continue l544;
@@ -6535,9 +6535,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6546,21 +6543,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l724: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l724;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6605,8 +6588,8 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,core:json_value/Val
     _licm_used_17 = _licm_entries_14.used;
     _licm_repr_18 = _licm_entries_14.repr;
     _licm_used_23 = key.used;
-    b728: block {
-        l729: loop {
+    b725: block {
+        l726: loop {
             let __match_scrut_0: ref "core:prelude/types.wado//Option<i32>";
             __match_scrut_0 = current;
             if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_0) {
@@ -6646,9 +6629,9 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,core:json_value/Val
                     current = n.right;
                 }
             } else {
-                break b728;
+                break b725;
             }
-            continue l729;
+            continue l726;
         };
     };
     return -1;
@@ -6658,9 +6641,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:prelude/array.wado/Array<u8>>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:prelude/array.wado/Array<u8>>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6669,21 +6649,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[String, Array<u8>]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l738: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[String, Array<u8>]">(new_repr, i, builtin::array_get<ref "tuple//[String, Array<u8>]">(old_repr, i));
-                i = i + 1;
-                continue l738;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[String, Array<u8>]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6691,9 +6657,6 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<u8>>::grow"(self
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/array.wado/Array<u8>>";
-    let old_repr: ref "builtin::array<core:prelude/array.wado/Array<u8>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6702,21 +6665,7 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<u8>>::grow"(self
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude//Array<u8>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l741: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude//Array<u8>">(new_repr, i, builtin::array_get<ref "core:prelude//Array<u8>">(old_repr, i));
-                i = i + 1;
-                continue l741;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude//Array<u8>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6724,9 +6673,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:json_value/Value>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:json_value/Value>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6735,21 +6681,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[String, Value]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l744: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[String, Value]">(new_repr, i, builtin::array_get<ref "tuple//[String, Value]">(old_repr, i));
-                i = i + 1;
-                continue l744;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[String, Value]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6910,9 +6842,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6921,21 +6850,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l762: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>">(old_repr, i));
-                i = i + 1;
-                continue l762;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -7110,9 +7025,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -7121,21 +7033,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l788: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(old_repr, i));
-                i = i + 1;
-                continue l788;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/httpbin_post.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/httpbin_post.wir.wado
@@ -5424,16 +5424,16 @@ fn "core:prelude/string.wado/StrSplitIter^Iterator::next"(self) {
                 break b540;
             }
             matched = 1;
-            __for_13: block {
+            __for_12: block {
                 j = 0;
                 block {
                     l544: loop {
                         if j >= _licm_sep_len_13 {
-                            break __for_13;
+                            break __for_12;
                         }
                         if builtin::array_get_u8(_licm_repr_14, i + j) != builtin::array_get_u8(_licm_sep_repr_15, j) {
                             matched = 0;
-                            break __for_13;
+                            break __for_12;
                         }
                         j = j + 1;
                         continue l544;
@@ -6535,9 +6535,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6546,21 +6543,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l724: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l724;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6605,8 +6588,8 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,core:json_value/Val
     _licm_used_17 = _licm_entries_14.used;
     _licm_repr_18 = _licm_entries_14.repr;
     _licm_used_23 = key.used;
-    b728: block {
-        l729: loop {
+    b725: block {
+        l726: loop {
             let __match_scrut_0: ref "core:prelude/types.wado//Option<i32>";
             __match_scrut_0 = current;
             if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_0) {
@@ -6646,9 +6629,9 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,core:json_value/Val
                     current = n.right;
                 }
             } else {
-                break b728;
+                break b725;
             }
-            continue l729;
+            continue l726;
         };
     };
     return -1;
@@ -6658,9 +6641,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:prelude/array.wado/Array<u8>>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:prelude/array.wado/Array<u8>>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6669,21 +6649,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[String, Array<u8>]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l738: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[String, Array<u8>]">(new_repr, i, builtin::array_get<ref "tuple//[String, Array<u8>]">(old_repr, i));
-                i = i + 1;
-                continue l738;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[String, Array<u8>]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6691,9 +6657,6 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<u8>>::grow"(self
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/array.wado/Array<u8>>";
-    let old_repr: ref "builtin::array<core:prelude/array.wado/Array<u8>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6702,21 +6665,7 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<u8>>::grow"(self
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude//Array<u8>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l741: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude//Array<u8>">(new_repr, i, builtin::array_get<ref "core:prelude//Array<u8>">(old_repr, i));
-                i = i + 1;
-                continue l741;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude//Array<u8>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6724,9 +6673,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:json_value/Value>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:json_value/Value>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6735,21 +6681,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[String, Value]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l744: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[String, Value]">(new_repr, i, builtin::array_get<ref "tuple//[String, Value]">(old_repr, i));
-                i = i + 1;
-                continue l744;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[String, Value]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6910,9 +6842,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6921,21 +6850,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l762: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>">(old_repr, i));
-                i = i + 1;
-                continue l762;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -7110,9 +7025,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -7121,21 +7033,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l788: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(old_repr, i));
-                i = i + 1;
-                continue l788;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/httpbin_server_404.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/httpbin_server_404.wir.wado
@@ -1053,9 +1053,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1064,21 +1061,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l84: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l84;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/httpbin_server_hello.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/httpbin_server_hello.wir.wado
@@ -1053,9 +1053,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1064,21 +1061,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l84: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l84;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/httpbin_status.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/httpbin_status.wir.wado
@@ -5424,16 +5424,16 @@ fn "core:prelude/string.wado/StrSplitIter^Iterator::next"(self) {
                 break b540;
             }
             matched = 1;
-            __for_13: block {
+            __for_12: block {
                 j = 0;
                 block {
                     l544: loop {
                         if j >= _licm_sep_len_13 {
-                            break __for_13;
+                            break __for_12;
                         }
                         if builtin::array_get_u8(_licm_repr_14, i + j) != builtin::array_get_u8(_licm_sep_repr_15, j) {
                             matched = 0;
-                            break __for_13;
+                            break __for_12;
                         }
                         j = j + 1;
                         continue l544;
@@ -6535,9 +6535,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6546,21 +6543,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l724: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l724;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6605,8 +6588,8 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,core:json_value/Val
     _licm_used_17 = _licm_entries_14.used;
     _licm_repr_18 = _licm_entries_14.repr;
     _licm_used_23 = key.used;
-    b728: block {
-        l729: loop {
+    b725: block {
+        l726: loop {
             let __match_scrut_0: ref "core:prelude/types.wado//Option<i32>";
             __match_scrut_0 = current;
             if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_0) {
@@ -6646,9 +6629,9 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,core:json_value/Val
                     current = n.right;
                 }
             } else {
-                break b728;
+                break b725;
             }
-            continue l729;
+            continue l726;
         };
     };
     return -1;
@@ -6658,9 +6641,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:prelude/array.wado/Array<u8>>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:prelude/array.wado/Array<u8>>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6669,21 +6649,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[String, Array<u8>]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l738: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[String, Array<u8>]">(new_repr, i, builtin::array_get<ref "tuple//[String, Array<u8>]">(old_repr, i));
-                i = i + 1;
-                continue l738;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[String, Array<u8>]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6691,9 +6657,6 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<u8>>::grow"(self
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/array.wado/Array<u8>>";
-    let old_repr: ref "builtin::array<core:prelude/array.wado/Array<u8>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6702,21 +6665,7 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<u8>>::grow"(self
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude//Array<u8>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l741: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude//Array<u8>">(new_repr, i, builtin::array_get<ref "core:prelude//Array<u8>">(old_repr, i));
-                i = i + 1;
-                continue l741;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude//Array<u8>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6724,9 +6673,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:json_value/Value>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:json_value/Value>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6735,21 +6681,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[String, Value]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l744: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[String, Value]">(new_repr, i, builtin::array_get<ref "tuple//[String, Value]">(old_repr, i));
-                i = i + 1;
-                continue l744;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[String, Value]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6910,9 +6842,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6921,21 +6850,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l762: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>">(old_repr, i));
-                i = i + 1;
-                continue l762;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:json_value/Value>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -7110,9 +7025,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -7121,21 +7033,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l788: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(old_repr, i));
-                i = i + 1;
-                continue l788;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/ice_treeset_iter_by_ref.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/ice_treeset_iter_by_ref.wir.wado
@@ -1267,9 +1267,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,()>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,()>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1278,21 +1275,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,()>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l120: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,()>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,()>">(old_repr, i));
-                i = i + 1;
-                continue l120;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,()>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1467,9 +1450,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<i32,()>>::grow"(
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapEntry<i32,()>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapEntry<i32,()>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1478,21 +1458,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<i32,()>>::grow"(
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapEntry<i32,()>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l146: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapEntry<i32,()>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<i32,()>">(old_repr, i));
-                i = i + 1;
-                continue l146;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapEntry<i32,()>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1667,9 +1633,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<i32>>::grow"(self
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapNode<i32>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapNode<i32>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1678,21 +1641,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<i32>>::grow"(self
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapNode<i32>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l172: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapNode<i32>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapNode<i32>">(old_repr, i));
-                i = i + 1;
-                continue l172;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapNode<i32>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1700,9 +1649,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1711,21 +1657,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l175: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(old_repr, i));
-                i = i + 1;
-                continue l175;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/inline_array_append_nested.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/inline_array_append_nested.wir.wado
@@ -553,9 +553,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -564,21 +561,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l54: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l54;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/inline_cross_module_method.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/inline_cross_module_method.wir.wado
@@ -501,9 +501,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -512,21 +509,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l45: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l45;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/inline_merged.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/inline_merged.wir.wado
@@ -844,9 +844,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -855,21 +852,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l69: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l69;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/inline_mutual_recursive_generic_visit.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/inline_mutual_recursive_generic_visit.wir.wado
@@ -781,7 +781,7 @@ fn "core:prelude/array.wado/Array<wado-compiler/tests/fixtures/inline_mutual_rec
     if self.used != other.used {
         return 0;
     }
-    __for_9: block {
+    __for_3: block {
         i = 0;
         _licm_used_3 = self.used;
         _licm_repr_4 = self.repr;
@@ -789,7 +789,7 @@ fn "core:prelude/array.wado/Array<wado-compiler/tests/fixtures/inline_mutual_rec
         block {
             l58: loop {
                 if i >= _licm_used_3 {
-                    break __for_9;
+                    break __for_3;
                 }
                 if "wado-compiler/tests/fixtures/inline_mutual_recursive_generic_visit.wado/Node^Eq::eq"(builtin::array_get<ref "wado-compiler/tests/fixtures/inline_mutual_recursive_generic_visit.wado//Node">(_licm_repr_4, i), builtin::array_get<ref "wado-compiler/tests/fixtures/inline_mutual_recursive_generic_visit.wado//Node">(_licm_repr_5, i)) == 0 {
                     return 0;

--- a/wado-compiler/tests/generated/fixtures/iter_map_collect_variant.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/iter_map_collect_variant.wir.wado
@@ -377,14 +377,14 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::join"(self, 
         unreachable;
     };
     f_3 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: buf_2 };
-    __for_14: block {
+    __for_8: block {
         i = 0;
         _licm_used_12 = self.used;
         _licm_repr_13 = self.repr;
         block {
             l20: loop {
                 if i >= _licm_used_12 {
-                    break __for_14;
+                    break __for_8;
                 }
                 if i > 0 {
                     "core:prelude/string.wado/String::push_str"(f_3.buf, separator);
@@ -438,9 +438,6 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let old_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -449,21 +446,7 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude/string.wado//String">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l28: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude/string.wado//String">(new_repr, i, builtin::array_get<ref "core:prelude/string.wado//String">(old_repr, i));
-                i = i + 1;
-                continue l28;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude/string.wado//String">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/iterator_assoc_type_chain.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/iterator_assoc_type_chain.wir.wado
@@ -683,9 +683,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -694,21 +691,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l58: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l58;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/iterator_filter_o3_regression.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/iterator_filter_o3_regression.wir.wado
@@ -835,9 +835,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -846,21 +843,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l68: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l68;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/key_value_literal_blanket_impl.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/key_value_literal_blanket_impl.wir.wado
@@ -616,9 +616,6 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let old_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -627,21 +624,7 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude/string.wado//String">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l48: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude/string.wado//String">(new_repr, i, builtin::array_get<ref "core:prelude/string.wado//String">(old_repr, i));
-                i = i + 1;
-                continue l48;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude/string.wado//String">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -659,9 +642,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -670,21 +650,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l52: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l52;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/key_value_literal_both_traits.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/key_value_literal_both_traits.wir.wado
@@ -907,9 +907,6 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let old_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -918,21 +915,7 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude/string.wado//String">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l69: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude/string.wado//String">(new_repr, i, builtin::array_get<ref "core:prelude/string.wado//String">(old_repr, i));
-                i = i + 1;
-                continue l69;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude/string.wado//String">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -950,9 +933,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -961,21 +941,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l73: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l73;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/key_value_literal_conditional.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/key_value_literal_conditional.wir.wado
@@ -1064,9 +1064,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,i32>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,i32>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1075,21 +1072,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l94: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(old_repr, i));
-                i = i + 1;
-                continue l94;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1264,9 +1247,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1275,21 +1255,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l120: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(old_repr, i));
-                i = i + 1;
-                continue l120;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/key_value_literal_immutable.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/key_value_literal_immutable.wir.wado
@@ -849,9 +849,6 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let old_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -860,21 +857,7 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude/string.wado//String">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l63: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude/string.wado//String">(new_repr, i, builtin::array_get<ref "core:prelude/string.wado//String">(old_repr, i));
-                i = i + 1;
-                continue l63;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude/string.wado//String">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -892,9 +875,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -903,21 +883,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l67: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l67;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/mut_param_merged.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/mut_param_merged.wir.wado
@@ -1320,9 +1320,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1331,21 +1328,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l85: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l85;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/nested_array.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/nested_array.wir.wado
@@ -1148,9 +1148,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1159,21 +1156,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l92: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l92;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/newtype_array_sort.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/newtype_array_sort.wir.wado
@@ -664,18 +664,18 @@ fn "wado-compiler/tests/fixtures/newtype_array_sort.wado/Array<wado-compiler/tes
     src = self.repr;
     buf = builtin::array_new<i32>(n);
     width = 1;
-    __for_11: block {
+    __for_5: block {
         block {
             l52: loop {
                 if width >= n {
-                    break __for_11;
+                    break __for_5;
                 }
-                __for_12: block {
+                __for_6: block {
                     start = 0;
                     block {
                         l55: loop {
                             if start >= n {
-                                break __for_12;
+                                break __for_6;
                             }
                             mid = start + width;
                             if mid < n {
@@ -686,12 +686,12 @@ fn "wado-compiler/tests/fixtures/newtype_array_sort.wado/Array<wado-compiler/tes
                                 };
                                 i = start;
                                 j = mid;
-                                __for_13: block {
+                                __for_7: block {
                                     k = start;
                                     block {
                                         l59: loop {
                                             if k >= end {
-                                                break __for_13;
+                                                break __for_7;
                                             }
                                             if i < mid {
                                                 if j < end {

--- a/wado-compiler/tests/generated/fixtures/newtype_generic.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/newtype_generic.wir.wado
@@ -604,9 +604,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -615,21 +612,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l46: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l46;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/newtype_generic_container_return.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/newtype_generic_container_return.wir.wado
@@ -597,9 +597,6 @@ fn "core:prelude/array.wado/Array<wado-compiler/tests/fixtures/newtype_generic_c
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<wado-compiler/tests/fixtures/newtype_generic_container_return.wado/Point>";
-    let old_repr: ref "builtin::array<wado-compiler/tests/fixtures/newtype_generic_container_return.wado/Point>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -608,21 +605,7 @@ fn "core:prelude/array.wado/Array<wado-compiler/tests/fixtures/newtype_generic_c
         unreachable;
     };
     new_repr = builtin::array_new<ref "wado-compiler/tests/fixtures/newtype_generic_container_return.wado//Point">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l47: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "wado-compiler/tests/fixtures/newtype_generic_container_return.wado//Point">(new_repr, i, builtin::array_get<ref "wado-compiler/tests/fixtures/newtype_generic_container_return.wado//Point">(old_repr, i));
-                i = i + 1;
-                continue l47;
-            };
-        };
-    };
+    builtin::array_copy<ref "wado-compiler/tests/fixtures/newtype_generic_container_return.wado//Point">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/opt_container_sroa_edge.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/opt_container_sroa_edge.wir.wado
@@ -1126,9 +1126,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1137,21 +1134,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l88: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l88;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1159,9 +1142,6 @@ fn "core:prelude/array.wado/Array<i64>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i64>;
-    let old_repr: ref builtin::array<i64>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1170,21 +1150,7 @@ fn "core:prelude/array.wado/Array<i64>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i64>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l91: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i64>(new_repr, i, builtin::array_get<i64>(old_repr, i));
-                i = i + 1;
-                continue l91;
-            };
-        };
-    };
+    builtin::array_copy<i64>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/opt_container_sroa_nondup_idx.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/opt_container_sroa_nondup_idx.wir.wado
@@ -1016,9 +1016,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1027,21 +1024,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l74: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l74;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1049,9 +1032,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<i32,i32>>::grow"
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<i32,i32>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<i32,i32>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1060,21 +1040,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<i32,i32>>::grow"
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[i32, i32]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l77: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[i32, i32]">(new_repr, i, builtin::array_get<ref "tuple//[i32, i32]">(old_repr, i));
-                i = i + 1;
-                continue l77;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[i32, i32]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/opt_container_sroa_struct.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/opt_container_sroa_struct.wir.wado
@@ -1383,9 +1383,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1394,21 +1391,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l98: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l98;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1416,9 +1399,6 @@ fn "core:prelude/array.wado/Array<i64>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i64>;
-    let old_repr: ref builtin::array<i64>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1427,21 +1407,7 @@ fn "core:prelude/array.wado/Array<i64>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i64>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l101: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i64>(new_repr, i, builtin::array_get<i64>(old_repr, i));
-                i = i + 1;
-                continue l101;
-            };
-        };
-    };
+    builtin::array_copy<i64>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/opt_container_sroa_tuple.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/opt_container_sroa_tuple.wir.wado
@@ -847,9 +847,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -858,21 +855,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l69: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l69;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/opt_hfs_immut_ref_method_reread.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/opt_hfs_immut_ref_method_reread.wir.wado
@@ -806,9 +806,6 @@ fn "core:prelude/array.wado/Array<char>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<char>;
-    let old_repr: ref builtin::array<char>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -817,21 +814,7 @@ fn "core:prelude/array.wado/Array<char>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<char>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l75: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<char>(new_repr, i, builtin::array_get<char>(old_repr, i));
-                i = i + 1;
-                continue l75;
-            };
-        };
-    };
+    builtin::array_copy<char>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/ordering_basic.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/ordering_basic.wir.wado
@@ -325,7 +325,7 @@ fn "core:prelude/array.wado/Array<i32>^Eq::eq"(self, other) {
     if self.used != other.used {
         return 0;
     }
-    __for_9: block {
+    __for_3: block {
         i = 0;
         _licm_used_3 = self.used;
         _licm_repr_4 = self.repr;
@@ -333,7 +333,7 @@ fn "core:prelude/array.wado/Array<i32>^Eq::eq"(self, other) {
         block {
             l31: loop {
                 if i >= _licm_used_3 {
-                    break __for_9;
+                    break __for_3;
                 }
                 if builtin::array_get<i32>(_licm_repr_4, i) != builtin::array_get<i32>(_licm_repr_5, i) {
                     return 0;
@@ -365,14 +365,14 @@ fn "core:prelude/array.wado/Array<i32>^Ord::cmp"(self, other) {
         break __inline_i32_min_0: select i32(a_6 < b_7, a_6, b_7);
         unreachable;
     };
-    __for_10: block {
+    __for_4: block {
         i = 0;
         _licm_repr_12 = self.repr;
         _licm_repr_13 = other.repr;
         block {
             l35: loop {
                 if i >= min_len {
-                    break __for_10;
+                    break __for_4;
                 }
                 a_4 = builtin::array_get<i32>(_licm_repr_12, i);
                 b_5 = builtin::array_get<i32>(_licm_repr_13, i);

--- a/wado-compiler/tests/generated/fixtures/pattern_mut_binding.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/pattern_mut_binding.wir.wado
@@ -1126,9 +1126,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1137,21 +1134,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l79: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l79;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/ref_2.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/ref_2.wir.wado
@@ -951,9 +951,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -962,21 +959,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l73: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l73;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -984,9 +967,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -995,21 +975,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l76: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l76;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/result_unit_cm_variant_passthrough.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/result_unit_cm_variant_passthrough.wir.wado
@@ -689,9 +689,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -700,21 +697,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l66: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l66;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -722,9 +705,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -733,21 +713,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[Descriptor, String]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l69: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[Descriptor, String]">(new_repr, i, builtin::array_get<ref "tuple//[Descriptor, String]">(old_repr, i));
-                i = i + 1;
-                continue l69;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[Descriptor, String]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/result_unwrap_fresh_elision.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/result_unwrap_fresh_elision.wir.wado
@@ -578,9 +578,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -589,21 +586,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l47: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l47;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/sequence_literal_custom.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/sequence_literal_custom.wir.wado
@@ -739,9 +739,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -750,21 +747,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l53: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l53;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/sequence_literal_fn_arg.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/sequence_literal_fn_arg.wir.wado
@@ -616,9 +616,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -627,21 +624,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l47: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l47;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/serde_json_default.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/serde_json_default.wir.wado
@@ -3450,9 +3450,6 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let old_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -3461,21 +3458,7 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude/string.wado//String">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l389: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude/string.wado//String">(new_repr, i, builtin::array_get<ref "core:prelude/string.wado//String">(old_repr, i));
-                i = i + 1;
-                continue l389;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude/string.wado//String">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -3512,8 +3495,8 @@ fn "wado-compiler/tests/fixtures/serde_json_default.wado/Config^Deserialize::des
             unreachable;
         };
         __local_8 = ref.null none;
-        b392: block {
-            l393: loop {
+        b389: block {
+            l390: loop {
                 let __sroa___local_9_discriminant: i32;
                 let __sroa___local_9_case0_payload_0: ref null "core:prelude/types.wado//Option<i32>";
                 let __sroa___local_9_case1_payload_0: ref null "core:serde//DeserializeError";
@@ -3586,12 +3569,12 @@ fn "wado-compiler/tests/fixtures/serde_json_default.wado/Config^Deserialize::des
                             drop("core:json/JsonDeserializer::skip_value"(__local_2.de));
                         }
                     } else {
-                        break b392;
+                        break b389;
                     }
                 } else {
                     return struct.new "core:prelude/types.wado//Result<wado-compiler/tests/fixtures/serde_json_default.wado/Config,core:serde/DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__sroa___local_9_case1_payload_0) };
                 }
-                continue l393;
+                continue l390;
             };
         };
         if (__local_3 & 1) != 1 {
@@ -3654,7 +3637,7 @@ fn "core:serde/Array<core:prelude/string.wado/String>^Deserialize::deserialize<c
         items = struct.new "core:prelude//Array<core:prelude/string.wado/String>" { repr: builtin::array_new<ref "core:prelude/string.wado//String">(2), used: 0 };
         "core:prelude/array.wado/Array<core:prelude/string.wado/String>::push"(items, first_elem);
         block {
-            l412: loop {
+            l409: loop {
                 let __match_scrut_5: ref "core:prelude/types.wado//Result<core:prelude/types.wado/Option<core:prelude/string.wado/String>,core:serde/DeserializeError>";
                 __match_scrut_5 = "core:json/JsonSeqAccess^DeserializeSeq::next_element<core:prelude/string.wado/String>"(seq);
                 next_opt = (if ref.test "core:prelude/types.wado//Result<core:prelude/types.wado/Option<core:prelude/string.wado/String>,core:serde/DeserializeError>::Ok"(__match_scrut_5) -> ref null "core:prelude/string.wado//String" {
@@ -3676,7 +3659,7 @@ fn "core:serde/Array<core:prelude/string.wado/String>^Deserialize::deserialize<c
                     }
                     return 0, items, ref.null none;
                 }
-                continue l412;
+                continue l409;
             };
         };
     } else {

--- a/wado-compiler/tests/generated/fixtures/serde_json_deser_error_edge.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/serde_json_deser_error_edge.wir.wado
@@ -6018,9 +6018,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6029,21 +6026,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l611: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l611;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/serde_json_option_array_fields.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/serde_json_option_array_fields.wir.wado
@@ -3747,9 +3747,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -3758,21 +3755,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l408: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l408;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -3801,8 +3784,8 @@ fn "core:serde/Array<i32>^Serialize::serialize<core:json/JsonSerializer>"(self, 
         break __inline__i32_IntoIterator__into_iter_2: struct.new "core:prelude/array.wado//ArrayRefIter<i32>" { repr: self.repr, used: self.used, index: 0 };
         unreachable;
     };
-    b411: block {
-        l412: loop {
+    b408: block {
+        l409: loop {
             __match_9 = "core:prelude/array.wado/ArrayRefIter<i32>^Iterator::next"(__iter_5);
             if ref.is_null(__match_9) == 0 {
                 item = ref.as_non_null(__match_9);
@@ -3813,9 +3796,9 @@ fn "core:serde/Array<i32>^Serialize::serialize<core:json/JsonSerializer>"(self, 
                     return __qm_e_8;
                 }
             } else {
-                break b411;
+                break b408;
             }
-            continue l412;
+            continue l409;
         };
     };
     return __inline_JsonSeqSerializer_SerializeSeq__end_3: block -> ref null "core:serde//SerializeError" {
@@ -3906,7 +3889,7 @@ fn "core:serde/Array<i32>^Deserialize::deserialize<core:json/JsonDeserializer>"(
         items = struct.new "core:prelude//Array<i32>" { repr: builtin::array_new<i32>(2), used: 0 };
         "core:prelude/array.wado/Array<i32>::push"(items, first_elem);
         block {
-            l423: loop {
+            l420: loop {
                 let __match_scrut_5: ref "core:prelude/types.wado//Result<core:prelude/types.wado/Option<i32>,core:serde/DeserializeError>";
                 __match_scrut_5 = "core:json/JsonSeqAccess^DeserializeSeq::next_element<i32>"(seq);
                 next_opt = (if ref.test "core:prelude/types.wado//Result<core:prelude/types.wado/Option<i32>,core:serde/DeserializeError>::Ok"(__match_scrut_5) -> ref "core:prelude/types.wado//Option<i32>" {
@@ -3928,7 +3911,7 @@ fn "core:serde/Array<i32>^Deserialize::deserialize<core:json/JsonDeserializer>"(
                     }
                     return 0, items, ref.null none;
                 }
-                continue l423;
+                continue l420;
             };
         };
     } else {

--- a/wado-compiler/tests/generated/fixtures/serde_json_roundtrip_complex.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/serde_json_roundtrip_complex.wir.wado
@@ -9837,9 +9837,6 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let old_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -9848,21 +9845,7 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude/string.wado//String">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l797: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude/string.wado//String">(new_repr, i, builtin::array_get<ref "core:prelude/string.wado//String">(old_repr, i));
-                i = i + 1;
-                continue l797;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude/string.wado//String">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -9935,8 +9918,8 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/FullStruct^De
         };
         __local_9 = ref.null none;
         __local_10 = struct.new "core:prelude/types.wado//Option<i32>" { 1 };
-        b801: block {
-            l802: loop {
+        b798: block {
+            l799: loop {
                 let __sroa___local_11_discriminant: i32;
                 let __sroa___local_11_case0_payload_0: ref null "core:prelude/types.wado//Option<i32>";
                 let __sroa___local_11_case1_payload_0: ref null "core:serde//DeserializeError";
@@ -10031,12 +10014,12 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/FullStruct^De
                             drop("core:json/JsonDeserializer::skip_value"(__local_2.de));
                         }
                     } else {
-                        break b801;
+                        break b798;
                     }
                 } else {
                     return struct.new "core:prelude/types.wado//Result<wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/FullStruct,core:serde/DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__sroa___local_11_case1_payload_0) };
                 }
-                continue l802;
+                continue l799;
             };
         };
         if (__local_3 & 127) != 127 {
@@ -10092,8 +10075,8 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Outer^Deseria
         __local_3 = 0;
         __local_4 = ref.null none;
         __local_5 = 0;
-        b822: block {
-            l823: loop {
+        b819: block {
+            l820: loop {
                 let __sroa___local_6_discriminant: i32;
                 let __sroa___local_6_case0_payload_0: ref null "core:prelude/types.wado//Option<i32>";
                 let __sroa___local_6_case1_payload_0: ref null "core:serde//DeserializeError";
@@ -10128,12 +10111,12 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Outer^Deseria
                             drop("core:json/JsonDeserializer::skip_value"(__local_2.de));
                         }
                     } else {
-                        break b822;
+                        break b819;
                     }
                 } else {
                     return struct.new "core:prelude/types.wado//Result<wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Outer,core:serde/DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__sroa___local_6_case1_payload_0) };
                 }
-                continue l823;
+                continue l820;
             };
         };
         if (__local_3 & 3) != 3 {
@@ -10181,8 +10164,8 @@ fn "core:serde/Array<wado-compiler/tests/fixtures/serde_json_roundtrip_complex.w
         break __inline__wado_compiler_tests_fixtures_serde_json_roundtrip_complex_wado_Inner_IntoIterator__into_iter_2: struct.new "core:prelude/array.wado//ArrayRefIter<wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Inner>" { repr: self.repr, used: self.used, index: 0 };
         unreachable;
     };
-    b833: block {
-        l834: loop {
+    b830: block {
+        l831: loop {
             __match_9 = "core:prelude/array.wado/ArrayRefIter<wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Inner>^Iterator::next"(__iter_5);
             if ref.is_null(__match_9) == 0 {
                 item = ref.as_non_null(__match_9);
@@ -10193,9 +10176,9 @@ fn "core:serde/Array<wado-compiler/tests/fixtures/serde_json_roundtrip_complex.w
                     return __qm_e_8;
                 }
             } else {
-                break b833;
+                break b830;
             }
-            continue l834;
+            continue l831;
         };
     };
     return __inline_JsonSeqSerializer_SerializeSeq__end_3: block -> ref null "core:serde//SerializeError" {
@@ -10255,7 +10238,7 @@ fn "core:serde/Array<wado-compiler/tests/fixtures/serde_json_roundtrip_complex.w
         items = struct.new "core:prelude//Array<wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Inner>" { repr: builtin::array_new<ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner">(2), used: 0 };
         "core:prelude/array.wado/Array<wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Inner>::push"(items, first_elem);
         block {
-            l842: loop {
+            l839: loop {
                 let __match_scrut_5: ref "core:prelude/types.wado//Result<core:prelude/types.wado/Option<wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Inner>,core:serde/DeserializeError>";
                 __match_scrut_5 = "core:json/JsonSeqAccess^DeserializeSeq::next_element<wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Inner>"(seq);
                 next_opt = (if ref.test "core:prelude/types.wado//Result<core:prelude/types.wado/Option<wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Inner>,core:serde/DeserializeError>::Ok"(__match_scrut_5) -> ref null "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner" {
@@ -10277,7 +10260,7 @@ fn "core:serde/Array<wado-compiler/tests/fixtures/serde_json_roundtrip_complex.w
                     }
                     return struct.new "core:prelude/types.wado//Result<core:prelude/array.wado/Array<wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Inner>,core:serde/DeserializeError>::Ok" { discriminant: 0, payload_0: items };
                 }
-                continue l842;
+                continue l839;
             };
         };
     } else {
@@ -10539,8 +10522,8 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,core:prelude/string
         return __qm_e_4;
     }));
     __iter_6 = struct.new "core:prelude/array.wado//ArrayIter<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:prelude/string.wado/String>>" { repr: entries.repr, used: entries.used, index: 0 };
-    b867: block {
-        l868: loop {
+    b864: block {
+        l865: loop {
             __match_13 = "core:prelude/array.wado/ArrayIter<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:prelude/string.wado/String>>^Iterator::next"(__iter_6);
             if ref.is_null(__match_13) == 0 {
                 let __variant_payload_1: ref "tuple//[String, String]";
@@ -10560,9 +10543,9 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,core:prelude/string
                     return __qm_e_12;
                 }
             } else {
-                break b867;
+                break b864;
             }
-            continue l868;
+            continue l865;
         };
     };
     return __inline_JsonMapSerializer_SerializeMap__end_3: block -> ref null "core:serde//SerializeError" {
@@ -10622,7 +10605,7 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,core:prelude/string
         unreachable;
     };
     block {
-        l875: loop {
+        l872: loop {
             let __match_scrut_2: ref "core:prelude/types.wado//Result<core:prelude/types.wado/Option<core:prelude/string.wado/String>,core:serde/DeserializeError>";
             __match_scrut_2 = "core:json/JsonMapAccess^DeserializeMap::next_key_string"(map);
             key_opt = (if ref.test "core:prelude/types.wado//Result<core:prelude/types.wado/Option<core:prelude/string.wado/String>,core:serde/DeserializeError>::Ok"(__match_scrut_2) -> ref null "core:prelude/string.wado//String" {
@@ -10657,7 +10640,7 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,core:prelude/string
                 }
                 return struct.new "core:prelude/types.wado//Result<core:collections/TreeMap<core:prelude/string.wado/String,core:prelude/string.wado/String>,core:serde/DeserializeError>::Ok" { discriminant: 0, payload_0: result };
             }
-            continue l875;
+            continue l872;
         };
     };
     "core:internal/unreachable"();
@@ -10685,8 +10668,8 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,core:prelude/string
     _licm_used_17 = _licm_entries_14.used;
     _licm_repr_18 = _licm_entries_14.repr;
     _licm_used_23 = key.used;
-    b880: block {
-        l881: loop {
+    b877: block {
+        l878: loop {
             let __match_scrut_0: ref "core:prelude/types.wado//Option<i32>";
             __match_scrut_0 = current;
             if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_0) {
@@ -10726,9 +10709,9 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,core:prelude/string
                     current = n.right;
                 }
             } else {
-                break b880;
+                break b877;
             }
-            continue l881;
+            continue l878;
         };
     };
     return -1;
@@ -10784,8 +10767,8 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,i32>^Serialize::ser
         return __qm_e_4;
     }));
     __iter_6 = struct.new "core:prelude/array.wado//ArrayIter<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,i32>>" { repr: entries.repr, used: entries.used, index: 0 };
-    b892: block {
-        l893: loop {
+    b889: block {
+        l890: loop {
             __match_13 = "core:prelude/array.wado/ArrayIter<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,i32>>^Iterator::next"(__iter_6);
             if ref.is_null(__match_13) == 0 {
                 let __variant_payload_1: ref "tuple//[String, i32]";
@@ -10805,9 +10788,9 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,i32>^Serialize::ser
                     return __qm_e_12;
                 }
             } else {
-                break b892;
+                break b889;
             }
-            continue l893;
+            continue l890;
         };
     };
     return __inline_JsonMapSerializer_SerializeMap__end_3: block -> ref null "core:serde//SerializeError" {
@@ -10867,7 +10850,7 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,i32>^Deserialize::d
         unreachable;
     };
     block {
-        l900: loop {
+        l897: loop {
             let __match_scrut_2: ref "core:prelude/types.wado//Result<core:prelude/types.wado/Option<core:prelude/string.wado/String>,core:serde/DeserializeError>";
             __match_scrut_2 = "core:json/JsonMapAccess^DeserializeMap::next_key_string"(map);
             key_opt = (if ref.test "core:prelude/types.wado//Result<core:prelude/types.wado/Option<core:prelude/string.wado/String>,core:serde/DeserializeError>::Ok"(__match_scrut_2) -> ref null "core:prelude/string.wado//String" {
@@ -10902,7 +10885,7 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,i32>^Deserialize::d
                 }
                 return struct.new "core:prelude/types.wado//Result<core:collections/TreeMap<core:prelude/string.wado/String,i32>,core:serde/DeserializeError>::Ok" { discriminant: 0, payload_0: result };
             }
-            continue l900;
+            continue l897;
         };
     };
     "core:internal/unreachable"();
@@ -10930,8 +10913,8 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,i32>::find_index"(s
     _licm_used_17 = _licm_entries_14.used;
     _licm_repr_18 = _licm_entries_14.repr;
     _licm_used_23 = key.used;
-    b905: block {
-        l906: loop {
+    b902: block {
+        l903: loop {
             let __match_scrut_0: ref "core:prelude/types.wado//Option<i32>";
             __match_scrut_0 = current;
             if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_0) {
@@ -10971,9 +10954,9 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,i32>::find_index"(s
                     current = n.right;
                 }
             } else {
-                break b905;
+                break b902;
             }
-            continue l906;
+            continue l903;
         };
     };
     return -1;
@@ -11429,8 +11412,8 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Config^Deseri
             break __inline_TreeMap_core_prelude_string_wado_String_i32___new_1____seq_lit: __b_11;
             unreachable;
         }), size: 0, deleted_count: 0 };
-        b968: block {
-            l969: loop {
+        b965: block {
+            l966: loop {
                 let __sroa___local_5_discriminant: i32;
                 let __sroa___local_5_case0_payload_0: ref null "core:prelude/types.wado//Option<i32>";
                 let __sroa___local_5_case1_payload_0: ref null "core:serde//DeserializeError";
@@ -11452,12 +11435,12 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Config^Deseri
                             drop("core:json/JsonDeserializer::skip_value"(__local_2.de));
                         }
                     } else {
-                        break b968;
+                        break b965;
                     }
                 } else {
                     return struct.new "core:prelude/types.wado//Result<wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Config,core:serde/DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__sroa___local_5_case1_payload_0) };
                 }
-                continue l969;
+                continue l966;
             };
         };
         if (__local_3 & 1) != 1 {
@@ -11546,8 +11529,8 @@ fn "core:serde/Array<core:prelude/types.wado/Option<i32>>^Serialize::serialize<c
         break __inline__core_prelude_types_wado_Option_i32__IntoIterator__into_iter_2: struct.new "core:prelude/array.wado//ArrayRefIter<core:prelude/types.wado/Option<i32>>" { repr: self.repr, used: self.used, index: 0 };
         unreachable;
     };
-    b981: block {
-        l982: loop {
+    b978: block {
+        l979: loop {
             __match_9 = "core:prelude/array.wado/ArrayRefIter<core:prelude/types.wado/Option<i32>>^Iterator::next"(__iter_5);
             if ref.is_null(__match_9) == 0 {
                 item = ref.as_non_null(__match_9);
@@ -11558,9 +11541,9 @@ fn "core:serde/Array<core:prelude/types.wado/Option<i32>>^Serialize::serialize<c
                     return __qm_e_8;
                 }
             } else {
-                break b981;
+                break b978;
             }
-            continue l982;
+            continue l979;
         };
     };
     return __inline_JsonSeqSerializer_SerializeSeq__end_3: block -> ref null "core:serde//SerializeError" {
@@ -11620,7 +11603,7 @@ fn "core:serde/Array<core:prelude/types.wado/Option<i32>>^Deserialize::deseriali
         items = struct.new "core:prelude//Array<core:prelude/types.wado/Option<i32>>" { repr: builtin::array_new<ref "core:prelude/types.wado//Option<i32>">(2), used: 0 };
         "core:prelude/array.wado/Array<core:prelude/types.wado/Option<i32>>::push"(items, first_elem);
         block {
-            l990: loop {
+            l987: loop {
                 let __match_scrut_5: ref "core:prelude/types.wado//Result<core:prelude/types.wado/Option<core:prelude/types.wado/Option<i32>>,core:serde/DeserializeError>";
                 __match_scrut_5 = "core:json/JsonSeqAccess^DeserializeSeq::next_element<core:prelude/types.wado/Option<i32>>"(seq);
                 next_opt = (if ref.test "core:prelude/types.wado//Result<core:prelude/types.wado/Option<core:prelude/types.wado/Option<i32>>,core:serde/DeserializeError>::Ok"(__match_scrut_5) -> ref null "core:prelude/types.wado//Option<i32>" {
@@ -11642,7 +11625,7 @@ fn "core:serde/Array<core:prelude/types.wado/Option<i32>>^Deserialize::deseriali
                     }
                     return struct.new "core:prelude/types.wado//Result<core:prelude/array.wado/Array<core:prelude/types.wado/Option<i32>>,core:serde/DeserializeError>::Ok" { discriminant: 0, payload_0: items };
                 }
-                continue l990;
+                continue l987;
             };
         };
     } else {
@@ -11744,9 +11727,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Option<i32>>::grow"(se
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Option<i32>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Option<i32>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -11755,21 +11735,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Option<i32>>::grow"(se
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude/types.wado//Option<i32>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l1005: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude/types.wado//Option<i32>">(new_repr, i, builtin::array_get<ref "core:prelude/types.wado//Option<i32>">(old_repr, i));
-                i = i + 1;
-                continue l1005;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude/types.wado//Option<i32>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -11823,7 +11789,7 @@ fn "core:serde/Array<i32>^Deserialize::deserialize<core:json/JsonDeserializer>"(
         items = struct.new "core:prelude//Array<i32>" { repr: builtin::array_new<i32>(2), used: 0 };
         "core:prelude/array.wado/Array<i32>::push"(items, first_elem);
         block {
-            l1012: loop {
+            l1006: loop {
                 let __match_scrut_5: ref "core:prelude/types.wado//Result<core:prelude/types.wado/Option<i32>,core:serde/DeserializeError>";
                 __match_scrut_5 = "core:json/JsonSeqAccess^DeserializeSeq::next_element<i32>"(seq);
                 next_opt = (if ref.test "core:prelude/types.wado//Result<core:prelude/types.wado/Option<i32>,core:serde/DeserializeError>::Ok"(__match_scrut_5) -> ref "core:prelude/types.wado//Option<i32>" {
@@ -11845,7 +11811,7 @@ fn "core:serde/Array<i32>^Deserialize::deserialize<core:json/JsonDeserializer>"(
                     }
                     return struct.new "core:prelude/types.wado//Result<core:prelude/array.wado/Array<i32>,core:serde/DeserializeError>::Ok" { discriminant: 0, payload_0: items };
                 }
-                continue l1012;
+                continue l1006;
             };
         };
     } else {
@@ -11888,8 +11854,8 @@ fn "core:serde/Array<i32>^Serialize::serialize<core:json/JsonSerializer>"(self, 
         break __inline__i32_IntoIterator__into_iter_2: struct.new "core:prelude/array.wado//ArrayRefIter<i32>" { repr: self.repr, used: self.used, index: 0 };
         unreachable;
     };
-    b1018: block {
-        l1019: loop {
+    b1012: block {
+        l1013: loop {
             __match_9 = "core:prelude/array.wado/ArrayRefIter<i32>^Iterator::next"(__iter_5);
             if ref.is_null(__match_9) == 0 {
                 item = ref.as_non_null(__match_9);
@@ -11900,9 +11866,9 @@ fn "core:serde/Array<i32>^Serialize::serialize<core:json/JsonSerializer>"(self, 
                     return __qm_e_8;
                 }
             } else {
-                break b1018;
+                break b1012;
             }
-            continue l1019;
+            continue l1013;
         };
     };
     return __inline_JsonSeqSerializer_SerializeSeq__end_3: block -> ref null "core:serde//SerializeError" {
@@ -11916,9 +11882,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -11927,21 +11890,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l1023: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l1023;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -11993,8 +11942,8 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,i32>::entries"(self
         unreachable;
     };
     __iter_3 = struct.new "core:prelude/array.wado//ArrayIter<core:collections/TreeMapEntry<core:prelude/string.wado/String,i32>>" { repr: self.entries.repr, used: self.entries.used, index: 0 };
-    b1027: block {
-        l1028: loop {
+    b1018: block {
+        l1019: loop {
             __match_5 = "core:prelude/array.wado/ArrayIter<core:collections/TreeMapEntry<core:prelude/string.wado/String,i32>>^Iterator::next"(__iter_3);
             if ref.is_null(__match_5) == 0 {
                 entry = ref.as_non_null(__match_5);
@@ -12002,9 +11951,9 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,i32>::entries"(self
                     "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,i32>>::push"(result, struct.new "tuple//[String, i32]" { 0: entry.key, 1: entry.value });
                 }
             } else {
-                break b1027;
+                break b1018;
             }
-            continue l1028;
+            continue l1019;
         };
     };
     return result;
@@ -12166,8 +12115,8 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,core:prelude/string
         unreachable;
     };
     __iter_3 = struct.new "core:prelude/array.wado//ArrayIter<core:collections/TreeMapEntry<core:prelude/string.wado/String,core:prelude/string.wado/String>>" { repr: self.entries.repr, used: self.entries.used, index: 0 };
-    b1045: block {
-        l1046: loop {
+    b1036: block {
+        l1037: loop {
             __match_5 = "core:prelude/array.wado/ArrayIter<core:collections/TreeMapEntry<core:prelude/string.wado/String,core:prelude/string.wado/String>>^Iterator::next"(__iter_3);
             if ref.is_null(__match_5) == 0 {
                 entry = ref.as_non_null(__match_5);
@@ -12175,9 +12124,9 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,core:prelude/string
                     "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:prelude/string.wado/String>>::push"(result, struct.new "tuple//[String, String]" { 0: entry.key, 1: entry.value });
                 }
             } else {
-                break b1045;
+                break b1036;
             }
-            continue l1046;
+            continue l1037;
         };
     };
     return result;
@@ -12351,9 +12300,6 @@ fn "core:prelude/array.wado/Array<wado-compiler/tests/fixtures/serde_json_roundt
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Inner>";
-    let old_repr: ref "builtin::array<wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Inner>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -12362,21 +12308,7 @@ fn "core:prelude/array.wado/Array<wado-compiler/tests/fixtures/serde_json_roundt
         unreachable;
     };
     new_repr = builtin::array_new<ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l1069: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner">(new_repr, i, builtin::array_get<ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner">(old_repr, i));
-                i = i + 1;
-                continue l1069;
-            };
-        };
-    };
+    builtin::array_copy<ref "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado//Inner">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -12550,8 +12482,8 @@ fn "core:serde/Array<core:prelude/string.wado/String>^Serialize::serialize<core:
         break __inline__core_prelude_string_wado_String_IntoIterator__into_iter_2: struct.new "core:prelude/array.wado//ArrayRefIter<core:prelude/string.wado/String>" { repr: self.repr, used: self.used, index: 0 };
         unreachable;
     };
-    b1082: block {
-        l1083: loop {
+    b1070: block {
+        l1071: loop {
             __match_9 = "core:prelude/array.wado/ArrayRefIter<core:prelude/string.wado/String>^Iterator::next"(__iter_5);
             if ref.is_null(__match_9) == 0 {
                 item = ref.as_non_null(__match_9);
@@ -12562,9 +12494,9 @@ fn "core:serde/Array<core:prelude/string.wado/String>^Serialize::serialize<core:
                     return __qm_e_8;
                 }
             } else {
-                break b1082;
+                break b1070;
             }
-            continue l1083;
+            continue l1071;
         };
     };
     return __inline_JsonSeqSerializer_SerializeSeq__end_3: block -> ref null "core:serde//SerializeError" {
@@ -12624,7 +12556,7 @@ fn "core:serde/Array<core:prelude/string.wado/String>^Deserialize::deserialize<c
         items = struct.new "core:prelude//Array<core:prelude/string.wado/String>" { repr: builtin::array_new<ref "core:prelude/string.wado//String">(2), used: 0 };
         "core:prelude/array.wado/Array<core:prelude/string.wado/String>::push"(items, first_elem);
         block {
-            l1091: loop {
+            l1079: loop {
                 let __match_scrut_5: ref "core:prelude/types.wado//Result<core:prelude/types.wado/Option<core:prelude/string.wado/String>,core:serde/DeserializeError>";
                 __match_scrut_5 = "core:json/JsonSeqAccess^DeserializeSeq::next_element<core:prelude/string.wado/String>"(seq);
                 next_opt = (if ref.test "core:prelude/types.wado//Result<core:prelude/types.wado/Option<core:prelude/string.wado/String>,core:serde/DeserializeError>::Ok"(__match_scrut_5) -> ref null "core:prelude/string.wado//String" {
@@ -12646,7 +12578,7 @@ fn "core:serde/Array<core:prelude/string.wado/String>^Deserialize::deserialize<c
                     }
                     return 0, items, ref.null none;
                 }
-                continue l1091;
+                continue l1079;
             };
         };
     } else {
@@ -12699,9 +12631,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -12710,21 +12639,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:prelude/string.wado/String>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l1100: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:prelude/string.wado/String>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:prelude/string.wado/String>">(old_repr, i));
-                i = i + 1;
-                continue l1100;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:prelude/string.wado/String>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -12909,9 +12824,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,i32>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,i32>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -12920,21 +12832,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l1127: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(old_repr, i));
-                i = i + 1;
-                continue l1127;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -13159,8 +13057,8 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Inner^Deseria
         __local_3 = 0;
         __local_4 = 0;
         __local_5 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 };
-        b1155: block {
-            l1156: loop {
+        b1137: block {
+            l1138: loop {
                 let __sroa___local_6_discriminant: i32;
                 let __sroa___local_6_case0_payload_0: ref null "core:prelude/types.wado//Option<i32>";
                 let __sroa___local_6_case1_payload_0: ref null "core:serde//DeserializeError";
@@ -13199,12 +13097,12 @@ fn "wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Inner^Deseria
                             drop("core:json/JsonDeserializer::skip_value"(__local_2.de));
                         }
                     } else {
-                        break b1155;
+                        break b1137;
                     }
                 } else {
                     return struct.new "core:prelude/types.wado//Result<wado-compiler/tests/fixtures/serde_json_roundtrip_complex.wado/Inner,core:serde/DeserializeError>::Err" { discriminant: 1, payload_0: ref.as_non_null(__sroa___local_6_case1_payload_0) };
                 }
-                continue l1156;
+                continue l1138;
             };
         };
         if (__local_3 & 3) != 3 {
@@ -13320,9 +13218,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,i32>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,i32>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -13331,21 +13226,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[String, i32]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l1175: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[String, i32]">(new_repr, i, builtin::array_get<ref "tuple//[String, i32]">(old_repr, i));
-                i = i + 1;
-                continue l1175;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[String, i32]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -13353,9 +13234,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -13364,21 +13242,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l1178: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(old_repr, i));
-                i = i + 1;
-                continue l1178;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -13386,9 +13250,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -13397,21 +13258,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[String, String]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l1181: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[String, String]">(new_repr, i, builtin::array_get<ref "tuple//[String, String]">(old_repr, i));
-                i = i + 1;
-                continue l1181;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[String, String]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/serde_json_treemap.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/serde_json_treemap.wir.wado
@@ -5732,9 +5732,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,i32>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,i32>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -5743,21 +5740,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l500: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(old_repr, i));
-                i = i + 1;
-                continue l500;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -5942,9 +5925,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -5953,21 +5933,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:prelude/string.wado/String>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l527: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:prelude/string.wado/String>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:prelude/string.wado/String>">(old_repr, i));
-                i = i + 1;
-                continue l527;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:prelude/string.wado/String>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6152,9 +6118,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,bool>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,bool>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6163,21 +6126,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,bool>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l554: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,bool>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,bool>">(old_repr, i));
-                i = i + 1;
-                continue l554;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,bool>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6362,9 +6311,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,core:prelude/array.wado/Array<i32>>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,core:prelude/array.wado/Array<i32>>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6373,21 +6319,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:prelude/array.wado/Array<i32>>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l581: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:prelude/array.wado/Array<i32>>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:prelude/array.wado/Array<i32>>">(old_repr, i));
-                i = i + 1;
-                continue l581;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:prelude/array.wado/Array<i32>>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6593,8 +6525,8 @@ fn "core:serde/Array<i32>^Serialize::serialize<core:json/JsonSerializer>"(self, 
         break __inline__i32_IntoIterator__into_iter_2: struct.new "core:prelude/array.wado//ArrayRefIter<i32>" { repr: self.repr, used: self.used, index: 0 };
         unreachable;
     };
-    b608: block {
-        l609: loop {
+    b596: block {
+        l597: loop {
             __match_9 = "core:prelude/array.wado/ArrayRefIter<i32>^Iterator::next"(__iter_5);
             if ref.is_null(__match_9) == 0 {
                 item = ref.as_non_null(__match_9);
@@ -6605,9 +6537,9 @@ fn "core:serde/Array<i32>^Serialize::serialize<core:json/JsonSerializer>"(self, 
                     return __qm_e_8;
                 }
             } else {
-                break b608;
+                break b596;
             }
-            continue l609;
+            continue l597;
         };
     };
     return __inline_JsonSeqSerializer_SerializeSeq__end_3: block -> ref null "core:serde//SerializeError" {
@@ -6621,9 +6553,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,core:prelude/types.wado/Option<i32>>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,core:prelude/types.wado/Option<i32>>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6632,21 +6561,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:prelude/types.wado/Option<i32>>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l613: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:prelude/types.wado/Option<i32>>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:prelude/types.wado/Option<i32>>">(old_repr, i));
-                i = i + 1;
-                continue l613;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:prelude/types.wado/Option<i32>>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6841,9 +6756,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:prelude/types.wado/Option<i32>>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:prelude/types.wado/Option<i32>>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6852,21 +6764,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[String, Option<i32>]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l641: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[String, Option<i32>]">(new_repr, i, builtin::array_get<ref "tuple//[String, Option<i32>]">(old_repr, i));
-                i = i + 1;
-                continue l641;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[String, Option<i32>]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6874,9 +6772,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6885,21 +6780,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l644: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(old_repr, i));
-                i = i + 1;
-                continue l644;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6930,9 +6811,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:prelude/array.wado/Array<i32>>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:prelude/array.wado/Array<i32>>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6941,21 +6819,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[String, Array<i32>]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l649: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[String, Array<i32>]">(new_repr, i, builtin::array_get<ref "tuple//[String, Array<i32>]">(old_repr, i));
-                i = i + 1;
-                continue l649;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[String, Array<i32>]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6963,9 +6827,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,bool>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,bool>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -6974,21 +6835,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[String, bool]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l652: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[String, bool]">(new_repr, i, builtin::array_get<ref "tuple//[String, bool]">(old_repr, i));
-                i = i + 1;
-                continue l652;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[String, bool]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -6996,9 +6843,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -7007,21 +6851,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[String, String]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l655: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[String, String]">(new_repr, i, builtin::array_get<ref "tuple//[String, String]">(old_repr, i));
-                i = i + 1;
-                continue l655;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[String, String]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -7029,9 +6859,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,i32>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,i32>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -7040,21 +6867,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[String, i32]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l658: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[String, i32]">(new_repr, i, builtin::array_get<ref "tuple//[String, i32]">(old_repr, i));
-                i = i + 1;
-                continue l658;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[String, i32]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/static_1.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/static_1.wir.wado
@@ -1283,9 +1283,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1294,21 +1291,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l93: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l93;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/static_2.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/static_2.wir.wado
@@ -1141,9 +1141,6 @@ fn "core:prelude/array.wado/Array<i64>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i64>;
-    let old_repr: ref builtin::array<i64>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1152,21 +1149,7 @@ fn "core:prelude/array.wado/Array<i64>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i64>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l79: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i64>(new_repr, i, builtin::array_get<i64>(old_repr, i));
-                i = i + 1;
-                continue l79;
-            };
-        };
-    };
+    builtin::array_copy<i64>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/stream_http_echo.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/stream_http_echo.wir.wado
@@ -1018,9 +1018,6 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<u8>>::grow"(self
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/array.wado/Array<u8>>";
-    let old_repr: ref "builtin::array<core:prelude/array.wado/Array<u8>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1029,21 +1026,7 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<u8>>::grow"(self
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude//Array<u8>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l80: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude//Array<u8>">(new_repr, i, builtin::array_get<ref "core:prelude//Array<u8>">(old_repr, i));
-                i = i + 1;
-                continue l80;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude//Array<u8>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/stream_http_response_body_string.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/stream_http_response_body_string.wir.wado
@@ -964,9 +964,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -975,21 +972,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l76: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l76;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/string_insert_panic_boundary.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/string_insert_panic_boundary.wir.wado
@@ -423,28 +423,12 @@ condition: self.is_char_boundary(byte_index)
 fn "core:prelude/string.wado/String::insert_unchecked"(self, byte_index, ch) {
     let char_len: i32;
     let new_used: i32;
-    let i: i32;
-    let _licm_repr_7: ref builtin::array<u8>;
     char_len = "core:prelude/primitive.wado/char::len_utf8"(ch);
     new_used = self.used + char_len;
     if new_used > builtin::array_len(self.repr) {
         "core:prelude/string.wado/String::grow"(self, new_used);
     }
-    i = self.used - 1;
-    _licm_repr_7 = self.repr;
-    b33: block {
-        l34: loop {
-            if i < byte_index {
-                break b33;
-            }
-            builtin::array_set_u8(_licm_repr_7, i + char_len, builtin::array_get_u8(_licm_repr_7, i));
-            if i == 0 {
-                break b33;
-            }
-            i = i - 1;
-            continue l34;
-        };
-    };
+    builtin::array_copy<u8>(self.repr, byte_index + char_len, self.repr, byte_index, self.used - byte_index);
     if ch <u 128 {
         builtin::array_set_u8(self.repr, byte_index, ch & 255);
     } else if ch <u 2048 {
@@ -470,13 +454,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l41: loop {
+            l37: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l41;
+                continue l37;
             };
         };
     };

--- a/wado-compiler/tests/generated/fixtures/string_insert_str_panic_boundary.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/string_insert_str_panic_boundary.wir.wado
@@ -381,7 +381,7 @@ fn "core:prelude/string.wado/String::insert_str"(self, byte_index, s) {
             "core:prelude/string.wado/String::push"(__local_5, 58);
             __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_5 };
             f_10 = __local_6;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(889, f_10);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(882, f_10);
             "core:prelude/string.wado/String::push"(__local_5, 58);
             "core:prelude/string.wado/String::push"(__local_5, 32);
             "core:prelude/string.wado/String::push_str"(__local_5, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("insert_str index not on UTF-8 character boundary"), used: 48 });
@@ -408,8 +408,6 @@ condition: self.is_char_boundary(byte_index)
 fn "core:prelude/string.wado/String::insert_str_unchecked"(self, byte_index, s) {
     let s_len: i32;
     let new_used: i32;
-    let i: i32;
-    let _licm_repr_8: ref builtin::array<u8>;
     s_len = s.used;
     if s_len == 0 {
         return;
@@ -418,21 +416,7 @@ fn "core:prelude/string.wado/String::insert_str_unchecked"(self, byte_index, s) 
     if new_used > builtin::array_len(self.repr) {
         "core:prelude/string.wado/String::grow"(self, new_used);
     }
-    i = self.used - 1;
-    _licm_repr_8 = self.repr;
-    b31: block {
-        l32: loop {
-            if i < byte_index {
-                break b31;
-            }
-            builtin::array_set_u8(_licm_repr_8, i + s_len, builtin::array_get_u8(_licm_repr_8, i));
-            if i == 0 {
-                break b31;
-            }
-            i = i - 1;
-            continue l32;
-        };
-    };
+    builtin::array_copy<u8>(self.repr, byte_index + s_len, self.repr, byte_index, self.used - byte_index);
     builtin::array_copy<u8>(self.repr, byte_index, s.repr, 0, s_len);
     self.used = new_used;
 }
@@ -444,13 +428,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l36: loop {
+            l32: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l36;
+                continue l32;
             };
         };
     };

--- a/wado-compiler/tests/generated/fixtures/string_remove_panic_boundary.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/string_remove_panic_boundary.wir.wado
@@ -399,7 +399,7 @@ fn "core:prelude/string.wado/String::remove"(self, byte_index) {
             "core:prelude/string.wado/String::push"(__local_9, 58);
             __local_10 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_9 };
             f_16 = __local_10;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(924, f_16);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(910, f_16);
             "core:prelude/string.wado/String::push"(__local_9, 58);
             "core:prelude/string.wado/String::push"(__local_9, 32);
             "core:prelude/string.wado/String::push_str"(__local_9, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("index out of bounds"), used: 19 });
@@ -453,7 +453,7 @@ condition: byte_index >= 0 && byte_index < self.used
             "core:prelude/string.wado/String::push"(__local_11, 58);
             __local_12 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_11 };
             f_42 = __local_12;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(925, f_42);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(911, f_42);
             "core:prelude/string.wado/String::push"(__local_11, 58);
             "core:prelude/string.wado/String::push"(__local_11, 32);
             "core:prelude/string.wado/String::push_str"(__local_11, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("remove index not on UTF-8 character boundary"), used: 44 });
@@ -487,10 +487,6 @@ fn "core:prelude/string.wado/String::remove_unchecked"(self, byte_index) {
     let b2_8: u32;
     let b3: u32;
     let code: u32;
-    let src: i32;
-    let i: i32;
-    let _licm_used_14: i32;
-    let _licm_repr_15: ref builtin::array<u8>;
     b0 = builtin::array_get_u8(self.repr, byte_index);
     char_len = (if b0 <u 128 -> i32 {
         1;
@@ -514,22 +510,7 @@ fn "core:prelude/string.wado/String::remove_unchecked"(self, byte_index) {
         b3 = builtin::array_get_u8(self.repr, byte_index + 3);
         ((((b0 & 7) << 18) | ((b1_7 & 63) << 12)) | ((b2_8 & 63) << 6)) | (b3 & 63);
     });
-    src = byte_index + char_len;
-    __for_10: block {
-        i = src;
-        _licm_used_14 = self.used;
-        _licm_repr_15 = self.repr;
-        block {
-            l39: loop {
-                if i >= _licm_used_14 {
-                    break __for_10;
-                }
-                builtin::array_set_u8(_licm_repr_15, i - char_len, builtin::array_get_u8(_licm_repr_15, i));
-                i = i + 1;
-                continue l39;
-            };
-        };
-    };
+    builtin::array_copy<u8>(self.repr, byte_index, self.repr, byte_index + char_len, (self.used - byte_index) - char_len);
     self.used = self.used - char_len;
     return code;
 }
@@ -541,13 +522,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l42: loop {
+            l39: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l42;
+                continue l39;
             };
         };
     };

--- a/wado-compiler/tests/generated/fixtures/string_remove_panic_oob.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/string_remove_panic_oob.wir.wado
@@ -399,7 +399,7 @@ fn "core:prelude/string.wado/String::remove"(self, byte_index) {
             "core:prelude/string.wado/String::push"(__local_9, 58);
             __local_10 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_9 };
             f_16 = __local_10;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(924, f_16);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(910, f_16);
             "core:prelude/string.wado/String::push"(__local_9, 58);
             "core:prelude/string.wado/String::push"(__local_9, 32);
             "core:prelude/string.wado/String::push_str"(__local_9, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("index out of bounds"), used: 19 });
@@ -453,7 +453,7 @@ condition: byte_index >= 0 && byte_index < self.used
             "core:prelude/string.wado/String::push"(__local_11, 58);
             __local_12 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -1, indent: 0, buf: __local_11 };
             f_42 = __local_12;
-            "core:prelude/primitive.wado/i32::fmt_decimal"(925, f_42);
+            "core:prelude/primitive.wado/i32::fmt_decimal"(911, f_42);
             "core:prelude/string.wado/String::push"(__local_11, 58);
             "core:prelude/string.wado/String::push"(__local_11, 32);
             "core:prelude/string.wado/String::push_str"(__local_11, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("remove index not on UTF-8 character boundary"), used: 44 });
@@ -487,10 +487,6 @@ fn "core:prelude/string.wado/String::remove_unchecked"(self, byte_index) {
     let b2_8: u32;
     let b3: u32;
     let code: u32;
-    let src: i32;
-    let i: i32;
-    let _licm_used_14: i32;
-    let _licm_repr_15: ref builtin::array<u8>;
     b0 = builtin::array_get_u8(self.repr, byte_index);
     char_len = (if b0 <u 128 -> i32 {
         1;
@@ -514,22 +510,7 @@ fn "core:prelude/string.wado/String::remove_unchecked"(self, byte_index) {
         b3 = builtin::array_get_u8(self.repr, byte_index + 3);
         ((((b0 & 7) << 18) | ((b1_7 & 63) << 12)) | ((b2_8 & 63) << 6)) | (b3 & 63);
     });
-    src = byte_index + char_len;
-    __for_10: block {
-        i = src;
-        _licm_used_14 = self.used;
-        _licm_repr_15 = self.repr;
-        block {
-            l39: loop {
-                if i >= _licm_used_14 {
-                    break __for_10;
-                }
-                builtin::array_set_u8(_licm_repr_15, i - char_len, builtin::array_get_u8(_licm_repr_15, i));
-                i = i + 1;
-                continue l39;
-            };
-        };
-    };
+    builtin::array_copy<u8>(self.repr, byte_index, self.repr, byte_index + char_len, (self.used - byte_index) - char_len);
     self.used = self.used - char_len;
     return code;
 }
@@ -541,13 +522,13 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
         i = 0;
         _licm_buf_4 = self.buf;
         block {
-            l42: loop {
+            l39: loop {
                 if i >= n {
                     break __for_0;
                 }
                 "core:prelude/string.wado/String::push"(_licm_buf_4, c);
                 i = i + 1;
-                continue l42;
+                continue l39;
             };
         };
     };

--- a/wado-compiler/tests/generated/fixtures/struct_literal_string_key_keyword.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/struct_literal_string_key_keyword.wir.wado
@@ -1070,9 +1070,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,i32>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,i32>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1081,21 +1078,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l95: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(old_repr, i));
-                i = i + 1;
-                continue l95;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1270,9 +1253,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1281,21 +1261,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l121: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(old_repr, i));
-                i = i + 1;
-                continue l121;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/struct_literal_string_key_treemap.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/struct_literal_string_key_treemap.wir.wado
@@ -1441,9 +1441,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1452,21 +1449,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:prelude/string.wado/String>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l124: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:prelude/string.wado/String>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:prelude/string.wado/String>">(old_repr, i));
-                i = i + 1;
-                continue l124;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:prelude/string.wado/String>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1631,9 +1614,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,i32>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,i32>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1642,21 +1622,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l149: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(old_repr, i));
-                i = i + 1;
-                continue l149;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1831,9 +1797,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1842,21 +1805,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l175: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(old_repr, i));
-                i = i + 1;
-                continue l175;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/template_string_option_loop.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/template_string_option_loop.wir.wado
@@ -784,9 +784,6 @@ fn "core:prelude/array.wado/Array<wado-compiler/tests/fixtures/template_string_o
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<wado-compiler/tests/fixtures/template_string_option_loop.wado/Case>";
-    let old_repr: ref "builtin::array<wado-compiler/tests/fixtures/template_string_option_loop.wado/Case>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -795,21 +792,7 @@ fn "core:prelude/array.wado/Array<wado-compiler/tests/fixtures/template_string_o
         unreachable;
     };
     new_repr = builtin::array_new<ref "wado-compiler/tests/fixtures/template_string_option_loop.wado//Case">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l71: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "wado-compiler/tests/fixtures/template_string_option_loop.wado//Case">(new_repr, i, builtin::array_get<ref "wado-compiler/tests/fixtures/template_string_option_loop.wado//Case">(old_repr, i));
-                i = i + 1;
-                continue l71;
-            };
-        };
-    };
+    builtin::array_copy<ref "wado-compiler/tests/fixtures/template_string_option_loop.wado//Case">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/temporary_mut_array_arg.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/temporary_mut_array_arg.wir.wado
@@ -536,9 +536,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,i32>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,i32>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -547,21 +544,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[String, i32]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l53: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[String, i32]">(new_repr, i, builtin::array_get<ref "tuple//[String, i32]">(old_repr, i));
-                i = i + 1;
-                continue l53;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[String, i32]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/tmpl_hoist_escape_unsafe.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/tmpl_hoist_escape_unsafe.wir.wado
@@ -1133,9 +1133,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,i32>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,i32>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1144,21 +1141,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l104: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(old_repr, i));
-                i = i + 1;
-                continue l104;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1333,9 +1316,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1344,21 +1324,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l130: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(old_repr, i));
-                i = i + 1;
-                continue l130;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/trait_bound_4.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/trait_bound_4.wir.wado
@@ -599,7 +599,7 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<i32>>^Eq::eq"(se
     if self.used != other.used {
         return 0;
     }
-    __for_9: block {
+    __for_3: block {
         i = 0;
         _licm_used_3 = self.used;
         _licm_repr_4 = self.repr;
@@ -607,7 +607,7 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<i32>>^Eq::eq"(se
         block {
             l45: loop {
                 if i >= _licm_used_3 {
-                    break __for_9;
+                    break __for_3;
                 }
                 if "core:prelude/array.wado/Array<i32>^Eq::eq"(builtin::array_get<ref "core:prelude//Array<i32>">(_licm_repr_4, i), builtin::array_get<ref "core:prelude//Array<i32>">(_licm_repr_5, i)) == 0 {
                     return 0;
@@ -628,7 +628,7 @@ fn "core:prelude/array.wado/Array<i32>^Eq::eq"(self, other) {
     if self.used != other.used {
         return 0;
     }
-    __for_9: block {
+    __for_3: block {
         i = 0;
         _licm_used_3 = self.used;
         _licm_repr_4 = self.repr;
@@ -636,7 +636,7 @@ fn "core:prelude/array.wado/Array<i32>^Eq::eq"(self, other) {
         block {
             l50: loop {
                 if i >= _licm_used_3 {
-                    break __for_9;
+                    break __for_3;
                 }
                 if builtin::array_get<i32>(_licm_repr_4, i) != builtin::array_get<i32>(_licm_repr_5, i) {
                     return 0;

--- a/wado-compiler/tests/generated/fixtures/treemap_btree.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/treemap_btree.wir.wado
@@ -1031,9 +1031,6 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let old_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1042,21 +1039,7 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude/string.wado//String">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l80: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude/string.wado//String">(new_repr, i, builtin::array_get<ref "core:prelude/string.wado//String">(old_repr, i));
-                i = i + 1;
-                continue l80;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude/string.wado//String">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1076,8 +1059,8 @@ fn "wado-compiler/tests/fixtures/treemap_btree.wado/TreeMap<core:prelude/string.
         _licm_keys_33 = node.keys;
         _licm_used_34 = _licm_keys_33.used;
         _licm_repr_35 = _licm_keys_33.repr;
-        b83: block {
-            l84: loop {
+        b80: block {
+            l81: loop {
                 if (if pos_4 < _licm_used_34 -> i32 {
                     "core:prelude/string.wado/String^Ord::cmp"(__inline_Array_core_prelude_string_wado_String__IndexValue_i32___index_value_1: block -> ref "core:prelude/string.wado//String" {
                         if pos_4 >= _licm_used_34 {
@@ -1090,10 +1073,10 @@ fn "wado-compiler/tests/fixtures/treemap_btree.wado/TreeMap<core:prelude/string.
                 } else {
                     0;
                 }) == 0 {
-                    break b83;
+                    break b80;
                 }
                 pos_4 = pos_4 + 1;
-                continue l84;
+                continue l81;
             };
         };
         if (if pos_4 < node.keys.used -> i32 {
@@ -1148,8 +1131,8 @@ fn "wado-compiler/tests/fixtures/treemap_btree.wado/TreeMap<core:prelude/string.
         _licm_keys_36 = node.keys;
         _licm_used_37 = _licm_keys_36.used;
         _licm_repr_38 = _licm_keys_36.repr;
-        b96: block {
-            l97: loop {
+        b93: block {
+            l94: loop {
                 if (if pos_5 < _licm_used_37 -> i32 {
                     "core:prelude/string.wado/String^Ord::cmp"(key, __inline_Array_core_prelude_string_wado_String__IndexValue_i32___index_value_9: block -> ref "core:prelude/string.wado//String" {
                         if pos_5 >= _licm_used_37 {
@@ -1162,10 +1145,10 @@ fn "wado-compiler/tests/fixtures/treemap_btree.wado/TreeMap<core:prelude/string.
                 } else {
                     0;
                 }) == 0 {
-                    break b96;
+                    break b93;
                 }
                 pos_5 = pos_5 + 1;
-                continue l97;
+                continue l94;
             };
         };
         if "wado-compiler/tests/fixtures/treemap_btree.wado/BTreeNode<core:prelude/string.wado/String,i32>::is_full"(__inline_Array__mut_wado_compiler_tests_fixtures_treemap_btree_wado_BTreeNode_core_prelude_string_wado_String_i32___IndexValue_i32___index_value_10: block -> ref "wado-compiler/tests/fixtures/treemap_btree.wado//BTreeNode<core:prelude/string.wado/String,i32>" {
@@ -1250,7 +1233,7 @@ fn "wado-compiler/tests/fixtures/treemap_btree.wado/TreeMap<core:prelude/string.
         _licm_used_39 = _licm_deleted_34.used;
         _licm_repr_40 = _licm_deleted_34.repr;
         block {
-            l108: loop {
+            l105: loop {
                 if i_6 >= _licm_used_35 {
                     break __for_3;
                 }
@@ -1272,7 +1255,7 @@ fn "wado-compiler/tests/fixtures/treemap_btree.wado/TreeMap<core:prelude/string.
                     unreachable;
                 });
                 i_6 = i_6 + 1;
-                continue l108;
+                continue l105;
             };
         };
     };
@@ -1284,13 +1267,13 @@ fn "wado-compiler/tests/fixtures/treemap_btree.wado/TreeMap<core:prelude/string.
             _licm_used_43 = _licm_children_41.used;
             _licm_repr_44 = _licm_children_41.repr;
             block {
-                l114: loop {
+                l111: loop {
                     if i_7 >= _licm_used_43 {
                         break __for_4;
                     }
                     "core:prelude/array.wado/Array<&mut wado-compiler/tests/fixtures/treemap_btree.wado/BTreeNode<core:prelude/string.wado/String,i32>>::push"(_licm_children_42, builtin::array_get<ref "wado-compiler/tests/fixtures/treemap_btree.wado//BTreeNode<core:prelude/string.wado/String,i32>">(_licm_repr_44, i_7));
                     i_7 = i_7 + 1;
-                    continue l114;
+                    continue l111;
                 };
             };
         };
@@ -1377,7 +1360,7 @@ fn "wado-compiler/tests/fixtures/treemap_btree.wado/BTreeNode<core:prelude/strin
         _licm_used_10 = _licm_deleted_8.used;
         _licm_repr_11 = _licm_deleted_8.repr;
         block {
-            l121: loop {
+            l118: loop {
                 if i >= _licm_used_9 {
                     break __for_0;
                 }
@@ -1390,7 +1373,7 @@ fn "wado-compiler/tests/fixtures/treemap_btree.wado/BTreeNode<core:prelude/strin
                     unreachable;
                 } == 0);
                 i = i + 1;
-                continue l121;
+                continue l118;
             };
         };
     };
@@ -1452,8 +1435,8 @@ fn "wado-compiler/tests/fixtures/treemap_btree.wado/TreeMap<core:prelude/string.
     _licm_keys_19 = node.keys;
     _licm_used_20 = _licm_keys_19.used;
     _licm_repr_21 = _licm_keys_19.repr;
-    b126: block {
-        l127: loop {
+    b123: block {
+        l124: loop {
             if (if i < _licm_used_20 -> i32 {
                 "core:prelude/string.wado/String^Ord::cmp"(key, __inline_Array_core_prelude_string_wado_String__IndexValue_i32___index_value_1: block -> ref "core:prelude/string.wado//String" {
                     if i >= _licm_used_20 {
@@ -1466,10 +1449,10 @@ fn "wado-compiler/tests/fixtures/treemap_btree.wado/TreeMap<core:prelude/string.
             } else {
                 0;
             }) == 0 {
-                break b126;
+                break b123;
             }
             i = i + 1;
-            continue l127;
+            continue l124;
         };
     };
     if (if i < node.keys.used -> i32 {
@@ -1535,8 +1518,8 @@ fn "wado-compiler/tests/fixtures/treemap_btree.wado/TreeMap<core:prelude/string.
     _licm_keys_20 = node.keys;
     _licm_used_21 = _licm_keys_20.used;
     _licm_repr_22 = _licm_keys_20.repr;
-    b140: block {
-        l141: loop {
+    b137: block {
+        l138: loop {
             if (if i < _licm_used_21 -> i32 {
                 "core:prelude/string.wado/String^Ord::cmp"(key, __inline_Array_core_prelude_string_wado_String__IndexValue_i32___index_value_1: block -> ref "core:prelude/string.wado//String" {
                     if i >= _licm_used_21 {
@@ -1549,10 +1532,10 @@ fn "wado-compiler/tests/fixtures/treemap_btree.wado/TreeMap<core:prelude/string.
             } else {
                 0;
             }) == 0 {
-                break b140;
+                break b137;
             }
             i = i + 1;
-            continue l141;
+            continue l138;
         };
     };
     if (if i < node.keys.used -> i32 {
@@ -1636,10 +1619,10 @@ fn "wado-compiler/tests/fixtures/treemap_btree.wado/TreeMap<core:prelude/string.
     _licm_repr_27 = _licm_keys_17.repr;
     _licm_used_28 = _licm_values_21.used;
     _licm_repr_29 = _licm_values_21.repr;
-    b154: block {
-        l155: loop {
+    b151: block {
+        l152: loop {
             if i >= _licm_used_22 {
-                break b154;
+                break b151;
             }
             if (if _licm_is_leaf_18 == 0 -> i32 {
                 i < _licm_used_23;
@@ -1673,7 +1656,7 @@ fn "wado-compiler/tests/fixtures/treemap_btree.wado/TreeMap<core:prelude/string.
                 } });
             }
             i = i + 1;
-            continue l155;
+            continue l152;
         };
     };
     if (if node.is_leaf == 0 -> i32 {
@@ -1740,7 +1723,7 @@ fn "wado-compiler/tests/fixtures/treemap_btree.wado/BTreeNode<core:prelude/strin
         _licm_used_35 = _licm_values_30.used;
         _licm_repr_36 = _licm_values_30.repr;
         block {
-            l167: loop {
+            l164: loop {
                 if i_7 >= _licm_used_31 {
                     break __for_1;
                 }
@@ -1764,7 +1747,7 @@ fn "wado-compiler/tests/fixtures/treemap_btree.wado/BTreeNode<core:prelude/strin
                     "core:prelude/array.wado/Array<bool>::push"(new_deleted, 0);
                 }
                 i_7 = i_7 + 1;
-                continue l167;
+                continue l164;
             };
         };
     };
@@ -1778,13 +1761,13 @@ fn "wado-compiler/tests/fixtures/treemap_btree.wado/BTreeNode<core:prelude/strin
             _licm_used_38 = _licm_children_37.used;
             _licm_repr_39 = _licm_children_37.repr;
             block {
-                l174: loop {
+                l171: loop {
                     if i_8 >= _licm_used_38 {
                         break __for_2;
                     }
                     "wado-compiler/tests/fixtures/treemap_btree.wado/BTreeNode<core:prelude/string.wado/String,i32>::compact"(builtin::array_get<ref "wado-compiler/tests/fixtures/treemap_btree.wado//BTreeNode<core:prelude/string.wado/String,i32>">(_licm_repr_39, i_8));
                     i_8 = i_8 + 1;
-                    continue l174;
+                    continue l171;
                 };
             };
         };
@@ -1805,9 +1788,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1816,21 +1796,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l178: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l178;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1838,9 +1804,6 @@ fn "core:prelude/array.wado/Array<bool>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<bool>;
-    let old_repr: ref builtin::array<bool>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1849,21 +1812,7 @@ fn "core:prelude/array.wado/Array<bool>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<bool>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l181: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<bool>(new_repr, i, builtin::array_get<bool>(old_repr, i));
-                i = i + 1;
-                continue l181;
-            };
-        };
-    };
+    builtin::array_copy<bool>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1871,9 +1820,6 @@ fn "core:prelude/array.wado/Array<&mut wado-compiler/tests/fixtures/treemap_btre
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<&mut wado-compiler/tests/fixtures/treemap_btree.wado/BTreeNode<core:prelude/string.wado/String,i32>>";
-    let old_repr: ref "builtin::array<&mut wado-compiler/tests/fixtures/treemap_btree.wado/BTreeNode<core:prelude/string.wado/String,i32>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1882,21 +1828,7 @@ fn "core:prelude/array.wado/Array<&mut wado-compiler/tests/fixtures/treemap_btre
         unreachable;
     };
     new_repr = builtin::array_new<ref "wado-compiler/tests/fixtures/treemap_btree.wado//BTreeNode<core:prelude/string.wado/String,i32>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l184: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "wado-compiler/tests/fixtures/treemap_btree.wado//BTreeNode<core:prelude/string.wado/String,i32>">(new_repr, i, builtin::array_get<ref "wado-compiler/tests/fixtures/treemap_btree.wado//BTreeNode<core:prelude/string.wado/String,i32>">(old_repr, i));
-                i = i + 1;
-                continue l184;
-            };
-        };
-    };
+    builtin::array_copy<ref "wado-compiler/tests/fixtures/treemap_btree.wado//BTreeNode<core:prelude/string.wado/String,i32>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1930,14 +1862,14 @@ fn "wado-compiler/tests/fixtures/treemap_btree.wado/TreeMap<core:prelude/string.
         _licm_used_49 = _licm_deleted_44.used;
         _licm_repr_50 = _licm_deleted_44.repr;
         block {
-            l187: loop {
+            l175: loop {
                 if i >= _licm_used_45 {
                     break __for_5;
                 }
                 __for_6: block {
                     j = i + 1;
                     block {
-                        l190: loop {
+                        l178: loop {
                             if j >= _licm_used_45 {
                                 break __for_6;
                             }
@@ -2000,12 +1932,12 @@ fn "wado-compiler/tests/fixtures/treemap_btree.wado/TreeMap<core:prelude/string.
                                 builtin::array_set<bool>(_licm_repr_50, j, temp_d);
                             }
                             j = j + 1;
-                            continue l190;
+                            continue l178;
                         };
                     };
                 };
                 i = i + 1;
-                continue l187;
+                continue l175;
             };
         };
     };
@@ -2015,9 +1947,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,i32>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,i32>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -2026,21 +1955,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[String, i32]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l202: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[String, i32]">(new_repr, i, builtin::array_get<ref "tuple//[String, i32]">(old_repr, i));
-                i = i + 1;
-                continue l202;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[String, i32]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/treemap_btree2.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/treemap_btree2.wir.wado
@@ -1065,9 +1065,6 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let old_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1076,21 +1073,7 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude/string.wado//String">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l82: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude/string.wado//String">(new_repr, i, builtin::array_get<ref "core:prelude/string.wado//String">(old_repr, i));
-                i = i + 1;
-                continue l82;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude/string.wado//String">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1143,8 +1126,8 @@ fn "wado-compiler/tests/fixtures/treemap_btree2.wado/TreeMap<core:prelude/string
     _licm_keys_20 = node.keys;
     _licm_used_21 = _licm_keys_20.used;
     _licm_repr_22 = _licm_keys_20.repr;
-    b88: block {
-        l89: loop {
+    b85: block {
+        l86: loop {
             if (if i < _licm_used_21 -> i32 {
                 "core:prelude/string.wado/String^Ord::cmp"(key, __inline_Array_core_prelude_string_wado_String__IndexValue_i32___index_value_1: block -> ref "core:prelude/string.wado//String" {
                     if i >= _licm_used_21 {
@@ -1157,10 +1140,10 @@ fn "wado-compiler/tests/fixtures/treemap_btree2.wado/TreeMap<core:prelude/string
             } else {
                 0;
             }) == 0 {
-                break b88;
+                break b85;
             }
             i = i + 1;
-            continue l89;
+            continue l86;
         };
     };
     if (if i < node.keys.used -> i32 {
@@ -1244,10 +1227,10 @@ fn "wado-compiler/tests/fixtures/treemap_btree2.wado/TreeMap<core:prelude/string
     _licm_repr_27 = _licm_keys_17.repr;
     _licm_used_28 = _licm_values_21.used;
     _licm_repr_29 = _licm_values_21.repr;
-    b102: block {
-        l103: loop {
+    b99: block {
+        l100: loop {
             if i >= _licm_used_22 {
-                break b102;
+                break b99;
             }
             if (if _licm_is_leaf_18 == 0 -> i32 {
                 i < _licm_used_23;
@@ -1281,7 +1264,7 @@ fn "wado-compiler/tests/fixtures/treemap_btree2.wado/TreeMap<core:prelude/string
                 } });
             }
             i = i + 1;
-            continue l103;
+            continue l100;
         };
     };
     if (if node.is_leaf == 0 -> i32 {
@@ -1348,7 +1331,7 @@ fn "wado-compiler/tests/fixtures/treemap_btree2.wado/BTreeNode<core:prelude/stri
         _licm_used_35 = _licm_values_30.used;
         _licm_repr_36 = _licm_values_30.repr;
         block {
-            l115: loop {
+            l112: loop {
                 if i_7 >= _licm_used_31 {
                     break __for_1;
                 }
@@ -1372,7 +1355,7 @@ fn "wado-compiler/tests/fixtures/treemap_btree2.wado/BTreeNode<core:prelude/stri
                     "core:prelude/array.wado/Array<bool>::push"(new_deleted, 0);
                 }
                 i_7 = i_7 + 1;
-                continue l115;
+                continue l112;
             };
         };
     };
@@ -1386,13 +1369,13 @@ fn "wado-compiler/tests/fixtures/treemap_btree2.wado/BTreeNode<core:prelude/stri
             _licm_used_38 = _licm_children_37.used;
             _licm_repr_39 = _licm_children_37.repr;
             block {
-                l122: loop {
+                l119: loop {
                     if i_8 >= _licm_used_38 {
                         break __for_2;
                     }
                     "wado-compiler/tests/fixtures/treemap_btree2.wado/BTreeNode<core:prelude/string.wado/String,i32>::compact"(builtin::array_get<ref "wado-compiler/tests/fixtures/treemap_btree2.wado//BTreeNode<core:prelude/string.wado/String,i32>">(_licm_repr_39, i_8));
                     i_8 = i_8 + 1;
-                    continue l122;
+                    continue l119;
                 };
             };
         };
@@ -1420,8 +1403,8 @@ fn "wado-compiler/tests/fixtures/treemap_btree2.wado/TreeMap<core:prelude/string
     _licm_keys_19 = node.keys;
     _licm_used_20 = _licm_keys_19.used;
     _licm_repr_21 = _licm_keys_19.repr;
-    b125: block {
-        l126: loop {
+    b122: block {
+        l123: loop {
             if (if i < _licm_used_20 -> i32 {
                 "core:prelude/string.wado/String^Ord::cmp"(key, __inline_Array_core_prelude_string_wado_String__IndexValue_i32___index_value_1: block -> ref "core:prelude/string.wado//String" {
                     if i >= _licm_used_20 {
@@ -1434,10 +1417,10 @@ fn "wado-compiler/tests/fixtures/treemap_btree2.wado/TreeMap<core:prelude/string
             } else {
                 0;
             }) == 0 {
-                break b125;
+                break b122;
             }
             i = i + 1;
-            continue l126;
+            continue l123;
         };
     };
     if (if i < node.keys.used -> i32 {
@@ -1508,8 +1491,8 @@ fn "wado-compiler/tests/fixtures/treemap_btree2.wado/TreeMap<core:prelude/string
         _licm_keys_33 = node.keys;
         _licm_used_34 = _licm_keys_33.used;
         _licm_repr_35 = _licm_keys_33.repr;
-        b140: block {
-            l141: loop {
+        b137: block {
+            l138: loop {
                 if (if pos_4 < _licm_used_34 -> i32 {
                     "core:prelude/string.wado/String^Ord::cmp"(__inline_Array_core_prelude_string_wado_String__IndexValue_i32___index_value_1: block -> ref "core:prelude/string.wado//String" {
                         if pos_4 >= _licm_used_34 {
@@ -1522,10 +1505,10 @@ fn "wado-compiler/tests/fixtures/treemap_btree2.wado/TreeMap<core:prelude/string
                 } else {
                     0;
                 }) == 0 {
-                    break b140;
+                    break b137;
                 }
                 pos_4 = pos_4 + 1;
-                continue l141;
+                continue l138;
             };
         };
         if (if pos_4 < node.keys.used -> i32 {
@@ -1580,8 +1563,8 @@ fn "wado-compiler/tests/fixtures/treemap_btree2.wado/TreeMap<core:prelude/string
         _licm_keys_36 = node.keys;
         _licm_used_37 = _licm_keys_36.used;
         _licm_repr_38 = _licm_keys_36.repr;
-        b153: block {
-            l154: loop {
+        b150: block {
+            l151: loop {
                 if (if pos_5 < _licm_used_37 -> i32 {
                     "core:prelude/string.wado/String^Ord::cmp"(key, __inline_Array_core_prelude_string_wado_String__IndexValue_i32___index_value_9: block -> ref "core:prelude/string.wado//String" {
                         if pos_5 >= _licm_used_37 {
@@ -1594,10 +1577,10 @@ fn "wado-compiler/tests/fixtures/treemap_btree2.wado/TreeMap<core:prelude/string
                 } else {
                     0;
                 }) == 0 {
-                    break b153;
+                    break b150;
                 }
                 pos_5 = pos_5 + 1;
-                continue l154;
+                continue l151;
             };
         };
         if "wado-compiler/tests/fixtures/treemap_btree2.wado/BTreeNode<core:prelude/string.wado/String,i32>::is_full"(__inline_Array__mut_wado_compiler_tests_fixtures_treemap_btree2_wado_BTreeNode_core_prelude_string_wado_String_i32___IndexValue_i32___index_value_10: block -> ref "wado-compiler/tests/fixtures/treemap_btree2.wado//BTreeNode<core:prelude/string.wado/String,i32>" {
@@ -1682,7 +1665,7 @@ fn "wado-compiler/tests/fixtures/treemap_btree2.wado/TreeMap<core:prelude/string
         _licm_used_39 = _licm_deleted_34.used;
         _licm_repr_40 = _licm_deleted_34.repr;
         block {
-            l165: loop {
+            l162: loop {
                 if i_6 >= _licm_used_35 {
                     break __for_3;
                 }
@@ -1704,7 +1687,7 @@ fn "wado-compiler/tests/fixtures/treemap_btree2.wado/TreeMap<core:prelude/string
                     unreachable;
                 });
                 i_6 = i_6 + 1;
-                continue l165;
+                continue l162;
             };
         };
     };
@@ -1716,13 +1699,13 @@ fn "wado-compiler/tests/fixtures/treemap_btree2.wado/TreeMap<core:prelude/string
             _licm_used_43 = _licm_children_41.used;
             _licm_repr_44 = _licm_children_41.repr;
             block {
-                l171: loop {
+                l168: loop {
                     if i_7 >= _licm_used_43 {
                         break __for_4;
                     }
                     "core:prelude/array.wado/Array<&mut wado-compiler/tests/fixtures/treemap_btree2.wado/BTreeNode<core:prelude/string.wado/String,i32>>::push"(_licm_children_42, builtin::array_get<ref "wado-compiler/tests/fixtures/treemap_btree2.wado//BTreeNode<core:prelude/string.wado/String,i32>">(_licm_repr_44, i_7));
                     i_7 = i_7 + 1;
-                    continue l171;
+                    continue l168;
                 };
             };
         };
@@ -1809,7 +1792,7 @@ fn "wado-compiler/tests/fixtures/treemap_btree2.wado/BTreeNode<core:prelude/stri
         _licm_used_10 = _licm_deleted_8.used;
         _licm_repr_11 = _licm_deleted_8.repr;
         block {
-            l178: loop {
+            l175: loop {
                 if i >= _licm_used_9 {
                     break __for_0;
                 }
@@ -1822,7 +1805,7 @@ fn "wado-compiler/tests/fixtures/treemap_btree2.wado/BTreeNode<core:prelude/stri
                     unreachable;
                 } == 0);
                 i = i + 1;
-                continue l178;
+                continue l175;
             };
         };
     };
@@ -1877,9 +1860,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1888,21 +1868,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l184: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l184;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1910,9 +1876,6 @@ fn "core:prelude/array.wado/Array<bool>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<bool>;
-    let old_repr: ref builtin::array<bool>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1921,21 +1884,7 @@ fn "core:prelude/array.wado/Array<bool>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<bool>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l187: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<bool>(new_repr, i, builtin::array_get<bool>(old_repr, i));
-                i = i + 1;
-                continue l187;
-            };
-        };
-    };
+    builtin::array_copy<bool>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1943,9 +1892,6 @@ fn "core:prelude/array.wado/Array<&mut wado-compiler/tests/fixtures/treemap_btre
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<&mut wado-compiler/tests/fixtures/treemap_btree2.wado/BTreeNode<core:prelude/string.wado/String,i32>>";
-    let old_repr: ref "builtin::array<&mut wado-compiler/tests/fixtures/treemap_btree2.wado/BTreeNode<core:prelude/string.wado/String,i32>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1954,21 +1900,7 @@ fn "core:prelude/array.wado/Array<&mut wado-compiler/tests/fixtures/treemap_btre
         unreachable;
     };
     new_repr = builtin::array_new<ref "wado-compiler/tests/fixtures/treemap_btree2.wado//BTreeNode<core:prelude/string.wado/String,i32>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l190: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "wado-compiler/tests/fixtures/treemap_btree2.wado//BTreeNode<core:prelude/string.wado/String,i32>">(new_repr, i, builtin::array_get<ref "wado-compiler/tests/fixtures/treemap_btree2.wado//BTreeNode<core:prelude/string.wado/String,i32>">(old_repr, i));
-                i = i + 1;
-                continue l190;
-            };
-        };
-    };
+    builtin::array_copy<ref "wado-compiler/tests/fixtures/treemap_btree2.wado//BTreeNode<core:prelude/string.wado/String,i32>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -2002,14 +1934,14 @@ fn "wado-compiler/tests/fixtures/treemap_btree2.wado/TreeMap<core:prelude/string
         _licm_used_49 = _licm_deleted_44.used;
         _licm_repr_50 = _licm_deleted_44.repr;
         block {
-            l193: loop {
+            l181: loop {
                 if i >= _licm_used_45 {
                     break __for_5;
                 }
                 __for_6: block {
                     j = i + 1;
                     block {
-                        l196: loop {
+                        l184: loop {
                             if j >= _licm_used_45 {
                                 break __for_6;
                             }
@@ -2072,12 +2004,12 @@ fn "wado-compiler/tests/fixtures/treemap_btree2.wado/TreeMap<core:prelude/string
                                 builtin::array_set<bool>(_licm_repr_50, j, temp_d);
                             }
                             j = j + 1;
-                            continue l196;
+                            continue l184;
                         };
                     };
                 };
                 i = i + 1;
-                continue l193;
+                continue l181;
             };
         };
     };
@@ -2087,9 +2019,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,i32>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,i32>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -2098,21 +2027,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[String, i32]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l208: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[String, i32]">(new_repr, i, builtin::array_get<ref "tuple//[String, i32]">(old_repr, i));
-                i = i + 1;
-                continue l208;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[String, i32]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/treemap_literal_basic.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/treemap_literal_basic.wir.wado
@@ -1189,9 +1189,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,i32>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,i32>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1200,21 +1197,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l103: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(old_repr, i));
-                i = i + 1;
-                continue l103;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1389,9 +1372,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1400,21 +1380,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l129: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(old_repr, i));
-                i = i + 1;
-                continue l129;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/treemap_literal_cast.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/treemap_literal_cast.wir.wado
@@ -1084,9 +1084,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,i32>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,i32>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1095,21 +1092,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l95: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(old_repr, i));
-                i = i + 1;
-                continue l95;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1284,9 +1267,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1295,21 +1275,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l121: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(old_repr, i));
-                i = i + 1;
-                continue l121;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/treemap_literal_fn_arg.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/treemap_literal_fn_arg.wir.wado
@@ -994,9 +994,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,i32>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,i32>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1005,21 +1002,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[String, i32]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l89: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[String, i32]">(new_repr, i, builtin::array_get<ref "tuple//[String, i32]">(old_repr, i));
-                i = i + 1;
-                continue l89;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[String, i32]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1027,9 +1010,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,i32>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,i32>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1038,21 +1018,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l92: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(old_repr, i));
-                i = i + 1;
-                continue l92;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1227,9 +1193,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1238,21 +1201,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l118: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(old_repr, i));
-                i = i + 1;
-                continue l118;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/treemap_literal_mutable.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/treemap_literal_mutable.wir.wado
@@ -1080,9 +1080,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,i32>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,i32>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1091,21 +1088,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l95: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(old_repr, i));
-                i = i + 1;
-                continue l95;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,i32>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1280,9 +1263,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1291,21 +1271,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l121: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(old_repr, i));
-                i = i + 1;
-                continue l121;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/treemap_literal_string_values.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/treemap_literal_string_values.wir.wado
@@ -1137,9 +1137,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1148,21 +1145,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:prelude/string.wado/String>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l99: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:prelude/string.wado/String>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:prelude/string.wado/String>">(old_repr, i));
-                i = i + 1;
-                continue l99;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,core:prelude/string.wado/String>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1337,9 +1320,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1348,21 +1328,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l125: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(old_repr, i));
-                i = i + 1;
-                continue l125;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/treeset_mut_ref_deep.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/treeset_mut_ref_deep.wir.wado
@@ -1176,9 +1176,6 @@ fn "core:prelude/array.wado/Array<wado-compiler/tests/fixtures/treeset_mut_ref_d
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<wado-compiler/tests/fixtures/treeset_mut_ref_deep.wado/LitToken>";
-    let old_repr: ref "builtin::array<wado-compiler/tests/fixtures/treeset_mut_ref_deep.wado/LitToken>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1187,21 +1184,7 @@ fn "core:prelude/array.wado/Array<wado-compiler/tests/fixtures/treeset_mut_ref_d
         unreachable;
     };
     new_repr = builtin::array_new<ref "wado-compiler/tests/fixtures/treeset_mut_ref_deep.wado//LitToken">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l91: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "wado-compiler/tests/fixtures/treeset_mut_ref_deep.wado//LitToken">(new_repr, i, builtin::array_get<ref "wado-compiler/tests/fixtures/treeset_mut_ref_deep.wado//LitToken">(old_repr, i));
-                i = i + 1;
-                continue l91;
-            };
-        };
-    };
+    builtin::array_copy<ref "wado-compiler/tests/fixtures/treeset_mut_ref_deep.wado//LitToken">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1327,8 +1310,8 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,()>::find_index"(se
     _licm_used_17 = _licm_entries_14.used;
     _licm_repr_18 = _licm_entries_14.repr;
     _licm_used_23 = key.used;
-    b105: block {
-        l106: loop {
+    b102: block {
+        l103: loop {
             let __match_scrut_0: ref "core:prelude/types.wado//Option<i32>";
             __match_scrut_0 = current;
             if ref.test "core:prelude/types.wado//Option<i32>::Some"(__match_scrut_0) {
@@ -1368,9 +1351,9 @@ fn "core:collections/TreeMap<core:prelude/string.wado/String,()>::find_index"(se
                     current = n.right;
                 }
             } else {
-                break b105;
+                break b102;
             }
-            continue l106;
+            continue l103;
         };
     };
     return -1;
@@ -1380,9 +1363,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,()>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapEntry<core:prelude/string.wado/String,()>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1391,21 +1371,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapEntry<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,()>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l115: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,()>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,()>">(old_repr, i));
-                i = i + 1;
-                continue l115;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapEntry<core:prelude/string.wado/String,()>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1580,9 +1546,6 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:collections/TreeMapNode<core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1591,21 +1554,7 @@ fn "core:prelude/array.wado/Array<core:collections/TreeMapNode<core:prelude/stri
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l141: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, i, builtin::array_get<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(old_repr, i));
-                i = i + 1;
-                continue l141;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:collections//TreeMapNode<core:prelude/string.wado/String>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/tuple_for_of.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/tuple_for_of.wir.wado
@@ -3241,9 +3241,6 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let old_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -3252,21 +3249,7 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude/string.wado//String">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l277: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude/string.wado//String">(new_repr, i, builtin::array_get<ref "core:prelude/string.wado//String">(old_repr, i));
-                i = i + 1;
-                continue l277;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude/string.wado//String">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -3274,9 +3257,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -3285,21 +3265,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l280: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l280;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/u64_arithmetic.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/u64_arithmetic.wir.wado
@@ -775,9 +775,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -786,21 +783,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l59: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l59;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/value_copy_demote.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/value_copy_demote.wir.wado
@@ -668,18 +668,18 @@ fn "wado-compiler/tests/fixtures/value_copy_demote.wado/Array<core:prelude/strin
     src = self.repr;
     buf = builtin::array_new<ref "core:prelude/string.wado//String">(n);
     width = 1;
-    __for_11: block {
+    __for_5: block {
         block {
             l65: loop {
                 if width >= n {
-                    break __for_11;
+                    break __for_5;
                 }
-                __for_12: block {
+                __for_6: block {
                     start = 0;
                     block {
                         l68: loop {
                             if start >= n {
-                                break __for_12;
+                                break __for_6;
                             }
                             mid = start + width;
                             if mid < n {
@@ -690,12 +690,12 @@ fn "wado-compiler/tests/fixtures/value_copy_demote.wado/Array<core:prelude/strin
                                 };
                                 i = start;
                                 j = mid;
-                                __for_13: block {
+                                __for_7: block {
                                     k = start;
                                     block {
                                         l72: loop {
                                             if k >= end {
-                                                break __for_13;
+                                                break __for_7;
                                             }
                                             if i < mid {
                                                 if j < end {

--- a/wado-compiler/tests/generated/fixtures/value_copy_demote_mixed_sites.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/value_copy_demote_mixed_sites.wir.wado
@@ -424,18 +424,18 @@ fn "wado-compiler/tests/fixtures/value_copy_demote_mixed_sites.wado/Array<core:p
     src = self.repr;
     buf = builtin::array_new<ref "core:prelude/string.wado//String">(n);
     width = 1;
-    __for_11: block {
+    __for_5: block {
         block {
             l26: loop {
                 if width >= n {
-                    break __for_11;
+                    break __for_5;
                 }
-                __for_12: block {
+                __for_6: block {
                     start = 0;
                     block {
                         l29: loop {
                             if start >= n {
-                                break __for_12;
+                                break __for_6;
                             }
                             mid = start + width;
                             if mid < n {
@@ -446,12 +446,12 @@ fn "wado-compiler/tests/fixtures/value_copy_demote_mixed_sites.wado/Array<core:p
                                 };
                                 i = start;
                                 j = mid;
-                                __for_13: block {
+                                __for_7: block {
                                     k = start;
                                     block {
                                         l33: loop {
                                             if k >= end {
-                                                break __for_13;
+                                                break __for_7;
                                             }
                                             if i < mid {
                                                 if j < end {

--- a/wado-compiler/tests/generated/fixtures/value_copy_nested_array_helper_chain.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/value_copy_nested_array_helper_chain.wir.wado
@@ -3241,9 +3241,6 @@ fn "core:prelude/array.wado/Array<wado-compiler/tests/fixtures/value_copy_nested
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<wado-compiler/tests/fixtures/value_copy_nested_array_helper_chain.wado/Item>";
-    let old_repr: ref "builtin::array<wado-compiler/tests/fixtures/value_copy_nested_array_helper_chain.wado/Item>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -3252,21 +3249,7 @@ fn "core:prelude/array.wado/Array<wado-compiler/tests/fixtures/value_copy_nested
         unreachable;
     };
     new_repr = builtin::array_new<ref "wado-compiler/tests/fixtures/value_copy_nested_array_helper_chain.wado//Item">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l368: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "wado-compiler/tests/fixtures/value_copy_nested_array_helper_chain.wado//Item">(new_repr, i, builtin::array_get<ref "wado-compiler/tests/fixtures/value_copy_nested_array_helper_chain.wado//Item">(old_repr, i));
-                i = i + 1;
-                continue l368;
-            };
-        };
-    };
+    builtin::array_copy<ref "wado-compiler/tests/fixtures/value_copy_nested_array_helper_chain.wado//Item">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -3290,8 +3273,8 @@ fn "wado-compiler/tests/fixtures/value_copy_nested_array_helper_chain.wado/Geom^
             break __inline_Array_core_prelude_array_wado_Array_core_prelude_array_wado_Array_f64____Default__default_0____seq_lit: __b;
             unreachable;
         };
-        b371: block {
-            l372: loop {
+        b368: block {
+            l369: loop {
                 let __sroa___local_5_discriminant: i32;
                 let __sroa___local_5_case0_payload_0: ref null "core:prelude/types.wado//Option<i32>";
                 let __sroa___local_5_case1_payload_0: ref null "core:serde//DeserializeError";
@@ -3316,12 +3299,12 @@ fn "wado-compiler/tests/fixtures/value_copy_nested_array_helper_chain.wado/Geom^
                             drop("core:json/JsonDeserializer::skip_value"(__local_2.de));
                         }
                     } else {
-                        break b371;
+                        break b368;
                     }
                 } else {
                     return 1, ref.null none, ref.as_non_null(__sroa___local_5_case1_payload_0);
                 }
-                continue l372;
+                continue l369;
             };
         };
         if (__local_3 & 1) != 1 {
@@ -3384,7 +3367,7 @@ fn "core:serde/Array<core:prelude/array.wado/Array<core:prelude/array.wado/Array
         items = struct.new "core:prelude//Array<core:prelude/array.wado/Array<core:prelude/array.wado/Array<f64>>>" { repr: builtin::array_new<ref "core:prelude//Array<core:prelude/array.wado/Array<f64>>">(2), used: 0 };
         "core:prelude/array.wado/Array<core:prelude/array.wado/Array<core:prelude/array.wado/Array<f64>>>::push"(items, first_elem);
         block {
-            l383: loop {
+            l380: loop {
                 let __match_scrut_5: ref "core:prelude/types.wado//Result<core:prelude/types.wado/Option<core:prelude/array.wado/Array<core:prelude/array.wado/Array<f64>>>,core:serde/DeserializeError>";
                 __match_scrut_5 = "core:json/JsonSeqAccess^DeserializeSeq::next_element<core:prelude/array.wado/Array<core:prelude/array.wado/Array<f64>>>"(seq);
                 next_opt = (if ref.test "core:prelude/types.wado//Result<core:prelude/types.wado/Option<core:prelude/array.wado/Array<core:prelude/array.wado/Array<f64>>>,core:serde/DeserializeError>::Ok"(__match_scrut_5) -> ref null "core:prelude//Array<core:prelude/array.wado/Array<f64>>" {
@@ -3406,7 +3389,7 @@ fn "core:serde/Array<core:prelude/array.wado/Array<core:prelude/array.wado/Array
                     }
                     return 0, items, ref.null none;
                 }
-                continue l383;
+                continue l380;
             };
         };
     } else {
@@ -3524,7 +3507,7 @@ fn "core:serde/Array<core:prelude/array.wado/Array<f64>>^Deserialize::deserializ
         items = struct.new "core:prelude//Array<core:prelude/array.wado/Array<f64>>" { repr: builtin::array_new<ref "core:prelude//Array<f64>">(2), used: 0 };
         "core:prelude/array.wado/Array<core:prelude/array.wado/Array<f64>>::push"(items, first_elem);
         block {
-            l399: loop {
+            l396: loop {
                 let __match_scrut_5: ref "core:prelude/types.wado//Result<core:prelude/types.wado/Option<core:prelude/array.wado/Array<f64>>,core:serde/DeserializeError>";
                 __match_scrut_5 = "core:json/JsonSeqAccess^DeserializeSeq::next_element<core:prelude/array.wado/Array<f64>>"(seq);
                 next_opt = (if ref.test "core:prelude/types.wado//Result<core:prelude/types.wado/Option<core:prelude/array.wado/Array<f64>>,core:serde/DeserializeError>::Ok"(__match_scrut_5) -> ref null "core:prelude//Array<f64>" {
@@ -3546,7 +3529,7 @@ fn "core:serde/Array<core:prelude/array.wado/Array<f64>>^Deserialize::deserializ
                     }
                     return struct.new "core:prelude/types.wado//Result<core:prelude/array.wado/Array<core:prelude/array.wado/Array<f64>>,core:serde/DeserializeError>::Ok" { discriminant: 0, payload_0: items };
                 }
-                continue l399;
+                continue l396;
             };
         };
     } else {
@@ -3568,9 +3551,6 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<core:prelude/arr
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/array.wado/Array<core:prelude/array.wado/Array<f64>>>";
-    let old_repr: ref "builtin::array<core:prelude/array.wado/Array<core:prelude/array.wado/Array<f64>>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -3579,21 +3559,7 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<core:prelude/arr
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude//Array<core:prelude/array.wado/Array<f64>>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l405: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude//Array<core:prelude/array.wado/Array<f64>>">(new_repr, i, builtin::array_get<ref "core:prelude//Array<core:prelude/array.wado/Array<f64>>">(old_repr, i));
-                i = i + 1;
-                continue l405;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude//Array<core:prelude/array.wado/Array<f64>>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -3697,7 +3663,7 @@ fn "core:serde/Array<f64>^Deserialize::deserialize<core:json/JsonDeserializer>"(
         items = struct.new "core:prelude//Array<f64>" { repr: builtin::array_new<f64>(2), used: 0 };
         "core:prelude/array.wado/Array<f64>::push"(items, first_elem);
         block {
-            l418: loop {
+            l412: loop {
                 let __match_scrut_5: ref "core:prelude/types.wado//Result<core:prelude/types.wado/Option<f64>,core:serde/DeserializeError>";
                 __match_scrut_5 = "core:json/JsonSeqAccess^DeserializeSeq::next_element<f64>"(seq);
                 next_opt = (if ref.test "core:prelude/types.wado//Result<core:prelude/types.wado/Option<f64>,core:serde/DeserializeError>::Ok"(__match_scrut_5) -> ref "core:prelude/types.wado//Option<f64>" {
@@ -3719,7 +3685,7 @@ fn "core:serde/Array<f64>^Deserialize::deserialize<core:json/JsonDeserializer>"(
                     }
                     return struct.new "core:prelude/types.wado//Result<core:prelude/array.wado/Array<f64>,core:serde/DeserializeError>::Ok" { discriminant: 0, payload_0: items };
                 }
-                continue l418;
+                continue l412;
             };
         };
     } else {
@@ -3741,9 +3707,6 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<f64>>::grow"(sel
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/array.wado/Array<f64>>";
-    let old_repr: ref "builtin::array<core:prelude/array.wado/Array<f64>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -3752,21 +3715,7 @@ fn "core:prelude/array.wado/Array<core:prelude/array.wado/Array<f64>>::grow"(sel
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude//Array<f64>">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l424: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude//Array<f64>">(new_repr, i, builtin::array_get<ref "core:prelude//Array<f64>">(old_repr, i));
-                i = i + 1;
-                continue l424;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude//Array<f64>">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -3829,9 +3778,6 @@ fn "core:prelude/array.wado/Array<f64>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<f64>;
-    let old_repr: ref builtin::array<f64>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -3840,21 +3786,7 @@ fn "core:prelude/array.wado/Array<f64>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<f64>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l433: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<f64>(new_repr, i, builtin::array_get<f64>(old_repr, i));
-                i = i + 1;
-                continue l433;
-            };
-        };
-    };
+    builtin::array_copy<f64>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/value_copy_nested_struct.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/value_copy_nested_struct.wir.wado
@@ -780,9 +780,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -791,21 +788,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l53: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l53;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/variadic_1.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/variadic_1.wir.wado
@@ -2120,9 +2120,6 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let old_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -2131,21 +2128,7 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude/string.wado//String">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l114: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude/string.wado//String">(new_repr, i, builtin::array_get<ref "core:prelude/string.wado//String">(old_repr, i));
-                i = i + 1;
-                continue l114;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude/string.wado//String">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/wasi_cli.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/wasi_cli.wir.wado
@@ -659,9 +659,6 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let old_repr: ref "builtin::array<core:prelude/string.wado/String>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -670,21 +667,7 @@ fn "core:prelude/array.wado/Array<core:prelude/string.wado/String>::grow"(self) 
         unreachable;
     };
     new_repr = builtin::array_new<ref "core:prelude/string.wado//String">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l56: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "core:prelude/string.wado//String">(new_repr, i, builtin::array_get<ref "core:prelude/string.wado//String">(old_repr, i));
-                i = i + 1;
-                continue l56;
-            };
-        };
-    };
+    builtin::array_copy<ref "core:prelude/string.wado//String">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -692,9 +675,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -703,21 +683,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<core:prelude/str
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[String, String]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l59: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[String, String]">(new_repr, i, builtin::array_get<ref "tuple//[String, String]">(old_repr, i));
-                i = i + 1;
-                continue l59;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[String, String]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/wasi_filesystem.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/wasi_filesystem.wir.wado
@@ -610,9 +610,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -621,21 +618,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[Descriptor, String]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l55: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[Descriptor, String]">(new_repr, i, builtin::array_get<ref "tuple//[Descriptor, String]">(old_repr, i));
-                i = i + 1;
-                continue l55;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[Descriptor, String]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/wasi_filesystem_advise_sync.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/wasi_filesystem_advise_sync.wir.wado
@@ -1623,9 +1623,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1634,21 +1631,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[Descriptor, String]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l280: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[Descriptor, String]">(new_repr, i, builtin::array_get<ref "tuple//[Descriptor, String]">(old_repr, i));
-                i = i + 1;
-                continue l280;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[Descriptor, String]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/wasi_filesystem_append_stream.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/wasi_filesystem_append_stream.wir.wado
@@ -920,9 +920,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -931,21 +928,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[Descriptor, String]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l108: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[Descriptor, String]">(new_repr, i, builtin::array_get<ref "tuple//[Descriptor, String]">(old_repr, i));
-                i = i + 1;
-                continue l108;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[Descriptor, String]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/wasi_filesystem_dir_ops.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/wasi_filesystem_dir_ops.wir.wado
@@ -1372,9 +1372,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1383,21 +1380,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[Descriptor, String]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l176: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[Descriptor, String]">(new_repr, i, builtin::array_get<ref "tuple//[Descriptor, String]">(old_repr, i));
-                i = i + 1;
-                continue l176;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[Descriptor, String]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -1405,9 +1388,6 @@ fn "core:prelude/array.wado/Array<wasi:filesystem/types.wado/DirectoryEntry>::gr
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<wasi:filesystem/types.wado/DirectoryEntry>";
-    let old_repr: ref "builtin::array<wasi:filesystem/types.wado/DirectoryEntry>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1416,21 +1396,7 @@ fn "core:prelude/array.wado/Array<wasi:filesystem/types.wado/DirectoryEntry>::gr
         unreachable;
     };
     new_repr = builtin::array_new<ref "wasi:filesystem/types.wado//DirectoryEntry">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l179: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "wasi:filesystem/types.wado//DirectoryEntry">(new_repr, i, builtin::array_get<ref "wasi:filesystem/types.wado//DirectoryEntry">(old_repr, i));
-                i = i + 1;
-                continue l179;
-            };
-        };
-    };
+    builtin::array_copy<ref "wasi:filesystem/types.wado//DirectoryEntry">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/wasi_filesystem_get_type.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/wasi_filesystem_get_type.wir.wado
@@ -1145,9 +1145,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1156,21 +1153,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[Descriptor, String]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l165: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[Descriptor, String]">(new_repr, i, builtin::array_get<ref "tuple//[Descriptor, String]">(old_repr, i));
-                i = i + 1;
-                continue l165;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[Descriptor, String]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/wasi_filesystem_metadata_hash.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/wasi_filesystem_metadata_hash.wir.wado
@@ -1131,9 +1131,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1142,21 +1139,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[Descriptor, String]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l158: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[Descriptor, String]">(new_repr, i, builtin::array_get<ref "tuple//[Descriptor, String]">(old_repr, i));
-                i = i + 1;
-                continue l158;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[Descriptor, String]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/wasi_filesystem_open_at.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/wasi_filesystem_open_at.wir.wado
@@ -736,9 +736,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -747,21 +744,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[Descriptor, String]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l71: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[Descriptor, String]">(new_repr, i, builtin::array_get<ref "tuple//[Descriptor, String]">(old_repr, i));
-                i = i + 1;
-                continue l71;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[Descriptor, String]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/wasi_filesystem_open_flags.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/wasi_filesystem_open_flags.wir.wado
@@ -862,9 +862,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -873,21 +870,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[Descriptor, String]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l110: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[Descriptor, String]">(new_repr, i, builtin::array_get<ref "tuple//[Descriptor, String]">(old_repr, i));
-                i = i + 1;
-                continue l110;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[Descriptor, String]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/wasi_filesystem_read_stream.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/wasi_filesystem_read_stream.wir.wado
@@ -723,9 +723,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -734,21 +731,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[Descriptor, String]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l66: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[Descriptor, String]">(new_repr, i, builtin::array_get<ref "tuple//[Descriptor, String]">(old_repr, i));
-                i = i + 1;
-                continue l66;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[Descriptor, String]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/wasi_filesystem_read_transform_stream.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/wasi_filesystem_read_transform_stream.wir.wado
@@ -737,9 +737,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -748,21 +745,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l71: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l71;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -770,9 +753,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -781,21 +761,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[Descriptor, String]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l74: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[Descriptor, String]">(new_repr, i, builtin::array_get<ref "tuple//[Descriptor, String]">(old_repr, i));
-                i = i + 1;
-                continue l74;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[Descriptor, String]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/wasi_filesystem_rename_unlink.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/wasi_filesystem_rename_unlink.wir.wado
@@ -1710,9 +1710,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1721,21 +1718,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[Descriptor, String]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l249: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[Descriptor, String]">(new_repr, i, builtin::array_get<ref "tuple//[Descriptor, String]">(old_repr, i));
-                i = i + 1;
-                continue l249;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[Descriptor, String]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/wasi_filesystem_set_size.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/wasi_filesystem_set_size.wir.wado
@@ -1968,9 +1968,6 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1979,21 +1976,7 @@ fn "core:prelude/array.wado/Array<u8>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l274: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l274;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -2001,9 +1984,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -2012,21 +1992,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[Descriptor, String]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l277: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[Descriptor, String]">(new_repr, i, builtin::array_get<ref "tuple//[Descriptor, String]">(old_repr, i));
-                i = i + 1;
-                continue l277;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[Descriptor, String]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/wasi_filesystem_set_times.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/wasi_filesystem_set_times.wir.wado
@@ -1542,9 +1542,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1553,21 +1550,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[Descriptor, String]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l249: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[Descriptor, String]">(new_repr, i, builtin::array_get<ref "tuple//[Descriptor, String]">(old_repr, i));
-                i = i + 1;
-                continue l249;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[Descriptor, String]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/wasi_filesystem_stat.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/wasi_filesystem_stat.wir.wado
@@ -1495,9 +1495,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -1506,21 +1503,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[Descriptor, String]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l209: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[Descriptor, String]">(new_repr, i, builtin::array_get<ref "tuple//[Descriptor, String]">(old_repr, i));
-                i = i + 1;
-                continue l209;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[Descriptor, String]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/wasi_filesystem_symlink.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/wasi_filesystem_symlink.wir.wado
@@ -2108,9 +2108,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -2119,21 +2116,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[Descriptor, String]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l354: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[Descriptor, String]">(new_repr, i, builtin::array_get<ref "tuple//[Descriptor, String]">(old_repr, i));
-                i = i + 1;
-                continue l354;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[Descriptor, String]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/wasi_filesystem_write_stream.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/wasi_filesystem_write_stream.wir.wado
@@ -894,9 +894,6 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let old_repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -905,21 +902,7 @@ fn "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/
         unreachable;
     };
     new_repr = builtin::array_new<ref "tuple//[Descriptor, String]">(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l108: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<ref "tuple//[Descriptor, String]">(new_repr, i, builtin::array_get<ref "tuple//[Descriptor, String]">(old_repr, i));
-                i = i + 1;
-                continue l108;
-            };
-        };
-    };
+    builtin::array_copy<ref "tuple//[Descriptor, String]">(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/wasi_tls_mock_recv.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/wasi_tls_mock_recv.wir.wado
@@ -766,40 +766,23 @@ fn "core:prelude/array.wado/Array<u8>::grow_to"(self, min_capacity) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<u8>;
-    let old_repr: ref builtin::array<u8>;
-    let used: i32;
-    let i: i32;
-    let a_8: i32;
-    let a_10: i32;
+    let a_5: i32;
+    let a_7: i32;
     capacity = builtin::array_len(self.repr);
     if min_capacity <= capacity {
         return;
     }
     new_capacity = __inline_i32_max_0: block -> i32 {
-        a_8 = __inline_i32_max_1: block -> i32 {
-            a_10 = capacity * 2;
-            break __inline_i32_max_1: select i32(a_10 > min_capacity, a_10, min_capacity);
+        a_5 = __inline_i32_max_1: block -> i32 {
+            a_7 = capacity * 2;
+            break __inline_i32_max_1: select i32(a_7 > min_capacity, a_7, min_capacity);
             unreachable;
         };
-        break __inline_i32_max_0: select i32(a_8 > 4, a_8, 4);
+        break __inline_i32_max_0: select i32(a_5 > 4, a_5, 4);
         unreachable;
     };
     new_repr = builtin::array_new<u8>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_1: block {
-        i = 0;
-        block {
-            l66: loop {
-                if i >= used {
-                    break __for_1;
-                }
-                builtin::array_set_u8(new_repr, i, builtin::array_get<u8>(old_repr, i));
-                i = i + 1;
-                continue l66;
-            };
-        };
-    };
+    builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/wir_optimize_value_copy_call_arg_needed.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/wir_optimize_value_copy_call_arg_needed.wir.wado
@@ -488,9 +488,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -499,21 +496,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l44: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l44;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/fixtures/wir_optimize_vcopy_deref_snapshot.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/wir_optimize_vcopy_deref_snapshot.wir.wado
@@ -498,9 +498,6 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
     let capacity: i32;
     let new_capacity: i32;
     let new_repr: ref builtin::array<i32>;
-    let old_repr: ref builtin::array<i32>;
-    let used: i32;
-    let i: i32;
     let a: i32;
     capacity = builtin::array_len(self.repr);
     new_capacity = __inline_i32_max_0: block -> i32 {
@@ -509,21 +506,7 @@ fn "core:prelude/array.wado/Array<i32>::grow"(self) {
         unreachable;
     };
     new_repr = builtin::array_new<i32>(new_capacity);
-    old_repr = self.repr;
-    used = self.used;
-    __for_0: block {
-        i = 0;
-        block {
-            l44: loop {
-                if i >= used {
-                    break __for_0;
-                }
-                builtin::array_set<i32>(new_repr, i, builtin::array_get<i32>(old_repr, i));
-                i = i + 1;
-                continue l44;
-            };
-        };
-    };
+    builtin::array_copy<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/format.fixtures/all.lower.wado
+++ b/wado-compiler/tests/generated/format.fixtures/all.lower.wado
@@ -5428,12 +5428,12 @@ pub fn i128::from_str_radix(s: &String, radix: u32) -> Result<i128, ParseIntErro
 
 pub fn i128::from_str_radix_range(s: &String, start: i32, end: i32, radix: u32) -> Result<i128, ParseIntError> {
     "core::prelude/intparse.wado::assert_radix"(radix);
-    let __pattern_temp_0: [bool, i32] = match "core::prelude/intparse.wado::parse_signed_prefix_range"(s, start, end) {
+    let __pattern_temp_0: [bool, i32] = "$value_copy$T238"(match "core::prelude/intparse.wado::parse_signed_prefix_range"(s, start, end) {
         Ok(p) => p,
         Err(k) => {
             return Result<i128, ParseIntError>::Err("core::prelude/intparse.wado::ParseIntError::new"(k));
         },
-    };
+    });
     let is_negative: bool = __pattern_temp_0.0;
     let digit_start: i32 = __pattern_temp_0.1;
     let max_pos: u128 = "core::prelude/int128.wado::u128::from_pair"(18446744073709551615, 9223372036854775807 as u64);
@@ -6346,12 +6346,12 @@ pub fn parse_unsigned_prefix(s: &String) -> Result<i32, IntErrorKind> {
 
 pub fn parse_i64_radix_range(s: &String, start: i32, end: i32, radix: u32, max: i64, min_abs: u64) -> Result<i64, ParseIntError> {
     "core::prelude/intparse.wado::assert_radix"(radix);
-    let __pattern_temp_0: [bool, i32] = match "core::prelude/intparse.wado::parse_signed_prefix_range"(s, start, end) {
+    let __pattern_temp_0: [bool, i32] = "$value_copy$T238"(match "core::prelude/intparse.wado::parse_signed_prefix_range"(s, start, end) {
         Ok(p) => p,
         Err(k) => {
             return Result<i64, ParseIntError>::Err("core::prelude/intparse.wado::ParseIntError::new"(k));
         },
-    };
+    });
     let is_negative: bool = __pattern_temp_0.0;
     let digit_start: i32 = __pattern_temp_0.1;
     return match "core::prelude/intparse.wado::parse_u64_digits"(s, digit_start, end, radix) {
@@ -11484,17 +11484,7 @@ pub fn String::insert_unchecked(self: &mut String, byte_index: i32, ch: char) {
     if (new_used > core::builtin::array_len(self.repr)) {
         self.String::grow(new_used);
     }
-    let mut i: i32 = (self.used - 1);
-    loop {
-        if !(i >= byte_index) {
-            break;
-        }
-        core::builtin::array_set_u8(self.repr, (i + char_len), core::builtin::array_get_u8(self.repr, i));
-        if (i == 0) {
-            break;
-        }
-        i = (i - 1);
-    }
+    "core::builtin::core/builtin/array_copy<u8>"(self.repr, (byte_index + char_len), self.repr, byte_index, (self.used - byte_index));
     if (code < 0x80) {
         core::builtin::array_set_u8(self.repr, byte_index, code as u8);
     } else {
@@ -11530,7 +11520,7 @@ pub fn String::insert_str(self: &mut String, byte_index: i32, s: String) {
                 __r.String::push_str(&"core:prelude/string.wado");
                 __r.String::push_str(&":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 889 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 882 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(&": ");
                 __r.String::push_str(&"insert_str index not on UTF-8 character boundary");
                 __r.String::push_str(&"\ncondition: self.is_char_boundary(byte_index)\n");
@@ -11554,17 +11544,7 @@ pub fn String::insert_str_unchecked(self: &mut String, byte_index: i32, s: Strin
     if (new_used > core::builtin::array_len(self.repr)) {
         self.String::grow(new_used);
     }
-    let mut i: i32 = (self.used - 1);
-    loop {
-        if !(i >= byte_index) {
-            break;
-        }
-        core::builtin::array_set_u8(self.repr, (i + s_len), core::builtin::array_get_u8(self.repr, i));
-        if (i == 0) {
-            break;
-        }
-        i = (i - 1);
-    }
+    "core::builtin::core/builtin/array_copy<u8>"(self.repr, (byte_index + s_len), self.repr, byte_index, (self.used - byte_index));
     "core::builtin::core/builtin/array_copy<u8>"(self.repr, byte_index, s.String::internal_raw_bytes(), 0, s_len);
     self.used = new_used;
 }
@@ -11585,7 +11565,7 @@ pub fn String::remove(self: &mut String, byte_index: i32) -> char {
                 __r.String::push_str(&"core:prelude/string.wado");
                 __r.String::push_str(&":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 924 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 910 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(&": ");
                 __r.String::push_str(&"index out of bounds");
                 __r.String::push_str(&"\ncondition: byte_index >= 0 && byte_index < self.used\n");
@@ -11621,7 +11601,7 @@ pub fn String::remove(self: &mut String, byte_index: i32) -> char {
                 __r.String::push_str(&"core:prelude/string.wado");
                 __r.String::push_str(&":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 925 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 911 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(&": ");
                 __r.String::push_str(&"remove index not on UTF-8 character boundary");
                 __r.String::push_str(&"\ncondition: self.is_char_boundary(byte_index)\n");
@@ -11670,19 +11650,7 @@ pub fn String::remove_unchecked(self: &mut String, byte_index: i32) -> char {
             };
         };
     };
-    let src: i32 = (byte_index + char_len);
-    __for_10: {
-        let mut i: i32 = src;
-        loop {
-            if !(i < self.used) {
-                break __for_10;
-            }
-            __for_10_body: {
-                core::builtin::array_set_u8(self.repr, (i - char_len), core::builtin::array_get_u8(self.repr, i));
-            }
-            i = (i + 1);
-        }
-    }
+    "core::builtin::core/builtin/array_copy<u8>"(self.repr, byte_index, self.repr, (byte_index + char_len), ((self.used - byte_index) - char_len));
     self.used = (self.used - char_len);
     return "core::prelude/primitive.wado::char::from_u32_unchecked"(code);
 }
@@ -11693,13 +11661,13 @@ pub fn String::repeat(self: &String, n: i32) -> String {
     }
     let total: i32 = (self.used * n);
     let repr: builtin::array<u8> = "core::builtin::core/builtin/array_new<u8>"(total);
-    __for_11: {
+    __for_10: {
         let mut r: i32 = 0;
         loop {
             if !(r < n) {
-                break __for_11;
+                break __for_10;
             }
-            __for_11_body: {
+            __for_10_body: {
                 "core::builtin::core/builtin/array_copy<u8>"(repr, (r * self.used), self.repr, 0, self.used);
             }
             r = (r + 1);
@@ -11732,16 +11700,16 @@ pub fn String::replacen(self: &String, from: String, to: String, count: i32) -> 
             break;
         }
         let mut matched: bool = true;
-        __for_12: {
+        __for_11: {
             let mut j: i32 = 0;
             loop {
                 if !(j < from_len) {
-                    break __for_12;
+                    break __for_11;
                 }
-                __for_12_body: {
+                __for_11_body: {
                     if (core::builtin::array_get_u8(self.repr, (pos + j)) != core::builtin::array_get_u8(from_repr, j)) {
                         matched = false;
-                        break __for_12;
+                        break __for_11;
                     }
                 }
                 j = (j + 1);
@@ -11802,16 +11770,16 @@ pub fn "StrSplitIter^Iterator::next"(self: &mut StrSplitIter) -> Option<String> 
             break;
         }
         let mut matched: bool = true;
-        __for_13: {
+        __for_12: {
             let mut j: i32 = 0;
             loop {
                 if !(j < self.sep_len) {
-                    break __for_13;
+                    break __for_12;
                 }
-                __for_13_body: {
+                __for_12_body: {
                     if (core::builtin::array_get_u8(self.repr, (i + j)) != core::builtin::array_get_u8(self.sep_repr, j)) {
                         matched = false;
-                        break __for_13;
+                        break __for_12;
                     }
                 }
                 j = (j + 1);
@@ -12044,16 +12012,16 @@ pub fn "StrSplitNIter^Iterator::next"(self: &mut StrSplitNIter) -> Option<String
             break;
         }
         let mut matched: bool = true;
-        __for_14: {
+        __for_13: {
             let mut j: i32 = 0;
             loop {
                 if !(j < self.sep_len) {
-                    break __for_14;
+                    break __for_13;
                 }
-                __for_14_body: {
+                __for_13_body: {
                     if (core::builtin::array_get_u8(self.repr, (i + j)) != core::builtin::array_get_u8(self.sep_repr, j)) {
                         matched = false;
-                        break __for_14;
+                        break __for_13;
                     }
                 }
                 j = (j + 1);
@@ -20086,20 +20054,7 @@ pub fn "Array<u8>::grow"(self: &mut Array<u8>) {
     let capacity: i32 = core::builtin::array_len(self.repr);
     let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
     let new_repr: builtin::array<u8> = "core::builtin::core/builtin/array_new<u8>"(new_capacity);
-    let old_repr: builtin::array<u8> = self.repr;
-    let used: i32 = self.used;
-    __for_0: {
-        let mut i: i32 = 0;
-        loop {
-            if !(i < used) {
-                break __for_0;
-            }
-            __for_0_body: {
-                core::builtin::array_set::<u8>(new_repr, i, core::builtin::array_get::<u8>(old_repr, i));
-            }
-            i = (i + 1);
-        }
-    }
+    "core::builtin::core/builtin/array_copy<u8>"(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -20111,20 +20066,7 @@ pub fn "Array<char>::grow"(self: &mut Array<char>) {
     let capacity: i32 = core::builtin::array_len(self.repr);
     let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
     let new_repr: builtin::array<char> = core::builtin::array_new::<char>(new_capacity);
-    let old_repr: builtin::array<char> = self.repr;
-    let used: i32 = self.used;
-    __for_0: {
-        let mut i: i32 = 0;
-        loop {
-            if !(i < used) {
-                break __for_0;
-            }
-            __for_0_body: {
-                core::builtin::array_set::<char>(new_repr, i, core::builtin::array_get::<char>(old_repr, i));
-            }
-            i = (i + 1);
-        }
-    }
+    core::builtin::array_copy::<char>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -20147,20 +20089,7 @@ pub fn "Array<core:prelude/string.wado/String>::grow"(self: &mut Array<String>) 
     let capacity: i32 = core::builtin::array_len(self.repr);
     let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
     let new_repr: builtin::array<String> = core::builtin::array_new::<String>(new_capacity);
-    let old_repr: builtin::array<String> = self.repr;
-    let used: i32 = self.used;
-    __for_0: {
-        let mut i: i32 = 0;
-        loop {
-            if !(i < used) {
-                break __for_0;
-            }
-            __for_0_body: {
-                core::builtin::array_set::<String>(new_repr, i, core::builtin::array_get::<String>(old_repr, i));
-            }
-            i = (i + 1);
-        }
-    }
+    core::builtin::array_copy::<String>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -20172,20 +20101,7 @@ pub fn "Array<core:prelude/types.wado/Tuple<i32,char>>::grow"(self: &mut Array<[
     let capacity: i32 = core::builtin::array_len(self.repr);
     let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
     let new_repr: builtin::array<[i32, char]> = core::builtin::array_new::<[i32, char]>(new_capacity);
-    let old_repr: builtin::array<[i32, char]> = self.repr;
-    let used: i32 = self.used;
-    __for_0: {
-        let mut i: i32 = 0;
-        loop {
-            if !(i < used) {
-                break __for_0;
-            }
-            __for_0_body: {
-                core::builtin::array_set::<[i32, char]>(new_repr, i, core::builtin::array_get::<[i32, char]>(old_repr, i));
-            }
-            i = (i + 1);
-        }
-    }
+    core::builtin::array_copy::<[i32, char]>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -20223,20 +20139,7 @@ pub fn "Array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core
     let capacity: i32 = core::builtin::array_len(self.repr);
     let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
     let new_repr: builtin::array<[String, String]> = core::builtin::array_new::<[String, String]>(new_capacity);
-    let old_repr: builtin::array<[String, String]> = self.repr;
-    let used: i32 = self.used;
-    __for_0: {
-        let mut i: i32 = 0;
-        loop {
-            if !(i < used) {
-                break __for_0;
-            }
-            __for_0_body: {
-                core::builtin::array_set::<[String, String]>(new_repr, i, core::builtin::array_get::<[String, String]>(old_repr, i));
-            }
-            i = (i + 1);
-        }
-    }
+    core::builtin::array_copy::<[String, String]>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -20257,20 +20160,7 @@ pub fn "Array<u64>::grow"(self: &mut Array<u64>) {
     let capacity: i32 = core::builtin::array_len(self.repr);
     let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
     let new_repr: builtin::array<u64> = core::builtin::array_new::<u64>(new_capacity);
-    let old_repr: builtin::array<u64> = self.repr;
-    let used: i32 = self.used;
-    __for_0: {
-        let mut i: i32 = 0;
-        loop {
-            if !(i < used) {
-                break __for_0;
-            }
-            __for_0_body: {
-                core::builtin::array_set::<u64>(new_repr, i, core::builtin::array_get::<u64>(old_repr, i));
-            }
-            i = (i + 1);
-        }
-    }
+    core::builtin::array_copy::<u64>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -20278,20 +20168,7 @@ pub fn "Array<core:prelude/array.wado/Array<i32>>::grow"(self: &mut Array<Array<
     let capacity: i32 = core::builtin::array_len(self.repr);
     let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
     let new_repr: builtin::array<Array<i32>> = core::builtin::array_new::<Array<i32>>(new_capacity);
-    let old_repr: builtin::array<Array<i32>> = self.repr;
-    let used: i32 = self.used;
-    __for_0: {
-        let mut i: i32 = 0;
-        loop {
-            if !(i < used) {
-                break __for_0;
-            }
-            __for_0_body: {
-                core::builtin::array_set::<Array<i32>>(new_repr, i, core::builtin::array_get::<Array<i32>>(old_repr, i));
-            }
-            i = (i + 1);
-        }
-    }
+    core::builtin::array_copy::<Array<i32>>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -20299,20 +20176,7 @@ pub fn "Array<i32>::grow"(self: &mut Array<i32>) {
     let capacity: i32 = core::builtin::array_len(self.repr);
     let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
     let new_repr: builtin::array<i32> = core::builtin::array_new::<i32>(new_capacity);
-    let old_repr: builtin::array<i32> = self.repr;
-    let used: i32 = self.used;
-    __for_0: {
-        let mut i: i32 = 0;
-        loop {
-            if !(i < used) {
-                break __for_0;
-            }
-            __for_0_body: {
-                core::builtin::array_set::<i32>(new_repr, i, core::builtin::array_get::<i32>(old_repr, i));
-            }
-            i = (i + 1);
-        }
-    }
+    core::builtin::array_copy::<i32>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/format.fixtures/mess.lower.wado
+++ b/wado-compiler/tests/generated/format.fixtures/mess.lower.wado
@@ -5085,12 +5085,12 @@ pub fn i128::from_str_radix(s: &String, radix: u32) -> Result<i128, ParseIntErro
 
 pub fn i128::from_str_radix_range(s: &String, start: i32, end: i32, radix: u32) -> Result<i128, ParseIntError> {
     "core::prelude/intparse.wado::assert_radix"(radix);
-    let __pattern_temp_0: [bool, i32] = match "core::prelude/intparse.wado::parse_signed_prefix_range"(s, start, end) {
+    let __pattern_temp_0: [bool, i32] = "$value_copy$T234"(match "core::prelude/intparse.wado::parse_signed_prefix_range"(s, start, end) {
         Ok(p) => p,
         Err(k) => {
             return Result<i128, ParseIntError>::Err("core::prelude/intparse.wado::ParseIntError::new"(k));
         },
-    };
+    });
     let is_negative: bool = __pattern_temp_0.0;
     let digit_start: i32 = __pattern_temp_0.1;
     let max_pos: u128 = "core::prelude/int128.wado::u128::from_pair"(18446744073709551615, 9223372036854775807 as u64);
@@ -5967,12 +5967,12 @@ pub fn parse_unsigned_prefix(s: &String) -> Result<i32, IntErrorKind> {
 
 pub fn parse_i64_radix_range(s: &String, start: i32, end: i32, radix: u32, max: i64, min_abs: u64) -> Result<i64, ParseIntError> {
     "core::prelude/intparse.wado::assert_radix"(radix);
-    let __pattern_temp_0: [bool, i32] = match "core::prelude/intparse.wado::parse_signed_prefix_range"(s, start, end) {
+    let __pattern_temp_0: [bool, i32] = "$value_copy$T234"(match "core::prelude/intparse.wado::parse_signed_prefix_range"(s, start, end) {
         Ok(p) => p,
         Err(k) => {
             return Result<i64, ParseIntError>::Err("core::prelude/intparse.wado::ParseIntError::new"(k));
         },
-    };
+    });
     let is_negative: bool = __pattern_temp_0.0;
     let digit_start: i32 = __pattern_temp_0.1;
     return match "core::prelude/intparse.wado::parse_u64_digits"(s, digit_start, end, radix) {
@@ -10997,17 +10997,7 @@ pub fn String::insert_unchecked(self: &mut String, byte_index: i32, ch: char) {
     if (new_used > core::builtin::array_len(self.repr)) {
         self.String::grow(new_used);
     }
-    let mut i: i32 = (self.used - 1);
-    loop {
-        if !(i >= byte_index) {
-            break;
-        }
-        core::builtin::array_set_u8(self.repr, (i + char_len), core::builtin::array_get_u8(self.repr, i));
-        if (i == 0) {
-            break;
-        }
-        i = (i - 1);
-    }
+    "core::builtin::core/builtin/array_copy<u8>"(self.repr, (byte_index + char_len), self.repr, byte_index, (self.used - byte_index));
     if (code < 0x80) {
         core::builtin::array_set_u8(self.repr, byte_index, code as u8);
     } else {
@@ -11043,7 +11033,7 @@ pub fn String::insert_str(self: &mut String, byte_index: i32, s: String) {
                 __r.String::push_str(&"core:prelude/string.wado");
                 __r.String::push_str(&":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 889 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 882 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(&": ");
                 __r.String::push_str(&"insert_str index not on UTF-8 character boundary");
                 __r.String::push_str(&"\ncondition: self.is_char_boundary(byte_index)\n");
@@ -11067,17 +11057,7 @@ pub fn String::insert_str_unchecked(self: &mut String, byte_index: i32, s: Strin
     if (new_used > core::builtin::array_len(self.repr)) {
         self.String::grow(new_used);
     }
-    let mut i: i32 = (self.used - 1);
-    loop {
-        if !(i >= byte_index) {
-            break;
-        }
-        core::builtin::array_set_u8(self.repr, (i + s_len), core::builtin::array_get_u8(self.repr, i));
-        if (i == 0) {
-            break;
-        }
-        i = (i - 1);
-    }
+    "core::builtin::core/builtin/array_copy<u8>"(self.repr, (byte_index + s_len), self.repr, byte_index, (self.used - byte_index));
     "core::builtin::core/builtin/array_copy<u8>"(self.repr, byte_index, s.String::internal_raw_bytes(), 0, s_len);
     self.used = new_used;
 }
@@ -11098,7 +11078,7 @@ pub fn String::remove(self: &mut String, byte_index: i32) -> char {
                 __r.String::push_str(&"core:prelude/string.wado");
                 __r.String::push_str(&":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 924 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 910 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(&": ");
                 __r.String::push_str(&"index out of bounds");
                 __r.String::push_str(&"\ncondition: byte_index >= 0 && byte_index < self.used\n");
@@ -11134,7 +11114,7 @@ pub fn String::remove(self: &mut String, byte_index: i32) -> char {
                 __r.String::push_str(&"core:prelude/string.wado");
                 __r.String::push_str(&":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 925 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 911 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(&": ");
                 __r.String::push_str(&"remove index not on UTF-8 character boundary");
                 __r.String::push_str(&"\ncondition: self.is_char_boundary(byte_index)\n");
@@ -11183,19 +11163,7 @@ pub fn String::remove_unchecked(self: &mut String, byte_index: i32) -> char {
             };
         };
     };
-    let src: i32 = (byte_index + char_len);
-    __for_10: {
-        let mut i: i32 = src;
-        loop {
-            if !(i < self.used) {
-                break __for_10;
-            }
-            __for_10_body: {
-                core::builtin::array_set_u8(self.repr, (i - char_len), core::builtin::array_get_u8(self.repr, i));
-            }
-            i = (i + 1);
-        }
-    }
+    "core::builtin::core/builtin/array_copy<u8>"(self.repr, byte_index, self.repr, (byte_index + char_len), ((self.used - byte_index) - char_len));
     self.used = (self.used - char_len);
     return "core::prelude/primitive.wado::char::from_u32_unchecked"(code);
 }
@@ -11206,13 +11174,13 @@ pub fn String::repeat(self: &String, n: i32) -> String {
     }
     let total: i32 = (self.used * n);
     let repr: builtin::array<u8> = "core::builtin::core/builtin/array_new<u8>"(total);
-    __for_11: {
+    __for_10: {
         let mut r: i32 = 0;
         loop {
             if !(r < n) {
-                break __for_11;
+                break __for_10;
             }
-            __for_11_body: {
+            __for_10_body: {
                 "core::builtin::core/builtin/array_copy<u8>"(repr, (r * self.used), self.repr, 0, self.used);
             }
             r = (r + 1);
@@ -11245,16 +11213,16 @@ pub fn String::replacen(self: &String, from: String, to: String, count: i32) -> 
             break;
         }
         let mut matched: bool = true;
-        __for_12: {
+        __for_11: {
             let mut j: i32 = 0;
             loop {
                 if !(j < from_len) {
-                    break __for_12;
+                    break __for_11;
                 }
-                __for_12_body: {
+                __for_11_body: {
                     if (core::builtin::array_get_u8(self.repr, (pos + j)) != core::builtin::array_get_u8(from_repr, j)) {
                         matched = false;
-                        break __for_12;
+                        break __for_11;
                     }
                 }
                 j = (j + 1);
@@ -11315,16 +11283,16 @@ pub fn "StrSplitIter^Iterator::next"(self: &mut StrSplitIter) -> Option<String> 
             break;
         }
         let mut matched: bool = true;
-        __for_13: {
+        __for_12: {
             let mut j: i32 = 0;
             loop {
                 if !(j < self.sep_len) {
-                    break __for_13;
+                    break __for_12;
                 }
-                __for_13_body: {
+                __for_12_body: {
                     if (core::builtin::array_get_u8(self.repr, (i + j)) != core::builtin::array_get_u8(self.sep_repr, j)) {
                         matched = false;
-                        break __for_13;
+                        break __for_12;
                     }
                 }
                 j = (j + 1);
@@ -11557,16 +11525,16 @@ pub fn "StrSplitNIter^Iterator::next"(self: &mut StrSplitNIter) -> Option<String
             break;
         }
         let mut matched: bool = true;
-        __for_14: {
+        __for_13: {
             let mut j: i32 = 0;
             loop {
                 if !(j < self.sep_len) {
-                    break __for_14;
+                    break __for_13;
                 }
-                __for_14_body: {
+                __for_13_body: {
                     if (core::builtin::array_get_u8(self.repr, (i + j)) != core::builtin::array_get_u8(self.sep_repr, j)) {
                         matched = false;
-                        break __for_14;
+                        break __for_13;
                     }
                 }
                 j = (j + 1);
@@ -18465,20 +18433,7 @@ pub fn "Array<u8>::grow"(self: &mut Array<u8>) {
     let capacity: i32 = core::builtin::array_len(self.repr);
     let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
     let new_repr: builtin::array<u8> = "core::builtin::core/builtin/array_new<u8>"(new_capacity);
-    let old_repr: builtin::array<u8> = self.repr;
-    let used: i32 = self.used;
-    __for_0: {
-        let mut i: i32 = 0;
-        loop {
-            if !(i < used) {
-                break __for_0;
-            }
-            __for_0_body: {
-                core::builtin::array_set::<u8>(new_repr, i, core::builtin::array_get::<u8>(old_repr, i));
-            }
-            i = (i + 1);
-        }
-    }
+    "core::builtin::core/builtin/array_copy<u8>"(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -18490,20 +18445,7 @@ pub fn "Array<char>::grow"(self: &mut Array<char>) {
     let capacity: i32 = core::builtin::array_len(self.repr);
     let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
     let new_repr: builtin::array<char> = core::builtin::array_new::<char>(new_capacity);
-    let old_repr: builtin::array<char> = self.repr;
-    let used: i32 = self.used;
-    __for_0: {
-        let mut i: i32 = 0;
-        loop {
-            if !(i < used) {
-                break __for_0;
-            }
-            __for_0_body: {
-                core::builtin::array_set::<char>(new_repr, i, core::builtin::array_get::<char>(old_repr, i));
-            }
-            i = (i + 1);
-        }
-    }
+    core::builtin::array_copy::<char>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -18526,20 +18468,7 @@ pub fn "Array<core:prelude/string.wado/String>::grow"(self: &mut Array<String>) 
     let capacity: i32 = core::builtin::array_len(self.repr);
     let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
     let new_repr: builtin::array<String> = core::builtin::array_new::<String>(new_capacity);
-    let old_repr: builtin::array<String> = self.repr;
-    let used: i32 = self.used;
-    __for_0: {
-        let mut i: i32 = 0;
-        loop {
-            if !(i < used) {
-                break __for_0;
-            }
-            __for_0_body: {
-                core::builtin::array_set::<String>(new_repr, i, core::builtin::array_get::<String>(old_repr, i));
-            }
-            i = (i + 1);
-        }
-    }
+    core::builtin::array_copy::<String>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -18551,20 +18480,7 @@ pub fn "Array<core:prelude/types.wado/Tuple<i32,char>>::grow"(self: &mut Array<[
     let capacity: i32 = core::builtin::array_len(self.repr);
     let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
     let new_repr: builtin::array<[i32, char]> = core::builtin::array_new::<[i32, char]>(new_capacity);
-    let old_repr: builtin::array<[i32, char]> = self.repr;
-    let used: i32 = self.used;
-    __for_0: {
-        let mut i: i32 = 0;
-        loop {
-            if !(i < used) {
-                break __for_0;
-            }
-            __for_0_body: {
-                core::builtin::array_set::<[i32, char]>(new_repr, i, core::builtin::array_get::<[i32, char]>(old_repr, i));
-            }
-            i = (i + 1);
-        }
-    }
+    core::builtin::array_copy::<[i32, char]>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -18572,20 +18488,7 @@ pub fn "Array<core:prelude/types.wado/Tuple<core:prelude/string.wado/String,core
     let capacity: i32 = core::builtin::array_len(self.repr);
     let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
     let new_repr: builtin::array<[String, String]> = core::builtin::array_new::<[String, String]>(new_capacity);
-    let old_repr: builtin::array<[String, String]> = self.repr;
-    let used: i32 = self.used;
-    __for_0: {
-        let mut i: i32 = 0;
-        loop {
-            if !(i < used) {
-                break __for_0;
-            }
-            __for_0_body: {
-                core::builtin::array_set::<[String, String]>(new_repr, i, core::builtin::array_get::<[String, String]>(old_repr, i));
-            }
-            i = (i + 1);
-        }
-    }
+    core::builtin::array_copy::<[String, String]>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -18606,20 +18509,7 @@ pub fn "Array<u64>::grow"(self: &mut Array<u64>) {
     let capacity: i32 = core::builtin::array_len(self.repr);
     let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
     let new_repr: builtin::array<u64> = core::builtin::array_new::<u64>(new_capacity);
-    let old_repr: builtin::array<u64> = self.repr;
-    let used: i32 = self.used;
-    __for_0: {
-        let mut i: i32 = 0;
-        loop {
-            if !(i < used) {
-                break __for_0;
-            }
-            __for_0_body: {
-                core::builtin::array_set::<u64>(new_repr, i, core::builtin::array_get::<u64>(old_repr, i));
-            }
-            i = (i + 1);
-        }
-    }
+    core::builtin::array_copy::<u64>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/format.fixtures/ops.all.lower.wado
+++ b/wado-compiler/tests/generated/format.fixtures/ops.all.lower.wado
@@ -4628,12 +4628,12 @@ pub fn i128::from_str_radix(s: &String, radix: u32) -> Result<i128, ParseIntErro
 
 pub fn i128::from_str_radix_range(s: &String, start: i32, end: i32, radix: u32) -> Result<i128, ParseIntError> {
     "core::prelude/intparse.wado::assert_radix"(radix);
-    let __pattern_temp_0: [bool, i32] = match "core::prelude/intparse.wado::parse_signed_prefix_range"(s, start, end) {
+    let __pattern_temp_0: [bool, i32] = "$value_copy$T218"(match "core::prelude/intparse.wado::parse_signed_prefix_range"(s, start, end) {
         Ok(p) => p,
         Err(k) => {
             return Result<i128, ParseIntError>::Err("core::prelude/intparse.wado::ParseIntError::new"(k));
         },
-    };
+    });
     let is_negative: bool = __pattern_temp_0.0;
     let digit_start: i32 = __pattern_temp_0.1;
     let max_pos: u128 = "core::prelude/int128.wado::u128::from_pair"(18446744073709551615, 9223372036854775807 as u64);
@@ -5498,12 +5498,12 @@ pub fn parse_unsigned_prefix(s: &String) -> Result<i32, IntErrorKind> {
 
 pub fn parse_i64_radix_range(s: &String, start: i32, end: i32, radix: u32, max: i64, min_abs: u64) -> Result<i64, ParseIntError> {
     "core::prelude/intparse.wado::assert_radix"(radix);
-    let __pattern_temp_0: [bool, i32] = match "core::prelude/intparse.wado::parse_signed_prefix_range"(s, start, end) {
+    let __pattern_temp_0: [bool, i32] = "$value_copy$T218"(match "core::prelude/intparse.wado::parse_signed_prefix_range"(s, start, end) {
         Ok(p) => p,
         Err(k) => {
             return Result<i64, ParseIntError>::Err("core::prelude/intparse.wado::ParseIntError::new"(k));
         },
-    };
+    });
     let is_negative: bool = __pattern_temp_0.0;
     let digit_start: i32 = __pattern_temp_0.1;
     return match "core::prelude/intparse.wado::parse_u64_digits"(s, digit_start, end, radix) {
@@ -10492,17 +10492,7 @@ pub fn String::insert_unchecked(self: &mut String, byte_index: i32, ch: char) {
     if (new_used > core::builtin::array_len(self.repr)) {
         self.String::grow(new_used);
     }
-    let mut i: i32 = (self.used - 1);
-    loop {
-        if !(i >= byte_index) {
-            break;
-        }
-        core::builtin::array_set_u8(self.repr, (i + char_len), core::builtin::array_get_u8(self.repr, i));
-        if (i == 0) {
-            break;
-        }
-        i = (i - 1);
-    }
+    "core::builtin::core/builtin/array_copy<u8>"(self.repr, (byte_index + char_len), self.repr, byte_index, (self.used - byte_index));
     if (code < 0x80) {
         core::builtin::array_set_u8(self.repr, byte_index, code as u8);
     } else {
@@ -10538,7 +10528,7 @@ pub fn String::insert_str(self: &mut String, byte_index: i32, s: String) {
                 __r.String::push_str(&"core:prelude/string.wado");
                 __r.String::push_str(&":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 889 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 882 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(&": ");
                 __r.String::push_str(&"insert_str index not on UTF-8 character boundary");
                 __r.String::push_str(&"\ncondition: self.is_char_boundary(byte_index)\n");
@@ -10562,17 +10552,7 @@ pub fn String::insert_str_unchecked(self: &mut String, byte_index: i32, s: Strin
     if (new_used > core::builtin::array_len(self.repr)) {
         self.String::grow(new_used);
     }
-    let mut i: i32 = (self.used - 1);
-    loop {
-        if !(i >= byte_index) {
-            break;
-        }
-        core::builtin::array_set_u8(self.repr, (i + s_len), core::builtin::array_get_u8(self.repr, i));
-        if (i == 0) {
-            break;
-        }
-        i = (i - 1);
-    }
+    "core::builtin::core/builtin/array_copy<u8>"(self.repr, (byte_index + s_len), self.repr, byte_index, (self.used - byte_index));
     "core::builtin::core/builtin/array_copy<u8>"(self.repr, byte_index, s.String::internal_raw_bytes(), 0, s_len);
     self.used = new_used;
 }
@@ -10593,7 +10573,7 @@ pub fn String::remove(self: &mut String, byte_index: i32) -> char {
                 __r.String::push_str(&"core:prelude/string.wado");
                 __r.String::push_str(&":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 924 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 910 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(&": ");
                 __r.String::push_str(&"index out of bounds");
                 __r.String::push_str(&"\ncondition: byte_index >= 0 && byte_index < self.used\n");
@@ -10629,7 +10609,7 @@ pub fn String::remove(self: &mut String, byte_index: i32) -> char {
                 __r.String::push_str(&"core:prelude/string.wado");
                 __r.String::push_str(&":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 925 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 911 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(&": ");
                 __r.String::push_str(&"remove index not on UTF-8 character boundary");
                 __r.String::push_str(&"\ncondition: self.is_char_boundary(byte_index)\n");
@@ -10678,19 +10658,7 @@ pub fn String::remove_unchecked(self: &mut String, byte_index: i32) -> char {
             };
         };
     };
-    let src: i32 = (byte_index + char_len);
-    __for_10: {
-        let mut i: i32 = src;
-        loop {
-            if !(i < self.used) {
-                break __for_10;
-            }
-            __for_10_body: {
-                core::builtin::array_set_u8(self.repr, (i - char_len), core::builtin::array_get_u8(self.repr, i));
-            }
-            i = (i + 1);
-        }
-    }
+    "core::builtin::core/builtin/array_copy<u8>"(self.repr, byte_index, self.repr, (byte_index + char_len), ((self.used - byte_index) - char_len));
     self.used = (self.used - char_len);
     return "core::prelude/primitive.wado::char::from_u32_unchecked"(code);
 }
@@ -10701,13 +10669,13 @@ pub fn String::repeat(self: &String, n: i32) -> String {
     }
     let total: i32 = (self.used * n);
     let repr: builtin::array<u8> = "core::builtin::core/builtin/array_new<u8>"(total);
-    __for_11: {
+    __for_10: {
         let mut r: i32 = 0;
         loop {
             if !(r < n) {
-                break __for_11;
+                break __for_10;
             }
-            __for_11_body: {
+            __for_10_body: {
                 "core::builtin::core/builtin/array_copy<u8>"(repr, (r * self.used), self.repr, 0, self.used);
             }
             r = (r + 1);
@@ -10740,16 +10708,16 @@ pub fn String::replacen(self: &String, from: String, to: String, count: i32) -> 
             break;
         }
         let mut matched: bool = true;
-        __for_12: {
+        __for_11: {
             let mut j: i32 = 0;
             loop {
                 if !(j < from_len) {
-                    break __for_12;
+                    break __for_11;
                 }
-                __for_12_body: {
+                __for_11_body: {
                     if (core::builtin::array_get_u8(self.repr, (pos + j)) != core::builtin::array_get_u8(from_repr, j)) {
                         matched = false;
-                        break __for_12;
+                        break __for_11;
                     }
                 }
                 j = (j + 1);
@@ -10810,16 +10778,16 @@ pub fn "StrSplitIter^Iterator::next"(self: &mut StrSplitIter) -> Option<String> 
             break;
         }
         let mut matched: bool = true;
-        __for_13: {
+        __for_12: {
             let mut j: i32 = 0;
             loop {
                 if !(j < self.sep_len) {
-                    break __for_13;
+                    break __for_12;
                 }
-                __for_13_body: {
+                __for_12_body: {
                     if (core::builtin::array_get_u8(self.repr, (i + j)) != core::builtin::array_get_u8(self.sep_repr, j)) {
                         matched = false;
-                        break __for_13;
+                        break __for_12;
                     }
                 }
                 j = (j + 1);
@@ -11052,16 +11020,16 @@ pub fn "StrSplitNIter^Iterator::next"(self: &mut StrSplitNIter) -> Option<String
             break;
         }
         let mut matched: bool = true;
-        __for_14: {
+        __for_13: {
             let mut j: i32 = 0;
             loop {
                 if !(j < self.sep_len) {
-                    break __for_14;
+                    break __for_13;
                 }
-                __for_14_body: {
+                __for_13_body: {
                     if (core::builtin::array_get_u8(self.repr, (i + j)) != core::builtin::array_get_u8(self.sep_repr, j)) {
                         matched = false;
-                        break __for_14;
+                        break __for_13;
                     }
                 }
                 j = (j + 1);
@@ -15363,20 +15331,7 @@ pub fn "Array<u8>::grow"(self: &mut Array<u8>) {
     let capacity: i32 = core::builtin::array_len(self.repr);
     let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
     let new_repr: builtin::array<u8> = "core::builtin::core/builtin/array_new<u8>"(new_capacity);
-    let old_repr: builtin::array<u8> = self.repr;
-    let used: i32 = self.used;
-    __for_0: {
-        let mut i: i32 = 0;
-        loop {
-            if !(i < used) {
-                break __for_0;
-            }
-            __for_0_body: {
-                core::builtin::array_set::<u8>(new_repr, i, core::builtin::array_get::<u8>(old_repr, i));
-            }
-            i = (i + 1);
-        }
-    }
+    "core::builtin::core/builtin/array_copy<u8>"(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -15388,20 +15343,7 @@ pub fn "Array<char>::grow"(self: &mut Array<char>) {
     let capacity: i32 = core::builtin::array_len(self.repr);
     let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
     let new_repr: builtin::array<char> = core::builtin::array_new::<char>(new_capacity);
-    let old_repr: builtin::array<char> = self.repr;
-    let used: i32 = self.used;
-    __for_0: {
-        let mut i: i32 = 0;
-        loop {
-            if !(i < used) {
-                break __for_0;
-            }
-            __for_0_body: {
-                core::builtin::array_set::<char>(new_repr, i, core::builtin::array_get::<char>(old_repr, i));
-            }
-            i = (i + 1);
-        }
-    }
+    core::builtin::array_copy::<char>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -15428,20 +15370,7 @@ pub fn "Array<core:prelude/string.wado/String>::grow"(self: &mut Array<String>) 
     let capacity: i32 = core::builtin::array_len(self.repr);
     let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
     let new_repr: builtin::array<String> = core::builtin::array_new::<String>(new_capacity);
-    let old_repr: builtin::array<String> = self.repr;
-    let used: i32 = self.used;
-    __for_0: {
-        let mut i: i32 = 0;
-        loop {
-            if !(i < used) {
-                break __for_0;
-            }
-            __for_0_body: {
-                core::builtin::array_set::<String>(new_repr, i, core::builtin::array_get::<String>(old_repr, i));
-            }
-            i = (i + 1);
-        }
-    }
+    core::builtin::array_copy::<String>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -15453,20 +15382,7 @@ pub fn "Array<core:prelude/types.wado/Tuple<i32,char>>::grow"(self: &mut Array<[
     let capacity: i32 = core::builtin::array_len(self.repr);
     let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
     let new_repr: builtin::array<[i32, char]> = core::builtin::array_new::<[i32, char]>(new_capacity);
-    let old_repr: builtin::array<[i32, char]> = self.repr;
-    let used: i32 = self.used;
-    __for_0: {
-        let mut i: i32 = 0;
-        loop {
-            if !(i < used) {
-                break __for_0;
-            }
-            __for_0_body: {
-                core::builtin::array_set::<[i32, char]>(new_repr, i, core::builtin::array_get::<[i32, char]>(old_repr, i));
-            }
-            i = (i + 1);
-        }
-    }
+    core::builtin::array_copy::<[i32, char]>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -15487,20 +15403,7 @@ pub fn "Array<u64>::grow"(self: &mut Array<u64>) {
     let capacity: i32 = core::builtin::array_len(self.repr);
     let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
     let new_repr: builtin::array<u64> = core::builtin::array_new::<u64>(new_capacity);
-    let old_repr: builtin::array<u64> = self.repr;
-    let used: i32 = self.used;
-    __for_0: {
-        let mut i: i32 = 0;
-        loop {
-            if !(i < used) {
-                break __for_0;
-            }
-            __for_0_body: {
-                core::builtin::array_set::<u64>(new_repr, i, core::builtin::array_get::<u64>(old_repr, i));
-            }
-            i = (i + 1);
-        }
-    }
+    core::builtin::array_copy::<u64>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 

--- a/wado-compiler/tests/generated/format.fixtures/ops.mess.lower.wado
+++ b/wado-compiler/tests/generated/format.fixtures/ops.mess.lower.wado
@@ -4628,12 +4628,12 @@ pub fn i128::from_str_radix(s: &String, radix: u32) -> Result<i128, ParseIntErro
 
 pub fn i128::from_str_radix_range(s: &String, start: i32, end: i32, radix: u32) -> Result<i128, ParseIntError> {
     "core::prelude/intparse.wado::assert_radix"(radix);
-    let __pattern_temp_0: [bool, i32] = match "core::prelude/intparse.wado::parse_signed_prefix_range"(s, start, end) {
+    let __pattern_temp_0: [bool, i32] = "$value_copy$T218"(match "core::prelude/intparse.wado::parse_signed_prefix_range"(s, start, end) {
         Ok(p) => p,
         Err(k) => {
             return Result<i128, ParseIntError>::Err("core::prelude/intparse.wado::ParseIntError::new"(k));
         },
-    };
+    });
     let is_negative: bool = __pattern_temp_0.0;
     let digit_start: i32 = __pattern_temp_0.1;
     let max_pos: u128 = "core::prelude/int128.wado::u128::from_pair"(18446744073709551615, 9223372036854775807 as u64);
@@ -5498,12 +5498,12 @@ pub fn parse_unsigned_prefix(s: &String) -> Result<i32, IntErrorKind> {
 
 pub fn parse_i64_radix_range(s: &String, start: i32, end: i32, radix: u32, max: i64, min_abs: u64) -> Result<i64, ParseIntError> {
     "core::prelude/intparse.wado::assert_radix"(radix);
-    let __pattern_temp_0: [bool, i32] = match "core::prelude/intparse.wado::parse_signed_prefix_range"(s, start, end) {
+    let __pattern_temp_0: [bool, i32] = "$value_copy$T218"(match "core::prelude/intparse.wado::parse_signed_prefix_range"(s, start, end) {
         Ok(p) => p,
         Err(k) => {
             return Result<i64, ParseIntError>::Err("core::prelude/intparse.wado::ParseIntError::new"(k));
         },
-    };
+    });
     let is_negative: bool = __pattern_temp_0.0;
     let digit_start: i32 = __pattern_temp_0.1;
     return match "core::prelude/intparse.wado::parse_u64_digits"(s, digit_start, end, radix) {
@@ -10492,17 +10492,7 @@ pub fn String::insert_unchecked(self: &mut String, byte_index: i32, ch: char) {
     if (new_used > core::builtin::array_len(self.repr)) {
         self.String::grow(new_used);
     }
-    let mut i: i32 = (self.used - 1);
-    loop {
-        if !(i >= byte_index) {
-            break;
-        }
-        core::builtin::array_set_u8(self.repr, (i + char_len), core::builtin::array_get_u8(self.repr, i));
-        if (i == 0) {
-            break;
-        }
-        i = (i - 1);
-    }
+    "core::builtin::core/builtin/array_copy<u8>"(self.repr, (byte_index + char_len), self.repr, byte_index, (self.used - byte_index));
     if (code < 0x80) {
         core::builtin::array_set_u8(self.repr, byte_index, code as u8);
     } else {
@@ -10538,7 +10528,7 @@ pub fn String::insert_str(self: &mut String, byte_index: i32, s: String) {
                 __r.String::push_str(&"core:prelude/string.wado");
                 __r.String::push_str(&":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 889 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 882 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(&": ");
                 __r.String::push_str(&"insert_str index not on UTF-8 character boundary");
                 __r.String::push_str(&"\ncondition: self.is_char_boundary(byte_index)\n");
@@ -10562,17 +10552,7 @@ pub fn String::insert_str_unchecked(self: &mut String, byte_index: i32, s: Strin
     if (new_used > core::builtin::array_len(self.repr)) {
         self.String::grow(new_used);
     }
-    let mut i: i32 = (self.used - 1);
-    loop {
-        if !(i >= byte_index) {
-            break;
-        }
-        core::builtin::array_set_u8(self.repr, (i + s_len), core::builtin::array_get_u8(self.repr, i));
-        if (i == 0) {
-            break;
-        }
-        i = (i - 1);
-    }
+    "core::builtin::core/builtin/array_copy<u8>"(self.repr, (byte_index + s_len), self.repr, byte_index, (self.used - byte_index));
     "core::builtin::core/builtin/array_copy<u8>"(self.repr, byte_index, s.String::internal_raw_bytes(), 0, s_len);
     self.used = new_used;
 }
@@ -10593,7 +10573,7 @@ pub fn String::remove(self: &mut String, byte_index: i32) -> char {
                 __r.String::push_str(&"core:prelude/string.wado");
                 __r.String::push_str(&":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 924 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 910 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(&": ");
                 __r.String::push_str(&"index out of bounds");
                 __r.String::push_str(&"\ncondition: byte_index >= 0 && byte_index < self.used\n");
@@ -10629,7 +10609,7 @@ pub fn String::remove(self: &mut String, byte_index: i32) -> char {
                 __r.String::push_str(&"core:prelude/string.wado");
                 __r.String::push_str(&":");
                 let mut __f: Formatter = "core::prelude/format.wado::Formatter::new"(&mut __r);
-                Box<i32> { value: 925 }."i32^Display::fmt"(&mut __f);
+                Box<i32> { value: 911 }."i32^Display::fmt"(&mut __f);
                 __r.String::push_str(&": ");
                 __r.String::push_str(&"remove index not on UTF-8 character boundary");
                 __r.String::push_str(&"\ncondition: self.is_char_boundary(byte_index)\n");
@@ -10678,19 +10658,7 @@ pub fn String::remove_unchecked(self: &mut String, byte_index: i32) -> char {
             };
         };
     };
-    let src: i32 = (byte_index + char_len);
-    __for_10: {
-        let mut i: i32 = src;
-        loop {
-            if !(i < self.used) {
-                break __for_10;
-            }
-            __for_10_body: {
-                core::builtin::array_set_u8(self.repr, (i - char_len), core::builtin::array_get_u8(self.repr, i));
-            }
-            i = (i + 1);
-        }
-    }
+    "core::builtin::core/builtin/array_copy<u8>"(self.repr, byte_index, self.repr, (byte_index + char_len), ((self.used - byte_index) - char_len));
     self.used = (self.used - char_len);
     return "core::prelude/primitive.wado::char::from_u32_unchecked"(code);
 }
@@ -10701,13 +10669,13 @@ pub fn String::repeat(self: &String, n: i32) -> String {
     }
     let total: i32 = (self.used * n);
     let repr: builtin::array<u8> = "core::builtin::core/builtin/array_new<u8>"(total);
-    __for_11: {
+    __for_10: {
         let mut r: i32 = 0;
         loop {
             if !(r < n) {
-                break __for_11;
+                break __for_10;
             }
-            __for_11_body: {
+            __for_10_body: {
                 "core::builtin::core/builtin/array_copy<u8>"(repr, (r * self.used), self.repr, 0, self.used);
             }
             r = (r + 1);
@@ -10740,16 +10708,16 @@ pub fn String::replacen(self: &String, from: String, to: String, count: i32) -> 
             break;
         }
         let mut matched: bool = true;
-        __for_12: {
+        __for_11: {
             let mut j: i32 = 0;
             loop {
                 if !(j < from_len) {
-                    break __for_12;
+                    break __for_11;
                 }
-                __for_12_body: {
+                __for_11_body: {
                     if (core::builtin::array_get_u8(self.repr, (pos + j)) != core::builtin::array_get_u8(from_repr, j)) {
                         matched = false;
-                        break __for_12;
+                        break __for_11;
                     }
                 }
                 j = (j + 1);
@@ -10810,16 +10778,16 @@ pub fn "StrSplitIter^Iterator::next"(self: &mut StrSplitIter) -> Option<String> 
             break;
         }
         let mut matched: bool = true;
-        __for_13: {
+        __for_12: {
             let mut j: i32 = 0;
             loop {
                 if !(j < self.sep_len) {
-                    break __for_13;
+                    break __for_12;
                 }
-                __for_13_body: {
+                __for_12_body: {
                     if (core::builtin::array_get_u8(self.repr, (i + j)) != core::builtin::array_get_u8(self.sep_repr, j)) {
                         matched = false;
-                        break __for_13;
+                        break __for_12;
                     }
                 }
                 j = (j + 1);
@@ -11052,16 +11020,16 @@ pub fn "StrSplitNIter^Iterator::next"(self: &mut StrSplitNIter) -> Option<String
             break;
         }
         let mut matched: bool = true;
-        __for_14: {
+        __for_13: {
             let mut j: i32 = 0;
             loop {
                 if !(j < self.sep_len) {
-                    break __for_14;
+                    break __for_13;
                 }
-                __for_14_body: {
+                __for_13_body: {
                     if (core::builtin::array_get_u8(self.repr, (i + j)) != core::builtin::array_get_u8(self.sep_repr, j)) {
                         matched = false;
-                        break __for_14;
+                        break __for_13;
                     }
                 }
                 j = (j + 1);
@@ -15363,20 +15331,7 @@ pub fn "Array<u8>::grow"(self: &mut Array<u8>) {
     let capacity: i32 = core::builtin::array_len(self.repr);
     let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
     let new_repr: builtin::array<u8> = "core::builtin::core/builtin/array_new<u8>"(new_capacity);
-    let old_repr: builtin::array<u8> = self.repr;
-    let used: i32 = self.used;
-    __for_0: {
-        let mut i: i32 = 0;
-        loop {
-            if !(i < used) {
-                break __for_0;
-            }
-            __for_0_body: {
-                core::builtin::array_set::<u8>(new_repr, i, core::builtin::array_get::<u8>(old_repr, i));
-            }
-            i = (i + 1);
-        }
-    }
+    "core::builtin::core/builtin/array_copy<u8>"(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -15388,20 +15343,7 @@ pub fn "Array<char>::grow"(self: &mut Array<char>) {
     let capacity: i32 = core::builtin::array_len(self.repr);
     let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
     let new_repr: builtin::array<char> = core::builtin::array_new::<char>(new_capacity);
-    let old_repr: builtin::array<char> = self.repr;
-    let used: i32 = self.used;
-    __for_0: {
-        let mut i: i32 = 0;
-        loop {
-            if !(i < used) {
-                break __for_0;
-            }
-            __for_0_body: {
-                core::builtin::array_set::<char>(new_repr, i, core::builtin::array_get::<char>(old_repr, i));
-            }
-            i = (i + 1);
-        }
-    }
+    core::builtin::array_copy::<char>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -15428,20 +15370,7 @@ pub fn "Array<core:prelude/string.wado/String>::grow"(self: &mut Array<String>) 
     let capacity: i32 = core::builtin::array_len(self.repr);
     let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
     let new_repr: builtin::array<String> = core::builtin::array_new::<String>(new_capacity);
-    let old_repr: builtin::array<String> = self.repr;
-    let used: i32 = self.used;
-    __for_0: {
-        let mut i: i32 = 0;
-        loop {
-            if !(i < used) {
-                break __for_0;
-            }
-            __for_0_body: {
-                core::builtin::array_set::<String>(new_repr, i, core::builtin::array_get::<String>(old_repr, i));
-            }
-            i = (i + 1);
-        }
-    }
+    core::builtin::array_copy::<String>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -15453,20 +15382,7 @@ pub fn "Array<core:prelude/types.wado/Tuple<i32,char>>::grow"(self: &mut Array<[
     let capacity: i32 = core::builtin::array_len(self.repr);
     let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
     let new_repr: builtin::array<[i32, char]> = core::builtin::array_new::<[i32, char]>(new_capacity);
-    let old_repr: builtin::array<[i32, char]> = self.repr;
-    let used: i32 = self.used;
-    __for_0: {
-        let mut i: i32 = 0;
-        loop {
-            if !(i < used) {
-                break __for_0;
-            }
-            __for_0_body: {
-                core::builtin::array_set::<[i32, char]>(new_repr, i, core::builtin::array_get::<[i32, char]>(old_repr, i));
-            }
-            i = (i + 1);
-        }
-    }
+    core::builtin::array_copy::<[i32, char]>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
@@ -15487,20 +15403,7 @@ pub fn "Array<u64>::grow"(self: &mut Array<u64>) {
     let capacity: i32 = core::builtin::array_len(self.repr);
     let new_capacity: i32 = "core::prelude/array.wado::i32_max"((capacity * 2), 4);
     let new_repr: builtin::array<u64> = core::builtin::array_new::<u64>(new_capacity);
-    let old_repr: builtin::array<u64> = self.repr;
-    let used: i32 = self.used;
-    __for_0: {
-        let mut i: i32 = 0;
-        loop {
-            if !(i < used) {
-                break __for_0;
-            }
-            __for_0_body: {
-                core::builtin::array_set::<u64>(new_repr, i, core::builtin::array_get::<u64>(old_repr, i));
-            }
-            i = (i + 1);
-        }
-    }
+    core::builtin::array_copy::<u64>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 


### PR DESCRIPTION
## Summary

The WIR emitter now lowers `array.copy` to a JIT-friendly loop, so the hand-rolled element-by-element shift/copy loops scattered through the stdlib are no longer needed for performance. Replaces 9 of them with single `builtin::array_copy` calls in:

- `prelude/array.wado`: `Array::{grow, grow_to, insert, remove, shrink_to_fit, repeat}` and the grow branch of `copy_within_append`.
- `prelude/string.wado`: `String::{insert_unchecked, insert_str_unchecked, remove_unchecked}`.

For the shift-style cases (`insert`, `remove`, `insert_unchecked`, `insert_str_unchecked`, `remove_unchecked`), the Wasm `array.copy` spec handles overlapping source/destination correctly by choosing copy direction based on offsets, so the manual reverse-iteration loops are unnecessary.

The second loop in `copy_within_append` is intentionally left as a manual loop: it depends on forward propagation of just-written values for DEFLATE-style run-length back-references, which `array.copy`'s copy-as-if-buffered semantics cannot express. The comment is updated to explain.

All original loops were shallow get/set (no per-element `value_copy`), so `array_copy` is the right shallow replacement — `array_clone` (deep-copy) was not needed anywhere.

Net change: +14 / -55 lines.

---
_Generated by [Claude Code](https://claude.ai/code/session_0129p3fRT6XdevfYwTDzrsqf)_