### PR TITLE
ci(release): rename assets to `<os>-<arch>` matching `uname` output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,26 +49,35 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # `asset_id` matches `$(uname -s | tr A-Z a-z)-$(uname -m)` on the
+          # host platform so that install scripts can use `uname` output
+          # directly without an arch/os normalization table. Note that macOS
+          # `uname -m` returns `arm64` (not `aarch64`).
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             ext: ''
             archive: tar.gz
+            asset_id: linux-x86_64
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm     # native ARM runner; no `*-latest` alias exists
             ext: ''
             archive: tar.gz
+            asset_id: linux-aarch64
           - target: aarch64-apple-darwin
             os: macos-latest         # `macos-latest` is Apple Silicon since macos-14
             ext: ''
             archive: tar.gz
+            asset_id: darwin-arm64
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             ext: '.exe'
             archive: zip
+            asset_id: windows-x86_64
           - target: aarch64-pc-windows-msvc
             os: windows-11-arm       # native ARM Windows runner; no `*-latest` alias
             ext: '.exe'
             archive: zip
+            asset_id: windows-aarch64
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -91,7 +100,7 @@ jobs:
       - name: Stage artifacts
         shell: bash
         run: |
-          name="wado-${{ needs.validate.outputs.tag }}-${{ matrix.target }}"
+          name="wado-${{ needs.validate.outputs.tag }}-${{ matrix.asset_id }}"
           mkdir -p "dist/$name"
           cp "target/${{ matrix.target }}/release/wado${{ matrix.ext }}" "dist/$name/"
           cp LICENSE README.md "dist/$name/"


### PR DESCRIPTION
## Summary

Drop noise (`unknown`, `apple`, `pc`, `gnu`, `msvc`) from release archive names so that install scripts can locate the asset using `uname -s` / `uname -m` directly without an arch/os normalization table.

Before:
```
wado-v0.0.4-x86_64-unknown-linux-gnu.tar.gz
wado-v0.0.4-aarch64-unknown-linux-gnu.tar.gz
wado-v0.0.4-aarch64-apple-darwin.tar.gz
wado-v0.0.4-x86_64-pc-windows-msvc.zip
wado-v0.0.4-aarch64-pc-windows-msvc.zip
```

After:
```
wado-vX.Y.Z-linux-x86_64.tar.gz
wado-vX.Y.Z-linux-aarch64.tar.gz
wado-vX.Y.Z-darwin-arm64.tar.gz
wado-vX.Y.Z-windows-x86_64.zip
wado-vX.Y.Z-windows-aarch64.zip
```

The naming matches `$(uname -s | tr A-Z a-z)-$(uname -m)` on each host platform, so an install script can do:

```sh
OS=$(uname -s | tr '[:upper:]' '[:lower:]')
ARCH=$(uname -m)
curl -LO https://github.com/wado-lang/wado/releases/download/vX.Y.Z/wado-vX.Y.Z-${OS}-${ARCH}.tar.gz
```

Note: macOS `uname -m` returns `arm64` (not `aarch64`), which is intentionally reflected in the `darwin-arm64` asset name.

## Test plan

- [ ] Confirm the next tagged release produces the new asset names
- [ ] Confirm `SHA256SUMS.txt` and the GitHub Release upload glob (`wado-*.tar.gz` / `wado-*.zip`) still match


---
_Generated by [Claude Code](https://claude.ai/code/session_015AV82CkBQN14Mp3nP5spJh)_