### PR TITLE
ci(release): drop version from artifact basenames

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,10 @@ jobs:
       - name: Stage artifacts
         shell: bash
         run: |
-          name="wado-${{ needs.validate.outputs.tag }}-${{ matrix.asset_id }}"
+          # Keep the asset basename version-free so that
+          # `releases/latest/download/<name>` URLs resolve to the most
+          # recent release without needing to embed the version.
+          name="wado-${{ matrix.asset_id }}"
           mkdir -p "dist/$name"
           cp "target/${{ matrix.target }}/release/wado${{ matrix.ext }}" "dist/$name/"
           cp LICENSE README.md "dist/$name/"


### PR DESCRIPTION
## Summary

- Rename release artifacts from `wado-${tag}-${asset_id}` to `wado-${asset_id}` (e.g. `wado-v0.1.0-linux-x86_64.tar.gz` → `wado-linux-x86_64.tar.gz`).
- Embedding the tag prevented using GitHub's `releases/latest/download/<name>` alias, which requires a stable filename. Install scripts can now fetch the latest binaries without knowing the current version.
- Existing globs (`wado-*.tar.gz`, `wado-*.zip`, `SHA256SUMS`) continue to match.

## Test plan

- [ ] Trigger a release (tag push or `workflow_dispatch`) and confirm each matrix entry uploads `wado-<asset_id>.{tar.gz,zip}` to the draft release.
- [ ] Verify `https://github.com/wado-lang/wado/releases/latest/download/wado-linux-x86_64.tar.gz` resolves after publish.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LFYWnT2zh6xanKbCrK478k)_