### PR TITLE
chore: align wasm-tools crates with wasmtime's generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,27 @@ jobs:
       - uses: actions/checkout@v6
       - run: cargo check --locked -p wado-compiler --target wasm32-unknown-unknown
 
+  check-deps:
+    name: Check (Deps aligned)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci
+          save-if: false
+
+      - uses: jdx/mise-action@v4
+        with:
+          cache: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          MISE_VERBOSE: ${{ runner.debug }}
+
+      - run: mise run check-deps
+
   test:
     name: Test
     if: always()
@@ -198,13 +219,14 @@ jobs:
         test-e2e-o3,
         test-e2e-os,
         check-wasm32,
+        check-deps,
       ]
     runs-on: ubuntu-latest
     permissions: {}
     steps:
       - name: Check all jobs passed
         run: |
-          results="${{ needs.test-core.result }} ${{ needs.test-wado.result }} ${{ needs.test-gale-o1.result }} ${{ needs.test-gale-o2.result }} ${{ needs.test-gale-o3.result }} ${{ needs.test-e2e-o0.result }} ${{ needs.test-e2e-o1.result }} ${{ needs.test-e2e-o3.result }} ${{ needs.test-e2e-os.result }} ${{ needs.check-wasm32.result }}"
+          results="${{ needs.test-core.result }} ${{ needs.test-wado.result }} ${{ needs.test-gale-o1.result }} ${{ needs.test-gale-o2.result }} ${{ needs.test-gale-o3.result }} ${{ needs.test-e2e-o0.result }} ${{ needs.test-e2e-o1.result }} ${{ needs.test-e2e-o3.result }} ${{ needs.test-e2e-os.result }} ${{ needs.check-wasm32.result }} ${{ needs.check-deps.result }}"
           for result in $results; do
             if [ "$result" != "success" ]; then
               echo "One or more jobs failed"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,6 +220,16 @@ Whenever the syntax changes, regenerate the grammar and update the formatter fix
 
 See `wado-vscode/README.md` for more details.
 
+## Dependencies
+
+The wasm-tools crates (`wasmparser`, `wasm-encoder`, `wasmprinter`, `wit-parser`, `wat`) are pinned in `[workspace.dependencies]` to the same generation wasmtime depends on, so cargo dedupes them instead of compiling parallel 0.x trees. `mise run check-deps` enforces this (also a CI job) and lists the irreducible exceptions.
+
+When bumping wasmtime, re-align them:
+
+1. Find wasmtime's generation, e.g. `cargo tree -i wasmparser@<ver>`.
+2. Re-pin the wasm-tools crates in `Cargo.toml` to that generation (`wat = "~1.<gen>"`, the rest `"0.<gen>"`).
+3. `cargo update`, then `mise run check-deps`.
+
 ## References
 
 ### Wasm and WASI

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,8 +1129,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "foldhash 0.2.0",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -3028,7 +3026,7 @@ dependencies = [
  "wado-compiler",
  "wado-lsp",
  "wado-manifest",
- "wasmprinter 0.249.0",
+ "wasmprinter",
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-http",
@@ -3061,9 +3059,9 @@ dependencies = [
  "tempfile",
  "tokio",
  "walrus",
- "wasm-encoder 0.249.0",
- "wasmparser 0.249.0",
- "wasmprinter 0.249.0",
+ "wasm-encoder 0.246.2",
+ "wasmparser 0.246.2",
+ "wasmprinter",
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-http",
@@ -3083,7 +3081,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "wado-compiler",
- "wasmprinter 0.249.0",
+ "wasmprinter",
 ]
 
 [[package]]
@@ -3094,7 +3092,7 @@ dependencies = [
  "heck",
  "indexmap",
  "lexopt",
- "wit-parser 0.249.0",
+ "wit-parser 0.246.2",
 ]
 
 [[package]]
@@ -3302,16 +3300,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.249.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69830ccbbf41c55eb585991659fb70867ef628193af3a495f09a6956f7615e59"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.249.0",
-]
-
-[[package]]
 name = "wasm-metadata"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3362,19 +3350,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.249.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30538cae9a794215f490b532df01c557e2e2bfac92569482554acd0992a102ea"
-dependencies = [
- "bitflags",
- "hashbrown 0.17.1",
- "indexmap",
- "semver",
- "serde",
-]
-
-[[package]]
 name = "wasmprinter"
 version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3383,17 +3358,6 @@ dependencies = [
  "anyhow",
  "termcolor",
  "wasmparser 0.246.2",
-]
-
-[[package]]
-name = "wasmprinter"
-version = "0.249.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e227e800fc74c0d60117391f71d60e4c956333cfc3be796ae72d269002aa52"
-dependencies = [
- "anyhow",
- "termcolor",
- "wasmparser 0.249.0",
 ]
 
 [[package]]
@@ -3476,7 +3440,7 @@ dependencies = [
  "target-lexicon",
  "wasm-encoder 0.246.2",
  "wasmparser 0.246.2",
- "wasmprinter 0.246.2",
+ "wasmprinter",
  "wasmtime-internal-component-util",
  "wasmtime-internal-core",
 ]
@@ -3749,24 +3713,24 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "249.0.0"
+version = "246.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474a321bf9ae2808e9fa23ac4ec2b27300e70985e30bcb5a38d43b76bfc901a"
+checksum = "fe3fe8e3bf88ad96d031b4181ddbd64634b17cb0d06dfc3de589ef43591a9a62"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.2",
- "wasm-encoder 0.249.0",
+ "wasm-encoder 0.246.2",
 ]
 
 [[package]]
 name = "wat"
-version = "1.249.0"
+version = "1.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28af699d0a9c7e4e250b7b8e36167ae5215fbb4b7ae526bb4ce7b234ba0afc90"
+checksum = "4bd7fda1199b94fff395c2d19a153f05dbe7807630316fa9673367666fd2ad8c"
 dependencies = [
- "wast 249.0.0",
+ "wast 246.0.2",
 ]
 
 [[package]]
@@ -4179,25 +4143,6 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.246.2",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.249.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50840f2e2cf170d910858089d7dfb3e97c6f9a0d6ec7bff7f7cc28f5aeacc15f"
-dependencies = [
- "anyhow",
- "hashbrown 0.17.1",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.249.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,16 @@ libm = { version = "0.2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync"] }
-wat = { version = "1" }
-wasm-encoder = { version = "0.249" }
-wasmparser = { version = "0.249" }
-wasmprinter = { version = "0.249" }
+# Keep the wasm-tools family aligned with the generation wasmtime depends on
+# (wasmtime 44 -> 0.246) so cargo can dedupe instead of carrying parallel 0.x
+# trees. `wat` must use the tilde pin: a bare "1" floats up to 1.249 and drags
+# wast/wasm-encoder 0.249 back in through both wado and wasmtime's wasm-compose.
+wat = { version = "~1.246" }
+wasm-encoder = { version = "0.246" }
+wasmparser = { version = "0.246" }
+wasmprinter = { version = "0.246" }
 walrus = { version = "0.26" }
-wit-parser = { version = "0.249" }
+wit-parser = { version = "0.246" }
 wasmtime = { version = "44", features = ["async", "component-model", "component-model-async"] }
 wasmtime-wasi = { version = "44", features = ["p3"] }
 wasmtime-wasi-http = { version = "44", features = ["p3"] }

--- a/mise.toml
+++ b/mise.toml
@@ -63,6 +63,46 @@ cargo check -p wado-compiler --target wasm32-unknown-unknown
 cargo check -p wado-manifest --target wasm32-unknown-unknown
 """
 
+[tasks.check-deps]
+description = "Fail if wasm-tools crates drift off wasmtime's generation (duplicate 0.x trees)"
+run = """
+#!/usr/bin/env bash
+set -e -o pipefail
+
+# wado pins the wasm-tools family (wasmparser/wasm-encoder/wasmprinter/wit-parser/
+# wat) to the same generation wasmtime depends on, so cargo dedupes instead of
+# compiling parallel 0.x trees. See [workspace.dependencies] in Cargo.toml. This
+# guard fails when a new duplicate sneaks in (e.g. a dep bumped back to a
+# different generation, or `wat` floating up past its tilde pin).
+#
+# A few duplicates are irreducible: they come from transitive deps we do not pin
+# directly. List their exact versions in `allow` so the guard ignores them:
+#   wasmparser / wasm-encoder 0.245.1  <- walrus 0.26
+#   wast 35.0.2                        <- witx <- wasmtime-wasi (wiggle)
+# (wit-bindgen's 0.244 generation is pulled by the target-gated `wasip3` guest
+#  crate, never reaches the host tree, and so never shows up in `cargo tree -d`.)
+family='wasm-encoder|wasmparser|wasmprinter|wasm-metadata|wat|wast|wit-parser|wit-component'
+allow='wasmparser v0.245.1|wasm-encoder v0.245.1|wast v35.0.2'
+
+offenders=$(cargo tree -d 2>/dev/null \
+    | awk '{print $1, $2}' \
+    | grep -E "^(${family}) v" \
+    | sort -u \
+    | grep -Ev "^(${allow})$" \
+    | awk '{seen[$1]++; vers[$1]=vers[$1] " " $2} END {for (n in seen) if (seen[n] > 1) print "  " n ":" vers[n]}' \
+    || true)
+
+if [ -n "${offenders}" ]; then
+    echo "error: wasm-tools crates are not aligned with wasmtime's generation:" >&2
+    echo "${offenders}" >&2
+    echo "" >&2
+    echo "Pin them in [workspace.dependencies] to match wasmtime, or add the exact" >&2
+    echo "version to 'allow' above if it comes from an unpinnable transitive dep." >&2
+    exit 1
+fi
+echo "ok: wasm-tools crates are deduped on wasmtime's generation"
+"""
+
 [tasks.release-build]
 description = "Build the wado CLI with the release profile (LTO, fully optimized)"
 run = """

--- a/wado-compiler/src/codegen/component.rs
+++ b/wado-compiler/src/codegen/component.rs
@@ -2900,7 +2900,7 @@ fn import_interfaces_with_resources(
                     instance_type.ty().defined_type().variant(cm_cases);
                     let variant_idx = local_type_idx;
                     instance_type.export(
-                        *cm_name,
+                        cm_name,
                         wasm_encoder::ComponentTypeRef::Type(TypeBounds::Eq(variant_idx)),
                     );
                 }


### PR DESCRIPTION
## What

Align the wasm-tools crate family with the generation wasmtime depends on, so cargo can dedupe the dependency tree instead of compiling parallel `0.x` generations.

## Why

`wado` pinned `wasmparser` / `wasm-encoder` / `wasmprinter` / `wit-parser` to `0.249`, while wasmtime 44 brings in `0.246`. Because these are `0.x` crates, `^0.246` and `0.249` are semver-incompatible, so cargo kept both generations side by side — four parallel `wasmparser` / `wasm-encoder` trees in total.

## Changes

- **Pin to wasmtime's generation (`0.246`)** in `[workspace.dependencies]`. `wat` uses the tilde pin `~1.246`: a bare `"1"` floats up to `1.249` and drags `wast` / `wasm-encoder 0.249` back in through both wado and wasmtime's `wasm-compose`.
- **`mise run check-deps`** — a guard task, wired into CI as the *Check (Deps aligned)* job, that fails when the family drifts off a single generation. The irreducible transitive duplicates are allow-listed: `wasmparser` / `wasm-encoder 0.245.1` (walrus 0.26) and `wast 35.0.2` (witx ← wasmtime-wasi).
- **`AGENTS.md`** — a `Dependencies` section documenting the policy and the re-alignment steps to follow on the next wasmtime bump.
- **Codegen** — drop a now-redundant explicit deref (`*cm_name`) in component import codegen that the `0.246` `wasm-encoder` API makes auto-derefable (otherwise the Tidy clippy-fix would flag it).

## Result

The `0.249` generation is gone from `Cargo.lock` (−68 / +13 lines); only the two irreducible transitive duplicates remain. Going forward, drift is caught automatically by the CI guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
