### PR TITLE
test(e2e): surface the wasmtime Trap kind on test-world trap

### DIFF
--- a/wado-compiler/tests/e2e.rs
+++ b/wado-compiler/tests/e2e.rs
@@ -517,6 +517,23 @@ fn verify_http_result(result: &HttpTestResult, spec: &HttpServiceSpec, fixture_n
 #[derive(Debug)]
 struct TodoResolved(String);
 
+/// Format a trap-producing error with the full diagnostic chain.
+///
+/// `func.call_async` returns `wasmtime::Error` for traps. Its `Display` (`{e}`)
+/// only shows the top-level "error while executing at wasm backtrace" wrapper
+/// and the backtrace lines, but loses the specific trap kind (e.g.
+/// `CannotBlockSyncTask`, `AsyncDeadlock`) which lives further down the source
+/// chain as a `wasmtime::Trap`. The Debug format prints the whole chain
+/// including the Trap variant; we also fish the `Trap` out explicitly so the
+/// trap kind appears on its own line for quick scanning.
+fn format_wasm_trap(e: &wasmtime::Error) -> String {
+    let trap_kind = e
+        .downcast_ref::<wasmtime::Trap>()
+        .map(|trap| format!(" (trap: {trap:?} — {trap})"))
+        .unwrap_or_default();
+    format!("{e:?}{trap_kind}")
+}
+
 /// Run all test exports from a Wasm component compiled with the `test` world.
 /// Each test function is called in its own Store. All tests must pass.
 fn run_test_world(
@@ -604,8 +621,9 @@ fn run_test_world(
                     if !expect_trap && !is_todo {
                         let stderr_text =
                             String::from_utf8_lossy(&stderr_clone.contents()).to_string();
+                        let detail = format_wasm_trap(&e);
                         anyhow::bail!(
-                            "[{test_id}] test '{test_name}' trapped: {e}. stderr: {stderr_text}"
+                            "[{test_id}] test '{test_name}' trapped: {detail}\n  stderr: {stderr_text}"
                         );
                     }
                     // expected trap (expect_trap or TODO): pending


### PR DESCRIPTION
## Summary

Refs #1176.

The test-world runner reported test traps using the top-level `{e}` display of `wasmtime::Error`, which prints "error while executing at wasm backtrace:" plus the backtrace frames but drops the specific `wasmtime::Trap` variant attached deeper in the source chain. For the flaky trap in #1176 that only reproduces under heavy parallel load, losing the trap kind (`CannotBlockSyncTask`, `AsyncDeadlock`, `Interrupt`, `SubtaskDropNotResolved`, …) makes triage guesswork — exactly the gap the issue's "Possible next steps" calls out first.

This PR adds `format_wasm_trap` which:

1. Renders the error in Debug format so the full anyhow-style "Caused by:" chain shows up.
2. Additionally pulls the `wasmtime::Trap` out of the chain via `downcast_ref` and appends `(trap: <Variant> — <description>)` so the trap kind is scannable at a glance without parsing the chain.

The CLI / HTTP runners already use `{e:#}` (alternate display, which walks the source chain), so no change is needed there — only the test-world `Err(e)` branch was dropping detail.

## What was traced before settling on this fix

I walked through the codepath end-to-end to look for an actual logic bug before falling back to "improve diagnostics":

- **`AsyncCall<T>::wait` and `cm_waitable_set_wait` (Wado side):** loop breaks only on `event.payload == 2` (`Status::Returned`). Our `WaitableSet` only has the subtask joined, so only `Event::Subtask` codes can fire; payload semantics are correct.
- **WIR / codegen for `WaitableSetWait`:** we pass `false` to `builder.waitable_set_wait`. Reading wasmparser / wasmtime-environ 44, that byte is `cancellable` (wasm-encoder's parameter name `async_` is misleading); wasmtime hard-codes `async_: false` for this intrinsic. `cancellable = false` is the right choice for our "wait for the subtask, ignore task-level cancel" semantics.
- **Test-world export lifting:** test exports are lifted with `CanonicalOption::Async` and `async_(true)` on the function type, so the guest task has `async_function == true`, which makes `check_blocking()` pass — i.e. `CannotBlockSyncTask` *should not* fire here under correct behavior.

In other words, no clear logic bug in our code; the flake is most plausibly a wasmtime 45 host-side race under contention (the issue's hypothesis). Without a reproducer, the highest-leverage action is to make sure that **when** it reproduces in CI the message tells us the exact `Trap` variant. That unblocks the real investigation.

## Test plan

- [x] `cargo build -p wado-compiler --tests` succeeds.
- [x] `cargo clippy -p wado-compiler --tests --no-deps` clean.
- [x] `cargo test -p wado-compiler --test e2e -- fixture_test_o0::wasi_clocks_full_wado` passes in isolation (multiple runs).
- [ ] When the flake recurs on a full parallel run, the failure message now includes `(trap: <Variant> — <description>)` for triage.

https://claude.ai/code/session_014vvtj6u8k7mtoskStMAL7z

---
_Generated by [Claude Code](https://claude.ai/code/session_014vvtj6u8k7mtoskStMAL7z)_