### PR TITLE
refactor(cli): make subcommands testable in-process

### DIFF
--- a/wado-cli/src/args.rs
+++ b/wado-cli/src/args.rs
@@ -7,12 +7,21 @@ use std::process;
 use lexopt::Parser;
 use wado_compiler::LogLevel;
 
-/// Represents a CLI exit (help or error) without calling `process::exit()`.
+/// Represents the outcome of a subcommand: a message to print and an exit
+/// code.
 ///
-/// Returned by `parse_args` functions to enable in-process testing.
+/// Returned by both `parse_args()` and `run()` so the only `process::exit()`
+/// call lives in `main()`. The two extreme shapes are:
+///
+/// - `error(msg)` / `error_with_usage(msg, usage)` — print a formatted error
+///   to stderr and exit non-zero.
+/// - `silent_failure(code)` — diagnostics were already printed by the
+///   subcommand (e.g., the compiler host emitted error spans to stderr);
+///   `main()` should exit non-zero without printing anything extra.
 #[derive(Debug)]
 pub struct CliExit {
-    /// The full message to display (to stderr).
+    /// The full message to display (to stderr). Empty when the subcommand
+    /// already printed its own diagnostics.
     pub message: String,
     /// Process exit code (0 for help, 1 for errors).
     pub exit_code: i32,
@@ -44,16 +53,23 @@ impl CliExit {
         }
     }
 
+    /// Create a failure exit with no message. The caller has already
+    /// printed everything the user needs to see (compiler diagnostics,
+    /// per-iteration failure lines, etc.); `main()` only needs the exit
+    /// code.
+    #[must_use]
+    pub const fn silent_failure(exit_code: i32) -> Self {
+        Self {
+            message: String::new(),
+            exit_code,
+        }
+    }
+
     /// Exit the process with the stored message and code.
     pub fn exit(&self) -> ! {
         eprint!("{}", self.message);
         process::exit(self.exit_code);
     }
-}
-
-/// Exit with an error message (for use in `run()` functions that still need `-> !`).
-pub fn exit_error(msg: &str) -> ! {
-    CliExit::error(msg).exit()
 }
 
 /// Get the next argument, returning an error on failure.

--- a/wado-cli/src/args.rs
+++ b/wado-cli/src/args.rs
@@ -7,28 +7,19 @@ use std::process;
 use lexopt::Parser;
 use wado_compiler::LogLevel;
 
-/// Represents the outcome of a subcommand: a message to print and an exit
-/// code.
+/// Outcome of a subcommand: a message to print and an exit code.
 ///
 /// Returned by both `parse_args()` and `run()` so the only `process::exit()`
-/// call lives in `main()`. The two extreme shapes are:
-///
-/// - `error(msg)` / `error_with_usage(msg, usage)` — print a formatted error
-///   to stderr and exit non-zero.
-/// - `silent_failure(code)` — diagnostics were already printed by the
-///   subcommand (e.g., the compiler host emitted error spans to stderr);
-///   `main()` should exit non-zero without printing anything extra.
+/// call lives in `main()`. `silent_failure` covers the case where the
+/// subcommand has already printed its own diagnostics and only needs to
+/// signal a non-zero exit.
 #[derive(Debug)]
 pub struct CliExit {
-    /// The full message to display (to stderr). Empty when the subcommand
-    /// already printed its own diagnostics.
     pub message: String,
-    /// Process exit code (0 for help, 1 for errors).
     pub exit_code: i32,
 }
 
 impl CliExit {
-    /// Create an error exit with a message.
     pub fn error(msg: impl std::fmt::Display) -> Self {
         Self {
             message: format!("Error: {msg}\n"),
@@ -36,7 +27,6 @@ impl CliExit {
         }
     }
 
-    /// Create an error exit with a message followed by usage text.
     pub fn error_with_usage(msg: impl std::fmt::Display, usage: &str) -> Self {
         Self {
             message: format!("Error: {msg}\n{usage}"),
@@ -44,7 +34,6 @@ impl CliExit {
         }
     }
 
-    /// Create a help exit (exit code 0).
     #[must_use]
     pub fn help(usage: String) -> Self {
         Self {
@@ -53,10 +42,6 @@ impl CliExit {
         }
     }
 
-    /// Create a failure exit with no message. The caller has already
-    /// printed everything the user needs to see (compiler diagnostics,
-    /// per-iteration failure lines, etc.); `main()` only needs the exit
-    /// code.
     #[must_use]
     pub const fn silent_failure(exit_code: i32) -> Self {
         Self {
@@ -65,54 +50,28 @@ impl CliExit {
         }
     }
 
-    /// Exit the process with the stored message and code.
     pub fn exit(&self) -> ! {
         eprint!("{}", self.message);
         process::exit(self.exit_code);
     }
 }
 
-/// Get the next argument, returning an error on failure.
-///
-/// # Errors
-///
-/// Returns an error if the parser fails to retrieve the next argument.
 pub fn next_arg(parser: &mut Parser) -> Result<Option<lexopt::Arg<'_>>, CliExit> {
     parser.next().map_err(CliExit::error)
 }
 
-/// Get a required value for an option.
-///
-/// # Errors
-///
-/// Returns an error if no value is provided for the option.
 pub fn require_value(parser: &mut Parser) -> Result<OsString, CliExit> {
     parser.value().map_err(CliExit::error)
 }
 
-/// Get a required string value for an option.
-///
-/// # Errors
-///
-/// Returns an error if no value is provided for the option.
 pub fn require_string(parser: &mut Parser) -> Result<String, CliExit> {
     Ok(require_value(parser)?.to_string_lossy().into_owned())
 }
 
-/// Require that an input file was specified.
-///
-/// # Errors
-///
-/// Returns an error if no input file was provided.
 pub fn require_input(input: Option<String>, usage: &str) -> Result<String, CliExit> {
     input.ok_or_else(|| CliExit::error_with_usage("no input file specified", usage))
 }
 
-/// Require that at least one input file was specified.
-///
-/// # Errors
-///
-/// Returns an error if no input files were provided.
 pub fn require_inputs(inputs: Vec<String>, usage: &str) -> Result<Vec<String>, CliExit> {
     if inputs.is_empty() {
         Err(CliExit::error_with_usage("no input file specified", usage))
@@ -121,11 +80,6 @@ pub fn require_inputs(inputs: Vec<String>, usage: &str) -> Result<Vec<String>, C
     }
 }
 
-/// Check for multiple input files and error.
-///
-/// # Errors
-///
-/// Returns an error if multiple input files were specified.
 pub fn reject_multiple_inputs(input: &Option<String>) -> Result<(), CliExit> {
     if input.is_some() {
         Err(CliExit::error("multiple input files not supported"))
@@ -134,7 +88,6 @@ pub fn reject_multiple_inputs(input: &Option<String>) -> Result<(), CliExit> {
     }
 }
 
-/// Create an error for an unexpected argument.
 #[must_use]
 pub fn unexpected_arg(arg: lexopt::Arg, usage: &str) -> CliExit {
     CliExit::error_with_usage(arg.unexpected(), usage)
@@ -146,17 +99,14 @@ pub fn unexpected_arg(arg: lexopt::Arg, usage: &str) -> CliExit {
 /// This ensures exhaustive match catches missing definitions at compile time.
 #[derive(Clone, Copy)]
 pub struct OptSpec {
-    /// Long option name (without `--`), e.g., `Some("format")`
     pub long: Option<&'static str>,
-    /// Short option character, e.g., `Some('o')`
     pub short: Option<char>,
-    /// Value placeholder for help text, e.g., `Some("<fmt>")`. `None` for flags.
+    /// Value placeholder for help text. `None` for flags.
     pub value: Option<&'static str>,
-    /// Description for help text. Use `\n` for continuation lines.
+    /// Help description. `\n` introduces continuation lines.
     pub desc: &'static str,
 }
 
-/// Shared spec: `--help`
 pub const HELP_SPEC: OptSpec = OptSpec {
     long: Some("help"),
     short: None,
@@ -164,7 +114,6 @@ pub const HELP_SPEC: OptSpec = OptSpec {
     desc: "Show this help message",
 };
 
-/// Shared spec: `-O <n>`
 pub const OPT_LEVEL_SPEC: OptSpec = OptSpec {
     long: None,
     short: Some('O'),
@@ -172,7 +121,6 @@ pub const OPT_LEVEL_SPEC: OptSpec = OptSpec {
     desc: "Optimization level: -O0, -O1, -O2, -O3, -Os",
 };
 
-/// Shared spec: `--optimize-inline-threshold <n>`
 pub const INLINE_THRESHOLD_SPEC: OptSpec = OptSpec {
     long: Some("optimize-inline-threshold"),
     short: None,
@@ -180,7 +128,6 @@ pub const INLINE_THRESHOLD_SPEC: OptSpec = OptSpec {
     desc: "Override inlining threshold (max statement count per function)",
 };
 
-/// Shared spec: `--optimize-iterations <n>`
 pub const OPT_ITERATIONS_SPEC: OptSpec = OptSpec {
     long: Some("optimize-iterations"),
     short: None,
@@ -188,7 +135,6 @@ pub const OPT_ITERATIONS_SPEC: OptSpec = OptSpec {
     desc: "Override number of fixed-point optimization iterations",
 };
 
-/// Shared spec: `--log-level <level>`
 pub const LOG_LEVEL_SPEC: OptSpec = OptSpec {
     long: Some("log-level"),
     short: None,
@@ -196,7 +142,6 @@ pub const LOG_LEVEL_SPEC: OptSpec = OptSpec {
     desc: "Log level: debug, info, warn, error, off (default: info)",
 };
 
-/// Shared spec: `--world <name>`
 pub const WORLD_SPEC: OptSpec = OptSpec {
     long: Some("world"),
     short: None,
@@ -204,7 +149,6 @@ pub const WORLD_SPEC: OptSpec = OptSpec {
     desc: "Target world (default: wasi:cli/command)\nUse 'test' to export test functions only",
 };
 
-/// Shared spec: `--no-validate`
 pub const NO_VALIDATE_SPEC: OptSpec = OptSpec {
     long: Some("no-validate"),
     short: None,
@@ -212,7 +156,6 @@ pub const NO_VALIDATE_SPEC: OptSpec = OptSpec {
     desc: "Skip Wasm validation (output raw bytes even if invalid)",
 };
 
-/// Shared spec: `--allocator <mode>`
 pub const ALLOCATOR_SPEC: OptSpec = OptSpec {
     long: Some("allocator"),
     short: None,
@@ -220,7 +163,6 @@ pub const ALLOCATOR_SPEC: OptSpec = OptSpec {
     desc: "Allocator mode (default depends on target world):\nbump (CLI), freelist (HTTP), debug (test; no-reuse + 0xFF poison)",
 };
 
-/// Shared spec: `--dir <path>` (preopen for WASI filesystem access).
 pub const DIR_SPEC: OptSpec = OptSpec {
     long: Some("dir"),
     short: None,
@@ -228,7 +170,6 @@ pub const DIR_SPEC: OptSpec = OptSpec {
     desc: "Preopen directory for WASI filesystem access\nUse --dir host::guest to specify different guest path",
 };
 
-/// Shared spec: `--no-dir`.
 pub const NO_DIR_SPEC: OptSpec = OptSpec {
     long: Some("no-dir"),
     short: None,
@@ -236,10 +177,6 @@ pub const NO_DIR_SPEC: OptSpec = OptSpec {
     desc: "Do not preopen any directories (disables the default)",
 };
 
-/// Match a `lexopt::Arg` against a set of option variants using their specs.
-///
-/// Returns the matching variant if the argument matches a long or short option
-/// defined in the specs. Returns `None` for positional `Value` arguments.
 pub fn match_opt<T: Copy>(
     arg: &lexopt::Arg<'_>,
     all: &[T],
@@ -252,9 +189,6 @@ pub fn match_opt<T: Copy>(
     }
 }
 
-/// Format an option spec as a help label.
-///
-/// - `-o <file>`, `--format <fmt>`, `-f, --filter <pattern>`, `--help`
 fn format_opt_label(spec: &OptSpec) -> String {
     let mut result = String::new();
     if let Some(c) = spec.short {
@@ -275,7 +209,6 @@ fn format_opt_label(spec: &OptSpec) -> String {
     result
 }
 
-/// Format help entries from option variants into a string, auto-aligned.
 pub fn format_opts_help<T>(all: &[T], spec: impl Fn(&T) -> OptSpec) -> String {
     let labels: Vec<String> = all.iter().map(|t| format_opt_label(&spec(t))).collect();
     let max_w = labels.iter().map(String::len).max().unwrap_or(0);
@@ -293,16 +226,10 @@ pub fn format_opts_help<T>(all: &[T], spec: impl Fn(&T) -> OptSpec) -> String {
     buf
 }
 
-/// Print help entries from option variants, auto-aligned.
-///
-/// Each option's label is generated from its spec and descriptions are
-/// aligned to the widest label. Multi-line descriptions (using `\n`) are
-/// printed with continuation lines indented to the description column.
 pub fn print_opts_help<T>(all: &[T], spec: impl Fn(&T) -> OptSpec) {
     eprint!("{}", format_opts_help(all, &spec));
 }
 
-/// Parse log level from string (consolidated from duplicate implementations).
 #[must_use]
 pub fn parse_log_level(s: &str) -> Option<LogLevel> {
     match s.to_lowercase().as_str() {
@@ -315,11 +242,6 @@ pub fn parse_log_level(s: &str) -> Option<LogLevel> {
     }
 }
 
-/// Parse `--log-level` argument value from parser.
-///
-/// # Errors
-///
-/// Returns an error if the log level string is not recognized.
 pub fn parse_log_level_arg(parser: &mut Parser) -> Result<LogLevel, CliExit> {
     let level_str = require_string(parser)?;
     parse_log_level(&level_str).ok_or_else(|| {
@@ -329,37 +251,20 @@ pub fn parse_log_level_arg(parser: &mut Parser) -> Result<LogLevel, CliExit> {
     })
 }
 
-/// Parse `--optimize-inline-threshold <n>` argument value from parser.
-///
-/// # Errors
-///
-/// Returns an error if the value is not a valid non-negative integer.
 pub fn parse_inline_threshold_arg(opt: &str, parser: &mut Parser) -> Result<usize, CliExit> {
     let s = require_string(parser)?;
     s.parse::<usize>()
         .map_err(|_| CliExit::error(format!("{opt} requires a non-negative integer, got '{s}'")))
 }
 
-/// Parse `--optimize-iterations <n>` argument value from parser.
-///
-/// # Errors
-///
-/// Returns an error if the value is not a valid non-negative integer.
 pub fn parse_opt_iterations_arg(opt: &str, parser: &mut Parser) -> Result<u32, CliExit> {
     let s = require_string(parser)?;
     s.parse::<u32>()
         .map_err(|_| CliExit::error(format!("{opt} requires a non-negative integer, got '{s}'")))
 }
 
-/// Parse `--dir <host_path>[::<guest_path>]` into a `(host, guest)` pair.
-///
-/// When the user omits `::guest_path`, the guest path defaults to the host
-/// path — matching the conventional WASI preopen behaviour where the guest
-/// sees the same name it would on the host.
-///
-/// # Errors
-///
-/// Returns an error if no value is provided.
+/// Parse `--dir <host_path>[::<guest_path>]`. When `::guest_path` is
+/// omitted, guest = host (the conventional WASI preopen behaviour).
 pub fn parse_dir_arg(parser: &mut Parser) -> Result<(String, String), CliExit> {
     let dir_spec = require_string(parser)?;
     if let Some((h, g)) = dir_spec.split_once("::") {

--- a/wado-cli/src/check.rs
+++ b/wado-cli/src/check.rs
@@ -78,11 +78,6 @@ pub fn print_usage() {
     eprint!("{}", format_usage());
 }
 
-/// Parse command-line arguments for the `check` subcommand.
-///
-/// # Errors
-///
-/// Returns an error if the arguments are invalid or required arguments are missing.
 pub fn parse_args(mut parser: lexopt::Parser) -> Result<CheckOptions, CliExit> {
     let usage = format_usage();
     let mut input: Option<String> = None;
@@ -145,9 +140,9 @@ pub async fn run(opts: CheckOptions) -> Result<(), CliExit> {
 
     let kiln_drift = !outcome.stale.is_empty() || !outcome.missing.is_empty();
 
-    // Run the rest of the compile pipeline so type-/resolve-level errors
-    // also gate `wado check`. We discard the produced wasm; codegen-skip
-    // is a follow-up optimization.
+    // Drive the rest of the compile pipeline so type/resolve errors also
+    // gate `wado check`. The produced wasm is discarded; skipping codegen
+    // is a follow-up.
     let source = fs::read_to_string(path).map_err(|e| {
         CliExit::error(format!(
             "wado check: failed to read {}: {e}",

--- a/wado-cli/src/check.rs
+++ b/wado-cli/src/check.rs
@@ -9,7 +9,6 @@
 use std::fmt::Write as _;
 use std::fs;
 use std::path::Path;
-use std::process;
 
 use lexopt::Arg::Value;
 use wado_compiler::{Code, LogLevel};
@@ -113,7 +112,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<CheckOptions, CliExit> {
     })
 }
 
-pub async fn run(opts: CheckOptions) {
+pub async fn run(opts: CheckOptions) -> Result<(), CliExit> {
     let path = Path::new(&opts.input);
     let base_path = path
         .parent()
@@ -139,21 +138,9 @@ pub async fn run(opts: CheckOptions) {
             .map(|(m, _)| m)
             .unwrap_or_else(crate::compile::empty_manifest);
         let provider = CliGeneratorProvider::new(manifest_root.clone());
-        match crate::kiln_driver::check_pipeline(
-            &manifest,
-            &manifest_root,
-            &host,
-            &provider,
-            inline,
-        )
-        .await
-        {
-            Ok(o) => o,
-            Err(e) => {
-                eprintln!("{}", FormatPipelineError(&e));
-                process::exit(1);
-            }
-        }
+        crate::kiln_driver::check_pipeline(&manifest, &manifest_root, &host, &provider, inline)
+            .await
+            .map_err(|e| CliExit::error(FormatPipelineError(&e)))?
     };
 
     let kiln_drift = !outcome.stale.is_empty() || !outcome.missing.is_empty();
@@ -161,13 +148,12 @@ pub async fn run(opts: CheckOptions) {
     // Run the rest of the compile pipeline so type-/resolve-level errors
     // also gate `wado check`. We discard the produced wasm; codegen-skip
     // is a follow-up optimization.
-    let source = match fs::read_to_string(path) {
-        Ok(s) => s,
-        Err(e) => {
-            eprintln!("wado check: failed to read {}: {e}", path.display());
-            process::exit(1);
-        }
-    };
+    let source = fs::read_to_string(path).map_err(|e| {
+        CliExit::error(format!(
+            "wado check: failed to read {}: {e}",
+            path.display()
+        ))
+    })?;
     let compiler_options = wado_compiler::CompilerOptions {
         log_level: Some(opts.log_level),
         invocations: outcome.invocations.clone(),
@@ -184,16 +170,16 @@ pub async fn run(opts: CheckOptions) {
         .any(|d| is_kiln_diagnostic(&d.code));
 
     if has_compile_errors {
-        process::exit(1);
+        return Err(CliExit::silent_failure(1));
     }
     if !opts.warn_only && (kiln_drift || has_kiln_warnings) {
-        eprintln!(
+        return Err(CliExit::error(
             "wado check: Kiln integrity check failed — \
              one or more generators produced output that differs from on-disk source. \
-             Pass --warn to keep warnings as warnings."
-        );
-        process::exit(1);
+             Pass --warn to keep warnings as warnings.",
+        ));
     }
+    Ok(())
 }
 
 fn is_kiln_diagnostic(code: &Code) -> bool {

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -12,32 +12,24 @@ use crate::kiln_driver::{PipelineError, PipelineOutcome};
 use crate::kiln_provider::CliGeneratorProvider;
 use crate::manifest;
 
-/// Optimization level
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 pub enum OptLevel {
-    /// No optimizations. Used for debugging.
     O0,
-    /// Development optimizations. All passes except DCE.
-    /// Keeps dead code visible for debugging while improving runtime.
-    /// Iterations: 2, Inline threshold: 10.
+    /// All passes except DCE. Iterations: 2, inline threshold: 10.
     O1,
-    /// Production optimizations. Full passes including DCE (default).
-    /// Iterations: 10, Inline threshold: 10.
+    /// Production: all passes, including DCE. Iterations: 10, inline threshold: 10.
     #[default]
     O2,
-    /// Aggressive production optimizations. Full passes including DCE.
-    /// Iterations: 100, Inline threshold: 20.
+    /// Aggressive. Iterations: 100, inline threshold: 20.
     O3,
-    /// Size optimizations. O2 plus name section stripping.
+    /// `O2` plus name-section stripping.
     Os,
 }
 
 impl OptLevel {
-    /// Convert to the matching wasmtime Cranelift `opt_level` so the runtime
-    /// JIT pipeline tracks the Wado front-end optimization level. wasmtime
-    /// has only three Cranelift settings (`None`/`Speed`/`SpeedAndSize`),
-    /// so `O1`/`O2`/`O3` collapse to the same `Speed`. This mirrors what
-    /// `wasmtime` CLI's own `-O` mapping does.
+    /// wasmtime exposes only `None`/`Speed`/`SpeedAndSize`, so `O1`/`O2`/
+    /// `O3` collapse to `Speed` — mirroring the `wasmtime` CLI's own `-O`
+    /// mapping.
     #[must_use]
     pub const fn to_wasmtime(self) -> wasmtime::OptLevel {
         match self {
@@ -89,14 +81,11 @@ pub struct CompileOptions {
     pub lib: bool,
 }
 
-/// Compile-time options shared by every subcommand that produces a Wasm
-/// component (`compile`, `run`, `serve`, `test`).
+/// Compile-time options shared by `compile`/`run`/`serve`/`test`.
 ///
-/// `target_world` and `allocator` are left as `Option`s because each
-/// subcommand has a different default: `wado run` expects
-/// `wasi:cli/command`, `wado serve` pins `wasi:http/service`, `wado test`
-/// pins `test`, and `wado compile` lets the user override via `--world`.
-/// Same for the allocator, which the compiler picks per-world when `None`.
+/// `target_world` and `allocator` stay `Option` so each subcommand can
+/// pin its own default (`run` → cli/command, `serve` → http/service,
+/// `test` → test) while letting `compile` accept `--world`.
 #[derive(Clone, Debug, Default)]
 pub struct CompileFlags {
     pub opt_level: OptLevel,
@@ -208,11 +197,6 @@ pub fn print_usage() {
     eprint!("{}", format_usage());
 }
 
-/// Parse command-line arguments for the `compile` subcommand.
-///
-/// # Errors
-///
-/// Returns an error if the arguments are invalid or required arguments are missing.
 pub fn parse_args(mut parser: lexopt::Parser) -> Result<CompileOptions, CliExit> {
     let usage = format_usage();
     let mut output: Option<String> = None;
@@ -290,7 +274,6 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<CompileOptions, CliExit>
     })
 }
 
-/// Convert CLI `OptLevel` to compiler `OptLevel`
 fn to_compiler_opt_level(level: OptLevel) -> wado_compiler::OptLevel {
     match level {
         OptLevel::O0 => wado_compiler::OptLevel::O0,
@@ -301,12 +284,8 @@ fn to_compiler_opt_level(level: OptLevel) -> wado_compiler::OptLevel {
     }
 }
 
-/// Parse the `-O<n>` value (with optional bare-`-O`). Shared by every
-/// subcommand that exposes optimization-level control.
-///
-/// # Errors
-///
-/// Returns an error if the level token after `-O` is not recognised.
+/// Parse `-O<n>` (with optional bare-`-O`). Shared by every subcommand
+/// that exposes optimization-level control.
 pub fn parse_opt_level_arg(parser: &mut Parser) -> Result<OptLevel, CliExit> {
     let val = parser.optional_value();
     let level_str = val
@@ -325,13 +304,9 @@ pub fn parse_opt_level_arg(parser: &mut Parser) -> Result<OptLevel, CliExit> {
     }
 }
 
-/// Try to compile a Wado source file, returning the compiler result without
-/// exiting. Used by the test runner to handle `#![TODO]` modules gracefully.
-///
-/// # Errors
-///
-/// Propagates the compiler's own `CompileFailure` (with `is_todo_module`
-/// set when the failure was an expected one for a `#![TODO]` module).
+/// Compile without bailing. Used by the test runner so `#![TODO]` modules
+/// can be observed (via `CompileFailure::is_todo_module`) rather than
+/// aborting the whole batch.
 pub async fn try_compile(
     filename: &str,
     flags: &CompileFlags,
@@ -379,17 +354,9 @@ pub async fn try_compile(
     wado_compiler::compile_with_options(&source, &host, Some(filename), options).await
 }
 
-/// Compile a Wado source file and return the produced wasm bytes.
-///
-/// On failure, diagnostics have already been printed via the compiler host;
-/// the returned [`CliExit::silent_failure`] tells the caller to exit non-zero
-/// without printing anything extra.
-///
-/// # Errors
-///
-/// Returns [`CliExit::silent_failure`] when compilation fails. Diagnostics
-/// for the failure are emitted by the configured `CompilerHost` (see
-/// [`FilesystemCompilerHost`]).
+/// Compile a Wado source file and return the produced wasm bytes. On
+/// failure, the host has already printed diagnostics — the returned
+/// `CliExit::silent_failure` only carries the exit code.
 pub async fn compile(filename: &str, flags: &CompileFlags) -> Result<Vec<u8>, CliExit> {
     try_compile(filename, flags)
         .await
@@ -433,13 +400,8 @@ async fn maybe_run_pipeline(
     crate::kiln_driver::run_pipeline(&manifest, &manifest_root, host, &provider, inline).await
 }
 
-/// Parse the entry file to collect inline Kiln invocations from
-/// `use ... with { generator: { ... } }` clauses. Returns an empty vector when
-/// the file cannot be parsed — downstream compilation will surface the parse
-/// error, so we don't need to report it twice.
-/// Construct an empty in-memory `wado.toml` manifest used as a fallback
-/// when the compiled file has no nearby manifest. Shared with
-/// [`crate::check`].
+/// Empty in-memory `wado.toml` manifest used as a fallback when the
+/// compiled file has no nearby manifest. Shared with [`crate::check`].
 #[must_use]
 pub fn empty_manifest() -> wado_manifest::Manifest {
     wado_manifest::Manifest {
@@ -465,11 +427,9 @@ pub fn collect_inline_invocations_for_entry(
     };
     let mut modules =
         wado_compiler::hashmap::IndexMap::<String, wado_compiler::ast::Module>::default();
-    // Key the module by the same string the loader uses as the entry's
-    // `ModuleSource::EntryPoint { filename }` — the full path — so the
-    // The `decl_site.module` recorded here matches the `decl_file`
-    // the loader feeds into `InvocationIndex::redirect` at resolve time.
-    // Without this, the inline redirect misses entirely.
+    // Key by the full path so `decl_site.module` here matches the
+    // `decl_file` the loader feeds into `InvocationIndex::redirect`;
+    // otherwise the inline redirect misses.
     let entry_name = entry_file.to_string_lossy().to_string();
     modules.insert(entry_name, parsed.ast);
     let descriptors = wado_compiler::hashmap::IndexMap::default();
@@ -478,11 +438,8 @@ pub fn collect_inline_invocations_for_entry(
         .unwrap_or_default()
 }
 
-/// Walk up from `entry_file` looking for the nearest `wado.toml`. Returns the
-/// parsed manifest plus the directory that contains it (the Kiln pipeline's
-/// `manifest_root`). Silently returns `None` when no manifest is found or the
-/// manifest cannot be parsed — the caller treats this as "no Kiln config" and
-/// continues.
+/// Walk up from `entry_file` looking for the nearest `wado.toml`. Returns
+/// `None` (treated as "no Kiln config") on missing or malformed manifest.
 pub fn load_nearest_manifest(
     entry_file: &Path,
 ) -> Option<(wado_manifest::Manifest, std::path::PathBuf)> {
@@ -506,7 +463,6 @@ pub fn load_nearest_manifest(
     }
 }
 
-/// Convert Wasm binary to WAT text format (folded style).
 fn wasm_to_wat(wasm: &[u8]) -> Result<String, CliExit> {
     let mut config = wasmprinter::Config::new();
     config.fold_instructions(true);
@@ -521,14 +477,13 @@ pub async fn run(opts: CompileOptions) -> Result<(), CliExit> {
     let flags = opts.flags();
     let wasm = compile(&opts.input, &flags).await?;
 
-    // Handle --wat-to-stdout: output WAT to stdout and return
     if opts.wat_to_stdout {
         let wat = wasm_to_wat(&wasm)?;
         print!("{wat}");
         return Ok(());
     }
 
-    // Determine format: explicit > guessed from -o extension > default (wasm)
+    // Format precedence: explicit `--format` > guessed from `-o` extension > wasm.
     let format = opts
         .format
         .or_else(|| {
@@ -538,7 +493,6 @@ pub async fn run(opts: CompileOptions) -> Result<(), CliExit> {
         })
         .unwrap_or(OutputFormat::Wasm);
 
-    // Determine output path, using format to pick extension if no -o specified
     let output_path = if let Some(path) = &opts.output {
         Path::new(path).to_path_buf()
     } else {

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -1,7 +1,6 @@
 use std::fmt::Write as _;
 use std::fs;
 use std::path::Path;
-use std::process;
 
 use lexopt::Arg::Value;
 use lexopt::Parser;
@@ -380,13 +379,22 @@ pub async fn try_compile(
     wado_compiler::compile_with_options(&source, &host, Some(filename), options).await
 }
 
-/// Compile a Wado source file and return the produced wasm bytes. Aborts
-/// the process on any failure (diagnostics already printed via the host).
-pub async fn compile(filename: &str, flags: &CompileFlags) -> Vec<u8> {
-    match try_compile(filename, flags).await {
-        Ok(result) => result.wasm,
-        Err(_) => process::exit(1),
-    }
+/// Compile a Wado source file and return the produced wasm bytes.
+///
+/// On failure, diagnostics have already been printed via the compiler host;
+/// the returned [`CliExit::silent_failure`] tells the caller to exit non-zero
+/// without printing anything extra.
+///
+/// # Errors
+///
+/// Returns [`CliExit::silent_failure`] when compilation fails. Diagnostics
+/// for the failure are emitted by the configured `CompilerHost` (see
+/// [`FilesystemCompilerHost`]).
+pub async fn compile(filename: &str, flags: &CompileFlags) -> Result<Vec<u8>, CliExit> {
+    try_compile(filename, flags)
+        .await
+        .map(|result| result.wasm)
+        .map_err(|_| CliExit::silent_failure(1))
 }
 
 /// Collect inline `with { generator: { ... } }` clauses from `entry_file`
@@ -498,29 +506,26 @@ pub fn load_nearest_manifest(
     }
 }
 
-/// Convert Wasm binary to WAT text format (folded style)
-fn wasm_to_wat(wasm: &[u8]) -> String {
+/// Convert Wasm binary to WAT text format (folded style).
+fn wasm_to_wat(wasm: &[u8]) -> Result<String, CliExit> {
     let mut config = wasmprinter::Config::new();
     config.fold_instructions(true);
     let mut wat = String::new();
     config
         .print(wasm, &mut wasmprinter::PrintFmtWrite(&mut wat))
-        .unwrap_or_else(|e| {
-            eprintln!("Error generating WAT: {e}");
-            process::exit(1);
-        });
-    wat
+        .map_err(|e| CliExit::error(format!("generating WAT: {e}")))?;
+    Ok(wat)
 }
 
-pub async fn run(opts: CompileOptions) {
+pub async fn run(opts: CompileOptions) -> Result<(), CliExit> {
     let flags = opts.flags();
-    let wasm = compile(&opts.input, &flags).await;
+    let wasm = compile(&opts.input, &flags).await?;
 
     // Handle --wat-to-stdout: output WAT to stdout and return
     if opts.wat_to_stdout {
-        let wat = wasm_to_wat(&wasm);
+        let wat = wasm_to_wat(&wasm)?;
         print!("{wat}");
-        return;
+        return Ok(());
     }
 
     // Determine format: explicit > guessed from -o extension > default (wasm)
@@ -544,27 +549,12 @@ pub async fn run(opts: CompileOptions) {
         Path::new(&opts.input).with_extension(ext)
     };
 
-    match format {
-        OutputFormat::Wasm => match fs::write(&output_path, &wasm) {
-            Ok(()) => {
-                eprintln!("Generated: {}", output_path.display());
-            }
-            Err(e) => {
-                eprintln!("Error writing output file: {e}");
-                process::exit(1);
-            }
-        },
-        OutputFormat::Wat => {
-            let wat = wasm_to_wat(&wasm);
-            match fs::write(&output_path, &wat) {
-                Ok(()) => {
-                    eprintln!("Generated: {}", output_path.display());
-                }
-                Err(e) => {
-                    eprintln!("Error writing output file: {e}");
-                    process::exit(1);
-                }
-            }
-        }
-    }
+    let bytes = match format {
+        OutputFormat::Wasm => wasm,
+        OutputFormat::Wat => wasm_to_wat(&wasm)?.into_bytes(),
+    };
+    fs::write(&output_path, &bytes)
+        .map_err(|e| CliExit::error(format!("writing output file: {e}")))?;
+    eprintln!("Generated: {}", output_path.display());
+    Ok(())
 }

--- a/wado-cli/src/compiler_host.rs
+++ b/wado-cli/src/compiler_host.rs
@@ -1,7 +1,6 @@
-//! Filesystem-based compiler host for CLI usage.
-//!
-//! Wraps [`wado_lsp::FilesystemCompilerHost`] with CLI-specific decorations:
-//! phase-tracking timestamps, log-level filtering, and stderr printing.
+//! Filesystem-based compiler host for CLI usage. Wraps
+//! [`wado_lsp::FilesystemCompilerHost`] with CLI decorations: phase-tracking
+//! timestamps, log-level filtering, and stderr printing.
 
 use std::path::PathBuf;
 use std::sync::{Arc, OnceLock};
@@ -15,11 +14,6 @@ use wado_compiler::{
 use crate::kiln_runtime::{self, KilnRunPolicy};
 use crate::runtime::create_kiln_engine;
 
-/// Filesystem-based compiler host for the CLI.
-///
-/// Loads sources and collects diagnostics via an inner
-/// [`wado_lsp::FilesystemCompilerHost`], then layers stderr printing with
-/// timestamps and a log-level filter on top.
 pub struct FilesystemCompilerHost {
     inner: Arc<wado_lsp::FilesystemCompilerHost>,
     print_diagnostics: bool,
@@ -40,8 +34,6 @@ impl FilesystemCompilerHost {
         }
     }
 
-    /// Collect diagnostics without printing — equivalent to the bare
-    /// `wado_lsp::FilesystemCompilerHost`, but kept for API compatibility.
     #[must_use]
     pub fn silent(base_path: PathBuf) -> Self {
         Self {
@@ -91,16 +83,13 @@ impl FilesystemCompilerHost {
         }
     }
 
-    /// Format elapsed time as `hh:mm:ss.mmmm` (fixed-width under 100 minutes).
-    ///
-    /// Time tracking is done here in the CLI to keep the compiler syscall-free.
+    // Timestamps live here, not in the compiler, to keep the compiler syscall-free.
     fn format_timestamp(&self) -> String {
         let elapsed = self.start_time.elapsed();
         let total_secs = elapsed.as_secs();
         let hours = total_secs / 3600;
         let minutes = (total_secs % 3600) / 60;
         let seconds = total_secs % 60;
-        // 4 decimal places = 0.1ms precision
         let frac = elapsed.subsec_micros() / 100;
         format!("[{hours:02}:{minutes:02}:{seconds:02}.{frac:04}]")
     }
@@ -158,9 +147,7 @@ impl CompilerHost for FilesystemCompilerHost {
                     "failed to create kiln wasmtime engine: {error}"
                 ))
             })?;
-            // Racing callers may both compute an engine; the first `set`
-            // wins and we clone from the stored value. `OnceLock` keeps
-            // at most one.
+            // Racing callers: first `set` wins; we always clone from the stored value.
             let _ = self.kiln_engine.set(engine);
             self.kiln_engine
                 .get()

--- a/wado-cli/src/doc.rs
+++ b/wado-cli/src/doc.rs
@@ -112,11 +112,6 @@ pub fn print_usage() {
     eprint!("{}", format_usage());
 }
 
-/// Parse command-line arguments for the `doc` subcommand.
-///
-/// # Errors
-///
-/// Returns an error if the arguments are invalid or required arguments are missing.
 pub fn parse_args(mut parser: lexopt::Parser) -> Result<DocOptions, CliExit> {
     let usage = format_usage();
     let mut inputs: Vec<String> = Vec::new();

--- a/wado-cli/src/doc.rs
+++ b/wado-cli/src/doc.rs
@@ -1,7 +1,6 @@
 use std::fmt::Write as FmtWrite;
 use std::fs;
 use std::path::Path;
-use std::process;
 
 use lexopt::Arg::Value;
 use wado_compiler::doc::{
@@ -187,12 +186,12 @@ fn is_stdlib_module(input: &str) -> bool {
     input.starts_with("core:") || input.starts_with("wasi:")
 }
 
-pub fn run(opts: DocOptions) {
+pub fn run(opts: DocOptions) -> Result<(), CliExit> {
     let docs: Vec<(String, DocModule)> = opts
         .inputs
         .iter()
-        .map(|input| (input.clone(), load_doc(input)))
-        .collect();
+        .map(|input| load_doc(input).map(|doc| (input.clone(), doc)))
+        .collect::<Result<_, _>>()?;
 
     let format_name = match opts.format {
         OutputFormat::Markdown => "markdown",
@@ -210,42 +209,37 @@ pub fn run(opts: DocOptions) {
         for (input, doc) in &docs {
             let path = template.replace(MODULE_PLACEHOLDER, &module_filename_stem(input));
             let content = render_single(doc, format_name, input, opts.format);
-            write_to_file(&path, &content);
+            write_to_file(&path, &content)?;
         }
-        return;
+        return Ok(());
     }
 
     let combined = render_combined(&docs, opts.title.as_deref(), format_name, &opts);
     match opts.output.as_deref() {
-        Some(path) => write_to_file(path, &combined),
+        Some(path) => write_to_file(path, &combined)?,
         None => print!("{combined}"),
     }
+    Ok(())
 }
 
-fn load_doc(input: &str) -> DocModule {
+fn load_doc(input: &str) -> Result<DocModule, CliExit> {
     if is_stdlib_module(input) {
-        return extract_stdlib_doc(input).unwrap_or_else(|| {
-            eprintln!("Unknown stdlib module: {input}");
-            process::exit(1);
-        });
+        return extract_stdlib_doc(input)
+            .ok_or_else(|| CliExit::error(format!("Unknown stdlib module: {input}")));
     }
 
     let path = Path::new(input);
-    let source = fs::read_to_string(path).unwrap_or_else(|e| {
-        eprintln!("Error reading '{}': {e}", path.display());
-        process::exit(1);
-    });
+    let source = fs::read_to_string(path)
+        .map_err(|e| CliExit::error(format!("reading '{}': {e}", path.display())))?;
 
-    let parsed = wado_compiler::parse(&source).unwrap_or_else(|e| {
-        eprintln!("Error parsing '{}': {e:?}", path.display());
-        process::exit(1);
-    });
+    let parsed = wado_compiler::parse(&source)
+        .map_err(|e| CliExit::error(format!("parsing '{}': {e:?}", path.display())))?;
 
     let module_name = path
         .file_stem()
         .map_or("unknown", |s| s.to_str().unwrap_or("unknown"));
 
-    extract_doc(&parsed.ast, &parsed.trivia, module_name)
+    Ok(extract_doc(&parsed.ast, &parsed.trivia, module_name))
 }
 
 /// Filesystem-safe stem for a module input: stdlib `core:cli` -> `core-cli`,
@@ -260,18 +254,15 @@ fn module_filename_stem(input: &str) -> String {
         .map_or_else(|| input.to_string(), str::to_string)
 }
 
-fn write_to_file(path: &str, content: &str) {
+fn write_to_file(path: &str, content: &str) -> Result<(), CliExit> {
     if let Some(parent) = Path::new(path).parent()
         && !parent.as_os_str().is_empty()
-        && let Err(e) = fs::create_dir_all(parent)
     {
-        eprintln!("Error creating '{}': {e}", parent.display());
-        process::exit(1);
+        fs::create_dir_all(parent)
+            .map_err(|e| CliExit::error(format!("creating '{}': {e}", parent.display())))?;
     }
-    if let Err(e) = fs::write(path, content) {
-        eprintln!("Error writing '{path}': {e}");
-        process::exit(1);
-    }
+    fs::write(path, content).map_err(|e| CliExit::error(format!("writing '{path}': {e}")))?;
+    Ok(())
 }
 
 fn render_single(doc: &DocModule, format_name: &str, input: &str, format: OutputFormat) -> String {

--- a/wado-cli/src/dump.rs
+++ b/wado-cli/src/dump.rs
@@ -1,7 +1,6 @@
 use std::fmt::Write as FmtWrite;
 use std::fs;
 use std::path::Path;
-use std::process;
 
 use lexopt::Arg::Value;
 use wado_compiler::OptLevel;
@@ -328,7 +327,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<DumpOptions, CliExit> {
     })
 }
 
-pub async fn run(opts: DumpOptions) {
+pub async fn run(opts: DumpOptions) -> Result<(), CliExit> {
     let multiple_files = opts.inputs.len() > 1;
 
     for input in &opts.inputs {
@@ -336,21 +335,17 @@ pub async fn run(opts: DumpOptions) {
             println!("// ========== {input} ==========");
         }
 
-        run_single(&opts, input).await;
+        run_single(&opts, input).await?;
     }
+    Ok(())
 }
 
-async fn run_single(opts: &DumpOptions, input: &str) {
+async fn run_single(opts: &DumpOptions, input: &str) -> Result<(), CliExit> {
     let path = Path::new(input);
 
     // Read source file
-    let source = match fs::read_to_string(path) {
-        Ok(s) => s,
-        Err(e) => {
-            eprintln!("Error reading '{}': {e}", path.display());
-            process::exit(1);
-        }
-    };
+    let source = fs::read_to_string(path)
+        .map_err(|e| CliExit::error(format!("reading '{}': {e}", path.display())))?;
 
     // Get base path for relative imports
     let base_path = path
@@ -362,8 +357,9 @@ async fn run_single(opts: &DumpOptions, input: &str) {
     // Extract target world from __DATA__ section if present
     let target_world = extract_world_from_data_section(&source);
 
-    // Dump using async API with target world
-    let result = match wado_compiler::dump_with_host_and_world(
+    // Dump using async API with target world. Errors are already printed by
+    // the host via `emit_diagnostic`; signal a non-zero exit silently.
+    let result = wado_compiler::dump_with_host_and_world(
         &source,
         &host,
         Some(input),
@@ -373,13 +369,7 @@ async fn run_single(opts: &DumpOptions, input: &str) {
         opts.opt_iterations,
     )
     .await
-    {
-        Ok(r) => r,
-        Err(_bail) => {
-            // Errors already printed by host via emit_diagnostic
-            process::exit(1);
-        }
-    };
+    .map_err(|_bail| CliExit::silent_failure(1))?;
 
     // Tokens section (Lexer phase)
     if opts.show_tokens {
@@ -647,6 +637,7 @@ async fn run_single(opts: &DumpOptions, input: &str) {
             println!();
         }
     }
+    Ok(())
 }
 
 /// Extract the target world from the `__DATA__` JSON section of a source file.

--- a/wado-cli/src/dump.rs
+++ b/wado-cli/src/dump.rs
@@ -198,11 +198,6 @@ pub fn print_usage() {
     eprint!("{}", format_usage());
 }
 
-/// Parse command-line arguments for the `dump` subcommand.
-///
-/// # Errors
-///
-/// Returns an error if the arguments are invalid or required arguments are missing.
 pub fn parse_args(mut parser: lexopt::Parser) -> Result<DumpOptions, CliExit> {
     let usage = format_usage();
     let mut inputs: Vec<String> = Vec::new();
@@ -343,22 +338,18 @@ pub async fn run(opts: DumpOptions) -> Result<(), CliExit> {
 async fn run_single(opts: &DumpOptions, input: &str) -> Result<(), CliExit> {
     let path = Path::new(input);
 
-    // Read source file
     let source = fs::read_to_string(path)
         .map_err(|e| CliExit::error(format!("reading '{}': {e}", path.display())))?;
 
-    // Get base path for relative imports
     let base_path = path
         .parent()
         .map(std::path::Path::to_path_buf)
         .unwrap_or_default();
     let host = FilesystemCompilerHost::new(base_path);
 
-    // Extract target world from __DATA__ section if present
     let target_world = extract_world_from_data_section(&source);
 
-    // Dump using async API with target world. Errors are already printed by
-    // the host via `emit_diagnostic`; signal a non-zero exit silently.
+    // Diagnostics are already emitted by the host; signal silently on failure.
     let result = wado_compiler::dump_with_host_and_world(
         &source,
         &host,
@@ -370,8 +361,6 @@ async fn run_single(opts: &DumpOptions, input: &str) -> Result<(), CliExit> {
     )
     .await
     .map_err(|_bail| CliExit::silent_failure(1))?;
-
-    // Tokens section (Lexer phase)
     if opts.show_tokens {
         println!("=== Tokens ===");
         for (i, token) in result.tokens.iter().enumerate() {
@@ -379,8 +368,6 @@ async fn run_single(opts: &DumpOptions, input: &str) -> Result<(), CliExit> {
         }
         println!();
     }
-
-    // AST section (Parser phase)
     if opts.show_ast {
         println!("=== AST ===");
         let unparser = wado_compiler::unparse::Unparser::new().with_trivia(&result.trivia);
@@ -388,8 +375,6 @@ async fn run_single(opts: &DumpOptions, input: &str) -> Result<(), CliExit> {
         println!("{unparsed}");
         println!();
     }
-
-    // Modules section
     if opts.show_modules {
         println!("=== Loaded Modules ===");
         for module_source in &result.loaded_modules {
@@ -410,8 +395,6 @@ async fn run_single(opts: &DumpOptions, input: &str) -> Result<(), CliExit> {
         }
         println!();
     }
-
-    // Symbols section
     if opts.show_symbols {
         println!("=== Symbol Table ===");
         for symbol in result.symbols.all_symbols() {
@@ -519,8 +502,6 @@ async fn run_single(opts: &DumpOptions, input: &str) -> Result<(), CliExit> {
         }
         println!();
     }
-
-    // Types section (after type resolution)
     if opts.show_types {
         if let Some(ref tir_modules) = result.tir_modules {
             // Type table is shared across modules; grab from the first one
@@ -565,8 +546,6 @@ async fn run_single(opts: &DumpOptions, input: &str) -> Result<(), CliExit> {
         }
         println!();
     }
-
-    // TIR resolved section (after type resolution, before lowering)
     if opts.show_tir_resolved {
         if let Some(ref tir_modules) = result.tir_modules {
             println!("=== TIR Resolved ===");
@@ -582,8 +561,6 @@ async fn run_single(opts: &DumpOptions, input: &str) -> Result<(), CliExit> {
             println!();
         }
     }
-
-    // TIR monomorphized section
     if opts.show_tir_monomorphized {
         if let Some(ref text) = result.monomorphized_tir_text {
             println!("=== TIR Monomorphized ===");
@@ -594,8 +571,6 @@ async fn run_single(opts: &DumpOptions, input: &str) -> Result<(), CliExit> {
             println!();
         }
     }
-
-    // NIR lowered section (NIR right after `lower`, before optimize).
     if opts.show_nir_lowered {
         if let Some(ref text) = result.lowered_nir_text {
             println!("=== NIR Lowered ===");
@@ -606,8 +581,6 @@ async fn run_single(opts: &DumpOptions, input: &str) -> Result<(), CliExit> {
             println!();
         }
     }
-
-    // Final NIR section (after optimization).
     if opts.show_nir {
         if let Some(ref project) = result.optimized_package {
             println!("=== NIR ===");
@@ -620,8 +593,6 @@ async fn run_single(opts: &DumpOptions, input: &str) -> Result<(), CliExit> {
             println!();
         }
     }
-
-    // Final WIR section (after optimization)
     if opts.show_wir {
         if let Some(ref wir_package) = result.wir_package {
             let unparsed = wado_compiler::wir_unparse::unparse_wir(wir_package, None);

--- a/wado-cli/src/format.rs
+++ b/wado-cli/src/format.rs
@@ -61,11 +61,6 @@ pub fn print_usage() {
     eprint!("{}", format_usage());
 }
 
-/// Parse command-line arguments for the `format` subcommand.
-///
-/// # Errors
-///
-/// Returns an error if the arguments are invalid or required arguments are missing.
 pub fn parse_args(mut parser: lexopt::Parser) -> Result<FormatOptions, CliExit> {
     let usage = format_usage();
     let mut inputs: Vec<String> = Vec::new();
@@ -112,7 +107,6 @@ pub fn run(opts: FormatOptions) -> Result<(), CliExit> {
     for input in &opts.inputs {
         let path = Path::new(input);
 
-        // Read original source
         let original = match fs::read_to_string(path) {
             Ok(s) => s,
             Err(e) => {
@@ -122,7 +116,6 @@ pub fn run(opts: FormatOptions) -> Result<(), CliExit> {
             }
         };
 
-        // Format
         let start = Instant::now();
         let formatted = match wado_compiler::format(&original) {
             Ok(f) => f,
@@ -135,13 +128,11 @@ pub fn run(opts: FormatOptions) -> Result<(), CliExit> {
         let elapsed_ms = start.elapsed().as_millis();
 
         if opts.check {
-            // Check mode: track if any file would change
             if original != formatted {
                 eprintln!("{input}: would reformat");
                 any_would_reformat = true;
             }
         } else if opts.write_in_place {
-            // Write back to file only if changed
             if original != formatted {
                 match fs::write(path, &formatted) {
                     Ok(()) => {
@@ -154,7 +145,6 @@ pub fn run(opts: FormatOptions) -> Result<(), CliExit> {
                 }
             }
         } else {
-            // Output to stdout (single file only)
             print!("{formatted}");
         }
     }

--- a/wado-cli/src/format.rs
+++ b/wado-cli/src/format.rs
@@ -1,7 +1,6 @@
 use std::fmt::Write as _;
 use std::fs;
 use std::path::Path;
-use std::process;
 use std::time::Instant;
 
 use lexopt::Arg::Value;
@@ -106,7 +105,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<FormatOptions, CliExit> 
     })
 }
 
-pub fn run(opts: FormatOptions) {
+pub fn run(opts: FormatOptions) -> Result<(), CliExit> {
     let mut any_would_reformat = false;
     let mut any_error = false;
 
@@ -160,10 +159,8 @@ pub fn run(opts: FormatOptions) {
         }
     }
 
-    if any_error {
-        process::exit(1);
+    if any_error || (opts.check && any_would_reformat) {
+        return Err(CliExit::silent_failure(1));
     }
-    if opts.check && any_would_reformat {
-        process::exit(1);
-    }
+    Ok(())
 }

--- a/wado-cli/src/init.rs
+++ b/wado-cli/src/init.rs
@@ -64,11 +64,6 @@ fn format_usage() -> String {
     buf
 }
 
-/// Parse command-line arguments for the `init` subcommand.
-///
-/// # Errors
-///
-/// Returns an error if the arguments are invalid or required arguments are missing.
 pub fn parse_args(mut parser: lexopt::Parser) -> Result<InitOptions, CliExit> {
     let usage = format_usage();
     let mut name: Option<String> = None;

--- a/wado-cli/src/init.rs
+++ b/wado-cli/src/init.rs
@@ -102,27 +102,21 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<InitOptions, CliExit> {
     })
 }
 
-pub fn run(opts: InitOptions) {
+pub fn run(opts: InitOptions) -> Result<(), CliExit> {
     let manifest_path = Path::new("wado.toml");
 
     if manifest_path.exists() && !opts.force {
-        eprintln!(
-            "Error: wado.toml already exists in the current directory (use --force to overwrite)"
-        );
-        std::process::exit(1);
+        return Err(CliExit::error(
+            "wado.toml already exists in the current directory (use --force to overwrite)",
+        ));
     }
 
     let content = generate_manifest(&opts.name, opts.namespace.as_deref());
 
-    match fs::write(manifest_path, &content) {
-        Ok(()) => {
-            eprintln!("Created wado.toml");
-        }
-        Err(e) => {
-            eprintln!("Error writing wado.toml: {e}");
-            std::process::exit(1);
-        }
-    }
+    fs::write(manifest_path, &content)
+        .map_err(|e| CliExit::error(format!("writing wado.toml: {e}")))?;
+    eprintln!("Created wado.toml");
+    Ok(())
 }
 
 fn generate_manifest(name: &str, namespace: Option<&str>) -> String {

--- a/wado-cli/src/lib.rs
+++ b/wado-cli/src/lib.rs
@@ -1,9 +1,3 @@
-// Allow certain pedantic lints that are common in CLI code:
-// - ref_option: &Option<T> is fine when coming from struct fields
-// - missing_panics_doc: Mutex unwrap panics are obvious
-// - struct_excessive_bools: CLI option structs naturally have many bools
-// - too_many_lines: Large functions are acceptable in CLI code
-// - needless_pass_by_value: Ownership transfer is sometimes intentional
 #![allow(
     clippy::ref_option,
     clippy::missing_panics_doc,

--- a/wado-cli/src/lsp.rs
+++ b/wado-cli/src/lsp.rs
@@ -2,13 +2,6 @@
 
 use crate::args::CliExit;
 
-/// Run the LSP server over stdio.
-///
-/// # Errors
-///
-/// Currently infallible — `wado_lsp::server::run_stdio` returns `()`. The
-/// `Result` shape exists so the `lsp` subcommand's signature matches every
-/// other subcommand and propagates uniformly through `main::dispatch`.
 pub async fn run() -> Result<(), CliExit> {
     wado_lsp::server::run_stdio().await;
     Ok(())

--- a/wado-cli/src/lsp.rs
+++ b/wado-cli/src/lsp.rs
@@ -1,6 +1,15 @@
 //! `wado lsp` subcommand — delegates to the stdio LSP server in `wado-lsp`.
 
+use crate::args::CliExit;
+
 /// Run the LSP server over stdio.
-pub async fn run() {
+///
+/// # Errors
+///
+/// Currently infallible — `wado_lsp::server::run_stdio` returns `()`. The
+/// `Result` shape exists so the `lsp` subcommand's signature matches every
+/// other subcommand and propagates uniformly through `main::dispatch`.
+pub async fn run() -> Result<(), CliExit> {
     wado_lsp::server::run_stdio().await;
+    Ok(())
 }

--- a/wado-cli/src/main.rs
+++ b/wado-cli/src/main.rs
@@ -2,6 +2,7 @@ use std::process;
 
 use lexopt::Arg::{Long, Value};
 use mimalloc::MiMalloc;
+use wado_cli::args::CliExit;
 
 // `wado serve` allocates and frees a burst of small per-request objects
 // (request/response buffers, header maps, resource tables) on every request.
@@ -91,24 +92,29 @@ impl Cmd {
     }
 }
 
-fn print_usage() {
-    eprintln!("Usage: wado <command> [options]");
-    eprintln!();
-    eprintln!("Commands:");
+fn write_usage(buf: &mut String) {
+    use std::fmt::Write as _;
+    writeln!(buf, "Usage: wado <command> [options]").unwrap();
+    writeln!(buf).unwrap();
+    writeln!(buf, "Commands:").unwrap();
     let labels: Vec<String> = Cmd::ALL
         .iter()
         .map(|c| format!("{} {}", c.name(), c.args()))
         .collect();
     let max_w = labels.iter().map(String::len).max().unwrap_or(0);
     for (label, cmd) in labels.iter().zip(Cmd::ALL) {
-        eprintln!("  {label:<max_w$}  {}", cmd.desc());
+        writeln!(buf, "  {label:<max_w$}  {}", cmd.desc()).unwrap();
     }
-    eprintln!();
-    eprintln!("Global options:");
-    eprintln!("  --help     Show this help message");
-    eprintln!("  --version  Show version information");
-    eprintln!();
-    eprintln!("Use 'wado <command> --help' for more information on a command.");
+    writeln!(buf).unwrap();
+    writeln!(buf, "Global options:").unwrap();
+    writeln!(buf, "  --help     Show this help message").unwrap();
+    writeln!(buf, "  --version  Show version information").unwrap();
+    writeln!(buf).unwrap();
+    writeln!(
+        buf,
+        "Use 'wado <command> --help' for more information on a command."
+    )
+    .unwrap();
 }
 
 fn print_version() {
@@ -123,106 +129,110 @@ fn main() {
             eprintln!("Error: failed to create tokio runtime: {e}");
             process::exit(1);
         });
-    runtime.block_on(async_main());
+    let outcome = runtime.block_on(async_main());
+    outcome.exit();
 }
 
-async fn async_main() {
+async fn async_main() -> CliExit {
+    match dispatch().await {
+        Ok(()) => CliExit::silent_failure(0),
+        Err(exit) => exit,
+    }
+}
+
+async fn dispatch() -> Result<(), CliExit> {
     let mut parser = lexopt::Parser::from_env();
 
-    let Some(arg) = parser.next().unwrap_or_else(|e| {
-        eprintln!("Error: {e}");
-        process::exit(1);
-    }) else {
-        print_usage();
-        process::exit(1);
+    let Some(arg) = parser.next().map_err(CliExit::error)? else {
+        let mut usage = String::new();
+        write_usage(&mut usage);
+        return Err(CliExit::error_with_usage("missing command", &usage));
     };
 
     match arg {
         Long("help") => {
-            print_usage();
-            process::exit(0);
+            let mut usage = String::new();
+            write_usage(&mut usage);
+            Err(CliExit::help(usage))
         }
         Long("version") => {
             print_version();
-            process::exit(0);
+            Ok(())
         }
         Value(cmd_val) => {
             let cmd_str = cmd_val.to_string_lossy();
-            if let Some(cmd) = Cmd::from_name(&cmd_str) {
-                match cmd {
-                    Cmd::Init => {
-                        let opts = wado_cli::init::parse_args(parser).unwrap_or_else(|e| e.exit());
-                        wado_cli::init::run(opts);
-                    }
-                    // Each subcommand's `async fn run()` is wrapped in
-                    // `Box::pin` so its future is type-erased at this
-                    // boundary. Without this, the compiler must compute
-                    // the layout of `async_main`'s state machine by
-                    // recursively inlining the futures of EVERY subcommand
-                    // (12 of them), each of which transitively pulls in
-                    // its own await chain (compile → try_compile →
-                    // wado_compiler::compile_with_options → ...). That
-                    // recursion blows past Rust's default query-depth
-                    // limit on `--release` builds. Boxing here costs one
-                    // heap allocation per CLI invocation, which is free
-                    // for a one-shot binary.
-                    Cmd::Compile => {
-                        let opts =
-                            wado_cli::compile::parse_args(parser).unwrap_or_else(|e| e.exit());
-                        Box::pin(wado_cli::compile::run(opts)).await;
-                    }
-                    Cmd::Check => {
-                        let opts = wado_cli::check::parse_args(parser).unwrap_or_else(|e| e.exit());
-                        Box::pin(wado_cli::check::run(opts)).await;
-                    }
-                    Cmd::Run => {
-                        let opts = wado_cli::run::parse_args(parser).unwrap_or_else(|e| e.exit());
-                        Box::pin(wado_cli::run::run(opts)).await;
-                    }
-                    Cmd::Serve => {
-                        let opts = wado_cli::serve::parse_args(parser).unwrap_or_else(|e| e.exit());
-                        Box::pin(wado_cli::serve::run(opts)).await;
-                    }
-                    Cmd::Test => {
-                        let opts = wado_cli::test::parse_args(parser).unwrap_or_else(|e| e.exit());
-                        Box::pin(wado_cli::test::run(opts)).await;
-                    }
-                    Cmd::Format => {
-                        let opts =
-                            wado_cli::format::parse_args(parser).unwrap_or_else(|e| e.exit());
-                        wado_cli::format::run(opts);
-                    }
-                    Cmd::Doc => {
-                        let opts = wado_cli::doc::parse_args(parser).unwrap_or_else(|e| e.exit());
-                        wado_cli::doc::run(opts);
-                    }
-                    Cmd::Dump => {
-                        let opts = wado_cli::dump::parse_args(parser).unwrap_or_else(|e| e.exit());
-                        Box::pin(wado_cli::dump::run(opts)).await;
-                    }
-                    Cmd::Syntax => {
-                        let opts =
-                            wado_cli::syntax::parse_args(parser).unwrap_or_else(|e| e.exit());
-                        wado_cli::syntax::run(opts);
-                    }
-                    Cmd::Lsp => {
-                        Box::pin(wado_cli::lsp::run()).await;
-                    }
-                    Cmd::Query => {
-                        let opts = wado_cli::query::parse_args(parser).unwrap_or_else(|e| e.exit());
-                        Box::pin(wado_cli::query::run(opts)).await;
-                    }
+            let Some(cmd) = Cmd::from_name(&cmd_str) else {
+                let mut usage = String::new();
+                write_usage(&mut usage);
+                return Err(CliExit::error_with_usage(
+                    format!("unknown command '{cmd_str}'"),
+                    &usage,
+                ));
+            };
+            match cmd {
+                Cmd::Init => {
+                    let opts = wado_cli::init::parse_args(parser)?;
+                    wado_cli::init::run(opts)
                 }
-            } else {
-                eprintln!("Error: unknown command '{cmd_str}'");
-                print_usage();
-                process::exit(1);
+                // Each subcommand's `async fn run()` is wrapped in
+                // `Box::pin` so its future is type-erased at this
+                // boundary. Without this, the compiler must compute
+                // the layout of `dispatch`'s state machine by
+                // recursively inlining the futures of EVERY subcommand
+                // (12 of them), each of which transitively pulls in
+                // its own await chain (compile → try_compile →
+                // wado_compiler::compile_with_options → ...). That
+                // recursion blows past Rust's default query-depth
+                // limit on `--release` builds. Boxing here costs one
+                // heap allocation per CLI invocation, which is free
+                // for a one-shot binary.
+                Cmd::Compile => {
+                    let opts = wado_cli::compile::parse_args(parser)?;
+                    Box::pin(wado_cli::compile::run(opts)).await
+                }
+                Cmd::Check => {
+                    let opts = wado_cli::check::parse_args(parser)?;
+                    Box::pin(wado_cli::check::run(opts)).await
+                }
+                Cmd::Run => {
+                    let opts = wado_cli::run::parse_args(parser)?;
+                    Box::pin(wado_cli::run::run(opts)).await
+                }
+                Cmd::Serve => {
+                    let opts = wado_cli::serve::parse_args(parser)?;
+                    Box::pin(wado_cli::serve::run(opts)).await
+                }
+                Cmd::Test => {
+                    let opts = wado_cli::test::parse_args(parser)?;
+                    Box::pin(wado_cli::test::run(opts)).await
+                }
+                Cmd::Format => {
+                    let opts = wado_cli::format::parse_args(parser)?;
+                    wado_cli::format::run(opts)
+                }
+                Cmd::Doc => {
+                    let opts = wado_cli::doc::parse_args(parser)?;
+                    wado_cli::doc::run(opts)
+                }
+                Cmd::Dump => {
+                    let opts = wado_cli::dump::parse_args(parser)?;
+                    Box::pin(wado_cli::dump::run(opts)).await
+                }
+                Cmd::Syntax => {
+                    let opts = wado_cli::syntax::parse_args(parser)?;
+                    wado_cli::syntax::run(opts)
+                }
+                Cmd::Lsp => Box::pin(wado_cli::lsp::run()).await,
+                Cmd::Query => {
+                    let opts = wado_cli::query::parse_args(parser)?;
+                    Box::pin(wado_cli::query::run(opts)).await
+                }
             }
         }
         _ => {
-            eprintln!("Error: expected command");
-            print_usage();
-            process::exit(1);
+            let mut usage = String::new();
+            write_usage(&mut usage);
+            Err(CliExit::error_with_usage("expected command", &usage))
         }
     }
 }

--- a/wado-cli/src/main.rs
+++ b/wado-cli/src/main.rs
@@ -4,10 +4,8 @@ use lexopt::Arg::{Long, Value};
 use mimalloc::MiMalloc;
 use wado_cli::args::CliExit;
 
-// `wado serve` allocates and frees a burst of small per-request objects
-// (request/response buffers, header maps, resource tables) on every request.
-// The system allocator's cross-thread contention dominates the host CPU
-// profile under load, so route all allocation through mimalloc.
+// `wado serve` is allocation-heavy per request; mimalloc avoids the
+// system allocator's cross-thread contention.
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 
@@ -174,18 +172,10 @@ async fn dispatch() -> Result<(), CliExit> {
                     let opts = wado_cli::init::parse_args(parser)?;
                     wado_cli::init::run(opts)
                 }
-                // Each subcommand's `async fn run()` is wrapped in
-                // `Box::pin` so its future is type-erased at this
-                // boundary. Without this, the compiler must compute
-                // the layout of `dispatch`'s state machine by
-                // recursively inlining the futures of EVERY subcommand
-                // (12 of them), each of which transitively pulls in
-                // its own await chain (compile → try_compile →
-                // wado_compiler::compile_with_options → ...). That
-                // recursion blows past Rust's default query-depth
-                // limit on `--release` builds. Boxing here costs one
-                // heap allocation per CLI invocation, which is free
-                // for a one-shot binary.
+                // Each subcommand's future is boxed so `dispatch`'s state
+                // machine doesn't recursively inline all 12 subcommands'
+                // await chains and blow past Rust's query-depth limit on
+                // `--release` builds.
                 Cmd::Compile => {
                     let opts = wado_cli::compile::parse_args(parser)?;
                     Box::pin(wado_cli::compile::run(opts)).await

--- a/wado-cli/src/query.rs
+++ b/wado-cli/src/query.rs
@@ -112,11 +112,6 @@ fn parse_position_value(opt_name: &str, val: String) -> Result<u32, CliExit> {
     })
 }
 
-/// Parse command-line arguments for the `query` subcommand.
-///
-/// # Errors
-///
-/// Returns an error if the arguments are invalid or required arguments are missing.
 pub fn parse_args(mut parser: lexopt::Parser) -> Result<QueryOptions, CliExit> {
     let usage = format_usage();
     let mut kind: Option<QueryKind> = None;

--- a/wado-cli/src/query.rs
+++ b/wado-cli/src/query.rs
@@ -195,7 +195,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<QueryOptions, CliExit> {
     })
 }
 
-pub async fn run(opts: QueryOptions) {
+pub async fn run(opts: QueryOptions) -> Result<(), CliExit> {
     match opts.kind {
         QueryKind::Diagnostics => query_adapter::run_diagnostics(&opts.input, opts.json).await,
         QueryKind::References => {
@@ -206,7 +206,7 @@ pub async fn run(opts: QueryOptions) {
                 opts.include_declaration,
                 opts.json,
             )
-            .await;
+            .await
         }
         QueryKind::DocumentHighlight => {
             query_adapter::run_document_highlight(
@@ -215,7 +215,7 @@ pub async fn run(opts: QueryOptions) {
                 opts.column.unwrap(),
                 opts.json,
             )
-            .await;
+            .await
         }
         QueryKind::Definition => {
             query_adapter::run_definition(
@@ -224,7 +224,7 @@ pub async fn run(opts: QueryOptions) {
                 opts.column.unwrap(),
                 opts.json,
             )
-            .await;
+            .await
         }
     }
 }

--- a/wado-cli/src/query_adapter.rs
+++ b/wado-cli/src/query_adapter.rs
@@ -43,7 +43,6 @@ fn position_from_one_based(line: u32, column: u32) -> Position {
     }
 }
 
-/// Run diagnostics query and print results.
 pub async fn run_diagnostics(filename: &str, json_output: bool) -> Result<(), CliExit> {
     let prepared = prepare_query(filename)?;
     let diagnostics = prepared
@@ -66,7 +65,6 @@ pub async fn run_diagnostics(filename: &str, json_output: bool) -> Result<(), Cl
     Ok(())
 }
 
-/// Run references query and print results.
 pub async fn run_references(
     filename: &str,
     line: u32,
@@ -91,7 +89,6 @@ pub async fn run_references(
     Ok(())
 }
 
-/// Run definition query and print results.
 pub async fn run_definition(
     filename: &str,
     line: u32,
@@ -115,7 +112,6 @@ pub async fn run_definition(
     Ok(())
 }
 
-/// Run document-highlight query and print results.
 pub async fn run_document_highlight(
     filename: &str,
     line: u32,
@@ -139,11 +135,9 @@ pub async fn run_document_highlight(
     Ok(())
 }
 
-/// When a position-based query returns no results, the cause is ambiguous —
-/// the cursor might genuinely be on nothing, or the file might have failed to
-/// compile far enough to populate the symbol table. Surface the compiler
-/// errors on stderr so users can distinguish the two without re-running
-/// `wado query diagnostics`.
+/// An empty position-based result is ambiguous (cursor on nothing vs.
+/// symbol table never populated). Surface the underlying errors so the
+/// user doesn't need to re-run `wado query diagnostics` to find out.
 fn warn_on_compile_errors(host: &FilesystemCompilerHost, result_was_empty: bool) {
     if !result_was_empty || !host.has_errors() {
         return;

--- a/wado-cli/src/query_adapter.rs
+++ b/wado-cli/src/query_adapter.rs
@@ -1,10 +1,10 @@
 use std::fs;
 use std::path::Path;
-use std::process;
 
 use serde_json::json;
 use wado_lsp::{DefinitionResult, DocumentHighlight, HighlightKind, Position, ReferenceLocation};
 
+use crate::args::CliExit;
 use crate::compiler_host::FilesystemCompilerHost;
 
 struct PreparedQuery {
@@ -13,15 +13,10 @@ struct PreparedQuery {
     host: FilesystemCompilerHost,
 }
 
-fn prepare_query(filename: &str) -> PreparedQuery {
+fn prepare_query(filename: &str) -> Result<PreparedQuery, CliExit> {
     let path = Path::new(filename);
-    let source = match fs::read_to_string(path) {
-        Ok(s) => s,
-        Err(e) => {
-            eprintln!("Error reading '{}': {e}", path.display());
-            process::exit(1);
-        }
-    };
+    let source = fs::read_to_string(path)
+        .map_err(|e| CliExit::error(format!("reading '{}': {e}", path.display())))?;
 
     let base_path = path
         .parent()
@@ -38,7 +33,7 @@ fn prepare_query(filename: &str) -> PreparedQuery {
     let mut engine = wado_lsp::Engine::new();
     engine.open_document(&uri, source);
 
-    PreparedQuery { uri, engine, host }
+    Ok(PreparedQuery { uri, engine, host })
 }
 
 fn position_from_one_based(line: u32, column: u32) -> Position {
@@ -49,8 +44,8 @@ fn position_from_one_based(line: u32, column: u32) -> Position {
 }
 
 /// Run diagnostics query and print results.
-pub async fn run_diagnostics(filename: &str, json_output: bool) {
-    let prepared = prepare_query(filename);
+pub async fn run_diagnostics(filename: &str, json_output: bool) -> Result<(), CliExit> {
+    let prepared = prepare_query(filename)?;
     let diagnostics = prepared
         .engine
         .diagnostics(&prepared.uri, &prepared.host)
@@ -66,8 +61,9 @@ pub async fn run_diagnostics(filename: &str, json_output: bool) {
         .iter()
         .any(|d| matches!(d.severity, wado_lsp::Severity::Error))
     {
-        process::exit(1);
+        return Err(CliExit::silent_failure(1));
     }
+    Ok(())
 }
 
 /// Run references query and print results.
@@ -77,8 +73,8 @@ pub async fn run_references(
     column: u32,
     include_declaration: bool,
     json_output: bool,
-) {
-    let prepared = prepare_query(filename);
+) -> Result<(), CliExit> {
+    let prepared = prepare_query(filename)?;
     let position = position_from_one_based(line, column);
     let refs = prepared
         .engine
@@ -92,11 +88,17 @@ pub async fn run_references(
     }
 
     warn_on_compile_errors(&prepared.host, refs.is_empty());
+    Ok(())
 }
 
 /// Run definition query and print results.
-pub async fn run_definition(filename: &str, line: u32, column: u32, json_output: bool) {
-    let prepared = prepare_query(filename);
+pub async fn run_definition(
+    filename: &str,
+    line: u32,
+    column: u32,
+    json_output: bool,
+) -> Result<(), CliExit> {
+    let prepared = prepare_query(filename)?;
     let position = position_from_one_based(line, column);
     let result = prepared
         .engine
@@ -110,11 +112,17 @@ pub async fn run_definition(filename: &str, line: u32, column: u32, json_output:
     }
 
     warn_on_compile_errors(&prepared.host, result.is_none());
+    Ok(())
 }
 
 /// Run document-highlight query and print results.
-pub async fn run_document_highlight(filename: &str, line: u32, column: u32, json_output: bool) {
-    let prepared = prepare_query(filename);
+pub async fn run_document_highlight(
+    filename: &str,
+    line: u32,
+    column: u32,
+    json_output: bool,
+) -> Result<(), CliExit> {
+    let prepared = prepare_query(filename)?;
     let position = position_from_one_based(line, column);
     let highlights = prepared
         .engine
@@ -128,6 +136,7 @@ pub async fn run_document_highlight(filename: &str, line: u32, column: u32, json
     }
 
     warn_on_compile_errors(&prepared.host, highlights.is_empty());
+    Ok(())
 }
 
 /// When a position-based query returns no results, the cause is ambiguous —

--- a/wado-cli/src/run.rs
+++ b/wado-cli/src/run.rs
@@ -1,6 +1,5 @@
 use std::fmt::Write as _;
 use std::io::BufWriter;
-use std::process;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -327,7 +326,7 @@ async fn run_cli_component(
     Ok(())
 }
 
-pub async fn run(opts: RunOptions) {
+pub async fn run(opts: RunOptions) -> Result<(), CliExit> {
     // `wado run` always targets `wasi:cli/command`; pass `None` so the
     // compiler picks its default world (and bump allocator unless the
     // caller overrode it via --allocator).
@@ -341,9 +340,9 @@ pub async fn run(opts: RunOptions) {
         allocator: opts.allocator,
     };
     let cranelift_opt = opts.opt_level.to_wasmtime();
-    let wasm = compile::compile(&opts.input, &flags).await;
+    let wasm = compile::compile(&opts.input, &flags).await?;
 
-    if let Err(e) = run_cli_component(
+    run_cli_component(
         &wasm,
         cranelift_opt,
         &opts.profile,
@@ -351,8 +350,5 @@ pub async fn run(opts: RunOptions) {
         &opts.program_args,
     )
     .await
-    {
-        eprintln!("Runtime error: {e:?}");
-        process::exit(1);
-    }
+    .map_err(|e| CliExit::error(format!("Runtime error: {e:?}")))
 }

--- a/wado-cli/src/run.rs
+++ b/wado-cli/src/run.rs
@@ -20,10 +20,9 @@ pub struct RunOptions {
     pub opt_level: OptLevel,
     pub log_level: LogLevel,
     pub profile: ProfileMode,
-    /// Preopened directories as `(host_path, guest_path)` pairs.
-    /// Populated by `--dir host_path[::guest_path]`.
+    /// `(host_path, guest_path)` pairs from `--dir host[::guest]`.
     pub preopened_dirs: Vec<(String, String)>,
-    /// Arguments passed to the guest program via `wasi:cli/environment.get-arguments`.
+    /// Arguments forwarded to the guest via `wasi:cli/environment.get-arguments`.
     pub program_args: Vec<String>,
     pub inline_threshold: Option<usize>,
     pub opt_iterations: Option<u32>,
@@ -58,8 +57,8 @@ impl Opt {
 
     const fn spec(self) -> args::OptSpec {
         match self {
-            // `run` overrides the shared --dir description because it
-            // ALSO documents the implicit "preopen cwd by default" rule.
+            // Override the shared --dir description to also document the
+            // implicit "preopen cwd by default" rule.
             Self::Dir => args::OptSpec {
                 long: Some("dir"),
                 short: None,
@@ -131,13 +130,7 @@ pub fn print_usage() {
     eprint!("{}", format_usage());
 }
 
-/// Parse a `--profile` argument value into a [`ProfileMode`].
-///
-/// Shared by the `run` and `serve` subcommands.
-///
-/// # Errors
-///
-/// Returns an error if the profile mode string is unrecognized.
+/// Parse `--profile`. Shared by `run` and `serve`.
 pub fn parse_profile(s: &str) -> Result<ProfileMode, CliExit> {
     if s == "jitdump" {
         return Ok(ProfileMode::JitDump);
@@ -172,11 +165,6 @@ pub fn parse_profile(s: &str) -> Result<ProfileMode, CliExit> {
     )))
 }
 
-/// Parse command-line arguments for the `run` subcommand.
-///
-/// # Errors
-///
-/// Returns an error if the arguments are invalid or required arguments are missing.
 pub fn parse_args(mut parser: lexopt::Parser) -> Result<RunOptions, CliExit> {
     let usage = format_usage();
     let mut input: Option<String> = None;
@@ -222,8 +210,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<RunOptions, CliExit> {
             }
         } else if let Value(val) = arg {
             input = Some(val.to_string_lossy().into_owned());
-            // Once the input file is captured, all remaining arguments
-            // (including --flags) are passed to the guest program.
+            // Everything after the input file (flags included) is forwarded to the guest.
             if let Some(raw) = parser.try_raw_args() {
                 for raw_arg in raw {
                     program_args.push(raw_arg.to_string_lossy().into_owned());
@@ -265,7 +252,6 @@ async fn run_cli_component(
     let linker = runtime::create_linker(&engine)?;
     let mut store = runtime::create_store(&engine, preopened_dirs, program_args)?;
 
-    // Set up guest profiler if requested.
     let profiler = if let ProfileMode::Guest { interval_ms, .. } = profile {
         let interval = Duration::from_millis(*interval_ms);
         let profiler = GuestProfiler::new_component(
@@ -277,7 +263,6 @@ async fn run_cli_component(
         )?;
         let profiler = Arc::new(Mutex::new(Some(profiler)));
 
-        // Register epoch deadline callback for sampling.
         let profiler_for_cb = profiler.clone();
         store.epoch_deadline_callback(move |store_ctx| {
             if let Some(ref mut p) = *profiler_for_cb.lock().unwrap() {
@@ -287,7 +272,6 @@ async fn run_cli_component(
         });
         store.set_epoch_deadline(1);
 
-        // Start epoch-bumping thread.
         let stop = Arc::new(AtomicBool::new(false));
         let stop_clone = stop.clone();
         let engine_clone = engine.clone();
@@ -308,7 +292,6 @@ async fn run_cli_component(
 
     let (result,) = run_func.call_async(&mut store, ()).await?;
 
-    // Finish guest profiling.
     if let Some((profiler_arc, stop)) = profiler {
         stop.store(true, Ordering::Relaxed);
 
@@ -327,9 +310,8 @@ async fn run_cli_component(
 }
 
 pub async fn run(opts: RunOptions) -> Result<(), CliExit> {
-    // `wado run` always targets `wasi:cli/command`; pass `None` so the
-    // compiler picks its default world (and bump allocator unless the
-    // caller overrode it via --allocator).
+    // Pass `target_world: None` so the compiler picks the cli/command default
+    // (and bump allocator unless overridden).
     let flags = CompileFlags {
         opt_level: opts.opt_level,
         log_level: opts.log_level,

--- a/wado-cli/src/serve.rs
+++ b/wado-cli/src/serve.rs
@@ -37,28 +37,21 @@ use crate::manifest;
 use crate::runtime::{self, Preopens, ProfileMode, WasiState};
 use wado_compiler::LogLevel;
 
-/// Default per-request timeout in seconds. A guest that fails to produce a
-/// response head within this window is cut short by a first-byte timeout
-/// (see `dispatch_request`); a guest that runs away in pure wasm is
-/// trapped by the epoch deadline (see `worker_loop`).
+/// First-byte timeout cuts off guests stuck in the host; the epoch
+/// deadline (see `worker_loop`) catches runaway pure-wasm loops.
 const DEFAULT_TIMEOUT_SECS: u64 = 30;
 
-/// Epoch ticker interval. A background thread bumps the engine epoch every
-/// tick; a worker store's deadline counts these ticks, giving
-/// second-granularity runaway-guest detection.
+/// Engine epoch is bumped every tick; deadlines count ticks, so this
+/// is the granularity of runaway-guest detection.
 const EPOCH_TICK_MS: u64 = 1000;
 
-/// Default number of requests a worker instance handles before it is
-/// recycled (torn down and re-instantiated). Recycling resets state that
-/// accumulates in a long-lived instance — chiefly the component resource
-/// table (see issue #1133). Measured throughput is flat across recycle
-/// thresholds from ~1k to ~100k requests, so this is sized for infrequent
-/// recycling. `0` disables recycling.
+/// Recycling resets state that accumulates in a long-lived instance,
+/// notably the component resource table (issue #1133). Throughput is
+/// flat from ~1k to ~100k requests so recycling is sized rare. `0` disables.
 const DEFAULT_RECYCLE_REQUESTS: u64 = 10000;
 
-/// Default ceiling on concurrently in-flight requests. Each in-flight
-/// request needs an async fiber stack from the pooling allocator, so this
-/// also sizes the engine's stack pool.
+/// Each in-flight request needs an async fiber stack from the pooling
+/// allocator, so this also sizes the engine's stack pool.
 const DEFAULT_MAX_CONCURRENCY: usize = 1024;
 
 pub struct ServeOptions {
@@ -69,19 +62,15 @@ pub struct ServeOptions {
     pub inline_threshold: Option<usize>,
     pub opt_iterations: Option<u32>,
     pub allocator: Option<String>,
-    /// Preopened directories as `(host_path, guest_path)` pairs. Empty by
-    /// default — services rarely need filesystem access, so unlike `wado run`
-    /// we do NOT preopen the cwd unless the user passes `--dir`.
+    /// Empty by default: unlike `wado run`, services don't preopen cwd
+    /// automatically — the user must pass `--dir`.
     pub preopened_dirs: Vec<(String, String)>,
-    /// Per-request timeout in seconds.
     pub timeout_secs: u64,
-    /// Number of worker instances. `None` means "one per CPU".
+    /// `None` ⇒ one worker per CPU.
     pub workers: Option<usize>,
-    /// Recycle a worker after this many requests; `0` disables recycling.
+    /// Recycle a worker after this many requests; `0` disables.
     pub recycle_requests: u64,
-    /// Ceiling on concurrently in-flight requests.
     pub max_concurrency: usize,
-    /// Guest profiling mode. `--profile guest` samples a single worker.
     pub profile: ProfileMode,
 }
 
@@ -228,11 +217,6 @@ fn parse_count_arg(
     Ok(n)
 }
 
-/// Parse command-line arguments for the `serve` subcommand.
-///
-/// # Errors
-///
-/// Returns an error if the arguments are invalid or required arguments are missing.
 pub fn parse_args(mut parser: lexopt::Parser) -> Result<ServeOptions, CliExit> {
     let usage = format_usage();
     let mut input: Option<String> = None;
@@ -337,12 +321,8 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<ServeOptions, CliExit> {
     })
 }
 
-/// Outcome the spawned handler task delivers to the request entry point.
-///
-/// `Streaming` is the success path: response head plus a `Receiver` that
-/// will yield each body frame as the guest produces it. The other variants
-/// are terminal failure modes that have to be rendered as a synthetic 5xx
-/// because no part of the response has been put on the wire yet.
+/// `Streaming` is the success path — head + body receiver. The other
+/// variants are pre-head failures that must be rendered as a synthetic 5xx.
 enum HandlerOutcome {
     Streaming(http::response::Parts, mpsc::Receiver<Frame<Bytes>>),
     GuestError(wasmtime_wasi_http::p3::bindings::http::types::ErrorCode),
@@ -350,11 +330,9 @@ enum HandlerOutcome {
     Timeout,
 }
 
-/// `http_body::Body` implementation backed by a tokio `mpsc::Receiver` of
-/// frames. Used to stream the guest's response body to hyper one frame at
-/// a time without buffering the full body in memory.
-///
-/// Trailers travel through the same channel as `Frame::trailers(...)`.
+/// `http_body::Body` over a tokio `mpsc::Receiver` — frames flow one at a
+/// time, so the full body never sits in memory. Trailers piggyback on the
+/// same channel as `Frame::trailers(...)`.
 struct ChannelBody {
     rx: mpsc::Receiver<Frame<Bytes>>,
 }
@@ -385,35 +363,26 @@ fn error_response(status: u16, msg: String) -> HyperResponse<StreamingBody> {
         .expect("static status code should always build successfully")
 }
 
-/// A request handed to the engine task for processing on the shared
-/// component instance.
 struct RequestJob {
     wasi_req: WasiRequest,
     io: Pin<Box<dyn Future<Output = Result<(), HttpErrorCode>> + Send>>,
     resp_tx: oneshot::Sender<HandlerOutcome>,
 }
 
-/// Processes one HTTP request on the long-lived component instance.
+/// One HTTP request, spawned (via `Accessor::spawn`) onto the long-lived
+/// component instance — so guest state persists across requests, exactly
+/// like a conventional HTTP server daemon.
 ///
-/// The component is instantiated once at server startup; every request
-/// runs as a task spawned (via `Accessor::spawn`) onto that single shared
-/// instance. Guest state therefore persists across requests — managing it
-/// is the Wado program's responsibility, exactly as for a conventional
-/// HTTP server daemon.
-///
-/// As soon as the response head is available the task hands it — plus a
-/// body-frame channel — back to `dispatch_request` over a oneshot; from
-/// then on hyper drains body frames directly from that channel while the
-/// task keeps producing them. The channel is bounded (capacity 8), so a
-/// slow consumer back-pressures the guest.
+/// As soon as the response head is ready the task hands it — plus a
+/// body-frame channel — back to `dispatch_request` over a oneshot. Hyper
+/// then drains body frames directly from the bounded (cap 8) channel,
+/// back-pressuring a slow consumer onto the guest.
 struct HandlerTask {
     service: Arc<Service>,
     job: RequestJob,
-    /// Idle timeout for the body pump. A `frame_tx.send` that stalls longer
-    /// than this — a client that stops draining the response but keeps the
-    /// connection open — aborts the pump, so a non-draining client cannot
-    /// pin this task's fiber stack indefinitely (issue #1138). The timeout
-    /// is applied per frame, so a slow-but-progressing client is unaffected.
+    /// Per-frame idle timeout on the body pump. A non-draining client
+    /// (issue #1138) cannot pin this task's fiber stack indefinitely;
+    /// a slow-but-progressing client is unaffected.
     idle_timeout: Duration,
 }
 

--- a/wado-cli/src/serve.rs
+++ b/wado-cli/src/serve.rs
@@ -3,7 +3,6 @@ use std::fmt::Write as _;
 use std::future::Future;
 use std::net::SocketAddr;
 use std::pin::{Pin, pin};
-use std::process;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::task::{Context, Poll};
@@ -1172,7 +1171,7 @@ fn log_connection_join_error(res: Result<(), tokio::task::JoinError>) {
     }
 }
 
-pub async fn run(opts: ServeOptions) {
+pub async fn run(opts: ServeOptions) -> Result<(), CliExit> {
     let flags = CompileFlags {
         opt_level: opts.opt_level,
         log_level: opts.log_level,
@@ -1183,7 +1182,7 @@ pub async fn run(opts: ServeOptions) {
         allocator: opts.allocator,
     };
     let cranelift_opt = opts.opt_level.to_wasmtime();
-    let wasm = compile::compile(&opts.input, &flags).await;
+    let wasm = compile::compile(&opts.input, &flags).await?;
 
     let timeout = Duration::from_secs(opts.timeout_secs);
     // An explicit `--workers` is already validated against `--max-concurrency`
@@ -1203,7 +1202,7 @@ pub async fn run(opts: ServeOptions) {
         eprintln!("Profiling: forcing --workers 1");
         workers = 1;
     }
-    if let Err(e) = run_http_server(
+    run_http_server(
         wasm,
         &opts.addr,
         cranelift_opt,
@@ -1215,8 +1214,5 @@ pub async fn run(opts: ServeOptions) {
         opts.profile,
     )
     .await
-    {
-        eprintln!("Server error: {e}");
-        process::exit(1);
-    }
+    .map_err(|e| CliExit::error(format!("Server error: {e}")))
 }

--- a/wado-cli/src/syntax.rs
+++ b/wado-cli/src/syntax.rs
@@ -92,11 +92,6 @@ fn format_usage() -> String {
     buf
 }
 
-/// Parse command-line arguments for the `syntax` subcommand.
-///
-/// # Errors
-///
-/// Returns an error if the arguments are invalid or required arguments are missing.
 pub fn parse_args(mut parser: Parser) -> Result<SyntaxOptions, CliExit> {
     let usage = format_usage();
     let mut format = SyntaxFormat::TmLanguage;

--- a/wado-cli/src/syntax.rs
+++ b/wado-cli/src/syntax.rs
@@ -13,7 +13,7 @@ use serde_json::json;
 
 use wado_compiler::syntax::SyntaxDefinition;
 
-use crate::args::{self, CliExit, exit_error};
+use crate::args::{self, CliExit};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum SyntaxFormat {
@@ -126,7 +126,7 @@ pub fn parse_args(mut parser: Parser) -> Result<SyntaxOptions, CliExit> {
     Ok(SyntaxOptions { format, output })
 }
 
-pub fn run(opts: SyntaxOptions) {
+pub fn run(opts: SyntaxOptions) -> Result<(), CliExit> {
     let def = SyntaxDefinition::wado();
 
     let output_str = match opts.format {
@@ -141,9 +141,8 @@ pub fn run(opts: SyntaxOptions) {
     };
 
     if let Some(path) = opts.output {
-        fs::write(&path, &output_str).unwrap_or_else(|e| {
-            exit_error(&format!("failed to write to {path}: {e}"));
-        });
+        fs::write(&path, &output_str)
+            .map_err(|e| CliExit::error(format!("failed to write to {path}: {e}")))?;
         eprintln!("Generated: {path}");
     } else {
         io::stdout()
@@ -151,6 +150,7 @@ pub fn run(opts: SyntaxOptions) {
             .expect("failed to write to stdout");
         println!();
     }
+    Ok(())
 }
 
 /// Generate `TextMate` grammar JSON for VS Code

--- a/wado-cli/src/test.rs
+++ b/wado-cli/src/test.rs
@@ -27,17 +27,13 @@ use crate::runtime::{self, WasiState};
 use wado_compiler::LogLevel;
 
 const DEFAULT_TIMEOUT_MS: u64 = 5000;
-// Epoch tick interval for wasmtime's epoch-based interruption.
-// A coarser interval (1s) reduces thread wake-ups. The trade-off is up to 1s
-// of overshoot beyond the nominal timeout, which is acceptable since timeouts
-// only fire on runaway tests, not on normal execution.
+// Coarse epoch interval to keep thread wake-ups down. Cost: up to 1s
+// overshoot, which is fine because timeouts only fire on runaway tests.
 const EPOCH_INTERVAL_MS: u64 = 1000;
 
 pub struct TestOptions {
-    /// Each entry corresponds to one package context. The first entry is the
-    /// root package (or the synthetic `"."` label when `wado test` is invoked
-    /// outside a `wado.toml` project); subsequent entries come from
-    /// recursively discovered sub-packages.
+    /// First entry is the root package (label `"."` outside a `wado.toml`
+    /// project); later entries are sub-packages discovered recursively.
     pub package_runs: Vec<PackageRun>,
     pub jobs: usize,
     pub opt_level: OptLevel,
@@ -45,21 +41,17 @@ pub struct TestOptions {
     pub inline_threshold: Option<usize>,
     pub opt_iterations: Option<u32>,
     /// `None` lets the compiler auto-select the debug allocator for the
-    /// `test` world; explicit `--allocator` overrides that.
+    /// `test` world; `--allocator` overrides.
     pub allocator: Option<String>,
-    /// Preopened directories as `(host_path, guest_path)` pairs.
     pub preopened_dirs: Vec<(String, String)>,
-    /// `true` when `--no-run` is set: compile every discovered file
-    /// (which still writes `<primary>.kiln.json` as a side-effect of the
-    /// compile pipeline) but skip Phase 2 — the wasmtime execution.
-    /// Mirrors `cargo test --no-run`.
+    /// `--no-run`: compile every file (which still refreshes
+    /// `<primary>.kiln.json` as a side-effect) but skip wasmtime execution.
     pub no_run: bool,
 }
 
 impl TestOptions {
-    /// Build the `CompileFlags` shared with `compile`/`run`/`serve`. The
-    /// `target_world` is pinned to `test` so test functions become exports
-    /// and DCE prunes everything else.
+    // Pin `target_world` to `test` so test functions become exports and
+    // DCE prunes everything else.
     fn compile_flags(&self) -> CompileFlags {
         CompileFlags {
             opt_level: self.opt_level,
@@ -73,10 +65,8 @@ impl TestOptions {
     }
 }
 
-/// One package context's discovered test files.
 pub struct PackageRun {
-    /// Display label, relative to the original invocation directory
-    /// (`"."` for the root, `"subpkg"` for a nested sub-package).
+    /// `"."` for the root, `"subpkg"` for a nested sub-package.
     pub label: String,
     pub paths: Vec<String>,
 }
@@ -175,18 +165,13 @@ pub fn print_usage() {
     eprint!("{}", format_usage());
 }
 
-/// Walk `root` and produce one `PackageRun` for the root and one for each
-/// sub-package discovered transitively (cargo-workspace-style).
+/// Cargo-workspace-style walk: one `PackageRun` for `root`, plus one per
+/// transitively discovered sub-package. Returned root-first.
 ///
-/// `apply_manifest_excludes` controls whether the root package's
-/// `[test].exclude` is honoured. Sub-packages always apply their own
-/// manifest. CLI `--exclude` patterns (`extra_excludes`) apply to *every*
-/// package walked: each pattern is matched relative to the package being
-/// walked, so a project-wide `--exclude 'tests/**'` drops `tests/` in the
-/// root and in every nested package consistently.
-///
-/// The returned list is ordered: the root package first, then sub-packages in
-/// source order.
+/// `apply_manifest_excludes` gates the root's `[test].exclude`
+/// (sub-packages always apply their own). `extra_excludes` (CLI
+/// `--exclude`) apply per-package and are matched relative to the package
+/// being walked.
 fn discover_packages(
     root: &Path,
     apply_manifest_excludes: bool,
@@ -229,9 +214,8 @@ fn discover_packages(
     Ok(runs)
 }
 
-/// Compile a package's exclude set: the manifest's `[test].exclude` plus
-/// any CLI `--exclude` patterns. Both layers share the same shape so the
-/// walker treats them uniformly.
+// `[test].exclude` (manifest) + `--exclude` (CLI) share the same shape so
+// the walker treats them uniformly.
 fn compile_excludes(
     manifest: &[String],
     extra_excludes: &[String],
@@ -244,17 +228,12 @@ fn compile_excludes(
     discover::ExcludeSet::compile(&combined).map_err(CliExit::error)
 }
 
-/// Compile a package's include set from the manifest's `[test].include`
-/// patterns. There is no CLI counterpart (yet) — includes are a manifest
-/// concept that lets stdlib-style packages keep `*_test.wado` files visible
-/// inside an otherwise-excluded directory.
+// `[test].include` is manifest-only (no CLI flag yet) and lets stdlib-style
+// packages keep `*_test.wado` files visible inside an excluded directory.
 fn compile_includes(manifest: &[String]) -> Result<discover::IncludeSet, CliExit> {
     discover::IncludeSet::compile(manifest).map_err(CliExit::error)
 }
 
-/// Walk a single package root, append its `PackageRun`, and queue its
-/// sub-packages (in source order — pushed in reverse so the LIFO `pop`
-/// emits them root-first).
 fn walk_into(
     pkg_root: &Path,
     invocation_root: &Path,
@@ -274,10 +253,8 @@ fn walk_into(
     Ok(())
 }
 
-/// Read `[test].exclude` and `[test].include` from the `wado.toml` rooted at
-/// `pkg_root` (if any). Returns empty lists when no manifest sits exactly at
-/// that directory — sub-packages without their own `wado.toml` simply
-/// contribute no filters.
+// Returns `(exclude, include)` from the `wado.toml` rooted exactly at
+// `pkg_root`. Sub-packages without their own manifest contribute nothing.
 fn package_manifest_test_filters(pkg_root: &Path) -> Result<(Vec<String>, Vec<String>), CliExit> {
     match project_manifest::discover(pkg_root) {
         Ok(Some(project)) if project.root == pkg_root => {
@@ -288,8 +265,6 @@ fn package_manifest_test_filters(pkg_root: &Path) -> Result<(Vec<String>, Vec<St
     }
 }
 
-/// Format a sub-package path relative to the invocation root, falling back to
-/// the absolute display when not a descendant.
 fn relative_label(invocation_root: &Path, pkg_root: &Path) -> String {
     if pkg_root == invocation_root {
         return ".".to_string();
@@ -300,12 +275,9 @@ fn relative_label(invocation_root: &Path, pkg_root: &Path) -> String {
     )
 }
 
-/// Render a discovered path as the canonical string the runner stores and
-/// matches against. The walker emits `./pkg/file.wado` (or `.\pkg\file.wado`
-/// on Windows) when rooted at `.`; we normalise separators to `/` and strip
-/// the leading `./` so that `--filter` and `[test].exclude` patterns — which
-/// are documented as forward-slash globs — see a consistent shape regardless
-/// of OS or how the user invoked `wado test`.
+// Canonical path shape: forward-slashes, no leading `./`, regardless of
+// OS or invocation root. `--filter` and `[test].exclude` patterns are
+// documented as forward-slash globs and rely on this.
 fn display_path(p: &Path) -> String {
     let raw = p.display().to_string();
     let normalised = if cfg!(windows) {
@@ -319,8 +291,7 @@ fn display_path(p: &Path) -> String {
     }
 }
 
-/// Resolve a mix of files and directory arguments into a single flat path
-/// list. Directories are walked with the discovery rules; files pass through.
+// Directories are walked with the discovery rules; files pass through.
 fn resolve_paths(paths: Vec<String>, extra_excludes: &[String]) -> Result<Vec<String>, CliExit> {
     let excludes = discover::ExcludeSet::compile(extra_excludes).map_err(CliExit::error)?;
     let mut resolved = Vec::new();
@@ -338,11 +309,10 @@ fn resolve_paths(paths: Vec<String>, extra_excludes: &[String]) -> Result<Vec<St
                 resolved.extend(run.paths);
             }
         } else {
-            // Run explicit file arguments through the same canonical form
-            // as discovered paths so `--filter` and `--exclude` patterns
-            // see one consistent shape (forward-slash, no leading `./`).
-            // Honour `--exclude` even for explicit args, matching the
-            // flag's documented "drop files whose path matches" behaviour.
+            // Canonicalize so explicit args and discovered paths match
+            // filters/excludes against the same shape. `--exclude` applies
+            // to explicit args too — the flag is documented as "drop files
+            // whose path matches".
             let canonical = display_path(p);
             if !excludes.matches_str(&canonical) {
                 resolved.push(canonical);
@@ -352,11 +322,6 @@ fn resolve_paths(paths: Vec<String>, extra_excludes: &[String]) -> Result<Vec<St
     Ok(resolved)
 }
 
-/// Parse command-line arguments for the `test` subcommand.
-///
-/// # Errors
-///
-/// Returns an error if the arguments are invalid or required arguments are missing.
 pub fn parse_args(mut parser: lexopt::Parser) -> Result<TestOptions, CliExit> {
     let usage = format_usage();
     let mut paths: Vec<String> = Vec::new();
@@ -425,10 +390,8 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<TestOptions, CliExit> {
         preopened_dirs.push((".".to_owned(), ".".to_owned()));
     }
 
-    // Resolve paths into per-package runs. With no args, recurse from cwd
-    // through every nested `wado.toml`. With explicit args, collapse
-    // everything into a single synthetic root run; sub-package recursion
-    // only kicks in for the no-args (project-wide) case.
+    // No args ⇒ project-wide recursion through every nested `wado.toml`.
+    // With explicit args, collapse everything into one synthetic root run.
     let mut package_runs: Vec<PackageRun> = if paths.is_empty() {
         discover_packages(Path::new("."), true, &cli_excludes)?
     } else {
@@ -439,9 +402,10 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<TestOptions, CliExit> {
         }]
     };
 
-    // --filter: shell-style wildcard match against each discovered path.
-    // To match anywhere within a path, wrap the term in `*`s (e.g.
-    // `*foo*`). Repeatable: a path is kept if any pattern matches.
+    // `--filter` is a shell-style wildcard (`*foo*` to match anywhere) and
+    // is repeatable: a path is kept if any pattern matches. It shares the
+    // walker's match semantics (`discover::WALK_MATCH_OPTIONS`) with
+    // `--exclude` and `[test].exclude`.
     if !filters.is_empty() {
         let patterns: Vec<Pattern> = filters
             .iter()
@@ -450,9 +414,6 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<TestOptions, CliExit> {
                     .map_err(|e| CliExit::error(format!("invalid --filter pattern {s:?}: {e}")))
             })
             .collect::<Result<_, _>>()?;
-        // `--filter` shares the walker's match semantics so users get
-        // consistent results between `--filter`, `--exclude`, and the
-        // manifest's `[test].exclude`. See `discover::WALK_MATCH_OPTIONS`.
         for run in &mut package_runs {
             run.paths.retain(|p| {
                 patterns
@@ -475,11 +436,9 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<TestOptions, CliExit> {
         });
     }
 
-    // Default `jobs` = `cpus` (saturates physical cores for compile and
-    // execute). The load stage internally derives a lower cap because
-    // wasmtime's Cranelift JIT is itself multi-threaded — see `run`.
-    // The `.max(2)` floor handles single-core / containerised
-    // environments where `available_parallelism` reports 1.
+    // Default to CPU count to saturate compile/execute. Load derives a
+    // lower cap internally (Cranelift JIT is multi-threaded; see `run`).
+    // `.max(2)` covers single-core environments.
     let jobs = jobs.unwrap_or_else(|| {
         let cpus = std::thread::available_parallelism().map_or(4, std::num::NonZero::get);
         cpus.max(2)
@@ -498,30 +457,23 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<TestOptions, CliExit> {
     })
 }
 
-/// Output of the **compile** stage: the wado source compiled to a wasm
-/// component, without yet handing the bytes to wasmtime. Flows into the
-/// load stage, or — under `--no-run` — is dropped after the kiln cache
-/// side-effect has been written.
+/// Compile-stage output. Flows into the load stage, or — under `--no-run`
+/// — is dropped after kiln-cache side-effects have been written.
 struct CompiledArtifact {
     path: String,
     wasm: Vec<u8>,
 }
 
-/// Output of the **load** stage: a wasm component fully resident in
-/// wasmtime, with its `Engine`, `Component`, `Linker`, and discovered
-/// test exports cached for the execute stage. Wrapped in `Arc` so the
-/// execute stage can fan out multiple test jobs across the same module
-/// without re-cloning the heavy wasmtime objects.
+/// Load-stage output: a module fully resident in wasmtime. Wrapped in
+/// `Arc` so the execute stage can fan out test jobs without re-cloning
+/// the heavy wasmtime objects.
 ///
-/// The `Linker` is built once per engine alongside loading; every test
-/// in the module instantiates against the same linker so the WASI binding
-/// registration (`p3::add_to_linker` × 4) is paid once instead of per-test.
+/// The `Linker` is built once per engine; every test in the module
+/// instantiates against it so the four `p3::add_to_linker` calls are
+/// amortised across all tests in the module.
 ///
-/// Holds an `OwnedSemaphorePermit` for the pipeline's `modules` budget:
-/// when the last `Arc<LoadedModule>` drops, the permit releases and a
-/// new module is allowed to load. This caps simultaneously-live
-/// wasmtime `Component`s (the heaviest in-flight resource by far)
-/// regardless of how channels between stages buffer.
+/// `_module_permit` caps simultaneously-live `Component`s — the heaviest
+/// in-flight resource — independent of how channels between stages buffer.
 struct LoadedModule {
     path: String,
     engine: Arc<Engine>,
@@ -531,31 +483,21 @@ struct LoadedModule {
     _module_permit: OwnedSemaphorePermit,
 }
 
-/// A non-TODO module that failed the **load** stage (wasmtime
-/// `Component::new` / `create_linker` failed, or the load worker
-/// panicked). Counted on the `load` axis of the summary; does not
-/// abort the run.
+/// Non-TODO module that failed `Component::new`/`create_linker` or whose
+/// load worker panicked. Counted on the `load` axis; does not abort the run.
 struct LoadFailure {
     path: String,
 }
 
-/// Shared resource budget for the whole pipeline.
+/// Pipeline-wide resource caps.
 ///
-/// `cpu` caps the **total** number of CPU-bound tasks executing across
-/// all three stages, sized to `--parallel N` (default `cpus`). Every
-/// worker — compile, load, and execute — acquires one permit before
-/// doing its work and holds it until done. This gives a hard
-/// guarantee: peak in-flight CPU tasks never exceed `N`, irrespective
-/// of per-stage `buffer_unordered` caps. `--parallel N` is therefore
-/// a truthful cap, not a per-stage knob the streaming overlap can
-/// secretly multiply.
+/// `cpu` caps total CPU-bound tasks across all three stages — every worker
+/// acquires one permit. This makes `--parallel N` a truthful global cap
+/// that per-stage buffer sizes can't multiply.
 ///
-/// `modules` caps the number of fully-loaded wasmtime `Component`s
-/// alive simultaneously, regardless of how the inter-stage channels
-/// buffer. A `LoadedModule` acquires one permit before `Component::new`
-/// and holds it via `_module_permit` until the last `Arc<LoadedModule>`
-/// drops at the end of the execute stage. This bounds peak memory
-/// independently of `cpu`.
+/// `modules` caps live wasmtime `Component`s independently of channel
+/// buffering, bounding peak memory. The permit is held via
+/// `LoadedModule::_module_permit` until execute-stage `Arc`s drop.
 struct PipelineBudget {
     cpu: Arc<Semaphore>,
     modules: Arc<Semaphore>,
@@ -572,15 +514,10 @@ impl PipelineBudget {
     }
 }
 
-/// Per-stage timing observable from outside.
-///
-/// `record_input` / `record_output` mark the wall-clock span during
-/// which the stage was producing output. `add_work` is the more useful
-/// number for understanding bottlenecks: it accumulates the actual
-/// per-fixture / per-test work time across all workers, so the
-/// reported per-stage figure equals `Σ worker_duration` rather than
-/// the streaming span (which, for a well-overlapped pipeline, is
-/// indistinguishable from total wall-clock for every stage).
+/// `record_input`/`record_output` mark the stage's output wall-clock span;
+/// `add_work` accumulates per-worker durations — the latter is what reveals
+/// bottlenecks in a well-overlapped pipeline (the streaming span is
+/// indistinguishable from total wall-clock).
 struct StageObserver {
     first_input_at: Mutex<Option<Instant>>,
     last_output_at: Mutex<Option<Instant>>,
@@ -616,20 +553,15 @@ impl StageObserver {
     }
 }
 
-/// `lock().unwrap()` panics if any previous holder of the mutex
-/// panicked while holding it, which would silently take down the
-/// `EpochTicker` thread and disable timeout enforcement for the rest
-/// of the run. Recover the inner value instead — none of the data we
-/// protect with these mutexes is logically invalidated by a panic in
-/// an unrelated holder.
+// Plain `lock().unwrap()` would propagate poison — and the EpochTicker
+// thread silently dies with it, disabling timeout enforcement. None of
+// these mutexes guard logically-coupled invariants, so just recover.
 fn lock_resilient<T>(m: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
     m.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
-/// Format a panic payload into a one-line message suitable for the
-/// per-fixture failure log. Recovers `&'static str` and `String`
-/// payloads (the two `panic!` macro produces); anything else collapses
-/// to a placeholder.
+// Recovers `&'static str` and `String` payloads (what `panic!` produces);
+// anything else collapses to a placeholder.
 fn format_panic_payload(payload: &Box<dyn Any + Send>) -> String {
     if let Some(s) = payload.downcast_ref::<&'static str>() {
         (*s).to_string()
@@ -640,9 +572,6 @@ fn format_panic_payload(payload: &Box<dyn Any + Send>) -> String {
     }
 }
 
-/// A single test job to execute, carrying the module it belongs to so
-/// the execute stage can drive jobs across modules without a separate
-/// indirection table. The `Arc` clone is cheap.
 struct TestJob {
     module: Arc<LoadedModule>,
     test_name: String,
@@ -652,12 +581,9 @@ struct TestJob {
     timeout_ms: u64,
 }
 
-/// Outcome of a single test execution.
-///
-/// Regular tests are either Pass or Fail.
-/// TODO tests live on a separate axis:
-///   - `TodoPending`: trapped as expected (the feature is still unimplemented)
-///   - `TodoResolved`: passed unexpectedly (the feature may now work — remove #[TODO])
+/// Regular tests are Pass/Fail. TODO tests live on a separate axis:
+/// `TodoPending` trapped as expected, `TodoResolved` passed unexpectedly
+/// (consider dropping the `#[TODO]`).
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum TestOutcome {
     Pass,
@@ -666,7 +592,6 @@ enum TestOutcome {
     TodoResolved,
 }
 
-/// Result from a test execution
 struct TestResult {
     file_path: String,
     test_name: String,
@@ -676,7 +601,6 @@ struct TestResult {
     duration: Duration,
 }
 
-/// Kind of test, parsed from the export name prefix.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum TestKind {
     Normal,
@@ -684,16 +608,10 @@ enum TestKind {
     Todo,
 }
 
-/// Parsed test export name.
-///
-/// The compiler emits names of the shape
-/// `test-(trap-|todo-)?(tm{N}-)?{index}(-{name})?` when targeting the
-/// `test` world. The parser is intentionally tolerant of two edges so a
-/// stray name doesn't drop a test from the run:
-/// - a `tm…-` prefix that doesn't have a parseable `u64` (e.g. `tmfoo-…`)
-///   falls through into the index/name branch instead of being rejected;
-/// - a trailing dash with no name segment (`test-0-`) is treated as
-///   "no name provided" and rendered as `<test {index}>`.
+/// Parser for `test-(trap-|todo-)?(tm{N}-)?{index}(-{name})?` exports.
+/// Tolerant of two edges so a stray name doesn't drop a test from the
+/// run: malformed `tm…-` (e.g. `tmfoo-…`) falls into the index/name
+/// branch, and trailing-dash names (`test-0-`) render as `<test {index}>`.
 #[derive(Debug, PartialEq, Eq)]
 struct TestExportName {
     kind: TestKind,

--- a/wado-cli/src/test.rs
+++ b/wado-cli/src/test.rs
@@ -4,7 +4,6 @@ use std::future::Future;
 use std::panic::AssertUnwindSafe;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
-use std::process;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, Weak};
 use std::time::{Duration, Instant};
@@ -2044,7 +2043,7 @@ async fn prewarm_stdlib_snapshot_on_workers(parallelism: usize) {
     }
 }
 
-pub async fn run(opts: TestOptions) {
+pub async fn run(opts: TestOptions) -> Result<(), CliExit> {
     let overall_start = Instant::now();
     let multi_pkg = opts.package_runs.len() > 1;
     let flags = Arc::new(opts.compile_flags());
@@ -2111,8 +2110,9 @@ pub async fn run(opts: TestOptions) {
         || grand.test_failed > 0
         || grand.todo_resolved > 0
     {
-        process::exit(1);
+        return Err(CliExit::silent_failure(1));
     }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/wado-cli/tests/cli.rs
+++ b/wado-cli/tests/cli.rs
@@ -4,7 +4,6 @@
 //! and integration with the compiler.
 
 use predicates::prelude::*;
-use std::fs;
 
 mod common;
 use common::wado;
@@ -48,210 +47,16 @@ fn test_unknown_command() {
 }
 
 #[test]
-fn test_compile_help() {
-    wado()
-        .args(["compile", "--help"])
-        .assert()
-        .success()
-        .stderr(predicate::str::contains("Usage: wado compile"));
-}
-
-#[test]
-fn test_compile_missing_input() {
-    // The repo root carries a `wado.toml` with no `[package].command` so the
-    // resolver can't synthesise an input file; the user gets a focused error.
-    wado()
-        .arg("compile")
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains(
-            "wado.toml found but [package].command is not set",
-        ));
-}
-
-#[test]
-fn test_compile_file_not_found() {
-    wado()
-        .args(["compile", "nonexistent.wado"])
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains("nonexistent.wado"));
-}
-
-#[test]
-fn test_compile_output_wasm() {
-    let dir = tempfile::tempdir().unwrap();
-    let output_path = dir.path().join("out.wasm");
-
-    wado()
-        .args([
-            "compile",
-            "-o",
-            output_path.to_str().unwrap(),
-            "example/hello.wado",
-        ])
-        .assert()
-        .success()
-        .stderr(predicate::str::contains("Generated:"));
-
-    let content = fs::read(&output_path).unwrap();
-    // Component model starts with \0asm but version differs from core wasm.
-    assert!(content.len() > 4, "Wasm file should have content");
-}
-
-#[test]
-fn test_compile_output_wat() {
-    let dir = tempfile::tempdir().unwrap();
-    let output_path = dir.path().join("out.wat");
-
-    wado()
-        .args([
-            "compile",
-            "-o",
-            output_path.to_str().unwrap(),
-            "example/hello.wado",
-        ])
-        .assert()
-        .success()
-        .stderr(predicate::str::contains("Generated:"));
-
-    let content = fs::read_to_string(&output_path).unwrap();
-    assert!(
-        content.contains("(component"),
-        "WAT file should contain component"
-    );
-}
-
-#[test]
-fn test_compile_format_wat() {
-    // Non-`.wat` extension forces format selection by `--format`, not by suffix.
-    let dir = tempfile::tempdir().unwrap();
-    let output_path = dir.path().join("out.txt");
-
-    wado()
-        .args([
-            "compile",
-            "--format",
-            "wat",
-            "-o",
-            output_path.to_str().unwrap(),
-            "example/hello.wado",
-        ])
-        .assert()
-        .success();
-
-    let content = fs::read_to_string(&output_path).unwrap();
-    assert!(
-        content.contains("(component"),
-        "Should be WAT format regardless of extension"
-    );
-}
-
-#[test]
-fn test_compile_format_wasm() {
-    let dir = tempfile::tempdir().unwrap();
-    let output_path = dir.path().join("out.bin");
-
-    wado()
-        .args([
-            "compile",
-            "--format",
-            "wasm",
-            "-o",
-            output_path.to_str().unwrap(),
-            "example/hello.wado",
-        ])
-        .assert()
-        .success();
-
-    let content = fs::read(&output_path).unwrap();
-    assert!(content.len() > 4, "Wasm file should have content");
-}
-
-#[test]
 fn test_compile_wat_to_stdout() {
+    // Subprocess-only because `--wat-to-stdout` writes to actual stdout;
+    // capturing it in-process would require redirecting std file
+    // descriptors, which we have not done yet. The file-output and
+    // opt-level variants moved to `tests/run_inprocess.rs`.
     wado()
         .args(["compile", "--wat-to-stdout", "example/hello.wado"])
         .assert()
         .success()
         .stdout(predicate::str::contains("(component"));
-}
-
-#[test]
-fn test_compile_invalid_format() {
-    wado()
-        .args(["compile", "--format", "invalid", "example/hello.wado"])
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains("unknown format"));
-}
-
-#[test]
-fn test_compile_unknown_option() {
-    wado()
-        .args(["compile", "--unknown", "example/hello.wado"])
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains("invalid option"));
-}
-
-#[test]
-fn test_compile_opt_level_o0() {
-    wado()
-        .args(["compile", "-O0", "--wat-to-stdout", "example/hello.wado"])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("(component"));
-}
-
-#[test]
-fn test_compile_opt_level_o2() {
-    wado()
-        .args(["compile", "-O2", "--wat-to-stdout", "example/hello.wado"])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("(component"));
-}
-
-#[test]
-fn test_compile_opt_level_os() {
-    wado()
-        .args(["compile", "-Os", "--wat-to-stdout", "example/hello.wado"])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("(component"));
-}
-
-#[test]
-fn test_compile_opt_level_invalid() {
-    wado()
-        .args(["compile", "-Ox", "example/hello.wado"])
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains("unknown optimization level"));
-}
-
-#[test]
-fn test_run_help() {
-    wado()
-        .args(["run", "--help"])
-        .assert()
-        .success()
-        .stderr(predicate::str::contains("Usage: wado run"));
-}
-
-#[test]
-fn test_run_missing_input() {
-    // Same story as `test_compile_missing_input`: the repo root has a
-    // `wado.toml` without `[package].command`, so the entry-point resolver
-    // surfaces a more specific failure.
-    wado()
-        .arg("run")
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains(
-            "wado.toml found but [package].command is not set",
-        ));
 }
 
 #[test]
@@ -261,34 +66,6 @@ fn test_run_hello() {
         .assert()
         .success()
         .stdout(predicate::str::contains("Hello, world!"));
-}
-
-#[test]
-fn test_run_file_not_found() {
-    wado()
-        .args(["run", "nonexistent.wado"])
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains("nonexistent.wado"));
-}
-
-#[test]
-fn test_run_unknown_option() {
-    wado()
-        .args(["run", "--unknown", "example/hello.wado"])
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains("invalid option"));
-}
-
-#[test]
-fn test_test_help() {
-    wado()
-        .args(["test", "--help"])
-        .assert()
-        .success()
-        .stderr(predicate::str::contains("Usage: wado test"))
-        .stderr(predicate::str::contains("--filter"));
 }
 
 #[test]
@@ -384,15 +161,6 @@ fn test_test_no_run_skips_phase_two() {
 }
 
 #[test]
-fn test_test_no_run_help_lists_flag() {
-    wado()
-        .args(["test", "--help"])
-        .assert()
-        .success()
-        .stderr(predicate::str::contains("--no-run"));
-}
-
-#[test]
 fn test_test_no_run_surfaces_todo_compile_errors() {
     // A `#![TODO]` module whose expected compile error fires is
     // module-level TODO-pending. Under `--no-run` we can't observe
@@ -459,47 +227,4 @@ fn test_test_parallel_long_option() {
         .assert()
         .success()
         .stdout(predicate::str::contains("2 passed, 0 failed"));
-}
-
-#[test]
-fn test_test_parallel_invalid() {
-    // Test with invalid parallel count
-    wado()
-        .args([
-            "test",
-            "-p",
-            "0",
-            "wado-compiler/tests/fixtures/test_decl.wado",
-        ])
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains(
-            "--parallel requires a positive integer",
-        ));
-}
-
-#[test]
-fn test_test_parallel_non_numeric() {
-    // Test with non-numeric parallel count
-    wado()
-        .args([
-            "test",
-            "-p",
-            "abc",
-            "wado-compiler/tests/fixtures/test_decl.wado",
-        ])
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains(
-            "--parallel requires a positive integer",
-        ));
-}
-
-#[test]
-fn test_test_help_shows_parallel_option() {
-    wado()
-        .args(["test", "--help"])
-        .assert()
-        .success()
-        .stderr(predicate::str::contains("-p, --parallel"));
 }

--- a/wado-cli/tests/cli_parse.rs
+++ b/wado-cli/tests/cli_parse.rs
@@ -510,7 +510,19 @@ fn test_parallel_non_numeric() {
 #[test]
 fn test_help() {
     let parser = Parser::from_args(&["--help"]);
-    assert_help(wado_cli::test::parse_args(parser), "Usage: wado test");
+    let Err(err) = wado_cli::test::parse_args(parser) else {
+        panic!("expected help exit");
+    };
+    assert_eq!(err.exit_code, 0);
+    // Spot-check that the rendered help still mentions the headline flags
+    // we want users to discover.
+    for fragment in ["Usage: wado test", "--filter", "-p, --parallel", "--no-run"] {
+        assert!(
+            err.message.contains(fragment),
+            "expected help to contain {fragment:?}, got {:?}",
+            err.message
+        );
+    }
 }
 
 #[test]

--- a/wado-cli/tests/run_inprocess.rs
+++ b/wado-cli/tests/run_inprocess.rs
@@ -1,10 +1,5 @@
-//! In-process `run()` tests.
-//!
-//! Exercises subcommand `run()` functions directly without spawning a
-//! subprocess. These are only possible because every `run()` returns
-//! `Result<(), CliExit>` instead of calling `process::exit(...)`; the
-//! exit-code propagates through the result, so the test can assert on it
-//! without forking.
+//! In-process subcommand `run()` tests — call each subcommand directly
+//! and assert on the returned `CliExit`, no subprocess.
 
 use std::env;
 use std::fs;
@@ -16,18 +11,11 @@ use wado_cli::compile::{self, CompileOptions, OptLevel, OutputFormat};
 
 mod common;
 
-/// Absolute path to a fixture under the repo root. Each in-process test
-/// runs with cwd = `wado-cli/` (cargo's default), but the existing example
-/// fixtures live one level up, so relative paths from the subprocess tests
-/// would resolve wrong here.
 fn fixture(rel: &str) -> PathBuf {
     common::project_root().join(rel)
 }
 
-/// Several tests below `env::set_current_dir` into a temporary directory.
-/// `set_current_dir` is process-wide, so without serialization concurrent
-/// cargo-test threads would race. The Mutex is held for the duration of
-/// each test that touches cwd.
+// `set_current_dir` is process-wide, so cwd-mutating tests serialize on this.
 fn cwd_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| Mutex::new(()))
@@ -97,10 +85,8 @@ fn init_run_force_overwrites() {
     });
 }
 
-/// Build a `CompileOptions` that writes `example/hello.wado` to the given
-/// output path. Each field is set explicitly because `CompileOptions` does
-/// not implement `Default` — defaulting fields piecemeal would invite drift
-/// the moment a new option is added.
+// Listed exhaustively so adding a new `CompileOptions` field forces a
+// conscious decision here instead of silently defaulting.
 fn hello_compile_opts(output_path: &Path, format: Option<OutputFormat>) -> CompileOptions {
     CompileOptions {
         input: fixture("example/hello.wado").to_string_lossy().into_owned(),
@@ -125,8 +111,6 @@ fn compile_writes_wasm_output() {
     let opts = hello_compile_opts(&out, None);
     futures::executor::block_on(compile::run(opts)).expect("compile should succeed");
     let bytes = fs::read(&out).unwrap();
-    // Component model binaries start with the 0asm magic but a distinct
-    // version word, so only the magic prefix is asserted here.
     assert!(bytes.len() > 4, "wasm output looked empty");
     assert_eq!(&bytes[0..4], b"\0asm", "wasm magic missing");
 }
@@ -146,7 +130,6 @@ fn compile_writes_wat_output() {
 
 #[test]
 fn compile_format_overrides_extension() {
-    // Non-`.wat` extension + `--format wat` must still write WAT text.
     let dir = tempfile::tempdir().unwrap();
     let out = dir.path().join("out.txt");
     let opts = hello_compile_opts(&out, Some(OutputFormat::Wat));
@@ -157,7 +140,6 @@ fn compile_format_overrides_extension() {
         "expected WAT despite .txt suffix"
     );
 
-    // Mirror: `--format wasm` with a non-`.wasm` extension still writes bytes.
     let out = dir.path().join("out.bin");
     let opts = hello_compile_opts(&out, Some(OutputFormat::Wasm));
     futures::executor::block_on(compile::run(opts)).expect("compile should succeed");
@@ -167,10 +149,6 @@ fn compile_format_overrides_extension() {
 
 #[test]
 fn compile_succeeds_at_each_opt_level() {
-    // Each optimization level threads a different config through the compiler
-    // pipeline; this test verifies none of them ICE on the hello-world
-    // program. Output content is incidental — `compile_writes_wat_output`
-    // already pins the happy path's shape.
     let dir = tempfile::tempdir().unwrap();
     for level in [
         OptLevel::O0,
@@ -193,21 +171,13 @@ fn compile_succeeds_at_each_opt_level() {
 
 #[test]
 fn compile_helper_returns_silent_failure_on_missing_file() {
-    // `compile::compile` is the helper shared by `run` / `serve` / `test`.
-    // A missing source file used to abort the process; now the caller can
-    // observe the failure and decide how to react.
     let flags = wado_cli::compile::CompileFlags::default();
     let err: CliExit = futures::executor::block_on(wado_cli::compile::compile(
         "/definitely/does/not/exist.wado",
         &flags,
     ))
     .expect_err("expected CliExit");
-    // The diagnostics ("Error reading ...") were already printed by the
-    // host, so the failure is silent: just an exit code.
+    // Host already printed "Error reading ...", so the CliExit is empty.
     assert_eq!(err.exit_code, 1);
-    assert!(
-        err.message.is_empty(),
-        "expected silent failure (no message), got {:?}",
-        err.message
-    );
+    assert!(err.message.is_empty(), "got {:?}", err.message);
 }

--- a/wado-cli/tests/run_inprocess.rs
+++ b/wado-cli/tests/run_inprocess.rs
@@ -8,9 +8,21 @@
 
 use std::env;
 use std::fs;
+use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
 use wado_cli::args::CliExit;
+use wado_cli::compile::{self, CompileOptions, OptLevel, OutputFormat};
+
+mod common;
+
+/// Absolute path to a fixture under the repo root. Each in-process test
+/// runs with cwd = `wado-cli/` (cargo's default), but the existing example
+/// fixtures live one level up, so relative paths from the subprocess tests
+/// would resolve wrong here.
+fn fixture(rel: &str) -> PathBuf {
+    common::project_root().join(rel)
+}
 
 /// Several tests below `env::set_current_dir` into a temporary directory.
 /// `set_current_dir` is process-wide, so without serialization concurrent
@@ -83,6 +95,100 @@ fn init_run_force_overwrites() {
         let content = fs::read_to_string("wado.toml").unwrap();
         assert!(content.contains("name = \"demo\""));
     });
+}
+
+/// Build a `CompileOptions` that writes `example/hello.wado` to the given
+/// output path. Each field is set explicitly because `CompileOptions` does
+/// not implement `Default` — defaulting fields piecemeal would invite drift
+/// the moment a new option is added.
+fn hello_compile_opts(output_path: &Path, format: Option<OutputFormat>) -> CompileOptions {
+    CompileOptions {
+        input: fixture("example/hello.wado").to_string_lossy().into_owned(),
+        output: Some(output_path.to_string_lossy().into_owned()),
+        format,
+        opt_level: OptLevel::default(),
+        wat_to_stdout: false,
+        log_level: wado_compiler::LogLevel::default(),
+        target_world: None,
+        skip_validation: false,
+        inline_threshold: None,
+        opt_iterations: None,
+        allocator: None,
+        lib: false,
+    }
+}
+
+#[test]
+fn compile_writes_wasm_output() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("out.wasm");
+    let opts = hello_compile_opts(&out, None);
+    futures::executor::block_on(compile::run(opts)).expect("compile should succeed");
+    let bytes = fs::read(&out).unwrap();
+    // Component model binaries start with the 0asm magic but a distinct
+    // version word, so only the magic prefix is asserted here.
+    assert!(bytes.len() > 4, "wasm output looked empty");
+    assert_eq!(&bytes[0..4], b"\0asm", "wasm magic missing");
+}
+
+#[test]
+fn compile_writes_wat_output() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("out.wat");
+    let opts = hello_compile_opts(&out, None);
+    futures::executor::block_on(compile::run(opts)).expect("compile should succeed");
+    let text = fs::read_to_string(&out).unwrap();
+    assert!(
+        text.contains("(component"),
+        "WAT output missing component sexp: {text:.80}"
+    );
+}
+
+#[test]
+fn compile_format_overrides_extension() {
+    // Non-`.wat` extension + `--format wat` must still write WAT text.
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("out.txt");
+    let opts = hello_compile_opts(&out, Some(OutputFormat::Wat));
+    futures::executor::block_on(compile::run(opts)).expect("compile should succeed");
+    let text = fs::read_to_string(&out).unwrap();
+    assert!(
+        text.contains("(component"),
+        "expected WAT despite .txt suffix"
+    );
+
+    // Mirror: `--format wasm` with a non-`.wasm` extension still writes bytes.
+    let out = dir.path().join("out.bin");
+    let opts = hello_compile_opts(&out, Some(OutputFormat::Wasm));
+    futures::executor::block_on(compile::run(opts)).expect("compile should succeed");
+    let bytes = fs::read(&out).unwrap();
+    assert_eq!(&bytes[0..4], b"\0asm");
+}
+
+#[test]
+fn compile_succeeds_at_each_opt_level() {
+    // Each optimization level threads a different config through the compiler
+    // pipeline; this test verifies none of them ICE on the hello-world
+    // program. Output content is incidental — `compile_writes_wat_output`
+    // already pins the happy path's shape.
+    let dir = tempfile::tempdir().unwrap();
+    for level in [
+        OptLevel::O0,
+        OptLevel::O1,
+        OptLevel::O2,
+        OptLevel::O3,
+        OptLevel::Os,
+    ] {
+        let out = dir.path().join(format!("hello-{level:?}.wasm"));
+        let mut opts = hello_compile_opts(&out, None);
+        opts.opt_level = level;
+        futures::executor::block_on(compile::run(opts))
+            .unwrap_or_else(|e| panic!("compile failed at {level:?}: {:?}", e.message));
+        assert!(
+            fs::metadata(&out).is_ok_and(|m| m.len() > 4),
+            "output missing for {level:?}"
+        );
+    }
 }
 
 #[test]

--- a/wado-cli/tests/run_inprocess.rs
+++ b/wado-cli/tests/run_inprocess.rs
@@ -1,0 +1,107 @@
+//! In-process `run()` tests.
+//!
+//! Exercises subcommand `run()` functions directly without spawning a
+//! subprocess. These are only possible because every `run()` returns
+//! `Result<(), CliExit>` instead of calling `process::exit(...)`; the
+//! exit-code propagates through the result, so the test can assert on it
+//! without forking.
+
+use std::env;
+use std::fs;
+use std::sync::{Mutex, OnceLock};
+
+use wado_cli::args::CliExit;
+
+/// Several tests below `env::set_current_dir` into a temporary directory.
+/// `set_current_dir` is process-wide, so without serialization concurrent
+/// cargo-test threads would race. The Mutex is held for the duration of
+/// each test that touches cwd.
+fn cwd_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn with_tempdir<F: FnOnce() -> R, R>(f: F) -> R {
+    let guard = cwd_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let dir = tempfile::tempdir().unwrap();
+    let prev = env::current_dir().unwrap();
+    env::set_current_dir(dir.path()).unwrap();
+    let result = f();
+    env::set_current_dir(prev).unwrap();
+    drop(guard);
+    result
+}
+
+#[test]
+fn init_run_creates_manifest_in_cwd() {
+    with_tempdir(|| {
+        let opts = wado_cli::init::InitOptions {
+            name: "demo".to_string(),
+            namespace: None,
+            force: false,
+        };
+        let result = wado_cli::init::run(opts);
+        assert!(result.is_ok(), "init::run should succeed in empty cwd");
+        let content = fs::read_to_string("wado.toml").unwrap();
+        assert!(content.contains("name = \"demo\""));
+    });
+}
+
+#[test]
+fn init_run_refuses_to_overwrite_without_force() {
+    with_tempdir(|| {
+        fs::write("wado.toml", "pre-existing").unwrap();
+        let opts = wado_cli::init::InitOptions {
+            name: "demo".to_string(),
+            namespace: None,
+            force: false,
+        };
+        let err = wado_cli::init::run(opts).expect_err("expected CliExit");
+        assert_eq!(err.exit_code, 1);
+        assert!(
+            err.message.contains("already exists"),
+            "unexpected message: {:?}",
+            err.message
+        );
+        // File is untouched.
+        assert_eq!(fs::read_to_string("wado.toml").unwrap(), "pre-existing");
+    });
+}
+
+#[test]
+fn init_run_force_overwrites() {
+    with_tempdir(|| {
+        fs::write("wado.toml", "pre-existing").unwrap();
+        let opts = wado_cli::init::InitOptions {
+            name: "demo".to_string(),
+            namespace: None,
+            force: true,
+        };
+        wado_cli::init::run(opts).expect("force should succeed");
+        let content = fs::read_to_string("wado.toml").unwrap();
+        assert!(content.contains("name = \"demo\""));
+    });
+}
+
+#[test]
+fn compile_helper_returns_silent_failure_on_missing_file() {
+    // `compile::compile` is the helper shared by `run` / `serve` / `test`.
+    // A missing source file used to abort the process; now the caller can
+    // observe the failure and decide how to react.
+    let flags = wado_cli::compile::CompileFlags::default();
+    let err: CliExit = futures::executor::block_on(wado_cli::compile::compile(
+        "/definitely/does/not/exist.wado",
+        &flags,
+    ))
+    .expect_err("expected CliExit");
+    // The diagnostics ("Error reading ...") were already printed by the
+    // host, so the failure is silent: just an exit code.
+    assert_eq!(err.exit_code, 1);
+    assert!(
+        err.message.is_empty(),
+        "expected silent failure (no message), got {:?}",
+        err.message
+    );
+}


### PR DESCRIPTION
## Motivation

`wado-cli` was hard to test in-process because every subcommand's `run()`
function called `process::exit(...)` directly (33 call sites across 14
files) — invoking `run()` from a `#[test]` would abort the test binary.
The integration suite worked around this by spawning the `wado` binary
via `assert_cmd` for nearly every error case, including duplicates of
parsing tests that `cli_parse.rs` already covered in-process.

## Changes

### Centralize exit via `Result<(), CliExit>`

- Every subcommand `run()` now returns `Result<(), CliExit>`.
- `args::CliExit` gains a `silent_failure(code)` constructor for the
  "diagnostics already printed, just exit non-zero" path (used by
  helpers like `compile::compile` where the `CompilerHost` already
  rendered errors to stderr).
- Shared helpers (`compile::compile`, `compile::wasm_to_wat`,
  `doc::load_doc`, `doc::write_to_file`, `query_adapter::*`) propagate
  `CliExit` via `?` instead of aborting.
- `main()` collapses to a single `dispatch().await` that surfaces a
  `CliExit`, which it prints and exits with at the very end. The
  `Box::pin` per-subcommand future remains (it keeps the dispatcher's
  state machine within the compiler's recursion limit).
- Only two `process::exit()` call sites remain in the crate:
  `args.rs::CliExit::exit()` (the sanctioned single exit path) and the
  pre-runtime tokio-build failure in `main()`.

### Trim duplicate subprocess tests

- `cli.rs` shrinks from 38 to 16 `assert_cmd` invocations.
- 15 tests dropped: equivalents already live in `cli_parse.rs`
  (`compile_help`, `compile_invalid_format`, `run_unknown_option`,
  `test_parallel_invalid`, etc.).
- 7 success-path tests dropped: their replacements drive `compile::run`
  directly against `example/hello.wado` and assert on the tempfile
  output instead (`compile_writes_wasm_output`, `compile_writes_wat_output`,
  `compile_format_overrides_extension`,
  `compile_succeeds_at_each_opt_level`).
- `cli_parse.rs::test_help` is extended to also assert on `--filter`,
  `-p, --parallel`, `--no-run` so the ad-hoc "help-mentions-this-flag"
  subprocess tests can be removed without losing coverage.
- `test_compile_wat_to_stdout` is kept as a subprocess test, with a
  comment explaining that in-process stdout capture is out of scope.

### New in-process test file

`wado-cli/tests/run_inprocess.rs` demonstrates the payoff — `init::run`,
`compile::compile`, and `compile::run` are now driven directly from
`#[test]` functions, asserting on the returned `CliExit` and on file-
system side effects, with no subprocess fork.

## Stats

- Net: -22 subprocess tests, +8 in-process tests. Total: 313 → 295.
- 18 files changed, +505 / -570.
- `process::exit` call sites: 33 → 2.
- Direct `eprintln!`/`println!` calls untouched (185); they remain
  acceptable since libtest captures them automatically.


---
_Generated by [Claude Code](https://claude.ai/code/session_01S7utgT4GpEfXuQ5FLGPvsT)_