### PR TITLE
refactor(lsp): dedupe test fixtures, codepoint helpers, enum repr, query plumbing, and dispatch

### DIFF
--- a/wado-lsp/AGENTS.md
+++ b/wado-lsp/AGENTS.md
@@ -27,6 +27,7 @@ Language service engine for the Wado compiler toolchain.
 | `src/server/dispatch.rs`    | LSP method routing, position-encoding negotiation, and server-lifecycle enforcement                                       |
 | `src/server/rpc.rs`         | LSP wire types (params, capabilities, notifications)                                                                      |
 | `src/bin/wado-lsp.rs`       | Binary entrypoint; drives `run_stdio()` via `futures::executor::block_on`                                                 |
+| `src/test_support.rs`       | Shared in-memory `MapHost` for unit + integration tests (`#[doc(hidden)] pub`); replaces per-file `TestHost` duplication  |
 
 ### Engine
 

--- a/wado-lsp/src/definition.rs
+++ b/wado-lsp/src/definition.rs
@@ -15,7 +15,7 @@ use wado_compiler::name::resolve_import_with_entry;
 use wado_compiler::token::Span;
 
 use crate::diagnostics::{Position, Range};
-use crate::location::{module_uri, span_to_range, symbol_uri};
+use crate::location::{module_uri, source_for_key, span_to_range, symbol_uri};
 use crate::text::{PositionEncoding, lsp_position_to_line_col};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -73,17 +73,9 @@ pub fn find_definition(
         Some(symbol) => symbol_uri(annotated, symbol, uri)?,
         None => module_uri(annotated, &def_key.module, uri)?,
     };
-    // Mirror references.rs: spans for defs in OTHER modules are
-    // codepoint-indexed against their own module's source, not the
-    // request document. Re-encoding against `source` would walk the
-    // wrong text and emit a drifted `character` under UTF-16/UTF-8
-    // whenever the entry document and the def module differ on the
-    // matching line. Pass `None` to preserve the compiler's codepoint
-    // column verbatim (correct under UTF-32 / ASCII).
-    let source_for_range = (def_key.module == annotated.entry_module_source).then_some(source);
     Some(DefinitionResult {
         uri: def_uri,
-        range: span_to_range(&span, source_for_range, encoding),
+        range: span_to_range(&span, source_for_key(annotated, &def_key, source), encoding),
     })
 }
 

--- a/wado-lsp/src/diagnostics.rs
+++ b/wado-lsp/src/diagnostics.rs
@@ -1,38 +1,19 @@
 use serde::{Deserialize, Serialize};
 use wado_compiler::{Code, Diagnostic as CompilerDiagnostic, Severity as CompilerSeverity};
 
+use crate::macros::lsp_repr_u32_enum;
 use crate::text::{PositionEncoding, codepoint_offset_to_character};
 
-/// LSP-compatible diagnostic severity. Serializes as the 1..=4 integer
-/// defined by the LSP wire format.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(into = "u32", try_from = "u32")]
-pub enum Severity {
-    Error = 1,
-    Warning = 2,
-    Information = 3,
-    Hint = 4,
-}
-
-impl From<Severity> for u32 {
-    fn from(s: Severity) -> Self {
-        s as Self
+lsp_repr_u32_enum!(
+    /// LSP-compatible diagnostic severity. Serializes as the 1..=4 integer
+    /// defined by the LSP wire format.
+    pub enum Severity {
+        Error = 1,
+        Warning = 2,
+        Information = 3,
+        Hint = 4,
     }
-}
-
-impl TryFrom<u32> for Severity {
-    type Error = String;
-
-    fn try_from(n: u32) -> Result<Self, <Self as TryFrom<u32>>::Error> {
-        match n {
-            1 => Ok(Self::Error),
-            2 => Ok(Self::Warning),
-            3 => Ok(Self::Information),
-            4 => Ok(Self::Hint),
-            _ => Err(format!("invalid Severity: {n}")),
-        }
-    }
-}
+);
 
 /// Zero-based line/column position in a text document.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/wado-lsp/src/diagnostics.rs
+++ b/wado-lsp/src/diagnostics.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use wado_compiler::{Code, Diagnostic as CompilerDiagnostic, Severity as CompilerSeverity};
 
-use crate::text::PositionEncoding;
+use crate::text::{PositionEncoding, codepoint_offset_to_character};
 
 /// LSP-compatible diagnostic severity. Serializes as the 1..=4 integer
 /// defined by the LSP wire format.
@@ -106,8 +106,8 @@ pub fn from_compiler_diagnostic(
 
     let (start_char, end_char) = match source {
         Some(src) => (
-            codepoint_column_to_character(src, start_line, start_codepoint, encoding),
-            codepoint_column_to_character(src, end_line, end_codepoint, encoding),
+            codepoint_offset_to_character(src, start_line, start_codepoint, encoding),
+            codepoint_offset_to_character(src, end_line, end_codepoint, encoding),
         ),
         None => (start_codepoint, end_codepoint),
     };
@@ -128,39 +128,6 @@ pub fn from_compiler_diagnostic(
         source: Some("wado".to_string()),
         message: diag.message.clone(),
     })
-}
-
-/// Resolve a 0-based codepoint column on `line` of `source` into a
-/// 0-based LSP `character` in `encoding`. Saturates to the end of the
-/// line on overflow.
-fn codepoint_column_to_character(
-    source: &str,
-    line: u32,
-    codepoint_col: u32,
-    encoding: PositionEncoding,
-) -> u32 {
-    let Some(line_text) = source.split_inclusive('\n').nth(line as usize) else {
-        return codepoint_col;
-    };
-    let line_content = line_text
-        .strip_suffix('\n')
-        .map(|s| s.strip_suffix('\r').unwrap_or(s))
-        .unwrap_or(line_text);
-    let max = line_content.chars().count() as u32;
-    let codepoint_col = codepoint_col.min(max);
-    match encoding {
-        PositionEncoding::Utf8 => line_content
-            .chars()
-            .take(codepoint_col as usize)
-            .map(|c| c.len_utf8() as u32)
-            .sum(),
-        PositionEncoding::Utf16 => line_content
-            .chars()
-            .take(codepoint_col as usize)
-            .map(|c| c.len_utf16() as u32)
-            .sum(),
-        PositionEncoding::Utf32 => codepoint_col,
-    }
 }
 
 #[cfg(test)]

--- a/wado-lsp/src/document_highlight.rs
+++ b/wado-lsp/src/document_highlight.rs
@@ -112,40 +112,13 @@ pub fn document_highlight(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use indexmap::IndexMap;
-    use wado_compiler::CompilerHost;
+    use crate::test_support::MapHost;
     use wado_compiler::annotate::annotate_with_invocations;
-    use wado_compiler::{Diagnostic as CompilerDiagnostic, SourceError};
-
-    struct TestHost {
-        sources: IndexMap<String, Vec<u8>>,
-    }
-
-    impl TestHost {
-        fn single(path: &str, source: &str) -> Self {
-            let mut sources = IndexMap::new();
-            sources.insert(path.to_string(), source.as_bytes().to_vec());
-            Self { sources }
-        }
-    }
-
-    impl CompilerHost for TestHost {
-        async fn load_source(&self, path: &str) -> Result<Vec<u8>, SourceError> {
-            self.sources
-                .get(path)
-                .cloned()
-                .ok_or_else(|| SourceError::NotFound {
-                    path: path.to_string(),
-                })
-        }
-
-        fn emit_diagnostic(&self, _diagnostic: CompilerDiagnostic) {}
-    }
 
     async fn highlights_at(source: &str, line: u32, character: u32) -> Vec<DocumentHighlight> {
         let path = "/test.wado";
         let uri = format!("file://{path}");
-        let host = TestHost::single(path, source);
+        let host = MapHost::single(path, source);
         let invocations = wado_compiler::kiln::InvocationIndex::new();
         let annotated = annotate_with_invocations(source, &host, Some(path), invocations).await;
         document_highlight(

--- a/wado-lsp/src/document_highlight.rs
+++ b/wado-lsp/src/document_highlight.rs
@@ -18,36 +18,18 @@ use wado_compiler::annotate::Annotated;
 
 use crate::diagnostics::{Position, Range};
 use crate::location::span_to_range;
+use crate::macros::lsp_repr_u32_enum;
 use crate::text::{PositionEncoding, lsp_position_to_line_col};
 
-/// LSP `DocumentHighlightKind` values. Serializes as the 1..=3 integer
-/// defined by the LSP wire format.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(into = "u32", try_from = "u32")]
-pub enum HighlightKind {
-    Text = 1,
-    Read = 2,
-    Write = 3,
-}
-
-impl From<HighlightKind> for u32 {
-    fn from(k: HighlightKind) -> Self {
-        k as Self
+lsp_repr_u32_enum!(
+    /// LSP `DocumentHighlightKind` values. Serializes as the 1..=3 integer
+    /// defined by the LSP wire format.
+    pub enum HighlightKind {
+        Text = 1,
+        Read = 2,
+        Write = 3,
     }
-}
-
-impl TryFrom<u32> for HighlightKind {
-    type Error = String;
-
-    fn try_from(n: u32) -> Result<Self, <Self as TryFrom<u32>>::Error> {
-        match n {
-            1 => Ok(Self::Text),
-            2 => Ok(Self::Read),
-            3 => Ok(Self::Write),
-            _ => Err(format!("invalid HighlightKind: {n}")),
-        }
-    }
-}
+);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DocumentHighlight {

--- a/wado-lsp/src/hover.rs
+++ b/wado-lsp/src/hover.rs
@@ -371,40 +371,13 @@ fn item_info(item: &Item, name: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use indexmap::IndexMap;
-    use wado_compiler::CompilerHost;
+    use crate::test_support::MapHost;
     use wado_compiler::annotate::annotate_with_invocations;
-    use wado_compiler::{Diagnostic as CompilerDiagnostic, SourceError};
-
-    struct TestHost {
-        sources: IndexMap<String, Vec<u8>>,
-    }
-
-    impl TestHost {
-        fn new(path: &str, source: &str) -> Self {
-            let mut sources = IndexMap::new();
-            sources.insert(path.to_string(), source.as_bytes().to_vec());
-            Self { sources }
-        }
-    }
-
-    impl CompilerHost for TestHost {
-        async fn load_source(&self, path: &str) -> Result<Vec<u8>, SourceError> {
-            self.sources
-                .get(path)
-                .cloned()
-                .ok_or_else(|| SourceError::NotFound {
-                    path: path.to_string(),
-                })
-        }
-
-        fn emit_diagnostic(&self, _diagnostic: CompilerDiagnostic) {}
-    }
 
     async fn hover_at(source: &str, line: u32, character: u32) -> Option<HoverResult> {
         let path = "/test.wado";
         let uri = format!("file://{path}");
-        let host = TestHost::new(path, source);
+        let host = MapHost::single(path, source);
         let invocations = wado_compiler::kiln::InvocationIndex::new();
         let annotated = annotate_with_invocations(source, &host, Some(path), invocations).await;
         find_hover(
@@ -565,7 +538,7 @@ mod tests {
     ) -> Option<HoverResult> {
         let path = "/test.wado";
         let uri = format!("file://{path}");
-        let host = TestHost::new(path, source);
+        let host = MapHost::single(path, source);
         let invocations = wado_compiler::kiln::InvocationIndex::new();
         let annotated = annotate_with_invocations(source, &host, Some(path), invocations).await;
         find_hover(

--- a/wado-lsp/src/lib.rs
+++ b/wado-lsp/src/lib.rs
@@ -1,3 +1,5 @@
+mod macros;
+
 mod definition;
 mod diagnostics;
 mod document_highlight;
@@ -193,6 +195,29 @@ impl Engine {
         Some(snapshot)
     }
 
+    /// Compute the snapshot + document text for `uri` and hand them to
+    /// `f`. Returns `default` when either lookup misses (closed
+    /// document or load failure).
+    ///
+    /// Every position-bearing query (`definition`, `hover`, `references`,
+    /// `document_highlight`) used to inline the same `snapshot.await? +
+    /// doc_text` prologue. Centralising it here means a future change
+    /// to that prologue (e.g. caching the doc text on `Snapshot`) lands
+    /// in one place.
+    async fn with_doc_snapshot<H, F, R>(&self, uri: &str, host: &H, default: R, f: F) -> R
+    where
+        H: CompilerHost,
+        F: FnOnce(&Snapshot, &str) -> R,
+    {
+        let Some(snapshot) = self.snapshot(uri, host).await else {
+            return default;
+        };
+        let Some(doc_text) = self.documents.get(uri).map(|d| d.text.as_str()) else {
+            return default;
+        };
+        f(&snapshot, doc_text)
+    }
+
     /// Find the definition of the symbol at the given position.
     pub async fn definition<H: CompilerHost>(
         &self,
@@ -200,15 +225,16 @@ impl Engine {
         position: Position,
         host: &H,
     ) -> Option<DefinitionResult> {
-        let snapshot = self.snapshot(uri, host).await?;
-        let doc_text = self.documents.get(uri)?.text.as_str();
-        definition::find_definition(
-            &snapshot.annotated,
-            doc_text,
-            position,
-            uri,
-            self.position_encoding,
-        )
+        self.with_doc_snapshot(uri, host, None, |snapshot, doc_text| {
+            definition::find_definition(
+                &snapshot.annotated,
+                doc_text,
+                position,
+                uri,
+                self.position_encoding,
+            )
+        })
+        .await
     }
 
     /// Compute hover information for the symbol at the given position.
@@ -218,15 +244,16 @@ impl Engine {
         position: Position,
         host: &H,
     ) -> Option<HoverResult> {
-        let snapshot = self.snapshot(uri, host).await?;
-        let doc_text = self.documents.get(uri)?.text.as_str();
-        hover::find_hover(
-            &snapshot.annotated,
-            doc_text,
-            position,
-            uri,
-            self.position_encoding,
-        )
+        self.with_doc_snapshot(uri, host, None, |snapshot, doc_text| {
+            hover::find_hover(
+                &snapshot.annotated,
+                doc_text,
+                position,
+                uri,
+                self.position_encoding,
+            )
+        })
+        .await
     }
 
     /// Find every reference to the symbol named at the given position.
@@ -237,20 +264,17 @@ impl Engine {
         include_declaration: bool,
         host: &H,
     ) -> Vec<ReferenceLocation> {
-        let Some(snapshot) = self.snapshot(uri, host).await else {
-            return Vec::new();
-        };
-        let Some(doc_text) = self.documents.get(uri).map(|d| d.text.as_str()) else {
-            return Vec::new();
-        };
-        references::find_references(
-            &snapshot.annotated,
-            doc_text,
-            position,
-            uri,
-            include_declaration,
-            self.position_encoding,
-        )
+        self.with_doc_snapshot(uri, host, Vec::new(), |snapshot, doc_text| {
+            references::find_references(
+                &snapshot.annotated,
+                doc_text,
+                position,
+                uri,
+                include_declaration,
+                self.position_encoding,
+            )
+        })
+        .await
     }
 
     /// Find every occurrence of the symbol named at the given position
@@ -262,19 +286,16 @@ impl Engine {
         position: Position,
         host: &H,
     ) -> Vec<DocumentHighlight> {
-        let Some(snapshot) = self.snapshot(uri, host).await else {
-            return Vec::new();
-        };
-        let Some(doc_text) = self.documents.get(uri).map(|d| d.text.as_str()) else {
-            return Vec::new();
-        };
-        document_highlight::document_highlight(
-            &snapshot.annotated,
-            doc_text,
-            position,
-            uri,
-            self.position_encoding,
-        )
+        self.with_doc_snapshot(uri, host, Vec::new(), |snapshot, doc_text| {
+            document_highlight::document_highlight(
+                &snapshot.annotated,
+                doc_text,
+                position,
+                uri,
+                self.position_encoding,
+            )
+        })
+        .await
     }
 
     /// Resolve a `core:` / `wasi:` URI to its bundled stdlib source.

--- a/wado-lsp/src/lib.rs
+++ b/wado-lsp/src/lib.rs
@@ -8,6 +8,8 @@ mod location;
 mod references;
 pub mod semantic_tokens;
 pub mod server;
+#[doc(hidden)]
+pub mod test_support;
 pub mod text;
 pub mod uri;
 
@@ -400,51 +402,8 @@ impl<H: CompilerHost> CompilerHost for DiagnosticCollector<'_, H> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::MapHost;
     use futures::executor::block_on;
-    use indexmap::IndexMap as IndexMapAlias;
-    use wado_compiler::SourceError;
-
-    struct EmptyHost;
-    impl CompilerHost for EmptyHost {
-        async fn load_source(&self, path: &str) -> Result<Vec<u8>, SourceError> {
-            Err(SourceError::NotFound {
-                path: path.to_string(),
-            })
-        }
-        fn emit_diagnostic(&self, _: CompilerDiagnostic) {}
-    }
-
-    struct MapHost {
-        sources: IndexMapAlias<String, Vec<u8>>,
-        emitted: std::sync::Mutex<Vec<CompilerDiagnostic>>,
-    }
-
-    impl MapHost {
-        fn new(entries: &[(&str, &str)]) -> Self {
-            let mut sources = IndexMapAlias::new();
-            for (path, body) in entries {
-                sources.insert((*path).to_string(), body.as_bytes().to_vec());
-            }
-            Self {
-                sources,
-                emitted: std::sync::Mutex::new(Vec::new()),
-            }
-        }
-    }
-
-    impl CompilerHost for MapHost {
-        async fn load_source(&self, path: &str) -> Result<Vec<u8>, SourceError> {
-            self.sources
-                .get(path)
-                .cloned()
-                .ok_or_else(|| SourceError::NotFound {
-                    path: path.to_string(),
-                })
-        }
-        fn emit_diagnostic(&self, d: CompilerDiagnostic) {
-            self.emitted.lock().unwrap().push(d);
-        }
-    }
 
     #[test]
     fn test_open_and_close_document() {
@@ -474,7 +433,7 @@ mod tests {
         // removed.
         let mut engine = Engine::new();
         engine.open_document("file:///t.wado", "fn a() {}".to_string());
-        let host = EmptyHost;
+        let host = MapHost::empty();
         let _ = block_on(engine.snapshot("file:///t.wado", &host)).expect("snapshot");
         assert!(
             engine
@@ -508,7 +467,7 @@ mod tests {
         let mut engine = Engine::new();
         engine.open_document("file:///foo.wado", "fn a() {}".to_string());
         engine.open_document("file:///bar.wado", "fn b() {}".to_string());
-        let host = EmptyHost;
+        let host = MapHost::empty();
         let _ = block_on(engine.snapshot("file:///foo.wado", &host)).expect("foo snapshot");
         let _ = block_on(engine.snapshot("file:///bar.wado", &host)).expect("bar snapshot");
         engine.update_document("file:///bar.wado", "fn bb() {}".to_string());
@@ -531,13 +490,12 @@ mod tests {
         // side effects (logging, error counting) would otherwise vanish
         // silently when Engine::snapshot wraps the host.
         let text = "fn f() -> i32 { return \"oops\"; }";
-        let host = MapHost::new(&[("/t.wado", text)]);
+        let host = MapHost::single("/t.wado", text);
         let mut engine = Engine::new();
         engine.open_document("file:///t.wado", text.to_string());
         let _ = block_on(engine.snapshot("file:///t.wado", &host)).expect("snapshot");
-        let emitted = host.emitted.lock().unwrap();
         assert!(
-            !emitted.is_empty(),
+            !host.emitted().is_empty(),
             "inner host should have received forwarded diagnostics",
         );
     }

--- a/wado-lsp/src/location.rs
+++ b/wado-lsp/src/location.rs
@@ -8,7 +8,7 @@
 
 use wado_compiler::annotate::Annotated;
 use wado_compiler::module_source::ModuleSource;
-use wado_compiler::symbol::Symbol;
+use wado_compiler::symbol::{Symbol, SymbolKey};
 use wado_compiler::token::Span;
 
 use crate::diagnostics::Range;
@@ -93,6 +93,25 @@ pub(crate) fn symbol_uri(
     request_uri: &str,
 ) -> Option<String> {
     module_uri(annotated, &symbol.defined_at.module, request_uri)
+}
+
+/// Decide which source text (if any) to pass to [`span_to_range`] when
+/// re-encoding a span whose [`SymbolKey`] sits in `key.module`.
+///
+/// Returns `Some(source)` only when `key` points at the entry module —
+/// spans in other modules are codepoint-indexed against THEIR source,
+/// not the entry document's, so re-encoding against `source` would walk
+/// the wrong text and emit a drifted `character` under UTF-16 / UTF-8
+/// whenever the two modules disagree on the matching line. Cross-file
+/// callers pass the returned `None` straight through to
+/// `span_to_range`, which falls back to "codepoint columns as code
+/// units" (correct under UTF-32 / ASCII).
+pub(crate) fn source_for_key<'a>(
+    annotated: &Annotated,
+    key: &SymbolKey,
+    entry_source: &'a str,
+) -> Option<&'a str> {
+    (key.module == annotated.entry_module_source).then_some(entry_source)
 }
 
 /// Convert a compiler `Span` (1-based byte column) to an LSP `Range` in

--- a/wado-lsp/src/macros.rs
+++ b/wado-lsp/src/macros.rs
@@ -1,0 +1,73 @@
+//! Small internal macros shared across the crate.
+
+/// Declare a `pub` enum whose LSP wire form is a small `u32` discriminant.
+///
+/// Generates the same `serde` plumbing (`#[serde(into = "u32", try_from
+/// = "u32")]`), the `From<Self> for u32` cast, and a `TryFrom<u32>`
+/// impl whose `Err` is a human-readable diagnostic. The LSP wire types
+/// `Severity` (1..=4) and `HighlightKind` (1..=3) used to spell these
+/// impls out by hand — identical shape, drifty when one side gets a new
+/// variant.
+///
+/// Usage:
+///
+/// ```ignore
+/// lsp_repr_u32_enum!(Severity {
+///     Error = 1,
+///     Warning = 2,
+/// });
+/// ```
+macro_rules! lsp_repr_u32_enum {
+    (
+        $(#[$enum_meta:meta])*
+        $vis:vis enum $name:ident {
+            $(
+                $(#[$variant_meta:meta])*
+                $variant:ident = $val:literal
+            ),+ $(,)?
+        }
+    ) => {
+        $(#[$enum_meta])*
+        #[derive(
+            Debug, Clone, Copy, PartialEq, Eq,
+            ::serde::Serialize, ::serde::Deserialize,
+        )]
+        #[serde(into = "u32", try_from = "u32")]
+        $vis enum $name {
+            $(
+                $(#[$variant_meta])*
+                $variant = $val,
+            )+
+        }
+
+        impl ::core::convert::From<$name> for u32 {
+            fn from(value: $name) -> Self {
+                value as Self
+            }
+        }
+
+        impl ::core::convert::TryFrom<u32> for $name {
+            // Spelled out explicitly because variants named `Error`
+            // (e.g. `Severity::Error`) would otherwise make
+            // `Self::Error` ambiguous with the associated type.
+            type Error = ::std::string::String;
+
+            fn try_from(
+                n: u32,
+            ) -> ::core::result::Result<
+                Self,
+                <Self as ::core::convert::TryFrom<u32>>::Error,
+            > {
+                match n {
+                    $($val => ::core::result::Result::Ok(Self::$variant),)+
+                    _ => ::core::result::Result::Err(format!(
+                        concat!("invalid ", stringify!($name), ": {}"),
+                        n,
+                    )),
+                }
+            }
+        }
+    };
+}
+
+pub(crate) use lsp_repr_u32_enum;

--- a/wado-lsp/src/references.rs
+++ b/wado-lsp/src/references.rs
@@ -112,35 +112,8 @@ pub(crate) fn use_site_location(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use indexmap::IndexMap;
-    use wado_compiler::CompilerHost;
+    use crate::test_support::MapHost;
     use wado_compiler::annotate::annotate_with_invocations;
-    use wado_compiler::{Diagnostic as CompilerDiagnostic, SourceError};
-
-    struct TestHost {
-        sources: IndexMap<String, Vec<u8>>,
-    }
-
-    impl TestHost {
-        fn single(path: &str, source: &str) -> Self {
-            let mut sources = IndexMap::new();
-            sources.insert(path.to_string(), source.as_bytes().to_vec());
-            Self { sources }
-        }
-    }
-
-    impl CompilerHost for TestHost {
-        async fn load_source(&self, path: &str) -> Result<Vec<u8>, SourceError> {
-            self.sources
-                .get(path)
-                .cloned()
-                .ok_or_else(|| SourceError::NotFound {
-                    path: path.to_string(),
-                })
-        }
-
-        fn emit_diagnostic(&self, _diagnostic: CompilerDiagnostic) {}
-    }
 
     async fn refs_at(
         source: &str,
@@ -150,7 +123,7 @@ mod tests {
     ) -> Vec<ReferenceLocation> {
         let path = "/test.wado";
         let uri = format!("file://{path}");
-        let host = TestHost::single(path, source);
+        let host = MapHost::single(path, source);
         let invocations = wado_compiler::kiln::InvocationIndex::new();
         let annotated = annotate_with_invocations(source, &host, Some(path), invocations).await;
         find_references(

--- a/wado-lsp/src/references.rs
+++ b/wado-lsp/src/references.rs
@@ -13,7 +13,7 @@ use wado_compiler::annotate::Annotated;
 use wado_compiler::symbol::SymbolKey;
 
 use crate::diagnostics::{Position, Range};
-use crate::location::{module_uri, span_to_range, symbol_uri};
+use crate::location::{module_uri, source_for_key, span_to_range, symbol_uri};
 use crate::text::{PositionEncoding, lsp_position_to_line_col};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -78,18 +78,9 @@ pub(crate) fn declaration_location(
     let symbol = annotated.symbol_at(def_key)?;
     let span = annotated.name_span_of(def_key).or(symbol.span)?;
     let uri = symbol_uri(annotated, symbol, request_uri)?;
-    // Spans for declarations in other modules are byte-indexed against
-    // *that* module's source, not the request document. Only re-encode
-    // against `source` when the def lives in the entry module; otherwise
-    // pass `None` so the conversion stays byte-accurate. This is the
-    // same conservative choice `span_to_range` documents for non-ASCII
-    // cross-file results — the value carries the compiler's byte column
-    // verbatim, which is correct for ASCII and the only choice we can
-    // make without loading the other module's text on every query.
-    let source_for_range = (def_key.module == annotated.entry_module_source).then_some(source);
     Some(ReferenceLocation {
         uri,
-        range: span_to_range(&span, source_for_range, encoding),
+        range: span_to_range(&span, source_for_key(annotated, def_key, source), encoding),
     })
 }
 
@@ -102,10 +93,9 @@ pub(crate) fn use_site_location(
 ) -> Option<ReferenceLocation> {
     let span = annotated.span_of_key(use_key)?;
     let uri = module_uri(annotated, &use_key.module, request_uri)?;
-    let source_for_range = (use_key.module == annotated.entry_module_source).then_some(source);
     Some(ReferenceLocation {
         uri,
-        range: span_to_range(&span, source_for_range, encoding),
+        range: span_to_range(&span, source_for_key(annotated, use_key, source), encoding),
     })
 }
 

--- a/wado-lsp/src/semantic_tokens.rs
+++ b/wado-lsp/src/semantic_tokens.rs
@@ -3,7 +3,7 @@ use wado_compiler::ast::{self, Expr, Item, Stmt, Type};
 use wado_compiler::lexer::Lexer;
 use wado_compiler::token::{Token, TokenKind};
 
-use crate::text::PositionEncoding;
+use crate::text::{PositionEncoding, codepoints_to_code_units, line_without_terminator};
 
 /// LSP semantic token type indices (must match `TOKEN_TYPES` order).
 pub mod token_type {
@@ -134,10 +134,7 @@ pub fn delta_encode(
     let lines: Vec<(&str, u32)> = source
         .split_inclusive('\n')
         .map(|line| {
-            let text = line
-                .strip_suffix('\n')
-                .map(|s| s.strip_suffix('\r').unwrap_or(s))
-                .unwrap_or(line);
+            let text = line_without_terminator(line);
             (text, text.chars().count() as u32)
         })
         .collect();
@@ -150,8 +147,8 @@ pub fn delta_encode(
         let (line_text, line_codepoints) =
             lines.get(token.line as usize).copied().unwrap_or(("", 0));
         let start_char =
-            codepoint_to_encoding(line_text, line_codepoints, token.start_char, encoding);
-        let end_char = codepoint_to_encoding(
+            codepoints_to_code_units(line_text, line_codepoints, token.start_char, encoding);
+        let end_char = codepoints_to_code_units(
             line_text,
             line_codepoints,
             token.start_char + token.length,
@@ -176,31 +173,6 @@ pub fn delta_encode(
         prev_start = start_char;
     }
     data
-}
-
-/// Codepoint offset → LSP code-unit offset in the requested `encoding`.
-/// `line_codepoints` is the cached codepoint count of `line`, so the
-/// saturation check avoids a second `chars().count()` pass.
-fn codepoint_to_encoding(
-    line: &str,
-    line_codepoints: u32,
-    codepoint_col: u32,
-    encoding: PositionEncoding,
-) -> u32 {
-    let codepoint_col = codepoint_col.min(line_codepoints);
-    match encoding {
-        PositionEncoding::Utf8 => line
-            .chars()
-            .take(codepoint_col as usize)
-            .map(|c| c.len_utf8() as u32)
-            .sum(),
-        PositionEncoding::Utf16 => line
-            .chars()
-            .take(codepoint_col as usize)
-            .map(|c| c.len_utf16() as u32)
-            .sum(),
-        PositionEncoding::Utf32 => codepoint_col,
-    }
 }
 
 // --- AST-based type span collection ---

--- a/wado-lsp/src/server/dispatch.rs
+++ b/wado-lsp/src/server/dispatch.rs
@@ -151,77 +151,56 @@ pub async fn dispatch<W: Write>(
             }
         }
         "textDocument/definition" => {
-            if let Some(id) = id {
-                let Some(p) = transport::decode_or_error::<TextDocumentPositionParams, _>(
-                    writer, id, params,
-                )?
-                else {
-                    return Ok(());
-                };
+            let engine = &*engine;
+            transport::typed_request(writer, id, params, async |p: TextDocumentPositionParams| {
                 let host = transport::host_for_uri(&p.text_document.uri);
-                let result = engine
+                engine
                     .definition(&p.text_document.uri, p.position, &host)
-                    .await;
-                transport::send_response(writer, id, result)?;
-            }
+                    .await
+            })
+            .await?;
         }
         "textDocument/hover" => {
-            if let Some(id) = id {
-                let Some(p) = transport::decode_or_error::<TextDocumentPositionParams, _>(
-                    writer, id, params,
-                )?
-                else {
-                    return Ok(());
-                };
+            let engine = &*engine;
+            transport::typed_request(writer, id, params, async |p: TextDocumentPositionParams| {
                 let host = transport::host_for_uri(&p.text_document.uri);
-                let result = engine.hover(&p.text_document.uri, p.position, &host).await;
-                transport::send_response(writer, id, result)?;
-            }
+                engine.hover(&p.text_document.uri, p.position, &host).await
+            })
+            .await?;
         }
         "textDocument/references" => {
-            if let Some(id) = id {
-                let Some(p) = transport::decode_or_error::<ReferenceParams, _>(writer, id, params)?
-                else {
-                    return Ok(());
-                };
+            let engine = &*engine;
+            transport::typed_request(writer, id, params, async |p: ReferenceParams| {
                 let host = transport::host_for_uri(&p.text_document.uri);
-                let refs = engine
+                engine
                     .references(
                         &p.text_document.uri,
                         p.position,
                         p.context.include_declaration,
                         &host,
                     )
-                    .await;
-                transport::send_response(writer, id, refs)?;
-            }
+                    .await
+            })
+            .await?;
         }
         "textDocument/documentHighlight" => {
-            if let Some(id) = id {
-                let Some(p) = transport::decode_or_error::<TextDocumentPositionParams, _>(
-                    writer, id, params,
-                )?
-                else {
-                    return Ok(());
-                };
+            let engine = &*engine;
+            transport::typed_request(writer, id, params, async |p: TextDocumentPositionParams| {
                 let host = transport::host_for_uri(&p.text_document.uri);
-                let highlights = engine
+                engine
                     .document_highlight(&p.text_document.uri, p.position, &host)
-                    .await;
-                transport::send_response(writer, id, highlights)?;
-            }
+                    .await
+            })
+            .await?;
         }
         "textDocument/semanticTokens/full" => {
-            if let Some(id) = id {
-                let Some(p) =
-                    transport::decode_or_error::<SemanticTokensParams, _>(writer, id, params)?
-                else {
-                    return Ok(());
-                };
-                let data = engine.semantic_tokens(&p.text_document.uri);
-                let result = SemanticTokens { data };
-                transport::send_response(writer, id, result)?;
-            }
+            let engine = &*engine;
+            transport::typed_request(writer, id, params, async |p: SemanticTokensParams| {
+                SemanticTokens {
+                    data: engine.semantic_tokens(&p.text_document.uri),
+                }
+            })
+            .await?;
         }
         "workspace/textDocumentContent" => {
             if let Some(id) = id {

--- a/wado-lsp/src/server/transport.rs
+++ b/wado-lsp/src/server/transport.rs
@@ -5,6 +5,7 @@
 //! wrapping runtime is still async: dispatch awaits `Engine` queries between
 //! blocking `read_message` / `send_*` calls.
 
+use std::future::Future;
 use std::io::{BufRead, Write};
 use std::path::PathBuf;
 
@@ -149,6 +150,36 @@ where
             Ok(None)
         }
     }
+}
+
+/// Run a typed request: decode the JSON params into `P`, invoke
+/// `handler(p).await`, and serialize the result as a JSON-RPC response.
+///
+/// Skips the body when `id` is `None` (notification-shaped envelope on
+/// a request method), and bails after sending an `InvalidParams` error
+/// when the params don't deserialize. This shell is what every
+/// query-style handler in `dispatch.rs` used to inline by hand.
+pub async fn typed_request<P, R, W, F, Fut>(
+    writer: &mut W,
+    id: Option<&Value>,
+    params: Value,
+    handler: F,
+) -> Result<(), String>
+where
+    P: DeserializeOwned,
+    R: Serialize,
+    W: Write,
+    F: FnOnce(P) -> Fut,
+    Fut: Future<Output = R>,
+{
+    let Some(id) = id else {
+        return Ok(());
+    };
+    let Some(p) = decode_or_error::<P, _>(writer, id, params)? else {
+        return Ok(());
+    };
+    let result = handler(p).await;
+    send_response(writer, id, result)
 }
 
 /// Build a filesystem host rooted at the directory containing `uri`.

--- a/wado-lsp/src/test_support.rs
+++ b/wado-lsp/src/test_support.rs
@@ -1,0 +1,96 @@
+//! Shared test fixtures for `wado-lsp`.
+//!
+//! Centralises the in-memory `CompilerHost` implementation that every test
+//! file used to redeclare. The module is publicly exposed but marked
+//! `#[doc(hidden)]` so it is reachable from both unit tests (inside
+//! `src/`) and integration tests (`tests/*.rs`) without inflating the
+//! crate's documented surface.
+//!
+//! Adding a new shared helper here is preferable to growing yet another
+//! `TestHost` per file — the previous duplication drifted across files
+//! (different constructor names, different diagnostic-capture behaviour)
+//! and made it easy to accidentally test against a non-canonical host.
+//!
+//! Typical usage in tests:
+//!
+//! ```ignore
+//! use wado_lsp::test_support::MapHost;
+//!
+//! let host = MapHost::single("/test.wado", source);
+//! ```
+//!
+//! For multi-file fixtures use [`MapHost::with_files`]; for tests that
+//! expect lookups to fail, use [`MapHost::empty`].
+//!
+//! Diagnostics emitted via `CompilerHost::emit_diagnostic` are captured
+//! in an internal buffer and observable through
+//! [`MapHost::emitted`] — useful for asserting that a wrapper host
+//! (e.g. `DiagnosticCollector`) actually forwards to the inner host.
+
+use std::sync::Mutex;
+
+use indexmap::IndexMap;
+use wado_compiler::{CompilerHost, Diagnostic as CompilerDiagnostic, SourceError};
+
+/// In-memory `CompilerHost` backed by an `IndexMap` of path → source bytes.
+///
+/// Emitted diagnostics are captured into an internal buffer so tests can
+/// assert on forwarding without supplying a separate observer host.
+pub struct MapHost {
+    sources: IndexMap<String, Vec<u8>>,
+    emitted: Mutex<Vec<CompilerDiagnostic>>,
+}
+
+impl MapHost {
+    /// A host with no source files; every `load_source` call returns
+    /// [`SourceError::NotFound`].
+    #[must_use]
+    pub fn empty() -> Self {
+        Self {
+            sources: IndexMap::new(),
+            emitted: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// A host serving exactly one file.
+    #[must_use]
+    pub fn single(path: &str, source: &str) -> Self {
+        Self::with_files(&[(path, source)])
+    }
+
+    /// A host serving each `(path, source)` pair. Later entries with the
+    /// same path overwrite earlier ones (matches `IndexMap::insert`).
+    #[must_use]
+    pub fn with_files(files: &[(&str, &str)]) -> Self {
+        let mut sources = IndexMap::new();
+        for (path, body) in files {
+            sources.insert((*path).to_string(), body.as_bytes().to_vec());
+        }
+        Self {
+            sources,
+            emitted: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Snapshot of diagnostics this host has received via
+    /// `CompilerHost::emit_diagnostic`.
+    #[must_use]
+    pub fn emitted(&self) -> Vec<CompilerDiagnostic> {
+        self.emitted.lock().unwrap().clone()
+    }
+}
+
+impl CompilerHost for MapHost {
+    async fn load_source(&self, path: &str) -> Result<Vec<u8>, SourceError> {
+        self.sources
+            .get(path)
+            .cloned()
+            .ok_or_else(|| SourceError::NotFound {
+                path: path.to_string(),
+            })
+    }
+
+    fn emit_diagnostic(&self, diagnostic: CompilerDiagnostic) {
+        self.emitted.lock().unwrap().push(diagnostic);
+    }
+}

--- a/wado-lsp/src/text.rs
+++ b/wado-lsp/src/text.rs
@@ -103,10 +103,7 @@ pub fn lsp_position_to_line_col(
             // terminator before locating the column so a cursor at the
             // end-of-line does not slide into the next line on UTF-16
             // counting.
-            let line_content = line
-                .strip_suffix('\n')
-                .map(|s| s.strip_suffix('\r').unwrap_or(s))
-                .unwrap_or(line);
+            let line_content = line_without_terminator(line);
             let codepoint_col =
                 character_to_codepoint_offset(line_content, position.character, encoding);
             // Compiler convention: 1-based line + 1-based codepoint column.
@@ -116,6 +113,16 @@ pub fn lsp_position_to_line_col(
     // Cursor past EOF: out-of-range sentinel so the compiler's
     // `ast_id_at` returns `None`. See doc-comment above.
     (usize::MAX, 1)
+}
+
+/// Strip a trailing `\n` (and optional preceding `\r`) from a single
+/// line slice. Every line lookup in this crate uses this idiom because
+/// `split_inclusive('\n')` keeps the terminator on each line.
+#[must_use]
+pub(crate) fn line_without_terminator(line: &str) -> &str {
+    line.strip_suffix('\n')
+        .map(|s| s.strip_suffix('\r').unwrap_or(s))
+        .unwrap_or(line)
 }
 
 /// Convert a compiler `Span` to an LSP `Range` in the negotiated
@@ -191,8 +198,12 @@ fn character_to_codepoint_offset(line: &str, character: u32, encoding: PositionE
 }
 
 /// Translate a 0-based codepoint offset at `line` (of `source`) into a
-/// 0-based `character` in `encoding` code units.
-fn codepoint_offset_to_character(
+/// 0-based `character` in `encoding` code units. Looks the line up in
+/// `source` on each call; callers that already have the line slice on
+/// hand (e.g. a delta-encoding loop) should use
+/// [`codepoints_to_code_units`] directly to skip the lookup.
+#[must_use]
+pub(crate) fn codepoint_offset_to_character(
     source: &str,
     line: u32,
     codepoint_col: u32,
@@ -201,19 +212,34 @@ fn codepoint_offset_to_character(
     let Some(line_text) = source.split_inclusive('\n').nth(line as usize) else {
         return codepoint_col;
     };
-    let line_content = line_text
-        .strip_suffix('\n')
-        .map(|s| s.strip_suffix('\r').unwrap_or(s))
-        .unwrap_or(line_text);
-    let max = line_content.chars().count() as u32;
-    let codepoint_col = codepoint_col.min(max);
+    let line_content = line_without_terminator(line_text);
+    let line_codepoints = line_content.chars().count() as u32;
+    codepoints_to_code_units(line_content, line_codepoints, codepoint_col, encoding)
+}
+
+/// Codepoint offset → LSP `character` (code-unit count) inside a single
+/// line slice. The caller supplies `line_codepoints` (the line's
+/// pre-computed codepoint count) so hot loops can hoist the
+/// `chars().count()` walk out — see `semantic_tokens::delta_encode`,
+/// which converts twice per emitted token.
+///
+/// `codepoint_col` is saturated against `line_codepoints` so callers
+/// don't need a separate clamp.
+#[must_use]
+pub(crate) fn codepoints_to_code_units(
+    line: &str,
+    line_codepoints: u32,
+    codepoint_col: u32,
+    encoding: PositionEncoding,
+) -> u32 {
+    let codepoint_col = codepoint_col.min(line_codepoints);
     match encoding {
-        PositionEncoding::Utf8 => line_content
+        PositionEncoding::Utf8 => line
             .chars()
             .take(codepoint_col as usize)
             .map(|c| c.len_utf8() as u32)
             .sum(),
-        PositionEncoding::Utf16 => line_content
+        PositionEncoding::Utf16 => line
             .chars()
             .take(codepoint_col as usize)
             .map(|c| c.len_utf16() as u32)

--- a/wado-lsp/tests/definition.rs
+++ b/wado-lsp/tests/definition.rs
@@ -2,47 +2,13 @@
 //! across parameters, locals, items, types, method calls, imports, effects,
 //! and file-path jumps.
 
-use indexmap::IndexMap;
-use wado_compiler::{CompilerHost, Diagnostic as CompilerDiagnostic, SourceError};
+use wado_lsp::test_support::MapHost;
 use wado_lsp::{DefinitionResult, Engine, Position};
-
-struct TestHost {
-    sources: IndexMap<String, Vec<u8>>,
-}
-
-impl TestHost {
-    fn new(path: &str, source: &str) -> Self {
-        let mut sources = IndexMap::new();
-        sources.insert(path.to_string(), source.as_bytes().to_vec());
-        Self { sources }
-    }
-
-    fn with_files(files: &[(&str, &str)]) -> Self {
-        let mut sources = IndexMap::new();
-        for (path, source) in files {
-            sources.insert((*path).to_string(), source.as_bytes().to_vec());
-        }
-        Self { sources }
-    }
-}
-
-impl CompilerHost for TestHost {
-    async fn load_source(&self, path: &str) -> Result<Vec<u8>, SourceError> {
-        if let Some(b) = self.sources.get(path) {
-            return Ok(b.clone());
-        }
-        Err(SourceError::NotFound {
-            path: path.to_string(),
-        })
-    }
-
-    fn emit_diagnostic(&self, _diagnostic: CompilerDiagnostic) {}
-}
 
 async fn def_at(source: &str, line: u32, character: u32) -> Option<DefinitionResult> {
     let path = "/test.wado";
     let uri = format!("file://{path}");
-    let host = TestHost::new(path, source);
+    let host = MapHost::single(path, source);
     let mut engine = Engine::new();
     engine.open_document(&uri, source.to_string());
     engine
@@ -57,7 +23,7 @@ async fn def_at_in(
     character: u32,
 ) -> Option<DefinitionResult> {
     let uri = format!("file://{entry}");
-    let host = TestHost::with_files(files);
+    let host = MapHost::with_files(files);
     let entry_source = files
         .iter()
         .find(|(p, _)| *p == entry)

--- a/wado-lsp/tests/diagnostics.rs
+++ b/wado-lsp/tests/diagnostics.rs
@@ -12,38 +12,12 @@
 //! - Inputs that historically panicked during codegen validation now
 //!   complete cleanly because `Engine::diagnostics` stops at `annotate`.
 
-use indexmap::IndexMap;
-use wado_compiler::{CompilerHost, Diagnostic as CompilerDiagnostic, SourceError};
+use wado_lsp::test_support::MapHost;
 use wado_lsp::{Diagnostic, Engine, Severity};
-
-struct TestHost {
-    sources: IndexMap<String, Vec<u8>>,
-}
-
-impl TestHost {
-    fn empty() -> Self {
-        Self {
-            sources: IndexMap::new(),
-        }
-    }
-}
-
-impl CompilerHost for TestHost {
-    async fn load_source(&self, path: &str) -> Result<Vec<u8>, SourceError> {
-        if let Some(b) = self.sources.get(path) {
-            return Ok(b.clone());
-        }
-        Err(SourceError::NotFound {
-            path: path.to_string(),
-        })
-    }
-
-    fn emit_diagnostic(&self, _diagnostic: CompilerDiagnostic) {}
-}
 
 async fn diagnostics_for(path: &str, source: &str) -> Vec<Diagnostic> {
     let uri = format!("file://{path}");
-    let host = TestHost::empty();
+    let host = MapHost::empty();
     let mut engine = Engine::new();
     engine.open_document(&uri, source.to_string());
     engine.diagnostics(&uri, &host).await


### PR DESCRIPTION
## Summary

Pure-refactor sweep through `wado-lsp` focused on maintainability. Six categories of duplication that each spanned 3–6 files were collapsed into one shared helper apiece. No public LSP behavior changes; **16 files / +407 / −460 / net −53 LOC** (the new helper files account for ~240 of those `+` lines, so the call-site delta is much deeper than the bottom-line number).

### What got deduped

| Before | After |
|---|---|
| 5 nearly identical per-file `TestHost { sources: IndexMap<…> }` declarations in `lib.rs` / `hover.rs` / `references.rs` / `document_highlight.rs` / `tests/definition.rs` / `tests/diagnostics.rs` (each ~30 LOC) | Single `MapHost` in new `src/test_support.rs` (`#[doc(hidden)] pub`); `empty` / `single` / `with_files` / `emitted` |
| `codepoint→encoding` conversion duplicated 3× (`text.rs`, `diagnostics.rs::codepoint_column_to_character`, `semantic_tokens.rs::codepoint_to_encoding`) plus 4 copies of the `\n` / `\r\n` strip | `text::{codepoint_offset_to_character, codepoints_to_code_units, line_without_terminator}` `pub(crate)` helpers |
| `Severity` (1..=4) and `HighlightKind` (1..=3) each spelled out `serde(into/try_from = "u32")` + `From<u32>` + `TryFrom<u32>` by hand (≈18 lines each, drifty when a variant grows) | `lsp_repr_u32_enum!` macro in new `src/macros.rs` |
| `(key.module == annotated.entry_module_source).then_some(source)` idiom + multiline rationale in 3 call sites (`definition.rs`, `references.rs` ×2) | `location::source_for_key` helper, comment lives in one place |
| `Engine::{definition, hover, references, document_highlight}` each inlined `snapshot.await? + documents.get(uri)?.text + …` (14–18 lines × 4) | `Engine::with_doc_snapshot(uri, host, default, |s, t| …)` private helper. Works for both `Option<R>` and `Vec<R>` return shapes via the `default` arg |
| 5 dispatch arms (`definition`, `hover`, `references`, `documentHighlight`, `semanticTokens/full`) repeated `if let Some(id) = id { decode_or_error → host_for_uri → engine.X → send_response }` | `transport::typed_request<P, R, …>` shell + per-arm async closure |

Two commits, each landable independently:

- `4e4823ab refactor(lsp): consolidate test fixtures and codepoint→encoding helpers`
- `3128d74a refactor(lsp): further dedupe across enums, query plumbing, and dispatcher`

`wado-lsp/AGENTS.md` updated for the new `test_support.rs`.

## Test plan

- [x] `cargo test -p wado-lsp` — 129 passed (70 unit + 44 definition + 6 diagnostics + 9 kiln)
- [x] `cargo check -p wado-lsp --target wasm32-wasip2` — wasm build OK
- [x] `cargo build -p wado-cli` — downstream still links
- [x] `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` — clean
- [x] `mise run on-task-done` full sweep — clippy-fix / golden-fixtures / golden-format-fixtures / doc-stdlib / format / `cargo test` (2634 + ~1000 across workspace, all 0 failed) / `cargo run -p wado-cli -- test` (968 compile / 968 load / 2920 wado tests, 0 failed)
- [x] `git status` clean after the sweep

https://claude.ai/code/session_01FXYAQkRsbh3RCcQeCfz7gt

---
_Generated by [Claude Code](https://claude.ai/code/session_01FXYAQkRsbh3RCcQeCfz7gt)_