### PR TITLE
perf(kiln): resolve generators once per pipeline and cache compiled Components

### DIFF
--- a/wado-cli/src/compiler_host.rs
+++ b/wado-cli/src/compiler_host.rs
@@ -3,7 +3,8 @@
 //! timestamps, log-level filtering, and stderr printing.
 
 use std::path::PathBuf;
-use std::sync::{Arc, OnceLock};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Instant;
 
 use wado_compiler::{
@@ -20,6 +21,19 @@ pub struct FilesystemCompilerHost {
     log_level: LogLevel,
     start_time: Instant,
     kiln_engine: OnceLock<wasmtime::Engine>,
+    /// Cache of compiled wasmtime [`Component`]s, keyed by SHA-256 of
+    /// the generator wasm bytes. Building a [`Component`] from a 432KB
+    /// generator wasm runs cranelift AOT for ~7s; many kiln invocations
+    /// in a single pipeline run typically share the same generator
+    /// (and therefore the same bytes), so a per-host cache turns N×AOT
+    /// into 1×AOT + (N-1) lookups. Lives only for the lifetime of this
+    /// host — no on-disk `.cwasm` is written, so there is no
+    /// trust-the-disk attack surface from caching.
+    kiln_components: Mutex<Vec<([u8; 32], wasmtime::component::Component)>>,
+    /// Number of times [`compile_component`] has actually been invoked
+    /// (i.e. cache misses). Tests use this to assert that the cache
+    /// dedups across `run_generator` calls.
+    kiln_component_compile_count: AtomicUsize,
 }
 
 impl FilesystemCompilerHost {
@@ -31,6 +45,8 @@ impl FilesystemCompilerHost {
             log_level: LogLevel::Info,
             start_time: Instant::now(),
             kiln_engine: OnceLock::new(),
+            kiln_components: Mutex::new(Vec::new()),
+            kiln_component_compile_count: AtomicUsize::new(0),
         }
     }
 
@@ -42,6 +58,8 @@ impl FilesystemCompilerHost {
             log_level: LogLevel::Off,
             start_time: Instant::now(),
             kiln_engine: OnceLock::new(),
+            kiln_components: Mutex::new(Vec::new()),
+            kiln_component_compile_count: AtomicUsize::new(0),
         }
     }
 
@@ -53,7 +71,49 @@ impl FilesystemCompilerHost {
             log_level,
             start_time: Instant::now(),
             kiln_engine: OnceLock::new(),
+            kiln_components: Mutex::new(Vec::new()),
+            kiln_component_compile_count: AtomicUsize::new(0),
         }
+    }
+
+    /// Number of times this host has actually run cranelift AOT on a
+    /// generator wasm (i.e. cache misses for `kiln_components`). Cache
+    /// hits do not contribute. Used by tests to assert that
+    /// `run_generator` shares compiled components across invocations.
+    #[must_use]
+    pub fn kiln_component_compile_count(&self) -> usize {
+        self.kiln_component_compile_count.load(Ordering::SeqCst)
+    }
+
+    /// Look up the compiled wasmtime [`Component`] for `wasm` (keyed by
+    /// SHA-256), building it on miss and caching the result. The build
+    /// path holds a brief Mutex on the cache, races for the same key
+    /// will each compile once but the latter overwrites the former in
+    /// the map — the result is equivalent so the wasted work is just a
+    /// duplicated compile on the (rare) racing path. Wasmtime's
+    /// `Component` is internally Arc, so cache hits are cheap clones.
+    fn get_or_compile_kiln_component(
+        &self,
+        engine: &wasmtime::Engine,
+        wasm: &[u8],
+    ) -> Result<wasmtime::component::Component, GeneratorRunnerError> {
+        let key = wado_compiler::kiln::content_hash(wasm);
+        if let Ok(guard) = self.kiln_components.lock()
+            && let Some((_, component)) = guard.iter().find(|(k, _)| k == &key)
+        {
+            return Ok(component.clone());
+        }
+        let component = kiln_runtime::compile_component(engine, wasm)?;
+        self.kiln_component_compile_count
+            .fetch_add(1, Ordering::SeqCst);
+        if let Ok(mut guard) = self.kiln_components.lock() {
+            if let Some(slot) = guard.iter_mut().find(|(k, _)| k == &key) {
+                slot.1 = component.clone();
+            } else {
+                guard.push((key, component.clone()));
+            }
+        }
+        Ok(component)
     }
 
     pub fn diagnostics(&self) -> Vec<Diagnostic> {
@@ -154,10 +214,11 @@ impl CompilerHost for FilesystemCompilerHost {
                 .expect("kiln_engine was set above or by a racing caller")
                 .clone()
         };
+        let component = self.get_or_compile_kiln_component(&engine, component_wasm)?;
         kiln_runtime::run_generator(
             &engine,
             self.inner.clone(),
-            component_wasm,
+            &component,
             request,
             KilnRunPolicy::default(),
         )

--- a/wado-cli/src/compiler_host.rs
+++ b/wado-cli/src/compiler_host.rs
@@ -21,18 +21,15 @@ pub struct FilesystemCompilerHost {
     log_level: LogLevel,
     start_time: Instant,
     kiln_engine: OnceLock<wasmtime::Engine>,
-    /// Cache of compiled wasmtime [`Component`]s, keyed by SHA-256 of
-    /// the generator wasm bytes. Building a [`Component`] from a 432KB
-    /// generator wasm runs cranelift AOT for ~7s; many kiln invocations
-    /// in a single pipeline run typically share the same generator
-    /// (and therefore the same bytes), so a per-host cache turns N×AOT
-    /// into 1×AOT + (N-1) lookups. Lives only for the lifetime of this
-    /// host — no on-disk `.cwasm` is written, so there is no
-    /// trust-the-disk attack surface from caching.
+    /// In-memory only: when N invocations in one pipeline run share a
+    /// generator they share the same wasm bytes, so caching the
+    /// `Component` (which is internally `Arc`) turns N×cranelift-AOT
+    /// into 1×AOT + (N-1) cheap clones. Not persisted to disk —
+    /// caching a serialized `.cwasm` would expose a trust-the-disk
+    /// code-injection vector that this in-memory cache does not.
     kiln_components: Mutex<Vec<([u8; 32], wasmtime::component::Component)>>,
-    /// Number of times [`compile_component`] has actually been invoked
-    /// (i.e. cache misses). Tests use this to assert that the cache
-    /// dedups across `run_generator` calls.
+    /// Cache misses on `kiln_components`. Tests assert against this
+    /// rather than wall-clock timing.
     kiln_component_compile_count: AtomicUsize,
 }
 
@@ -76,22 +73,16 @@ impl FilesystemCompilerHost {
         }
     }
 
-    /// Number of times this host has actually run cranelift AOT on a
-    /// generator wasm (i.e. cache misses for `kiln_components`). Cache
-    /// hits do not contribute. Used by tests to assert that
-    /// `run_generator` shares compiled components across invocations.
     #[must_use]
     pub fn kiln_component_compile_count(&self) -> usize {
         self.kiln_component_compile_count.load(Ordering::SeqCst)
     }
 
-    /// Look up the compiled wasmtime [`Component`] for `wasm` (keyed by
-    /// SHA-256), building it on miss and caching the result. The build
-    /// path holds a brief Mutex on the cache, races for the same key
-    /// will each compile once but the latter overwrites the former in
-    /// the map — the result is equivalent so the wasted work is just a
-    /// duplicated compile on the (rare) racing path. Wasmtime's
-    /// `Component` is internally Arc, so cache hits are cheap clones.
+    /// Concurrent callers with the same key may each compile once and
+    /// overwrite each other in the map — that's wasted but correct
+    /// (the resulting `Component`s are equivalent). Holding the Mutex
+    /// across the multi-second cranelift call would serialize unrelated
+    /// generators, which is the worse tradeoff.
     fn get_or_compile_kiln_component(
         &self,
         engine: &wasmtime::Engine,

--- a/wado-cli/src/kiln_driver.rs
+++ b/wado-cli/src/kiln_driver.rs
@@ -702,15 +702,24 @@ fn validate_rel_output_path(p: &str) -> Result<PathBuf, ExecuteError> {
     Ok(candidate.to_path_buf())
 }
 
-/// Component bytes returned by [`GeneratorProvider::get_component`],
-/// paired with a content-addressed hash of the generator's source
-/// closure. The hash flows into [`Metadata::generator_source_hash`] so
-/// the kiln-output cache invalidates when the generator changes — even
-/// when the consumer's primary `.g4` (or other inputs) is unchanged.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct GeneratorComponent {
+/// Generator artifacts produced by [`GeneratorProvider::resolve`].
+///
+/// One `ResolvedGenerator` is produced per unique [`GeneratorModule`]
+/// per pipeline run; downstream phases ([`typed_encode_options`], the
+/// per-invocation `execute` loop) receive a reference to this struct
+/// rather than calling back into the provider. The driver therefore
+/// reads the on-disk Kiln cache at most once per module, regardless of
+/// how many invocations share the module.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedGenerator {
     /// Component model `.wasm` bytes ready for `run_generator`.
-    pub bytes: Vec<u8>,
+    pub wasm: Vec<u8>,
+    /// Generator's `pub struct Options` shape, when the compile
+    /// produced one. `None` means the generator did not expose a
+    /// describable `Options` (or the provider could not introspect),
+    /// and [`typed_encode_options`] falls back to provisional TOML
+    /// encoding for that invocation.
+    pub descriptor: Option<OptionsDescriptor>,
     /// Hex-encoded SHA-256 of the generator's source closure (entry
     /// `.wado` plus every transitively imported `.wado`). Empty when
     /// the provider could not compute one (e.g. the spec-form path on
@@ -722,52 +731,35 @@ pub struct GeneratorComponent {
     pub source_hash: String,
 }
 
-/// Resolves a generator's component bytes for execution.
+/// Resolves a generator module to its artifacts (component wasm,
+/// typed options descriptor, source-closure hash).
 ///
-/// The runner is deliberately decoupled from how a given module becomes a
-/// component `.wasm`. Two concrete providers land in later commits:
+/// The trait is deliberately a single method: the driver calls it once
+/// per unique module per pipeline run and holds the result for the
+/// remainder of the pipeline. Implementations are free to populate the
+/// fields via a build-from-source pass, a registry fetch, or a
+/// pre-baked artifact bundle — the driver does not care.
 ///
-/// - A production `CliGeneratorProvider` that compiles and caches generator
-///   components under `build/kiln/generators/…` (ships with M6.6,
-///   when there is a real generator to compile).
-/// - A test provider that returns pre-built bytes.
+/// Two concrete providers exist today:
+///
+/// - A production `CliGeneratorProvider` that compiles generators with
+///   the inner `wado` pipeline and caches the artifacts under
+///   `build/kiln/generators/…`.
+/// - Test stubs that return pre-built bytes.
 pub trait GeneratorProvider {
-    /// Resolve `module` to component bytes plus a content-addressed
-    /// identity for the generator's source closure. The driver caches
-    /// the result by `GeneratorModule` for the duration of one
-    /// `run_pipeline`, so a module shared across N invocations triggers
-    /// at most one call here. Implementations should still honor their
-    /// own internal cache so the steady-state hit on a *cold* pipeline
-    /// is a small filesystem read rather than a recompile.
-    fn get_component(
+    /// Resolve `module` to its [`ResolvedGenerator`]. Implementations
+    /// should consult any on-disk cache they own, falling back to a
+    /// fresh build only on miss; the driver itself does not cache
+    /// across calls — it relies on the per-pipeline `HashMap` populated
+    /// upfront to dedup work within a single run.
+    fn resolve(
         &self,
         module: &GeneratorModule,
-    ) -> impl std::future::Future<Output = Result<GeneratorComponent, ProviderError>> + Send;
-
-    /// Resolve `module` to its typed [`OptionsDescriptor`]. Used by the
-    /// driver to validate a user-supplied options table before calling the
-    /// generator — see
-    /// [`wado_compiler::kiln::validate_options`]. When a provider cannot
-    /// introspect the generator (e.g. consume-only mode on the LSP), it
-    /// returns [`ProviderError::Unsupported`] and the driver falls back to
-    /// the provisional TOML encoder on the raw options table.
-    fn descriptor(
-        &self,
-        module: &GeneratorModule,
-    ) -> impl std::future::Future<Output = Result<OptionsDescriptor, ProviderError>> + Send {
-        let _ = module;
-        async {
-            Err(ProviderError::Unsupported {
-                message:
-                    "kiln: provider does not expose OptionsDescriptor (typed options unavailable)"
-                        .to_string(),
-            })
-        }
-    }
+    ) -> impl std::future::Future<Output = Result<ResolvedGenerator, ProviderError>> + Send;
 }
 
 /// Error returned by a [`GeneratorProvider`].
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ProviderError {
     /// The provider cannot resolve the module (e.g. build-dependency
     /// resolution not yet wired). The message should guide the user.
@@ -959,20 +951,19 @@ where
         return Ok(PipelineOutcome::default());
     }
 
+    // Resolve every unique generator module exactly once; downstream
+    // phases read from this map rather than calling back into the
+    // provider. This is what guarantees the on-disk Kiln cache is
+    // consulted at most once per generator per pipeline run.
+    let resolved = resolve_modules(&planned.plan.order, provider, host).await;
+
     {
         let _s = KilnSpan::new(host, "kiln/typed_encode_options");
-        typed_encode_options(manifest, &mut planned.plan.order, provider, host).await;
+        typed_encode_options(manifest, &mut planned.plan.order, &resolved, host);
     }
 
     let mut outcome = PipelineOutcome::default();
     let mut kept_by_dir: indexmap::IndexMap<String, Vec<String>> = indexmap::IndexMap::new();
-    // Per-pipeline cache of provider results, keyed by `GeneratorModule`.
-    // Many invocations typically share a single generator module (one
-    // generator package emits parsers for every grammar in a project), so
-    // looking it up once per pipeline keeps the per-invocation hot path to
-    // an in-memory `Arc::clone` instead of a fresh sidecar walk + WASM read.
-    // Linear scan is fine: the unique-module count is O(1) in practice.
-    let mut module_cache: Vec<(GeneratorModule, Arc<GeneratorComponent>)> = Vec::new();
 
     for invocation in &planned.plan.order {
         let invocation_name = invocation_id(invocation);
@@ -1001,24 +992,11 @@ where
         let options_hash =
             wado_compiler::kiln::hash_options_canonical(&invocation.options_canonical);
 
-        // Resolve the component once per unique module. The provider's
-        // own internal cache makes a first call's hit path cheap; the
-        // pipeline-level cache here ensures we don't repeat that walk
-        // for every invocation that shares the same module.
-        let component_result: Result<Arc<GeneratorComponent>, ProviderError> =
-            if let Some((_, cached)) = module_cache.iter().find(|(m, _)| m == &invocation.module) {
-                Ok(Arc::clone(cached))
-            } else {
-                let _s = KilnSpan::new(host, "kiln/get_component");
-                match provider.get_component(&invocation.module).await {
-                    Ok(c) => {
-                        let arc = Arc::new(c);
-                        module_cache.push((invocation.module.clone(), Arc::clone(&arc)));
-                        Ok(arc)
-                    }
-                    Err(e) => Err(e),
-                }
-            };
+        // Pull this module's resolution result out of the upfront map.
+        // Cloning the inner `Result` is cheap: `Arc::clone` on the Ok
+        // side, message-clone on the Err side.
+        let component_result: Result<Arc<ResolvedGenerator>, ProviderError> =
+            lookup_resolved(&resolved, &invocation.module);
 
         let (entry, executed) =
             if let Some(prior) = existing.clone().filter(|m| m.options_hash == options_hash) {
@@ -1226,22 +1204,22 @@ where
         return Ok(CheckOutcome::default());
     }
 
-    typed_encode_options(manifest, &mut planned.plan.order, provider, host).await;
+    let resolved = resolve_modules(&planned.plan.order, provider, host).await;
+    typed_encode_options(manifest, &mut planned.plan.order, &resolved, host);
 
     let mut outcome = CheckOutcome::default();
     for invocation in &planned.plan.order {
         let invocation_name = invocation_id(invocation);
 
-        let component = provider
-            .get_component(&invocation.module)
-            .await
-            .map_err(|source| PipelineError::Provider {
+        let generator = lookup_resolved(&resolved, &invocation.module).map_err(|source| {
+            PipelineError::Provider {
                 invocation: invocation_name.clone(),
                 source,
-            })?;
+            }
+        })?;
         let run = execute_with_mode(
             invocation,
-            &component.bytes,
+            &generator.wasm,
             manifest_root,
             host,
             ExecuteMode::DryRun,
@@ -1337,18 +1315,79 @@ fn emit_stale_warning<H: CompilerHost>(host: &H, invocation: &str) {
     });
 }
 
+/// Resolve every unique [`GeneratorModule`] in `order` exactly once,
+/// emitting one `kiln/resolve/<id>` span per call so the per-generator
+/// disk/compile cost shows up in `--log-level debug` traces. Resolution
+/// errors are kept in the returned map (rather than bubbled up) because
+/// the per-invocation loop is the one that decides whether to fail the
+/// pipeline, emit a stale-cache warning, or skip option validation —
+/// behavior that is per-invocation, not per-module.
+///
+/// Linear scan over a `Vec` is fine: the unique-module count is O(1)
+/// in practice (typically a single generator per project).
+async fn resolve_modules<H, P>(
+    order: &[Invocation],
+    provider: &P,
+    host: &H,
+) -> Vec<(
+    GeneratorModule,
+    Result<Arc<ResolvedGenerator>, ProviderError>,
+)>
+where
+    H: CompilerHost,
+    P: GeneratorProvider,
+{
+    let _s = KilnSpan::new(host, "kiln/resolve");
+    let mut out: Vec<(
+        GeneratorModule,
+        Result<Arc<ResolvedGenerator>, ProviderError>,
+    )> = Vec::new();
+    for inv in order {
+        if out.iter().any(|(m, _)| m == &inv.module) {
+            continue;
+        }
+        let result = provider.resolve(&inv.module).await.map(Arc::new);
+        out.push((inv.module.clone(), result));
+    }
+    out
+}
+
+/// Project the resolved-modules map into a per-invocation result. The
+/// `Err` arm is cloned so different invocations sharing the same broken
+/// module each get an independent error to fold into their own outcome
+/// (the wrapped messages are small `String`s — clones are essentially
+/// free).
+fn lookup_resolved(
+    resolved: &[(
+        GeneratorModule,
+        Result<Arc<ResolvedGenerator>, ProviderError>,
+    )],
+    module: &GeneratorModule,
+) -> Result<Arc<ResolvedGenerator>, ProviderError> {
+    resolved
+        .iter()
+        .find(|(m, _)| m == module)
+        .map(|(_, r)| match r {
+            Ok(arc) => Ok(Arc::clone(arc)),
+            Err(e) => Err(e.clone()),
+        })
+        .expect("resolve_modules populates every module referenced by the plan")
+}
+
 /// Re-encode each invocation's `options_canonical` bytes using the typed
-/// pipeline from [`wado_compiler::kiln::encode_options_canonical`] when the
-/// provider exposes a descriptor. Falls back silently to the provisional
-/// bytes already produced by [`lower`] when:
+/// pipeline from [`wado_compiler::kiln::encode_options_canonical`] when
+/// the resolved generator exposed a descriptor. Falls back silently to
+/// the provisional bytes already produced by [`lower`] when:
 ///
 /// - the invocation is anonymous (inline `use ... with`) — M5 clauses already
 ///   encode via the typed path when they are built, so this code path skips
 ///   them;
-/// - the provider returns [`ProviderError::Unsupported`] (e.g. consume-only
-///   LSP mode);
-/// - the provider returns [`ProviderError::Internal`] — a warning diagnostic
-///   is surfaced through `host.emit_diagnostic`, but the pipeline continues.
+/// - the generator did not expose a `pub struct Options` (e.g. consume-only
+///   generator) — the resolved entry's `descriptor` is `None`;
+/// - the resolution itself failed (e.g. spec-form module, source not found)
+///   — the resolution result is `Err`. The per-invocation loop is where
+///   that error becomes either a pipeline failure or a stale-cache warning,
+///   so this function just skips the invocation silently.
 ///
 /// Validation failures (unknown / missing / type-mismatched fields) surface
 /// as error diagnostics on `host`; the provisional bytes remain in place so
@@ -1356,36 +1395,23 @@ fn emit_stale_warning<H: CompilerHost>(host: &H, invocation: &str) {
 /// step — `run_and_build_entry` — will fail fast when the generator rejects
 /// the options blob, so the user sees both the compiler-side validation
 /// error and the generator-side trap in the same run.
-async fn typed_encode_options<H, P>(
+fn typed_encode_options<H: CompilerHost>(
     manifest: &Manifest,
     invocations: &mut [Invocation],
-    provider: &P,
+    resolved: &[(
+        GeneratorModule,
+        Result<Arc<ResolvedGenerator>, ProviderError>,
+    )],
     host: &H,
-) where
-    H: CompilerHost,
-    P: GeneratorProvider,
-{
-    use wado_compiler::{Code, Diagnostic, Severity};
-
+) {
     let _ = manifest;
     for inv in invocations.iter_mut() {
-        let display_name = inv.decl_site.synthetic_id.clone();
-
-        let descriptor = match provider.descriptor(&inv.module).await {
-            Ok(d) => d,
-            Err(ProviderError::Unsupported { .. }) => continue,
-            Err(ProviderError::Internal { message }) => {
-                host.emit_diagnostic(Diagnostic {
-                    severity: Severity::Warning,
-                    code: Code::Log,
-                    message: format!(
-                        "kiln[{display_name}]: failed to introspect generator options schema \
-                         ({message}); falling back to raw TOML encoding",
-                    ),
-                    span: None,
-                });
-                continue;
-            }
+        let descriptor = match lookup_resolved(resolved, &inv.module) {
+            Ok(arc) => match &arc.descriptor {
+                Some(d) => d.clone(),
+                None => continue,
+            },
+            Err(_) => continue,
         };
 
         let supplied: Option<&AttrValue> = match inv.raw_options.as_ref() {
@@ -1410,13 +1436,13 @@ async fn run_and_build_metadata<H>(
     invocation: &Invocation,
     manifest_root: &Path,
     host: &H,
-    component: &GeneratorComponent,
+    generator: &ResolvedGenerator,
     options_hash: String,
 ) -> Result<Metadata, PipelineError>
 where
     H: CompilerHost,
 {
-    let run = execute(invocation, &component.bytes, manifest_root, host)
+    let run = execute(invocation, &generator.wasm, manifest_root, host)
         .await
         .map_err(|source| PipelineError::Execute {
             invocation: invocation_name.to_string(),
@@ -1427,7 +1453,7 @@ where
         invocation,
         &run,
         options_hash,
-        component.source_hash.clone(),
+        generator.source_hash.clone(),
     ))
 }
 

--- a/wado-cli/src/kiln_driver.rs
+++ b/wado-cli/src/kiln_driver.rs
@@ -702,56 +702,37 @@ fn validate_rel_output_path(p: &str) -> Result<PathBuf, ExecuteError> {
     Ok(candidate.to_path_buf())
 }
 
-/// Generator artifacts produced by [`GeneratorProvider::resolve`].
-///
-/// One `ResolvedGenerator` is produced per unique [`GeneratorModule`]
-/// per pipeline run; downstream phases ([`typed_encode_options`], the
-/// per-invocation `execute` loop) receive a reference to this struct
-/// rather than calling back into the provider. The driver therefore
-/// reads the on-disk Kiln cache at most once per module, regardless of
-/// how many invocations share the module.
+/// Generator artifacts produced once per unique [`GeneratorModule`]
+/// per pipeline run, by [`GeneratorProvider::resolve`]. Every
+/// downstream phase reads from the resolved bundle rather than
+/// re-asking the provider, so on-disk cache reads happen at most once
+/// per module per run.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ResolvedGenerator {
-    /// Component model `.wasm` bytes ready for `run_generator`.
     pub wasm: Vec<u8>,
-    /// Generator's `pub struct Options` shape, when the compile
-    /// produced one. `None` means the generator did not expose a
-    /// describable `Options` (or the provider could not introspect),
-    /// and [`typed_encode_options`] falls back to provisional TOML
-    /// encoding for that invocation.
+    /// `None` when the generator has no `pub struct Options` (or the
+    /// provider can't introspect it); [`typed_encode_options`] then
+    /// falls back to the provisional TOML encoding.
     pub descriptor: Option<OptionsDescriptor>,
-    /// Hex-encoded SHA-256 of the generator's source closure (entry
-    /// `.wado` plus every transitively imported `.wado`). Empty when
-    /// the provider could not compute one (e.g. the spec-form path on
-    /// providers that have not implemented source-distribution
-    /// hashing). An empty string is recorded verbatim in the metadata
-    /// and matches another empty string only — the driver therefore
-    /// keeps caching consistent for generators that can never produce
-    /// a hash, while still invalidating once one is produced.
+    /// Hex SHA-256 of the generator's transitive `.wado` closure. The
+    /// empty string is a valid value (providers that can't compute
+    /// one) and is recorded verbatim — so two such generators never
+    /// share a kiln-output cache entry by accident.
     pub source_hash: String,
 }
 
 /// Resolves a generator module to its artifacts (component wasm,
 /// typed options descriptor, source-closure hash).
 ///
-/// The trait is deliberately a single method: the driver calls it once
-/// per unique module per pipeline run and holds the result for the
-/// remainder of the pipeline. Implementations are free to populate the
-/// fields via a build-from-source pass, a registry fetch, or a
-/// pre-baked artifact bundle — the driver does not care.
-///
-/// Two concrete providers exist today:
-///
-/// - A production `CliGeneratorProvider` that compiles generators with
-///   the inner `wado` pipeline and caches the artifacts under
-///   `build/kiln/generators/…`.
-/// - Test stubs that return pre-built bytes.
+/// The trait is deliberately a single method: [`run_pipeline`] calls
+/// it once per unique module up-front (see [`resolve_modules`]) and
+/// hands the same `ResolvedGenerator` to every downstream phase, so
+/// implementations don't need their own in-memory cache layer.
 pub trait GeneratorProvider {
     /// Resolve `module` to its [`ResolvedGenerator`]. Implementations
-    /// should consult any on-disk cache they own, falling back to a
-    /// fresh build only on miss; the driver itself does not cache
-    /// across calls — it relies on the per-pipeline `HashMap` populated
-    /// upfront to dedup work within a single run.
+    /// own whatever on-disk cache they read; nothing above this layer
+    /// dedups, so a second call for the same module will redo all the
+    /// work this method does.
     fn resolve(
         &self,
         module: &GeneratorModule,
@@ -906,25 +887,18 @@ impl<H: CompilerHost> Drop for KilnSpan<'_, H> {
     }
 }
 
-/// Run the full Kiln pipeline for the given inline invocations: plan →
-/// per-invocation cache check → execute on miss → reconcile stale outputs →
-/// persist lockfile.
-///
-/// `provider` resolves generator module bytes on demand. `host` is the
-/// compiler host used to load input files and (inside `execute`) to invoke
-/// the runner.
-///
-/// On success, the manifest's `wado.lock` is updated in place to persist
-/// the current `[[generator-cache]]` entries. The lockfile is re-serialized
-/// via [`wado_manifest::LockFile::to_toml`], so non-Kiln sections round-trip
-/// through the manifest-crate writer — byte-identity is not guaranteed.
+/// Run the full Kiln pipeline for the given inline invocations: resolve
+/// every unique generator once, plan → per-invocation cache check →
+/// execute on miss → reconcile stale outputs.
 ///
 /// Returns an empty outcome when `inline_invocations` is empty.
 ///
-/// When `no_cache` is `true`, the per-invocation sidecar metadata is
-/// ignored (every invocation falls through to the run branch) and the
-/// generator wasm itself is recompiled from source. Writes still happen
-/// so a subsequent cache-enabled run is warm again.
+/// `no_cache` only bypasses on-disk caches — the per-invocation
+/// `<primary>.kiln.json` and the per-generator `build/kiln/` artifacts.
+/// In-process artifact sharing (the upfront resolve map, the host-side
+/// compiled `Component` cache) is unaffected: it would be wrong to
+/// recompile or re-instantiate the same wasm twice within a single
+/// pipeline run regardless of how on-disk caching is configured.
 ///
 /// # Errors
 /// See [`PipelineError`].
@@ -951,10 +925,6 @@ where
         return Ok(PipelineOutcome::default());
     }
 
-    // Resolve every unique generator module exactly once; downstream
-    // phases read from this map rather than calling back into the
-    // provider. This is what guarantees the on-disk Kiln cache is
-    // consulted at most once per generator per pipeline run.
     let resolved = resolve_modules(&planned.plan.order, provider, host).await;
 
     {
@@ -992,9 +962,6 @@ where
         let options_hash =
             wado_compiler::kiln::hash_options_canonical(&invocation.options_canonical);
 
-        // Pull this module's resolution result out of the upfront map.
-        // Cloning the inner `Result` is cheap: `Arc::clone` on the Ok
-        // side, message-clone on the Err side.
         let component_result: Result<Arc<ResolvedGenerator>, ProviderError> =
             lookup_resolved(&resolved, &invocation.module);
 
@@ -1315,16 +1282,16 @@ fn emit_stale_warning<H: CompilerHost>(host: &H, invocation: &str) {
     });
 }
 
-/// Resolve every unique [`GeneratorModule`] in `order` exactly once,
-/// emitting one `kiln/resolve/<id>` span per call so the per-generator
-/// disk/compile cost shows up in `--log-level debug` traces. Resolution
-/// errors are kept in the returned map (rather than bubbled up) because
-/// the per-invocation loop is the one that decides whether to fail the
-/// pipeline, emit a stale-cache warning, or skip option validation —
-/// behavior that is per-invocation, not per-module.
+/// Resolve every unique [`GeneratorModule`] in `order` exactly once.
 ///
-/// Linear scan over a `Vec` is fine: the unique-module count is O(1)
-/// in practice (typically a single generator per project).
+/// Resolution errors are folded into the returned map rather than
+/// bubbled up: whether a per-module failure aborts the pipeline,
+/// degrades to a stale-cache warning, or just skips option validation
+/// is a per-invocation policy decision that lives in the run loop.
+///
+/// `Vec` not `HashMap`: the unique-module count is O(1) in practice
+/// (typically a single generator per project) and `GeneratorModule`
+/// isn't `Hash`.
 async fn resolve_modules<H, P>(
     order: &[Invocation],
     provider: &P,
@@ -1353,10 +1320,9 @@ where
 }
 
 /// Project the resolved-modules map into a per-invocation result. The
-/// `Err` arm is cloned so different invocations sharing the same broken
-/// module each get an independent error to fold into their own outcome
-/// (the wrapped messages are small `String`s — clones are essentially
-/// free).
+/// `Err` arm is cloned (rather than referenced) so each invocation
+/// sharing a broken module can fold an owned error into its own
+/// outcome independently.
 fn lookup_resolved(
     resolved: &[(
         GeneratorModule,
@@ -1374,27 +1340,18 @@ fn lookup_resolved(
         .expect("resolve_modules populates every module referenced by the plan")
 }
 
-/// Re-encode each invocation's `options_canonical` bytes using the typed
-/// pipeline from [`wado_compiler::kiln::encode_options_canonical`] when
-/// the resolved generator exposed a descriptor. Falls back silently to
-/// the provisional bytes already produced by [`lower`] when:
+/// Re-encode each invocation's `options_canonical` against the typed
+/// descriptor when one is available, falling back silently to the
+/// provisional bytes [`lower`] produced when no descriptor exists
+/// (`descriptor: None`) or the module failed to resolve at all
+/// (`Err` — the run loop will handle the failure as a per-invocation
+/// stale-cache warning or pipeline error).
 ///
-/// - the invocation is anonymous (inline `use ... with`) — M5 clauses already
-///   encode via the typed path when they are built, so this code path skips
-///   them;
-/// - the generator did not expose a `pub struct Options` (e.g. consume-only
-///   generator) — the resolved entry's `descriptor` is `None`;
-/// - the resolution itself failed (e.g. spec-form module, source not found)
-///   — the resolution result is `Err`. The per-invocation loop is where
-///   that error becomes either a pipeline failure or a stale-cache warning,
-///   so this function just skips the invocation silently.
-///
-/// Validation failures (unknown / missing / type-mismatched fields) surface
-/// as error diagnostics on `host`; the provisional bytes remain in place so
-/// downstream layers still see a consistent invocation. The caller's next
-/// step — `run_and_build_entry` — will fail fast when the generator rejects
-/// the options blob, so the user sees both the compiler-side validation
-/// error and the generator-side trap in the same run.
+/// Validation failures (unknown / missing / type-mismatched fields)
+/// surface as error diagnostics on `host`; the provisional bytes stay
+/// in place so downstream phases still see a consistent invocation
+/// and the generator-side trap surfaces in the same run as the
+/// compiler-side complaint.
 fn typed_encode_options<H: CompilerHost>(
     manifest: &Manifest,
     invocations: &mut [Invocation],

--- a/wado-cli/src/kiln_provider.rs
+++ b/wado-cli/src/kiln_provider.rs
@@ -46,26 +46,16 @@ pub const CACHE_DIR: &str = "build/kiln/generators";
 /// `build/kiln/metadata/`. Reserved for the descriptor-cache follow-up.
 pub const METADATA_DIR: &str = "build/kiln/metadata";
 
-/// CLI-side generator provider.
-///
-/// Holds the project-root directory so it can resolve `LocalPath` modules
-/// relative to the manifest. The `compile_count` counter records how many
-/// times the provider has fallen through to an actual generator-package
-/// compile (vs. a cache hit); tests use it to assert that the on-disk
-/// `build/kiln/generators/<stable-id>.wasm` cache is honored without
-/// relying on filesystem-level mtime observation.
 #[derive(Debug, Clone)]
 pub struct CliGeneratorProvider {
     manifest_root: PathBuf,
     compile_count: Arc<AtomicUsize>,
     /// When true, skip reads from the on-disk generator cache. Writes
-    /// still happen, so a follow-up cache-enabled run is warm again.
+    /// still happen so the next non-bypass run sees a warm tree.
     no_cache: bool,
 }
 
 impl CliGeneratorProvider {
-    /// Construct a provider rooted at `manifest_root` — typically the
-    /// directory containing `wado.toml`.
     #[must_use]
     pub fn new(manifest_root: PathBuf) -> Self {
         Self {
@@ -75,18 +65,16 @@ impl CliGeneratorProvider {
         }
     }
 
-    /// Toggle the cache-bypass mode; see [`CompileFlags::no_cache`].
     #[must_use]
     pub fn with_no_cache(mut self, no_cache: bool) -> Self {
         self.no_cache = no_cache;
         self
     }
 
-    /// Number of times this provider has run the inner wado-compiler
-    /// pipeline. Cache hits do not contribute. The counter is shared
-    /// across `Clone`s of the provider (backed by `Arc<AtomicUsize>`)
-    /// so callers that keep multiple handles still observe the same
-    /// total.
+    /// Number of times the inner wado-compiler pipeline has actually
+    /// run (cache hits do not contribute). Shared across `Clone`s of
+    /// the provider so test code with multiple handles still observes
+    /// a single total.
     #[must_use]
     pub fn compile_count(&self) -> usize {
         self.compile_count.load(Ordering::SeqCst)
@@ -114,18 +102,13 @@ impl CliGeneratorProvider {
             .join(format!("{stable_id}.sources.json"))
     }
 
-    /// Re-validate the cached generator artefacts at `stable_id` against
-    /// the on-disk sources captured by the previous compile. Returns the
-    /// freshly recomputed `combined_hash` when every listed source file
-    /// still matches its recorded hash; returns `None` when the sidecar
-    /// is missing, malformed, version-mismatched, or any source file has
-    /// drifted (or vanished). Callers must treat `None` as a cache miss
-    /// and recompile.
-    ///
-    /// The combined hash is recomputed from the validated entries rather
-    /// than trusted verbatim from the sidecar, so a hand-edited sidecar
-    /// cannot pin metadata to a value that disagrees with its own
-    /// `sources` list.
+    /// Re-validate the cached generator artefacts at `stable_id`
+    /// against the on-disk sources captured by the previous compile,
+    /// returning the freshly recomputed `combined_hash` on success and
+    /// `None` (= treat as cache miss) on any drift. The hash is
+    /// recomputed from the validated entries rather than trusted
+    /// verbatim from the sidecar, so a hand-edited sidecar cannot pin
+    /// metadata to a value that disagrees with its own `sources` list.
     fn validate_sources_sidecar(&self, stable_id: &str, base: &Path) -> Option<String> {
         let sidecar_path = self.sources_sidecar_path(stable_id);
         let bytes = std::fs::read(&sidecar_path).ok()?;
@@ -147,9 +130,6 @@ impl CliGeneratorProvider {
         Some(combined_sources_hash(&validated))
     }
 
-    /// Resolve a `LocalPath` generator source, returning the absolute
-    /// path, raw bytes, UTF-8 source string, and stable id. Emits the
-    /// not-found / not-UTF-8 diagnostics surfaced by `resolve()`.
     fn read_local_source(
         &self,
         path: &wado_compiler::kiln::InvocationPath,
@@ -185,11 +165,11 @@ impl CliGeneratorProvider {
         Ok((abs, source, source_str, stable_id))
     }
 
-    /// Run the inner wado-compiler pipeline on the given source, then
-    /// persist both caches (`build/kiln/generators/<id>.wasm` and, when
-    /// the compile produces one, `build/kiln/metadata/<id>.descriptor`).
-    /// A subsequent `resolve()` on an unchanged source closure short-
-    /// circuits at [`Self::try_read_cache`] without re-running this.
+    /// Run the inner wado-compiler pipeline on the given source and
+    /// persist both on-disk artefacts (`<id>.wasm` and, when the
+    /// compile produces one, `<id>.descriptor`) plus the sources
+    /// sidecar that [`Self::try_read_cache`] needs for freshness
+    /// checks on later runs.
     async fn compile_local(
         &self,
         path_str: String,
@@ -338,35 +318,25 @@ fn make_relative_sources(base: &Path, raw: Vec<(String, [u8; 32])>) -> Vec<(Stri
         .collect()
 }
 
-/// Both artefacts produced by a single invocation of the inner compiler
-/// on a kiln generator package: the component bytes, the extracted
-/// `Options` descriptor (when extraction succeeded), and the combined
-/// hash of every `.wado` source the compiler loaded along the way.
-/// `source_hash` is filled by `compile_local` after the inner pipeline
-/// returns; it is the hex digest stored in `Metadata::generator_source_hash`.
+/// Provider-internal twin of [`ResolvedGenerator`]. Kept distinct so
+/// `compile_local` can fill `source_hash` after the inner pipeline
+/// returns (the recording host's `loaded` queue isn't drained until
+/// then), without exposing a half-built value to the trait surface.
 struct CompileArtifacts {
     wasm: Vec<u8>,
     descriptor: Option<OptionsDescriptor>,
     source_hash: String,
 }
 
-/// Compute the stable id for a local generator source file.
+/// Compute the stable id (per WEP 2026-04-12 §"`build/kiln/` directory
+/// layout"): first 16 hex chars of `SHA-256(path || entry-content)`.
 ///
-/// Key inputs (per WEP 2026-04-12 §"`build/kiln/` directory layout"):
-/// - normalized project-relative path
-/// - SHA-256 of the entry file's bytes
-///
-/// Note: the stable id intentionally hashes only the entry file. It is
-/// the cache *lookup* key, not the cache *freshness* key — `compile_local`
-/// writes a `<stable_id>.sources.json` sidecar listing every transitively
-/// imported `.wado` (path + hash) and `validate_sources_sidecar` rejects
-/// the cached WASM whenever any of those files drifts on disk. Without
-/// the sidecar, an edit to e.g. `parser_gen.wado` (a dep of the entry
-/// `generator.wado`) would silently reuse stale bytes.
-///
-/// Returns the first 16 hex chars of the digest, enough to distinguish
-/// typical generator files without bloating `build/kiln/generators/`
-/// directory listings.
+/// Intentionally hashes only the entry file — it is the cache *lookup*
+/// key, not the freshness key. Freshness comes from
+/// [`CliGeneratorProvider::validate_sources_sidecar`], which rehashes
+/// every transitively imported `.wado`. Without that sidecar an edit
+/// to a dep (e.g. `parser_gen.wado` behind a `generator.wado` entry)
+/// would silently keep returning stale wasm.
 fn stable_id_for_local(path_str: &str, content: &[u8]) -> String {
     let mut hasher = Sha256::new();
     hasher.update(b"kiln-generator-v1\n");
@@ -382,20 +352,17 @@ fn stable_id_for_local(path_str: &str, content: &[u8]) -> String {
     out
 }
 
-/// A thin `CompilerHost` wrapper that discards diagnostics emitted by
-/// the host — we want to swallow generator-compile diagnostics so they
-/// don't mix with the consuming project's own compile output. The
-/// provider surfaces a single `ProviderError::Compile` instead.
+/// `CompilerHost` wrapper used by `compile_local` for two reasons:
 ///
-/// Also records every `load_source` call into `loaded` (path + content
-/// hash) so the provider can persist the generator's transitive load
-/// closure into a sidecar file and invalidate the WASM cache when any
-/// of those files drifts on disk. "Load closure" is the right framing
-/// here: `CompilerHost::load_source` carries both `.wado` modules and
-/// raw assets pulled in via `#include_bytes`, so an edit to either kind
-/// of file drops the WASM cache. The recording is best-effort: a
-/// duplicate `load_source` for the same path appends a duplicate
-/// entry, which the dedup step in `compile_local` collapses.
+/// 1. Swallow generator-compile diagnostics (info/debug) so the
+///    consuming project's stderr isn't flooded with nested compile
+///    output; the provider surfaces a single `ProviderError` instead.
+/// 2. Record every `load_source` call into `loaded` (path + content
+///    hash) so the transitive *load closure* — `.wado` modules **and**
+///    raw assets pulled via `#include_bytes` — is persisted into the
+///    sidecar, letting an edit to either kind invalidate the wasm
+///    cache. The recording is best-effort: duplicate paths from the
+///    compiler are collapsed by the dedup step in `compile_local`.
 struct SilentHost {
     inner: FilesystemCompilerHost,
     loaded: Arc<Mutex<Vec<(String, [u8; 32])>>>,
@@ -581,11 +548,6 @@ fn hex32(bytes: &[u8; 32]) -> String {
 }
 
 impl GeneratorProvider for CliGeneratorProvider {
-    /// Resolve `module` to its compiled artifacts. Consults the
-    /// on-disk cache once (gated by `no_cache`), falling back to a
-    /// fresh `wado` compile on miss. No in-memory state is kept
-    /// between calls — the driver is responsible for not calling this
-    /// more than once per unique module per pipeline run.
     async fn resolve(&self, module: &GeneratorModule) -> Result<ResolvedGenerator, ProviderError> {
         match module {
             GeneratorModule::Spec(spec) => Err(ProviderError::Unsupported {
@@ -598,13 +560,6 @@ impl GeneratorProvider for CliGeneratorProvider {
             GeneratorModule::LocalPath(path) => {
                 let (abs, _source, source_str, stable_id) = self.read_local_source(path)?;
                 let base = abs.parent().map(Path::to_path_buf).unwrap_or_default();
-                // On-disk cache hit only when (a) the wasm blob exists,
-                // (b) the descriptor cache (if any) exists, and (c) the
-                // sidecar listing the transitive `.wado` closure
-                // re-validates against current on-disk bytes. Without
-                // (c) an edit to a transitive import would silently
-                // reuse stale wasm (the entry-file `stable_id` would
-                // still match).
                 if !self.no_cache
                     && let Some(resolved) = self.try_read_cache(&stable_id, &base)
                 {
@@ -624,12 +579,10 @@ impl GeneratorProvider for CliGeneratorProvider {
 }
 
 impl CliGeneratorProvider {
-    /// Read `(wasm, descriptor?, source_hash)` from the on-disk Kiln
-    /// cache for `stable_id`, returning `None` when the cache is
-    /// missing or stale. The descriptor sidecar is optional —
-    /// generators without a `pub struct Options` write only the wasm
-    /// and sources sidecar, so a missing `.descriptor` file is treated
-    /// as `descriptor: None` rather than a cache miss.
+    /// Returns `None` on any cache miss or staleness — the caller
+    /// recompiles. The descriptor sidecar is *optional* (generators
+    /// without `pub struct Options` never write one), so its absence
+    /// is `descriptor: None`, not a miss.
     fn try_read_cache(&self, stable_id: &str, base: &Path) -> Option<ResolvedGenerator> {
         let cache_path = self.cache_path(stable_id);
         if !cache_path.is_file() {

--- a/wado-cli/src/kiln_provider.rs
+++ b/wado-cli/src/kiln_provider.rs
@@ -1,23 +1,23 @@
 //! CLI-side [`GeneratorProvider`] implementation.
 //!
-//! Resolves a [`GeneratorModule`] into component bytes and an
-//! [`OptionsDescriptor`] for the Kiln driver. v1 supports
-//! [`GeneratorModule::LocalPath`] (`module = { path = "..." }`) resolution.
-//! Spec-form generators (`module = "ns:name@ver"`) surface
-//! [`ProviderError::Unsupported`] with a clear message, matching WEP open-q
-//! #4 — registry/git module sources are deferred to a follow-up.
+//! Resolves a [`GeneratorModule`] into a [`ResolvedGenerator`] (wasm
+//! bytes + options descriptor + source-closure hash) for the Kiln
+//! driver. v1 supports [`GeneratorModule::LocalPath`] (`module = { path
+//! = "..." }`) resolution. Spec-form generators (`module =
+//! "ns:name@ver"`) surface [`ProviderError::Unsupported`] with a clear
+//! message, matching WEP open-q #4 — registry/git module sources are
+//! deferred to a follow-up.
 //!
-//! For `LocalPath`, `get_component` reads the generator source, compiles it
-//! with `target_world = "core:kiln/generator"` via the ordinary
-//! [`wado_compiler::compile_with_options`] pipeline, and caches the
-//! resulting component bytes at
-//! `build/kiln/generators/<stable-id>.wasm`.  Subsequent calls with the
-//! same source tree hash hit the cache without re-running codegen.
+//! For `LocalPath`, `resolve` reads the generator source, consults the
+//! on-disk cache at `build/kiln/{generators,metadata}/<stable-id>.*`
+//! (gated by `no_cache`), and falls back to a fresh
+//! [`wado_compiler::compile_with_options`] run on miss. The compile
+//! path always rewrites both the wasm and descriptor caches so a
+//! subsequent run sees a warm tree.
 //!
-//! `descriptor` extracts the generator's `pub struct Options` shape via
-//! `wado_compiler::kiln::extract_options_descriptor` on each call. The
-//! descriptor is tiny enough that caching it on disk was deferred in
-//! favour of simpler semantics.
+//! The driver is responsible for not calling `resolve` more than once
+//! per unique module per pipeline run — this provider holds no
+//! in-memory artifact state.
 
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -34,7 +34,7 @@ use wado_compiler::token::canonical_token_bytes;
 use wado_compiler::{CompilerHost, CompilerOptions, Diagnostic, LogLevel};
 
 use crate::compiler_host::FilesystemCompilerHost;
-use crate::kiln_driver::{GeneratorComponent, GeneratorProvider, ProviderError};
+use crate::kiln_driver::{GeneratorProvider, ProviderError, ResolvedGenerator};
 
 /// Directory under the project root where compiled generator
 /// components are cached: `build/kiln/generators/`. See WEP 2026-04-12
@@ -149,8 +149,7 @@ impl CliGeneratorProvider {
 
     /// Resolve a `LocalPath` generator source, returning the absolute
     /// path, raw bytes, UTF-8 source string, and stable id. Emits the
-    /// same not-found / not-UTF-8 diagnostics for both `get_component`
-    /// and `descriptor` code paths.
+    /// not-found / not-UTF-8 diagnostics surfaced by `resolve()`.
     fn read_local_source(
         &self,
         path: &wado_compiler::kiln::InvocationPath,
@@ -189,8 +188,8 @@ impl CliGeneratorProvider {
     /// Run the inner wado-compiler pipeline on the given source, then
     /// persist both caches (`build/kiln/generators/<id>.wasm` and, when
     /// the compile produces one, `build/kiln/metadata/<id>.descriptor`).
-    /// Whichever of `get_component` or `descriptor` runs the first
-    /// compile warms both, so the second call is a pure disk read.
+    /// A subsequent `resolve()` on an unchanged source closure short-
+    /// circuits at [`Self::try_read_cache`] without re-running this.
     async fn compile_local(
         &self,
         path_str: String,
@@ -582,10 +581,12 @@ fn hex32(bytes: &[u8; 32]) -> String {
 }
 
 impl GeneratorProvider for CliGeneratorProvider {
-    async fn get_component(
-        &self,
-        module: &GeneratorModule,
-    ) -> Result<GeneratorComponent, ProviderError> {
+    /// Resolve `module` to its compiled artifacts. Consults the
+    /// on-disk cache once (gated by `no_cache`), falling back to a
+    /// fresh `wado` compile on miss. No in-memory state is kept
+    /// between calls — the driver is responsible for not calling this
+    /// more than once per unique module per pipeline run.
+    async fn resolve(&self, module: &GeneratorModule) -> Result<ResolvedGenerator, ProviderError> {
         match module {
             GeneratorModule::Spec(spec) => Err(ProviderError::Unsupported {
                 message: format!(
@@ -595,74 +596,55 @@ impl GeneratorProvider for CliGeneratorProvider {
                 ),
             }),
             GeneratorModule::LocalPath(path) => {
-                let (abs, source, source_str, stable_id) = self.read_local_source(path)?;
+                let (abs, _source, source_str, stable_id) = self.read_local_source(path)?;
                 let base = abs.parent().map(Path::to_path_buf).unwrap_or_default();
-                let cache_path = self.cache_path(&stable_id);
-                // Cache hit only when (a) the WASM blob exists, (b) the
-                // sidecar listing the transitive `.wado` closure exists
-                // and re-validates against the current on-disk bytes.
-                // Without (b) an edit to a transitive import would
-                // silently reuse a stale WASM (the entry-file based
-                // `stable_id` would still match), so the kiln-output
-                // cache further down the pipeline would be checked
-                // against an old generator.
+                // On-disk cache hit only when (a) the wasm blob exists,
+                // (b) the descriptor cache (if any) exists, and (c) the
+                // sidecar listing the transitive `.wado` closure
+                // re-validates against current on-disk bytes. Without
+                // (c) an edit to a transitive import would silently
+                // reuse stale wasm (the entry-file `stable_id` would
+                // still match).
                 if !self.no_cache
-                    && cache_path.is_file()
-                    && let Some(source_hash) = self.validate_sources_sidecar(&stable_id, &base)
-                    && let Ok(bytes) = std::fs::read(&cache_path)
+                    && let Some(resolved) = self.try_read_cache(&stable_id, &base)
                 {
-                    return Ok(GeneratorComponent { bytes, source_hash });
+                    return Ok(resolved);
                 }
                 let artifacts = self
                     .compile_local(path.as_str().to_string(), abs, source_str, stable_id)
                     .await?;
-                let _ = source;
-                Ok(GeneratorComponent {
-                    bytes: artifacts.wasm,
+                Ok(ResolvedGenerator {
+                    wasm: artifacts.wasm,
+                    descriptor: artifacts.descriptor,
                     source_hash: artifacts.source_hash,
                 })
             }
         }
     }
+}
 
-    async fn descriptor(
-        &self,
-        module: &GeneratorModule,
-    ) -> Result<OptionsDescriptor, ProviderError> {
-        match module {
-            GeneratorModule::Spec(_) => Err(ProviderError::Unsupported {
-                message: "kiln: cannot introspect options for spec-form generators in v1"
-                    .to_string(),
-            }),
-            GeneratorModule::LocalPath(path) => {
-                let (abs, _source, source_str, stable_id) = self.read_local_source(path)?;
-                let base = abs.parent().map(Path::to_path_buf).unwrap_or_default();
-                let desc_path = self.descriptor_cache_path(&stable_id);
-                // Same validation rule as `get_component`: a cached
-                // descriptor is only honored when the recorded source
-                // closure still matches on disk.
-                if !self.no_cache
-                    && desc_path.is_file()
-                    && self.validate_sources_sidecar(&stable_id, &base).is_some()
-                    && let Ok(bytes) = std::fs::read(&desc_path)
-                    && let Ok(descriptor) = serde_json::from_slice::<OptionsDescriptor>(&bytes)
-                {
-                    return Ok(descriptor);
-                }
-                let artifacts = self
-                    .compile_local(path.as_str().to_string(), abs, source_str, stable_id)
-                    .await?;
-                artifacts
-                    .descriptor
-                    .ok_or_else(|| ProviderError::Unsupported {
-                        message: format!(
-                            "kiln: generator `{}` did not expose a `pub struct Options` the \
-                             compiler could describe — falling back to provisional TOML encoding",
-                            path.as_str(),
-                        ),
-                    })
-            }
+impl CliGeneratorProvider {
+    /// Read `(wasm, descriptor?, source_hash)` from the on-disk Kiln
+    /// cache for `stable_id`, returning `None` when the cache is
+    /// missing or stale. The descriptor sidecar is optional —
+    /// generators without a `pub struct Options` write only the wasm
+    /// and sources sidecar, so a missing `.descriptor` file is treated
+    /// as `descriptor: None` rather than a cache miss.
+    fn try_read_cache(&self, stable_id: &str, base: &Path) -> Option<ResolvedGenerator> {
+        let cache_path = self.cache_path(stable_id);
+        if !cache_path.is_file() {
+            return None;
         }
+        let source_hash = self.validate_sources_sidecar(stable_id, base)?;
+        let wasm = std::fs::read(&cache_path).ok()?;
+        let descriptor = std::fs::read(self.descriptor_cache_path(stable_id))
+            .ok()
+            .and_then(|bytes| serde_json::from_slice::<OptionsDescriptor>(&bytes).ok());
+        Some(ResolvedGenerator {
+            wasm,
+            descriptor,
+            source_hash,
+        })
     }
 }
 
@@ -683,7 +665,7 @@ mod tests {
         let provider = CliGeneratorProvider::new(PathBuf::from("/tmp"));
         let err = runtime().block_on(async {
             provider
-                .get_component(&GeneratorModule::Spec("ns:x@1.0.0".to_string()))
+                .resolve(&GeneratorModule::Spec("ns:x@1.0.0".to_string()))
                 .await
                 .unwrap_err()
         });
@@ -700,7 +682,7 @@ mod tests {
         let provider = CliGeneratorProvider::new(PathBuf::from("/nonexistent"));
         let err = runtime().block_on(async {
             provider
-                .get_component(&GeneratorModule::LocalPath(InvocationPath::normalize(
+                .resolve(&GeneratorModule::LocalPath(InvocationPath::normalize(
                     "./does-not-exist",
                 )))
                 .await
@@ -726,9 +708,10 @@ mod tests {
     }
 
     #[test]
-    fn local_path_compiles_and_caches_component_bytes() {
+    fn local_path_compiles_and_caches_resolved_generator() {
         let tmp =
             std::env::temp_dir().join(format!("wado-kiln-provider-compile-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
         std::fs::create_dir_all(&tmp).unwrap();
 
         let generator_src = "\
@@ -755,85 +738,98 @@ export fn generate(raw: RawRequest) -> Result<Response, Error> {\n\
 
         assert_eq!(provider.compile_count(), 0);
 
-        let component = runtime()
-            .block_on(async { provider.get_component(&module).await })
+        let resolved = runtime()
+            .block_on(async { provider.resolve(&module).await })
             .unwrap_or_else(|e| panic!("compile failed: {e:?}"));
+        assert!(resolved.wasm.starts_with(b"\0asm"), "wasm magic missing");
         assert!(
-            !component.bytes.is_empty(),
-            "component bytes must be non-empty"
-        );
-        assert!(
-            component.bytes.starts_with(b"\0asm"),
-            "component must start with wasm magic"
-        );
-        assert!(
-            !component.source_hash.is_empty(),
+            !resolved.source_hash.is_empty(),
             "local generators must produce a non-empty source hash"
         );
-        assert_eq!(
-            provider.compile_count(),
-            1,
-            "first call runs the inner compiler exactly once"
-        );
-
-        // Second call should hit the on-disk cache — observed directly via
-        // `compile_count` rather than filesystem state.
-        let cache_dir = tmp.join(CACHE_DIR);
-        let entries: Vec<_> = std::fs::read_dir(&cache_dir)
-            .map(|it| it.filter_map(Result::ok).collect())
-            .unwrap_or_default();
-        let wasm_entries: Vec<_> = entries
-            .iter()
-            .filter(|e| e.path().extension().is_some_and(|ext| ext == "wasm"))
-            .collect();
-        assert_eq!(
-            wasm_entries.len(),
-            1,
-            "exactly one cached component .wasm expected"
-        );
-        // The compile-and-write path also persists a sources sidecar
-        // alongside the WASM; assert it landed so the next call's
-        // sidecar-validation path is exercised.
-        let sidecar_entries: Vec<_> = entries
-            .iter()
-            .filter(|e| e.path().to_string_lossy().ends_with(".sources.json"))
-            .collect();
-        assert_eq!(
-            sidecar_entries.len(),
-            1,
-            "exactly one cached sources sidecar expected"
-        );
-
-        let component2 = runtime()
-            .block_on(async { provider.get_component(&module).await })
-            .unwrap();
-        assert_eq!(component, component2, "cached second call must match first");
-        assert_eq!(
-            provider.compile_count(),
-            1,
-            "cache hit must not re-invoke the inner compiler"
-        );
-
-        // The first compile also populated the descriptor cache; an
-        // explicit descriptor() call must not trigger a second compile.
-        let descriptor = runtime()
-            .block_on(async { provider.descriptor(&module).await })
-            .expect("descriptor() should succeed once the compile cache is warm");
+        let descriptor = resolved
+            .descriptor
+            .as_ref()
+            .expect("Options struct present → descriptor must be Some");
         assert_eq!(descriptor.fields.len(), 1);
         assert_eq!(descriptor.fields[0].name, "verbose");
         assert_eq!(
             provider.compile_count(),
             1,
-            "descriptor cache hit after warm component cache must not re-compile"
+            "first resolve runs the inner compiler exactly once"
+        );
+
+        // The compile-and-write path persists wasm + sources sidecar
+        // (+ descriptor); assert they all landed so the next resolve
+        // exercises the on-disk cache.
+        let cache_dir = tmp.join(CACHE_DIR);
+        let entries: Vec<_> = std::fs::read_dir(&cache_dir)
+            .map(|it| it.filter_map(Result::ok).collect())
+            .unwrap_or_default();
+        assert_eq!(
+            entries
+                .iter()
+                .filter(|e| e.path().extension().is_some_and(|ext| ext == "wasm"))
+                .count(),
+            1,
+            "exactly one cached component .wasm expected"
+        );
+        assert_eq!(
+            entries
+                .iter()
+                .filter(|e| e.path().to_string_lossy().ends_with(".sources.json"))
+                .count(),
+            1,
+            "exactly one cached sources sidecar expected"
+        );
+        let metadata_dir = tmp.join(METADATA_DIR);
+        assert_eq!(
+            std::fs::read_dir(&metadata_dir)
+                .map(|it| it.filter_map(Result::ok).count())
+                .unwrap_or(0),
+            1,
+            "exactly one cached descriptor expected"
+        );
+
+        // Second resolve must hit the on-disk cache and skip the compile.
+        // The wasm and source-hash must match byte-for-byte; the
+        // descriptor's `span` info is intentionally not persisted
+        // through the JSON sidecar (it would drift across edits), so
+        // compare descriptor facets rather than the whole struct.
+        let resolved2 = runtime()
+            .block_on(async { provider.resolve(&module).await })
+            .unwrap();
+        assert_eq!(resolved.wasm, resolved2.wasm, "wasm must round-trip cache");
+        assert_eq!(
+            resolved.source_hash, resolved2.source_hash,
+            "source_hash must round-trip cache",
+        );
+        let descriptor2 = resolved2
+            .descriptor
+            .as_ref()
+            .expect("warm descriptor cache must rehydrate");
+        assert_eq!(descriptor.fields.len(), descriptor2.fields.len());
+        for (a, b) in descriptor.fields.iter().zip(descriptor2.fields.iter()) {
+            assert_eq!(a.name, b.name);
+            assert_eq!(a.ty, b.ty);
+            assert_eq!(a.default, b.default);
+        }
+        assert_eq!(
+            provider.compile_count(),
+            1,
+            "warm on-disk cache must not re-invoke the inner compiler"
         );
 
         let _ = std::fs::remove_dir_all(&tmp);
     }
 
     #[test]
-    fn descriptor_populates_metadata_cache_and_hits_on_second_call() {
+    fn resolve_after_source_edit_recompiles() {
+        // Regression: keying purely off the entry-file `stable_id`
+        // must invalidate when the source changes. Combined with the
+        // sidecar's transitive-file hash list, an edit to either the
+        // entry or a dep must trigger exactly one fresh compile.
         let tmp = std::env::temp_dir().join(format!(
-            "wado-kiln-provider-descriptor-{}",
+            "wado-kiln-provider-resolve-edit-{}",
             std::process::id()
         ));
         let _ = std::fs::remove_dir_all(&tmp);
@@ -863,51 +859,29 @@ export fn generate(raw: RawRequest) -> Result<Response, Error> {\n\
         let module = GeneratorModule::LocalPath(InvocationPath::normalize("./generator.wado"));
 
         let first = runtime()
-            .block_on(async { provider.descriptor(&module).await })
-            .expect("first descriptor call");
-        assert_eq!(first.fields.len(), 2);
-        assert_eq!(first.fields[0].name, "highlight");
-        assert_eq!(first.fields[1].name, "depth");
+            .block_on(async { provider.resolve(&module).await })
+            .expect("first resolve");
+        let first_desc = first.descriptor.expect("Options struct → Some(descriptor)");
+        assert_eq!(first_desc.fields.len(), 2);
+        assert_eq!(first_desc.fields[0].name, "highlight");
+        assert_eq!(first_desc.fields[1].name, "depth");
         assert_eq!(provider.compile_count(), 1);
 
-        let metadata_dir = tmp.join(METADATA_DIR);
-        let desc_entries: Vec<_> = std::fs::read_dir(&metadata_dir)
-            .map(|it| it.filter_map(Result::ok).collect())
-            .unwrap_or_default();
-        assert_eq!(
-            desc_entries.len(),
-            1,
-            "exactly one cached descriptor expected"
-        );
+        // Second resolve, no edit: disk cache hits, no recompile.
+        let _ = runtime()
+            .block_on(async { provider.resolve(&module).await })
+            .expect("second resolve");
+        assert_eq!(provider.compile_count(), 1);
 
-        // Second call: disk cache hits, no recompile. Spans are not
-        // persisted (intentionally — they would drift across edits), so
-        // compare the persisted facets instead of full equality.
-        let second = runtime()
-            .block_on(async { provider.descriptor(&module).await })
-            .expect("second descriptor call");
-        assert_eq!(second.fields.len(), first.fields.len());
-        for (a, b) in second.fields.iter().zip(first.fields.iter()) {
-            assert_eq!(a.name, b.name);
-            assert_eq!(a.ty, b.ty);
-            assert_eq!(a.default, b.default);
-        }
-        assert_eq!(
-            provider.compile_count(),
-            1,
-            "descriptor cache hit must not re-invoke the inner compiler"
-        );
-
-        // Editing the source invalidates the stable-id and forces a
-        // fresh compile that populates a new descriptor entry.
+        // Source edit → fresh compile.
         let updated_src = generator_src.replace("pub depth: i32,\n", "pub depth: i64,\n");
         std::fs::write(&gen_path, &updated_src).unwrap();
-
         let third = runtime()
-            .block_on(async { provider.descriptor(&module).await })
-            .expect("descriptor after source edit");
-        assert_eq!(third.fields.len(), 2);
-        assert_eq!(third.fields[1].name, "depth");
+            .block_on(async { provider.resolve(&module).await })
+            .expect("resolve after source edit");
+        let third_desc = third.descriptor.expect("Options struct → Some(descriptor)");
+        assert_eq!(third_desc.fields.len(), 2);
+        assert_eq!(third_desc.fields[1].name, "depth");
         assert_eq!(
             provider.compile_count(),
             2,

--- a/wado-cli/src/kiln_runtime.rs
+++ b/wado-cli/src/kiln_runtime.rs
@@ -113,14 +113,10 @@ fn lift_error(e: kiln_types::Error) -> GeneratorError {
     }
 }
 
-/// Build a wasmtime [`Component`] from raw bytes. This is the
-/// cranelift-AOT step (~7s on a 432KB generator) and is intended to be
-/// cached by the host across invocations that share the same bytes.
-///
-/// # Errors
-///
-/// Surfaces a [`GeneratorRunnerError::Host`] when wasmtime rejects the
-/// wasm (malformed module, unsupported feature, …).
+/// Build a wasmtime [`Component`] from raw bytes. Cranelift-AOT
+/// dominates here (~7s on a 432KB generator), so the host caches the
+/// result across invocations that share the same bytes — see
+/// [`crate::compiler_host::FilesystemCompilerHost`].
 pub fn compile_component(
     engine: &Engine,
     component_wasm: &[u8],
@@ -130,11 +126,10 @@ pub fn compile_component(
 }
 
 /// Instantiate a pre-built [`Component`] against the
-/// `core:kiln/generator` world, call its exported `generate`, and
-/// return the response plus the list of every file the generator read
-/// via `host::read-file`. Use [`compile_component`] to build the
-/// `Component` once; calling this with a fresh `Component` on every
-/// invocation forfeits the AOT-caching win.
+/// `core:kiln/generator` world, invoke `generate`, and return the
+/// response plus the files the generator read via `host::read-file`.
+/// Always pass a [`Component`] obtained from the host's cache rather
+/// than building one inline — see [`compile_component`].
 pub async fn run_generator<H: CompilerHost + 'static>(
     engine: &Engine,
     host: Arc<H>,

--- a/wado-cli/src/kiln_runtime.rs
+++ b/wado-cli/src/kiln_runtime.rs
@@ -113,19 +113,35 @@ fn lift_error(e: kiln_types::Error) -> GeneratorError {
     }
 }
 
-/// Instantiate `component_wasm` against the `core:kiln/generator` world, call
-/// its exported `generate`, and return the response plus the list of every
-/// file the generator read via `host::read-file`.
+/// Build a wasmtime [`Component`] from raw bytes. This is the
+/// cranelift-AOT step (~7s on a 432KB generator) and is intended to be
+/// cached by the host across invocations that share the same bytes.
+///
+/// # Errors
+///
+/// Surfaces a [`GeneratorRunnerError::Host`] when wasmtime rejects the
+/// wasm (malformed module, unsupported feature, …).
+pub fn compile_component(
+    engine: &Engine,
+    component_wasm: &[u8],
+) -> Result<Component, GeneratorRunnerError> {
+    Component::from_binary(engine, component_wasm)
+        .map_err(|e| GeneratorRunnerError::Host(format!("component compile: {e}")))
+}
+
+/// Instantiate a pre-built [`Component`] against the
+/// `core:kiln/generator` world, call its exported `generate`, and
+/// return the response plus the list of every file the generator read
+/// via `host::read-file`. Use [`compile_component`] to build the
+/// `Component` once; calling this with a fresh `Component` on every
+/// invocation forfeits the AOT-caching win.
 pub async fn run_generator<H: CompilerHost + 'static>(
     engine: &Engine,
     host: Arc<H>,
-    component_wasm: &[u8],
+    component: &Component,
     request: GeneratorRequest,
     policy: KilnRunPolicy,
 ) -> Result<GeneratorResponse, GeneratorRunnerError> {
-    let component = Component::from_binary(engine, component_wasm)
-        .map_err(|e| GeneratorRunnerError::Host(format!("component compile: {e}")))?;
-
     let reads = Arc::new(Mutex::new(Vec::<GeneratorReadRecord>::new()));
     let diagnostics = Arc::new(Mutex::new(Vec::<GeneratorDiagnostic>::new()));
 
@@ -154,7 +170,7 @@ pub async fn run_generator<H: CompilerHost + 'static>(
         .set_fuel(fuel)
         .map_err(|e| GeneratorRunnerError::Host(format!("set fuel: {e}")))?;
 
-    let generator = Generator::instantiate_async(&mut store, &component, &linker)
+    let generator = Generator::instantiate_async(&mut store, component, &linker)
         .await
         .map_err(|e| GeneratorRunnerError::Host(format!("instantiate: {e}")))?;
 
@@ -214,51 +230,21 @@ fn relay_diagnostic<H: CompilerHost + ?Sized>(host: &H, diag: GeneratorDiagnosti
 mod tests {
     use super::*;
     use crate::runtime::create_kiln_engine;
-    use wado_compiler::{Diagnostic, SourceError};
-
-    struct DummyHost;
-
-    impl CompilerHost for DummyHost {
-        async fn load_source(&self, _path: &str) -> Result<Vec<u8>, SourceError> {
-            Err(SourceError::NotFound {
-                path: "unused".to_string(),
-            })
-        }
-        fn emit_diagnostic(&self, _diagnostic: Diagnostic) {}
-    }
 
     #[test]
     fn malformed_component_is_host_error() {
-        tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap()
-            .block_on(async {
-                let engine = create_kiln_engine(wasmtime::OptLevel::Speed).expect("engine");
-                let host = Arc::new(DummyHost);
-                let request = GeneratorRequest {
-                    primary: GeneratorInputFile {
-                        path: "schema.proto".to_string(),
-                        content: "syntax = \"proto3\";".to_string(),
-                    },
-                    inputs: vec![],
-                    options: String::new(),
-                };
-                let result = run_generator(
-                    &engine,
-                    host,
-                    &[0, 1, 2, 3],
-                    request,
-                    KilnRunPolicy::default(),
-                )
-                .await;
-                match result {
-                    Err(GeneratorRunnerError::Host(msg)) => {
-                        assert!(msg.contains("component compile"), "msg = {msg}");
-                    }
-                    other => panic!("expected Host error, got {other:?}"),
-                }
-            });
+        // Cranelift AOT now happens up-front in `compile_component`
+        // (so the host can cache the result across invocations); this
+        // is where a malformed module surfaces, not from
+        // `run_generator`.
+        let engine = create_kiln_engine(wasmtime::OptLevel::Speed).expect("engine");
+        match compile_component(&engine, &[0, 1, 2, 3]) {
+            Err(GeneratorRunnerError::Host(msg)) => {
+                assert!(msg.contains("component compile"), "msg = {msg}");
+            }
+            Err(other) => panic!("expected Host error, got {other:?}"),
+            Ok(_) => panic!("expected error on malformed bytes, got Ok"),
+        }
     }
 
     #[test]

--- a/wado-cli/tests/kiln_compile.rs
+++ b/wado-cli/tests/kiln_compile.rs
@@ -1,4 +1,4 @@
-//! End-to-end test for `CliGeneratorProvider::get_component` — compiles a
+//! End-to-end test for `CliGeneratorProvider::resolve` — compiles a
 //! synthetic single-file Kiln generator through the real wado-compiler
 //! pipeline and verifies:
 //!
@@ -82,13 +82,13 @@ fn first_run_compiles_second_run_hits_cache() {
     );
 
     let first = runtime()
-        .block_on(async { provider.get_component(&module).await })
+        .block_on(async { provider.resolve(&module).await })
         .expect("first compile should succeed");
     assert!(
-        first.bytes.starts_with(b"\0asm"),
+        first.wasm.starts_with(b"\0asm"),
         "component must start with wasm magic"
     );
-    assert!(first.bytes.len() > 100, "component must be non-trivial");
+    assert!(first.wasm.len() > 100, "component must be non-trivial");
     assert_eq!(
         provider.compile_count(),
         1,
@@ -124,9 +124,19 @@ fn first_run_compiles_second_run_hits_cache() {
     // No sleep needed — `compile_count` is the direct observation
     // point, not filesystem mtime.
     let second = runtime()
-        .block_on(async { provider.get_component(&module).await })
+        .block_on(async { provider.resolve(&module).await })
         .expect("second compile should succeed from cache");
-    assert_eq!(first, second, "cache hit must return identical bytes");
+    // Wasm bytes and source hash must round-trip. Descriptor `span`
+    // info is intentionally not persisted through the JSON sidecar, so
+    // descriptor equality is checked field-by-field where it matters.
+    assert_eq!(
+        first.wasm, second.wasm,
+        "cache hit must return identical wasm"
+    );
+    assert_eq!(
+        first.source_hash, second.source_hash,
+        "cache hit must return identical source hash",
+    );
     assert_eq!(
         provider.compile_count(),
         1,
@@ -149,7 +159,7 @@ fn source_edit_invalidates_cache() {
     let module = GeneratorModule::LocalPath(InvocationPath::normalize("./my_generator.wado"));
 
     let first = runtime()
-        .block_on(async { provider.get_component(&module).await })
+        .block_on(async { provider.resolve(&module).await })
         .expect("first compile should succeed");
     assert_eq!(provider.compile_count(), 1);
 
@@ -160,7 +170,7 @@ fn source_edit_invalidates_cache() {
     std::fs::write(&gen_path, edited).unwrap();
 
     let second = runtime()
-        .block_on(async { provider.get_component(&module).await })
+        .block_on(async { provider.resolve(&module).await })
         .expect("second compile after edit should succeed");
     assert_eq!(
         provider.compile_count(),
@@ -172,7 +182,7 @@ fn source_edit_invalidates_cache() {
     // verify it produced something on second compile, but don't require
     // bytewise divergence.
     assert!(
-        !second.bytes.is_empty() && second.bytes.starts_with(b"\0asm"),
+        !second.wasm.is_empty() && second.wasm.starts_with(b"\0asm"),
         "second compile should produce valid component bytes"
     );
     let _ = first;
@@ -192,14 +202,14 @@ fn adapter_generator_compiles_like_raw_request_generator() {
     let module = GeneratorModule::LocalPath(InvocationPath::normalize("./adapter_generator.wado"));
 
     let component = runtime()
-        .block_on(async { provider.get_component(&module).await })
+        .block_on(async { provider.resolve(&module).await })
         .expect("adapter-form generator must compile");
     assert!(
-        component.bytes.starts_with(b"\0asm"),
+        component.wasm.starts_with(b"\0asm"),
         "adapter generator must produce a valid wasm component"
     );
     assert!(
-        component.bytes.len() > 100,
+        component.wasm.len() > 100,
         "adapter generator must produce a non-trivial component"
     );
 
@@ -211,7 +221,7 @@ fn missing_local_path_surfaces_internal() {
     let provider = CliGeneratorProvider::new(PathBuf::from("/nonexistent-wado-kiln-root"));
     let module = GeneratorModule::LocalPath(InvocationPath::normalize("./nowhere.wado"));
     let err = runtime()
-        .block_on(async { provider.get_component(&module).await })
+        .block_on(async { provider.resolve(&module).await })
         .expect_err("missing path should fail");
     match err {
         ProviderError::Internal { message } => {
@@ -275,14 +285,14 @@ export fn generate(raw: RawRequest) -> Result<Response, Error> {
     let module = GeneratorModule::LocalPath(InvocationPath::normalize("./entry.wado"));
 
     let _first = runtime()
-        .block_on(async { provider.get_component(&module).await })
+        .block_on(async { provider.resolve(&module).await })
         .expect("first compile should succeed");
     assert_eq!(provider.compile_count(), 1);
 
     // Cache hit on the entry file alone — the entry's SHA-256 is
     // unchanged, so the v1 stable-id keeps pointing at the same WASM.
     let _second = runtime()
-        .block_on(async { provider.get_component(&module).await })
+        .block_on(async { provider.resolve(&module).await })
         .expect("second compile should succeed");
     assert_eq!(
         provider.compile_count(),
@@ -302,7 +312,7 @@ export fn generate(raw: RawRequest) -> Result<Response, Error> {
     .unwrap();
 
     let _third = runtime()
-        .block_on(async { provider.get_component(&module).await })
+        .block_on(async { provider.resolve(&module).await })
         .expect("third compile should succeed");
     assert_eq!(
         provider.compile_count(),
@@ -313,7 +323,7 @@ export fn generate(raw: RawRequest) -> Result<Response, Error> {
     // After the rebuild the new sidecar should reflect the latest
     // helper hash, so a fourth call hits cache cleanly.
     let _fourth = runtime()
-        .block_on(async { provider.get_component(&module).await })
+        .block_on(async { provider.resolve(&module).await })
         .expect("fourth compile should succeed");
     assert_eq!(
         provider.compile_count(),
@@ -363,7 +373,7 @@ export fn generate(raw: RawRequest) -> Result<Response, Error> {
 
     // Run 1: cold cache.
     let first = runtime()
-        .block_on(async { provider.get_component(&module).await })
+        .block_on(async { provider.resolve(&module).await })
         .expect("first compile should succeed");
     assert_eq!(provider.compile_count(), 1);
     assert!(
@@ -377,7 +387,7 @@ export fn generate(raw: RawRequest) -> Result<Response, Error> {
 
     // Run 2: same source bytes, fresh compile.
     let second = runtime()
-        .block_on(async { provider.get_component(&module).await })
+        .block_on(async { provider.resolve(&module).await })
         .expect("second compile should succeed");
     assert_eq!(
         provider.compile_count(),
@@ -436,7 +446,7 @@ export fn generate(raw: RawRequest) -> Result<Response, Error> {
     let module = GeneratorModule::LocalPath(InvocationPath::normalize("./entry.wado"));
 
     let baseline = runtime()
-        .block_on(async { provider.get_component(&module).await })
+        .block_on(async { provider.resolve(&module).await })
         .expect("baseline compile should succeed");
 
     // Edit only the docstring. Comment-only/whitespace-only edits in
@@ -448,7 +458,7 @@ export fn generate(raw: RawRequest) -> Result<Response, Error> {
     )
     .unwrap();
     let after_doc = runtime()
-        .block_on(async { provider.get_component(&module).await })
+        .block_on(async { provider.resolve(&module).await })
         .expect("post-doc-edit compile should succeed");
     assert_eq!(
         baseline.source_hash, after_doc.source_hash,
@@ -462,7 +472,7 @@ export fn generate(raw: RawRequest) -> Result<Response, Error> {
     )
     .unwrap();
     let after_format = runtime()
-        .block_on(async { provider.get_component(&module).await })
+        .block_on(async { provider.resolve(&module).await })
         .expect("post-format compile should succeed");
     assert_eq!(
         baseline.source_hash, after_format.source_hash,
@@ -476,7 +486,7 @@ export fn generate(raw: RawRequest) -> Result<Response, Error> {
     )
     .unwrap();
     let after_semantic = runtime()
-        .block_on(async { provider.get_component(&module).await })
+        .block_on(async { provider.resolve(&module).await })
         .expect("post-semantic-edit compile should succeed");
     assert_ne!(
         baseline.source_hash, after_semantic.source_hash,
@@ -527,14 +537,14 @@ export fn generate(raw: RawRequest) -> Result<Response, Error> {
 
     // Step 1: compile at "HEAD" — capture the baseline hash.
     let head = runtime()
-        .block_on(async { provider.get_component(&module).await })
+        .block_on(async { provider.resolve(&module).await })
         .expect("HEAD compile should succeed");
     let baseline = head.source_hash;
 
     // Step 2: edit the transitive helper to a different body.
     std::fs::write(&helper_path, "pub fn answer() -> i32 { return 99; }\n").unwrap();
     let edited = runtime()
-        .block_on(async { provider.get_component(&module).await })
+        .block_on(async { provider.resolve(&module).await })
         .expect("edited compile should succeed");
     assert_ne!(
         edited.source_hash, baseline,
@@ -545,7 +555,7 @@ export fn generate(raw: RawRequest) -> Result<Response, Error> {
     // Step 3: revert the helper to its original byte content.
     std::fs::write(&helper_path, helper_original).unwrap();
     let reverted = runtime()
-        .block_on(async { provider.get_component(&module).await })
+        .block_on(async { provider.resolve(&module).await })
         .expect("post-revert compile should succeed");
     assert_eq!(
         reverted.source_hash, baseline,
@@ -565,7 +575,7 @@ fn spec_module_surfaces_unsupported() {
     let provider = CliGeneratorProvider::new(tmp.clone());
     let module = GeneratorModule::Spec("example:proto-codegen@1.2.3".to_string());
     let err = runtime()
-        .block_on(async { provider.get_component(&module).await })
+        .block_on(async { provider.resolve(&module).await })
         .expect_err("spec module should fail until registry support lands");
     match err {
         ProviderError::Unsupported { message } => {

--- a/wado-cli/tests/kiln_compile.rs
+++ b/wado-cli/tests/kiln_compile.rs
@@ -16,9 +16,11 @@
 
 use std::path::PathBuf;
 
+use wado_cli::compiler_host::FilesystemCompilerHost;
 use wado_cli::kiln_driver::{GeneratorProvider, ProviderError};
 use wado_cli::kiln_provider::{CACHE_DIR, CliGeneratorProvider};
 use wado_compiler::kiln::{GeneratorModule, InvocationPath};
+use wado_compiler::{CompilerHost, GeneratorInputFile, GeneratorRequest, LogLevel};
 
 mod common;
 use common::runtime;
@@ -586,6 +588,85 @@ fn spec_module_surfaces_unsupported() {
         }
         _ => panic!("expected ProviderError::Unsupported, got {err:?}"),
     }
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Many kiln invocations in a real project share a single generator
+/// (one `parser_gen` package, N grammars). Each call into
+/// `CompilerHost::run_generator` used to rebuild the wasmtime
+/// `Component` from scratch — i.e. ~7s of cranelift AOT per grammar
+/// for a 432KB generator. The host now caches compiled `Component`s
+/// by wasm-bytes SHA-256, so the second `run_generator` for the same
+/// bytes must not re-invoke cranelift.
+#[test]
+fn host_caches_compiled_component_across_run_generator_calls() {
+    let tmp = unique_tmp("kiln-compile-component-cache");
+    let _ = std::fs::remove_dir_all(&tmp);
+    std::fs::create_dir_all(&tmp).unwrap();
+
+    let gen_path = tmp.join("my_generator.wado");
+    std::fs::write(&gen_path, MINIMAL_GENERATOR).unwrap();
+
+    // Reuse the existing provider plumbing to get a real, runnable
+    // generator wasm — that's what exercises the cranelift path on
+    // first call.
+    let provider = CliGeneratorProvider::new(tmp.clone());
+    let module = GeneratorModule::LocalPath(InvocationPath::normalize("./my_generator.wado"));
+    let resolved = runtime()
+        .block_on(async { provider.resolve(&module).await })
+        .expect("generator compiles");
+
+    let host = FilesystemCompilerHost::with_log_level(tmp.clone(), LogLevel::Off);
+    assert_eq!(host.kiln_component_compile_count(), 0);
+
+    let request = || GeneratorRequest {
+        primary: GeneratorInputFile {
+            path: "schema.proto".to_string(),
+            content: "syntax = \"proto3\";".to_string(),
+        },
+        inputs: vec![],
+        options: r#"{"verbose": false}"#.to_string(),
+    };
+
+    // First call: cranelift AOT runs, count goes to 1.
+    runtime()
+        .block_on(async { host.run_generator(&resolved.wasm, request()).await })
+        .expect("first generator run");
+    assert_eq!(host.kiln_component_compile_count(), 1);
+
+    // Second call with the same bytes: cache must hit, count stays at 1.
+    runtime()
+        .block_on(async { host.run_generator(&resolved.wasm, request()).await })
+        .expect("second generator run");
+    assert_eq!(
+        host.kiln_component_compile_count(),
+        1,
+        "shared wasm bytes must reuse the cached Component"
+    );
+
+    // Different bytes (a structurally distinct generator) → cache
+    // miss, count goes to 2. Use the v2-adapter shape so the wasm
+    // body genuinely differs rather than being byte-identical after
+    // dead-code elimination on a no-op edit.
+    let alt_path = tmp.join("alt_generator.wado");
+    std::fs::write(&alt_path, ADAPTER_GENERATOR).unwrap();
+    let alt_module = GeneratorModule::LocalPath(InvocationPath::normalize("./alt_generator.wado"));
+    let alt = runtime()
+        .block_on(async { provider.resolve(&alt_module).await })
+        .expect("alt generator compiles");
+    assert_ne!(
+        resolved.wasm, alt.wasm,
+        "distinct generators must produce distinct wasm"
+    );
+    runtime()
+        .block_on(async { host.run_generator(&alt.wasm, request()).await })
+        .expect("alt generator run");
+    assert_eq!(
+        host.kiln_component_compile_count(),
+        2,
+        "distinct wasm bytes must trigger a fresh component compile"
+    );
 
     let _ = std::fs::remove_dir_all(&tmp);
 }

--- a/wado-cli/tests/kiln_pipeline.rs
+++ b/wado-cli/tests/kiln_pipeline.rs
@@ -10,7 +10,7 @@ use std::sync::Mutex;
 
 use indexmap::IndexMap;
 use wado_cli::kiln_driver::{
-    GeneratorComponent, GeneratorProvider, PipelineOutcome, ProviderError, run_pipeline,
+    GeneratorProvider, PipelineOutcome, ProviderError, ResolvedGenerator, run_pipeline,
 };
 use wado_cli::kiln_metadata;
 use wado_compiler::compiler_host::{
@@ -38,13 +38,11 @@ impl StubProvider {
 }
 
 impl GeneratorProvider for StubProvider {
-    async fn get_component(
-        &self,
-        _: &GeneratorModule,
-    ) -> Result<GeneratorComponent, ProviderError> {
+    async fn resolve(&self, _: &GeneratorModule) -> Result<ResolvedGenerator, ProviderError> {
         *self.calls.lock().unwrap() += 1;
-        Ok(GeneratorComponent {
-            bytes: self.bytes.clone(),
+        Ok(ResolvedGenerator {
+            wasm: self.bytes.clone(),
+            descriptor: None,
             // Tests share a single fixed byte stream across calls; an
             // empty source hash matches the legacy behaviour where the
             // metadata's `generator_source_hash` was likewise empty.
@@ -237,10 +235,10 @@ fn end_to_end_two_generators_execute_cache_and_reuse() {
     let outcome2 = run(&m, tmp.path(), &host2, &provider2, invs);
     assert_eq!(outcome2.cached.len(), 2);
     assert!(outcome2.executed.is_empty());
-    // alpha and beta declare distinct `GeneratorModule` values, so each
-    // is fetched once through the driver's per-pipeline module cache.
-    // The pre-fetch is what feeds `cache_matches` the current
-    // `source_hash`; the cache itself never had to recompile, hence no
+    // alpha and beta declare distinct `GeneratorModule` values, so the
+    // upfront `resolve_modules` step asks the provider once per module.
+    // The resolution feeds `cache_matches` the current `source_hash`;
+    // the on-disk Kiln cache itself never had to recompile, hence no
     // entry in `executed`. (See
     // `shared_module_across_invocations_calls_provider_once` for the
     // case where a single module covers both invocations.)
@@ -498,16 +496,17 @@ fn inline_invocation_populates_invocation_index_for_redirect() {
 
 #[test]
 fn shared_module_across_invocations_calls_provider_once() {
-    // The pipeline caches the provider's `get_component` result by
-    // `GeneratorModule`. Two invocations targeting the same module
-    // should resolve to a single provider call — the second invocation
-    // reuses the already-fetched component (and its source hash).
+    // The pipeline calls `provider.resolve` once per unique
+    // `GeneratorModule` upfront via `resolve_modules`, then hands the
+    // resolved artifacts to every invocation that shares the module.
+    // Two invocations targeting the same module must therefore trigger
+    // exactly one provider call.
     let tmp = tempfile::tempdir().unwrap();
     let m = empty_manifest();
 
     // Two invocations sharing the same `Spec` module. (Spec doesn't
-    // resolve through `CliGeneratorProvider` in v1, but the driver-level
-    // cache is module-keyed and target-agnostic, so the test is valid.)
+    // resolve through `CliGeneratorProvider` in v1, but the dedup is
+    // module-keyed and target-agnostic, so the test is valid.)
     let shared_module = GeneratorModule::Spec("ns:proto@1.0.0".to_string());
     let inv_a = invocation(
         "entry.wado",


### PR DESCRIPTION
## Background

Profiling `package-gale/tests/driver_rust_test.wado` with `--no-cache` showed the kiln phase eating ~21s out of ~36s total wall time. Two problems:

1. `CliGeneratorProvider` had separate `get_component()` and `descriptor()` methods that each consulted the on-disk cache and, on `--no-cache`, each independently ran the full wado-compile of the generator. The Rust grammar generator was being compiled **twice** per pipeline (~7s each).
2. `kiln_runtime::run_generator` called `wasmtime::component::Component::from_binary(engine, wasm)` on every invocation — i.e. ~7s of cranelift AOT per kiln invocation, even when multiple invocations in the same pipeline shared the same generator wasm.

## Changes

### `GeneratorProvider` trait surface

Collapse `get_component()` + `descriptor()` into a single `resolve(module) -> ResolvedGenerator { wasm, descriptor, source_hash }`. The provider no longer needs an in-memory artifact cache, and the API no longer invites double-compile via two unrelated cache-bypass paths.

### Driver flow

`run_pipeline` and `run_check_pipeline` now resolve every unique `GeneratorModule` exactly once up-front via the new `resolve_modules` helper, then hand the resolved bundle to `typed_encode_options` and the per-invocation execute loop. The driver-local `module_cache` is gone — superseded by the upfront map. `--no-cache` only bypasses on-disk caches; in-process artifact reuse is unconditional (re-doing the same work in one pipeline run would always be a bug, regardless of cache settings).

### Host-side Component cache

`FilesystemCompilerHost` now caches `wasmtime::component::Component` instances keyed by SHA-256 of the wasm bytes. Cache hits clone in O(1) (Wasmtime's `Component` is internally `Arc`). The cache is in-memory only — no `.cwasm` written to disk, so no trust-the-disk code-injection surface that on-disk AOT caching would introduce. `kiln_runtime::run_generator` now takes `&Component`; the cranelift AOT step is exposed as `kiln_runtime::compile_component` so the host can wrap it with caching.

### Comment cleanup

A consistency pass across the four kiln files (driver, provider, runtime, host) dropping stale text (lockfile-persistence claims removed at WEP M9, "per-pipeline HashMap" references that never matched the actual Vec, a doc claim that `resolve_modules` emits per-id spans) and trimming what-comments where the name and signature already convey intent. Net −104 lines without losing any why-rationale.

## Results

`package-gale/tests/driver_rust_test.wado` with `--no-cache`:

| Phase | Before | After |
|---|---:|---:|
| kiln/typed_encode_options (incl. duplicate compile) | 7.25s | ~0ms |
| kiln/get_component (duplicate compile) | 6.81s | — (folded into resolve) |
| kiln/resolve | — | 7.21s |
| kiln/run | 7.17s | 7.01s |
| **kiln total** | **21.23s** | **14.01s (−34%)** |

Single-invocation pipelines see the −7s win from dropping the duplicate compile but no extra win from the Component cache (only one AOT runs either way). Multi-invocation workloads sharing one generator (e.g. the `antlr4_compat_a` corpus with dozens of grammars per generator) get an additional `(N−1)×~7s` save.

## WEP

WEP 2026-04-12 (Kiln) was reviewed and intentionally left untouched: the spec sections still match (the `CompilerHost::run_generator` trait signature is unchanged), and the M6.6/M6.7 milestone logs are historical snapshots of what shipped at those milestones, not living implementation references.


---
_Generated by [Claude Code](https://claude.ai/code/session_018v8XLT8QCNFHgcsgMFuKKE)_