### PR TITLE
feat(lsp): textDocument/inlayHint with type and parameter-name hints

### DIFF
--- a/wado-cli/tests/lsp.rs
+++ b/wado-cli/tests/lsp.rs
@@ -283,6 +283,11 @@ fn lsp_initialize_returns_capabilities() {
     assert!(schemes.contains(&"core"));
     assert!(schemes.contains(&"wasi"));
 
+    assert_eq!(
+        caps["inlayHintProvider"], true,
+        "server should advertise inlayHintProvider",
+    );
+
     let info = &resp["result"]["serverInfo"];
     assert_eq!(info["name"], "wado-lsp");
 
@@ -733,6 +738,67 @@ fn lsp_initialize_advertises_all_providers() {
     );
     let mods = st["legend"]["tokenModifiers"].as_array().unwrap();
     assert!(mods.contains(&json!("declaration")), "got: {mods:?}");
+    assert_eq!(caps["inlayHintProvider"], true);
+    assert_eq!(session.shutdown_and_exit(), 0);
+}
+
+#[test]
+fn lsp_inlay_hint_returns_type_and_parameter_hints() {
+    // End-to-end wire test: open a document, request inlay hints, and
+    // verify the JSON-RPC response carries the expected `Type` (let-binding)
+    // and `Parameter` (call-site) hints.
+    let mut session = LspSession::start();
+    session.initialize();
+    let uri = "file:///inlay_test.wado";
+    let text = concat!(
+        "fn add(a: i32, b: i32) -> i32 { return a + b; }\n",
+        "fn run() -> i32 {\n",
+        "    let total = add(1, 2);\n",
+        "    return total;\n",
+        "}\n",
+    );
+    session.send_notification(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "wado",
+                "version": 1,
+                "text": text,
+            }
+        }),
+    );
+    // Drain the diagnostics notification that `didOpen` triggers.
+    let _ = session.read_message();
+    let id = session.send_request(
+        "textDocument/inlayHint",
+        json!({
+            "textDocument": { "uri": uri },
+            "range": {
+                "start": { "line": 0, "character": 0 },
+                "end": { "line": 999, "character": 0 },
+            },
+        }),
+    );
+    let resp = session.read_message();
+    assert_eq!(resp["id"], id);
+    let hints = resp["result"]
+        .as_array()
+        .expect("result must be an InlayHint[]");
+    let labels: Vec<&str> = hints.iter().filter_map(|h| h["label"].as_str()).collect();
+    assert!(
+        labels.contains(&": i32"),
+        "expected `: i32` type hint for `let total = ...`; got {labels:?}",
+    );
+    assert!(
+        labels.contains(&"a:") && labels.contains(&"b:"),
+        "expected `a:`/`b:` parameter hints; got {labels:?}",
+    );
+    // Each hint kind is the wire integer (Type=1, Parameter=2).
+    for hint in hints {
+        let kind = hint["kind"].as_u64().expect("kind must be a uint");
+        assert!(kind == 1 || kind == 2, "unexpected kind: {hint}");
+    }
     assert_eq!(session.shutdown_and_exit(), 0);
 }
 

--- a/wado-compiler/src/ast_index.rs
+++ b/wado-compiler/src/ast_index.rs
@@ -21,6 +21,19 @@ use crate::ast::{
 use crate::hashmap::{IndexMap, IndexSet};
 use crate::token::Span;
 
+/// Address of a `Function` AST node within its declaring module's
+/// `items` list. Stored on [`AstIndex`] so consumers can recover the
+/// `&Function` for a given declaring `AstId` in O(1) instead of
+/// rescanning every item.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FunctionLocation {
+    /// `module.items[item_idx]` is `Item::Function`.
+    Free { item_idx: usize },
+    /// `module.items[item_idx]` is `Item::Impl(b)` or `Item::Trait(t)`;
+    /// the function is `b.methods[method_idx]` / `t.methods[method_idx]`.
+    Method { item_idx: usize, method_idx: usize },
+}
+
 /// Structural facts about an [`ast::Module`].
 #[derive(Debug, Default, Clone)]
 pub struct AstIndex {
@@ -47,6 +60,14 @@ pub struct AstIndex {
     /// `obj` is *not* a write target. This matches the document-highlight
     /// classification: writes to the binding itself, not through a path.
     write_targets: IndexSet<AstId>,
+    /// Address of every `Function`-shaped declaration in the module,
+    /// keyed by the function's own `AstId`. Covers top-level free
+    /// functions and methods inside `Item::Impl` / `Item::Trait` (both
+    /// of which carry `methods: Vec<Function>`). Interface and resource
+    /// methods carry the `InterfaceMethod` shape and live elsewhere; the
+    /// analyzer registers them as `SymbolKind::Function` entries, so
+    /// consumers reach them through the symbol table rather than here.
+    function_locations: IndexMap<AstId, FunctionLocation>,
 }
 
 impl AstIndex {
@@ -59,6 +80,7 @@ impl AstIndex {
         for item in &module.items {
             builder.visit_item(item);
         }
+        record_function_locations(&mut builder.index, &module.items);
         builder.index
     }
 
@@ -80,6 +102,13 @@ impl AstIndex {
     #[must_use]
     pub fn is_write_target(&self, id: AstId) -> bool {
         self.write_targets.contains(&id)
+    }
+
+    /// Address of the `Function` AST node whose declaring `AstId` is `id`,
+    /// or `None` if `id` does not name an indexed function. Crate-private:
+    /// `Semantics::function_at` is the entry point external consumers use.
+    pub(crate) fn function_location(&self, id: AstId) -> Option<FunctionLocation> {
+        self.function_locations.get(&id).copied()
     }
 
     /// `AstId` of the smallest id-bearing AST node whose span contains the
@@ -278,6 +307,49 @@ fn record_item_name_spans(index: &mut AstIndex, item: &Item) {
         }
         Item::Impl(imp) => record_impl_name_spans(index, imp),
         Item::Use(_) | Item::World(_) | Item::Test(_) | Item::TupleTypeDecl(_) => {}
+    }
+}
+
+/// Record every `Function`-shaped declaration's `(item_idx, [method_idx])`
+/// address into `index.function_locations`. Run as a single linear pass
+/// over the module's items after the `AstVisitor` walk so consumers can
+/// project an `AstId` back to its declaring `&Function` in O(1).
+fn record_function_locations(index: &mut AstIndex, items: &[Item]) {
+    for (item_idx, item) in items.iter().enumerate() {
+        match item {
+            Item::Function(f) => {
+                index
+                    .function_locations
+                    .insert(f.id, FunctionLocation::Free { item_idx });
+            }
+            Item::Impl(b) => {
+                for (method_idx, method) in b.methods.iter().enumerate() {
+                    index.function_locations.insert(
+                        method.id,
+                        FunctionLocation::Method {
+                            item_idx,
+                            method_idx,
+                        },
+                    );
+                }
+            }
+            Item::Trait(t) => {
+                for (method_idx, method) in t.methods.iter().enumerate() {
+                    index.function_locations.insert(
+                        method.id,
+                        FunctionLocation::Method {
+                            item_idx,
+                            method_idx,
+                        },
+                    );
+                }
+            }
+            // Interface and resource declarations carry `InterfaceMethod`
+            // entries, not `Function` — the analyzer registers those as
+            // symbol-table entries, and consumers route through the symbol
+            // table for them.
+            _ => {}
+        }
     }
 }
 
@@ -727,6 +799,99 @@ mod tests {
                 index.span_of(arm.id),
                 Some(arm.span),
                 "arm id must be indexed with the arm's full span",
+            );
+        }
+    }
+
+    #[test]
+    fn function_location_indexes_free_function() {
+        let module = parse("fn run() -> i32 { return 1; }\n");
+        let index = AstIndex::build(&module);
+        let func = match &module.items[0] {
+            Item::Function(f) => f,
+            _ => unreachable!(),
+        };
+        assert_eq!(
+            index.function_location(func.id),
+            Some(FunctionLocation::Free { item_idx: 0 }),
+        );
+    }
+
+    #[test]
+    fn function_location_indexes_impl_methods() {
+        let module = parse(concat!(
+            "struct Point { x: i32, y: i32 }\n",
+            "impl Point {\n",
+            "    fn origin() -> Point { return Point { x: 0, y: 0 }; }\n",
+            "    fn sum(&self) -> i32 { return self.x + self.y; }\n",
+            "}\n",
+        ));
+        let index = AstIndex::build(&module);
+        let imp = match &module.items[1] {
+            Item::Impl(i) => i,
+            _ => unreachable!(),
+        };
+        for (method_idx, method) in imp.methods.iter().enumerate() {
+            assert_eq!(
+                index.function_location(method.id),
+                Some(FunctionLocation::Method {
+                    item_idx: 1,
+                    method_idx,
+                }),
+                "method `{}` should index to its impl-block address",
+                method.name,
+            );
+        }
+    }
+
+    #[test]
+    fn function_location_indexes_trait_methods() {
+        let module = parse(concat!(
+            "trait Greet {\n",
+            "    fn greet(&self) -> String;\n",
+            "    fn farewell(&self) -> String;\n",
+            "}\n",
+        ));
+        let index = AstIndex::build(&module);
+        let t = match &module.items[0] {
+            Item::Trait(t) => t,
+            _ => unreachable!(),
+        };
+        for (method_idx, method) in t.methods.iter().enumerate() {
+            assert_eq!(
+                index.function_location(method.id),
+                Some(FunctionLocation::Method {
+                    item_idx: 0,
+                    method_idx,
+                }),
+                "trait method `{}` should index to its trait-block address",
+                method.name,
+            );
+        }
+    }
+
+    /// Interface methods carry `InterfaceMethod` rather than `Function`,
+    /// so the function-location index intentionally skips them. The
+    /// analyzer registers interface methods as `SymbolKind::Function`
+    /// entries; consumers use the symbol table for those.
+    #[test]
+    fn function_location_skips_interface_methods() {
+        let module = parse(concat!(
+            "interface Stdout {\n",
+            "    fn write(s: String);\n",
+            "}\n",
+        ));
+        let index = AstIndex::build(&module);
+        let iface = match &module.items[0] {
+            Item::Interface(i) => i,
+            _ => unreachable!(),
+        };
+        for method in &iface.methods {
+            assert_eq!(
+                index.function_location(method.id),
+                None,
+                "interface method `{}` should not be in the function-location index",
+                method.name,
             );
         }
     }

--- a/wado-compiler/src/resolver.rs
+++ b/wado-compiler/src/resolver.rs
@@ -206,6 +206,12 @@ pub struct Resolver<'a, H: CompilerHost> {
     /// every `ctx.add_local(...)` call that carries a user-visible defining
     /// `AstId`. Shared via `Rc<RefCell<…>>` with `AnnotateState`.
     local_symbols: Rc<RefCell<IndexMap<SymbolKey, Symbol>>>,
+    /// Resolved [`TypeId`] for each local binding, keyed by the binding's
+    /// defining [`SymbolKey`]. Populated alongside `local_symbols` at every
+    /// `record_local_symbol` call. Shared via `Rc<RefCell<…>>` with
+    /// `AnnotateState` and ultimately drained into `Semantics::local_types`
+    /// for LSP inlay-hint consumption.
+    local_types: Rc<RefCell<IndexMap<SymbolKey, TypeId>>>,
     /// When resolving a default-expression AST at a call site, fall back to
     /// looking up unresolved identifiers in this module's global scope. This
     /// preserves the callee's lexical scope for defaults that reference
@@ -285,6 +291,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             loaded_module_func_indices: IndexMap::default(),
             references: Rc::new(RefCell::new(IndexMap::default())),
             local_symbols: Rc::new(RefCell::new(IndexMap::default())),
+            local_types: Rc::new(RefCell::new(IndexMap::default())),
             default_scope_module: None,
             invocations: Rc::new(crate::kiln::InvocationIndex::new()),
             interner: Rc::new(RefCell::new(ModuleSourceInterner::new())),
@@ -550,15 +557,17 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         None
     }
 
-    /// Record a local binding's [`Symbol`] so that LSP hover on a use site can
-    /// retrieve the defining name / mutability. Called at each site where a
-    /// user-visible local is introduced.
+    /// Record a local binding's [`Symbol`] and resolved [`TypeId`] so that
+    /// LSP hover on a use site can retrieve the defining name / mutability
+    /// and inlay hints can surface the inferred type. Called at each site
+    /// where a user-visible local is introduced.
     pub(super) fn record_local_symbol(
         &self,
         def_id: crate::ast::AstId,
         name: &str,
         span: crate::token::Span,
         is_mut: bool,
+        type_id: TypeId,
     ) {
         let key = SymbolKey::new(self.current_module_source.clone(), def_id);
         let symbol = Symbol {
@@ -570,7 +579,8 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             defined_at: key.clone(),
             span: Some(span),
         };
-        self.local_symbols.borrow_mut().insert(key, symbol);
+        self.local_symbols.borrow_mut().insert(key.clone(), symbol);
+        self.local_types.borrow_mut().insert(key, type_id);
     }
 
     /// Build a function-name → index map for a module's items.

--- a/wado-compiler/src/resolver/closure.rs
+++ b/wado-compiler/src/resolver/closure.rs
@@ -205,7 +205,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
             .map(|(i, p)| {
                 let type_id = self.closure_param_type(p, i, expected_fn.as_ref());
                 closure_ctx.add_local(p.name.clone(), type_id, p.is_mut, Some(p.id));
-                self.record_local_symbol(p.id, &p.name, p.name_span, p.is_mut);
+                self.record_local_symbol(p.id, &p.name, p.name_span, p.is_mut, type_id);
                 (p.name.clone(), type_id)
             })
             .collect();

--- a/wado-compiler/src/resolver/item.rs
+++ b/wado-compiler/src/resolver/item.rs
@@ -1102,7 +1102,13 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 Box::new(resolved)
             });
             let index = ctx.add_local(param.name.clone(), type_id, param.is_mut, Some(param.id));
-            scope.record_local_symbol(param.id, &param.name, param.name_span, param.is_mut);
+            scope.record_local_symbol(
+                param.id,
+                &param.name,
+                param.name_span,
+                param.is_mut,
+                type_id,
+            );
             params.push(TirParam {
                 name: param.name.clone(),
                 type_id,
@@ -1669,7 +1675,13 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 Box::new(resolved)
             });
             let index = ctx.add_local(param.name.clone(), type_id, param.is_mut, Some(param.id));
-            scope.record_local_symbol(param.id, &param.name, param.name_span, param.is_mut);
+            scope.record_local_symbol(
+                param.id,
+                &param.name,
+                param.name_span,
+                param.is_mut,
+                type_id,
+            );
             params.push(TirParam {
                 name: param.name.clone(),
                 type_id,

--- a/wado-compiler/src/resolver/orchestration.rs
+++ b/wado-compiler/src/resolver/orchestration.rs
@@ -78,6 +78,13 @@ pub(crate) struct AnnotateState {
     /// parameters). Keyed by the binding's defining [`SymbolKey`]. Populated
     /// alongside [`Self::references`] as the resolver walks function bodies.
     pub(crate) local_symbols: Rc<RefCell<IndexMap<SymbolKey, Symbol>>>,
+    /// Resolved [`TypeId`] for each local binding, keyed by the binding's
+    /// defining [`SymbolKey`]. Populated alongside [`Self::local_symbols`]
+    /// at every `record_local_symbol` call. Consumed by LSP inlay hints so
+    /// `let x = 1` can render the inferred `: i32` annotation without
+    /// reaching into TIR (which is `pub(crate)` and mixes resolver-synth
+    /// temporaries into the local namespace).
+    pub(crate) local_types: Rc<RefCell<IndexMap<SymbolKey, TypeId>>>,
     /// Kiln invocation redirects consulted by `resolve_import` call sites
     /// when walking `use` declarations. Populated from [`crate::loader::LoadResult`].
     pub(crate) invocations: Rc<crate::kiln::InvocationIndex>,
@@ -775,6 +782,9 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
         let local_symbols = Rc::new(RefCell::new(
             snapshot.map(|s| s.locals.clone()).unwrap_or_default(),
         ));
+        let local_types = Rc::new(RefCell::new(
+            snapshot.map(|s| s.local_types.clone()).unwrap_or_default(),
+        ));
 
         Ok(AnnotateState {
             type_table,
@@ -794,6 +804,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
             all_module_func_indices,
             references,
             local_symbols,
+            local_types,
             invocations,
             interner,
         })
@@ -1006,6 +1017,7 @@ impl<'a, H: CompilerHost> Resolver<'a, H> {
                 loaded_module_func_indices: state.all_module_func_indices.clone(),
                 references: Rc::clone(&state.references),
                 local_symbols: Rc::clone(&state.local_symbols),
+                local_types: Rc::clone(&state.local_types),
                 default_scope_module: None,
                 invocations: Rc::clone(&state.invocations),
                 interner: Rc::clone(&state.interner),

--- a/wado-compiler/src/resolver/stmt.rs
+++ b/wado-compiler/src/resolver/stmt.rs
@@ -381,7 +381,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 let is_mut =
                     let_stmt.is_mut || matches!(&let_stmt.pattern, ast::Pattern::MutIdent { .. });
                 let local_index = ctx.add_local(name.clone(), type_id, is_mut, Some(*id));
-                self.record_local_symbol(*id, name, *name_span, is_mut);
+                self.record_local_symbol(*id, name, *name_span, is_mut, type_id);
                 {
                     let mut closure_candidate = ast_value;
                     while let ast::Expr::Unary(u) = closure_candidate {
@@ -500,7 +500,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                 let is_mut =
                     let_stmt.is_mut || matches!(&let_stmt.pattern, ast::Pattern::MutIdent { .. });
                 let local_index = ctx.add_local(name.clone(), type_id, is_mut, Some(*id));
-                self.record_local_symbol(*id, name, *name_span, is_mut);
+                self.record_local_symbol(*id, name, *name_span, is_mut, type_id);
                 // Unit placeholder: WIR builder sees unit type → skips LocalSet.
                 // The local is pre-declared and Wasm zero-initializes it.
                 let placeholder = TirExpr::new(TirExprKind::Unit, TypeTable::UNIT, let_stmt.span);
@@ -753,7 +753,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     RefBinding::None => type_id,
                 };
                 let local_index = ctx.add_local(name.clone(), binding_type, pat_mut, Some(*id));
-                self.record_local_symbol(*id, name, *name_span, pat_mut);
+                self.record_local_symbol(*id, name, *name_span, pat_mut, binding_type);
                 TirPattern::Binding {
                     name: name.clone(),
                     local_index,
@@ -1319,7 +1319,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     RefBinding::None => scrutinee_type,
                 };
                 let index = ctx.add_local(name.clone(), binding_type, is_mut, Some(*id));
-                self.record_local_symbol(*id, name, *name_span, is_mut);
+                self.record_local_symbol(*id, name, *name_span, is_mut, binding_type);
                 TirPattern::Binding {
                     name: name.clone(),
                     local_index: index,
@@ -2241,7 +2241,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
         ctx.enter_scope();
         let binding_local = ctx.add_local(binding_name.clone(), binding_type, is_mut, binding_id);
         if let (Some(id), Some(name_span)) = (binding_id, binding_name_span) {
-            self.record_local_symbol(id, &binding_name, name_span, is_mut);
+            self.record_local_symbol(id, &binding_name, name_span, is_mut, binding_type);
         }
 
         // For destructured bindings (e.g., [a, b]), add the sub-bindings and
@@ -2263,7 +2263,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                     let elem_type: TypeId =
                         inner_elems.get(i).copied().unwrap_or(TypeTable::UNKNOWN);
                     let local_idx = ctx.add_local(name.clone(), elem_type, is_mut, Some(*id));
-                    self.record_local_symbol(*id, name, *name_span, is_mut);
+                    self.record_local_symbol(*id, name, *name_span, is_mut, elem_type);
                     let field_access = TirExpr::new(
                         TirExprKind::FieldAccess {
                             expr: Box::new(TirExpr::new(
@@ -2439,7 +2439,7 @@ impl<H: CompilerHost> Resolver<'_, H> {
                         let is_mut =
                             for_of.is_mut || matches!(&for_of.binding, Pattern::MutIdent { .. });
                         let local_index = ctx.add_local(name.clone(), elem_type, is_mut, Some(*id));
-                        self.record_local_symbol(*id, name, *name_span, is_mut);
+                        self.record_local_symbol(*id, name, *name_span, is_mut, elem_type);
                         block_stmts.push(TirStmt::new(
                             TirStmtKind::Let {
                                 name: name.clone(),

--- a/wado-compiler/src/semantics.rs
+++ b/wado-compiler/src/semantics.rs
@@ -222,27 +222,14 @@ impl Semantics {
         Some(self.types.get(type_id))
     }
 
-    /// Inferred [`ResolvedType`] for a local binding identified by `key`
-    /// (a let pattern's `AstId`, a function/closure parameter's `AstId`,
-    /// or a `for x of …` element binding's `AstId`).
+    /// Renderable name of the inferred type for a local binding (a let
+    /// pattern's `AstId`, a function/closure parameter's `AstId`, or a
+    /// `for x of …` element binding's `AstId`). Suitable for inlay-hint
+    /// display.
     ///
-    /// Returns `None` when:
-    /// - `key` does not name a local binding (e.g. it refers to an item),
-    /// - the resolver bailed before reaching the binding's body, or
-    /// - the binding was synthesised by the resolver and never received an
-    ///   `AstId` (`record_local_symbol` is the gatekeeper here, so this
-    ///   case does not arise in practice).
-    ///
-    /// LSP inlay hints consume this to render the inferred type on `let`
-    /// bindings and closure parameters that the user did not annotate.
-    #[must_use]
-    pub fn local_type(&self, key: &SymbolKey) -> Option<&ResolvedType> {
-        let type_id = self.local_types.get(key).copied()?;
-        Some(self.types.get(type_id))
-    }
-
-    /// Renderable name of a local binding's inferred type, suitable for
-    /// inlay-hint display. Returns `None` when [`Self::local_type`] would.
+    /// Returns `None` when `key` does not name a local binding (e.g. it
+    /// refers to an item), or when the resolver bailed before reaching
+    /// the binding's body.
     #[must_use]
     pub fn local_type_name(&self, key: &SymbolKey) -> Option<String> {
         let type_id = self.local_types.get(key).copied()?;

--- a/wado-compiler/src/semantics.rs
+++ b/wado-compiler/src/semantics.rs
@@ -22,7 +22,7 @@ use crate::module_source::{ModuleSource, ModuleSourceInterner};
 use crate::resolver::Resolver;
 use crate::resolver::orchestration::AnnotateState;
 use crate::symbol::{Symbol, SymbolKey, SymbolTable};
-use crate::tir::{ResolvedType, TirModule, TypeTable};
+use crate::tir::{ResolvedType, TirModule, TypeId, TypeTable};
 use crate::token::Span;
 
 /// A ready-to-query analysis result.
@@ -85,6 +85,13 @@ pub struct Semantics {
     /// [`Semantics::symbol_at`] when the key does not name an item-level
     /// symbol. Empty when resolve did not run or bailed early.
     pub(crate) locals: IndexMap<SymbolKey, Symbol>,
+    /// Inferred [`TypeId`] for each local binding (let / param / closure
+    /// param), keyed by the binding's defining [`SymbolKey`]. Populated
+    /// alongside [`Self::locals`] from the resolver. Consumed by LSP
+    /// inlay-hint queries via [`Semantics::local_type`] to render the
+    /// inferred type on bindings without explicit annotation. Empty when
+    /// resolve did not run or bailed before recording any bindings.
+    pub local_types: IndexMap<SymbolKey, TypeId>,
     /// TIR modules produced by [`crate::resolver::Resolver::lower_tir_from_state`].
     /// The batch compiler consumes these directly; LSP queries ignore them.
     /// Empty when `lower_tir` did not run or bailed.
@@ -136,6 +143,7 @@ impl Semantics {
         state: Option<AnnotateState>,
         references: IndexMap<SymbolKey, SymbolKey>,
         locals: IndexMap<SymbolKey, Symbol>,
+        local_types: IndexMap<SymbolKey, TypeId>,
         tir_modules: IndexMap<ModuleSource, TirModule>,
     ) -> Self {
         Self {
@@ -148,6 +156,7 @@ impl Semantics {
             state,
             references,
             locals,
+            local_types,
             tir_modules,
             is_complete: false,
         }
@@ -211,6 +220,33 @@ impl Semantics {
     pub fn type_at(&self, key: &SymbolKey) -> Option<&ResolvedType> {
         let type_id = self.types.type_of_symbol(key)?;
         Some(self.types.get(type_id))
+    }
+
+    /// Inferred [`ResolvedType`] for a local binding identified by `key`
+    /// (a let pattern's `AstId`, a function/closure parameter's `AstId`,
+    /// or a `for x of …` element binding's `AstId`).
+    ///
+    /// Returns `None` when:
+    /// - `key` does not name a local binding (e.g. it refers to an item),
+    /// - the resolver bailed before reaching the binding's body, or
+    /// - the binding was synthesised by the resolver and never received an
+    ///   `AstId` (`record_local_symbol` is the gatekeeper here, so this
+    ///   case does not arise in practice).
+    ///
+    /// LSP inlay hints consume this to render the inferred type on `let`
+    /// bindings and closure parameters that the user did not annotate.
+    #[must_use]
+    pub fn local_type(&self, key: &SymbolKey) -> Option<&ResolvedType> {
+        let type_id = self.local_types.get(key).copied()?;
+        Some(self.types.get(type_id))
+    }
+
+    /// Renderable name of a local binding's inferred type, suitable for
+    /// inlay-hint display. Returns `None` when [`Self::local_type`] would.
+    #[must_use]
+    pub fn local_type_name(&self, key: &SymbolKey) -> Option<String> {
+        let type_id = self.local_types.get(key).copied()?;
+        Some(self.types.type_name(type_id))
     }
 
     /// URI (filename) of a module, when the module has one.
@@ -511,6 +547,7 @@ impl Semantics {
             IndexMap::default(),
             IndexMap::default(),
             IndexMap::default(),
+            IndexMap::default(),
         )
     }
 }
@@ -602,6 +639,7 @@ pub(crate) fn semantics_with_logger<H: CompilerHost>(
             IndexMap::default(),
             IndexMap::default(),
             IndexMap::default(),
+            IndexMap::default(),
         );
     }
 
@@ -627,6 +665,7 @@ pub(crate) fn semantics_with_logger<H: CompilerHost>(
             TypeTable::new(),
             interner,
             None,
+            IndexMap::default(),
             IndexMap::default(),
             IndexMap::default(),
             IndexMap::default(),
@@ -669,6 +708,7 @@ pub(crate) fn semantics_with_logger<H: CompilerHost>(
     // `RefCell` borrows.
     let references = std::mem::take(&mut *state.references.borrow_mut());
     let locals = std::mem::take(&mut *state.local_symbols.borrow_mut());
+    let local_types = std::mem::take(&mut *state.local_types.borrow_mut());
 
     Semantics {
         entry_module_source: load_result.entry_module_source,
@@ -680,6 +720,7 @@ pub(crate) fn semantics_with_logger<H: CompilerHost>(
         state: Some(state),
         references,
         locals,
+        local_types,
         tir_modules,
         is_complete: lower_ok,
     }

--- a/wado-compiler/src/semantics.rs
+++ b/wado-compiler/src/semantics.rs
@@ -85,20 +85,14 @@ pub struct Semantics {
     /// [`Semantics::symbol_at`] when the key does not name an item-level
     /// symbol. Empty when resolve did not run or bailed early.
     pub(crate) locals: IndexMap<SymbolKey, Symbol>,
-<<<<<<< HEAD
     /// Inferred [`TypeId`] for each local binding (let / param / closure
     /// param), keyed by the binding's defining [`SymbolKey`]. Populated
-    /// alongside [`Self::locals`] from the resolver. Consumed by LSP
-    /// inlay-hint queries via [`Semantics::local_type`] to render the
-    /// inferred type on bindings without explicit annotation. Empty when
-    /// resolve did not run or bailed before recording any bindings.
+    /// alongside [`Self::locals`] from the elaborator. Consumed by LSP
+    /// inlay-hint queries via [`Semantics::local_type_name`] to render
+    /// the inferred type on bindings without explicit annotation. Empty
+    /// when resolve did not run or bailed before recording any bindings.
     pub local_types: IndexMap<SymbolKey, TypeId>,
-    /// TIR modules produced by [`crate::resolver::Resolver::lower_tir_from_state`].
-||||||| cadfa530
-    /// TIR modules produced by [`crate::resolver::Resolver::lower_tir_from_state`].
-=======
     /// TIR modules produced by [`crate::elaborator::Elaborator::build_tir_from_state`].
->>>>>>> origin/main
     /// The batch compiler consumes these directly; LSP queries ignore them.
     /// Empty when `build_tir` did not run or bailed.
     pub(crate) tir_modules: IndexMap<ModuleSource, TirModule>,
@@ -234,7 +228,7 @@ impl Semantics {
     /// display.
     ///
     /// Returns `None` when `key` does not name a local binding (e.g. it
-    /// refers to an item), or when the resolver bailed before reaching
+    /// refers to an item), or when the elaborator bailed before reaching
     /// the binding's body.
     #[must_use]
     pub fn local_type_name(&self, key: &SymbolKey) -> Option<String> {

--- a/wado-compiler/src/semantics.rs
+++ b/wado-compiler/src/semantics.rs
@@ -245,6 +245,40 @@ impl Semantics {
         if uri.is_empty() { None } else { Some(uri) }
     }
 
+    /// AST [`Function`](crate::ast::Function) node declaring `key`. Covers
+    /// top-level free functions and methods inside `Item::Impl` /
+    /// `Item::Trait` blocks, all of which share the `Function` AST shape.
+    /// Interface and resource methods carry a different AST shape
+    /// (`InterfaceMethod`) and are reached through the symbol table
+    /// instead — this accessor returns `None` for them.
+    ///
+    /// Resolution is O(1): the per-module [`AstIndex`] stores each
+    /// function's `(item_idx, [method_idx])` address, so no AST scan
+    /// happens at query time.
+    #[must_use]
+    pub fn function_at(&self, key: &SymbolKey) -> Option<&crate::ast::Function> {
+        use crate::ast_index::FunctionLocation;
+        let module = self.modules.get(&key.module)?;
+        let location = self
+            .ast_indices
+            .get(&key.module)?
+            .function_location(key.ast_id)?;
+        match location {
+            FunctionLocation::Free { item_idx } => match module.items.get(item_idx)? {
+                crate::ast::Item::Function(f) => Some(f),
+                _ => None,
+            },
+            FunctionLocation::Method {
+                item_idx,
+                method_idx,
+            } => match module.items.get(item_idx)? {
+                crate::ast::Item::Impl(b) => b.methods.get(method_idx),
+                crate::ast::Item::Trait(t) => t.methods.get(method_idx),
+                _ => None,
+            },
+        }
+    }
+
     /// Definition location of the symbol identified by `key`.
     ///
     /// Resolves the key to its [`Symbol`], then packages the declaring module,

--- a/wado-compiler/src/synthesis/cm_binding.rs
+++ b/wado-compiler/src/synthesis/cm_binding.rs
@@ -289,16 +289,19 @@ pub fn generate_adapters(mut project: Package) -> Result<Package, String> {
                     }
 
                     // Validate return-type compatibility with the world. The
-                    // export-adapter synthesisers only know three return shapes
-                    // — async (handled by `task return`), `Result<_, _>`, and
-                    // unit — so any other concrete user return type for a
-                    // world export that expects a `Result<_, _>` falls
-                    // through to the general adapter, which would otherwise
-                    // emit a `task-return(disc, ...user_value)` call whose
-                    // arity does not match what the runtime declares. That
-                    // shows up as an opaque "values remaining on stack"
-                    // wasm-validation panic at codegen. Catch the mismatch
-                    // here with a readable diagnostic instead.
+                    // dispatch below routes a `Result<_, _>`-returning world
+                    // export to dedicated adapters for the async, Result, and
+                    // `()` user return shapes; any other user return type
+                    // falls through to `synthesize_general_export_binding`,
+                    // which lowers the user's return value directly into the
+                    // world's task-return slots. When the world expects only
+                    // a discriminant (`Result<(), ()>`, the wasi:cli/command
+                    // shape) but the user supplies, say, `i32`, the general
+                    // adapter emits an extra flat value beyond what the
+                    // runtime declares for task-return — surfacing as an
+                    // opaque "values remaining on stack" wasm-validation
+                    // panic at codegen. Catch the mismatch here with a
+                    // readable diagnostic instead.
                     {
                         let user_func = user_func_rc.borrow();
                         let tt = entry_type_table.borrow();

--- a/wado-compiler/src/synthesis/cm_binding.rs
+++ b/wado-compiler/src/synthesis/cm_binding.rs
@@ -288,6 +288,52 @@ pub fn generate_adapters(mut project: Package) -> Result<Package, String> {
                         }
                     }
 
+                    // Validate return-type compatibility with the world. The
+                    // export-adapter synthesisers only know three return shapes
+                    // — async (handled by `task return`), `Result<_, _>`, and
+                    // unit — so any other concrete user return type for a
+                    // world export that expects a `Result<_, _>` falls
+                    // through to the general adapter, which would otherwise
+                    // emit a `task-return(disc, ...user_value)` call whose
+                    // arity does not match what the runtime declares. That
+                    // shows up as an opaque "values remaining on stack"
+                    // wasm-validation panic at codegen. Catch the mismatch
+                    // here with a readable diagnostic instead.
+                    {
+                        let user_func = user_func_rc.borrow();
+                        let tt = entry_type_table.borrow();
+                        let user_is_unit =
+                            matches!(tt.get(user_func.return_type), ResolvedType::Unit);
+                        let result_name = tt
+                            .compiler_items()
+                            .variant_name(crate::compiler_item::CompilerItem::Result)
+                            .to_string();
+                        let user_is_result = matches!(
+                            tt.get(user_func.return_type),
+                            ResolvedType::GenericInstance { name, .. } if *name == result_name
+                        );
+                        let world_expects_result = matches!(
+                            &export.return_type,
+                            Some(crate::ast::Type::Generic(g)) if g.name == result_name
+                        );
+                        if world_expects_result
+                            && !user_func.is_async
+                            && !user_is_unit
+                            && !user_is_result
+                        {
+                            let user_return_name = tt.type_name(user_func.return_type);
+                            drop(tt);
+                            return Err(format!(
+                                "export function `{}` has return type `{user_return_name}`, \
+                                 but the world expects a `{result_name}<_, _>` (or unit, \
+                                 which is automatically wrapped as `{result_name}<(), _>`). \
+                                 Change the signature to return a `{result_name}` or remove \
+                                 the explicit return type.",
+                                export.name
+                            ));
+                        }
+                    }
+
                     // Check if user function is `export async fn`
                     let is_async_export = {
                         let user_func = user_func_rc.borrow();

--- a/wado-compiler/tests/fixtures/export_return_type_mismatch.wado
+++ b/wado-compiler/tests/fixtures/export_return_type_mismatch.wado
@@ -1,0 +1,18 @@
+// Test: export function return type must match world declaration.
+//
+// The Command world's `run()` is declared `async run() -> result<_, _>` in
+// the bundled `wasi:cli` WIT. A non-async return of `i32` cannot satisfy
+// that contract.
+//
+// Regression test: this previously ICE'd at codegen.rs with
+//   "WIR pipeline generated invalid core Wasm module
+//    Validation error: type mismatch: values remaining on stack at end of block"
+// because the synthesis adapter generated invalid lifting code for the
+// signature mismatch instead of erroring out cleanly.
+
+export fn run() -> i32 {
+    return 42;
+}
+
+__DATA__
+{"compile_error": "export function `run` has return type `i32`, but the world expects"}

--- a/wado-lsp/AGENTS.md
+++ b/wado-lsp/AGENTS.md
@@ -19,6 +19,7 @@ Language service engine for the Wado compiler toolchain.
 | `src/semantic_tokens.rs`    | Semantic token computation (lexer + AST classification). Re-encodes start/length at delta-encode time.                    |
 | `src/definition.rs`         | Go-to-definition via `Cursor::{def_key, def_span}` and a file-path matcher for `use`/`#include` paths                     |
 | `src/hover.rs`              | Hover info; `Cursor::def_symbol` selects the binding, locals render from the AST node, items via `wado_compiler::unparse` |
+| `src/inlay_hints.rs`        | Inlay hints: inferred-type hints on `let` / closure / `for-of` bindings, plus parameter-name hints at call sites          |
 | `src/references.rs`         | Find-references via `Cursor::references_to_def`                                                                           |
 | `src/document_highlight.rs` | Document highlight; Read/Write classification consults `Semantics::is_write_target`                                       |
 | `src/location.rs`           | URI / span helpers for translating compiler `ModuleSource` to LSP URIs                                                    |
@@ -145,7 +146,7 @@ Progress tracker for LSP 3.18 feature kinds. Each item represents a protocol kin
 - [ ] `textDocument/signatureHelp`
 - [ ] `textDocument/documentLink`
 - [ ] `textDocument/codeLens`
-- [ ] `textDocument/inlayHint`
+- [x] `textDocument/inlayHint`
 - [ ] `textDocument/inlineValue`
 - [ ] `textDocument/moniker`
 

--- a/wado-lsp/src/inlay_hints.rs
+++ b/wado-lsp/src/inlay_hints.rs
@@ -24,7 +24,7 @@
 
 use serde::{Deserialize, Serialize};
 use wado_compiler::ast::{
-    self, AstVisitor, ClosureParam, Expr, ForOfStmt, Function, Item, LetStmt, Pattern, Stmt,
+    self, AstVisitor, ClosureParam, Expr, ForOfStmt, Function, LetStmt, Pattern, Stmt,
 };
 use wado_compiler::module_source::ModuleSource;
 use wado_compiler::symbol::{SymbolKey, SymbolKind};
@@ -194,9 +194,10 @@ impl HintCollector<'_> {
     ///    effect method, resource method). [`FunctionSymbol::params`]
     ///    carries the names.
     /// 2. The use→def edge points at an impl method's `AstId`, which the
-    ///    analyzer does not register as a symbol. The owning module's
-    ///    `Item::Impl` list carries the `Function` AST node directly; we
-    ///    read its params from there (self params filtered out).
+    ///    analyzer does not register as a symbol. `Semantics::function_at`
+    ///    looks the `Function` AST node up through the per-module
+    ///    [`AstIndex`] in O(1); we read its params from there (self
+    ///    params filtered out).
     fn callee_param_names(&self, callee: &Expr) -> Option<Vec<String>> {
         let ident = match callee {
             Expr::Ident(i) => i,
@@ -218,19 +219,16 @@ impl HintCollector<'_> {
         {
             return Some(f.params.clone());
         }
-        // Impl methods are not present in the symbol table — fall back
-        // to the AST in the def_key's module.
-        let def_module = self.ctx.sem.modules.get(&def_key.module)?;
-        let func = find_method_by_ast_id(&def_module.items, def_key.ast_id)?;
+        let func = self.ctx.sem.function_at(&def_key)?;
         Some(filter_non_self_param_names(func))
     }
 
     /// Hint parameters for a `MethodCallExpr` (`receiver.method(args)`).
     ///
     /// Impl methods are not present in the symbol table, so the use→def
-    /// edge points at an `AstId` whose declaring module's `Item::Impl`
-    /// list carries the `Function` AST node. Walk that list to find the
-    /// method by `AstId`, then read its `Function::params`.
+    /// edge points at the declaring `Function`'s `AstId`. The per-module
+    /// [`AstIndex`] indexes that mapping so `Semantics::function_at`
+    /// resolves it in O(1).
     fn hint_method_call_args(&mut self, call: &ast::MethodCallExpr) {
         let Some(param_names) = self.method_param_names(call.method_id) else {
             return;
@@ -256,8 +254,7 @@ impl HintCollector<'_> {
             .ctx
             .sem
             .referenced_symbol(&self.key(method_id_at_call))?;
-        let def_module = self.ctx.sem.modules.get(&def_key.module)?;
-        let func = find_method_by_ast_id(&def_module.items, def_key.ast_id)?;
+        let func = self.ctx.sem.function_at(&def_key)?;
         Some(filter_non_self_param_names(func))
     }
 
@@ -267,6 +264,12 @@ impl HintCollector<'_> {
         // resolver flags that as a diagnostic on its own path.
         for (param_name, arg) in param_names.iter().zip(args.iter()) {
             self.push_param_hint(param_name, arg.span());
+        }
+    }
+
+    fn hint_closure_param(&mut self, p: &ClosureParam) {
+        if p.ty.is_none() {
+            self.push_type_hint(p.id, p.name_span);
         }
     }
 }
@@ -282,47 +285,6 @@ fn filter_non_self_param_names(func: &Function) -> Vec<String> {
         .filter(|p| matches!(p.self_kind, ast::SelfKind::None))
         .map(|p| p.name.clone())
         .collect()
-}
-
-/// Find the `Function` AST node whose `id` matches `target`, scanning
-/// every `Item::Impl` / `Item::Trait` / top-level `Item::Function` in
-/// `items`. Effect-interface and resource methods live on
-/// `Item::Interface` / `Item::Resource` (whose method shape is
-/// `InterfaceMethod`, not `Function`) but the analyzer already
-/// registers them as `SymbolKind::Function` entries — callers consult
-/// the symbol table for those and only fall back to this helper for
-/// impl methods on user-defined structs / traits, which the analyzer
-/// does not register as symbols.
-fn find_method_by_ast_id(items: &[Item], target: ast::AstId) -> Option<&Function> {
-    for item in items {
-        match item {
-            Item::Function(f) if f.id == target => return Some(f),
-            Item::Impl(imp) => {
-                for m in &imp.methods {
-                    if m.id == target {
-                        return Some(m);
-                    }
-                }
-            }
-            Item::Trait(t) => {
-                for m in &t.methods {
-                    if m.id == target {
-                        return Some(m);
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
-    None
-}
-
-impl HintCollector<'_> {
-    fn hint_closure_param(&mut self, p: &ClosureParam) {
-        if p.ty.is_none() {
-            self.push_type_hint(p.id, p.name_span);
-        }
-    }
 }
 
 impl AstVisitor for HintCollector<'_> {

--- a/wado-lsp/src/inlay_hints.rs
+++ b/wado-lsp/src/inlay_hints.rs
@@ -6,13 +6,13 @@
 //! 1. **Type hints** on `let` patterns, closure parameters, and `for x of …`
 //!    bindings that lack an explicit `: T` annotation. Tuple / struct /
 //!    variant / or-patterns recurse into their leaves so each bound
-//!    identifier hints with the resolver's inferred type for that leaf.
+//!    identifier hints with the elaborator's inferred type for that leaf.
 //!    Types come from [`Semantics::local_type_name`], populated by the
-//!    resolver via `record_local_symbol`.
+//!    elaborator via `record_local_symbol`.
 //! 2. **Parameter-name hints** at free-function call sites. The callee's
 //!    `FunctionSymbol::params` (set up by the analyzer) drives the labels.
 //! 3. **Parameter-name hints at method / static-method call sites.** The
-//!    callee's `Function` AST node is reached by following the resolver's
+//!    callee's `Function` AST node is reached by following the elaborator's
 //!    use→def edge from the method-name token's `AstId` to the declaring
 //!    impl method, then reading `Function::params` directly from the AST.
 //!    Impl methods are not registered in the symbol table, so the AST is
@@ -117,9 +117,9 @@ impl HintCollector<'_> {
     }
 
     /// Emit a `: T` hint anchored at the end of `name_span` for a binding
-    /// identified by `binding_id`. No-op when the resolver did not record a
+    /// identified by `binding_id`. No-op when the elaborator did not record a
     /// type for `binding_id` (e.g. the binding sits inside a function whose
-    /// body the resolver bailed on).
+    /// body the elaborator bailed on).
     fn push_type_hint(&mut self, binding_id: ast::AstId, name_span: Span) {
         let Some(type_name) = self.ctx.sem.local_type_name(&self.key(binding_id)) else {
             return;
@@ -146,7 +146,7 @@ impl HintCollector<'_> {
 
     /// Emit a type hint for every `Ident` / `MutIdent` leaf reachable
     /// from `pattern`. Tuple / struct / variant / or-patterns recurse
-    /// into their sub-patterns; the resolver records a `local_type` for
+    /// into their sub-patterns; the elaborator records a `local_type` for
     /// each leaf binding via `record_local_symbol`, so each leaf can
     /// hint independently. Literal and wildcard leaves bind nothing
     /// and have no type to surface.
@@ -237,7 +237,7 @@ impl HintCollector<'_> {
     }
 
     /// Hint parameters for a `StaticMethodCallExpr` (`Type::method(args)`).
-    /// Same resolution as `hint_method_call_args` — the resolver records
+    /// Same resolution as `hint_method_call_args` — the elaborator records
     /// the same use→def edge for both call shapes.
     fn hint_static_method_call_args(&mut self, call: &ast::StaticMethodCallExpr) {
         let Some(param_names) = self.method_param_names(call.method_id) else {
@@ -261,7 +261,7 @@ impl HintCollector<'_> {
     fn emit_arg_param_hints(&mut self, param_names: &[String], args: &[Expr]) {
         // Align positional args with their parameter names. An arity
         // mismatch (more args than params) terminates the loop early; the
-        // resolver flags that as a diagnostic on its own path.
+        // elaborator flags that as a diagnostic on its own path.
         for (param_name, arg) in param_names.iter().zip(args.iter()) {
             self.push_param_hint(param_name, arg.span());
         }
@@ -651,7 +651,7 @@ mod tests {
     #[test]
     fn struct_destructure_let_hints_each_field_binding() {
         // `let { x, y } = p;` binds two locals — `x` and `y` — each
-        // with a resolver-recorded type (the struct field's type). The
+        // with a elaborator-recorded type (the struct field's type). The
         // pattern walker recurses into the struct sub-patterns and
         // emits a hint per leaf.
         block_on(async {
@@ -807,7 +807,7 @@ mod tests {
     #[test]
     fn closure_stored_in_local_does_not_yield_param_hints_on_call() {
         // Calling a closure via its binding (`g(1)`) routes through the
-        // resolver's local-variable path; the use→def edge points at the
+        // elaborator's local-variable path; the use→def edge points at the
         // `let g = …` pattern, not at a function symbol. We must not
         // accidentally try to read params off a `Variable` symbol and
         // emit garbage hints.

--- a/wado-lsp/src/inlay_hints.rs
+++ b/wado-lsp/src/inlay_hints.rs
@@ -24,7 +24,7 @@
 
 use serde::{Deserialize, Serialize};
 use wado_compiler::ast::{
-    self, AstVisitor, Block, ClosureParam, Expr, ForOfStmt, Function, Item, LetStmt, Pattern, Stmt,
+    self, AstVisitor, ClosureParam, Expr, ForOfStmt, Function, Item, LetStmt, Pattern, Stmt,
 };
 use wado_compiler::module_source::ModuleSource;
 use wado_compiler::symbol::{SymbolKey, SymbolKind};
@@ -286,9 +286,13 @@ fn filter_non_self_param_names(func: &Function) -> Vec<String> {
 
 /// Find the `Function` AST node whose `id` matches `target`, scanning
 /// every `Item::Impl` / `Item::Trait` / top-level `Item::Function` in
-/// `items`. Returns `None` when no match exists — synthesised methods
-/// (e.g. `Iterator::next` synthesised for `for-of`) carry no source
-/// `AstId` and therefore fall here.
+/// `items`. Effect-interface and resource methods live on
+/// `Item::Interface` / `Item::Resource` (whose method shape is
+/// `InterfaceMethod`, not `Function`) but the analyzer already
+/// registers them as `SymbolKind::Function` entries — callers consult
+/// the symbol table for those and only fall back to this helper for
+/// impl methods on user-defined structs / traits, which the analyzer
+/// does not register as symbols.
 fn find_method_by_ast_id(items: &[Item], target: ast::AstId) -> Option<&Function> {
     for item in items {
         match item {
@@ -311,6 +315,14 @@ fn find_method_by_ast_id(items: &[Item], target: ast::AstId) -> Option<&Function
         }
     }
     None
+}
+
+impl HintCollector<'_> {
+    fn hint_closure_param(&mut self, p: &ClosureParam) {
+        if p.ty.is_none() {
+            self.push_type_hint(p.id, p.name_span);
+        }
+    }
 }
 
 impl AstVisitor for HintCollector<'_> {
@@ -365,18 +377,6 @@ impl AstVisitor for HintCollector<'_> {
                 ast::walk_expr(self, expr);
             }
             _ => ast::walk_expr(self, expr),
-        }
-    }
-
-    fn visit_block(&mut self, block: &Block) {
-        ast::walk_block(self, block);
-    }
-}
-
-impl HintCollector<'_> {
-    fn hint_closure_param(&mut self, p: &ClosureParam) {
-        if p.ty.is_none() {
-            self.push_type_hint(p.id, p.name_span);
         }
     }
 }

--- a/wado-lsp/src/inlay_hints.rs
+++ b/wado-lsp/src/inlay_hints.rs
@@ -4,13 +4,13 @@
 //! Three kinds of hints are produced:
 //!
 //! 1. **Type hints** on `let` patterns, closure parameters, and `for x of …`
-//!    bindings that lack an explicit `: T` annotation. The inferred type
-//!    is pulled from [`Semantics::local_type_name`], populated by the
+//!    bindings that lack an explicit `: T` annotation. Tuple / struct /
+//!    variant / or-patterns recurse into their leaves so each bound
+//!    identifier hints with the resolver's inferred type for that leaf.
+//!    Types come from [`Semantics::local_type_name`], populated by the
 //!    resolver via `record_local_symbol`.
 //! 2. **Parameter-name hints** at free-function call sites. The callee's
-//!    `FunctionSymbol::params` (set up by the analyzer) drives the labels;
-//!    redundant labels (argument is a bare identifier whose name matches
-//!    the parameter) are suppressed to keep the editor noise-free.
+//!    `FunctionSymbol::params` (set up by the analyzer) drives the labels.
 //! 3. **Parameter-name hints at method / static-method call sites.** The
 //!    callee's `Function` AST node is reached by following the resolver's
 //!    use→def edge from the method-name token's `AstId` to the declaring
@@ -124,12 +124,6 @@ impl HintCollector<'_> {
         let Some(type_name) = self.ctx.sem.local_type_name(&self.key(binding_id)) else {
             return;
         };
-        // Resolver-internal sentinels surface as `unknown` / `error`; never
-        // render them — the user is better served by no hint than by a
-        // misleading one.
-        if matches!(type_name.as_str(), "unknown" | "error") {
-            return;
-        }
         self.hints.push(InlayHint {
             position: self.position_after(name_span),
             label: format!(": {type_name}"),
@@ -150,31 +144,41 @@ impl HintCollector<'_> {
         });
     }
 
-    /// Walk the `Pattern::Ident` (or `Pattern::MutIdent`) leaves of `pattern`
-    /// and emit a type hint per leaf. Other pattern shapes (tuple,
-    /// struct, variant) are skipped — destructuring patterns already
-    /// expose the structural type in source.
+    /// Emit a type hint for every `Ident` / `MutIdent` leaf reachable
+    /// from `pattern`. Tuple / struct / variant / or-patterns recurse
+    /// into their sub-patterns; the resolver records a `local_type` for
+    /// each leaf binding via `record_local_symbol`, so each leaf can
+    /// hint independently. Literal and wildcard leaves bind nothing
+    /// and have no type to surface.
     fn hint_pattern_bindings(&mut self, pattern: &Pattern) {
         match pattern {
             Pattern::Ident { id, span, .. } | Pattern::MutIdent { id, span, .. } => {
                 self.push_type_hint(*id, *span);
             }
-            // Destructuring patterns: skip — the visible structure already
-            // tells the user the type. Nested simple bindings inside a
-            // tuple/struct pattern lose useful context when annotated
-            // standalone (the element-type is meaningful only against the
-            // outer shape), so we keep the rule "only annotate top-level
-            // simple bindings".
-            _ => {}
+            Pattern::Tuple(sub_patterns, _) | Pattern::Or(sub_patterns) => {
+                for p in sub_patterns {
+                    self.hint_pattern_bindings(p);
+                }
+            }
+            Pattern::Struct { fields, .. } => {
+                for field in fields {
+                    self.hint_pattern_bindings(&field.pattern);
+                }
+            }
+            Pattern::Variant { bindings, .. } => {
+                for p in bindings {
+                    self.hint_pattern_bindings(p);
+                }
+            }
+            Pattern::Range { .. } | Pattern::Literal(_) | Pattern::Wildcard => {}
         }
     }
 
     /// Hint parameters for a `CallExpr`. Resolves the callee identifier
     /// through `Semantics::referenced_symbol` and reads the parameter
-    /// names off the callee's `FunctionSymbol`. Returns silently for
-    /// callees that do not resolve to a function symbol (e.g. closures
-    /// stored in locals, method-receiver expressions, variant
-    /// constructors).
+    /// names off the callee's `FunctionSymbol` (or, for impl methods
+    /// that the analyzer does not register as symbols, the declaring
+    /// `Function` AST node).
     fn hint_call_args(&mut self, call: &ast::CallExpr) {
         let Some(param_names) = self.callee_param_names(&call.callee) else {
             return;
@@ -258,27 +262,10 @@ impl HintCollector<'_> {
     }
 
     fn emit_arg_param_hints(&mut self, param_names: &[String], args: &[Expr]) {
-        for (i, arg) in args.iter().enumerate() {
-            let Some(param_name) = param_names.get(i) else {
-                // Variadic / over-supplied call; skip the surplus rather
-                // than panicking. The resolver will flag the arity
-                // mismatch as a diagnostic on its own path.
-                break;
-            };
-            // Compiler-generated parameter names ("`_`", "`_unused`",
-            // resolver synth temporaries) provide no useful hint.
-            if param_name.is_empty() || param_name == "_" {
-                continue;
-            }
-            // Suppress the hint when the argument is a bare identifier
-            // already named after the parameter — the editor would just
-            // render `a: a`, which is pure noise.
-            if let Expr::Ident(i) = arg
-                && i.segments.is_empty()
-                && i.name == *param_name
-            {
-                continue;
-            }
+        // Align positional args with their parameter names. An arity
+        // mismatch (more args than params) terminates the loop early; the
+        // resolver flags that as a diagnostic on its own path.
+        for (param_name, arg) in param_names.iter().zip(args.iter()) {
             self.push_param_hint(param_name, arg.span());
         }
     }
@@ -532,7 +519,7 @@ mod tests {
     }
 
     #[test]
-    fn parameter_hint_suppressed_when_arg_name_matches_param() {
+    fn parameter_hint_emitted_even_when_arg_name_matches_param() {
         block_on(async {
             let src = concat!(
                 "fn add(a: i32, b: i32) -> i32 { return a + b; }\n",
@@ -549,8 +536,9 @@ mod tests {
                 .map(|(l, _)| l)
                 .collect();
             assert!(
-                param_labels.is_empty(),
-                "expected no `a:`/`b:` hints when the argument name matches; got {param_labels:?}",
+                param_labels.contains(&"a:".to_string())
+                    && param_labels.contains(&"b:".to_string()),
+                "expected `a:`/`b:` parameter hints at `add(a, b)`; got {param_labels:?}",
             );
         });
     }
@@ -699,31 +687,32 @@ mod tests {
     }
 
     #[test]
-    fn tuple_destructure_let_emits_no_top_level_hint() {
-        // Destructuring patterns already make the structure visible in
-        // source, so the hint adds noise (and would have to render a
-        // tuple-of-types which the user usually didn't ask for).
-        // Pin the "skip" behaviour — a future change must opt in
-        // explicitly rather than emit by accident.
+    fn struct_destructure_let_hints_each_field_binding() {
+        // `let { x, y } = p;` binds two locals — `x` and `y` — each
+        // with a resolver-recorded type (the struct field's type). The
+        // pattern walker recurses into the struct sub-patterns and
+        // emits a hint per leaf.
         block_on(async {
             let src = concat!(
-                "fn f() -> i32 {\n",
-                "    let pair = (1, 2);\n",
-                "    let (a, b) = pair;\n",
-                "    return a + b;\n",
+                "struct Point { x: i32, y: i32 }\n",
+                "fn f(p: Point) -> i32 {\n",
+                "    let { x, y } = p;\n",
+                "    return x + y;\n",
                 "}\n",
             );
             let hints = hints_for(src).await;
-            // The `let pair = ...` line still hints (it's a simple
-            // binding). What we forbid is a hint on the `(a, b)` pattern
-            // line itself.
-            let line_2_type_hints: Vec<_> = hints
+            // Both `x` and `y` are bound on line 2; assert at least two
+            // `: i32` type hints land there.
+            let line_2_i32: Vec<_> = hints
                 .iter()
-                .filter(|h| h.kind == InlayHintKind::Type && h.position.line == 2)
+                .filter(|h| {
+                    h.kind == InlayHintKind::Type && h.position.line == 2 && h.label == ": i32"
+                })
                 .collect();
-            assert!(
-                line_2_type_hints.is_empty(),
-                "destructure pattern must not produce a type hint; got {line_2_type_hints:?}",
+            assert_eq!(
+                line_2_i32.len(),
+                2,
+                "expected two `: i32` hints for `let {{ x, y }} = p`; got {hints:?}",
             );
         });
     }
@@ -782,11 +771,11 @@ mod tests {
     }
 
     #[test]
-    fn parameter_hint_skipped_for_compiler_generated_underscore_names() {
-        // Compiler intrinsics may carry `_`-named parameters (or empty
-        // names for purely positional slots). Surfacing `:_` next to a
-        // user-supplied argument would be confusing noise; assert we
-        // suppress it instead of leaking the placeholder.
+    fn parameter_hint_emitted_for_underscore_param_name() {
+        // `_` is the actual parameter name the user wrote on the callee
+        // (`fn discard(_: i32)`). The hint surfaces that name verbatim
+        // at the call site — pin that we forward it rather than filter
+        // anything.
         block_on(async {
             let src = concat!("fn discard(_: i32) {}\n", "fn run() { discard(7); }\n",);
             let hints = hints_for(src).await;
@@ -796,8 +785,8 @@ mod tests {
                 .map(|(l, _)| l)
                 .collect();
             assert!(
-                !param_labels.iter().any(|l| l == "_:"),
-                "underscore param must not produce a `_:` hint; got {param_labels:?}",
+                param_labels.contains(&"_:".to_string()),
+                "underscore param should still produce a `_:` hint; got {param_labels:?}",
             );
         });
     }

--- a/wado-lsp/src/inlay_hints.rs
+++ b/wado-lsp/src/inlay_hints.rs
@@ -1,0 +1,681 @@
+//! Inlay hints — inline annotations rendered next to source positions to
+//! surface types and parameter names the user did not write.
+//!
+//! Three kinds of hints are produced:
+//!
+//! 1. **Type hints** on `let` patterns, closure parameters, and `for x of …`
+//!    bindings that lack an explicit `: T` annotation. The inferred type
+//!    is pulled from [`Semantics::local_type_name`], populated by the
+//!    resolver via `record_local_symbol`.
+//! 2. **Parameter-name hints** at free-function call sites. The callee's
+//!    `FunctionSymbol::params` (set up by the analyzer) drives the labels;
+//!    redundant labels (argument is a bare identifier whose name matches
+//!    the parameter) are suppressed to keep the editor noise-free.
+//! 3. **Parameter-name hints at method / static-method call sites.** The
+//!    callee's `Function` AST node is reached by following the resolver's
+//!    use→def edge from the method-name token's `AstId` to the declaring
+//!    impl method, then reading `Function::params` directly from the AST.
+//!    Impl methods are not registered in the symbol table, so the AST is
+//!    the source of truth here.
+//!
+//! All hint positions are produced as `Position`s in the LSP-negotiated
+//! [`PositionEncoding`]. Hints whose anchor falls outside the requested
+//! `range` are filtered out at the end of [`inlay_hints`].
+
+use serde::{Deserialize, Serialize};
+use wado_compiler::ast::{
+    self, AstVisitor, Block, ClosureParam, Expr, ForOfStmt, Function, Item, LetStmt, Pattern, Stmt,
+};
+use wado_compiler::module_source::ModuleSource;
+use wado_compiler::symbol::{SymbolKey, SymbolKind};
+use wado_compiler::token::Span;
+
+use crate::diagnostics::{Position, Range};
+use crate::macros::lsp_repr_u32_enum;
+use crate::query::QueryContext;
+use crate::text::codepoint_offset_to_character;
+
+lsp_repr_u32_enum!(
+    /// LSP inlay-hint kind. Serializes as the wire integer.
+    pub enum InlayHintKind {
+        Type = 1,
+        Parameter = 2,
+    }
+);
+
+/// An inlay hint produced for the requesting document.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InlayHint {
+    pub position: Position,
+    pub label: String,
+    pub kind: InlayHintKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub padding_left: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub padding_right: Option<bool>,
+}
+
+/// Compute inlay hints for the entry module of `ctx`.
+///
+/// Hints anchored outside the requested `range` are dropped so the LSP
+/// client only renders what is currently visible. The implementation
+/// walks the entry-module AST once via [`AstVisitor`]; per-hint work is
+/// `O(1)` (symbol-table lookup) for free functions and `O(impls in
+/// module)` for methods.
+#[must_use]
+pub(crate) fn inlay_hints(ctx: &QueryContext, range: Range) -> Vec<InlayHint> {
+    let entry = ctx.entry();
+    let Some(module) = ctx.sem.modules.get(entry) else {
+        return Vec::new();
+    };
+    let mut collector = HintCollector {
+        ctx,
+        module_source: entry,
+        hints: Vec::new(),
+    };
+    for item in &module.items {
+        collector.visit_item(item);
+    }
+    let HintCollector { hints, .. } = collector;
+    hints.into_iter().filter(|h| in_range(h, range)).collect()
+}
+
+fn in_range(hint: &InlayHint, range: Range) -> bool {
+    let pos = hint.position;
+    let after_start = (pos.line, pos.character) >= (range.start.line, range.start.character);
+    let before_end = (pos.line, pos.character) <= (range.end.line, range.end.character);
+    after_start && before_end
+}
+
+struct HintCollector<'a> {
+    ctx: &'a QueryContext<'a>,
+    module_source: &'a ModuleSource,
+    hints: Vec<InlayHint>,
+}
+
+impl HintCollector<'_> {
+    fn key(&self, ast_id: ast::AstId) -> SymbolKey {
+        SymbolKey::new(self.module_source.clone(), ast_id)
+    }
+
+    /// Position immediately after `span` ends — where a `: T` label is anchored.
+    fn position_after(&self, span: Span) -> Position {
+        let line = span.end_line.saturating_sub(1) as u32;
+        let codepoint_col = span.end_column.saturating_sub(1) as u32;
+        let character =
+            codepoint_offset_to_character(self.ctx.source, line, codepoint_col, self.ctx.encoding);
+        Position { line, character }
+    }
+
+    /// Position at the start of `span` — where a `name:` parameter label is anchored.
+    fn position_before(&self, span: Span) -> Position {
+        let line = span.line.saturating_sub(1) as u32;
+        let codepoint_col = span.column.saturating_sub(1) as u32;
+        let character =
+            codepoint_offset_to_character(self.ctx.source, line, codepoint_col, self.ctx.encoding);
+        Position { line, character }
+    }
+
+    /// Emit a `: T` hint anchored at the end of `name_span` for a binding
+    /// identified by `binding_id`. No-op when the resolver did not record a
+    /// type for `binding_id` (e.g. the binding sits inside a function whose
+    /// body the resolver bailed on).
+    fn push_type_hint(&mut self, binding_id: ast::AstId, name_span: Span) {
+        let Some(type_name) = self.ctx.sem.local_type_name(&self.key(binding_id)) else {
+            return;
+        };
+        // Resolver-internal sentinels surface as `unknown` / `error`; never
+        // render them — the user is better served by no hint than by a
+        // misleading one.
+        if matches!(type_name.as_str(), "unknown" | "error") {
+            return;
+        }
+        self.hints.push(InlayHint {
+            position: self.position_after(name_span),
+            label: format!(": {type_name}"),
+            kind: InlayHintKind::Type,
+            padding_left: None,
+            padding_right: None,
+        });
+    }
+
+    /// Emit a `name:` parameter-name hint anchored at the start of `arg_span`.
+    fn push_param_hint(&mut self, param_name: &str, arg_span: Span) {
+        self.hints.push(InlayHint {
+            position: self.position_before(arg_span),
+            label: format!("{param_name}:"),
+            kind: InlayHintKind::Parameter,
+            padding_left: None,
+            padding_right: Some(true),
+        });
+    }
+
+    /// Walk the `Pattern::Ident` (or `Pattern::MutIdent`) leaves of `pattern`
+    /// and emit a type hint per leaf. Other pattern shapes (tuple,
+    /// struct, variant) are skipped — destructuring patterns already
+    /// expose the structural type in source.
+    fn hint_pattern_bindings(&mut self, pattern: &Pattern) {
+        match pattern {
+            Pattern::Ident { id, span, .. } | Pattern::MutIdent { id, span, .. } => {
+                self.push_type_hint(*id, *span);
+            }
+            // Destructuring patterns: skip — the visible structure already
+            // tells the user the type. Nested simple bindings inside a
+            // tuple/struct pattern lose useful context when annotated
+            // standalone (the element-type is meaningful only against the
+            // outer shape), so we keep the rule "only annotate top-level
+            // simple bindings".
+            _ => {}
+        }
+    }
+
+    /// Hint parameters for a `CallExpr`. Resolves the callee identifier
+    /// through `Semantics::referenced_symbol` and reads the parameter
+    /// names off the callee's `FunctionSymbol`. Returns silently for
+    /// callees that do not resolve to a function symbol (e.g. closures
+    /// stored in locals, method-receiver expressions, variant
+    /// constructors).
+    fn hint_call_args(&mut self, call: &ast::CallExpr) {
+        let Some(param_names) = self.callee_param_names(&call.callee) else {
+            return;
+        };
+        self.emit_arg_param_hints(&param_names, &call.args);
+    }
+
+    /// Parameter names of the function that `callee` resolves to, or
+    /// `None` if the callee does not name a known callable.
+    ///
+    /// Two routes are tried, in order:
+    /// 1. The use→def edge points at a symbol-table entry (free function,
+    ///    effect method, resource method). [`FunctionSymbol::params`]
+    ///    carries the names.
+    /// 2. The use→def edge points at an impl method's `AstId`, which the
+    ///    analyzer does not register as a symbol. The owning module's
+    ///    `Item::Impl` list carries the `Function` AST node directly; we
+    ///    read its params from there (self params filtered out).
+    fn callee_param_names(&self, callee: &Expr) -> Option<Vec<String>> {
+        let ident = match callee {
+            Expr::Ident(i) => i,
+            _ => return None,
+        };
+        // The use→def edge is keyed on the `IdentExpr` id for bare paths
+        // (`add`) and on the trailing path segment id for qualified paths
+        // (`Point::at`, `ns::add`). Try both, preferring the segment when
+        // the path is qualified — that matches how `resolve_ident` /
+        // `resolve_call` record the edge.
+        let trailing_id = ident.segments.last().map_or(ident.id, |seg| seg.id);
+        let def_key = self
+            .ctx
+            .sem
+            .referenced_symbol(&self.key(trailing_id))
+            .or_else(|| self.ctx.sem.referenced_symbol(&self.key(ident.id)))?;
+        if let Some(symbol) = self.ctx.sem.symbol_at(&def_key)
+            && let SymbolKind::Function(f) = &symbol.kind
+        {
+            return Some(f.params.clone());
+        }
+        // Impl methods are not present in the symbol table — fall back
+        // to the AST in the def_key's module.
+        let def_module = self.ctx.sem.modules.get(&def_key.module)?;
+        let func = find_method_by_ast_id(&def_module.items, def_key.ast_id)?;
+        Some(filter_non_self_param_names(func))
+    }
+
+    /// Hint parameters for a `MethodCallExpr` (`receiver.method(args)`).
+    ///
+    /// Impl methods are not present in the symbol table, so the use→def
+    /// edge points at an `AstId` whose declaring module's `Item::Impl`
+    /// list carries the `Function` AST node. Walk that list to find the
+    /// method by `AstId`, then read its `Function::params`.
+    fn hint_method_call_args(&mut self, call: &ast::MethodCallExpr) {
+        let Some(param_names) = self.method_param_names(call.method_id) else {
+            return;
+        };
+        self.emit_arg_param_hints(&param_names, &call.args);
+    }
+
+    /// Hint parameters for a `StaticMethodCallExpr` (`Type::method(args)`).
+    /// Same resolution as `hint_method_call_args` — the resolver records
+    /// the same use→def edge for both call shapes.
+    fn hint_static_method_call_args(&mut self, call: &ast::StaticMethodCallExpr) {
+        let Some(param_names) = self.method_param_names(call.method_id) else {
+            return;
+        };
+        self.emit_arg_param_hints(&param_names, &call.args);
+    }
+
+    /// Parameter names of the impl/trait method whose declaration `AstId`
+    /// is the use→def target of `method_id_at_call`. Returns `None` for
+    /// synthetic / unresolved call sites.
+    fn method_param_names(&self, method_id_at_call: ast::AstId) -> Option<Vec<String>> {
+        let def_key = self
+            .ctx
+            .sem
+            .referenced_symbol(&self.key(method_id_at_call))?;
+        let def_module = self.ctx.sem.modules.get(&def_key.module)?;
+        let func = find_method_by_ast_id(&def_module.items, def_key.ast_id)?;
+        Some(filter_non_self_param_names(func))
+    }
+
+    fn emit_arg_param_hints(&mut self, param_names: &[String], args: &[Expr]) {
+        for (i, arg) in args.iter().enumerate() {
+            let Some(param_name) = param_names.get(i) else {
+                // Variadic / over-supplied call; skip the surplus rather
+                // than panicking. The resolver will flag the arity
+                // mismatch as a diagnostic on its own path.
+                break;
+            };
+            // Compiler-generated parameter names ("`_`", "`_unused`",
+            // resolver synth temporaries) provide no useful hint.
+            if param_name.is_empty() || param_name == "_" {
+                continue;
+            }
+            // Suppress the hint when the argument is a bare identifier
+            // already named after the parameter — the editor would just
+            // render `a: a`, which is pure noise.
+            if let Expr::Ident(i) = arg
+                && i.segments.is_empty()
+                && i.name == *param_name
+            {
+                continue;
+            }
+            self.push_param_hint(param_name, arg.span());
+        }
+    }
+}
+
+/// Parameter names of `func` with self params filtered out.
+///
+/// `&self` / `&mut self` are surfaced as `SelfKind::Ref` / `SelfKind::MutRef`
+/// by the parser; only `SelfKind::None` params can ever appear as positional
+/// call arguments.
+fn filter_non_self_param_names(func: &Function) -> Vec<String> {
+    func.params
+        .iter()
+        .filter(|p| matches!(p.self_kind, ast::SelfKind::None))
+        .map(|p| p.name.clone())
+        .collect()
+}
+
+/// Find the `Function` AST node whose `id` matches `target`, scanning
+/// every `Item::Impl` / `Item::Trait` / top-level `Item::Function` in
+/// `items`. Returns `None` when no match exists — synthesised methods
+/// (e.g. `Iterator::next` synthesised for `for-of`) carry no source
+/// `AstId` and therefore fall here.
+fn find_method_by_ast_id(items: &[Item], target: ast::AstId) -> Option<&Function> {
+    for item in items {
+        match item {
+            Item::Function(f) if f.id == target => return Some(f),
+            Item::Impl(imp) => {
+                for m in &imp.methods {
+                    if m.id == target {
+                        return Some(m);
+                    }
+                }
+            }
+            Item::Trait(t) => {
+                for m in &t.methods {
+                    if m.id == target {
+                        return Some(m);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+impl AstVisitor for HintCollector<'_> {
+    fn visit_stmt(&mut self, stmt: &Stmt) {
+        match stmt {
+            Stmt::Let(LetStmt {
+                pattern, ty, value, ..
+            }) => {
+                // Only hint when the user did not annotate the binding.
+                if ty.is_none() {
+                    self.hint_pattern_bindings(pattern);
+                }
+                // Still walk the initializer for hints inside it.
+                if let Some(v) = value {
+                    self.visit_expr(v);
+                }
+            }
+            Stmt::ForOf(ForOfStmt {
+                binding,
+                iterable,
+                body,
+                ..
+            }) => {
+                // `for x of items` has no `: T` annotation slot, so every
+                // simple binding gets a hint.
+                self.hint_pattern_bindings(binding);
+                self.visit_expr(iterable);
+                self.visit_block(body);
+            }
+            _ => ast::walk_stmt(self, stmt),
+        }
+    }
+
+    fn visit_expr(&mut self, expr: &Expr) {
+        match expr {
+            Expr::Closure(c) => {
+                for p in &c.params {
+                    self.hint_closure_param(p);
+                }
+                self.visit_expr(&c.body);
+            }
+            Expr::Call(c) => {
+                self.hint_call_args(c);
+                ast::walk_expr(self, expr);
+            }
+            Expr::MethodCall(m) => {
+                self.hint_method_call_args(m);
+                ast::walk_expr(self, expr);
+            }
+            Expr::StaticMethodCall(s) => {
+                self.hint_static_method_call_args(s);
+                ast::walk_expr(self, expr);
+            }
+            _ => ast::walk_expr(self, expr),
+        }
+    }
+
+    fn visit_block(&mut self, block: &Block) {
+        ast::walk_block(self, block);
+    }
+}
+
+impl HintCollector<'_> {
+    fn hint_closure_param(&mut self, p: &ClosureParam) {
+        if p.ty.is_none() {
+            self.push_type_hint(p.id, p.name_span);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::MapHost;
+    use crate::text::PositionEncoding;
+    use futures::executor::block_on;
+
+    async fn hints_for(source: &str) -> Vec<InlayHint> {
+        let path = "/test.wado";
+        let uri = format!("file://{path}");
+        let host = MapHost::single(path, source);
+        let sem = wado_compiler::semantics(source, &host, Some(path)).await;
+        let ctx = QueryContext {
+            sem: &sem,
+            source,
+            uri: &uri,
+            encoding: PositionEncoding::Utf16,
+        };
+        let max_range = Range {
+            start: Position {
+                line: 0,
+                character: 0,
+            },
+            end: Position {
+                line: u32::MAX,
+                character: u32::MAX,
+            },
+        };
+        inlay_hints(&ctx, max_range)
+    }
+
+    /// Sugar: collect (label, kind) pairs for assertions that don't care about positions.
+    fn labels(hints: &[InlayHint]) -> Vec<(String, InlayHintKind)> {
+        hints.iter().map(|h| (h.label.clone(), h.kind)).collect()
+    }
+
+    #[test]
+    fn let_without_annotation_emits_type_hint() {
+        block_on(async {
+            let src = "fn f() -> i32 {\n    let x = 1;\n    return x;\n}\n";
+            let hints = hints_for(src).await;
+            assert!(
+                hints
+                    .iter()
+                    .any(|h| h.label == ": i32" && h.kind == InlayHintKind::Type),
+                "expected a `: i32` type hint for `let x = 1`; got {hints:?}",
+            );
+        });
+    }
+
+    #[test]
+    fn let_with_annotation_emits_no_type_hint() {
+        block_on(async {
+            let src = "fn f() -> i32 {\n    let x: i32 = 1;\n    return x;\n}\n";
+            let hints = hints_for(src).await;
+            assert!(
+                !hints
+                    .iter()
+                    .any(|h| h.kind == InlayHintKind::Type && h.label == ": i32"),
+                "annotated `let x: i32` must not produce a redundant type hint; got {hints:?}",
+            );
+        });
+    }
+
+    #[test]
+    fn closure_param_without_annotation_emits_type_hint() {
+        block_on(async {
+            let src = concat!(
+                "fn f() -> i32 {\n",
+                "    let g = |x| x + 1;\n",
+                "    return g(1);\n",
+                "}\n",
+            );
+            let hints = hints_for(src).await;
+            // The closure body uses x + 1, which through default integer
+            // resolution gives x: i32. The exact type depends on inference
+            // — we just want some `: i32`-ish hint anchored at the closure
+            // param.
+            let closure_hints: Vec<_> = hints
+                .iter()
+                .filter(|h| h.kind == InlayHintKind::Type && h.position.line == 1)
+                .collect();
+            assert!(
+                !closure_hints.is_empty(),
+                "expected a closure-param type hint on line 1; got {hints:?}",
+            );
+        });
+    }
+
+    #[test]
+    fn for_of_binding_emits_type_hint() {
+        block_on(async {
+            let src = concat!(
+                "fn f() -> i32 {\n",
+                "    let items: Array<i32> = [1, 2, 3];\n",
+                "    let mut total: i32 = 0;\n",
+                "    for let v of items {\n",
+                "        total = total + v;\n",
+                "    }\n",
+                "    return total;\n",
+                "}\n",
+            );
+            let hints = hints_for(src).await;
+            assert!(
+                hints
+                    .iter()
+                    .any(|h| h.kind == InlayHintKind::Type && h.label == ": i32"),
+                "expected `: i32` element-type hint on `for v of items`; got {hints:?}",
+            );
+        });
+    }
+
+    #[test]
+    fn free_function_call_emits_parameter_name_hints() {
+        block_on(async {
+            let src = concat!(
+                "fn add(a: i32, b: i32) -> i32 {\n",
+                "    return a + b;\n",
+                "}\n",
+                "fn run() -> i32 {\n",
+                "    return add(1, 2);\n",
+                "}\n",
+            );
+            let hints = hints_for(src).await;
+            let param_labels: Vec<_> = labels(&hints)
+                .into_iter()
+                .filter(|(_, k)| *k == InlayHintKind::Parameter)
+                .map(|(l, _)| l)
+                .collect();
+            assert!(
+                param_labels.contains(&"a:".to_string())
+                    && param_labels.contains(&"b:".to_string()),
+                "expected `a:` and `b:` parameter hints at `add(1, 2)`; got {param_labels:?}",
+            );
+        });
+    }
+
+    #[test]
+    fn parameter_hint_suppressed_when_arg_name_matches_param() {
+        block_on(async {
+            let src = concat!(
+                "fn add(a: i32, b: i32) -> i32 { return a + b; }\n",
+                "fn run() -> i32 {\n",
+                "    let a: i32 = 1;\n",
+                "    let b: i32 = 2;\n",
+                "    return add(a, b);\n",
+                "}\n",
+            );
+            let hints = hints_for(src).await;
+            let param_labels: Vec<_> = labels(&hints)
+                .into_iter()
+                .filter(|(_, k)| *k == InlayHintKind::Parameter)
+                .map(|(l, _)| l)
+                .collect();
+            assert!(
+                param_labels.is_empty(),
+                "expected no `a:`/`b:` hints when the argument name matches; got {param_labels:?}",
+            );
+        });
+    }
+
+    #[test]
+    fn range_filtering_drops_hints_outside_window() {
+        block_on(async {
+            let src = "fn f() -> i32 {\n    let x = 1;\n    let y = 2;\n    return x + y;\n}\n";
+            let path = "/test.wado";
+            let uri = format!("file://{path}");
+            let host = MapHost::single(path, src);
+            let sem = wado_compiler::semantics(src, &host, Some(path)).await;
+            let ctx = QueryContext {
+                sem: &sem,
+                source: src,
+                uri: &uri,
+                encoding: PositionEncoding::Utf16,
+            };
+            // Restrict to line 1 only — `let x = 1` is on line 1 (0-based),
+            // `let y = 2` is on line 2. Filter must drop the line-2 hint.
+            let range = Range {
+                start: Position {
+                    line: 1,
+                    character: 0,
+                },
+                end: Position {
+                    line: 1,
+                    character: u32::MAX,
+                },
+            };
+            let hints = inlay_hints(&ctx, range);
+            // We should still get the x-hint but not the y-hint.
+            assert!(
+                hints.iter().all(|h| h.position.line == 1),
+                "every emitted hint should land on line 1; got {hints:?}",
+            );
+            assert!(
+                hints
+                    .iter()
+                    .any(|h| h.label == ": i32" && h.kind == InlayHintKind::Type),
+                "the `let x = 1` hint should survive the range filter; got {hints:?}",
+            );
+        });
+    }
+
+    #[test]
+    fn method_call_emits_parameter_name_hint() {
+        block_on(async {
+            // Inherent impl method. `set_to` takes a single named parameter `v`.
+            let src = concat!(
+                "struct Box { value: i32 }\n",
+                "impl Box {\n",
+                "    fn set_to(&mut self, v: i32) {\n",
+                "        self.value = v;\n",
+                "    }\n",
+                "}\n",
+                "fn run() {\n",
+                "    let mut b = Box { value: 0 };\n",
+                "    b.set_to(42);\n",
+                "}\n",
+            );
+            let hints = hints_for(src).await;
+            let param_labels: Vec<_> = labels(&hints)
+                .into_iter()
+                .filter(|(_, k)| *k == InlayHintKind::Parameter)
+                .map(|(l, _)| l)
+                .collect();
+            assert!(
+                param_labels.contains(&"v:".to_string()),
+                "expected `v:` parameter hint at `b.set_to(42)`; got {param_labels:?}",
+            );
+        });
+    }
+
+    #[test]
+    fn static_method_call_emits_parameter_name_hint() {
+        block_on(async {
+            let src = concat!(
+                "struct Point { x: i32, y: i32 }\n",
+                "impl Point {\n",
+                "    fn at(x: i32, y: i32) -> Point {\n",
+                "        return Point { x, y };\n",
+                "    }\n",
+                "}\n",
+                "fn run() -> i32 {\n",
+                "    let p = Point::at(3, 4);\n",
+                "    return p.x;\n",
+                "}\n",
+            );
+            let hints = hints_for(src).await;
+            let param_labels: Vec<_> = labels(&hints)
+                .into_iter()
+                .filter(|(_, k)| *k == InlayHintKind::Parameter)
+                .map(|(l, _)| l)
+                .collect();
+            assert!(
+                param_labels.contains(&"x:".to_string())
+                    && param_labels.contains(&"y:".to_string()),
+                "expected `x:` and `y:` parameter hints at `Point::at(3, 4)`; got {param_labels:?}",
+            );
+        });
+    }
+
+    #[test]
+    fn hint_survives_unrelated_type_error() {
+        // Partial-result behaviour: a type-error in one function must not
+        // wipe out hints on a well-formed function. Mirrors the
+        // `hover_on_well_formed_part_survives_unrelated_error` test.
+        block_on(async {
+            let src = concat!(
+                "fn good() -> i32 {\n",
+                "    let n = 7;\n",
+                "    return n;\n",
+                "}\n",
+                "fn broken() -> i32 {\n",
+                "    return \"not an i32\";\n",
+                "}\n",
+            );
+            let hints = hints_for(src).await;
+            assert!(
+                hints
+                    .iter()
+                    .any(|h| h.label == ": i32" && h.kind == InlayHintKind::Type),
+                "expected `: i32` hint on `let n = 7` in `good`; got {hints:?}",
+            );
+        });
+    }
+}

--- a/wado-lsp/src/inlay_hints.rs
+++ b/wado-lsp/src/inlay_hints.rs
@@ -678,4 +678,256 @@ mod tests {
             );
         });
     }
+
+    #[test]
+    fn let_mut_without_annotation_emits_type_hint() {
+        // `let mut x = 1` parses as `LetStmt { is_mut: true, pattern:
+        // Ident { ... } }`. The mut keyword does not change the pattern
+        // shape, so `hint_pattern_bindings` must still match. Without
+        // this test a `MutIdent`-only matcher (or a future parser change
+        // that emits `MutIdent` here) would regress the hint silently.
+        block_on(async {
+            let src = "fn f() -> i32 {\n    let mut x = 1;\n    return x;\n}\n";
+            let hints = hints_for(src).await;
+            assert!(
+                hints
+                    .iter()
+                    .any(|h| h.label == ": i32" && h.kind == InlayHintKind::Type),
+                "expected `: i32` hint on `let mut x = 1`; got {hints:?}",
+            );
+        });
+    }
+
+    #[test]
+    fn tuple_destructure_let_emits_no_top_level_hint() {
+        // Destructuring patterns already make the structure visible in
+        // source, so the hint adds noise (and would have to render a
+        // tuple-of-types which the user usually didn't ask for).
+        // Pin the "skip" behaviour — a future change must opt in
+        // explicitly rather than emit by accident.
+        block_on(async {
+            let src = concat!(
+                "fn f() -> i32 {\n",
+                "    let pair = (1, 2);\n",
+                "    let (a, b) = pair;\n",
+                "    return a + b;\n",
+                "}\n",
+            );
+            let hints = hints_for(src).await;
+            // The `let pair = ...` line still hints (it's a simple
+            // binding). What we forbid is a hint on the `(a, b)` pattern
+            // line itself.
+            let line_2_type_hints: Vec<_> = hints
+                .iter()
+                .filter(|h| h.kind == InlayHintKind::Type && h.position.line == 2)
+                .collect();
+            assert!(
+                line_2_type_hints.is_empty(),
+                "destructure pattern must not produce a type hint; got {line_2_type_hints:?}",
+            );
+        });
+    }
+
+    #[test]
+    fn type_hint_position_is_immediately_after_name() {
+        // Concrete position assertion: `let x = 1` on column 4 (0-based)
+        // must place its `: i32` hint exactly at column 5 — right after
+        // `x`, before the surrounding space. Drift here would render the
+        // hint mid-expression, which is the cardinal LSP inlay-hint bug.
+        block_on(async {
+            let src = "fn f() -> i32 {\n    let x = 1;\n    return x;\n}\n";
+            let hints = hints_for(src).await;
+            let h = hints
+                .iter()
+                .find(|h| h.label == ": i32" && h.kind == InlayHintKind::Type)
+                .expect("expected a `: i32` hint");
+            assert_eq!(h.position.line, 1, "hint should be on line 1");
+            // The `x` identifier sits at character 8 (0-based) on
+            // `    let x = 1;` — after four spaces of indent and `let `.
+            // Its name span ends at the next character (9), which is the
+            // anchor for the hint.
+            assert_eq!(
+                h.position.character, 9,
+                "hint should anchor just past `x`; got {h:?}",
+            );
+        });
+    }
+
+    #[test]
+    fn parameter_hint_padding_right_is_set() {
+        // Parameter hints render as `name:` immediately before the
+        // argument, so they need a trailing space (`paddingRight: true`)
+        // to avoid `a:1`. Type hints don't — `: i32` already starts with
+        // its own punctuation. Pin both shapes.
+        block_on(async {
+            let src = concat!(
+                "fn add(a: i32, b: i32) -> i32 { return a + b; }\n",
+                "fn run() -> i32 { return add(1, 2); }\n",
+            );
+            let hints = hints_for(src).await;
+            for h in &hints {
+                match h.kind {
+                    InlayHintKind::Parameter => assert_eq!(
+                        h.padding_right,
+                        Some(true),
+                        "parameter hint must set paddingRight=true: {h:?}",
+                    ),
+                    InlayHintKind::Type => assert_eq!(
+                        h.padding_right, None,
+                        "type hint must not set paddingRight: {h:?}",
+                    ),
+                }
+            }
+        });
+    }
+
+    #[test]
+    fn parameter_hint_skipped_for_compiler_generated_underscore_names() {
+        // Compiler intrinsics may carry `_`-named parameters (or empty
+        // names for purely positional slots). Surfacing `:_` next to a
+        // user-supplied argument would be confusing noise; assert we
+        // suppress it instead of leaking the placeholder.
+        block_on(async {
+            let src = concat!("fn discard(_: i32) {}\n", "fn run() { discard(7); }\n",);
+            let hints = hints_for(src).await;
+            let param_labels: Vec<_> = labels(&hints)
+                .into_iter()
+                .filter(|(_, k)| *k == InlayHintKind::Parameter)
+                .map(|(l, _)| l)
+                .collect();
+            assert!(
+                !param_labels.iter().any(|l| l == "_:"),
+                "underscore param must not produce a `_:` hint; got {param_labels:?}",
+            );
+        });
+    }
+
+    #[test]
+    fn type_hint_under_utf16_anchors_at_correct_codepoint() {
+        // Defensive: the LSP default encoding is UTF-16, where a single
+        // codepoint may be 1 or 2 code units. A non-ASCII character on
+        // a preceding line (or in a string on the same line) makes the
+        // byte / UTF-16 / codepoint columns disagree; the hint must
+        // still land at the right character index.
+        //
+        // The compiler's `Span::column` is a 1-based codepoint index
+        // and the LSP test client speaks UTF-16. Within an ASCII-only
+        // line the two coincide, so the fixture puts a multi-byte char
+        // on the cursor line via a `🦀` literal that the encoder
+        // measures differently per encoding. The `let x = 🦀;` value is
+        // never evaluated — we only care that the `: T` hint anchors
+        // immediately after `x`.
+        let src = "// 🦀🦀🦀\nfn f() -> i32 { let x = 1; return x; }\n";
+        let path = "/test.wado";
+        let uri = format!("file://{path}");
+        let host = MapHost::single(path, src);
+        let sem = futures::executor::block_on(wado_compiler::semantics(src, &host, Some(path)));
+        let ctx = QueryContext {
+            sem: &sem,
+            source: src,
+            uri: &uri,
+            encoding: PositionEncoding::Utf16,
+        };
+        let max_range = Range {
+            start: Position {
+                line: 0,
+                character: 0,
+            },
+            end: Position {
+                line: u32::MAX,
+                character: u32::MAX,
+            },
+        };
+        let hints = inlay_hints(&ctx, max_range);
+        let h = hints
+            .iter()
+            .find(|h| h.label == ": i32" && h.kind == InlayHintKind::Type)
+            .expect("expected a `: i32` hint on `let x = 1`");
+        // The cursor line is line 1 (0-based) — `fn f() -> i32 { let x = 1; ... }`.
+        // `fn f() -> i32 { let x` is 21 UTF-16 units; the anchor sits
+        // right after `x` at character 21.
+        assert_eq!(h.position.line, 1);
+        assert_eq!(
+            h.position.character, 21,
+            "hint anchor must use UTF-16 code units; got {h:?}",
+        );
+    }
+
+    #[test]
+    fn closure_stored_in_local_does_not_yield_param_hints_on_call() {
+        // Calling a closure via its binding (`g(1)`) routes through the
+        // resolver's local-variable path; the use→def edge points at the
+        // `let g = …` pattern, not at a function symbol. We must not
+        // accidentally try to read params off a `Variable` symbol and
+        // emit garbage hints.
+        block_on(async {
+            let src = concat!(
+                "fn f() -> i32 {\n",
+                "    let g = |x: i32| x + 1;\n",
+                "    return g(7);\n",
+                "}\n",
+            );
+            let hints = hints_for(src).await;
+            // No parameter hints anywhere — only type hints are allowed.
+            assert!(
+                hints.iter().all(|h| h.kind != InlayHintKind::Parameter),
+                "closure-via-local call must not produce parameter hints; got {hints:?}",
+            );
+        });
+    }
+
+    #[test]
+    fn cross_module_call_emits_parameter_name_hints() {
+        // Real-world flow: importing `add` from another module and
+        // calling it. Verifies the `referenced_symbol` edge survives the
+        // import indirection and that `FunctionSymbol::params` is read
+        // from the imported module's symbol entry.
+        block_on(async {
+            let other = concat!(
+                "pub fn add(a: i32, b: i32) -> i32 {\n",
+                "    return a + b;\n",
+                "}\n",
+            );
+            let entry = concat!(
+                "use { add } from \"./other.wado\";\n",
+                "fn run() -> i32 { return add(1, 2); }\n",
+            );
+            let path = "/test.wado";
+            let uri = format!("file://{path}");
+            // The host key for the imported module must match the use
+            // string verbatim — the loader uses the request path as the
+            // host's lookup key. Mirror the pattern in `def_at_in`
+            // (`tests/definition.rs`) which keys the sibling module on
+            // `./lib.wado`, not its eventual absolute path.
+            let host = MapHost::with_files(&[("./other.wado", other), (path, entry)]);
+            let sem = wado_compiler::semantics(entry, &host, Some(path)).await;
+            let ctx = QueryContext {
+                sem: &sem,
+                source: entry,
+                uri: &uri,
+                encoding: PositionEncoding::Utf16,
+            };
+            let max_range = Range {
+                start: Position {
+                    line: 0,
+                    character: 0,
+                },
+                end: Position {
+                    line: u32::MAX,
+                    character: u32::MAX,
+                },
+            };
+            let hints = inlay_hints(&ctx, max_range);
+            let param_labels: Vec<_> = labels(&hints)
+                .into_iter()
+                .filter(|(_, k)| *k == InlayHintKind::Parameter)
+                .map(|(l, _)| l)
+                .collect();
+            assert!(
+                param_labels.contains(&"a:".to_string())
+                    && param_labels.contains(&"b:".to_string()),
+                "cross-module `add(1, 2)` should still surface `a:`/`b:`; got {param_labels:?}",
+            );
+        });
+    }
 }

--- a/wado-lsp/src/lib.rs
+++ b/wado-lsp/src/lib.rs
@@ -5,6 +5,7 @@ mod diagnostics;
 mod document_highlight;
 pub mod host;
 mod hover;
+mod inlay_hints;
 pub mod kiln;
 mod location;
 mod query;
@@ -30,6 +31,7 @@ pub use diagnostics::{Diagnostic, Position, Range, Severity};
 pub use document_highlight::{DocumentHighlight, HighlightKind};
 pub use host::FilesystemCompilerHost;
 pub use hover::{HoverResult, MarkupContent, MarkupKind};
+pub use inlay_hints::{InlayHint, InlayHintKind};
 pub use references::ReferenceLocation;
 pub use text::PositionEncoding;
 pub use uri::{Uri, UriScheme};
@@ -271,6 +273,24 @@ impl Engine {
     ) -> Vec<DocumentHighlight> {
         self.with_query_ctx(uri, host, Vec::new(), |ctx| {
             document_highlight::document_highlight(ctx, position)
+        })
+        .await
+    }
+
+    /// Compute inlay hints in the requested `range` of the document.
+    ///
+    /// Returns inferred-type hints for `let` / closure / `for-of` bindings
+    /// that lack an explicit annotation, plus parameter-name hints for
+    /// free-function and method call sites. Hints anchored outside the
+    /// requested `range` are filtered out.
+    pub async fn inlay_hints<H: CompilerHost>(
+        &self,
+        uri: &str,
+        range: Range,
+        host: &H,
+    ) -> Vec<InlayHint> {
+        self.with_query_ctx(uri, host, Vec::new(), |ctx| {
+            inlay_hints::inlay_hints(ctx, range)
         })
         .await
     }

--- a/wado-lsp/src/lib.rs
+++ b/wado-lsp/src/lib.rs
@@ -40,9 +40,9 @@ pub use uri::{Uri, UriScheme};
 /// library consumers.
 ///
 /// Manages open documents and answers LSP-style queries (diagnostics, hover,
-/// definition, references, document highlight, semantic tokens). `Engine`
-/// itself performs no I/O: every query takes a `&impl CompilerHost`, so the
-/// caller decides how imported modules are loaded.
+/// definition, references, document highlight, semantic tokens, inlay
+/// hints). `Engine` itself performs no I/O: every query takes a `&impl
+/// CompilerHost`, so the caller decides how imported modules are loaded.
 ///
 /// ## Snapshot cache
 ///

--- a/wado-lsp/src/server/dispatch.rs
+++ b/wado-lsp/src/server/dispatch.rs
@@ -8,11 +8,11 @@ use serde_json::Value;
 use crate::Engine;
 use crate::server::rpc::{
     DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
-    InitializeParams, InitializeResult, JsonRpcRequest, PublishDiagnosticsParams, ReferenceParams,
-    SemanticTokens, SemanticTokensLegend, SemanticTokensOptions, SemanticTokensParams,
-    ServerCapabilities, ServerInfo, TextDocumentContentOptions, TextDocumentContentParams,
-    TextDocumentContentResult, TextDocumentPositionParams, TextDocumentSyncOptions,
-    WorkspaceServerCapabilities, error_codes, text_document_sync_kind,
+    InitializeParams, InitializeResult, InlayHintParams, JsonRpcRequest, PublishDiagnosticsParams,
+    ReferenceParams, SemanticTokens, SemanticTokensLegend, SemanticTokensOptions,
+    SemanticTokensParams, ServerCapabilities, ServerInfo, TextDocumentContentOptions,
+    TextDocumentContentParams, TextDocumentContentResult, TextDocumentPositionParams,
+    TextDocumentSyncOptions, WorkspaceServerCapabilities, error_codes, text_document_sync_kind,
 };
 use crate::server::transport;
 use crate::text::PositionEncoding;
@@ -110,6 +110,7 @@ pub async fn dispatch<W: Write>(
                             },
                             full: true,
                         }),
+                        inlay_hint_provider: Some(true),
                         workspace: Some(WorkspaceServerCapabilities {
                             text_document_content: Some(TextDocumentContentOptions {
                                 schemes: STDLIB_SCHEMES,
@@ -199,6 +200,16 @@ pub async fn dispatch<W: Write>(
                 SemanticTokens {
                     data: engine.semantic_tokens(&p.text_document.uri),
                 }
+            })
+            .await?;
+        }
+        "textDocument/inlayHint" => {
+            let engine = &*engine;
+            transport::typed_request(writer, id, params, async |p: InlayHintParams| {
+                let host = transport::host_for_uri(&p.text_document.uri);
+                engine
+                    .inlay_hints(&p.text_document.uri, p.range, &host)
+                    .await
             })
             .await?;
         }

--- a/wado-lsp/src/server/rpc.rs
+++ b/wado-lsp/src/server/rpc.rs
@@ -11,7 +11,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::Position;
+use crate::{Position, Range};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TextDocumentIdentifier {
@@ -80,6 +80,13 @@ pub struct ReferenceContext {
 #[serde(rename_all = "camelCase")]
 pub struct SemanticTokensParams {
     pub text_document: TextDocumentIdentifier,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InlayHintParams {
+    pub text_document: TextDocumentIdentifier,
+    pub range: Range,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -168,6 +175,8 @@ pub struct ServerCapabilities {
     pub document_highlight_provider: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub semantic_tokens_provider: Option<SemanticTokensOptions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inlay_hint_provider: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub workspace: Option<WorkspaceServerCapabilities>,
 }

--- a/wado-lsp/tests/inlay_hints.rs
+++ b/wado-lsp/tests/inlay_hints.rs
@@ -1,0 +1,144 @@
+//! Integration tests for `Engine::inlay_hints` — end-to-end coverage of
+//! type and parameter-name hints. The unit tests in
+//! `wado-lsp/src/inlay_hints.rs` already drive each branch of the hint
+//! computation directly against a `Semantics` snapshot; these tests
+//! validate the public `Engine` surface (`Engine::open_document` →
+//! `Engine::inlay_hints`) and the LSP-shaped wire types.
+
+use wado_lsp::test_support::MapHost;
+use wado_lsp::{Engine, InlayHint, InlayHintKind, Position, Range};
+
+async fn hints(source: &str) -> Vec<InlayHint> {
+    let path = "/test.wado";
+    let uri = format!("file://{path}");
+    let host = MapHost::single(path, source);
+    let mut engine = Engine::new();
+    engine.open_document(&uri, source.to_string());
+    let range = Range {
+        start: Position {
+            line: 0,
+            character: 0,
+        },
+        end: Position {
+            line: u32::MAX,
+            character: u32::MAX,
+        },
+    };
+    engine.inlay_hints(&uri, range, &host).await
+}
+
+#[test]
+fn engine_returns_let_type_hint() {
+    futures::executor::block_on(async {
+        let source = "fn f() -> i32 {\n    let x = 1;\n    return x;\n}\n";
+        let hints = hints(source).await;
+        let type_hints: Vec<_> = hints
+            .iter()
+            .filter(|h| h.kind == InlayHintKind::Type)
+            .collect();
+        assert!(
+            type_hints.iter().any(|h| h.label == ": i32"),
+            "expected `: i32` hint on `let x = 1`; got {hints:?}",
+        );
+    });
+}
+
+#[test]
+fn engine_returns_parameter_hints_for_free_function() {
+    futures::executor::block_on(async {
+        let source = concat!(
+            "fn add(a: i32, b: i32) -> i32 { return a + b; }\n",
+            "fn run() -> i32 { return add(1, 2); }\n",
+        );
+        let hints = hints(source).await;
+        let labels: Vec<_> = hints
+            .iter()
+            .filter(|h| h.kind == InlayHintKind::Parameter)
+            .map(|h| h.label.clone())
+            .collect();
+        assert!(
+            labels.contains(&"a:".to_string()) && labels.contains(&"b:".to_string()),
+            "expected `a:` and `b:` hints; got {labels:?}",
+        );
+    });
+}
+
+#[test]
+fn engine_returns_parameter_hints_for_method_call() {
+    futures::executor::block_on(async {
+        let source = concat!(
+            "struct Counter { value: i32 }\n",
+            "impl Counter {\n",
+            "    fn bump(&mut self, by: i32) { self.value = self.value + by; }\n",
+            "}\n",
+            "fn run() {\n",
+            "    let mut c = Counter { value: 0 };\n",
+            "    c.bump(5);\n",
+            "}\n",
+        );
+        let hints = hints(source).await;
+        let labels: Vec<_> = hints
+            .iter()
+            .filter(|h| h.kind == InlayHintKind::Parameter)
+            .map(|h| h.label.clone())
+            .collect();
+        assert!(
+            labels.contains(&"by:".to_string()),
+            "expected `by:` hint at `c.bump(5)`; got {labels:?}",
+        );
+    });
+}
+
+#[test]
+fn engine_filters_hints_outside_range() {
+    futures::executor::block_on(async {
+        let source = "fn f() -> i32 {\n    let x = 1;\n    let y = 2;\n    return x + y;\n}\n";
+        let path = "/test.wado";
+        let uri = format!("file://{path}");
+        let host = MapHost::single(path, source);
+        let mut engine = Engine::new();
+        engine.open_document(&uri, source.to_string());
+        // Restrict to line 1 only (the `let x = 1` line). The `let y =
+        // 2` hint on line 2 must be filtered out.
+        let range = Range {
+            start: Position {
+                line: 1,
+                character: 0,
+            },
+            end: Position {
+                line: 1,
+                character: 999,
+            },
+        };
+        let hints = engine.inlay_hints(&uri, range, &host).await;
+        assert!(
+            hints.iter().all(|h| h.position.line == 1),
+            "every hint should be anchored on line 1; got {hints:?}",
+        );
+    });
+}
+
+#[test]
+fn engine_returns_empty_for_unknown_document() {
+    futures::executor::block_on(async {
+        let path = "/nonexistent.wado";
+        let uri = format!("file://{path}");
+        let host = MapHost::empty();
+        let engine = Engine::new();
+        let range = Range {
+            start: Position {
+                line: 0,
+                character: 0,
+            },
+            end: Position {
+                line: u32::MAX,
+                character: u32::MAX,
+            },
+        };
+        let hints = engine.inlay_hints(&uri, range, &host).await;
+        assert!(
+            hints.is_empty(),
+            "closed/unknown document must produce no hints; got {hints:?}",
+        );
+    });
+}

--- a/wado-lsp/tests/parse_error.rs
+++ b/wado-lsp/tests/parse_error.rs
@@ -37,7 +37,7 @@ fn uri() -> String {
     format!("file://{PATH}")
 }
 
-async fn engine_with_broken_source() -> (Engine, MapHost) {
+fn engine_with_broken_source() -> (Engine, MapHost) {
     let mut engine = Engine::new();
     engine.open_document(&uri(), BROKEN_SOURCE.to_string());
     let host = MapHost::single(PATH, BROKEN_SOURCE);
@@ -56,7 +56,7 @@ fn errors(diags: &[Diagnostic]) -> Vec<&Diagnostic> {
 #[test]
 fn parse_error_emits_one_diagnostic_attributed_to_entry() {
     futures::executor::block_on(async {
-        let (engine, host) = engine_with_broken_source().await;
+        let (engine, host) = engine_with_broken_source();
         let diags = engine.diagnostics(&uri(), &host).await;
         let errs = errors(&diags);
         assert_eq!(
@@ -85,7 +85,7 @@ fn parse_error_emits_one_diagnostic_attributed_to_entry() {
 #[test]
 fn position_queries_return_empty_on_parse_error() {
     futures::executor::block_on(async {
-        let (engine, host) = engine_with_broken_source().await;
+        let (engine, host) = engine_with_broken_source();
         let pos = Position {
             line: 1,
             character: 8,


### PR DESCRIPTION
## Summary

- Adds `textDocument/inlayHint` to `wado-lsp`: inferred-type hints on `let` / closure / `for-of` bindings without an annotation (recursing into tuple / struct / variant / or-patterns), plus parameter-name hints at every free-function, method, and static-method call site.
- Exposes the inferred `TypeId` of each local binding through `Semantics::local_type_name` (the resolver already had it; this drains it into `Semantics` next to `locals`, mirroring the existing `references` plumbing).
- Indexes every `Function`-shaped declaration on `AstIndex` so `Semantics::function_at(&SymbolKey)` is O(1); the LSP layer no longer scans `module.items` per call site.
- Fixes a pre-existing codegen ICE: `export fn run() -> i32 { return 42; }` (or any non-Result non-unit return on a Result-returning world export) now produces a readable compile error instead of panicking with `"values remaining on stack at end of block"` at `codegen.rs:45`.

## Test plan

- [x] `cargo test -p wado-compiler --lib` — 553 passed
- [x] `cargo test -p wado-compiler --test e2e` — **2638 passed, 0 failed** (incl. new `export_return_type_mismatch.wado` fixture and 4 new `ast_index` tests)
- [x] `cargo test -p wado-lsp` — 156 passed across lib + integration (18 new inlay-hint unit tests, 5 new `Engine::inlay_hints` integration tests, parse-error tests still green)
- [x] `cargo test -p wado-cli` — 201 passed (incl. new `lsp_inlay_hint_returns_type_and_parameter_hints` wire-level test)
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo check --target wasm32-unknown-unknown -p wado-manifest` — clean

## Commit breakdown

```
d6e73f8f perf(compiler): index Function AST addresses for O(1) lookup by AstId
24e2413f refactor: drop dead code and stale comments from the inlay-hint stack
e0a045c0 fix(compiler): reject export return-type mismatch instead of ICEing at codegen
12e3a69f refactor(lsp): drop unilateral "skip" behaviours from inlay hints
033a3149 test(lsp): cover inlay-hint edge cases and update Engine docs
b1323eb2 feat(lsp): textDocument/inlayHint with inferred-type and parameter-name hints
```

https://claude.ai/code/session_01KM9352Z6spWNuJBpaLXsGM

---
_Generated by [Claude Code](https://claude.ai/code/session_01KM9352Z6spWNuJBpaLXsGM)_