### PR TITLE
docs(wep): elaborator re-architecture + align unused-diagnostics

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -112,3 +112,4 @@ It may include TODOs on WIP.
 - [String API — checked / unchecked / internal Discipline](./wep-2026-05-16-string-checked-unchecked-discipline.md)
 - [Unused Diagnostics](./wep-2026-05-16-unused-diagnostics.md)
 - [Resource Ownership and a Resource-Scoped Borrow Checker](./wep-2026-05-21-resource-ownership.md)
+- [Elaborator Re-architecture — TypeSystem / Annotate / Reify](./wep-2026-05-26-elaborator-rearchitecture.md)

--- a/docs/wep-2026-05-16-unused-diagnostics.md
+++ b/docs/wep-2026-05-16-unused-diagnostics.md
@@ -6,11 +6,17 @@ The Wado compiler today has no equivalent of rustc's `unused_imports`,
 `unused_variables`, or `dead_code` lints. Users get no signal when
 imports, locals, parameters, or private functions are written but never
 consumed. The infrastructure for warnings exists (`Severity::Warning`,
-`Logger`, `CompilerHost::emit_diagnostic`), and the analysis substrate
-for the policy questions has matured — use→def edges (`Semantics::references`),
-local-binding registry (`Semantics::locals`), per-module structural
-indices (`AstIndex`), and the DCE reachability pass (`optimize/dce.rs`) —
-but no pass turns those into user-facing diagnostics.
+`Logger`, `CompilerHost::emit_diagnostic`), and the elaborator
+re-architecture (see
+[elaborator rearchitecture](./wep-2026-05-26-elaborator-rearchitecture.md))
+provides the analysis substrate this WEP consumes: per-module
+`bindings` (use→def edges, local-binding registry), per-module
+structural indices (`AstIndex`), and the new `liveness` pass that
+runs between `annotate_bodies` and `reify`. The elaborate-time
+`liveness` pass is established by this WEP — the rearchitecture WEP
+commits only to "there is a pass here, its output lives on
+`Semantics`"; the policy that determines what is live, what is
+suppressed, and what is reported is owned here.
 
 The reachability roots for "unused" in Wado are not what rustc uses:
 
@@ -35,35 +41,45 @@ resolution and slow type checking, and the LSP cannot offer the
 
 ## Decision
 
-Add an unused-diagnostics subsystem split across two layers, each
-producing `Severity::Warning` diagnostics through the existing
-`CompilerHost`. The two layers map cleanly onto rustc's split between
-HIR-level `unused_*` lints and `dead_code` reachability:
+Add an unused-diagnostics subsystem driven entirely by elaborate-time
+analysis, producing `Severity::Warning` diagnostics through the
+existing `CompilerHost`. Two passes contribute, both consuming
+`&Semantics` and running before `reify`:
 
-1. Semantics layer — runs immediately after `semantics_of`, on
-   `&Semantics`. Emits `UnusedImport`, `UnusedVariable`,
-   `UnusedParameter`. LSP and batch compilation share this pass for
-   free.
-2. NIR + DCE layer — runs as hooks inside `optimize.rs::run_dce`, on
-   each iteration of DCE's fixed-point loop, between reachability
-   analysis and removal. Emits `DeadFunction` and `DeadGlobal`. A
-   cross-iteration dedup set keyed by `SymbolKey` ensures each item
-   is reported at most once.
+1. Reference pass — walks `ModuleSemantics.bindings` (use→def edges)
+   for every user-authored module. Emits `UnusedImport`,
+   `UnusedVariable`, `UnusedParameter`. A binding is reported when
+   no edge has it as the def-side.
+2. Liveness pass — the elaborate-time DCE pass introduced by
+   [elaborator rearchitecture](./wep-2026-05-26-elaborator-rearchitecture.md).
+   Computes source-level reachability from world-export roots over
+   the cross-module call graph that `bindings` already encodes.
+   Emits `DeadFunction` and `DeadGlobal` for source items the
+   computation does not reach.
 
-Both passes are guarded by `CompilerOptions::unused_diagnostics` (on by
-default). No package-kind toggle is needed: `export` already names the
-complete set of package-external roots for every entry-point kind
-(`command`, `service`, `lib`).
+Both passes are guarded by `CompilerOptions::unused_diagnostics` (on
+by default). No package-kind toggle is needed: `export` already names
+the complete set of package-external roots for every entry-point
+kind (`command`, `service`, `lib`).
+
+The optimize-time DCE in `optimize/dce.rs` stays in place as a
+silent post-monomorphization cleanup — it removes monomorphic
+instances and inlined-away code that became unreachable through
+specialisation, none of which are user-source-level dead. It no
+longer participates in diagnostic emission. The two roles separate
+cleanly: source-level "you wrote this and nothing uses it" is
+elaborate-time; "this monomorph fell out after inlining" is
+optimize-time and silent.
 
 ### What is in scope (MVP)
 
-| Lint              | Layer          | Code              |
-| ----------------- | -------------- | ----------------- |
-| `UnusedImport`    | Semantics      | `UnusedImport`    |
-| `UnusedVariable`  | Semantics      | `UnusedVariable`  |
-| `UnusedParameter` | Semantics      | `UnusedParameter` |
-| `DeadFunction`    | NIR (post-DCE) | `DeadFunction`    |
-| `DeadGlobal`      | NIR (post-DCE) | `DeadGlobal`      |
+| Lint              | Pass      | Code              |
+| ----------------- | --------- | ----------------- |
+| `UnusedImport`    | Reference | `UnusedImport`    |
+| `UnusedVariable`  | Reference | `UnusedVariable`  |
+| `UnusedParameter` | Reference | `UnusedParameter` |
+| `DeadFunction`    | Liveness  | `DeadFunction`    |
+| `DeadGlobal`      | Liveness  | `DeadGlobal`      |
 
 ### What is out of scope (deferred to follow-up WEPs / PRs)
 
@@ -76,24 +92,30 @@ complete set of package-external roots for every entry-point kind
 
 ### Reachability roots (package-external boundary)
 
-The DCE layer treats these as always-reachable:
+The liveness pass treats these source-level items as always-live:
 
-| Root                                 | Source                                                                              |
-| ------------------------------------ | ----------------------------------------------------------------------------------- |
-| `is_cm_export`                       | World export wrappers from synthesis (covers `command` / `service` / `lib` exports) |
-| `is_export` in `wasm_module_sources` | Raw Wasm exports                                                                    |
+| Root                                      | Source                                                                                                                  |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Items satisfying world-export contracts   | Functions whose name and signature satisfy a world export (`command` / `service` / `lib`); identified during `annotate` |
+| `#[export]`-attributed items              | Raw Wasm exports                                                                                                        |
+| Items in `wasm_module_sources` re-exports | Bridged Wasm module exports                                                                                             |
+| `test` items in the test world            | Test discovery roots                                                                                                    |
 
-This matches the existing DCE root set in `optimize/dce.rs`
-(`compute_reachable_from_entries`). No new roots are introduced.
-Synthesised functions and globals stay subject to the normal call-graph
-rules: a CM binding for an unreachable export, or an auto-derived impl
-that nothing references, is still removed by DCE. The synthesis
-exclusion only suppresses the diagnostic emission, never the removal.
+The root set matches the existing optimize-time DCE root set in
+`optimize/dce.rs` (`compute_reachable_from_entries`); the liveness
+pass restates them at the source level so reachability can be
+computed before TIR is emitted. Synthesised items — CM binding
+wrappers, effect-dispatch helpers, monomorphisation clones,
+auto-derived impls — are not in `Semantics` at all (they are born
+during `synthesis` / `monomorphize`) and therefore cannot appear in
+either the live set or the unused set. The optimize-time DCE
+continues to remove them silently.
 
 `is_pub` is never a root. In Wado it denotes package-internal
 visibility, never package-external API — that is `export`'s job, and
 `export` covers `lib` packages as well as `command` / `service`. An
-unreferenced `pub fn` is dead code regardless of the entry-point kind.
+unreferenced `pub fn` is dead code regardless of the entry-point
+kind.
 
 ### Stdlib exclusion
 
@@ -112,36 +134,20 @@ user's build output.
 - No attribute-based suppression in MVP; deferred to a follow-up that
   reuses the existing `#[...]` attribute machinery.
 
-### Defining-ast-id field
-
-`TirFunction` / `NirFunction` and `TirGlobal` / `NirGlobal` each gain a
-`defining_ast_id: Option<AstId>` field. Together with `module_source`,
-this forms a `SymbolKey` back to the originating AST node — the
-canonical identity already used by `Semantics`, the symbol table, and
-the LSP query API. `None` marks synthesised items, which are excluded
-from `DeadFunction` / `DeadGlobal` reporting (but still subject to
-normal DCE removal).
-
-This is the only structural change required outside the new
-`analyze/unused.rs` module.
-
 ## Implementation
 
 ### Source files
 
-| File                                  | Description                                                                                                                                                                                    |
-| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `wado-compiler/src/analyze/unused.rs` | New module hosting `check_unused` (Semantics layer), `emit_dead_function_diagnostics`, and `emit_dead_global_diagnostics` (DCE-loop hooks).                                                    |
-| `wado-compiler/src/compiler_host.rs`  | Adds `Code::UnusedImport`, `UnusedVariable`, `UnusedParameter`, `DeadFunction`, `DeadGlobal` and their `Display` mappings.                                                                     |
-| `wado-compiler/src/logger.rs`         | Adds `Logger::warn_at(code, message, span, file)` for span-bearing warnings.                                                                                                                   |
-| `wado-compiler/src/lib.rs`            | Adds `CompilerOptions::unused_diagnostics`. Calls `check_unused` after `semantics_of`. The DCE-layer diagnostic emitters are invoked from `optimize.rs::run_dce`.                              |
-| `wado-compiler/src/tir.rs`            | `TirFunction::defining_ast_id: Option<AstId>`, `TirGlobal::defining_ast_id: Option<AstId>`.                                                                                                    |
-| `wado-compiler/src/nir.rs`            | `NirFunction::defining_ast_id: Option<AstId>`, `NirGlobal::defining_ast_id: Option<AstId>`.                                                                                                    |
-| `wado-compiler/src/optimize/dce.rs`   | Adds `pub(crate) fn unreachable_function_source_keys(&NirPackage, &IndexSet<FunctionId>) -> Vec<SymbolKey>` and `pub(crate) fn unreachable_global_source_keys(&NirPackage) -> Vec<SymbolKey>`. |
-| `wado-compiler/src/optimize.rs`       | `run_dce` invokes the diagnostic emitters inside its fixed-point loop, with a cross-iteration dedup set keyed by `SymbolKey`.                                                                  |
-| `wado-compiler/src/ast_index.rs`      | Adds `is_param(id)` predicate (1-bit table) so the locals pass can distinguish `UnusedVariable` from `UnusedParameter`.                                                                        |
-| `wado-cli`                            | Adds `--no-unused` flag.                                                                                                                                                                       |
-| `wado-lsp`                            | Calls `analyze::unused::check_unused` from `Engine::diagnostics`.                                                                                                                              |
+| File                                              | Description                                                                                                                                                                               |
+| ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `wado-compiler/src/elaborator/liveness.rs`        | Owned by the elaborator rearchitecture. Computes source-level reachability and returns a `Liveness` value (live `SymbolKey` set, plus per-module unused-item / unused-binding lists).     |
+| `wado-compiler/src/elaborator/liveness/unused.rs` | This WEP's contribution: walks the `Liveness` output plus `ModuleSemantics.bindings` and emits the five diagnostics. Stdlib exclusion, underscore suppression, and root policy live here. |
+| `wado-compiler/src/compiler_host.rs`              | Adds `Code::UnusedImport`, `UnusedVariable`, `UnusedParameter`, `DeadFunction`, `DeadGlobal` and their `Display` mappings.                                                                |
+| `wado-compiler/src/logger.rs`                     | Adds `Logger::warn_at(code, message, span, file)` for span-bearing warnings.                                                                                                              |
+| `wado-compiler/src/lib.rs`                        | Adds `CompilerOptions::unused_diagnostics`. Invokes the diagnostic emitter once the elaborator has produced `Semantics` and its `Liveness`.                                               |
+| `wado-compiler/src/ast_index.rs`                  | Adds `is_param(id)` predicate (1-bit table) so the reference pass can distinguish `UnusedVariable` from `UnusedParameter`.                                                                |
+| `wado-cli`                                        | Adds `--no-unused` flag.                                                                                                                                                                  |
+| `wado-lsp`                                        | Invokes the diagnostic emitter from `Engine::diagnostics`. Renders `UnusedImport` / `UnusedVariable` / `UnusedParameter` as `Hint`-severity unused-token decorations as well.             |
 
 ### Algorithms
 
@@ -187,84 +193,67 @@ Walk `Semantics::locals`. For each `(key, sym)` whose kind is
 
 #### Dead functions and globals
 
-`optimize.rs::run_dce` runs DCE in a fixed-point loop:
-`analyze_project` → `remove_unreachable_functions` →
-`remove_unreachable_globals`, repeating until the function set
-stabilises. The cascade is real (removing a dead global may rewrite
-bodies and orphan a previously-reachable callee), so a single pre-loop
-snapshot is not enough.
+The elaborate-time `liveness` pass computes the closure of reachable
+source items from the root set (see Reachability roots) over the
+call-graph encoded in `ModuleSemantics.bindings`. The closure is
+computed once over source-level `SymbolKey`s, so there is no
+fixed-point loop and no per-iteration dedup. Globals reference
+functions through their initialiser, functions reference globals and
+other functions through their bodies; both edge kinds are already
+present in `bindings`.
 
-Strategy: emit diagnostics inside the loop, on each iteration, with a
-`reported: IndexSet<SymbolKey>` carried across iterations to dedup.
+For each user-authored module, the emitter walks the module's
+function and global declarations and reports any whose `SymbolKey` is
+absent from `Liveness::live_items`. Stdlib modules and synthesised
+items (which are not in `Semantics` at all) cannot appear.
 
-At the start of each iteration, after `analyze_project` returns the
-reachable set:
+Span: `Semantics::name_span_of(key)`, with fallback to the item's
+`span` for declarations without a narrow name span.
 
-1. `dce::unreachable_function_source_keys(project, &reachable)` walks
-   `project.functions` and returns the set of source `SymbolKey`s for
-   functions whose every monomorphisation is unreachable, skipping
-   entries with `defining_ast_id == None` (synthesised) and entries in
-   stdlib modules. Grouping by `(module_source, defining_ast_id)`
-   collapses monomorphisations to a single source-level key.
-2. `dce::unreachable_global_source_keys(project)` returns the source
-   keys for globals not referenced by any reachable function, with the
-   same exclusions.
-3. The emitter inserts each new key into `reported` and calls
-   `Logger::warn_at` with `Code::DeadFunction` or `Code::DeadGlobal`,
-   span from `Semantics::name_span_of(key)` (fallback to the item's
-   `span`).
-
-`is_export` / `is_cm_export` items are already roots, so they will not
-appear in the unreachable set. The diagnostic emitter does not need
-extra checks for them.
-
-The dedup set ensures a function or global is reported at most once
-even though it may be observed across multiple iterations
-(`analyze_project` is called each iteration; only items the previous
-iteration's `remove_unreachable_*` actually removed are gone from
-`project.functions` / `project.globals` next time round).
+Globals dropped during optimize-time DCE (e.g., constants inlined
+into all callers) do not surface as `DeadGlobal` because they were
+live at the source level — that is the intended separation.
 
 ### Pipeline integration
 
 ```
-parse → bind → desugar → load → analyze → annotate
-                                            │
-                                            ▼
-                                   check_unused
-                                  (imports, locals, params)
-                                            │
-                                            ▼
-                              build_tir → monomorphize
-                                  → lower → optimize
-                                            │
-                                            ▼
-                              run_dce (fixed-point loop)
-                              ┌───────────────────────────┐
-                              │ analyze_project           │
-                              │   │                       │
-                              │   ▼                       │
-                              │ emit dead-function /      │
-                              │   dead-global diagnostics │
-                              │   (dedup across iters)    │
-                              │   │                       │
-                              │   ▼                       │
-                              │ remove_unreachable_*      │
-                              │   │                       │
-                              │   ▼                       │
-                              │ converged? ──no──┐        │
-                              │   │ yes          │        │
-                              │   ▼              │        │
-                              └───┼──────────────┘        │
-                                  ▼                       │
-                                                          ▼
-                                                       codegen
+parse → bind → load → analyze
+   ↓
+annotate_decls
+   ↓
+annotate_bodies   (per module, populates ModuleSemantics)
+   ↓
+liveness          (source-level reachability → Liveness on Semantics)
+   ↓
+emit unused diagnostics
+   ↓                                    ↘
+reify                                    LSP terminates here
+   ↓
+monomorphize → lower → optimize         (optimize-time DCE runs silently)
+   ↓
+codegen
 ```
 
-`compile_with_options` gates both layers on
-`CompilerOptions::unused_diagnostics`. `Engine::diagnostics` (LSP)
-calls `check_unused` after `semantics_of` without any extra cost.
+Both the reference pass and the diagnostic emission against `Liveness`
+sit immediately after `liveness`. The LSP path consumes the same
+emitter (it reads diagnostics from `Engine::diagnostics`), so users
+get the warnings in the editor before `reify` runs. Batch
+compilation continues into `reify`, which skips items absent from
+`Liveness::live_items`.
+
+`compile_with_options` gates the emitter on
+`CompilerOptions::unused_diagnostics`. `Engine::diagnostics` does
+the same.
 
 ### Migration plan
+
+The reference-pass diagnostics (`UnusedImport`, `UnusedVariable`,
+`UnusedParameter`) depend only on `ModuleSemantics.bindings`, which
+the existing elaborator already populates; they can land before the
+elaborator rearchitecture completes. The liveness-pass diagnostics
+(`DeadFunction`, `DeadGlobal`) depend on the new `liveness` pass and
+land with stage 6 of the rearchitecture (see
+[elaborator rearchitecture](./wep-2026-05-26-elaborator-rearchitecture.md)).
 
 #### Phase 1 — diagnostic plumbing
 
@@ -273,36 +262,22 @@ calls `check_unused` after `semantics_of` without any extra cost.
 - [ ] Add `CompilerOptions::unused_diagnostics` (default `true`).
 - [ ] Add `AstIndex::is_param(id)` and tests.
 
-#### Phase 2 — `defining_ast_id` propagation
+#### Phase 2 — reference pass
 
-- [ ] Add `TirFunction::defining_ast_id: Option<AstId>` and `TirGlobal::defining_ast_id: Option<AstId>`; default to `None`.
-- [ ] Set `Some(function.id)` / `Some(global.id)` at every source-authored construction site (in `elaborator`).
-- [ ] Add `NirFunction::defining_ast_id` and `NirGlobal::defining_ast_id`; propagate from TIR through `link`, `monomorphize`, `erase`, `lower`. Monomorphisation clones inherit the original `defining_ast_id`.
-- [ ] Synthesis sites (`synthesis/cm_binding.rs`, `synthesis/effect_dispatch.rs`, auto-derives, etc.) leave the field as `None`.
-- [ ] No behaviour change in this phase — codegen output is bit-identical.
-
-#### Phase 3 — Semantics-layer lints
-
-- [ ] Confirm `elaborator` records `UseItem::Simple.id` as a use-site; patch if missing.
-- [ ] Implement `analyze::unused::check_unused` (imports, locals, params).
-- [ ] Wire into `lib.rs::compile_with_options` and `wado-lsp::Engine::diagnostics`.
+- [ ] Confirm the elaborator records `UseItem::Simple.id` as a use-site; patch if missing.
+- [ ] Implement the reference-pass emitter (imports, locals, params) against `Semantics`.
+- [ ] Wire into `compile_with_options` and `Engine::diagnostics`.
 - [ ] Add fixtures under `tests/fixtures/unused_*.wado`; touch `tests/e2e.rs`.
 
-#### Phase 4 — DCE-layer dead-function lint
+#### Phase 3 — liveness pass (lands with elaborator rearchitecture stage 6)
 
-- [ ] Add `pub(crate) fn unreachable_function_source_keys(&NirPackage, &IndexSet<FunctionId>) -> Vec<SymbolKey>` to `optimize/dce.rs`. Skip entries with `defining_ast_id == None` or stdlib module sources. Group monomorphisations by `(module_source, defining_ast_id)`.
-- [ ] Implement `analyze::unused::emit_dead_function_diagnostics` consuming the helper above.
-- [ ] Modify `optimize.rs::run_dce` to thread a `reported: IndexSet<SymbolKey>` through the fixed-point loop and invoke the emitter inside it, before the `remove_unreachable_*` calls.
-- [ ] Add fixtures under `tests/fixtures/dead_fn_*.wado`.
+- [ ] Land `elaborator/liveness.rs` per the rearchitecture WEP.
+- [ ] Implement the liveness-pass emitter (`DeadFunction`, `DeadGlobal`) consuming `Liveness::live_items`.
+- [ ] Wire `reify` to skip items absent from `live_items`.
+- [ ] Retire the optimize-time DCE's diagnostic role (it remains as silent cleanup).
+- [ ] Add fixtures under `tests/fixtures/dead_fn_*.wado` and `tests/fixtures/dead_global_*.wado`.
 
-#### Phase 5 — DCE-layer dead-global lint
-
-- [ ] Add `pub(crate) fn unreachable_global_source_keys(&NirPackage) -> Vec<SymbolKey>` to `optimize/dce.rs`, mirroring the function variant. Use the analysis already performed inside `remove_unreachable_globals` (extract the reachability predicate if needed).
-- [ ] Implement `analyze::unused::emit_dead_global_diagnostics`.
-- [ ] Wire into `run_dce` next to the dead-function emission, sharing the `reported` dedup set.
-- [ ] Add fixtures under `tests/fixtures/dead_global_*.wado`.
-
-#### Phase 6 — CLI wiring
+#### Phase 4 — CLI wiring
 
 - [ ] `wado-cli`: add `--no-unused` flag for `compile` / `run` / `serve` / `dump`.
 
@@ -338,48 +313,42 @@ through the diagnostics path.
 - Users get immediate, location-precise feedback on dead imports,
   locals, parameters, and private functions, matching the experience
   every rustc user expects.
-- LSP "greyed-out unused" works for free because the Semantics layer
-  shares a code path between batch compilation and `Engine::diagnostics`.
-- DCE keeps doing its silent removal job; the only addition is a
-  diagnostic hook in front of removal.
-- `defining_ast_id` becomes a reusable back-pointer for future
-  diagnostics and tooling (e.g., span-aware optimisation traces).
+- LSP "greyed-out unused" works without extra effort because the
+  diagnostic emitter consumes the same `Semantics` + `Liveness` that
+  batch compilation produces.
+- The optimize-time DCE keeps doing its silent removal job. Source-
+  level dead code is reported once, at the right phase, with the
+  right span; post-optimization specialisation noise stays internal.
+- `reify` consumes `Liveness::live_items` to skip dead items,
+  reducing the input size of `monomorphize` / `lower` / `optimize`.
 
 ### Costs
 
-- One new optional field on each of `TirFunction`, `NirFunction`,
-  `TirGlobal`, `NirGlobal`. Memory cost is negligible
-  (`Option<AstId>` is a `u32` + niche).
-- Every TIR construction site for a source-authored function or
-  global gains one line to thread the AST id through. The change is
-  mechanical but touches several files (`elaborator/item.rs`, closure
-  construction, global lowering).
-- `optimize.rs::run_dce` gains a `reported: IndexSet<SymbolKey>` set
-  threaded through its fixed-point loop. No structural change to the
-  loop itself.
 - New warnings will fire on every existing Wado source file the first
   time CI runs the new compiler. The MVP defaults `unused_diagnostics`
   to `true`; a one-time cleanup pass on the in-tree examples and
-  fixtures is part of Phase 3 / Phase 4 / Phase 5 landing.
+  fixtures is part of Phase 2 / Phase 3 landing.
+- The reference-pass emitter and the liveness-pass emitter are two
+  small additional walks over `Semantics` per compilation. Both are
+  linear in the size of the source-level call graph and cheap
+  relative to the elaborator itself.
 
 ### Risks and mitigations
 
-- Risk: synthesised functions accidentally receive `Some(ast_id)` and
-  start emitting spurious dead-code warnings. Mitigation:
-  `defining_ast_id` defaults to `None`; synthesis sites must
-  affirmatively opt in. Tests cover the synthesis paths.
 - Risk: a generic function with all monomorphisations unreachable is
-  reported once per group, but rare edge cases (specialisation through
-  effect dispatch) could leave one monomorph reachable from an
-  unreported path. Mitigation: rely on the existing DCE call-graph,
-  which already handles these edges for removal.
-- Risk: DCE's fixed-point loop interacts with the diagnostic emission
-  — a function that becomes dead only after a global is dropped on
-  iteration 2 must still be reported, while items already reported on
-  iteration 1 must not be repeated. Mitigation: the cross-iteration
-  `reported: IndexSet<SymbolKey>` dedup set; tests in
-  `dead_global_used_by_dead_fn.wado` and
-  `dead_fn_cascade_via_global.wado` exercise the cascade.
+  reported once at the source level, but rare edge cases
+  (specialisation through effect dispatch) could leave one
+  monomorph reachable from a path that the source-level call graph
+  in `bindings` does not see. Mitigation: such cases would also
+  break the source-level `bindings` edge model used by goto-def and
+  find-references — fix them there. The liveness pass does not
+  invent its own graph.
+- Risk: the source-level call graph misses a runtime-reachable item
+  (e.g. dispatch through a trait object built from a string at
+  runtime — not yet a Wado feature, but a future hazard). Mitigation:
+  `liveness` only consults edges recorded during `annotate`; adding
+  new edge kinds is part of the language feature that introduces
+  them.
 - Risk: users coming from Rust expect `pub fn` in a `lib` package to
   be a public API root and may be surprised that it is reported as
   dead. Mitigation: the lint message names the rule

--- a/docs/wep-2026-05-26-elaborator-rearchitecture.md
+++ b/docs/wep-2026-05-26-elaborator-rearchitecture.md
@@ -197,47 +197,34 @@ a new term.
 
 ### Module layout
 
+The top-level split inside `wado-compiler/src/elaborator/` follows
+the concerns named in the Decision. One file per concern at this
+level; internal splits emerge during migration as each file grows.
+
 ```
+wado-compiler/src/elaborator.rs    # umbrella
 wado-compiler/src/elaborator/
-├── mod.rs
-├── tysys/        # TypeSystem and pure type-system operations
-│   ├── mod.rs
-│   ├── coerce.rs
-│   ├── infer.rs
-│   ├── typecheck.rs
-│   ├── traits.rs
-│   └── methods.rs
-├── sem/          # ModuleSemantics and its sub-structs
-│   ├── mod.rs
+├── tysys.rs       # TypeSystem and its operations
+├── sem.rs         # ModuleSemantics (re-exports its sub-structs)
+├── sem/
 │   ├── bindings.rs
 │   ├── imports.rs
 │   ├── types.rs
 │   └── decls.rs
-├── annotate/     # annotate_decls + annotate_bodies
-│   ├── mod.rs
-│   ├── decls.rs
-│   ├── module.rs
-│   ├── item.rs
-│   ├── expr.rs
-│   ├── stmt.rs
-│   ├── call.rs
-│   ├── method.rs
-│   ├── closure.rs
-│   ├── handlers.rs
-│   └── desugar.rs
-├── liveness.rs   # cross-module reachability
-└── reify/        # AST + ModuleSemantics → TirModule
-    ├── mod.rs
-    ├── module.rs
-    ├── item.rs
-    ├── expr.rs
-    └── stmt.rs
+├── annotate.rs    # annotate_decls + annotate_bodies entry
+├── liveness.rs    # cross-module reachability
+└── reify.rs       # AST + ModuleSemantics → TirModule
 ```
 
-The current `elaborator.rs` and its 24 sibling modules are dissolved
-into this layout. The membership criterion for each file is its
-sub-struct or phase responsibility; no file collects "miscellaneous
-elaborator helpers."
+The four sub-structs of `ModuleSemantics` each get their own file
+because the membership rule (Decision §`ModuleSemantics`) is
+file-scoped. Everything else stays as a single file until the
+concern visibly demands subdivision; the current 24-module sprawl
+under `elaborator/` is the failure mode to avoid.
+
+The crate uses the no-`mod.rs` convention (a `foo.rs` next to a
+`foo/` directory), matching the existing `elaborator.rs` +
+`elaborator/` layout.
 
 ### TypeSystem surface
 

--- a/docs/wep-2026-05-26-elaborator-rearchitecture.md
+++ b/docs/wep-2026-05-26-elaborator-rearchitecture.md
@@ -1,0 +1,453 @@
+# WEP: Elaborator Re-architecture — TypeSystem / Annotate / Reify
+
+## Context
+
+The `elaborate` phase is the largest and most entangled part of the
+compiler. The `wado-compiler/src/elaborator/` tree carries about 33,000
+lines spread across two dozen modules, all of which extend the same
+`Elaborator<'a, H>` struct in `elaborator.rs`. That struct holds about
+35 fields and acts as the single home for type interning, trait
+resolution, method dispatch, name resolution, use→def recording, and
+AST → TIR construction. Adding a new fact, cache, or registry has no
+principled place to land; the default is "another field on
+`Elaborator`."
+
+Two structural problems have compounded as the language grew:
+
+### The elaborator is a God Object
+
+Every concern the phase touches has been bolted onto the same struct,
+and every module reaches into it via `impl<'a, H> Elaborator<'a, H>`.
+The conceptually independent layers — the type system, the per-module
+annotation facts, the AST → TIR walk — have no type-level boundary.
+Borrow-checker pressure pushes shared state into `Rc<RefCell<…>>` even
+where shared mutability is not conceptually required, which masks the
+real ownership question of where a fact lives.
+
+A symptom of this is the per-module construction in
+`Elaborator::build_tir_from_state`, which rebuilds the full 35-field
+struct for each loaded module. The construction site is the canonical
+demonstration of the problem: there is no way to introduce a new field
+without copying its initialisation into that site, and no way to
+remove a field without touching every module that reads from `self`.
+
+### The `annotate` phase name does not match what `annotate` does
+
+`semantics_with_logger` runs the elaborator in two calls:
+
+```
+let state = Elaborator::annotate_modules(...);
+let tir   = Elaborator::build_tir_from_state(&state, ...);
+```
+
+The intent of the split — documented in `orchestration.rs` and
+`semantics.rs` — is that `annotate` produces a snapshot the LSP can
+query, and `build_tir` is the batch-only extension that emits TIR.
+The implementation does not honour that intent. `annotate_modules`
+covers only declaration-level information (struct fields, variant
+cases, trait impls, decl-interned types). All body-level work —
+type inference, name resolution inside expressions, method dispatch,
+coercion choice, the desugar-replacement TIR rewrites — happens
+inside `build_tir_from_state`, which also emits TIR as a side effect
+of the same walk.
+
+The consequence is that the LSP path must run `build_tir_from_state`
+even though it discards the resulting `TirModule`s. The comment
+`semantics.rs:644` ("Run the full body-level resolve pass so
+`state.references` and `state.local_symbols` are populated by the real
+elaborator") states this directly. Every editor `didChange` pays for a
+full TIR emission whose output is thrown away.
+
+Further, the `Rc<RefCell<…>>` plumbing on `AnnotateState.references`
+and `AnnotateState.local_symbols` exists precisely because body walks
+mutate them after `annotate_modules` returns. The "phase boundary" is
+in the function signatures, not in the data flow.
+
+### LSP needs unused diagnostics; reify needs DCE
+
+A separate but related requirement is that `elaborate` must produce
+reachability information. The LSP rendering of unused locals,
+imports, and items is currently implemented against an optimize-time
+DCE pass (`optimize/dce.rs`); a planned rework
+(see `wep-2026-05-16-unused-diagnostics.md`) needs that information
+available from `Semantics`, before optimization runs. The same
+information lets `reify` skip TIR emission for items that are not
+reachable from world exports, reducing the size of the input to
+`monomorphize` / `lower` / `optimize`.
+
+There is no clean place for this analysis in the current elaborator,
+because the elaborator does not expose a "annotation complete"
+checkpoint.
+
+## Decision
+
+Re-architect `elaborate` around three layered types and an explicit
+phase order. The God Object disappears; the misleading
+`annotate` / `build_tir` split is replaced by a phase order that
+matches the work.
+
+### Three load-bearing types
+
+**`TypeSystem`** — the pipeline-wide type knowledge. Owned by the
+batch driver and by `Semantics`; passed by `&mut` reference into
+every per-module phase. Holds the `TypeTable` arena, the
+`TraitEnv`, the builtin / WASI / world registries, the included-files
+map, and the type-system caches (`method_info_cache`,
+`indexing_trait_cache`, `trait_check_stack`). Exposes operations that
+take only type IDs and names: coercion, inference, type checking,
+trait impl lookup, method lookup. It does not know about
+`Module`, `AstId`, or `ModuleSource`-keyed per-module state.
+
+The name is honest: this object *is* the type system, not a "type
+context." The naming criterion — "would a new field belong in the
+type system itself?" — gates membership and prevents drift back into
+God-Object behaviour.
+
+**`ModuleSemantics`** — per-module semantic facts produced by the
+elaborator. One instance per loaded module. Owned by `Semantics` in
+an `IndexMap<ModuleSource, ModuleSemantics>`. Built incrementally by
+`annotate` and extended by the body walk. Decomposed into four
+sub-structs with explicit membership rules:
+
+- **`bindings`** — `use → def` edges (`references`) and locally
+  defined symbols (`local_symbols`). What the LSP reads to answer
+  go-to-definition, find-references, and hover-on-local queries.
+- **`imports`** — per-module name resolution context derived from
+  `use` declarations: `imported_type_sources`,
+  `import_original_names`, `namespace_imports`, `effect_sources`.
+- **`types`** — per-`AstId` type annotations and dispatch decisions
+  recorded during the body walk: the `TypeId` of every typed
+  expression, the resolved target of each method call, the chosen
+  coercion at each conversion site, the desugar kind for each
+  TIR-direct rewrite (`assert`, `matches`, comparison chain,
+  for-of, while, compound assignment).
+- **`decls`** — module-internal declarations confirmed by
+  elaboration: `function_return_types`, `imported_functions`,
+  `current_module_globals`, `imported_globals`,
+  `associated_constants`, `generic_function_*`,
+  `generic_method_*`, `generic_struct_names`,
+  `pending_anonymous_structs`.
+
+Each sub-struct admits a new field only when "does this fit the
+sub-struct's responsibility?" has a clear yes/no answer. A field
+that cannot be placed is a design question, not a default-into-the-
+catch-all.
+
+**`Reify`** — the AST + `ModuleSemantics` → `TirModule` walker.
+Mechanical: it reads annotations placed by `annotate` and emits the
+corresponding TIR nodes. It does not perform type inference, name
+resolution, or method dispatch; those decisions were already made
+and recorded in `ModuleSemantics.types`. New types interned during
+reify (monomorphic instances created on demand) write through
+`TypeSystem`.
+
+### Phase order
+
+```
+parse → bind → load → analyze
+   ↓
+annotate_decls(modules, &mut TypeSystem)
+   ↓
+annotate_bodies(module, &mut TypeSystem, &mut ModuleSemantics)  ×N
+   ↓
+liveness(Semantics)
+   ↓
+reify(module, &TypeSystem, &ModuleSemantics) → TirModule       ×N
+   ↓
+monomorphize → lower → optimize → codegen
+```
+
+The LSP path stops after `liveness` and consumes `Semantics`. The
+batch path runs through `reify` and continues into the existing
+downstream pipeline.
+
+`annotate_decls` handles the cross-module declaration work that is
+already in today's `annotate_modules`. `annotate_bodies` is new in
+name only: it is the body walk that today lives inside
+`build_tir_from_state`, separated from TIR emission. Its sole output
+is a populated `ModuleSemantics`.
+
+`liveness` is a new pass that computes reachability from world-export
+roots over the `bindings` edges in every `ModuleSemantics`. The
+result is stored on `Semantics` as a `Liveness` value (live item set,
+unused-local list, unused-import list). The shape of the analysis and
+the policy questions around stdlib exclusion, attribute suppression,
+and synthesized items are owned by
+[`wep-2026-05-16-unused-diagnostics.md`](./wep-2026-05-16-unused-diagnostics.md);
+this WEP commits only to "there is a `liveness` pass between
+`annotate_bodies` and `reify`, its result lives on `Semantics`."
+
+`reify` reads `liveness.live_items` and skips items that are
+unreachable. The TIR delivered to `monomorphize` is therefore the
+reachable closure of the program, not the full source.
+
+### What changes about elaborate's name
+
+`elaborate` survives as the **umbrella term and physical directory
+name**. `wado-compiler/src/elaborator/` continues to host the three
+new layers as submodules (`tysys/`, `sem/`, `reify/`). The phase
+names exposed in pipeline diagrams and entry points become
+`annotate` and `reify`; `elaborate` is the name of the directory and
+the conversational name for the group of phases. This matches the
+established usage of "elaboration" in PL theory (Coq, Lean, Idris)
+for the same kind of work and keeps Wado contributors from needing
+a new term.
+
+## Implementation
+
+### Module layout
+
+```
+wado-compiler/src/elaborator/
+├── mod.rs
+├── tysys/        # TypeSystem and pure type-system operations
+│   ├── mod.rs
+│   ├── coerce.rs
+│   ├── infer.rs
+│   ├── typecheck.rs
+│   ├── traits.rs
+│   └── methods.rs
+├── sem/          # ModuleSemantics and its sub-structs
+│   ├── mod.rs
+│   ├── bindings.rs
+│   ├── imports.rs
+│   ├── types.rs
+│   └── decls.rs
+├── annotate/     # annotate_decls + annotate_bodies
+│   ├── mod.rs
+│   ├── decls.rs
+│   ├── module.rs
+│   ├── item.rs
+│   ├── expr.rs
+│   ├── stmt.rs
+│   ├── call.rs
+│   ├── method.rs
+│   ├── closure.rs
+│   ├── handlers.rs
+│   └── desugar.rs
+├── liveness.rs   # cross-module reachability
+└── reify/        # AST + ModuleSemantics → TirModule
+    ├── mod.rs
+    ├── module.rs
+    ├── item.rs
+    ├── expr.rs
+    └── stmt.rs
+```
+
+The current `elaborator.rs` and its 24 sibling modules are dissolved
+into this layout. The membership criterion for each file is its
+sub-struct or phase responsibility; no file collects "miscellaneous
+elaborator helpers."
+
+### TypeSystem surface
+
+`TypeSystem` exposes the operations that the rest of the compiler
+asks of "the type system":
+
+- **Interning** — `intern_*`, `make_type_param`, `make_type_pack`,
+  registration of associated-type resolutions.
+- **Coercion** — `coerce`, the numeric-literal and tuple-to-sequence
+  coercions, struct-to-map coercion. Inputs are `TypeId`s and
+  expression contexts; the operation returns a coerced expression or
+  rejection.
+- **Inference** — `InferCtx` is constructed from `&mut TypeSystem`
+  rather than from an `Elaborator`. Inference results are reported
+  back as type substitutions.
+- **Type checking** — `typecheck`, `typecheck_return`.
+- **Trait queries** — `implements`, impl resolution by trait and
+  target, blanket-impl resolution, bound checking, associated-type
+  binding lookup.
+- **Method lookup** — `lookup_method_info`, indexing-trait impls,
+  arithmetic-trait impls, key-value / sequence-literal trait impls,
+  trait-method resolution.
+
+Method-lookup and trait-query code that today depends on
+`Elaborator.trait_ctx` (the per-impl, per-function scope) splits:
+the queries that can be answered from `TypeId`s and decl indices
+move to `TypeSystem`; the queries that depend on the current
+function's `trait_ctx` move to the `annotate` layer and pass the
+scope explicitly.
+
+### ModuleSemantics surface
+
+Each sub-struct has a single-line responsibility and a small,
+inspectable API:
+
+- `ModuleBindings::record_reference`,
+  `ModuleBindings::record_local_symbol`, plus the
+  reference-resolution helpers used by `Semantics::referenced_symbol`
+  and `Semantics::references_to_def`.
+- `ModuleImports::lookup`, `ModuleImports::canonical_decl_key`, the
+  effect-source map, the namespace-alias map.
+- `TypeAnnotations::set(ast_id, type_id)`,
+  `TypeAnnotations::dispatch_target(ast_id)`,
+  `TypeAnnotations::coercion_at(ast_id)`,
+  `TypeAnnotations::desugar_kind(ast_id)`. The reify layer is the
+  primary consumer; LSP hover may read the type map directly.
+- `ModuleDecls::function_return_type(name)`, `generic_*`,
+  `imported_global`, `associated_constant`, the
+  `pending_anonymous_structs` list.
+
+`ModuleSemantics` is owned by `Semantics`. `annotate_bodies` takes
+`&mut ModuleSemantics` for the module it is processing; every other
+phase takes `&ModuleSemantics`.
+
+### Reify surface
+
+`reify_module(&Module, &TypeSystem, &ModuleSemantics) → TirModule`.
+The walker mirrors the AST shape; each visit method looks up the
+corresponding annotation on `ModuleSemantics.types` and emits a
+TIR node. No inference, no name resolution, no dispatch decisions.
+Monomorphic instances created during reify intern through
+`&mut TypeSystem`.
+
+### DCE / Liveness
+
+The `liveness` pass is documented in
+[`wep-2026-05-16-unused-diagnostics.md`](./wep-2026-05-16-unused-diagnostics.md);
+that WEP is rewritten to consume the new architecture (its current
+content places the analysis in `optimize/dce.rs`, which moves to the
+elaborator under this WEP). The contract on the elaborator side is
+narrow:
+
+- `liveness::compute(&Semantics) → Liveness` runs after every
+  `ModuleSemantics` is fully populated.
+- The result is stored on `Semantics` as a new field.
+- `reify_all` gates item emission on `liveness.live_items`.
+- LSP exposes unused diagnostics by reading `Liveness` directly.
+
+The roots, suppression rules, stdlib exclusion, and severity policy
+remain owned by the unused-diagnostics WEP and are not duplicated
+here.
+
+## Migration Plan
+
+The change touches every file under `elaborator/`. It must land
+incrementally with the test suite (E2E fixtures, WIR golden
+fixtures, LSP query tests) green at every step. The migration
+proceeds in seven stages, in dependency order. Stages are guidelines,
+not commitments to specific PR boundaries.
+
+**Stage 1 — Skeleton.** Introduce `TypeSystem`, `ModuleSemantics`,
+and the four sub-structs as empty types alongside the existing
+`Elaborator`. No method moves; the existing fields are annotated
+with their future destination. The goal is to fix the physical
+target before any logic moves.
+
+**Stage 2 — Move pure type-system operations to `TypeSystem`.**
+Coercion, inference, type checking, trait queries, and the
+type-only portion of method lookup migrate. The remaining
+`Elaborator` delegates through a `tysys: TypeSystem` field. The
+borrow checker enforces the boundary: methods on `TypeSystem`
+cannot reach `current_module_source` or `imported_type_sources`,
+which mechanically classifies each moved method.
+
+**Stage 3 — Move per-module state to `ModuleSemantics`.** The
+import context, decls, and `use → def` maps migrate into
+`ModuleSemantics`. The `Elaborator` becomes a thin wrapper holding
+`&mut TypeSystem` and the current `&mut ModuleSemantics`.
+`Rc<RefCell<…>>` plumbing that existed only to share these maps
+with `AnnotateState` is removed.
+
+**Stage 4 — Introduce explicit per-`AstId` annotation storage.**
+`ModuleSemantics.types` (`TypeAnnotations`) is populated by the
+existing body walk. TIR emission stays in the same walk for this
+stage. The objective is to make the data the future `reify` will
+read available, while preserving today's single-pass behaviour.
+
+**Stage 5 — Split `annotate_bodies` from `reify`.** Per-construct
+walkers split into a `annotate_*` form that writes
+`ModuleSemantics.types` and a `reify_*` form that reads it and
+emits TIR. Batch compilation now performs two walks. Equivalence
+is established by the E2E suite and the WIR golden fixtures; no
+separate TIR-identity check is required because the WIR comparison
+already binds the entire downstream pipeline.
+
+**Stage 6 — Liveness and DCE.** `liveness::compute` is added, its
+result is stored on `Semantics`, and `reify_all` gates item
+emission on it. The user-facing unused diagnostics land per the
+unused-diagnostics WEP. `optimize/dce.rs` retires from its current
+role as the source of the same information, with the
+optimize-time pass either deleted or repurposed per that WEP.
+
+**Stage 7 — Cleanup.** The old `Elaborator` struct and
+`AnnotateState` are removed; their last surviving fields move
+to their final homes. The pipeline diagram in `CLAUDE.md` and
+`docs/compiler.md` is updated. The `elaborator/` directory's
+file layout matches the module layout in this WEP.
+
+Each stage keeps `mise run test`, the WIR golden fixtures, and
+the LSP query tests green. Performance is not tracked during
+migration; see Trade-offs.
+
+## Consequences
+
+### Benefits
+
+- **The God Object is gone.** Every new field has a sub-struct it
+  belongs to, and the membership criterion is mechanical.
+- **`annotate` actually annotates.** The phase name matches its
+  work, and `Semantics` is genuinely complete after `annotate`
+  returns. The LSP no longer pays for thrown-away TIR.
+- **`reify` is mechanical.** It can be tested in isolation against
+  hand-built `ModuleSemantics` fixtures, and the type boundary
+  ensures it cannot reach for inference state.
+- **DCE has a place to live.** The `liveness` pass slots cleanly
+  between `annotate` and `reify`, gives the LSP its unused
+  diagnostics, and lets `reify` shrink its output before
+  monomorphization sees it.
+- **`Rc<RefCell<…>>` retreats to where it is genuinely needed.**
+  The `TypeTable` remains shared (anonymous structs and
+  monomorphic instances intern through both `annotate` and
+  `reify`); the `references` / `local_symbols` plumbing simplifies
+  to `&mut ModuleSemantics`.
+- **Plain Rust ownership.** Borrow-check pressure now reflects the
+  conceptual model rather than working around it.
+
+### Trade-offs
+
+- **Batch compilation walks bodies twice.** Once in
+  `annotate_bodies` (the heavy walk that does inference,
+  resolution, and dispatch) and once in `reify` (the mechanical
+  walk that reads the annotations). Performance is not optimised
+  during the migration; if a workload regresses unacceptably, the
+  remedy is to specialise `reify` over the recorded annotations,
+  not to merge the phases back. The clean phase boundary is
+  the load-bearing decision.
+- **Bigger up-front design surface.** The four sub-structs and
+  their membership rules need to be respected when adding fields.
+  This is a feature, not a bug — the membership rule replaces
+  the current absence of any rule.
+- **Migration is long.** The change touches roughly the entire
+  `elaborator/` tree. Stages 4 and 5 are the riskiest because
+  they restructure the body walk; the WIR golden fixtures and
+  E2E suite carry the equivalence guarantee.
+
+### Risks and mitigations
+
+- **`ModuleSemantics` becomes another God Object.** Mitigation:
+  the four sub-structs are non-optional, and every field added
+  during or after migration must justify its sub-struct. Reviews
+  reject "just put it on `ModuleSemantics` directly."
+- **The `annotate` / `reify` split leaks during migration.**
+  Mitigation: stage 4 introduces the annotation storage *before*
+  stage 5 splits the walk. Any annotation reify needs but
+  `annotate` does not record is a stage-4 omission, surfaced as a
+  panic in stage 5.
+- **DCE breaks a previously-reachable item.** Mitigation: the
+  unused-diagnostics WEP owns the reachability rules; stage 6
+  switches the source of truth from `optimize/dce.rs` to the
+  elaborator-time pass, with the same E2E and WIR fixtures
+  validating that no live item is dropped.
+
+## See Also
+
+- [`wep-2026-04-18-lsp-architecture.md`](./wep-2026-04-18-lsp-architecture.md)
+  — the LSP path's contract on `Semantics`.
+- [`wep-2026-05-16-unused-diagnostics.md`](./wep-2026-05-16-unused-diagnostics.md)
+  — the policy and surface for unused diagnostics. To be rewritten
+  to consume the elaborator-time `liveness` pass introduced here.
+- [`wep-2026-05-11-nir.md`](./wep-2026-05-11-nir.md) — the type
+  boundary between TIR and post-lower IR. The boundary this WEP
+  introduces between `annotate` and `reify` is the upstream
+  counterpart.

--- a/docs/wep-2026-05-26-elaborator-rearchitecture.md
+++ b/docs/wep-2026-05-26-elaborator-rearchitecture.md
@@ -98,7 +98,7 @@ take only type IDs and names: coercion, inference, type checking,
 trait impl lookup, method lookup. It does not know about
 `Module`, `AstId`, or `ModuleSource`-keyed per-module state.
 
-The name is honest: this object *is* the type system, not a "type
+The name is honest: this object _is_ the type system, not a "type
 context." The naming criterion — "would a new field belong in the
 type system itself?" — gates membership and prevents drift back into
 God-Object behaviour.
@@ -417,7 +417,7 @@ migration; see Trade-offs.
   during or after migration must justify its sub-struct. Reviews
   reject "just put it on `ModuleSemantics` directly."
 - **The `annotate` / `reify` split leaks during migration.**
-  Mitigation: stage 4 introduces the annotation storage *before*
+  Mitigation: stage 4 introduces the annotation storage _before_
   stage 5 splits the walk. Any annotation reify needs but
   `annotate` does not record is a stage-4 omission, surfaced as a
   panic in stage 5.


### PR DESCRIPTION
## Summary

- New WEP: **Elaborator Re-architecture — TypeSystem / Annotate / Reify**. Split the `Elaborator` God Object (33k LOC, ~35-field struct) into three load-bearing types: `TypeSystem` (pipeline-wide type knowledge), `ModuleSemantics` (per-module facts in 4 sub-structs `bindings`/`imports`/`types`/`decls`), and `Reify` (mechanical AST + ModuleSemantics → TIR). `annotate` is redefined to walk function bodies — today's "annotate" only covers decls while body-level work hides inside `build_tir_from_state`, which forces the LSP to run TIR emission it discards. The new `liveness` pass slots between `annotate_bodies` and `reify` as the source-level DCE checkpoint.
- Update: **Unused Diagnostics** WEP. The old plan placed `DeadFunction` / `DeadGlobal` emission inside `optimize.rs::run_dce`'s fixed-point loop with cross-iteration dedup; that machinery is removed. Both layers now run at elaborate-time: a reference pass over `ModuleSemantics.bindings` for `UnusedImport`/`Variable`/`Parameter`, and the new `liveness` pass for `DeadFunction`/`DeadGlobal`. The optimize-time DCE keeps doing silent post-monomorphization cleanup. The `defining_ast_id` plumbing through TIR/NIR/optimize is no longer needed (every source item is already addressable by `SymbolKey` at elaborate time).
- No code changes in this PR. WEPs only.

## Test plan

- [ ] Reviewers confirm the three-layer split and the four sub-structs of `ModuleSemantics` capture the right boundaries
- [ ] Reviewers confirm the `Reachability roots` table in unused-diagnostics matches the existing `optimize/dce.rs::compute_reachable_from_entries` root set
- [ ] Reviewers confirm the migration ordering: reference-pass diagnostics can land before the rearchitecture completes; liveness-pass diagnostics land with rearchitecture stage 6
- [ ] `mise run format` clean (already applied)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K57wddb8f9rWPHdsNBbCZi)_