### PR TITLE
elaborator: introduce TypeSystem / ModuleSemantics (Stage 1 + Stage 2)

### DIFF
--- a/docs/wep-2026-05-26-elaborator-rearchitecture.md
+++ b/docs/wep-2026-05-26-elaborator-rearchitecture.md
@@ -367,6 +367,110 @@ Each stage keeps `mise run test`, the WIR golden fixtures, and
 the LSP query tests green. Performance is not tracked during
 migration; see Trade-offs.
 
+## Status
+
+- [x] **Stage 1 — Skeleton.** Empty `TypeSystem` + `ModuleSemantics`
+      (`bindings`, `decls`, `imports`, `types`) introduced alongside the
+      existing `Elaborator` / `AnnotateState`. Every existing field
+      annotated with its future destination via `// MIGRATION:` markers.
+      No method or field moved.
+- [x] **Stage 2 — Pure type-system operations on `TypeSystem`.**
+  - Stage 2a: 15 pipeline-wide fields hoisted onto `TypeSystem`
+    (type arena, decl-interned tables, registries, included-files
+    map, read-only caches). `AnnotateState` and `Elaborator` each
+    hold one `tysys: TypeSystem` field; `TypeSystem` is `Clone`
+    (shallow `Rc` / `Arc` copy) so per-module elaborators get a
+    cheap view.
+  - Stage 2b: five host-agnostic helpers moved to `impl TypeSystem`:
+    `is_known_type_name`, `is_numeric_literal`,
+    `operator_trait_method`, `typecheck`, `typecheck_return`.
+  - The legacy `pub fn resolve_module` single-module wrapper and
+    `Elaborator::new` were removed as dead code; all entry now goes
+    through `annotate_modules` + `build_tir_from_state`.
+- [ ] **Stage 3 — `ModuleSemantics` population.**
+- [ ] **Stage 4 — Per-`AstId` annotation storage.**
+- [ ] **Stage 5 — `annotate_bodies` / `reify` split.**
+- [ ] **Stage 6 — Liveness and DCE.**
+- [ ] **Stage 7 — Cleanup.**
+
+### Stage 2 design notes
+
+The following decisions emerged while moving the type system out
+from under `Elaborator`. They refine — and in a few cases narrow
+— the surface sketched in "TypeSystem surface" above.
+
+#### TypeSystem stays host-agnostic
+
+`TypeSystem` operations that need to report a type error return
+`Result<(), TypeMismatchPayload>` (or analogous payload), never
+`&Logger<H>`. The `<H: CompilerHost>` parameter is confined to a
+thin wrapper on `Elaborator` that emits the diagnostic. Without
+this discipline `<H>` is contagious — every `TypeSystem` method
+that errors would propagate it, eventually pulling the host trait
+into the type-system API.
+
+The pattern in `typecheck.rs` is the template for the rest of the
+operations the WEP plans to move (`coerce`, method-lookup core,
+trait queries):
+
+1. A pure helper over `&TypeTable` (e.g. `check_assignable`).
+2. `impl TypeSystem { fn op(&self, …) -> Result<…, Payload> }`.
+3. `impl Elaborator { fn op(&self, …) { logger.error(payload) } }`.
+
+#### TypeSystem membership rule, in code
+
+`TypeSystem` only holds fields the elaborator queries while making
+type decisions. Concretely:
+
+- `wasi_registry` belongs (`call.rs` queries WASI function
+  signatures through it).
+- `world_registry` does **not** belong on `TypeSystem`, even
+  though it is built by the same `WasiRegistry::build_from_stdlib`
+  call. Only post-elaborator stages (`link`, `synthesis`,
+  `optimize/dce`, `lib.rs` world-existence validation) read it.
+  It lives on `AnnotateState` (driver state).
+
+The mechanical question to ask when adding a field: "does the
+elaborator's body walk query this field?" If no, it does not
+belong on `TypeSystem`.
+
+#### Three caches are deferred
+
+`indexing_trait_cache` and `method_info_cache` are genuine
+type-system caches whose keys are pure `TypeId` / name tuples;
+their move to `TypeSystem` is deferred only because the
+pipeline-wide cache lifetime story (today they are per-Elaborator
+mutable state, populated by the body walk) is not yet decided.
+
+`trait_check_stack` _looks_ similar — `RefCell<Vec<…>>` mutable
+state on `Elaborator` — but it is **not** a cache. It is the
+per-call frame stack used by `type_implements_trait` to break
+recursion on recursive types; sharing it across modules would
+either leak stale frames (a soundness bug — wrong "recursive,
+optimistically true" answers) or require per-call save/restore
+plumbing that defeats the move. Its migration target is the
+transient annotate-time scope bucket alongside `trait_ctx`, not
+`TypeSystem`.
+
+#### Unique-ownership contracts surface at the leak site
+
+`compile_after_load` consumes `Arc<TraitEnv>` and
+`Rc<BuiltinRegistry>` out of `state.tysys`. Both must be uniquely
+owned at that point — `synthesize`'s `extend_with_synthesised`
+panics on a shared `Arc<TraitEnv>`, and a shared
+`Rc<BuiltinRegistry>` silently falls back to a deep clone. The
+handoff uses `debug_assert_eq!` on `Arc::strong_count` /
+`Rc::strong_count` so a stray clone introduced by a later refactor
+surfaces at the leak site instead of in a downstream phase.
+
+#### Exhaustive matches over enum kinds
+
+Pure `TypeSystem` helpers (`is_numeric_literal`,
+`operator_trait_method`) enumerate every `Expr` / `BinaryOp`
+variant rather than using `_ => …`. A new variant added to either
+enum surfaces here as a compile error, forcing a deliberate
+decision instead of silently falling into the catch-all.
+
 ## Consequences
 
 ### Benefits

--- a/wado-compiler/src/elaborator.rs
+++ b/wado-compiler/src/elaborator.rs
@@ -40,9 +40,7 @@ use std::rc::Rc;
 use crate::hashmap::{IndexMap, IndexSet};
 
 use crate::ast::{self, Item, Module};
-use crate::builtin_registry::BuiltinRegistry;
 use crate::compiler_host::CompilerHost;
-use crate::component_model::WasiRegistry;
 use crate::logger::{Bail, Logger};
 use crate::module_source::{ModuleSource, ModuleSourceInterner};
 use crate::name::{self as name, MethodName};
@@ -51,8 +49,6 @@ use crate::tir::{
     self as tir, TirEnum, TirEnumCase, TirFlags, TirFlagsMember, TirModule, TirNewtype, TypeId,
     TypeTable,
 };
-
-use trait_env::TraitEnv;
 
 /// Build a function-name → item-index map for a module's items. Used
 /// once per loaded module during annotate
@@ -283,57 +279,6 @@ pub struct Elaborator<'a, H: CompilerHost> {
 }
 
 impl<'a, H: CompilerHost> Elaborator<'a, H> {
-    pub(crate) fn new(
-        symbols: &'a SymbolTable,
-        loaded_modules: &'a IndexMap<ModuleSource, Module>,
-        tysys: tysys::TypeSystem,
-        logger: &'a Logger<'a, H>,
-    ) -> Self {
-        Self {
-            tysys,
-            symbols,
-            loaded_modules,
-            imported_type_sources: IndexMap::default(),
-            import_original_names: IndexMap::default(),
-            local_struct_fields: IndexMap::default(),
-            local_newtypes: IndexMap::default(),
-            local_generic_newtypes: IndexMap::default(),
-            local_enum_cases: IndexMap::default(),
-            local_flags_cases: IndexMap::default(),
-            local_variant_cases: IndexMap::default(),
-            function_return_types: IndexMap::default(),
-            imported_functions: IndexSet::default(),
-            namespace_imports: IndexMap::default(),
-            logger,
-            current_module_source: ModuleSource::entry_point_uninitialized(),
-            entry_module_source: ModuleSource::entry_point_uninitialized(),
-            current_module_items: &[],
-            effect_sources: IndexMap::default(),
-            current_effect_params: IndexSet::default(),
-            current_effect_param_decls: IndexMap::default(),
-            trait_ctx: trait_env::TraitContext::default(),
-            generic_struct_names: IndexSet::default(),
-            generic_function_params: IndexMap::default(),
-            generic_function_resolved_param_types: IndexMap::default(),
-            generic_function_resolved_return_types: IndexMap::default(),
-            generic_method_params: IndexMap::default(),
-            generic_method_resolved_param_types: IndexMap::default(),
-            current_module_globals: IndexMap::default(),
-            imported_globals: IndexMap::default(),
-            associated_constants: IndexMap::default(),
-            indexing_trait_cache: IndexMap::default(),
-            trait_check_stack: RefCell::new(Vec::new()),
-            method_info_cache: IndexMap::default(),
-            pending_anonymous_structs: Vec::new(),
-            references: Rc::new(RefCell::new(IndexMap::default())),
-            local_symbols: Rc::new(RefCell::new(IndexMap::default())),
-            local_types: Rc::new(RefCell::new(IndexMap::default())),
-            default_scope_module: None,
-            invocations: Rc::new(crate::kiln::InvocationIndex::new()),
-            interner: Rc::new(RefCell::new(ModuleSourceInterner::new())),
-        }
-    }
-
     /// Construct a [`TypeLookup`] view over the elaborator's current import
     /// context and shared `all_*` tables. Use this for any type-name
     /// resolution; never reach into `all_*` directly.
@@ -1396,41 +1341,4 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
     pub fn into_type_table(self) -> Rc<RefCell<TypeTable>> {
         self.tysys.type_table
     }
-}
-
-pub fn resolve_module<H: CompilerHost>(
-    module: &Module,
-    module_source: ModuleSource,
-    symbols: &SymbolTable,
-    loaded_modules: &IndexMap<ModuleSource, Module>,
-    logger: &Logger<H>,
-) -> Result<TirModule, Bail> {
-    let type_table = Rc::new(RefCell::new(crate::tir::TypeTable::new()));
-    let builtin_registry = BuiltinRegistry::build_from_stdlib(&type_table);
-    let (wasi_registry, _world_registry) = WasiRegistry::build_from_stdlib();
-    let (trait_env, _) = TraitEnv::build(loaded_modules, symbols);
-    // Seed the loaded-module function index for the single module this
-    // path resolves. The main pipeline populates this map across every
-    // loaded module in `annotate_modules`; here we only need the one,
-    // so `lookup_current_func` can find functions defined in `module`.
-    let mut func_indices = IndexMap::default();
-    func_indices.insert(module_source.clone(), build_func_index(&module.items));
-    let tysys = tysys::TypeSystem {
-        type_table,
-        all_newtypes: Rc::new(IndexMap::default()),
-        all_generic_newtypes: Rc::new(IndexMap::default()),
-        all_struct_fields: Rc::new(IndexMap::default()),
-        all_variant_cases: Rc::new(IndexMap::default()),
-        all_enum_cases: Rc::new(IndexMap::default()),
-        all_flags_cases: Rc::new(IndexMap::default()),
-        all_resource_types: Rc::new(IndexMap::default()),
-        trait_env,
-        wasi_registry,
-        builtin_registry: Rc::new(builtin_registry),
-        included_files: Rc::new(IndexMap::default()),
-        known_type_names_cache: Rc::new(IndexSet::default()),
-        loaded_module_func_indices: Rc::new(func_indices),
-    };
-    let mut elaborator = Elaborator::new(symbols, loaded_modules, tysys, logger);
-    elaborator.resolve_module(module, module_source)
 }

--- a/wado-compiler/src/elaborator.rs
+++ b/wado-compiler/src/elaborator.rs
@@ -36,7 +36,6 @@ mod util;
 
 use std::cell::RefCell;
 use std::rc::Rc;
-use std::sync::Arc;
 
 use crate::hashmap::{IndexMap, IndexSet};
 
@@ -86,13 +85,13 @@ use types::{
 // re-architecture. Each `MIGRATION:` line names the field's future home —
 // `TypeSystem` (pipeline-wide type knowledge) or a sub-struct of
 // `ModuleSemantics` (per-module facts), or a transient annotate-time scope
-// or cross-cutting input that stays on the per-module driver. Stage 1
-// only fixes the placement; the fields themselves do not move.
+// or cross-cutting input that stays on the per-module driver.
 
 pub struct Elaborator<'a, H: CompilerHost> {
-    /// Type table (shared across all modules via Rc<RefCell>)
-    // MIGRATION: → TypeSystem (arena).
-    type_table: Rc<RefCell<TypeTable>>,
+    /// Pipeline-wide type knowledge: type arena, decl-interned type
+    /// tables, registries, included-files map, and the read-only caches
+    /// built once during `annotate_modules`. See [`tysys::TypeSystem`].
+    pub(crate) tysys: tysys::TypeSystem,
     /// Symbol table from analyzer
     // MIGRATION: cross-cutting input (stays on the driver).
     #[allow(dead_code)]
@@ -101,18 +100,6 @@ pub struct Elaborator<'a, H: CompilerHost> {
     // MIGRATION: cross-cutting input (stays on the driver).
     #[allow(dead_code)]
     loaded_modules: &'a IndexMap<ModuleSource, Module>,
-    /// Per-module nested maps for cross-module type resolution (shared via Rc).
-    /// These are the *single source of truth* for declared type info; all
-    /// per-module name resolution is performed by walking these via
-    /// [`TypeLookup`] without cloning their contents into per-module flat maps.
-    // MIGRATION: → TypeSystem (decl-interned type tables, all 7 below).
-    all_newtypes: Rc<IndexMap<ModuleSource, IndexMap<String, TypeId>>>,
-    all_generic_newtypes: Rc<IndexMap<ModuleSource, IndexMap<String, GenericNewtypeInfo>>>,
-    all_struct_fields: Rc<IndexMap<ModuleSource, IndexMap<String, StructFieldInfo>>>,
-    all_variant_cases: Rc<IndexMap<ModuleSource, IndexMap<String, VariantInfo>>>,
-    all_enum_cases: Rc<IndexMap<ModuleSource, IndexMap<String, EnumInfo>>>,
-    all_flags_cases: Rc<IndexMap<ModuleSource, IndexMap<String, FlagsInfo>>>,
-    all_resource_types: Rc<IndexMap<ModuleSource, IndexMap<String, ResourceInfo>>>,
     /// Per-module import context (consumed by [`TypeLookup`]). Built once per
     /// module from `use` declarations; replaces the 7 flat maps the elaborator
     /// used to clone for each module.
@@ -198,12 +185,6 @@ pub struct Elaborator<'a, H: CompilerHost> {
     /// Used to record use→def edges for effect parameter references in `with` clauses.
     // MIGRATION: transient annotate-time scope (per-function, not per-module).
     current_effect_param_decls: IndexMap<String, crate::ast::AstId>,
-    /// WASI registry for looking up effect return types
-    // MIGRATION: → TypeSystem (registry).
-    wasi_registry: &'static WasiRegistry,
-    /// Builtin registry for looking up builtin function return types
-    // MIGRATION: → TypeSystem (registry).
-    builtin_registry: &'a BuiltinRegistry,
     /// Global variables in the current module (name -> (type, `is_mutable`))
     // MIGRATION: → ModuleSemantics::decls.
     current_module_globals: IndexMap<String, (TypeId, bool)>,
@@ -214,42 +195,31 @@ pub struct Elaborator<'a, H: CompilerHost> {
     /// These are inlined at every use site during resolution.
     // MIGRATION: → ModuleSemantics::decls.
     associated_constants: IndexMap<String, (ast::Type, ast::Expr)>,
-    /// Immutable trait knowledge base: impl indices, trait declarations, and blanket impls.
-    /// Built once and shared across all module elaborators via `Arc`.
-    // MIGRATION: → TypeSystem.
-    trait_env: Arc<TraitEnv>,
-    /// Pre-loaded file contents for `#include_str` / `#include_bytes`.
-    /// Key: `[module_source_display, raw_path]`, value: raw bytes.
-    // MIGRATION: → TypeSystem (included-files map).
-    included_files: &'a IndexMap<[String; 2], Vec<u8>>,
-    /// Cached flat set of all known type names for fast `is_known_type_name` lookups.
-    // MIGRATION: → TypeSystem.
-    known_type_names_cache: IndexSet<String>,
     /// Anonymous structs created during expression resolution.
     /// Flushed into the `TirModule` at the end of `resolve_module`.
     // MIGRATION: → ModuleSemantics::decls.
     pending_anonymous_structs: Vec<crate::tir::TirStruct>,
     /// Cache for `find_indexing_trait_impl` results.
     /// Key: (`struct_name`, `base_type_id`, `trait_base_name`, `method_name`, `assoc_type_name`)
-    // MIGRATION: → TypeSystem (type-system cache).
+    // MIGRATION: → TypeSystem (type-system cache); deferred — needs the
+    //   pipeline-wide cache lifetime story (currently per-Elaborator).
     indexing_trait_cache: IndexMap<
         (String, TypeId, String, String, String),
         Option<(TypeId, ast::SelfKind, String, ModuleSource)>,
     >,
     /// Recursion guard for `type_implements_trait` to avoid infinite recursion
     /// on recursive types (e.g., variant Elem containing struct `RepeatElem` with field Elem).
-    // MIGRATION: → TypeSystem (type-system cache).
+    // MIGRATION: → TypeSystem (type-system cache); deferred — needs the
+    //   pipeline-wide cache lifetime story.
     trait_check_stack: RefCell<Vec<(TypeId, String)>>,
     /// Cache for `lookup_method_info` results.
     /// Key: (`base_type_id`, `method_name`) → cached `MethodInfo`
-    // MIGRATION: → TypeSystem (type-system cache).
+    // MIGRATION: → TypeSystem (type-system cache); deferred — needs the
+    //   pipeline-wide cache lifetime story.
     method_info_cache: IndexMap<(TypeId, String), Option<types::MethodInfo>>,
     /// Index from function name → position in `current_module_items` for O(1) lookup.
     // MIGRATION: transient annotate-time scope (rebuilt for the active module).
     current_module_func_index: IndexMap<String, usize>,
-    /// Per-module index from function name → position in module.items for O(1) lookup.
-    // MIGRATION: → TypeSystem (pipeline-wide func-name index over loaded modules).
-    loaded_module_func_indices: IndexMap<ModuleSource, IndexMap<String, usize>>,
     /// Use→def map for local variables. Shared via `Rc<RefCell<…>>` with
     /// [`crate::elaborator::orchestration::AnnotateState`] so LSP queries see
     /// references as soon as the elaborator has walked the body.
@@ -290,27 +260,16 @@ pub struct Elaborator<'a, H: CompilerHost> {
 }
 
 impl<'a, H: CompilerHost> Elaborator<'a, H> {
-    pub fn new(
+    pub(crate) fn new(
         symbols: &'a SymbolTable,
         loaded_modules: &'a IndexMap<ModuleSource, Module>,
-        builtin_registry: &'a BuiltinRegistry,
+        tysys: tysys::TypeSystem,
         logger: &'a Logger<'a, H>,
-        included_files: &'a IndexMap<[String; 2], Vec<u8>>,
     ) -> Self {
-        let (wasi_registry, _) = WasiRegistry::build_from_stdlib();
-        let type_table = Rc::new(RefCell::new(TypeTable::new()));
-        let (trait_env, _) = TraitEnv::build(loaded_modules, symbols);
         Self {
-            type_table,
+            tysys,
             symbols,
             loaded_modules,
-            all_newtypes: Rc::new(IndexMap::default()),
-            all_generic_newtypes: Rc::new(IndexMap::default()),
-            all_struct_fields: Rc::new(IndexMap::default()),
-            all_variant_cases: Rc::new(IndexMap::default()),
-            all_enum_cases: Rc::new(IndexMap::default()),
-            all_flags_cases: Rc::new(IndexMap::default()),
-            all_resource_types: Rc::new(IndexMap::default()),
             imported_type_sources: IndexMap::default(),
             import_original_names: IndexMap::default(),
             local_struct_fields: IndexMap::default(),
@@ -336,20 +295,14 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             generic_function_resolved_return_types: IndexMap::default(),
             generic_method_params: IndexMap::default(),
             generic_method_resolved_param_types: IndexMap::default(),
-            wasi_registry,
-            builtin_registry,
             current_module_globals: IndexMap::default(),
             imported_globals: IndexMap::default(),
             associated_constants: IndexMap::default(),
-            trait_env,
-            included_files,
-            known_type_names_cache: IndexSet::default(),
             indexing_trait_cache: IndexMap::default(),
             trait_check_stack: RefCell::new(Vec::new()),
             method_info_cache: IndexMap::default(),
             pending_anonymous_structs: Vec::new(),
             current_module_func_index: IndexMap::default(),
-            loaded_module_func_indices: IndexMap::default(),
             references: Rc::new(RefCell::new(IndexMap::default())),
             local_symbols: Rc::new(RefCell::new(IndexMap::default())),
             local_types: Rc::new(RefCell::new(IndexMap::default())),
@@ -367,13 +320,13 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             current_module_source: &self.current_module_source,
             imported_type_sources: &self.imported_type_sources,
             import_original_names: &self.import_original_names,
-            all_newtypes: &self.all_newtypes,
-            all_struct_fields: &self.all_struct_fields,
-            all_variant_cases: &self.all_variant_cases,
-            all_enum_cases: &self.all_enum_cases,
-            all_flags_cases: &self.all_flags_cases,
-            all_resource_types: &self.all_resource_types,
-            all_generic_newtypes: &self.all_generic_newtypes,
+            all_newtypes: &self.tysys.all_newtypes,
+            all_struct_fields: &self.tysys.all_struct_fields,
+            all_variant_cases: &self.tysys.all_variant_cases,
+            all_enum_cases: &self.tysys.all_enum_cases,
+            all_flags_cases: &self.tysys.all_flags_cases,
+            all_resource_types: &self.tysys.all_resource_types,
+            all_generic_newtypes: &self.tysys.all_generic_newtypes,
             local_struct_fields: &self.local_struct_fields,
             local_newtypes: &self.local_newtypes,
             local_enum_cases: &self.local_enum_cases,
@@ -697,7 +650,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             .get(name)
             .filter(|info| info.module_source == *module_source)
             .or_else(|| {
-                self.all_struct_fields
+                self.tysys.all_struct_fields
                     .get(module_source)
                     .and_then(|m| m.get(name))
             })
@@ -833,10 +786,10 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         // same-named items; this is the legacy bare-name behaviour and is
         // reachable only when the prior priorities (which DO disambiguate
         // user-visible cases) all miss.
-        if let Some(key) = self.trait_env.find_trait_decl_key(name) {
+        if let Some(key) = self.tysys.trait_env.find_trait_decl_key(name) {
             return key;
         }
-        if let Some(key) = self.trait_env.find_effect_or_resource_decl_key(name) {
+        if let Some(key) = self.tysys.trait_env.find_effect_or_resource_decl_key(name) {
             return key;
         }
         // Final fallback: a receiver type name (often a built-in primitive
@@ -845,7 +798,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         // build time by `(impl_module, type_name)`; scanning its keys for
         // a matching bare name recovers the receiver's canonical module
         // so the lookup site sees the same key the build phase wrote.
-        if let Some(key) = self.trait_env.find_static_method_decl_key(name) {
+        if let Some(key) = self.tysys.trait_env.find_static_method_decl_key(name) {
             return key;
         }
         (self.current_module_source.clone(), name.to_string())
@@ -1123,11 +1076,11 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                         }
                         if !self.trait_ctx.type_params.contains_key(&param.name) {
                             let type_id = if param.is_pack {
-                                self.type_table
+                                self.tysys.type_table
                                     .borrow_mut()
                                     .make_type_pack(param.name.clone(), actual_idx)
                             } else {
-                                self.type_table
+                                self.tysys.type_table
                                     .borrow_mut()
                                     .make_type_param(param.name.clone(), actual_idx)
                             };
@@ -1160,7 +1113,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                                     && !self.is_known_type_name(name)
                                 {
                                     let type_id = self
-                                        .type_table
+                                        .tysys.type_table
                                         .borrow_mut()
                                         .make_type_param(name.clone(), i as u32);
                                     self.trait_ctx
@@ -1203,7 +1156,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                         // Resolve the target type for registering associated type resolutions
                         let target_type_id = self.resolve_type(&impl_block.ty);
                         let is_concrete =
-                            !self.type_table.borrow().contains_type_param(target_type_id);
+                            !self.tysys.type_table.borrow().contains_type_param(target_type_id);
 
                         for binding in &impl_block.associated_types {
                             let type_id = self.resolve_type(&binding.ty);
@@ -1214,7 +1167,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                             // Register in TypeTable for substitution resolution
                             // Only for concrete types (not generic impls like impl<T> Trait for Array<T>)
                             if is_concrete {
-                                self.type_table.borrow_mut().register_assoc_type_resolution(
+                                self.tysys.type_table.borrow_mut().register_assoc_type_resolution(
                                     target_type_id,
                                     binding.name.clone(),
                                     type_id,
@@ -1222,7 +1175,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                             } else {
                                 // For generic impls, register the definition so the monomorphizer
                                 // can resolve associated types for GenericInstance types.
-                                self.type_table
+                                self.tysys.type_table
                                     .borrow_mut()
                                     .register_generic_assoc_type_def(
                                         struct_name.clone(),
@@ -1389,7 +1342,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
 
         drop(_resolve_funcs_span);
         // Share the type table via Rc::clone
-        tir_module.type_table = Rc::clone(&self.type_table);
+        tir_module.type_table = Rc::clone(&self.tysys.type_table);
 
         // Preserve data section
         if let Some(data) = module.data_section() {
@@ -1409,7 +1362,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
 
     /// Get the type table (after resolution)
     pub fn into_type_table(self) -> Rc<RefCell<TypeTable>> {
-        self.type_table
+        self.tysys.type_table
     }
 }
 
@@ -1420,15 +1373,27 @@ pub fn resolve_module<H: CompilerHost>(
     loaded_modules: &IndexMap<ModuleSource, Module>,
     logger: &Logger<H>,
 ) -> Result<TirModule, Bail> {
-    let type_table = std::cell::RefCell::new(crate::tir::TypeTable::new());
+    let type_table = Rc::new(RefCell::new(crate::tir::TypeTable::new()));
     let builtin_registry = BuiltinRegistry::build_from_stdlib(&type_table);
-    let empty_included = IndexMap::default();
-    let mut elaborator = Elaborator::new(
-        symbols,
-        loaded_modules,
-        &builtin_registry,
-        logger,
-        &empty_included,
-    );
+    let (wasi_registry, world_registry) = WasiRegistry::build_from_stdlib();
+    let (trait_env, _) = TraitEnv::build(loaded_modules, symbols);
+    let tysys = tysys::TypeSystem {
+        type_table,
+        all_newtypes: Rc::new(IndexMap::default()),
+        all_generic_newtypes: Rc::new(IndexMap::default()),
+        all_struct_fields: Rc::new(IndexMap::default()),
+        all_variant_cases: Rc::new(IndexMap::default()),
+        all_enum_cases: Rc::new(IndexMap::default()),
+        all_flags_cases: Rc::new(IndexMap::default()),
+        all_resource_types: Rc::new(IndexMap::default()),
+        trait_env,
+        wasi_registry,
+        world_registry,
+        builtin_registry: Rc::new(builtin_registry),
+        included_files: Rc::new(IndexMap::default()),
+        known_type_names_cache: Rc::new(IndexSet::default()),
+        loaded_module_func_indices: Rc::new(IndexMap::default()),
+    };
+    let mut elaborator = Elaborator::new(symbols, loaded_modules, tysys, logger);
     elaborator.resolve_module(module, module_source)
 }

--- a/wado-compiler/src/elaborator.rs
+++ b/wado-compiler/src/elaborator.rs
@@ -209,8 +209,18 @@ pub struct Elaborator<'a, H: CompilerHost> {
     >,
     /// Recursion guard for `type_implements_trait` to avoid infinite recursion
     /// on recursive types (e.g., variant Elem containing struct `RepeatElem` with field Elem).
-    // MIGRATION: → TypeSystem (type-system cache); deferred — needs the
-    //   pipeline-wide cache lifetime story.
+    /// Frames are pushed on entry and popped on return; the stack is empty
+    /// at every quiescent point.
+    // MIGRATION: transient annotate-time scope. Despite the `RefCell<Vec<…>>`
+    //   shape this is NOT a type-system cache (whose entries would persist
+    //   across calls) — it is a per-call frame stack. Sharing it across
+    //   modules via `TypeSystem` would either leak stale frames (producing
+    //   wrong "recursive, optimistically true" answers from
+    //   `type_implements_trait` — a soundness bug) or require per-call
+    //   save/restore plumbing that defeats the move. Belongs with
+    //   `trait_ctx` in Stage 5's per-function walker argument bag, not on
+    //   `TypeSystem`. See `tysys.rs` module docs ("Deferred fields") for
+    //   the full rationale.
     trait_check_stack: RefCell<Vec<(TypeId, String)>>,
     /// Cache for `lookup_method_info` results.
     /// Key: (`base_type_id`, `method_name`) → cached `MethodInfo`

--- a/wado-compiler/src/elaborator.rs
+++ b/wado-compiler/src/elaborator.rs
@@ -650,7 +650,8 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             .get(name)
             .filter(|info| info.module_source == *module_source)
             .or_else(|| {
-                self.tysys.all_struct_fields
+                self.tysys
+                    .all_struct_fields
                     .get(module_source)
                     .and_then(|m| m.get(name))
             })
@@ -1076,11 +1077,13 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                         }
                         if !self.trait_ctx.type_params.contains_key(&param.name) {
                             let type_id = if param.is_pack {
-                                self.tysys.type_table
+                                self.tysys
+                                    .type_table
                                     .borrow_mut()
                                     .make_type_pack(param.name.clone(), actual_idx)
                             } else {
-                                self.tysys.type_table
+                                self.tysys
+                                    .type_table
                                     .borrow_mut()
                                     .make_type_param(param.name.clone(), actual_idx)
                             };
@@ -1113,7 +1116,8 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                                     && !self.tysys.is_known_type_name(name)
                                 {
                                     let type_id = self
-                                        .tysys.type_table
+                                        .tysys
+                                        .type_table
                                         .borrow_mut()
                                         .make_type_param(name.clone(), i as u32);
                                     self.trait_ctx
@@ -1155,8 +1159,11 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                     if impl_block.trait_type.is_some() {
                         // Resolve the target type for registering associated type resolutions
                         let target_type_id = self.resolve_type(&impl_block.ty);
-                        let is_concrete =
-                            !self.tysys.type_table.borrow().contains_type_param(target_type_id);
+                        let is_concrete = !self
+                            .tysys
+                            .type_table
+                            .borrow()
+                            .contains_type_param(target_type_id);
 
                         for binding in &impl_block.associated_types {
                             let type_id = self.resolve_type(&binding.ty);
@@ -1167,15 +1174,19 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                             // Register in TypeTable for substitution resolution
                             // Only for concrete types (not generic impls like impl<T> Trait for Array<T>)
                             if is_concrete {
-                                self.tysys.type_table.borrow_mut().register_assoc_type_resolution(
-                                    target_type_id,
-                                    binding.name.clone(),
-                                    type_id,
-                                );
+                                self.tysys
+                                    .type_table
+                                    .borrow_mut()
+                                    .register_assoc_type_resolution(
+                                        target_type_id,
+                                        binding.name.clone(),
+                                        type_id,
+                                    );
                             } else {
                                 // For generic impls, register the definition so the monomorphizer
                                 // can resolve associated types for GenericInstance types.
-                                self.tysys.type_table
+                                self.tysys
+                                    .type_table
                                     .borrow_mut()
                                     .register_generic_assoc_type_def(
                                         struct_name.clone(),

--- a/wado-compiler/src/elaborator.rs
+++ b/wado-compiler/src/elaborator.rs
@@ -23,6 +23,7 @@ mod method_lookup;
 mod module;
 mod operators;
 pub(crate) mod orchestration;
+mod sem;
 mod stmt;
 mod template;
 pub(crate) mod trait_env;
@@ -30,6 +31,7 @@ mod trait_query;
 mod type_resolution;
 mod typecheck;
 pub(crate) mod types;
+mod tysys;
 mod util;
 
 use std::cell::RefCell;
@@ -80,19 +82,30 @@ use types::{
     EnumInfo, FlagsInfo, GenericNewtypeInfo, ResourceInfo, StructFieldInfo, TypeLookup, VariantInfo,
 };
 
+// Migration markers below trace the WEP 2026-05-26 elaborator
+// re-architecture. Each `MIGRATION:` line names the field's future home —
+// `TypeSystem` (pipeline-wide type knowledge) or a sub-struct of
+// `ModuleSemantics` (per-module facts), or a transient annotate-time scope
+// or cross-cutting input that stays on the per-module driver. Stage 1
+// only fixes the placement; the fields themselves do not move.
+
 pub struct Elaborator<'a, H: CompilerHost> {
     /// Type table (shared across all modules via Rc<RefCell>)
+    // MIGRATION: → TypeSystem (arena).
     type_table: Rc<RefCell<TypeTable>>,
     /// Symbol table from analyzer
+    // MIGRATION: cross-cutting input (stays on the driver).
     #[allow(dead_code)]
     symbols: &'a SymbolTable,
     /// Loaded modules from analyzer
+    // MIGRATION: cross-cutting input (stays on the driver).
     #[allow(dead_code)]
     loaded_modules: &'a IndexMap<ModuleSource, Module>,
     /// Per-module nested maps for cross-module type resolution (shared via Rc).
     /// These are the *single source of truth* for declared type info; all
     /// per-module name resolution is performed by walking these via
     /// [`TypeLookup`] without cloning their contents into per-module flat maps.
+    // MIGRATION: → TypeSystem (decl-interned type tables, all 7 below).
     all_newtypes: Rc<IndexMap<ModuleSource, IndexMap<String, TypeId>>>,
     all_generic_newtypes: Rc<IndexMap<ModuleSource, IndexMap<String, GenericNewtypeInfo>>>,
     all_struct_fields: Rc<IndexMap<ModuleSource, IndexMap<String, StructFieldInfo>>>,
@@ -103,6 +116,7 @@ pub struct Elaborator<'a, H: CompilerHost> {
     /// Per-module import context (consumed by [`TypeLookup`]). Built once per
     /// module from `use` declarations; replaces the 7 flat maps the elaborator
     /// used to clone for each module.
+    // MIGRATION: → ModuleSemantics::imports (both fields below).
     imported_type_sources: IndexMap<String, ModuleSource>,
     import_original_names: IndexMap<String, String>,
     /// Locally discovered additions to the type tables. Anonymous structs
@@ -110,6 +124,9 @@ pub struct Elaborator<'a, H: CompilerHost> {
     /// `module.items` insert here so [`TypeLookup`] can find them at the
     /// highest priority. Always empty unless the current module has a
     /// reason to override / extend the shared tables.
+    // MIGRATION: → ModuleSemantics::decls (per-module decl overrides, all 6 below).
+    //   Stage 2/3 may instead promote these into a per-module view on TypeSystem;
+    //   decided at the move site.
     local_struct_fields: IndexMap<String, StructFieldInfo>,
     local_newtypes: IndexMap<String, TypeId>,
     local_generic_newtypes: IndexMap<String, GenericNewtypeInfo>,
@@ -117,114 +134,158 @@ pub struct Elaborator<'a, H: CompilerHost> {
     local_flags_cases: IndexMap<String, FlagsInfo>,
     local_variant_cases: IndexMap<String, VariantInfo>,
     /// Function return types (name -> return type)
+    // MIGRATION: → ModuleSemantics::decls.
     function_return_types: IndexMap<String, TypeId>,
     /// Imported function names for the current module
+    // MIGRATION: → ModuleSemantics::decls.
     imported_functions: IndexSet<String>,
     /// Logger for emitting diagnostics
+    // MIGRATION: cross-cutting input (stays on the driver).
     logger: &'a Logger<'a, H>,
     /// Current module source being resolved (for struct type `module_source`)
+    // MIGRATION: identifies the active `ModuleSemantics` — the driver swaps
+    //   modules via the `IndexMap<ModuleSource, ModuleSemantics>` key, so this
+    //   field disappears after Stage 3.
     current_module_source: ModuleSource,
     /// Entry module source (for cross-module import dedup)
+    // MIGRATION: cross-cutting input (stays on the driver).
     entry_module_source: ModuleSource,
     /// Current module items (for local function parameter lookup)
+    // MIGRATION: cross-cutting input (the active module's AST is passed
+    //   alongside its `ModuleSemantics`).
     current_module_items: &'a [Item],
     /// Mutable trait resolution context: type params, bounds, associated type bindings, self type.
     /// Grouped together so scope entry/exit can save/restore the whole context at once.
+    // MIGRATION: transient annotate-time scope (Stage 5 carries it as an
+    //   explicit argument to `annotate_*` walkers).
     trait_ctx: trait_env::TraitContext,
     /// Generic struct definitions (name -> type param count)
     /// Used to determine if a struct is generic
+    // MIGRATION: → ModuleSemantics::decls.
     generic_struct_names: IndexSet<String>,
     /// Generic function type parameters (`func_name` -> `type_params`)
     /// Used for substituting type parameters in return types
+    // MIGRATION: → ModuleSemantics::decls.
     generic_function_params: IndexMap<String, Vec<(String, TypeId)>>,
     /// Resolved param types for generic functions (`func_name` -> `param TypeIds`)
     /// Resolved in the function's own type param scope so `TypeParams` have correct ids.
+    // MIGRATION: → ModuleSemantics::decls.
     generic_function_resolved_param_types: IndexMap<String, Vec<TypeId>>,
     /// Resolved return type for generic functions (`func_name` -> `return TypeId`)
     /// Resolved in the function's own type param scope; used for expected-return
     /// driven back-inference by [`infer::InferCtx::add_expected_return`].
+    // MIGRATION: → ModuleSemantics::decls.
     generic_function_resolved_return_types: IndexMap<String, TypeId>,
     /// Generic method type parameters (`mangled_name` -> `type_params`)
     /// Used for substituting type parameters in method return types
+    // MIGRATION: → ModuleSemantics::decls.
     generic_method_params: IndexMap<String, Vec<(String, TypeId)>>,
     /// Resolved param types for generic methods (`mangled_name` -> `param TypeIds`)
     /// Resolved in the method's own type param scope so `TypeParams` have correct ids.
+    // MIGRATION: → ModuleSemantics::decls.
     generic_method_resolved_param_types: IndexMap<String, Vec<TypeId>>,
     /// Namespace import aliases (e.g., "helper" -> module source for `use helper from "..."`)
+    // MIGRATION: → ModuleSemantics::imports.
     namespace_imports: IndexMap<String, ModuleSource>,
     /// Effect name to source module mapping (e.g., "Stdout" -> wasi:cli module source)
     /// Built from import declarations and local interface declarations.
+    // MIGRATION: → ModuleSemantics::imports.
     effect_sources: IndexMap<String, ModuleSource>,
     /// Effect parameter names currently in scope (from enclosing function's `<effect E>`)
+    // MIGRATION: transient annotate-time scope (per-function, not per-module).
     current_effect_params: IndexSet<String>,
     /// Map from effect parameter name to its declaration `AstId` in the current scope.
     /// Used to record use→def edges for effect parameter references in `with` clauses.
+    // MIGRATION: transient annotate-time scope (per-function, not per-module).
     current_effect_param_decls: IndexMap<String, crate::ast::AstId>,
     /// WASI registry for looking up effect return types
+    // MIGRATION: → TypeSystem (registry).
     wasi_registry: &'static WasiRegistry,
     /// Builtin registry for looking up builtin function return types
+    // MIGRATION: → TypeSystem (registry).
     builtin_registry: &'a BuiltinRegistry,
     /// Global variables in the current module (name -> (type, `is_mutable`))
+    // MIGRATION: → ModuleSemantics::decls.
     current_module_globals: IndexMap<String, (TypeId, bool)>,
     /// Imported globals (local name -> (source module, original name, type, `is_mutable`))
+    // MIGRATION: → ModuleSemantics::decls.
     imported_globals: IndexMap<String, (ModuleSource, String, TypeId, bool)>,
     /// Associated constants from impl blocks ("`TypeName::CONST`" -> (type, expr))
     /// These are inlined at every use site during resolution.
+    // MIGRATION: → ModuleSemantics::decls.
     associated_constants: IndexMap<String, (ast::Type, ast::Expr)>,
     /// Immutable trait knowledge base: impl indices, trait declarations, and blanket impls.
     /// Built once and shared across all module elaborators via `Arc`.
+    // MIGRATION: → TypeSystem.
     trait_env: Arc<TraitEnv>,
     /// Pre-loaded file contents for `#include_str` / `#include_bytes`.
     /// Key: `[module_source_display, raw_path]`, value: raw bytes.
+    // MIGRATION: → TypeSystem (included-files map).
     included_files: &'a IndexMap<[String; 2], Vec<u8>>,
     /// Cached flat set of all known type names for fast `is_known_type_name` lookups.
+    // MIGRATION: → TypeSystem.
     known_type_names_cache: IndexSet<String>,
     /// Anonymous structs created during expression resolution.
     /// Flushed into the `TirModule` at the end of `resolve_module`.
+    // MIGRATION: → ModuleSemantics::decls.
     pending_anonymous_structs: Vec<crate::tir::TirStruct>,
     /// Cache for `find_indexing_trait_impl` results.
     /// Key: (`struct_name`, `base_type_id`, `trait_base_name`, `method_name`, `assoc_type_name`)
+    // MIGRATION: → TypeSystem (type-system cache).
     indexing_trait_cache: IndexMap<
         (String, TypeId, String, String, String),
         Option<(TypeId, ast::SelfKind, String, ModuleSource)>,
     >,
     /// Recursion guard for `type_implements_trait` to avoid infinite recursion
     /// on recursive types (e.g., variant Elem containing struct `RepeatElem` with field Elem).
+    // MIGRATION: → TypeSystem (type-system cache).
     trait_check_stack: RefCell<Vec<(TypeId, String)>>,
     /// Cache for `lookup_method_info` results.
     /// Key: (`base_type_id`, `method_name`) → cached `MethodInfo`
+    // MIGRATION: → TypeSystem (type-system cache).
     method_info_cache: IndexMap<(TypeId, String), Option<types::MethodInfo>>,
     /// Index from function name → position in `current_module_items` for O(1) lookup.
+    // MIGRATION: transient annotate-time scope (rebuilt for the active module).
     current_module_func_index: IndexMap<String, usize>,
     /// Per-module index from function name → position in module.items for O(1) lookup.
+    // MIGRATION: → TypeSystem (pipeline-wide func-name index over loaded modules).
     loaded_module_func_indices: IndexMap<ModuleSource, IndexMap<String, usize>>,
     /// Use→def map for local variables. Shared via `Rc<RefCell<…>>` with
     /// [`crate::elaborator::orchestration::AnnotateState`] so LSP queries see
     /// references as soon as the elaborator has walked the body.
+    // MIGRATION: → ModuleSemantics::bindings (drops the `Rc<RefCell<…>>`;
+    //   the body walk takes `&mut ModuleSemantics`).
     references: Rc<RefCell<IndexMap<SymbolKey, SymbolKey>>>,
     /// Local binding [`Symbol`]s emitted alongside `references`. Populated at
     /// every `ctx.add_local(...)` call that carries a user-visible defining
     /// `AstId`. Shared via `Rc<RefCell<…>>` with `AnnotateState`.
+    // MIGRATION: → ModuleSemantics::bindings (drops the `Rc<RefCell<…>>`).
     local_symbols: Rc<RefCell<IndexMap<SymbolKey, Symbol>>>,
     /// Resolved [`TypeId`] for each local binding, keyed by the binding's
     /// defining [`SymbolKey`]. Populated alongside `local_symbols` at every
     /// `record_local_symbol` call. Shared via `Rc<RefCell<…>>` with
     /// `AnnotateState` and ultimately drained into `Semantics::local_types`
     /// for LSP inlay-hint consumption.
+    // MIGRATION: → ModuleSemantics::types (TypeId per binding-AstId fits the
+    //   "per-`AstId` type annotations" rule). LSP consumer
+    //   `Semantics::local_type_name` hides the placement.
     local_types: Rc<RefCell<IndexMap<SymbolKey, TypeId>>>,
     /// When resolving a default-expression AST at a call site, fall back to
     /// looking up unresolved identifiers in this module's global scope. This
     /// preserves the callee's lexical scope for defaults that reference
     /// module-private items (see WEP 2026-04-11).
+    // MIGRATION: transient annotate-time scope (per-call-site override).
     pub(super) default_scope_module: Option<ModuleSource>,
     /// Kiln invocation redirects consulted by `use` resolution sites. Shared
     /// by `Rc` so per-module Elaborator instances can read the single
     /// compilation-unit-wide redirect map cheaply.
+    // MIGRATION: cross-cutting input (loader-provided redirect map).
     pub(super) invocations: Rc<crate::kiln::InvocationIndex>,
     /// `ModuleSource` interner shared with the loader and downstream
     /// phases. Wrapped in `Rc<RefCell<>>` so per-module elaborator
     /// instances can `borrow_mut()` it from `&self` contexts (e.g.
     /// `record_use_specifier_references`).
+    // MIGRATION: cross-cutting input (shared interner).
     pub(super) interner: Rc<RefCell<ModuleSourceInterner>>,
 }
 

--- a/wado-compiler/src/elaborator.rs
+++ b/wado-compiler/src/elaborator.rs
@@ -1396,7 +1396,7 @@ pub fn resolve_module<H: CompilerHost>(
 ) -> Result<TirModule, Bail> {
     let type_table = Rc::new(RefCell::new(crate::tir::TypeTable::new()));
     let builtin_registry = BuiltinRegistry::build_from_stdlib(&type_table);
-    let (wasi_registry, world_registry) = WasiRegistry::build_from_stdlib();
+    let (wasi_registry, _world_registry) = WasiRegistry::build_from_stdlib();
     let (trait_env, _) = TraitEnv::build(loaded_modules, symbols);
     let tysys = tysys::TypeSystem {
         type_table,
@@ -1409,7 +1409,6 @@ pub fn resolve_module<H: CompilerHost>(
         all_resource_types: Rc::new(IndexMap::default()),
         trait_env,
         wasi_registry,
-        world_registry,
         builtin_registry: Rc::new(builtin_registry),
         included_files: Rc::new(IndexMap::default()),
         known_type_names_cache: Rc::new(IndexSet::default()),

--- a/wado-compiler/src/elaborator.rs
+++ b/wado-compiler/src/elaborator.rs
@@ -54,6 +54,22 @@ use crate::tir::{
 
 use trait_env::TraitEnv;
 
+/// Build a function-name → item-index map for a module's items. Used
+/// once per loaded module during annotate
+/// ([`orchestration::Elaborator::annotate_modules`]) to populate
+/// [`tysys::TypeSystem::loaded_module_func_indices`]; the per-module
+/// body walk then consults that pre-built index instead of rebuilding
+/// here.
+pub(crate) fn build_func_index(items: &[Item]) -> IndexMap<String, usize> {
+    let mut index = IndexMap::default();
+    for (i, item) in items.iter().enumerate() {
+        if let Item::Function(func) = item {
+            index.insert(func.name.clone(), i);
+        }
+    }
+    index
+}
+
 /// `true` if `name` denotes a built-in primitive Wado type. Primitives
 /// have inherent impl blocks in `core:prelude/primitive` but no
 /// `Symbol` entry to canonicalise through, so both
@@ -227,9 +243,6 @@ pub struct Elaborator<'a, H: CompilerHost> {
     // MIGRATION: → TypeSystem (type-system cache); deferred — needs the
     //   pipeline-wide cache lifetime story.
     method_info_cache: IndexMap<(TypeId, String), Option<types::MethodInfo>>,
-    /// Index from function name → position in `current_module_items` for O(1) lookup.
-    // MIGRATION: transient annotate-time scope (rebuilt for the active module).
-    current_module_func_index: IndexMap<String, usize>,
     /// Use→def map for local variables. Shared via `Rc<RefCell<…>>` with
     /// [`crate::elaborator::orchestration::AnnotateState`] so LSP queries see
     /// references as soon as the elaborator has walked the body.
@@ -312,7 +325,6 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             trait_check_stack: RefCell::new(Vec::new()),
             method_info_cache: IndexMap::default(),
             pending_anonymous_structs: Vec::new(),
-            current_module_func_index: IndexMap::default(),
             references: Rc::new(RefCell::new(IndexMap::default())),
             local_symbols: Rc::new(RefCell::new(IndexMap::default())),
             local_types: Rc::new(RefCell::new(IndexMap::default())),
@@ -607,17 +619,6 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         self.local_types.borrow_mut().insert(key, type_id);
     }
 
-    /// Build a function-name → index map for a module's items.
-    fn build_func_index(items: &[Item]) -> IndexMap<String, usize> {
-        let mut index = IndexMap::default();
-        for (i, item) in items.iter().enumerate() {
-            if let Item::Function(func) = item {
-                index.insert(func.name.clone(), i);
-            }
-        }
-        index
-    }
-
     /// Look up a function by name in a loaded module, returning the Item at that index.
     fn lookup_func_in_loaded_module<'b>(
         loaded_modules: &'b IndexMap<ModuleSource, Module>,
@@ -636,8 +637,16 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
     }
 
     /// Look up a function by name in current module items.
+    ///
+    /// Consults [`tysys::TypeSystem::loaded_module_func_indices`] — the
+    /// per-module name→item-index map built once during annotate — to
+    /// avoid rebuilding the index at every `resolve_module` call.
     fn lookup_current_func(&self, func_name: &str) -> Option<&ast::Function> {
-        let &idx = self.current_module_func_index.get(func_name)?;
+        let idx_map = self
+            .tysys
+            .loaded_module_func_indices
+            .get(&self.current_module_source)?;
+        let &idx = idx_map.get(func_name)?;
         if let Item::Function(func) = &self.current_module_items[idx] {
             Some(func)
         } else {
@@ -921,8 +930,10 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         self.current_module_source = module_source.clone();
         // Store current module items as a reference (no clone)
         self.current_module_items = &module.items;
-        // Build function name → index for O(1) lookup
-        self.current_module_func_index = Self::build_func_index(self.current_module_items);
+        // Function name → item-index lookup is pre-built per loaded
+        // module on `tysys.loaded_module_func_indices` during annotate;
+        // `lookup_current_func` consults it through
+        // `self.current_module_source` so no per-resolve rebuild here.
         // Clear trait lookup caches (current_module_items changed)
         self.indexing_trait_cache.clear();
         // Build effect source map from imports
@@ -1398,6 +1409,12 @@ pub fn resolve_module<H: CompilerHost>(
     let builtin_registry = BuiltinRegistry::build_from_stdlib(&type_table);
     let (wasi_registry, _world_registry) = WasiRegistry::build_from_stdlib();
     let (trait_env, _) = TraitEnv::build(loaded_modules, symbols);
+    // Seed the loaded-module function index for the single module this
+    // path resolves. The main pipeline populates this map across every
+    // loaded module in `annotate_modules`; here we only need the one,
+    // so `lookup_current_func` can find functions defined in `module`.
+    let mut func_indices = IndexMap::default();
+    func_indices.insert(module_source.clone(), build_func_index(&module.items));
     let tysys = tysys::TypeSystem {
         type_table,
         all_newtypes: Rc::new(IndexMap::default()),
@@ -1412,7 +1429,7 @@ pub fn resolve_module<H: CompilerHost>(
         builtin_registry: Rc::new(builtin_registry),
         included_files: Rc::new(IndexMap::default()),
         known_type_names_cache: Rc::new(IndexSet::default()),
-        loaded_module_func_indices: Rc::new(IndexMap::default()),
+        loaded_module_func_indices: Rc::new(func_indices),
     };
     let mut elaborator = Elaborator::new(symbols, loaded_modules, tysys, logger);
     elaborator.resolve_module(module, module_source)

--- a/wado-compiler/src/elaborator.rs
+++ b/wado-compiler/src/elaborator.rs
@@ -106,11 +106,9 @@ pub struct Elaborator<'a, H: CompilerHost> {
     pub(crate) tysys: tysys::TypeSystem,
     /// Symbol table from analyzer
     // MIGRATION: cross-cutting input (stays on the driver).
-    #[allow(dead_code)]
     symbols: &'a SymbolTable,
     /// Loaded modules from analyzer
     // MIGRATION: cross-cutting input (stays on the driver).
-    #[allow(dead_code)]
     loaded_modules: &'a IndexMap<ModuleSource, Module>,
     /// Per-module import context (consumed by [`TypeLookup`]). Built once per
     /// module from `use` declarations; replaces the 7 flat maps the elaborator

--- a/wado-compiler/src/elaborator.rs
+++ b/wado-compiler/src/elaborator.rs
@@ -1063,7 +1063,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                     // `impl<T: Bound> OtherTrait for T` (T is the impl type directly).
                     let mut actual_idx = 0u32;
                     for param in &impl_block.type_params {
-                        if self.is_known_type_name(&param.name) {
+                        if self.tysys.is_known_type_name(&param.name) {
                             // Concrete type in explicit params (e.g., `impl<i32, T>`): skip
                             if !param.bounds.is_empty() {
                                 self.trait_ctx
@@ -1110,7 +1110,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                             if let ast::Type::Named(named) = arg {
                                 let name = &named.name;
                                 if !self.trait_ctx.type_params.contains_key(name)
-                                    && !self.is_known_type_name(name)
+                                    && !self.tysys.is_known_type_name(name)
                                 {
                                     let type_id = self
                                         .tysys.type_table

--- a/wado-compiler/src/elaborator/call.rs
+++ b/wado-compiler/src/elaborator/call.rs
@@ -75,7 +75,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// fn-type newtypes such as `type Handler = fn(...);` — return its
     /// signature. Otherwise return `None`. Borrows the type table once.
     fn as_fn_signature(&self, type_id: TypeId) -> Option<FnSignature> {
-        let table = self.type_table.borrow();
+        let table = self.tysys.type_table.borrow();
         let peeled_ref = table.peel_refs(type_id);
         let base = table.get_ultimate_base_type(peeled_ref);
         match table.get(base) {
@@ -138,7 +138,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             return;
         }
         let is_mut_ref = matches!(
-            self.type_table.borrow().get(local.type_id),
+            self.tysys.type_table.borrow().get(local.type_id),
             ResolvedType::MutRef(_)
         );
         if is_mut_ref {
@@ -164,7 +164,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         if prefix == "Self"
             && let Some(self_type_id) = self.trait_ctx.self_type
         {
-            let self_name = self.type_table.borrow().type_name(self_type_id);
+            let self_name = self.tysys.type_table.borrow().type_name(self_type_id);
             return CalleeIdentKind::Rewritten(format!("{self_name}::{suffix}"));
         }
 
@@ -176,7 +176,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // abstract form and route through the trait-bound dispatch
             // path so the monomorphizer can substitute later.
             let is_abstract = matches!(
-                self.type_table.borrow().get(type_param_type_id),
+                self.tysys.type_table.borrow().get(type_param_type_id),
                 ResolvedType::TypeParam { .. } | ResolvedType::TypePack { .. }
             );
             if is_abstract {
@@ -187,7 +187,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 };
             }
             let concrete_name = self
-                .type_table
+                .tysys.type_table
                 .borrow()
                 .mangle_type_name(type_param_type_id);
             return CalleeIdentKind::Rewritten(format!("{concrete_name}::{suffix}"));
@@ -270,7 +270,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // when the callee already resolved to the error type so we
             // don't pile a second diagnostic on top of the first.
             if callee_expr.type_id != TypeTable::ERROR {
-                let type_name = self.type_table.borrow().type_name(callee_expr.type_id);
+                let type_name = self.tysys.type_table.borrow().type_name(callee_expr.type_id);
                 let _ = self.logger.error(TypeError::CalleeNotCallable {
                     type_name,
                     span: call.callee.span(),
@@ -335,7 +335,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     .find(|(_, c)| c.name == suffix)
             {
                 let payload_is_unit = matches!(
-                    self.type_table.borrow().get(case_data.payload),
+                    self.tysys.type_table.borrow().get(case_data.payload),
                     ResolvedType::Unit
                 );
                 if !payload_is_unit {
@@ -350,7 +350,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             self.substitute_type_params(payload_type, &variant_type_args);
                     } else if let Some(expected) = expected_type {
                         // Infer type args from expected type (e.g. Option::Some(null) expecting Option<Option<i32>>)
-                        let expected_resolved = self.type_table.borrow().get(expected).clone();
+                        let expected_resolved = self.tysys.type_table.borrow().get(expected).clone();
                         if let ResolvedType::GenericInstance {
                             name: expected_name,
                             type_args: expected_args,
@@ -417,7 +417,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 if let Some(suffix_seg) = ident.segments.get(1) {
                     let arg_hint = if (suffix == "from" || suffix == "try_from") && args.len() == 1
                     {
-                        Some(self.type_table.borrow().type_name(args[0].type_id))
+                        Some(self.tysys.type_table.borrow().type_name(args[0].type_id))
                     } else {
                         None
                     };
@@ -494,7 +494,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 // Handle From conversions with no explicit impl: reflexive and newtype.
                 if suffix == "from" && args.len() == 1 {
                     let arg_type = args[0].type_id;
-                    let arg_type_name = self.type_table.borrow().type_name(arg_type);
+                    let arg_type_name = self.tysys.type_table.borrow().type_name(arg_type);
 
                     // Reflexive: T::from(T_val) — identity conversion
                     if arg_type_name == prefix {
@@ -502,9 +502,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     }
 
                     // Newtype→Base: u64::from(UserId_val) where type UserId = u64
-                    let base_of_arg = self.type_table.borrow().get_newtype_base(arg_type);
+                    let base_of_arg = self.tysys.type_table.borrow().get_newtype_base(arg_type);
                     if let Some(base_id) = base_of_arg
-                        && self.type_table.borrow().type_name(base_id) == prefix
+                        && self.tysys.type_table.borrow().type_name(base_id) == prefix
                     {
                         return TirExpr::new(
                             TirExprKind::Cast {
@@ -518,9 +518,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
                     // Base→Newtype: UserId::from(u64_val) where type UserId = u64
                     if let Some(newtype_type_id) = self.lookup_newtype(prefix) {
-                        let base_opt = self.type_table.borrow().get_newtype_base(newtype_type_id);
+                        let base_opt = self.tysys.type_table.borrow().get_newtype_base(newtype_type_id);
                         if let Some(base_id) = base_opt
-                            && self.type_table.borrow().type_name(base_id) == arg_type_name
+                            && self.tysys.type_table.borrow().type_name(base_id) == arg_type_name
                         {
                             return TirExpr::new(
                                 TirExprKind::Cast {
@@ -618,7 +618,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     // Each variant case has exactly one payload.
                     // Unit variants expect 0 args, non-unit variants expect 1 arg.
                     let payload_is_unit = matches!(
-                        self.type_table.borrow().get(case_data.payload),
+                        self.tysys.type_table.borrow().get(case_data.payload),
                         ResolvedType::Unit
                     );
                     let expected_args = usize::from(!payload_is_unit);
@@ -636,7 +636,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
                     // Infer variant type: use GenericInstance for generic variants
                     let variant_type = if variant_info.type_params.is_empty() {
-                        self.type_table.borrow_mut().make_variant(
+                        self.tysys.type_table.borrow_mut().make_variant(
                             variant_info.name.clone(),
                             variant_info.module_source.clone(),
                         )
@@ -663,14 +663,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 }
                 // If no matching case, check for From<T> synthesis requests
                 else if suffix == "from" && args.len() == 1 {
-                    let target_type_id = self.type_table.borrow_mut().make_variant(
+                    let target_type_id = self.tysys.type_table.borrow_mut().make_variant(
                         variant_info.name.clone(),
                         variant_info.module_source.clone(),
                     );
                     let from_type = args[0].type_id;
-                    let from_type_name = self.type_table.borrow().type_name(from_type);
+                    let from_type_name = self.tysys.type_table.borrow().type_name(from_type);
                     let from_trait_name = self
-                        .type_table
+                        .tysys.type_table
                         .borrow()
                         .compiler_items()
                         .trait_name(crate::compiler_item::CompilerItem::From)
@@ -734,7 +734,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
                     // Check if this is a variant construction in the namespace
                     let ns_variant = self
-                        .all_variant_cases
+                        .tysys.all_variant_cases
                         .get(&ns_source)
                         .and_then(|m| m.get(type_name))
                         .cloned();
@@ -752,7 +752,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 case_data.ast_id,
                             );
                             let payload_is_unit = matches!(
-                                self.type_table.borrow().get(case_data.payload),
+                                self.tysys.type_table.borrow().get(case_data.payload),
                                 ResolvedType::Unit
                             );
                             let expected_args = usize::from(!payload_is_unit);
@@ -770,7 +770,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             }
                             let payload = args.into_iter().next().map(Box::new);
                             let variant_type = if variant_info.type_params.is_empty() {
-                                self.type_table.borrow_mut().make_variant(
+                                self.tysys.type_table.borrow_mut().make_variant(
                                     variant_info.name.clone(),
                                     variant_info.module_source.clone(),
                                 )
@@ -809,7 +809,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     let arg_type_hint = if (method_name == "from" || method_name == "try_from")
                         && args.len() == 1
                     {
-                        Some(self.type_table.borrow().type_name(args[0].type_id))
+                        Some(self.tysys.type_table.borrow().type_name(args[0].type_id))
                     } else {
                         None
                     };
@@ -898,7 +898,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // `CompilerItem` registry so a stdlib rename of any of
         // them is picked up here without re-editing the literal set.
         else if self.function_return_types.contains_key(effective_name) || {
-            let tt = self.type_table.borrow();
+            let tt = self.tysys.type_table.borrow();
             let items = tt.compiler_items();
             effective_name == items.variant_case_name(crate::compiler_item::CompilerItem::ResultOk)
                 || effective_name
@@ -1161,7 +1161,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // Clone the return type AST and type params to avoid borrow issues
             let func_info = Self::lookup_func_in_loaded_module(
                 self.loaded_modules,
-                &self.loaded_module_func_indices,
+                &self.tysys.loaded_module_func_indices,
                 callee_module,
                 func_name,
             )
@@ -1235,7 +1235,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // disambiguates which Logger this call site means.
         let canonical_key = self.canonical_decl_key(effect);
         let (module_source, item_idx) = self
-            .trait_env
+            .tysys.trait_env
             .effect_decl_index
             .get(&canonical_key)?
             .clone();
@@ -1259,7 +1259,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         operation: &str,
     ) -> Option<TypeId> {
         let func_key = format!("{effect}::{operation}");
-        let func = self.wasi_registry.get_function(&func_key)?;
+        let func = self.tysys.wasi_registry.get_function(&func_key)?;
         let is_async = func.is_async;
         let package = func.package.clone();
 
@@ -1269,7 +1269,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         };
 
         if is_async {
-            Some(self.type_table.borrow_mut().make_async_call(inner))
+            Some(self.tysys.type_table.borrow_mut().make_async_call(inner))
         } else if func.return_type.is_some() {
             Some(inner)
         } else {
@@ -1285,13 +1285,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         wasi_package: Option<&str>,
     ) -> TypeId {
         let string_struct_name = self
-            .type_table
+            .tysys.type_table
             .borrow()
             .compiler_items()
             .struct_name(crate::compiler_item::CompilerItem::String)
             .to_string();
         let array_struct_name = self
-            .type_table
+            .tysys.type_table
             .borrow()
             .compiler_items()
             .struct_name(crate::compiler_item::CompilerItem::Array)
@@ -1325,14 +1325,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     // Otherwise, try to resolve via WASI registry's newtypes.
                     // Scoped to `wasi:` to keep this elaborator path WASI-only.
                     let aliased = self
-                        .wasi_registry
+                        .tysys.wasi_registry
                         .find_wasi_newtype_source(&named.name)
-                        .and_then(|src| self.wasi_registry.get_newtype_by_source(src, &named.name))
+                        .and_then(|src| self.tysys.wasi_registry.get_newtype_by_source(src, &named.name))
                         .cloned();
                     if let Some(aliased) = aliased {
                         // Create a newtype for this WASI newtype
                         let base_type = self.resolve_wasi_type_scoped(&aliased, wasi_package);
-                        let newtype_id = self.type_table.borrow_mut().make_newtype(
+                        let newtype_id = self.tysys.type_table.borrow_mut().make_newtype(
                             named.name.clone(),
                             ModuleSource::wasi_clocks(),
                             base_type,
@@ -1341,7 +1341,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         self.local_newtypes.insert(named.name.clone(), newtype_id);
                         newtype_id
                     } else if self
-                        .wasi_registry
+                        .tysys.wasi_registry
                         .find_wasi_resource_source(&named.name)
                         .is_some()
                     {
@@ -1349,7 +1349,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         // method calls on the returned handle resolve correctly.
                         // Look up the actual module source from all_resource_types.
                         let module_source = self
-                            .all_resource_types
+                            .tysys.all_resource_types
                             .iter()
                             .find_map(|(ms, map)| {
                                 if map.contains_key(&named.name) {
@@ -1359,12 +1359,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 }
                             })
                             .unwrap_or_else(ModuleSource::wasi_filesystem);
-                        self.type_table
+                        self.tysys.type_table
                             .borrow_mut()
                             .make_resource(named.name.clone(), module_source)
                     } else if let Some(pkg) = wasi_package {
                         // Scoped lookup: use type table's package-aware search
-                        let tt = self.type_table.borrow();
+                        let tt = self.tysys.type_table.borrow();
                         if let Some(tid) = tt.find_named_type_by_cm_package(&named.name, pkg) {
                             tid
                         } else {
@@ -1373,33 +1373,33 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             // via find_wasi_*_source so same-named core:*
                             // types cannot leak in.
                             if self
-                                .wasi_registry
+                                .tysys.wasi_registry
                                 .find_wasi_enum_source(&named.name)
                                 .is_some()
                             {
                                 let module_source = self
-                                    .all_enum_cases
+                                    .tysys.all_enum_cases
                                     .iter()
                                     .find_map(|(ms, map)| {
                                         map.contains_key(&named.name).then(|| ms.clone())
                                     })
                                     .unwrap_or_else(ModuleSource::wasi_cli);
-                                self.type_table
+                                self.tysys.type_table
                                     .borrow_mut()
                                     .make_enum(named.name.clone(), module_source)
                             } else if self
-                                .wasi_registry
+                                .tysys.wasi_registry
                                 .find_wasi_struct_source(&named.name)
                                 .is_some()
                             {
                                 let module_source = self
-                                    .all_struct_fields
+                                    .tysys.all_struct_fields
                                     .iter()
                                     .find_map(|(ms, map)| {
                                         map.contains_key(&named.name).then(|| ms.clone())
                                     })
                                     .unwrap_or_else(ModuleSource::wasi_clocks);
-                                self.type_table
+                                self.tysys.type_table
                                     .borrow_mut()
                                     .make_struct(named.name.clone(), module_source)
                             } else {
@@ -1407,13 +1407,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             }
                         }
                     } else if self
-                        .wasi_registry
+                        .tysys.wasi_registry
                         .find_wasi_enum_source(&named.name)
                         .is_some()
                     {
                         // WASI enum type - look up the module source from all_enum_cases
                         let module_source = self
-                            .all_enum_cases
+                            .tysys.all_enum_cases
                             .iter()
                             .find_map(|(ms, map)| {
                                 if map.contains_key(&named.name) {
@@ -1423,17 +1423,17 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 }
                             })
                             .unwrap_or_else(ModuleSource::wasi_cli);
-                        self.type_table
+                        self.tysys.type_table
                             .borrow_mut()
                             .make_enum(named.name.clone(), module_source)
                     } else if self
-                        .wasi_registry
+                        .tysys.wasi_registry
                         .find_wasi_struct_source(&named.name)
                         .is_some()
                     {
                         // WASI struct (record) type - look up module source from all_struct_fields
                         let module_source = self
-                            .all_struct_fields
+                            .tysys.all_struct_fields
                             .iter()
                             .find_map(|(ms, map)| {
                                 if map.contains_key(&named.name) {
@@ -1443,7 +1443,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 }
                             })
                             .unwrap_or_else(ModuleSource::wasi_clocks);
-                        self.type_table
+                        self.tysys.type_table
                             .borrow_mut()
                             .make_struct(named.name.clone(), module_source)
                     } else {
@@ -1456,31 +1456,31 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 if generic.name == array_struct_name && generic.args.len() == 1 =>
             {
                 let elem_type = self.resolve_wasi_type_scoped(&generic.args[0], wasi_package);
-                self.type_table.borrow_mut().make_array(elem_type)
+                self.tysys.type_table.borrow_mut().make_array(elem_type)
             }
             Type::Generic(generic) => match generic.name.as_str() {
                 "Option" if generic.args.len() == 1 => {
                     let inner_type = self.resolve_wasi_type_scoped(&generic.args[0], wasi_package);
-                    self.type_table.borrow_mut().make_option(inner_type)
+                    self.tysys.type_table.borrow_mut().make_option(inner_type)
                 }
                 "Stream" if generic.args.len() == 1 => {
                     let inner_type = self.resolve_wasi_type_scoped(&generic.args[0], wasi_package);
-                    self.type_table.borrow_mut().make_stream(inner_type)
+                    self.tysys.type_table.borrow_mut().make_stream(inner_type)
                 }
                 "Future" if generic.args.len() == 1 => {
                     let inner_type = self.resolve_wasi_type_scoped(&generic.args[0], wasi_package);
-                    self.type_table.borrow_mut().make_future(inner_type)
+                    self.tysys.type_table.borrow_mut().make_future(inner_type)
                 }
                 "AsyncCall" if generic.args.len() == 1 => {
                     let inner_type = self.resolve_wasi_type_scoped(&generic.args[0], wasi_package);
-                    self.type_table.borrow_mut().make_async_call(inner_type)
+                    self.tysys.type_table.borrow_mut().make_async_call(inner_type)
                 }
                 "Result" if generic.args.len() == 2 => {
                     let ok_type = self.resolve_wasi_type_scoped(&generic.args[0], wasi_package);
                     let err_type = self.resolve_wasi_type_scoped(&generic.args[1], wasi_package);
                     // Look up the module source where Result variant is defined
                     let module_source = self
-                        .all_variant_cases
+                        .tysys.all_variant_cases
                         .iter()
                         .find_map(|(ms, map)| {
                             if map.contains_key("Result") {
@@ -1490,7 +1490,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             }
                         })
                         .unwrap_or_else(ModuleSource::prelude);
-                    self.type_table.borrow_mut().make_generic_instance(
+                    self.tysys.type_table.borrow_mut().make_generic_instance(
                         "Result".to_string(),
                         module_source,
                         vec![ok_type, err_type],
@@ -1506,7 +1506,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     .iter()
                     .map(|t| self.resolve_wasi_type_scoped(t, wasi_package))
                     .collect();
-                self.type_table.borrow_mut().make_tuple(resolved)
+                self.tysys.type_table.borrow_mut().make_tuple(resolved)
             }
             _ => TypeTable::UNIT,
         }
@@ -1514,7 +1514,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
     /// Get the String struct type (from core:prelude/string.wado)
     pub(super) fn get_string_struct_type(&mut self) -> TypeId {
-        self.type_table
+        self.tysys.type_table
             .borrow_mut()
             .make_compiler_struct(crate::compiler_item::CompilerItem::String)
     }
@@ -1578,7 +1578,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// For generic builtins like `array_new<T>`, returns a type containing
     /// `TypeParam` placeholders that get substituted during monomorphization.
     pub(super) fn get_builtin_return_type(&self, name: &str) -> TypeId {
-        self.builtin_registry
+        self.tysys.builtin_registry
             .get_return_type(name)
             .unwrap_or(TypeTable::UNIT)
     }
@@ -1601,7 +1601,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 let module_source = ModuleSource::builtin();
                 let params = Self::lookup_func_in_loaded_module(
                     self.loaded_modules,
-                    &self.loaded_module_func_indices,
+                    &self.tysys.loaded_module_func_indices,
                     &module_source,
                     suffix,
                 )
@@ -1657,7 +1657,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             let sym_name = symbol.name.clone();
             let params = Self::lookup_func_in_loaded_module(
                 self.loaded_modules,
-                &self.loaded_module_func_indices,
+                &self.tysys.loaded_module_func_indices,
                 &src,
                 &sym_name,
             )
@@ -1742,7 +1742,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 && expected_type != TypeTable::ERROR
                 && expected_type != TypeTable::UNKNOWN
             {
-                let expected_name = self.type_table.borrow().type_name(expected_type);
+                let expected_name = self.tysys.type_table.borrow().type_name(expected_type);
                 panic!(
                     "compiler bug: default expression for parameter '{name}' \
                      re-resolved to () at call site but parameter expects '{expected_name}'. \
@@ -1797,7 +1797,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             let name = symbol.name.clone();
             if let Some(func) = Self::lookup_func_in_loaded_module(
                 self.loaded_modules,
-                &self.loaded_module_func_indices,
+                &self.tysys.loaded_module_func_indices,
                 &src,
                 &name,
             ) {
@@ -1838,7 +1838,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             let name = symbol.name.clone();
             if let Some(func) = Self::lookup_func_in_loaded_module(
                 self.loaded_modules,
-                &self.loaded_module_func_indices,
+                &self.tysys.loaded_module_func_indices,
                 &src,
                 &name,
             ) {
@@ -1879,7 +1879,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // `builtin::array_new(n)` infer their generic type parameters from
         // argument types or LHS annotations the same way ordinary generic
         // functions do.
-        if let Some(info) = self.builtin_registry.get(func_name) {
+        if let Some(info) = self.tysys.builtin_registry.get(func_name) {
             let real_type_params: Vec<&String> = info.type_params.iter().collect();
             if real_type_params.is_empty() {
                 return vec![];
@@ -1888,7 +1888,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 .iter()
                 .enumerate()
                 .map(|(i, name)| {
-                    self.type_table
+                    self.tysys.type_table
                         .borrow_mut()
                         .intern(ResolvedType::TypeParam {
                             index: i as u32,
@@ -1899,7 +1899,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             let resolved_param_types: Vec<TypeId> = info.params.iter().map(|(_, t)| *t).collect();
             let decl_return_type = info.return_type;
 
-            let mut infer = InferCtx::new(&self.type_table, param_ids.clone());
+            let mut infer = InferCtx::new(&self.tysys.type_table, param_ids.clone());
             for (i, (param_type, arg)) in resolved_param_types.iter().zip(args.iter()).enumerate() {
                 if Self::is_literal_number_arg(raw_args.get(i)) {
                     infer.add_deferred(*param_type, arg.type_id);
@@ -1949,7 +1949,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
 
         let param_ids: Vec<TypeId> = type_param_list.iter().map(|(_, id)| *id).collect();
-        let mut infer = InferCtx::new(&self.type_table, param_ids.clone());
+        let mut infer = InferCtx::new(&self.tysys.type_table, param_ids.clone());
         for (i, (param_type, arg)) in resolved_param_types.iter().zip(args.iter()).enumerate() {
             if Self::is_literal_number_arg(raw_args.get(i)) {
                 infer.add_deferred(*param_type, arg.type_id);
@@ -1989,7 +1989,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let func_info: Option<(Vec<ast::GenericParam>, Vec<ast::Param>, Option<ast::Type>)> =
             Self::lookup_func_in_loaded_module(
                 self.loaded_modules,
-                &self.loaded_module_func_indices,
+                &self.tysys.loaded_module_func_indices,
                 &callee.module,
                 &callee.name,
             )
@@ -2157,7 +2157,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let mut impl_param_ids: Vec<TypeId> = Vec::with_capacity(impl_type_param_names.len());
         for (i, name) in impl_type_param_names.iter().enumerate() {
             let type_id = scope
-                .type_table
+                .tysys.type_table
                 .borrow_mut()
                 .make_type_param(name.clone(), i as u32);
             scope
@@ -2177,12 +2177,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             let idx = (m_offset + i) as u32;
             let type_id = if tp.is_pack {
                 scope
-                    .type_table
+                    .tysys.type_table
                     .borrow_mut()
                     .make_type_pack(tp.name.clone(), idx)
             } else {
                 scope
-                    .type_table
+                    .tysys.type_table
                     .borrow_mut()
                     .make_type_param(tp.name.clone(), idx)
             };
@@ -2206,7 +2206,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let mut all_param_ids = impl_param_ids.clone();
         all_param_ids.extend_from_slice(&method_param_ids);
 
-        let mut infer = InferCtx::new(&self.type_table, all_param_ids.clone());
+        let mut infer = InferCtx::new(&self.tysys.type_table, all_param_ids.clone());
         for (i, (param_type, arg)) in resolved_param_types.iter().zip(args.iter()).enumerate() {
             if Self::is_literal_number_arg(raw_args.get(i)) {
                 infer.add_deferred(*param_type, arg.type_id);
@@ -2254,7 +2254,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 let name = symbol.name.clone();
                 Self::lookup_func_in_loaded_module(
                     self.loaded_modules,
-                    &self.loaded_module_func_indices,
+                    &self.tysys.loaded_module_func_indices,
                     &src,
                     &name,
                 )
@@ -2324,7 +2324,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // which may differ from variant_info.module_source (e.g., prelude/types.wado).
         let mut canonical_module_source = None;
 
-        let mut infer = InferCtx::new(&self.type_table, variant_info.type_param_type_ids.clone());
+        let mut infer = InferCtx::new(&self.tysys.type_table, variant_info.type_param_type_ids.clone());
 
         // Forward inference: unify the case payload's declared type against
         // the actual payload expression's type.
@@ -2336,7 +2336,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Queued through `add_expected_return` so it runs after the payload pass,
         // preserving the "stronger constraint wins" policy via `or_insert`.
         if let Some(expected) = expected_type {
-            let expected_resolved = self.type_table.borrow().get(expected).clone();
+            let expected_resolved = self.tysys.type_table.borrow().get(expected).clone();
             if let ResolvedType::GenericInstance {
                 name,
                 module_source,
@@ -2364,16 +2364,16 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // If unresolved type params remain in concrete code, fall back to bare Variant
         let has_unresolved = type_args
             .iter()
-            .any(|&t| self.type_table.borrow().contains_type_param(t));
+            .any(|&t| self.tysys.type_table.borrow().contains_type_param(t));
 
         if has_unresolved && self.trait_ctx.type_params.is_empty() {
-            return self.type_table.borrow_mut().make_variant(
+            return self.tysys.type_table.borrow_mut().make_variant(
                 variant_info.name.clone(),
                 variant_info.module_source.clone(),
             );
         }
 
-        self.type_table.borrow_mut().make_generic_instance(
+        self.tysys.type_table.borrow_mut().make_generic_instance(
             variant_info.name.clone(),
             module_source,
             type_args,
@@ -2426,7 +2426,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 && !method_info_result.method_type_param_ids.is_empty()
             {
                 let method_param_ids = method_info_result.method_type_param_ids.clone();
-                let mut infer = InferCtx::new(&self.type_table, method_param_ids.clone());
+                let mut infer = InferCtx::new(&self.tysys.type_table, method_param_ids.clone());
                 for (i, (param_type, arg)) in method_info_result
                     .param_types
                     .iter()
@@ -2458,7 +2458,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // Build method_info with is_type_param_receiver = true
             let method_type_arg_names: Vec<String> = method_type_args
                 .iter()
-                .map(|t| self.type_table.borrow().mangle_type_name(*t))
+                .map(|t| self.tysys.type_table.borrow().mangle_type_name(*t))
                 .collect();
             let mut method_info = LocalMethodName::new(
                 type_param_name.to_string(),

--- a/wado-compiler/src/elaborator/call.rs
+++ b/wado-compiler/src/elaborator/call.rs
@@ -187,7 +187,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 };
             }
             let concrete_name = self
-                .tysys.type_table
+                .tysys
+                .type_table
                 .borrow()
                 .mangle_type_name(type_param_type_id);
             return CalleeIdentKind::Rewritten(format!("{concrete_name}::{suffix}"));
@@ -270,7 +271,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // when the callee already resolved to the error type so we
             // don't pile a second diagnostic on top of the first.
             if callee_expr.type_id != TypeTable::ERROR {
-                let type_name = self.tysys.type_table.borrow().type_name(callee_expr.type_id);
+                let type_name = self
+                    .tysys
+                    .type_table
+                    .borrow()
+                    .type_name(callee_expr.type_id);
                 let _ = self.logger.error(TypeError::CalleeNotCallable {
                     type_name,
                     span: call.callee.span(),
@@ -350,7 +355,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             self.substitute_type_params(payload_type, &variant_type_args);
                     } else if let Some(expected) = expected_type {
                         // Infer type args from expected type (e.g. Option::Some(null) expecting Option<Option<i32>>)
-                        let expected_resolved = self.tysys.type_table.borrow().get(expected).clone();
+                        let expected_resolved =
+                            self.tysys.type_table.borrow().get(expected).clone();
                         if let ResolvedType::GenericInstance {
                             name: expected_name,
                             type_args: expected_args,
@@ -518,7 +524,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
                     // Base→Newtype: UserId::from(u64_val) where type UserId = u64
                     if let Some(newtype_type_id) = self.lookup_newtype(prefix) {
-                        let base_opt = self.tysys.type_table.borrow().get_newtype_base(newtype_type_id);
+                        let base_opt = self
+                            .tysys
+                            .type_table
+                            .borrow()
+                            .get_newtype_base(newtype_type_id);
                         if let Some(base_id) = base_opt
                             && self.tysys.type_table.borrow().type_name(base_id) == arg_type_name
                         {
@@ -553,7 +563,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     self.recoerce_literal_args(&call.args, &mut args, &substituted);
                     for (i, arg) in args.iter().enumerate() {
                         if let Some(&expected) = substituted.get(i) {
-                            self.tysys.typecheck(self.logger, 
+                            self.tysys.typecheck(
+                                self.logger,
                                 arg.type_id,
                                 expected,
                                 call.args.get(i).map_or(call.span, ast::Expr::span),
@@ -670,7 +681,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     let from_type = args[0].type_id;
                     let from_type_name = self.tysys.type_table.borrow().type_name(from_type);
                     let from_trait_name = self
-                        .tysys.type_table
+                        .tysys
+                        .type_table
                         .borrow()
                         .compiler_items()
                         .trait_name(crate::compiler_item::CompilerItem::From)
@@ -734,7 +746,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
                     // Check if this is a variant construction in the namespace
                     let ns_variant = self
-                        .tysys.all_variant_cases
+                        .tysys
+                        .all_variant_cases
                         .get(&ns_source)
                         .and_then(|m| m.get(type_name))
                         .cloned();
@@ -1021,7 +1034,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
         for (i, arg) in args.iter().enumerate() {
             if let Some(&expected) = check_param_types.get(i) {
-                self.tysys.typecheck(self.logger, 
+                self.tysys.typecheck(
+                    self.logger,
                     arg.type_id,
                     expected,
                     call.args.get(i).map_or(call.span, ast::Expr::span),
@@ -1093,7 +1107,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         for (i, arg) in args.iter().enumerate() {
             if let Some(&expected) = fn_params.get(i) {
-                self.tysys.typecheck(self.logger, 
+                self.tysys.typecheck(
+                    self.logger,
                     arg.type_id,
                     expected,
                     call.args.get(i).map_or(call.span, ast::Expr::span),
@@ -1235,7 +1250,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // disambiguates which Logger this call site means.
         let canonical_key = self.canonical_decl_key(effect);
         let (module_source, item_idx) = self
-            .tysys.trait_env
+            .tysys
+            .trait_env
             .effect_decl_index
             .get(&canonical_key)?
             .clone();
@@ -1285,13 +1301,15 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         wasi_package: Option<&str>,
     ) -> TypeId {
         let string_struct_name = self
-            .tysys.type_table
+            .tysys
+            .type_table
             .borrow()
             .compiler_items()
             .struct_name(crate::compiler_item::CompilerItem::String)
             .to_string();
         let array_struct_name = self
-            .tysys.type_table
+            .tysys
+            .type_table
             .borrow()
             .compiler_items()
             .struct_name(crate::compiler_item::CompilerItem::Array)
@@ -1325,9 +1343,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     // Otherwise, try to resolve via WASI registry's newtypes.
                     // Scoped to `wasi:` to keep this elaborator path WASI-only.
                     let aliased = self
-                        .tysys.wasi_registry
+                        .tysys
+                        .wasi_registry
                         .find_wasi_newtype_source(&named.name)
-                        .and_then(|src| self.tysys.wasi_registry.get_newtype_by_source(src, &named.name))
+                        .and_then(|src| {
+                            self.tysys
+                                .wasi_registry
+                                .get_newtype_by_source(src, &named.name)
+                        })
                         .cloned();
                     if let Some(aliased) = aliased {
                         // Create a newtype for this WASI newtype
@@ -1341,7 +1364,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         self.local_newtypes.insert(named.name.clone(), newtype_id);
                         newtype_id
                     } else if self
-                        .tysys.wasi_registry
+                        .tysys
+                        .wasi_registry
                         .find_wasi_resource_source(&named.name)
                         .is_some()
                     {
@@ -1349,7 +1373,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         // method calls on the returned handle resolve correctly.
                         // Look up the actual module source from all_resource_types.
                         let module_source = self
-                            .tysys.all_resource_types
+                            .tysys
+                            .all_resource_types
                             .iter()
                             .find_map(|(ms, map)| {
                                 if map.contains_key(&named.name) {
@@ -1359,7 +1384,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 }
                             })
                             .unwrap_or_else(ModuleSource::wasi_filesystem);
-                        self.tysys.type_table
+                        self.tysys
+                            .type_table
                             .borrow_mut()
                             .make_resource(named.name.clone(), module_source)
                     } else if let Some(pkg) = wasi_package {
@@ -1373,33 +1399,39 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             // via find_wasi_*_source so same-named core:*
                             // types cannot leak in.
                             if self
-                                .tysys.wasi_registry
+                                .tysys
+                                .wasi_registry
                                 .find_wasi_enum_source(&named.name)
                                 .is_some()
                             {
                                 let module_source = self
-                                    .tysys.all_enum_cases
+                                    .tysys
+                                    .all_enum_cases
                                     .iter()
                                     .find_map(|(ms, map)| {
                                         map.contains_key(&named.name).then(|| ms.clone())
                                     })
                                     .unwrap_or_else(ModuleSource::wasi_cli);
-                                self.tysys.type_table
+                                self.tysys
+                                    .type_table
                                     .borrow_mut()
                                     .make_enum(named.name.clone(), module_source)
                             } else if self
-                                .tysys.wasi_registry
+                                .tysys
+                                .wasi_registry
                                 .find_wasi_struct_source(&named.name)
                                 .is_some()
                             {
                                 let module_source = self
-                                    .tysys.all_struct_fields
+                                    .tysys
+                                    .all_struct_fields
                                     .iter()
                                     .find_map(|(ms, map)| {
                                         map.contains_key(&named.name).then(|| ms.clone())
                                     })
                                     .unwrap_or_else(ModuleSource::wasi_clocks);
-                                self.tysys.type_table
+                                self.tysys
+                                    .type_table
                                     .borrow_mut()
                                     .make_struct(named.name.clone(), module_source)
                             } else {
@@ -1407,13 +1439,15 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             }
                         }
                     } else if self
-                        .tysys.wasi_registry
+                        .tysys
+                        .wasi_registry
                         .find_wasi_enum_source(&named.name)
                         .is_some()
                     {
                         // WASI enum type - look up the module source from all_enum_cases
                         let module_source = self
-                            .tysys.all_enum_cases
+                            .tysys
+                            .all_enum_cases
                             .iter()
                             .find_map(|(ms, map)| {
                                 if map.contains_key(&named.name) {
@@ -1423,17 +1457,20 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 }
                             })
                             .unwrap_or_else(ModuleSource::wasi_cli);
-                        self.tysys.type_table
+                        self.tysys
+                            .type_table
                             .borrow_mut()
                             .make_enum(named.name.clone(), module_source)
                     } else if self
-                        .tysys.wasi_registry
+                        .tysys
+                        .wasi_registry
                         .find_wasi_struct_source(&named.name)
                         .is_some()
                     {
                         // WASI struct (record) type - look up module source from all_struct_fields
                         let module_source = self
-                            .tysys.all_struct_fields
+                            .tysys
+                            .all_struct_fields
                             .iter()
                             .find_map(|(ms, map)| {
                                 if map.contains_key(&named.name) {
@@ -1443,7 +1480,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 }
                             })
                             .unwrap_or_else(ModuleSource::wasi_clocks);
-                        self.tysys.type_table
+                        self.tysys
+                            .type_table
                             .borrow_mut()
                             .make_struct(named.name.clone(), module_source)
                     } else {
@@ -1473,14 +1511,18 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 }
                 "AsyncCall" if generic.args.len() == 1 => {
                     let inner_type = self.resolve_wasi_type_scoped(&generic.args[0], wasi_package);
-                    self.tysys.type_table.borrow_mut().make_async_call(inner_type)
+                    self.tysys
+                        .type_table
+                        .borrow_mut()
+                        .make_async_call(inner_type)
                 }
                 "Result" if generic.args.len() == 2 => {
                     let ok_type = self.resolve_wasi_type_scoped(&generic.args[0], wasi_package);
                     let err_type = self.resolve_wasi_type_scoped(&generic.args[1], wasi_package);
                     // Look up the module source where Result variant is defined
                     let module_source = self
-                        .tysys.all_variant_cases
+                        .tysys
+                        .all_variant_cases
                         .iter()
                         .find_map(|(ms, map)| {
                             if map.contains_key("Result") {
@@ -1514,7 +1556,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
     /// Get the String struct type (from core:prelude/string.wado)
     pub(super) fn get_string_struct_type(&mut self) -> TypeId {
-        self.tysys.type_table
+        self.tysys
+            .type_table
             .borrow_mut()
             .make_compiler_struct(crate::compiler_item::CompilerItem::String)
     }
@@ -1578,7 +1621,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// For generic builtins like `array_new<T>`, returns a type containing
     /// `TypeParam` placeholders that get substituted during monomorphization.
     pub(super) fn get_builtin_return_type(&self, name: &str) -> TypeId {
-        self.tysys.builtin_registry
+        self.tysys
+            .builtin_registry
             .get_return_type(name)
             .unwrap_or(TypeTable::UNIT)
     }
@@ -1888,7 +1932,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 .iter()
                 .enumerate()
                 .map(|(i, name)| {
-                    self.tysys.type_table
+                    self.tysys
+                        .type_table
                         .borrow_mut()
                         .intern(ResolvedType::TypeParam {
                             index: i as u32,
@@ -2157,7 +2202,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let mut impl_param_ids: Vec<TypeId> = Vec::with_capacity(impl_type_param_names.len());
         for (i, name) in impl_type_param_names.iter().enumerate() {
             let type_id = scope
-                .tysys.type_table
+                .tysys
+                .type_table
                 .borrow_mut()
                 .make_type_param(name.clone(), i as u32);
             scope
@@ -2177,12 +2223,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             let idx = (m_offset + i) as u32;
             let type_id = if tp.is_pack {
                 scope
-                    .tysys.type_table
+                    .tysys
+                    .type_table
                     .borrow_mut()
                     .make_type_pack(tp.name.clone(), idx)
             } else {
                 scope
-                    .tysys.type_table
+                    .tysys
+                    .type_table
                     .borrow_mut()
                     .make_type_param(tp.name.clone(), idx)
             };
@@ -2324,7 +2372,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // which may differ from variant_info.module_source (e.g., prelude/types.wado).
         let mut canonical_module_source = None;
 
-        let mut infer = InferCtx::new(&self.tysys.type_table, variant_info.type_param_type_ids.clone());
+        let mut infer = InferCtx::new(
+            &self.tysys.type_table,
+            variant_info.type_param_type_ids.clone(),
+        );
 
         // Forward inference: unify the case payload's declared type against
         // the actual payload expression's type.

--- a/wado-compiler/src/elaborator/call.rs
+++ b/wado-compiler/src/elaborator/call.rs
@@ -553,7 +553,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     self.recoerce_literal_args(&call.args, &mut args, &substituted);
                     for (i, arg) in args.iter().enumerate() {
                         if let Some(&expected) = substituted.get(i) {
-                            self.typecheck(
+                            self.tysys.typecheck(self.logger, 
                                 arg.type_id,
                                 expected,
                                 call.args.get(i).map_or(call.span, ast::Expr::span),
@@ -717,7 +717,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             }
             // If prefix is a known type (struct/enum/newtype/flags) with no matching
             // static method, emit a compile error.
-            else if self.is_known_type_name(prefix) {
+            else if self.tysys.is_known_type_name(prefix) {
                 let _ = self.logger.error(TypeError::UnknownFunction {
                     name: format!("{prefix}::{suffix}"),
                     span: call.span,
@@ -1021,7 +1021,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
         for (i, arg) in args.iter().enumerate() {
             if let Some(&expected) = check_param_types.get(i) {
-                self.typecheck(
+                self.tysys.typecheck(self.logger, 
                     arg.type_id,
                     expected,
                     call.args.get(i).map_or(call.span, ast::Expr::span),
@@ -1093,7 +1093,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         for (i, arg) in args.iter().enumerate() {
             if let Some(&expected) = fn_params.get(i) {
-                self.typecheck(
+                self.tysys.typecheck(self.logger, 
                     arg.type_id,
                     expected,
                     call.args.get(i).map_or(call.span, ast::Expr::span),

--- a/wado-compiler/src/elaborator/call.rs
+++ b/wado-compiler/src/elaborator/call.rs
@@ -563,8 +563,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     self.recoerce_literal_args(&call.args, &mut args, &substituted);
                     for (i, arg) in args.iter().enumerate() {
                         if let Some(&expected) = substituted.get(i) {
-                            self.tysys.typecheck(
-                                self.logger,
+                            self.typecheck(
                                 arg.type_id,
                                 expected,
                                 call.args.get(i).map_or(call.span, ast::Expr::span),
@@ -1034,8 +1033,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
         for (i, arg) in args.iter().enumerate() {
             if let Some(&expected) = check_param_types.get(i) {
-                self.tysys.typecheck(
-                    self.logger,
+                self.typecheck(
                     arg.type_id,
                     expected,
                     call.args.get(i).map_or(call.span, ast::Expr::span),
@@ -1107,8 +1105,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         for (i, arg) in args.iter().enumerate() {
             if let Some(&expected) = fn_params.get(i) {
-                self.tysys.typecheck(
-                    self.logger,
+                self.typecheck(
                     arg.type_id,
                     expected,
                     call.args.get(i).map_or(call.span, ast::Expr::span),

--- a/wado-compiler/src/elaborator/closure.rs
+++ b/wado-compiler/src/elaborator/closure.rs
@@ -36,7 +36,7 @@ struct ExpectedFn {
 impl<H: CompilerHost> Elaborator<'_, H> {
     fn extract_expected_fn(&self, expected_type: Option<TypeId>) -> Option<ExpectedFn> {
         let tid = expected_type?;
-        let tt = self.type_table.borrow();
+        let tt = self.tysys.type_table.borrow();
         // See through newtype layers so a closure assigned to a `type Handler =
         // fn(...)` newtype still gets its parameter types inferred from the
         // underlying fn signature.
@@ -156,7 +156,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 any_mutating_capture = true;
                 let inner_type = local.type_id;
                 let outer_index = local.index;
-                let ref_type = self.type_table.borrow_mut().make_mut_ref(inner_type);
+                let ref_type = self.tysys.type_table.borrow_mut().make_mut_ref(inner_type);
                 let ref_name = format!("__ref_{var_name}");
                 let ref_index = ctx.add_local(ref_name.clone(), ref_type, false, None);
                 ctx.address_taken_locals.insert(outer_index);
@@ -194,7 +194,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Step 3: Open the closure scope with the deref overrides.
         let mut closure_ctx =
-            FunctionContext::new_closure(TypeTable::UNKNOWN, ctx, &self.type_table);
+            FunctionContext::new_closure(TypeTable::UNKNOWN, ctx, &self.tysys.type_table);
         closure_ctx.deref_overrides = deref_overrides;
 
         // Step 4: Add closure parameters.
@@ -250,7 +250,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         && body.type_id != TypeTable::NEVER
                     {
                         let _ = self.logger.error(TypeError::MissingReturn {
-                            return_type: self.type_table.borrow().type_name(t),
+                            return_type: self.tysys.type_table.borrow().type_name(t),
                             span: closure.span,
                         });
                     }
@@ -261,7 +261,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 }
                 None => {
                     let _ = self.logger.error(TypeError::MissingReturn {
-                        return_type: self.type_table.borrow().type_name(body.type_id),
+                        return_type: self.tysys.type_table.borrow().type_name(body.type_id),
                         span: closure.span,
                     });
                     TypeTable::UNIT
@@ -276,7 +276,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // the same reason as before: function-type assignability is
         // structural in params/return and ignores effects.
         let param_types: Vec<TypeId> = params.iter().map(|(_, t)| *t).collect();
-        let func_type = self.type_table.borrow_mut().make_function_with_mut(
+        let func_type = self.tysys.type_table.borrow_mut().make_function_with_mut(
             any_mutating_capture,
             param_types,
             return_type,

--- a/wado-compiler/src/elaborator/coercion.rs
+++ b/wado-compiler/src/elaborator/coercion.rs
@@ -395,7 +395,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Null literal → Option<T>
         if let Expr::Literal(lit) = expr
             && matches!(&lit.value, Literal::Null)
-            && self.tysys.type_table.borrow().as_option(target_type).is_some()
+            && self
+                .tysys
+                .type_table
+                .borrow()
+                .as_option(target_type)
+                .is_some()
         {
             return Some(TirExpr::new(TirExprKind::Null, target_type, lit.span));
         }
@@ -407,9 +412,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         ) || matches!(expr, Expr::TemplateString(_));
 
         if is_string_or_template {
-            let base_id = self.tysys.type_table.borrow().get_ultimate_base_type(target_type);
+            let base_id = self
+                .tysys
+                .type_table
+                .borrow()
+                .get_ultimate_base_type(target_type);
             let string_struct_name = self
-                .tysys.type_table
+                .tysys
+                .type_table
                 .borrow()
                 .compiler_items()
                 .struct_name(crate::compiler_item::CompilerItem::String)
@@ -429,7 +439,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // unwrapped base fn type (so unannotated params are inferred from the
         // expected signature) and retag the result with the newtype id.
         if matches!(expr, Expr::Closure(_)) {
-            let base_id = self.tysys.type_table.borrow().get_ultimate_base_type(target_type);
+            let base_id = self
+                .tysys
+                .type_table
+                .borrow()
+                .get_ultimate_base_type(target_type);
             let is_fn_newtype = matches!(
                 self.tysys.type_table.borrow().get(base_id),
                 ResolvedType::Function { .. }
@@ -523,7 +537,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // current-module fallback — if neither resolves, the builder
         // has no callable `new_literal` and that's a synthesis bug.
         let impl_module_source = self
-            .tysys.trait_env
+            .tysys
+            .trait_env
             .impl_module_for(
                 &builder_name_for_lookup,
                 &trait_name,
@@ -541,7 +556,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         let span = expr.span();
         let string_type = self
-            .tysys.type_table
+            .tysys
+            .type_table
             .borrow_mut()
             .make_compiler_struct(crate::compiler_item::CompilerItem::String);
         let i32_type = TypeTable::I32;
@@ -823,7 +839,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             .map(|info| (info, false))
             .or_else(|| {
                 // For newtypes, try the base type's SequenceLiteral impl
-                let base_type = self.tysys.type_table.borrow().get_newtype_base(target_type)?;
+                let base_type = self
+                    .tysys
+                    .type_table
+                    .borrow()
+                    .get_newtype_base(target_type)?;
                 let base_name = self.struct_name_for_type(base_type)?;
                 self.find_sequence_literal_trait_impl(&base_name, base_type)
                     .map(|info| (info, true))
@@ -938,7 +958,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             if elem_expr.type_id != element_type
                 && elem_expr.type_id != TypeTable::UNKNOWN
                 && element_type != TypeTable::UNKNOWN
-                && !self.tysys.type_table.borrow().contains_type_param(element_type)
+                && !self
+                    .tysys
+                    .type_table
+                    .borrow()
+                    .contains_type_param(element_type)
             {
                 let _ = self.logger.error(TypeError::TypeMismatch {
                     expected: format!(

--- a/wado-compiler/src/elaborator/coercion.rs
+++ b/wado-compiler/src/elaborator/coercion.rs
@@ -22,7 +22,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Number literal coercion to integer
         if let Expr::Literal(lit) = expr
             && let Literal::Number(repr) = &lit.value
-            && self.type_table.borrow().is_integer(target_type)
+            && self.tysys.type_table.borrow().is_integer(target_type)
         {
             if util::is_float_only_literal(repr) {
                 let _ = self.logger.error(TypeError::InvalidLiteral {
@@ -45,7 +45,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     if let Some(err_msg) = util::check_int_range_positive(
                         value,
                         target_type,
-                        &self.type_table.borrow(),
+                        &self.tysys.type_table.borrow(),
                         repr,
                     ) {
                         let _ = self.logger.error(TypeError::InvalidLiteral {
@@ -84,7 +84,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             && unary.op == UnaryOp::Neg
             && let Expr::Literal(lit) = &unary.expr
             && let Literal::Number(repr) = &lit.value
-            && self.type_table.borrow().is_integer(target_type)
+            && self.tysys.type_table.borrow().is_integer(target_type)
         {
             if util::is_float_only_literal(repr) {
                 let _ = self.logger.error(TypeError::InvalidLiteral {
@@ -107,7 +107,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     if let Some(err_msg) = util::check_int_range_negative(
                         value,
                         target_type,
-                        &self.type_table.borrow(),
+                        &self.tysys.type_table.borrow(),
                         repr,
                     ) {
                         let _ = self.logger.error(TypeError::InvalidLiteral {
@@ -145,7 +145,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Number literal coercion to float
         if let Expr::Literal(lit) = expr
             && let Literal::Number(repr) = &lit.value
-            && self.type_table.borrow().is_float(target_type)
+            && self.tysys.type_table.borrow().is_float(target_type)
         {
             return Some(match util::parse_float_literal(repr) {
                 Ok(value) => TirExpr::new(
@@ -178,7 +178,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             && unary.op == UnaryOp::Neg
             && let Expr::Literal(lit) = &unary.expr
             && let Literal::Number(repr) = &lit.value
-            && self.type_table.borrow().is_float(target_type)
+            && self.tysys.type_table.borrow().is_float(target_type)
         {
             return Some(match util::parse_float_literal(repr) {
                 Ok(value) => TirExpr::new(
@@ -211,7 +211,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             && let Literal::Number(repr) = &lit.value
             && !util::is_float_only_literal(repr)
         {
-            let struct_name = match self.type_table.borrow().get(target_type).clone() {
+            let struct_name = match self.tysys.type_table.borrow().get(target_type).clone() {
                 ResolvedType::Struct { name, .. } => Some(name),
                 _ => None,
             };
@@ -307,7 +307,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             && let Literal::Number(repr) = &lit.value
             && !util::is_float_only_literal(repr)
         {
-            let struct_name = match self.type_table.borrow().get(target_type).clone() {
+            let struct_name = match self.tysys.type_table.borrow().get(target_type).clone() {
                 ResolvedType::Struct { name, .. } => Some(name),
                 _ => None,
             };
@@ -366,7 +366,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 continue;
             }
             let is_numeric = {
-                let tt = self.type_table.borrow();
+                let tt = self.tysys.type_table.borrow();
                 tt.is_integer(expected) || tt.is_float(expected)
             };
             if !is_numeric {
@@ -395,7 +395,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Null literal → Option<T>
         if let Expr::Literal(lit) = expr
             && matches!(&lit.value, Literal::Null)
-            && self.type_table.borrow().as_option(target_type).is_some()
+            && self.tysys.type_table.borrow().as_option(target_type).is_some()
         {
             return Some(TirExpr::new(TirExprKind::Null, target_type, lit.span));
         }
@@ -407,15 +407,15 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         ) || matches!(expr, Expr::TemplateString(_));
 
         if is_string_or_template {
-            let base_id = self.type_table.borrow().get_ultimate_base_type(target_type);
+            let base_id = self.tysys.type_table.borrow().get_ultimate_base_type(target_type);
             let string_struct_name = self
-                .type_table
+                .tysys.type_table
                 .borrow()
                 .compiler_items()
                 .struct_name(crate::compiler_item::CompilerItem::String)
                 .to_string();
             let is_string_newtype = matches!(
-                self.type_table.borrow().get(base_id),
+                self.tysys.type_table.borrow().get(base_id),
                 ResolvedType::Struct { name, .. } if name == &string_struct_name
             ) && target_type != base_id;
             if is_string_newtype {
@@ -429,9 +429,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // unwrapped base fn type (so unannotated params are inferred from the
         // expected signature) and retag the result with the newtype id.
         if matches!(expr, Expr::Closure(_)) {
-            let base_id = self.type_table.borrow().get_ultimate_base_type(target_type);
+            let base_id = self.tysys.type_table.borrow().get_ultimate_base_type(target_type);
             let is_fn_newtype = matches!(
-                self.type_table.borrow().get(base_id),
+                self.tysys.type_table.borrow().get(base_id),
                 ResolvedType::Function { .. }
             ) && target_type != base_id;
             if is_fn_newtype {
@@ -456,11 +456,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         if let Expr::StructLiteral(struct_lit) = expr
             && struct_lit.name.is_none()
             && matches!(
-                self.type_table.borrow().get(target_type),
+                self.tysys.type_table.borrow().get(target_type),
                 ResolvedType::GenericInstance { .. }
             )
         {
-            let type_name = self.type_table.borrow().type_name(target_type);
+            let type_name = self.tysys.type_table.borrow().type_name(target_type);
             let _ = self.logger.error(TypeError::MissingTraitImpl {
                 type_name,
                 trait_name: "KeyValueLiteral".to_string(),
@@ -506,7 +506,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let builder_name_for_lookup = self
             .struct_name_for_type(builder_type)
             .unwrap_or_else(|| base_name.clone());
-        let builder_type_module = match self.type_table.borrow().get(builder_type) {
+        let builder_type_module = match self.tysys.type_table.borrow().get(builder_type) {
             ResolvedType::Struct { module_source, .. }
             | ResolvedType::GenericInstance { module_source, .. }
             | ResolvedType::Enum { module_source, .. }
@@ -523,7 +523,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // current-module fallback — if neither resolves, the builder
         // has no callable `new_literal` and that's a synthesis bug.
         let impl_module_source = self
-            .trait_env
+            .tysys.trait_env
             .impl_module_for(
                 &builder_name_for_lookup,
                 &trait_name,
@@ -541,7 +541,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         let span = expr.span();
         let string_type = self
-            .type_table
+            .tysys.type_table
             .borrow_mut()
             .make_compiler_struct(crate::compiler_item::CompilerItem::String);
         let i32_type = TypeTable::I32;
@@ -551,7 +551,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             .struct_name_for_type(builder_type)
             .unwrap_or_else(|| base_name.clone());
         let (type_arg_names, type_arg_ids): (Vec<String>, Vec<TypeId>) = {
-            let tt = self.type_table.borrow();
+            let tt = self.tysys.type_table.borrow();
             match tt.get(builder_type) {
                 ResolvedType::GenericInstance { type_args, .. } => {
                     let names: Vec<String> = type_args
@@ -676,8 +676,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 && value.type_id != TypeTable::NEVER
             {
                 let _ = self.logger.error(TypeError::TypeMismatch {
-                    expected: self.type_table.borrow().type_name(value_type),
-                    found: self.type_table.borrow().type_name(value.type_id),
+                    expected: self.tysys.type_table.borrow().type_name(value_type),
+                    found: self.tysys.type_table.borrow().type_name(value.type_id),
                     span: field.value.span(),
                 });
             }
@@ -823,7 +823,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             .map(|info| (info, false))
             .or_else(|| {
                 // For newtypes, try the base type's SequenceLiteral impl
-                let base_type = self.type_table.borrow().get_newtype_base(target_type)?;
+                let base_type = self.tysys.type_table.borrow().get_newtype_base(target_type)?;
                 let base_name = self.struct_name_for_type(base_type)?;
                 self.find_sequence_literal_trait_impl(&base_name, base_type)
                     .map(|info| (info, true))
@@ -841,7 +841,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let span = expr.span();
 
         let (type_arg_names, type_arg_ids): (Vec<String>, Vec<TypeId>) = {
-            let tt = self.type_table.borrow();
+            let tt = self.tysys.type_table.borrow();
             match tt.get(builder_type) {
                 ResolvedType::GenericInstance { type_args, .. } => {
                     let names: Vec<String> = type_args
@@ -938,16 +938,16 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             if elem_expr.type_id != element_type
                 && elem_expr.type_id != TypeTable::UNKNOWN
                 && element_type != TypeTable::UNKNOWN
-                && !self.type_table.borrow().contains_type_param(element_type)
+                && !self.tysys.type_table.borrow().contains_type_param(element_type)
             {
                 let _ = self.logger.error(TypeError::TypeMismatch {
                     expected: format!(
                         "homogeneous elements of type '{}'",
-                        self.type_table.borrow().type_name(element_type)
+                        self.tysys.type_table.borrow().type_name(element_type)
                     ),
                     found: format!(
                         "heterogeneous element of type '{}'",
-                        self.type_table.borrow().type_name(elem_expr.type_id)
+                        self.tysys.type_table.borrow().type_name(elem_expr.type_id)
                     ),
                     span: element.span(),
                 });

--- a/wado-compiler/src/elaborator/expr.rs
+++ b/wado-compiler/src/elaborator/expr.rs
@@ -1674,7 +1674,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 _ => None,
             };
             if let Some(expected) = derefed_index_type {
-                self.typecheck(index_type, expected, index.index.span());
+                self.tysys.typecheck(self.logger, index_type, expected, index.index.span());
             }
 
             // First, try Index trait (returns reference)
@@ -3305,7 +3305,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 if let Some((_, expected_type_id)) =
                     struct_field_types.iter().find(|(n, _)| n == &field.name)
                 {
-                    self.typecheck(value.type_id, *expected_type_id, field.value.span());
+                    self.tysys.typecheck(self.logger, value.type_id, *expected_type_id, field.value.span());
                 }
 
                 let decl_idx = struct_field_types
@@ -3340,7 +3340,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 let default_ast = struct_field_defaults.get(idx).and_then(Option::clone);
                 if let Some(default_expr) = default_ast {
                     let resolved = self.resolve_expr(&default_expr, ctx, Some(*expected_type_id));
-                    self.typecheck(resolved.type_id, *expected_type_id, struct_lit.span);
+                    self.tysys.typecheck(self.logger, resolved.type_id, *expected_type_id, struct_lit.span);
                     fields.push(TirStructField {
                         name: expected_name.clone(),
                         value: resolved,
@@ -4322,8 +4322,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         use crate::tir::{TirExprKind, TirStructField};
 
         // Bidirectional coercion: resolve non-literal first to infer the element type
-        let start_is_literal = self.is_numeric_literal(&range.start);
-        let end_is_literal = self.is_numeric_literal(&range.end);
+        let start_is_literal = self.tysys.is_numeric_literal(&range.start);
+        let end_is_literal = self.tysys.is_numeric_literal(&range.end);
 
         let (start, end) = if start_is_literal && !end_is_literal {
             let end = self.resolve_expr(&range.end, ctx, None);

--- a/wado-compiler/src/elaborator/expr.rs
+++ b/wado-compiler/src/elaborator/expr.rs
@@ -1685,8 +1685,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 _ => None,
             };
             if let Some(expected) = derefed_index_type {
-                self.tysys
-                    .typecheck(self.logger, index_type, expected, index.index.span());
+                self.typecheck(index_type, expected, index.index.span());
             }
 
             // First, try Index trait (returns reference)
@@ -3311,12 +3310,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 if let Some((_, expected_type_id)) =
                     struct_field_types.iter().find(|(n, _)| n == &field.name)
                 {
-                    self.tysys.typecheck(
-                        self.logger,
-                        value.type_id,
-                        *expected_type_id,
-                        field.value.span(),
-                    );
+                    self.typecheck(value.type_id, *expected_type_id, field.value.span());
                 }
 
                 let decl_idx = struct_field_types
@@ -3351,12 +3345,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 let default_ast = struct_field_defaults.get(idx).and_then(Option::clone);
                 if let Some(default_expr) = default_ast {
                     let resolved = self.resolve_expr(&default_expr, ctx, Some(*expected_type_id));
-                    self.tysys.typecheck(
-                        self.logger,
-                        resolved.type_id,
-                        *expected_type_id,
-                        struct_lit.span,
-                    );
+                    self.typecheck(resolved.type_id, *expected_type_id, struct_lit.span);
                     fields.push(TirStructField {
                         name: expected_name.clone(),
                         value: resolved,

--- a/wado-compiler/src/elaborator/expr.rs
+++ b/wado-compiler/src/elaborator/expr.rs
@@ -3238,22 +3238,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 // We use expected type for numeric literals (including negated ones)
                 // and null literals to avoid interfering with tuple-to-array coercion
                 // for generic struct fields
-                let is_numeric_literal = matches!(
-                    &field.value,
-                    ast::Expr::Literal(lit) if matches!(
-                        &lit.value,
-                        ast::Literal::Number(_)
-                    )
-                ) || matches!(
-                    &field.value,
-                    ast::Expr::Unary(unary) if unary.op == ast::UnaryOp::Neg && matches!(
-                        &unary.expr,
-                        ast::Expr::Literal(lit) if matches!(
-                            &lit.value,
-                            ast::Literal::Number(_)
-                        )
-                    )
-                );
+                let is_numeric_literal = self.tysys.is_numeric_literal(&field.value);
 
                 let is_null_literal = matches!(
                     &field.value,

--- a/wado-compiler/src/elaborator/expr.rs
+++ b/wado-compiler/src/elaborator/expr.rs
@@ -236,7 +236,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 let result_type = if let Some(ty) = expected_type {
                     ty
                 } else if !target.break_types.is_empty() {
-                    let tt = self.type_table.borrow();
+                    let tt = self.tysys.type_table.borrow();
                     target
                         .break_types
                         .iter()
@@ -264,7 +264,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 let mut tir_block = tir_block;
                 if !self.report_uninferable_result(result_type, lb.span, "labeled block") {
                     let unresolved = {
-                        let tt = self.type_table.borrow();
+                        let tt = self.tysys.type_table.borrow();
                         let mut patcher = NullBreakPatcher {
                             label: &lb.label,
                             target_type: result_type,
@@ -395,7 +395,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 (TirExprKind::StringLiteral(value), string_type)
             }
             Literal::Null => {
-                let option_unknown = self.type_table.borrow_mut().make_option(TypeTable::UNKNOWN);
+                let option_unknown = self.tysys.type_table.borrow_mut().make_option(TypeTable::UNKNOWN);
                 (TirExprKind::Null, option_unknown)
             }
             Literal::Unit => (TirExprKind::Unit, TypeTable::UNIT),
@@ -446,7 +446,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             Literal::IncludeStr(raw_path) => {
                 let key = [self.current_module_source.to_string(), raw_path.clone()];
                 let string_type = self.get_string_struct_type();
-                if let Some(bytes) = self.included_files.get(&key) {
+                if let Some(bytes) = self.tysys.included_files.get(&key) {
                     if let Ok(s) = std::str::from_utf8(bytes) {
                         (TirExprKind::StringLiteral(s.to_owned()), string_type)
                     } else {
@@ -466,8 +466,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             }
             Literal::IncludeBytes(raw_path) => {
                 let key = [self.current_module_source.to_string(), raw_path.clone()];
-                let array_u8_type = self.type_table.borrow_mut().make_array(TypeTable::U8);
-                if let Some(bytes) = self.included_files.get(&key) {
+                let array_u8_type = self.tysys.type_table.borrow_mut().make_array(TypeTable::U8);
+                if let Some(bytes) = self.tysys.included_files.get(&key) {
                     (TirExprKind::BytesLiteral(bytes.clone()), array_u8_type)
                 } else {
                     let _ = self.logger.error(TypeError::InvalidLiteral {
@@ -596,7 +596,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     );
                     // Unit variant - payload must be unit type
                     let payload_is_unit = matches!(
-                        self.type_table.borrow().get(case_data.payload),
+                        self.tysys.type_table.borrow().get(case_data.payload),
                         ResolvedType::Unit
                     );
                     if !payload_is_unit {
@@ -610,7 +610,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
                     // Infer variant type for generic variants
                     let variant_type = if variant_info.type_params.is_empty() {
-                        self.type_table.borrow_mut().make_variant(
+                        self.tysys.type_table.borrow_mut().make_variant(
                             variant_info.name.clone(),
                             variant_info.module_source.clone(),
                         )
@@ -649,7 +649,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 );
                 // Use canonical name (not import alias) for consistent TypeId interning
                 let enum_type = self
-                    .type_table
+                    .tysys.type_table
                     .borrow_mut()
                     .make_enum(enum_info.name.clone(), enum_info.module_source);
 
@@ -695,7 +695,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 // canonical name in the source module, so we can read directly
                 // from the shared `all_*` table without any per-module cache.
                 let ns_variant = self
-                    .all_variant_cases
+                    .tysys.all_variant_cases
                     .get(&ns_source)
                     .and_then(|m| m.get(type_name))
                     .cloned();
@@ -713,7 +713,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         case_data.ast_id,
                     );
                     let payload_is_unit = matches!(
-                        self.type_table.borrow().get(case_data.payload),
+                        self.tysys.type_table.borrow().get(case_data.payload),
                         ResolvedType::Unit
                     );
                     if !payload_is_unit {
@@ -725,7 +725,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         return TirExpr::new(TirExprKind::Unit, TypeTable::ERROR, ident.span);
                     }
                     let variant_type = if variant_info.type_params.is_empty() {
-                        self.type_table.borrow_mut().make_variant(
+                        self.tysys.type_table.borrow_mut().make_variant(
                             variant_info.name.clone(),
                             variant_info.module_source.clone(),
                         )
@@ -752,7 +752,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
                 // Check enum cases
                 let ns_enum = self
-                    .all_enum_cases
+                    .tysys.all_enum_cases
                     .get(&ns_source)
                     .and_then(|m| m.get(type_name))
                     .cloned();
@@ -761,7 +761,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 {
                     self.record_namespaced_case(ident, &enum_info.module_source, case_data.ast_id);
                     let enum_type = self
-                        .type_table
+                        .tysys.type_table
                         .borrow_mut()
                         .make_enum(enum_info.name.clone(), enum_info.module_source);
                     return TirExpr::new(
@@ -777,7 +777,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
                 // Check flags members
                 let ns_flags = self
-                    .all_flags_cases
+                    .tysys.all_flags_cases
                     .get(&ns_source)
                     .and_then(|m| m.get(type_name))
                     .cloned();
@@ -1014,7 +1014,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         if param_types.contains(&TypeTable::ERROR) || return_type == TypeTable::ERROR {
             return None;
         }
-        Some(self.type_table.borrow_mut().make_function(
+        Some(self.tysys.type_table.borrow_mut().make_function(
             param_types,
             return_type,
             effects,
@@ -1182,7 +1182,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let original = symbol.name.clone();
         let func = Self::lookup_func_in_loaded_module(
             self.loaded_modules,
-            &self.loaded_module_func_indices,
+            &self.tysys.loaded_module_func_indices,
             &src,
             &original,
         )?
@@ -1212,7 +1212,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         expected: TypeId,
     ) -> FuncRefInference {
         let (expected_params, expected_return) = {
-            let table = self.type_table.borrow();
+            let table = self.tysys.type_table.borrow();
             // Peel `&fn(...)` / `&mut fn(...)` — function values auto-deref
             // at call sites, so an expected reference-to-fn pins the same
             // signature for inference purposes as a bare `fn(...)` would.
@@ -1296,7 +1296,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             return FuncRefInference::NotApplicable;
         }
 
-        let mut infer = super::infer::InferCtx::new(&self.type_table, type_param_ids.clone());
+        let mut infer = super::infer::InferCtx::new(&self.tysys.type_table, type_param_ids.clone());
         for (decl, expected) in decl_params.iter().zip(expected_params.iter()) {
             infer.add(*decl, *expected);
         }
@@ -1348,7 +1348,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         field_name: &str,
         use_id: AstId,
     ) {
-        let resolved = self.type_table.borrow().get(receiver_type).clone();
+        let resolved = self.tysys.type_table.borrow().get(receiver_type).clone();
         let (struct_name, module_source) = match resolved {
             ResolvedType::Struct {
                 name,
@@ -1386,7 +1386,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         span: Span,
     ) -> (u32, TypeId) {
         // Clone the type to avoid borrow issues
-        let resolved = self.type_table.borrow().get(struct_type).clone();
+        let resolved = self.tysys.type_table.borrow().get(struct_type).clone();
         match resolved {
             // Struct field access
             ResolvedType::Struct {
@@ -1455,7 +1455,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// Check if a struct field is accessible from the current module.
     /// Non-pub fields are private to the module that defines them.
     fn check_field_visibility(&mut self, struct_type: TypeId, field_name: &str, span: Span) {
-        let resolved = self.type_table.borrow().get(struct_type).clone();
+        let resolved = self.tysys.type_table.borrow().get(struct_type).clone();
         let (struct_name, module_source) = match resolved {
             ResolvedType::Struct {
                 name,
@@ -1517,7 +1517,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             .enumerate()
             .map(|(i, &t)| (i as u32, t))
             .collect();
-        self.type_table
+        self.tysys.type_table
             .borrow_mut()
             .substitute_type_params(type_id, &substitution)
     }
@@ -1538,14 +1538,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         if let Some(&concrete) = map.get(&type_id) {
             return concrete;
         }
-        let resolved_type = self.type_table.borrow().get(type_id).clone();
+        let resolved_type = self.tysys.type_table.borrow().get(type_id).clone();
         match resolved_type {
             ResolvedType::BuiltinArray(elem) => {
                 let new_elem = self.substitute_type_params_by_map(elem, map);
                 if new_elem == elem {
                     type_id
                 } else {
-                    self.type_table
+                    self.tysys.type_table
                         .borrow_mut()
                         .intern(ResolvedType::BuiltinArray(new_elem))
                 }
@@ -1555,7 +1555,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 if new_inner == inner {
                     type_id
                 } else {
-                    self.type_table.borrow_mut().make_ref(new_inner)
+                    self.tysys.type_table.borrow_mut().make_ref(new_inner)
                 }
             }
             ResolvedType::MutRef(inner) => {
@@ -1563,7 +1563,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 if new_inner == inner {
                     type_id
                 } else {
-                    self.type_table.borrow_mut().make_mut_ref(new_inner)
+                    self.tysys.type_table.borrow_mut().make_mut_ref(new_inner)
                 }
             }
             ResolvedType::GenericInstance {
@@ -1578,7 +1578,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 if new_args == inner_args {
                     type_id
                 } else {
-                    self.type_table.borrow_mut().make_generic_instance(
+                    self.tysys.type_table.borrow_mut().make_generic_instance(
                         name,
                         module_source,
                         new_args,
@@ -1598,11 +1598,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let expr = self.resolve_expr(&index.expr, ctx, None);
 
         // Get base type (unwrap reference if needed)
-        let base_type_id = match self.type_table.borrow().get(expr.type_id) {
+        let base_type_id = match self.tysys.type_table.borrow().get(expr.type_id) {
             ResolvedType::Ref(inner) | ResolvedType::MutRef(inner) => *inner,
             _ => expr.type_id,
         };
-        let base_type = self.type_table.borrow().get(base_type_id).clone();
+        let base_type = self.tysys.type_table.borrow().get(base_type_id).clone();
 
         // Handle tuple indexing: t[0] is equivalent to t.0
         if let ResolvedType::GenericInstance {
@@ -1669,7 +1669,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             let index_type = index_expr.type_id;
 
             // Reject &T/&mut T used as index expression (would ICE in codegen)
-            let derefed_index_type = match self.type_table.borrow().get(index_type) {
+            let derefed_index_type = match self.tysys.type_table.borrow().get(index_type) {
                 ResolvedType::Ref(inner) | ResolvedType::MutRef(inner) => Some(*inner),
                 _ => None,
             };
@@ -1697,7 +1697,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
                 // The method returns &Output, so the type is Ref(output_type)
                 let ref_output_type = self
-                    .type_table
+                    .tysys.type_table
                     .borrow_mut()
                     .make_ref(trait_info.output_type);
 
@@ -1773,7 +1773,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
 
         // Fallback: report error for unsupported indexing
-        let type_name = self.type_table.borrow().type_name(expr.type_id);
+        let type_name = self.tysys.type_table.borrow().type_name(expr.type_id);
         let _ = self.logger.error(TypeError::MissingTraitImpl {
             type_name,
             trait_name: "Index or IndexValue".to_string(),
@@ -1837,8 +1837,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     } else if if_expr.else_block.is_none() {
                         TypeTable::UNIT
                     } else {
-                        let chain_name = self.type_table.borrow().type_name(chain_type);
-                        let else_name = self.type_table.borrow().type_name(else_type);
+                        let chain_name = self.tysys.type_table.borrow().type_name(chain_type);
+                        let else_name = self.tysys.type_table.borrow().type_name(else_type);
                         let _ = self.logger.error(TypeError::TypeMismatch {
                             expected: chain_name,
                             found: else_name,
@@ -1926,7 +1926,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     // We also let `Option<UNKNOWN>` (typically a bare `null` literal whose
                     // inner type could not be inferred) defer to the sibling branch's
                     // resolved type. The unresolved branch's tail is patched below.
-                    let tt = self.type_table.borrow();
+                    let tt = self.tysys.type_table.borrow();
                     let then_unknown = tt.contains_unknown(then_type);
                     let else_unknown = tt.contains_unknown(else_type);
                     drop(tt);
@@ -1942,7 +1942,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         then_type
                     } else if else_block.is_none() {
                         if then_type != TypeTable::UNIT {
-                            let type_name = self.type_table.borrow().type_name(then_type);
+                            let type_name = self.tysys.type_table.borrow().type_name(then_type);
                             let _ = self.logger.error(TypeError::TypeMismatch {
                                 expected: "()".to_string(),
                                 found: type_name,
@@ -1951,8 +1951,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         }
                         TypeTable::UNIT
                     } else {
-                        let then_name = self.type_table.borrow().type_name(then_type);
-                        let else_name = self.type_table.borrow().type_name(else_type);
+                        let then_name = self.tysys.type_table.borrow().type_name(then_type);
+                        let else_name = self.tysys.type_table.borrow().type_name(else_type);
                         let _ = self.logger.error(TypeError::TypeMismatch {
                             expected: then_name,
                             found: else_name,
@@ -1969,7 +1969,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 // rather than letting an unresolved type reach codegen.
                 if !self.report_uninferable_result(type_id, if_expr.span, "if expression") {
                     let unresolved = {
-                        let tt = self.type_table.borrow();
+                        let tt = self.tysys.type_table.borrow();
                         let mut unresolved = Vec::new();
                         patch_unresolved_null_in_block(
                             &mut then_block,
@@ -2049,12 +2049,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// `resolve_match_expr` for arm bodies.
     pub(super) fn check_branch_type(&mut self, actual: TypeId, expected: TypeId, span: Span) {
         let result = {
-            let tt = self.type_table.borrow();
+            let tt = self.tysys.type_table.borrow();
             check_assignable(actual, expected, &tt)
         };
         if matches!(result, TypeCheckResult::Incompatible) {
-            let expected_name = self.type_table.borrow().type_name(expected);
-            let found_name = self.type_table.borrow().type_name(actual);
+            let expected_name = self.tysys.type_table.borrow().type_name(expected);
+            let found_name = self.tysys.type_table.borrow().type_name(actual);
             let _ = self.logger.error(TypeError::TypeMismatch {
                 expected: expected_name,
                 found: found_name,
@@ -2074,7 +2074,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         span: Span,
         construct: &str,
     ) -> bool {
-        if !self.type_table.borrow().contains_unknown(result_type) {
+        if !self.tysys.type_table.borrow().contains_unknown(result_type) {
             return false;
         }
         let _ = self.logger.error(TypeError::CannotInferType {
@@ -2090,7 +2090,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// because `check_assignable` treats the still-`UNKNOWN` `null` leniently.
     fn report_unresolved_nulls(&mut self, unresolved: &[Span], result_type: TypeId) {
         for &span in unresolved {
-            let expected = self.type_table.borrow().type_name(result_type);
+            let expected = self.tysys.type_table.borrow().type_name(result_type);
             let _ = self.logger.error(TypeError::TypeMismatch {
                 expected,
                 found: "null".to_string(),
@@ -2126,7 +2126,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // the arm body alone. A sibling arm with a fully-resolved type
             // (e.g. `Option::Some(s)` where `s: String`) wins; we then patch the
             // unresolved `null` arm bodies below.
-            let tt = self.type_table.borrow();
+            let tt = self.tysys.type_table.borrow();
             arms.iter()
                 .map(|a| a.body.type_id)
                 .find(|&t| t != TypeTable::NEVER && !tt.contains_unknown(t))
@@ -2151,7 +2151,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // it rather than letting an unresolved type reach codegen.
         if !self.report_uninferable_result(type_id, match_expr.span, "match expression") {
             let unresolved = {
-                let tt = self.type_table.borrow();
+                let tt = self.tysys.type_table.borrow();
                 let mut unresolved = Vec::new();
                 for arm in &mut arms {
                     patch_unresolved_null(&mut arm.body, type_id, &tt, &mut unresolved);
@@ -2183,12 +2183,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             for arm in &arms {
                 let arm_type = arm.body.type_id;
                 let result = {
-                    let tt = self.type_table.borrow();
+                    let tt = self.tysys.type_table.borrow();
                     check_assignable(arm_type, type_id, &tt)
                 };
                 if matches!(result, TypeCheckResult::Incompatible) {
-                    let expected_name = self.type_table.borrow().type_name(type_id);
-                    let found_name = self.type_table.borrow().type_name(arm_type);
+                    let expected_name = self.tysys.type_table.borrow().type_name(type_id);
+                    let found_name = self.tysys.type_table.borrow().type_name(arm_type);
                     let _ = self.logger.error(TypeError::TypeMismatch {
                         expected: expected_name,
                         found: found_name,
@@ -2246,7 +2246,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             return;
         }
 
-        let tt = self.type_table.borrow();
+        let tt = self.tysys.type_table.borrow();
         let resolved = tt.get(scrutinee_type).clone();
         drop(tt);
 
@@ -2573,7 +2573,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Cast to i128/u128: expr as u128 → u128::from_u64(expr as u64)
         // For large literals: 170... as i128 → i128::from_string("170...")
-        let struct_name = match self.type_table.borrow().get(target_type).clone() {
+        let struct_name = match self.tysys.type_table.borrow().get(target_type).clone() {
             ResolvedType::Struct { name, .. } => Some(name),
             _ => None,
         };
@@ -2685,8 +2685,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             let source_type = expr_resolved.type_id;
 
             // Check if source type is a numeric type we can convert from
-            if self.type_table.borrow().is_integer(source_type)
-                || self.type_table.borrow().is_float(source_type)
+            if self.tysys.type_table.borrow().is_integer(source_type)
+                || self.tysys.type_table.borrow().is_float(source_type)
             {
                 // Determine intermediate type and method based on target
                 let (intermediate_type, method_name) = if name == "u128" {
@@ -2733,13 +2733,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Validate char casts: prohibit integer/float -> char (use char::from_u32 instead)
         // Exception: u8 -> char is always valid (0..255 are valid Unicode scalar values)
-        let source_base = self.type_table.borrow().get_ultimate_base_type(source_type);
-        let target_base = self.type_table.borrow().get_ultimate_base_type(target_type);
+        let source_base = self.tysys.type_table.borrow().get_ultimate_base_type(source_type);
+        let target_base = self.tysys.type_table.borrow().get_ultimate_base_type(target_type);
         if target_base == TypeTable::CHAR
             && source_base != TypeTable::CHAR
             && source_base != TypeTable::U8
         {
-            let from_name = self.type_table.borrow().type_name(source_type);
+            let from_name = self.tysys.type_table.borrow().type_name(source_type);
             let _ = self.logger.error(TypeError::InvalidCast {
                 from: from_name,
                 to: "char".to_string(),
@@ -2750,9 +2750,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // char -> non-integer is invalid (char -> integer extracts code point)
         if source_base == TypeTable::CHAR
             && target_base != TypeTable::CHAR
-            && !self.type_table.borrow().is_integer(target_base)
+            && !self.tysys.type_table.borrow().is_integer(target_base)
         {
-            let to_name = self.type_table.borrow().type_name(target_type);
+            let to_name = self.tysys.type_table.borrow().type_name(target_type);
             let _ = self.logger.error(TypeError::InvalidCast {
                 from: "char".to_string(),
                 to: to_name,
@@ -3272,7 +3272,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 // tuple and defer coercion to after type inference.
                 let needs_deferred_coercion = is_tuple_literal
                     && expected_field_type
-                        .is_some_and(|t| self.type_table.borrow().contains_type_param(t));
+                        .is_some_and(|t| self.tysys.type_table.borrow().contains_type_param(t));
                 let effective_expected = if needs_deferred_coercion {
                     None
                 } else {
@@ -3462,7 +3462,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 }
             }
 
-            let struct_type = self.type_table.borrow_mut().make_generic_instance(
+            let struct_type = self.tysys.type_table.borrow_mut().make_generic_instance(
                 struct_name.clone(),
                 struct_module_source,
                 type_args.clone(),
@@ -3470,13 +3470,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // Build mangled name with type arguments
             let arg_names: Vec<String> = type_args
                 .iter()
-                .map(|&t| self.type_table.borrow().type_name(t))
+                .map(|&t| self.tysys.type_table.borrow().type_name(t))
                 .collect();
             let mangled_name = mangle_generic_name(&struct_name, &arg_names);
             (struct_type, mangled_name, fields)
         } else {
             let struct_type = self
-                .type_table
+                .tysys.type_table
                 .borrow_mut()
                 .make_struct(struct_name.clone(), struct_module_source);
             (struct_type, struct_name, fields)
@@ -3515,7 +3515,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let anon_name = {
             let mut parts = Vec::new();
             for f in &resolved_fields {
-                let type_name = self.type_table.borrow().type_name(f.value.type_id);
+                let type_name = self.tysys.type_table.borrow().type_name(f.value.type_id);
                 parts.push(format!("{}:{}", f.name, type_name));
             }
             format!("__anon_{{{}}}", parts.join(","))
@@ -3525,7 +3525,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Check if this anonymous struct type already exists (structural equivalence)
         if let Some(existing_type) = self
-            .type_table
+            .tysys.type_table
             .borrow()
             .find_struct_type(&anon_name, &module_source)
         {
@@ -3542,7 +3542,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Register the new anonymous struct type
         let struct_type = self
-            .type_table
+            .tysys.type_table
             .borrow_mut()
             .make_struct(anon_name.clone(), module_source.clone());
 
@@ -3629,7 +3629,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             return vec![];
         }
 
-        let mut infer = InferCtx::new(&self.type_table, struct_info.type_param_type_ids.clone());
+        let mut infer = InferCtx::new(&self.tysys.type_table, struct_info.type_param_type_ids.clone());
 
         for (struct_field, (_, expected_field_type, _)) in
             fields.iter().zip(struct_info.fields.iter())
@@ -3641,7 +3641,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // of this same struct, unify its type-args against the declaration-order
         // type params so phantoms (fields-less params) get concrete bindings.
         if let Some(expected) = expected_type {
-            let expected_resolved = self.type_table.borrow().get(expected).clone();
+            let expected_resolved = self.tysys.type_table.borrow().get(expected).clone();
             if let ResolvedType::GenericInstance {
                 name,
                 type_args: expected_args,
@@ -3666,7 +3666,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
     /// Check if a type contains a `TypePack` (variadic pack parameter).
     pub(super) fn type_contains_pack(&self, type_id: TypeId) -> bool {
-        let ty = self.type_table.borrow().get(type_id).clone();
+        let ty = self.tysys.type_table.borrow().get(type_id).clone();
         match ty {
             ResolvedType::TypePack { .. } => true,
             ResolvedType::GenericInstance {
@@ -3698,7 +3698,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             if has_spread {
                 return None;
             }
-            let elems = self.type_table.borrow().as_tuple(ty)?;
+            let elems = self.tysys.type_table.borrow().as_tuple(ty)?;
             if elems.len() != tuple_lit.elements.len() {
                 return None;
             }
@@ -3714,7 +3714,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             if let Expr::Spread(inner, _span) = elem {
                 let spread_expr = self.resolve_expr(inner, ctx, None);
                 let contains_pack = self.type_contains_pack(spread_expr.type_id);
-                let spread_type = self.type_table.borrow().get(spread_expr.type_id).clone();
+                let spread_type = self.tysys.type_table.borrow().get(spread_expr.type_id).clone();
                 if contains_pack {
                     // Check if the expression's type IS a TypePack directly.
                     // If so, this is a type pack expansion (e.g., [..T::method()])
@@ -3722,7 +3722,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     // If the type is a Tuple containing TypePack, this is a value
                     // spread (e.g., [..rest] where rest: [..T]).
                     let is_direct_pack = matches!(
-                        self.type_table.borrow().get(spread_expr.type_id),
+                        self.tysys.type_table.borrow().get(spread_expr.type_id),
                         ResolvedType::TypePack { .. }
                     );
                     if is_direct_pack {
@@ -3804,7 +3804,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             }
         }
 
-        let tuple_type = self.type_table.borrow_mut().make_tuple(elem_types);
+        let tuple_type = self.tysys.type_table.borrow_mut().make_tuple(elem_types);
 
         let tuple_expr = TirExpr::new(
             TirExprKind::TupleLiteral { elements },
@@ -3858,7 +3858,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     ) -> TirExpr {
         let inner = self.resolve_expr(&qm.expr, ctx, None);
         let inner_type = inner.type_id;
-        let tt = self.type_table.borrow();
+        let tt = self.tysys.type_table.borrow();
         let type_name = tt.type_name(inner_type);
 
         // Determine whether the operand is Option<T> or Result<T, E>
@@ -3879,7 +3879,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Check that the enclosing function returns a compatible type
         let return_type = ctx.return_type;
-        let tt = self.type_table.borrow();
+        let tt = self.tysys.type_table.borrow();
         let ret_is_option = tt.as_option(return_type).is_some();
         let ret_is_result = matches!(
             tt.get(return_type),
@@ -3923,7 +3923,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         span: Span,
     ) -> TirExpr {
         let inner_type = inner.type_id;
-        let tt = self.type_table.borrow();
+        let tt = self.tysys.type_table.borrow();
         let some_type = tt.as_option(inner_type).unwrap();
         // Look up the `Some` / `None` case names through the
         // `CompilerItem` registry so a stdlib rename of either case
@@ -4013,7 +4013,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let return_type = ctx.return_type;
 
         // Extract T, E from inner Result<T, E>
-        let tt = self.type_table.borrow();
+        let tt = self.tysys.type_table.borrow();
         let (ok_type, inner_err_type) = match tt.get(inner_type) {
             ResolvedType::GenericInstance { type_args, .. } if type_args.len() == 2 => {
                 (type_args[0], type_args[1])
@@ -4035,7 +4035,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // `CompilerItem` registry so a stdlib rename of either case
         // flows through the `?` lowering path without touching this site.
         let (ok_name, _ok_index, err_name, err_index) = {
-            let tt = self.type_table.borrow();
+            let tt = self.tysys.type_table.borrow();
             let items = tt.compiler_items();
             let (_, _, ok_n, ok_i) =
                 items.require_variant_case(crate::compiler_item::CompilerItem::ResultOk);
@@ -4150,7 +4150,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         value: TirExpr,
         span: Span,
     ) -> TirExpr {
-        let tt = self.type_table.borrow();
+        let tt = self.tysys.type_table.borrow();
         let target_name = tt.type_name(target_type);
         let from_name = tt.type_name(from_type);
         let from_trait_name = tt
@@ -4201,7 +4201,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// Find the module that provides `impl From<FromType> for TargetType`.
     fn find_from_impl_module(&self, target_name: &str, from_name: &str) -> ModuleSource {
         let from_trait_name = self
-            .type_table
+            .tysys.type_table
             .borrow()
             .compiler_items()
             .trait_name(crate::compiler_item::CompilerItem::From)
@@ -4340,7 +4340,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             && start.type_id != TypeTable::ERROR
             && end.type_id != TypeTable::ERROR
         {
-            let type_table = self.type_table.borrow();
+            let type_table = self.tysys.type_table.borrow();
             let start_name = type_table.type_name(start.type_id);
             let end_name = type_table.type_name(end.type_id);
             if start_name != end_name {
@@ -4363,7 +4363,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Check that the element type implements Ord
         let ord_trait_name = self
-            .type_table
+            .tysys.type_table
             .borrow()
             .compiler_items()
             .trait_name(crate::compiler_item::CompilerItem::Ord)
@@ -4404,7 +4404,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let (struct_name, module_source, fields) = match range.kind {
             RangeKind::Exclusive => {
                 let ms = self
-                    .type_table
+                    .tysys.type_table
                     .borrow()
                     .compiler_items()
                     .struct_module(crate::compiler_item::CompilerItem::RangeExclusive)
@@ -4426,7 +4426,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             }
             RangeKind::Inclusive => {
                 let ms = self
-                    .type_table
+                    .tysys.type_table
                     .borrow()
                     .compiler_items()
                     .struct_module(crate::compiler_item::CompilerItem::RangeInclusive)
@@ -4457,7 +4457,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             }
         };
 
-        let struct_type = self.type_table.borrow_mut().make_generic_instance(
+        let struct_type = self.tysys.type_table.borrow_mut().make_generic_instance(
             struct_name.clone(),
             module_source,
             vec![element_type],

--- a/wado-compiler/src/elaborator/expr.rs
+++ b/wado-compiler/src/elaborator/expr.rs
@@ -395,7 +395,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 (TirExprKind::StringLiteral(value), string_type)
             }
             Literal::Null => {
-                let option_unknown = self.tysys.type_table.borrow_mut().make_option(TypeTable::UNKNOWN);
+                let option_unknown = self
+                    .tysys
+                    .type_table
+                    .borrow_mut()
+                    .make_option(TypeTable::UNKNOWN);
                 (TirExprKind::Null, option_unknown)
             }
             Literal::Unit => (TirExprKind::Unit, TypeTable::UNIT),
@@ -649,7 +653,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 );
                 // Use canonical name (not import alias) for consistent TypeId interning
                 let enum_type = self
-                    .tysys.type_table
+                    .tysys
+                    .type_table
                     .borrow_mut()
                     .make_enum(enum_info.name.clone(), enum_info.module_source);
 
@@ -695,7 +700,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 // canonical name in the source module, so we can read directly
                 // from the shared `all_*` table without any per-module cache.
                 let ns_variant = self
-                    .tysys.all_variant_cases
+                    .tysys
+                    .all_variant_cases
                     .get(&ns_source)
                     .and_then(|m| m.get(type_name))
                     .cloned();
@@ -752,7 +758,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
                 // Check enum cases
                 let ns_enum = self
-                    .tysys.all_enum_cases
+                    .tysys
+                    .all_enum_cases
                     .get(&ns_source)
                     .and_then(|m| m.get(type_name))
                     .cloned();
@@ -761,7 +768,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 {
                     self.record_namespaced_case(ident, &enum_info.module_source, case_data.ast_id);
                     let enum_type = self
-                        .tysys.type_table
+                        .tysys
+                        .type_table
                         .borrow_mut()
                         .make_enum(enum_info.name.clone(), enum_info.module_source);
                     return TirExpr::new(
@@ -777,7 +785,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
                 // Check flags members
                 let ns_flags = self
-                    .tysys.all_flags_cases
+                    .tysys
+                    .all_flags_cases
                     .get(&ns_source)
                     .and_then(|m| m.get(type_name))
                     .cloned();
@@ -1517,7 +1526,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             .enumerate()
             .map(|(i, &t)| (i as u32, t))
             .collect();
-        self.tysys.type_table
+        self.tysys
+            .type_table
             .borrow_mut()
             .substitute_type_params(type_id, &substitution)
     }
@@ -1545,7 +1555,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 if new_elem == elem {
                     type_id
                 } else {
-                    self.tysys.type_table
+                    self.tysys
+                        .type_table
                         .borrow_mut()
                         .intern(ResolvedType::BuiltinArray(new_elem))
                 }
@@ -1674,7 +1685,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 _ => None,
             };
             if let Some(expected) = derefed_index_type {
-                self.tysys.typecheck(self.logger, index_type, expected, index.index.span());
+                self.tysys
+                    .typecheck(self.logger, index_type, expected, index.index.span());
             }
 
             // First, try Index trait (returns reference)
@@ -1697,7 +1709,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
                 // The method returns &Output, so the type is Ref(output_type)
                 let ref_output_type = self
-                    .tysys.type_table
+                    .tysys
+                    .type_table
                     .borrow_mut()
                     .make_ref(trait_info.output_type);
 
@@ -2733,8 +2746,16 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Validate char casts: prohibit integer/float -> char (use char::from_u32 instead)
         // Exception: u8 -> char is always valid (0..255 are valid Unicode scalar values)
-        let source_base = self.tysys.type_table.borrow().get_ultimate_base_type(source_type);
-        let target_base = self.tysys.type_table.borrow().get_ultimate_base_type(target_type);
+        let source_base = self
+            .tysys
+            .type_table
+            .borrow()
+            .get_ultimate_base_type(source_type);
+        let target_base = self
+            .tysys
+            .type_table
+            .borrow()
+            .get_ultimate_base_type(target_type);
         if target_base == TypeTable::CHAR
             && source_base != TypeTable::CHAR
             && source_base != TypeTable::U8
@@ -3305,7 +3326,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 if let Some((_, expected_type_id)) =
                     struct_field_types.iter().find(|(n, _)| n == &field.name)
                 {
-                    self.tysys.typecheck(self.logger, value.type_id, *expected_type_id, field.value.span());
+                    self.tysys.typecheck(
+                        self.logger,
+                        value.type_id,
+                        *expected_type_id,
+                        field.value.span(),
+                    );
                 }
 
                 let decl_idx = struct_field_types
@@ -3340,7 +3366,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 let default_ast = struct_field_defaults.get(idx).and_then(Option::clone);
                 if let Some(default_expr) = default_ast {
                     let resolved = self.resolve_expr(&default_expr, ctx, Some(*expected_type_id));
-                    self.tysys.typecheck(self.logger, resolved.type_id, *expected_type_id, struct_lit.span);
+                    self.tysys.typecheck(
+                        self.logger,
+                        resolved.type_id,
+                        *expected_type_id,
+                        struct_lit.span,
+                    );
                     fields.push(TirStructField {
                         name: expected_name.clone(),
                         value: resolved,
@@ -3476,7 +3507,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             (struct_type, mangled_name, fields)
         } else {
             let struct_type = self
-                .tysys.type_table
+                .tysys
+                .type_table
                 .borrow_mut()
                 .make_struct(struct_name.clone(), struct_module_source);
             (struct_type, struct_name, fields)
@@ -3525,7 +3557,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Check if this anonymous struct type already exists (structural equivalence)
         if let Some(existing_type) = self
-            .tysys.type_table
+            .tysys
+            .type_table
             .borrow()
             .find_struct_type(&anon_name, &module_source)
         {
@@ -3542,7 +3575,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Register the new anonymous struct type
         let struct_type = self
-            .tysys.type_table
+            .tysys
+            .type_table
             .borrow_mut()
             .make_struct(anon_name.clone(), module_source.clone());
 
@@ -3629,7 +3663,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             return vec![];
         }
 
-        let mut infer = InferCtx::new(&self.tysys.type_table, struct_info.type_param_type_ids.clone());
+        let mut infer = InferCtx::new(
+            &self.tysys.type_table,
+            struct_info.type_param_type_ids.clone(),
+        );
 
         for (struct_field, (_, expected_field_type, _)) in
             fields.iter().zip(struct_info.fields.iter())
@@ -3714,7 +3751,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             if let Expr::Spread(inner, _span) = elem {
                 let spread_expr = self.resolve_expr(inner, ctx, None);
                 let contains_pack = self.type_contains_pack(spread_expr.type_id);
-                let spread_type = self.tysys.type_table.borrow().get(spread_expr.type_id).clone();
+                let spread_type = self
+                    .tysys
+                    .type_table
+                    .borrow()
+                    .get(spread_expr.type_id)
+                    .clone();
                 if contains_pack {
                     // Check if the expression's type IS a TypePack directly.
                     // If so, this is a type pack expansion (e.g., [..T::method()])
@@ -4201,7 +4243,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// Find the module that provides `impl From<FromType> for TargetType`.
     fn find_from_impl_module(&self, target_name: &str, from_name: &str) -> ModuleSource {
         let from_trait_name = self
-            .tysys.type_table
+            .tysys
+            .type_table
             .borrow()
             .compiler_items()
             .trait_name(crate::compiler_item::CompilerItem::From)
@@ -4363,7 +4406,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Check that the element type implements Ord
         let ord_trait_name = self
-            .tysys.type_table
+            .tysys
+            .type_table
             .borrow()
             .compiler_items()
             .trait_name(crate::compiler_item::CompilerItem::Ord)
@@ -4404,7 +4448,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let (struct_name, module_source, fields) = match range.kind {
             RangeKind::Exclusive => {
                 let ms = self
-                    .tysys.type_table
+                    .tysys
+                    .type_table
                     .borrow()
                     .compiler_items()
                     .struct_module(crate::compiler_item::CompilerItem::RangeExclusive)
@@ -4426,7 +4471,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             }
             RangeKind::Inclusive => {
                 let ms = self
-                    .tysys.type_table
+                    .tysys
+                    .type_table
                     .borrow()
                     .compiler_items()
                     .struct_module(crate::compiler_item::CompilerItem::RangeInclusive)

--- a/wado-compiler/src/elaborator/handlers.rs
+++ b/wado-compiler/src/elaborator/handlers.rs
@@ -464,8 +464,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let value = self.resolve_expr(&resume.value, ctx, expected);
 
         if ctx.in_handler_method {
-            self.tysys
-                .typecheck(self.logger, value.type_id, ctx.return_type, resume.span);
+            self.typecheck(value.type_id, ctx.return_type, resume.span);
         }
 
         TirExpr::new(

--- a/wado-compiler/src/elaborator/handlers.rs
+++ b/wado-compiler/src/elaborator/handlers.rs
@@ -142,7 +142,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     // import graph a second time via `canonical_decl_key`.
                     let key = (module_source.clone(), name.clone());
                     let is_known_effect = self.tysys.trait_env.effect_decl_index.contains_key(&key);
-                    let is_known_resource = self.tysys.trait_env.resource_decl_index.contains_key(&key);
+                    let is_known_resource =
+                        self.tysys.trait_env.resource_decl_index.contains_key(&key);
                     if !is_known_effect && !is_known_resource {
                         let _ = self.logger.error(TypeError::NotAnEffect {
                             name: name.clone(),
@@ -389,12 +390,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // a same-named effect / resource.
             let canonical_key = self.canonical_decl_key(&base_trait_name);
             let decl_module = self
-                .tysys.trait_env
+                .tysys
+                .trait_env
                 .effect_decl_index
                 .get(&canonical_key)
                 .map(|(m, _)| m.clone())
                 .or_else(|| {
-                    self.tysys.trait_env
+                    self.tysys
+                        .trait_env
                         .resource_decl_index
                         .get(&canonical_key)
                         .map(|(m, _)| m.clone())
@@ -461,7 +464,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let value = self.resolve_expr(&resume.value, ctx, expected);
 
         if ctx.in_handler_method {
-            self.tysys.typecheck(self.logger, value.type_id, ctx.return_type, resume.span);
+            self.tysys
+                .typecheck(self.logger, value.type_id, ctx.return_type, resume.span);
         }
 
         TirExpr::new(

--- a/wado-compiler/src/elaborator/handlers.rs
+++ b/wado-compiler/src/elaborator/handlers.rs
@@ -461,7 +461,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let value = self.resolve_expr(&resume.value, ctx, expected);
 
         if ctx.in_handler_method {
-            self.typecheck(value.type_id, ctx.return_type, resume.span);
+            self.tysys.typecheck(self.logger, value.type_id, ctx.return_type, resume.span);
         }
 
         TirExpr::new(

--- a/wado-compiler/src/elaborator/handlers.rs
+++ b/wado-compiler/src/elaborator/handlers.rs
@@ -141,8 +141,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     // decl-index key from it directly rather than walking the
                     // import graph a second time via `canonical_decl_key`.
                     let key = (module_source.clone(), name.clone());
-                    let is_known_effect = self.trait_env.effect_decl_index.contains_key(&key);
-                    let is_known_resource = self.trait_env.resource_decl_index.contains_key(&key);
+                    let is_known_effect = self.tysys.trait_env.effect_decl_index.contains_key(&key);
+                    let is_known_resource = self.tysys.trait_env.resource_decl_index.contains_key(&key);
                     if !is_known_effect && !is_known_resource {
                         let _ = self.logger.error(TypeError::NotAnEffect {
                             name: name.clone(),
@@ -171,12 +171,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             ..
         }) = &effect
         {
-            let type_name = self.type_table.borrow().type_name(handler_type);
+            let type_name = self.tysys.type_table.borrow().type_name(handler_type);
             // Skip the impl-presence check when the handler type is unresolved
             // (e.g. `Unknown` / `Error`), because earlier diagnostics already
             // reported the handler-side problem.
             let is_real_type = !matches!(
-                self.type_table.borrow().get(handler_type),
+                self.tysys.type_table.borrow().get(handler_type),
                 ResolvedType::Unknown | ResolvedType::Error
             );
             if is_real_type && !self.find_trait_impl_for_type(&type_name, interface_name) {
@@ -241,7 +241,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let handler = self.resolve_expr(&binding.handler, ctx, None);
         let handler_type = self.handler_underlying_type(handler.type_id);
 
-        let resolved = self.type_table.borrow().get(handler_type).clone();
+        let resolved = self.tysys.type_table.borrow().get(handler_type).clone();
         match resolved {
             // Already-diagnosed shapes: keep quiet so we don't pile a
             // bundled-specific error on top.
@@ -263,7 +263,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // empty bindings list lets the rest of the `with` body
             // continue resolving (the user gets one error, not a chain).
             ref other => {
-                let type_name = self.type_table.borrow().type_name(handler_type);
+                let type_name = self.tysys.type_table.borrow().type_name(handler_type);
                 let type_kind = describe_resolved_type_kind(other);
                 let _ = self
                     .logger
@@ -276,7 +276,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             }
         }
 
-        let type_name = self.type_table.borrow().type_name(handler_type);
+        let type_name = self.tysys.type_table.borrow().type_name(handler_type);
         let effects = self.collect_effect_impls_for_type(&type_name);
 
         if effects.is_empty() {
@@ -354,7 +354,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // borrows on `trait_env.impl_index` / `loaded_modules` /
         // `current_module_items`.
         let mut trait_types: Vec<ast::Type> = Vec::new();
-        if let Some(entries) = self.trait_env.impl_index.get(type_name) {
+        if let Some(entries) = self.tysys.trait_env.impl_index.get(type_name) {
             for (module_src, item_idx) in entries {
                 let module = &self.loaded_modules[module_src];
                 if let Item::Impl(impl_block) = &module.items[*item_idx]
@@ -389,12 +389,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // a same-named effect / resource.
             let canonical_key = self.canonical_decl_key(&base_trait_name);
             let decl_module = self
-                .trait_env
+                .tysys.trait_env
                 .effect_decl_index
                 .get(&canonical_key)
                 .map(|(m, _)| m.clone())
                 .or_else(|| {
-                    self.trait_env
+                    self.tysys.trait_env
                         .resource_decl_index
                         .get(&canonical_key)
                         .map(|(m, _)| m.clone())
@@ -426,7 +426,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// handler value points at. The handler's `impl Effect for T` block is
     /// indexed by `T`, not `&T`.
     fn handler_underlying_type(&self, type_id: TypeId) -> TypeId {
-        match self.type_table.borrow().get(type_id) {
+        match self.tysys.type_table.borrow().get(type_id) {
             ResolvedType::Ref(inner) | ResolvedType::MutRef(inner) => *inner,
             _ => type_id,
         }

--- a/wado-compiler/src/elaborator/item.rs
+++ b/wado-compiler/src/elaborator/item.rs
@@ -472,7 +472,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             });
             let default_expr = field.default.as_ref().map(|default_ast| {
                 let resolved = scope.resolve_expr(default_ast, &mut field_ctx, Some(type_id));
-                scope.tysys.typecheck(scope.logger, resolved.type_id, type_id, default_ast.span());
+                scope
+                    .tysys
+                    .typecheck(scope.logger, resolved.type_id, type_id, default_ast.span());
                 Box::new(resolved)
             });
             // A field with a declared default is implicitly non-required at
@@ -580,17 +582,17 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             .expect("type param registered by register_generic_params")
                     })
                     .collect();
-                scope
-                    .tysys.type_table
-                    .borrow_mut()
-                    .intern(crate::tir::ResolvedType::GenericResource {
+                scope.tysys.type_table.borrow_mut().intern(
+                    crate::tir::ResolvedType::GenericResource {
                         name: name.to_string(),
                         module_source: module,
                         type_args: type_arg_ids,
-                    })
+                    },
+                )
             } else {
                 scope
-                    .tysys.type_table
+                    .tysys
+                    .type_table
                     .borrow_mut()
                     .make_resource(name.to_string(), module)
             }
@@ -611,7 +613,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     // in the AST (`SelfKind` has no `Self_` variant),
                     // so the match is exhaustive over the resource
                     // case.
-                    (SelfKind::Ref, Some(self_t)) => scope.tysys.type_table.borrow_mut().make_ref(self_t),
+                    (SelfKind::Ref, Some(self_t)) => {
+                        scope.tysys.type_table.borrow_mut().make_ref(self_t)
+                    }
                     (SelfKind::MutRef, Some(self_t)) => {
                         scope.tysys.type_table.borrow_mut().make_mut_ref(self_t)
                     }
@@ -708,7 +712,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let initializer = self.resolve_expr(&global_decl.initializer, &mut ctx, Some(ty));
 
         // Type check: initializer type must match declared type.
-        self.tysys.typecheck(self.logger, initializer.type_id, ty, global_decl.initializer.span());
+        self.tysys.typecheck(
+            self.logger,
+            initializer.type_id,
+            ty,
+            global_decl.initializer.span(),
+        );
 
         Some(TirGlobal {
             name: global_decl.name.clone(),
@@ -1098,7 +1107,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     });
                 }
                 let resolved = scope.resolve_expr(default_ast, &mut ctx, Some(type_id));
-                scope.tysys.typecheck(scope.logger, resolved.type_id, type_id, default_ast.span());
+                scope
+                    .tysys
+                    .typecheck(scope.logger, resolved.type_id, type_id, default_ast.span());
                 Box::new(resolved)
             });
             let index = ctx.add_local(param.name.clone(), type_id, param.is_mut, Some(param.id));
@@ -1362,7 +1373,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     let name = &named.name;
                     if !scope.trait_ctx.type_params.contains_key(name) {
                         let type_id = scope
-                            .tysys.type_table
+                            .tysys
+                            .type_table
                             .borrow_mut()
                             .make_type_param(name.clone(), i as u32);
                         scope
@@ -1387,7 +1399,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // now living in the saved (parent) scope.
             if let Some(&(idx, _)) = scope.saved().type_params.get(&named.name) {
                 let type_id = scope
-                    .tysys.type_table
+                    .tysys
+                    .type_table
                     .borrow_mut()
                     .make_type_param(named.name.clone(), idx);
                 scope
@@ -1416,7 +1429,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 && let Some(&(idx, _)) = scope.saved().type_params.get(&named.name)
             {
                 let type_id = scope
-                    .tysys.type_table
+                    .tysys
+                    .type_table
                     .borrow_mut()
                     .make_type_param(named.name.clone(), idx);
                 scope
@@ -1446,7 +1460,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     && let Some(&(idx, _)) = scope.saved().type_params.get(name)
                 {
                     let type_id = scope
-                        .tysys.type_table
+                        .tysys
+                        .type_table
                         .borrow_mut()
                         .make_type_pack(name.clone(), idx);
                     scope
@@ -1526,7 +1541,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             let (type_id, consumed_index) = if param.is_pack {
                 (
                     scope
-                        .tysys.type_table
+                        .tysys
+                        .type_table
                         .borrow_mut()
                         .make_type_pack(param.name.clone(), idx),
                     true,
@@ -1536,7 +1552,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             } else {
                 (
                     scope
-                        .tysys.type_table
+                        .tysys
+                        .type_table
                         .borrow_mut()
                         .make_type_param(param.name.clone(), idx),
                     true,
@@ -1626,11 +1643,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // named effects / resources don't get a false negative here.
             let canonical_key = scope.canonical_decl_key(name);
             if scope
-                .tysys.trait_env
+                .tysys
+                .trait_env
                 .effect_decl_index
                 .contains_key(&canonical_key)
                 || scope
-                    .tysys.trait_env
+                    .tysys
+                    .trait_env
                     .resource_decl_index
                     .contains_key(&canonical_key)
             {
@@ -1671,7 +1690,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             }
             let default_expr = param.default.as_ref().map(|default_ast| {
                 let resolved = scope.resolve_expr(default_ast, &mut ctx, Some(type_id));
-                scope.tysys.typecheck(scope.logger, resolved.type_id, type_id, default_ast.span());
+                scope
+                    .tysys
+                    .typecheck(scope.logger, resolved.type_id, type_id, default_ast.span());
                 Box::new(resolved)
             });
             let index = ctx.add_local(param.name.clone(), type_id, param.is_mut, Some(param.id));

--- a/wado-compiler/src/elaborator/item.rs
+++ b/wado-compiler/src/elaborator/item.rs
@@ -388,7 +388,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// containers, newtype unwrap, and (when the struct's field registry is
     /// in scope) named-struct field types.
     pub(super) fn type_contains_closure(&self, type_id: TypeId) -> bool {
-        let type_table = self.type_table.borrow();
+        let type_table = self.tysys.type_table.borrow();
         let mut visited: IndexSet<TypeId> = IndexSet::default();
         self.type_contains_closure_inner(&type_table, type_id, &mut visited)
     }
@@ -581,7 +581,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     })
                     .collect();
                 scope
-                    .type_table
+                    .tysys.type_table
                     .borrow_mut()
                     .intern(crate::tir::ResolvedType::GenericResource {
                         name: name.to_string(),
@@ -590,7 +590,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     })
             } else {
                 scope
-                    .type_table
+                    .tysys.type_table
                     .borrow_mut()
                     .make_resource(name.to_string(), module)
             }
@@ -611,9 +611,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     // in the AST (`SelfKind` has no `Self_` variant),
                     // so the match is exhaustive over the resource
                     // case.
-                    (SelfKind::Ref, Some(self_t)) => scope.type_table.borrow_mut().make_ref(self_t),
+                    (SelfKind::Ref, Some(self_t)) => scope.tysys.type_table.borrow_mut().make_ref(self_t),
                     (SelfKind::MutRef, Some(self_t)) => {
-                        scope.type_table.borrow_mut().make_mut_ref(self_t)
+                        scope.tysys.type_table.borrow_mut().make_mut_ref(self_t)
                     }
                     // No `Self` in scope (effect decls) — drop the
                     // receiver as before; effect operations don't take
@@ -778,7 +778,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         drop(scope);
 
         register_variant_compiler_item(
-            &self.type_table,
+            &self.tysys.type_table,
             &variant_decl.attrs,
             &variant_decl.name,
             &self.current_module_source,
@@ -837,7 +837,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
     /// Validate that stores declarations reference valid reference parameters.
     fn validate_stores(&self, stores: &[String], params: &[TirParam], span: crate::token::Span) {
-        let tt = self.type_table.borrow();
+        let tt = self.tysys.type_table.borrow();
         for store_name in stores {
             if let Some(param) = params.iter().find(|p| p.name == *store_name) {
                 let resolved = tt.get(param.type_id);
@@ -980,7 +980,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             return;
         }
         let _ = self.logger.error(TypeError::MissingReturn {
-            return_type: self.type_table.borrow().type_name(return_type),
+            return_type: self.tysys.type_table.borrow().type_name(return_type),
             span,
         });
     }
@@ -1362,7 +1362,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     let name = &named.name;
                     if !scope.trait_ctx.type_params.contains_key(name) {
                         let type_id = scope
-                            .type_table
+                            .tysys.type_table
                             .borrow_mut()
                             .make_type_param(name.clone(), i as u32);
                         scope
@@ -1387,7 +1387,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // now living in the saved (parent) scope.
             if let Some(&(idx, _)) = scope.saved().type_params.get(&named.name) {
                 let type_id = scope
-                    .type_table
+                    .tysys.type_table
                     .borrow_mut()
                     .make_type_param(named.name.clone(), idx);
                 scope
@@ -1416,7 +1416,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 && let Some(&(idx, _)) = scope.saved().type_params.get(&named.name)
             {
                 let type_id = scope
-                    .type_table
+                    .tysys.type_table
                     .borrow_mut()
                     .make_type_param(named.name.clone(), idx);
                 scope
@@ -1446,7 +1446,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     && let Some(&(idx, _)) = scope.saved().type_params.get(name)
                 {
                     let type_id = scope
-                        .type_table
+                        .tysys.type_table
                         .borrow_mut()
                         .make_type_pack(name.clone(), idx);
                     scope
@@ -1526,7 +1526,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             let (type_id, consumed_index) = if param.is_pack {
                 (
                     scope
-                        .type_table
+                        .tysys.type_table
                         .borrow_mut()
                         .make_type_pack(param.name.clone(), idx),
                     true,
@@ -1536,7 +1536,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             } else {
                 (
                     scope
-                        .type_table
+                        .tysys.type_table
                         .borrow_mut()
                         .make_type_param(param.name.clone(), idx),
                     true,
@@ -1626,11 +1626,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // named effects / resources don't get a false negative here.
             let canonical_key = scope.canonical_decl_key(name);
             if scope
-                .trait_env
+                .tysys.trait_env
                 .effect_decl_index
                 .contains_key(&canonical_key)
                 || scope
-                    .trait_env
+                    .tysys.trait_env
                     .resource_decl_index
                     .contains_key(&canonical_key)
             {
@@ -1646,12 +1646,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 ast::SelfKind::Ref => {
                     // &self: wrap impl type in immutable reference
                     let inner_type = scope.resolve_type(impl_type);
-                    scope.type_table.borrow_mut().make_ref(inner_type)
+                    scope.tysys.type_table.borrow_mut().make_ref(inner_type)
                 }
                 ast::SelfKind::MutRef => {
                     // &mut self: wrap impl type in mutable reference
                     let inner_type = scope.resolve_type(impl_type);
-                    scope.type_table.borrow_mut().make_mut_ref(inner_type)
+                    scope.tysys.type_table.borrow_mut().make_mut_ref(inner_type)
                 }
                 ast::SelfKind::None => {
                     // Regular parameter

--- a/wado-compiler/src/elaborator/item.rs
+++ b/wado-compiler/src/elaborator/item.rs
@@ -472,7 +472,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             });
             let default_expr = field.default.as_ref().map(|default_ast| {
                 let resolved = scope.resolve_expr(default_ast, &mut field_ctx, Some(type_id));
-                scope.typecheck(resolved.type_id, type_id, default_ast.span());
+                scope.tysys.typecheck(scope.logger, resolved.type_id, type_id, default_ast.span());
                 Box::new(resolved)
             });
             // A field with a declared default is implicitly non-required at
@@ -708,7 +708,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let initializer = self.resolve_expr(&global_decl.initializer, &mut ctx, Some(ty));
 
         // Type check: initializer type must match declared type.
-        self.typecheck(initializer.type_id, ty, global_decl.initializer.span());
+        self.tysys.typecheck(self.logger, initializer.type_id, ty, global_decl.initializer.span());
 
         Some(TirGlobal {
             name: global_decl.name.clone(),
@@ -1098,7 +1098,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     });
                 }
                 let resolved = scope.resolve_expr(default_ast, &mut ctx, Some(type_id));
-                scope.typecheck(resolved.type_id, type_id, default_ast.span());
+                scope.tysys.typecheck(scope.logger, resolved.type_id, type_id, default_ast.span());
                 Box::new(resolved)
             });
             let index = ctx.add_local(param.name.clone(), type_id, param.is_mut, Some(param.id));
@@ -1671,7 +1671,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             }
             let default_expr = param.default.as_ref().map(|default_ast| {
                 let resolved = scope.resolve_expr(default_ast, &mut ctx, Some(type_id));
-                scope.typecheck(resolved.type_id, type_id, default_ast.span());
+                scope.tysys.typecheck(scope.logger, resolved.type_id, type_id, default_ast.span());
                 Box::new(resolved)
             });
             let index = ctx.add_local(param.name.clone(), type_id, param.is_mut, Some(param.id));

--- a/wado-compiler/src/elaborator/item.rs
+++ b/wado-compiler/src/elaborator/item.rs
@@ -472,9 +472,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             });
             let default_expr = field.default.as_ref().map(|default_ast| {
                 let resolved = scope.resolve_expr(default_ast, &mut field_ctx, Some(type_id));
-                scope
-                    .tysys
-                    .typecheck(scope.logger, resolved.type_id, type_id, default_ast.span());
+                scope.typecheck(resolved.type_id, type_id, default_ast.span());
                 Box::new(resolved)
             });
             // A field with a declared default is implicitly non-required at
@@ -712,12 +710,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let initializer = self.resolve_expr(&global_decl.initializer, &mut ctx, Some(ty));
 
         // Type check: initializer type must match declared type.
-        self.tysys.typecheck(
-            self.logger,
-            initializer.type_id,
-            ty,
-            global_decl.initializer.span(),
-        );
+        self.typecheck(initializer.type_id, ty, global_decl.initializer.span());
 
         Some(TirGlobal {
             name: global_decl.name.clone(),
@@ -1107,9 +1100,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     });
                 }
                 let resolved = scope.resolve_expr(default_ast, &mut ctx, Some(type_id));
-                scope
-                    .tysys
-                    .typecheck(scope.logger, resolved.type_id, type_id, default_ast.span());
+                scope.typecheck(resolved.type_id, type_id, default_ast.span());
                 Box::new(resolved)
             });
             let index = ctx.add_local(param.name.clone(), type_id, param.is_mut, Some(param.id));
@@ -1690,9 +1681,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             }
             let default_expr = param.default.as_ref().map(|default_ast| {
                 let resolved = scope.resolve_expr(default_ast, &mut ctx, Some(type_id));
-                scope
-                    .tysys
-                    .typecheck(scope.logger, resolved.type_id, type_id, default_ast.span());
+                scope.typecheck(resolved.type_id, type_id, default_ast.span());
                 Box::new(resolved)
             });
             let index = ctx.add_local(param.name.clone(), type_id, param.is_mut, Some(param.id));

--- a/wado-compiler/src/elaborator/matches.rs
+++ b/wado-compiler/src/elaborator/matches.rs
@@ -45,7 +45,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 // pre-refactor path routed through `resolve_match_expr`'s
                 // `check_assignable` loop, which caught this; do the
                 // equivalent explicit check here.
-                self.typecheck(body.type_id, TypeTable::BOOL, guard.span());
+                self.tysys.typecheck(self.logger, body.type_id, TypeTable::BOOL, guard.span());
                 body
             }
             None => bool_literal(true, m.span),

--- a/wado-compiler/src/elaborator/matches.rs
+++ b/wado-compiler/src/elaborator/matches.rs
@@ -45,8 +45,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 // pre-refactor path routed through `resolve_match_expr`'s
                 // `check_assignable` loop, which caught this; do the
                 // equivalent explicit check here.
-                self.tysys
-                    .typecheck(self.logger, body.type_id, TypeTable::BOOL, guard.span());
+                self.typecheck(body.type_id, TypeTable::BOOL, guard.span());
                 body
             }
             None => bool_literal(true, m.span),

--- a/wado-compiler/src/elaborator/matches.rs
+++ b/wado-compiler/src/elaborator/matches.rs
@@ -45,7 +45,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 // pre-refactor path routed through `resolve_match_expr`'s
                 // `check_assignable` loop, which caught this; do the
                 // equivalent explicit check here.
-                self.tysys.typecheck(self.logger, body.type_id, TypeTable::BOOL, guard.span());
+                self.tysys
+                    .typecheck(self.logger, body.type_id, TypeTable::BOOL, guard.span());
                 body
             }
             None => bool_literal(true, m.span),

--- a/wado-compiler/src/elaborator/method_call.rs
+++ b/wado-compiler/src/elaborator/method_call.rs
@@ -113,7 +113,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             } => (name.clone(), module_source.clone()),
             // Primitive types have impl blocks in core:prelude/primitive
             ResolvedType::Primitive(_) => (
-                self.tysys.type_table.borrow().mangle_type_name(base_type_id),
+                self.tysys
+                    .type_table
+                    .borrow()
+                    .mangle_type_name(base_type_id),
                 ModuleSource::primitive(),
             ),
             // Unit type () has impl blocks in core:prelude/primitive
@@ -143,7 +146,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 module_source,
             } => (name.clone(), module_source.clone()),
             _ => (
-                self.tysys.type_table.borrow().mangle_type_name(base_type_id),
+                self.tysys
+                    .type_table
+                    .borrow()
+                    .mangle_type_name(base_type_id),
                 self.current_module_source.clone(),
             ),
         };
@@ -317,7 +323,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Tuple.len() is a compile-time constant — return immediately without a function call.
         if method_name == "len" && self.tysys.type_table.borrow().is_tuple(base_type_id) {
             let len = self
-                .tysys.type_table
+                .tysys
+                .type_table
                 .borrow()
                 .as_tuple(base_type_id)
                 .unwrap()
@@ -347,7 +354,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 );
             }
             // Concrete tuples: expand inline now.
-            let outer_elems = self.tysys.type_table.borrow().as_tuple(base_type_id).unwrap();
+            let outer_elems = self
+                .tysys
+                .type_table
+                .borrow()
+                .as_tuple(base_type_id)
+                .unwrap();
             let inner_arities: Vec<Vec<TypeId>> = outer_elems
                 .iter()
                 .map(|e| self.tysys.type_table.borrow().as_tuple(*e).unwrap())
@@ -467,7 +479,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Check each argument against expected parameter type
         for (i, (arg, &expected_type)) in args.iter().zip(expected_param_types.iter()).enumerate() {
             let arg_span = args_ast.get(i).map_or(span, super::ast::Expr::span);
-            self.tysys.typecheck(self.logger, arg.type_id, expected_type, arg_span);
+            self.tysys
+                .typecheck(self.logger, arg.type_id, expected_type, arg_span);
         }
 
         // Substitute return type for inherited newtype methods
@@ -487,7 +500,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 ResolvedType::Ref(_) | ResolvedType::MutRef(_)
             )
             && matches!(
-                self.tysys.type_table
+                self.tysys
+                    .type_table
                     .borrow()
                     .get(self.get_base_type(receiver.type_id)),
                 ResolvedType::Primitive(_)
@@ -566,7 +580,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Apply unified substitution
         if !subst_ctx.is_empty() {
-            return_type = subst_ctx.substitute(return_type, &mut self.tysys.type_table.borrow_mut());
+            return_type =
+                subst_ctx.substitute(return_type, &mut self.tysys.type_table.borrow_mut());
         }
 
         // Re-coerce literal-number args and typecheck each arg against the substituted
@@ -582,7 +597,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             self.recoerce_literal_args(args_ast, &mut args, &substituted_param_types);
             for (i, arg) in args.iter().enumerate() {
                 if let Some(&expected) = substituted_param_types.get(i) {
-                    self.tysys.typecheck(self.logger, 
+                    self.tysys.typecheck(
+                        self.logger,
                         arg.type_id,
                         expected,
                         args_ast.get(i).map_or(span, super::ast::Expr::span),
@@ -600,7 +616,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             mut base_struct_name,
             impl_type_arg_names,
             receiver_type_args,
-        ) = match self.tysys.type_table.borrow().get(method_impl_type_id).clone() {
+        ) = match self
+            .tysys
+            .type_table
+            .borrow()
+            .get(method_impl_type_id)
+            .clone()
+        {
             ResolvedType::GenericInstance {
                 name, type_args, ..
             }
@@ -616,7 +638,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             }
             _ => {
                 let name = self
-                    .tysys.type_table
+                    .tysys
+                    .type_table
                     .borrow()
                     .mangle_type_name(method_impl_type_id);
                 (name.clone(), name, vec![], None)
@@ -1081,7 +1104,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             .args
                             .first()
                             .map_or(static_call.span, super::ast::Expr::span);
-                        self.tysys.typecheck(self.logger, args[0].type_id, expected_type, span);
+                        self.tysys
+                            .typecheck(self.logger, args[0].type_id, expected_type, span);
                     }
 
                     // Payload was already resolved with the correct expected type
@@ -1128,7 +1152,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Newtypes share the same representation as their base type, so this is a Cast.
         if static_call.method == "from" && args.len() == 1 {
             let arg_type = args[0].type_id;
-            let base_of_target = self.tysys.type_table.borrow().get_newtype_base(target_type_id);
+            let base_of_target = self
+                .tysys
+                .type_table
+                .borrow()
+                .get_newtype_base(target_type_id);
             let base_of_arg = self.tysys.type_table.borrow().get_newtype_base(arg_type);
             if base_of_target == Some(arg_type) || base_of_arg == Some(target_type_id) {
                 let arg = args.into_iter().next().unwrap();
@@ -1353,7 +1381,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 subst_ctx = subst_ctx.with_method_args(&method_type_args, impl_offset);
             }
             if !subst_ctx.is_empty() {
-                return_type = subst_ctx.substitute(return_type, &mut self.tysys.type_table.borrow_mut());
+                return_type =
+                    subst_ctx.substitute(return_type, &mut self.tysys.type_table.borrow_mut());
             }
         }
 
@@ -1567,7 +1596,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                             let name = &named.name;
                                             if !scope.trait_ctx.type_params.contains_key(name) {
                                                 let type_id = scope
-                                                    .tysys.type_table
+                                                    .tysys
+                                                    .type_table
                                                     .borrow_mut()
                                                     .make_type_param(name.clone(), i as u32);
                                                 scope
@@ -1593,12 +1623,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                     let idx = (m_offset + i) as u32;
                                     let type_id = if tp.is_pack {
                                         scope
-                                            .tysys.type_table
+                                            .tysys
+                                            .type_table
                                             .borrow_mut()
                                             .make_type_pack(tp.name.clone(), idx)
                                     } else {
                                         scope
-                                            .tysys.type_table
+                                            .tysys
+                                            .type_table
                                             .borrow_mut()
                                             .make_type_param(tp.name.clone(), idx)
                                     };
@@ -1642,7 +1674,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 let name = &param.name;
                                 if !scope.trait_ctx.type_params.contains_key(name) {
                                     let type_id = scope
-                                        .tysys.type_table
+                                        .tysys
+                                        .type_table
                                         .borrow_mut()
                                         .make_type_param(name.clone(), i as u32);
                                     scope
@@ -1703,7 +1736,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         let name = &named.name;
                         if !scope.trait_ctx.type_params.contains_key(name) {
                             let type_id = scope
-                                .tysys.type_table
+                                .tysys
+                                .type_table
                                 .borrow_mut()
                                 .make_type_param(name.clone(), i as u32);
                             scope
@@ -1729,12 +1763,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 let idx = (m_offset + i) as u32;
                 let type_id = if tp.is_pack {
                     scope
-                        .tysys.type_table
+                        .tysys
+                        .type_table
                         .borrow_mut()
                         .make_type_pack(tp.name.clone(), idx)
                 } else {
                     scope
-                        .tysys.type_table
+                        .tysys
+                        .type_table
                         .borrow_mut()
                         .make_type_param(tp.name.clone(), idx)
                 };
@@ -1758,7 +1794,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Search resource declarations via pre-built index. Same canonical
         // key disambiguation as the inherent-impl path above.
-        if let Some(methods) = self.tysys.trait_env.resource_static_method_index.get(&static_key) {
+        if let Some(methods) = self
+            .tysys
+            .trait_env
+            .resource_static_method_index
+            .get(&static_key)
+        {
             for (name, ms, item_idx, method_idx) in methods {
                 if name == method_name
                     && let Some(module) = self.loaded_modules.get(ms)
@@ -1774,7 +1815,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         let name = &param.name;
                         if !scope.trait_ctx.type_params.contains_key(name) {
                             let type_id = scope
-                                .tysys.type_table
+                                .tysys
+                                .type_table
                                 .borrow_mut()
                                 .make_type_param(name.clone(), i as u32);
                             scope
@@ -2025,7 +2067,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     && !scope.trait_ctx.type_params.contains_key(&named.name)
                 {
                     let type_id = scope
-                        .tysys.type_table
+                        .tysys
+                        .type_table
                         .borrow_mut()
                         .make_type_param(named.name.clone(), i as u32);
                     scope
@@ -2050,12 +2093,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             let idx = (offset + i) as u32;
             let type_id = if tp.is_pack {
                 scope
-                    .tysys.type_table
+                    .tysys
+                    .type_table
                     .borrow_mut()
                     .make_type_pack(tp.name.clone(), idx)
             } else {
                 scope
-                    .tysys.type_table
+                    .tysys
+                    .type_table
                     .borrow_mut()
                     .make_type_param(tp.name.clone(), idx)
             };
@@ -2215,7 +2260,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let target_name = Self::get_type_name_static(target_type);
         let arg_type_name = self.tysys.type_table.borrow().type_name(*arg_type_id);
         let from_trait_name = self
-            .tysys.type_table
+            .tysys
+            .type_table
             .borrow()
             .compiler_items()
             .trait_name(crate::compiler_item::CompilerItem::From)
@@ -2290,7 +2336,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         arg_type_name: Option<&str>,
     ) -> Option<StaticMethodRef> {
         let from_trait_name = self
-            .tysys.type_table
+            .tysys
+            .type_table
             .borrow()
             .compiler_items()
             .trait_name(crate::compiler_item::CompilerItem::From)
@@ -2395,7 +2442,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // the synthesis pass emits one in the struct's own module.
         if method_name == "default" && self.auto_derive_default_struct_type(struct_name).is_some() {
             let default_trait_name = self
-                .tysys.type_table
+                .tysys
+                .type_table
                 .borrow()
                 .compiler_items()
                 .trait_name(crate::compiler_item::CompilerItem::Default)
@@ -2450,7 +2498,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // O(1) lookup via pre-built resource static method index.
         // Same canonical-key disambiguation.
-        if let Some(methods) = self.tysys.trait_env.resource_static_method_index.get(&static_key)
+        if let Some(methods) = self
+            .tysys
+            .trait_env
+            .resource_static_method_index
+            .get(&static_key)
             && methods.iter().any(|(name, ..)| name == method_name)
         {
             return true;

--- a/wado-compiler/src/elaborator/method_call.rs
+++ b/wado-compiler/src/elaborator/method_call.rs
@@ -100,7 +100,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Get struct name and module source from base type
         // The struct_module is where the struct is defined (and inherent methods live)
-        let (struct_name, struct_module) = match self.type_table.borrow().get(base_type_id) {
+        let (struct_name, struct_module) = match self.tysys.type_table.borrow().get(base_type_id) {
             ResolvedType::Struct {
                 name,
                 module_source,
@@ -113,7 +113,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             } => (name.clone(), module_source.clone()),
             // Primitive types have impl blocks in core:prelude/primitive
             ResolvedType::Primitive(_) => (
-                self.type_table.borrow().mangle_type_name(base_type_id),
+                self.tysys.type_table.borrow().mangle_type_name(base_type_id),
                 ModuleSource::primitive(),
             ),
             // Unit type () has impl blocks in core:prelude/primitive
@@ -143,14 +143,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 module_source,
             } => (name.clone(), module_source.clone()),
             _ => (
-                self.type_table.borrow().mangle_type_name(base_type_id),
+                self.tysys.type_table.borrow().mangle_type_name(base_type_id),
                 self.current_module_source.clone(),
             ),
         };
 
         // Extract receiver type args for generic types (used for resolving associated types)
         let receiver_type_args_for_trait: Option<Vec<TypeId>> =
-            match self.type_table.borrow().get(base_type_id).clone() {
+            match self.tysys.type_table.borrow().get(base_type_id).clone() {
                 ResolvedType::GenericInstance { type_args, .. } if !type_args.is_empty() => {
                     Some(type_args)
                 }
@@ -168,12 +168,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Only specific ref impls are preferred (not blanket impls like impl Inspect for &T).
         {
             let is_ref = matches!(
-                self.type_table.borrow().get(receiver.type_id),
+                self.tysys.type_table.borrow().get(receiver.type_id),
                 ResolvedType::Ref(_) | ResolvedType::MutRef(_)
             );
             if is_ref {
                 let ref_struct_name = if matches!(
-                    self.type_table.borrow().get(receiver.type_id),
+                    self.tysys.type_table.borrow().get(receiver.type_id),
                     ResolvedType::Ref(_)
                 ) {
                     "&"
@@ -232,7 +232,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // e.g., T: Ord -> look up cmp() in Ord trait declaration
         if method_info.is_none() {
             let type_param_name = {
-                let resolved = self.type_table.borrow().get(base_type_id).clone();
+                let resolved = self.tysys.type_table.borrow().get(base_type_id).clone();
                 if let ResolvedType::TypeParam { name, .. } | ResolvedType::TypePack { name, .. } =
                     resolved
                 {
@@ -257,7 +257,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // e.g., S::SeqSerializer: SerializeSeq -> look up element() in SerializeSeq
         if method_info.is_none() {
             let assoc_bounds = {
-                let resolved = self.type_table.borrow().get(base_type_id).clone();
+                let resolved = self.tysys.type_table.borrow().get(base_type_id).clone();
                 if let ResolvedType::AssocTypeProjection { bounds, .. } = resolved {
                     if bounds.is_empty() {
                         None
@@ -292,7 +292,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         } = if let Some(info) = method_info {
             info
         } else {
-            let type_name = self.type_table.borrow().type_name(base_type_id);
+            let type_name = self.tysys.type_table.borrow().type_name(base_type_id);
             let _ = self.logger.error(TypeError::MethodNotFound {
                 type_name,
                 method_name: method_name.to_string(),
@@ -315,9 +315,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         };
 
         // Tuple.len() is a compile-time constant — return immediately without a function call.
-        if method_name == "len" && self.type_table.borrow().is_tuple(base_type_id) {
+        if method_name == "len" && self.tysys.type_table.borrow().is_tuple(base_type_id) {
             let len = self
-                .type_table
+                .tysys.type_table
                 .borrow()
                 .as_tuple(base_type_id)
                 .unwrap()
@@ -334,7 +334,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Tuple.zip() transposes a tuple-of-tuples.
         // [[A0, A1], [B0, B1]].zip() → [[A0, B0], [A1, B1]]
-        if method_name == "zip" && self.type_table.borrow().is_tuple(base_type_id) {
+        if method_name == "zip" && self.tysys.type_table.borrow().is_tuple(base_type_id) {
             let has_type_pack = self.type_contains_pack(base_type_id);
             if has_type_pack {
                 // TypePack present: defer expansion to monomorphization.
@@ -347,10 +347,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 );
             }
             // Concrete tuples: expand inline now.
-            let outer_elems = self.type_table.borrow().as_tuple(base_type_id).unwrap();
+            let outer_elems = self.tysys.type_table.borrow().as_tuple(base_type_id).unwrap();
             let inner_arities: Vec<Vec<TypeId>> = outer_elems
                 .iter()
-                .map(|e| self.type_table.borrow().as_tuple(*e).unwrap())
+                .map(|e| self.tysys.type_table.borrow().as_tuple(*e).unwrap())
                 .collect();
             let arity = inner_arities[0].len();
             let num_rows = outer_elems.len();
@@ -379,7 +379,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     row_exprs.push(cell);
                 }
                 let col_types: Vec<TypeId> = inner_arities.iter().map(|row| row[col]).collect();
-                let col_tuple_type = self.type_table.borrow_mut().make_tuple(col_types);
+                let col_tuple_type = self.tysys.type_table.borrow_mut().make_tuple(col_types);
                 col_exprs.push(TirExpr::new(
                     TirExprKind::TupleLiteral {
                         elements: row_exprs,
@@ -400,7 +400,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Static methods (no self parameter) cannot be called with instance method syntax.
         // e.g., `obj.static_method()` should be `Type::static_method()` instead.
         if self_kind == ast::SelfKind::None {
-            let type_name = self.type_table.borrow().type_name(base_type_id);
+            let type_name = self.tysys.type_table.borrow().type_name(base_type_id);
             let _ = self.logger.error(TypeError::MethodNotFound {
                 type_name: type_name.clone(),
                 method_name: method_name.to_string(),
@@ -483,11 +483,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let needs_implicit_mut_borrow_on_primitive_local = !is_ref_impl
             && matches!(self_kind, ast::SelfKind::MutRef)
             && !matches!(
-                self.type_table.borrow().get(receiver.type_id),
+                self.tysys.type_table.borrow().get(receiver.type_id),
                 ResolvedType::Ref(_) | ResolvedType::MutRef(_)
             )
             && matches!(
-                self.type_table
+                self.tysys.type_table
                     .borrow()
                     .get(self.get_base_type(receiver.type_id)),
                 ResolvedType::Primitive(_)
@@ -514,7 +514,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // incorrectly substitute TypeParams from the OUTER context (e.g., TreeMap's K, V) that
         // happen to have the same indices as this impl's type params (e.g., Array's T).
         if trait_name.is_none() {
-            match self.type_table.borrow().get(base_type_id).clone() {
+            match self.tysys.type_table.borrow().get(base_type_id).clone() {
                 ResolvedType::GenericInstance {
                     type_args: receiver_type_args,
                     ..
@@ -530,7 +530,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             }
         } else {
             // For trait methods, just compute impl_offset for method type args
-            match self.type_table.borrow().get(base_type_id).clone() {
+            match self.tysys.type_table.borrow().get(base_type_id).clone() {
                 ResolvedType::GenericInstance { type_args, .. }
                 | ResolvedType::GenericResource { type_args, .. }
                     if !type_args.is_empty() =>
@@ -566,7 +566,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Apply unified substitution
         if !subst_ctx.is_empty() {
-            return_type = subst_ctx.substitute(return_type, &mut self.type_table.borrow_mut());
+            return_type = subst_ctx.substitute(return_type, &mut self.tysys.type_table.borrow_mut());
         }
 
         // Re-coerce literal-number args and typecheck each arg against the substituted
@@ -577,7 +577,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         if !method_type_args.is_empty() {
             let substituted_param_types: Vec<TypeId> = expected_param_types
                 .iter()
-                .map(|&t| subst_ctx.substitute(t, &mut self.type_table.borrow_mut()))
+                .map(|&t| subst_ctx.substitute(t, &mut self.tysys.type_table.borrow_mut()))
                 .collect();
             self.recoerce_literal_args(args_ast, &mut args, &substituted_param_types);
             for (i, arg) in args.iter().enumerate() {
@@ -600,7 +600,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             mut base_struct_name,
             impl_type_arg_names,
             receiver_type_args,
-        ) = match self.type_table.borrow().get(method_impl_type_id).clone() {
+        ) = match self.tysys.type_table.borrow().get(method_impl_type_id).clone() {
             ResolvedType::GenericInstance {
                 name, type_args, ..
             }
@@ -609,14 +609,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             } => {
                 let type_arg_names: Vec<String> = type_args
                     .iter()
-                    .map(|t| self.type_table.borrow().mangle_type_name(*t))
+                    .map(|t| self.tysys.type_table.borrow().mangle_type_name(*t))
                     .collect();
                 let mangled = format!("{}<{}>", name, type_arg_names.join(","));
                 (mangled, name, type_arg_names, Some(type_args))
             }
             _ => {
                 let name = self
-                    .type_table
+                    .tysys.type_table
                     .borrow()
                     .mangle_type_name(method_impl_type_id);
                 (name.clone(), name, vec![], None)
@@ -663,12 +663,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Use inferred type args if available, otherwise use explicit type args
         let method_type_arg_names: Vec<String> = method_type_args
             .iter()
-            .map(|t| self.type_table.borrow().mangle_type_name(*t))
+            .map(|t| self.tysys.type_table.borrow().mangle_type_name(*t))
             .collect();
 
         // Build method_info with base struct name, then apply impl and method type args
         let is_type_param_receiver = matches!(
-            self.type_table.borrow().get(base_type_id),
+            self.tysys.type_table.borrow().get(base_type_id),
             ResolvedType::TypeParam { .. }
                 | ResolvedType::TypePack { .. }
                 | ResolvedType::AssocTypeProjection { .. }
@@ -696,7 +696,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let method_module_source = trait_impl_module_source
             .or_else(|| {
                 inherited_from_base.and_then(|base_id| {
-                    match self.type_table.borrow().get(base_id) {
+                    match self.tysys.type_table.borrow().get(base_id) {
                         ResolvedType::Struct { module_source, .. }
                         | ResolvedType::GenericInstance { module_source, .. }
                         | ResolvedType::Enum { module_source, .. }
@@ -761,7 +761,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let struct_key_for_lookup: Option<crate::elaborator::trait_env::DeclKey> = {
             let mut current_type = target_type_id;
             loop {
-                match self.type_table.borrow().get(current_type).clone() {
+                match self.tysys.type_table.borrow().get(current_type).clone() {
                     ResolvedType::Struct {
                         name,
                         module_source,
@@ -800,7 +800,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // compute substituted payload type so literal coercion works on first resolve.
         if param_types.is_empty() {
             let generic_data = {
-                let resolved = self.type_table.borrow().get(target_type_id).clone();
+                let resolved = self.tysys.type_table.borrow().get(target_type_id).clone();
                 if let ResolvedType::GenericInstance {
                     name,
                     type_args: instance_type_args,
@@ -821,7 +821,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     .find(|(_, c)| c.name == static_call.method)
             {
                 let payload_is_unit = matches!(
-                    self.type_table.borrow().get(case_data.payload),
+                    self.tysys.type_table.borrow().get(case_data.payload),
                     ResolvedType::Unit
                 );
                 if !payload_is_unit {
@@ -921,7 +921,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Handle flags type static methods: none() and all()
         {
-            let flags_name = match self.type_table.borrow().get(target_type_id).clone() {
+            let flags_name = match self.tysys.type_table.borrow().get(target_type_id).clone() {
                 ResolvedType::Flags { ref name, .. } => Some(name.clone()),
                 _ => None,
             };
@@ -990,7 +990,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         if let ResolvedType::Variant {
             name,
             module_source: _,
-        } = self.type_table.borrow().get(target_type_id).clone()
+        } = self.tysys.type_table.borrow().get(target_type_id).clone()
         {
             // Look up the variant case info
             if let Some(variant_info) = self.lookup_variant_case(&name) {
@@ -1003,7 +1003,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 {
                     // Each variant case has exactly one payload.
                     let payload_is_unit = matches!(
-                        self.type_table.borrow().get(case_data.payload),
+                        self.tysys.type_table.borrow().get(case_data.payload),
                         ResolvedType::Unit
                     );
                     let expected_args = usize::from(!payload_is_unit);
@@ -1039,7 +1039,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Handle generic variant construction: Result::<i32, String>::Ok(42)
         let generic_name = {
-            let tt = self.type_table.borrow();
+            let tt = self.tysys.type_table.borrow();
             if let ResolvedType::GenericInstance { name, .. } = tt.get(target_type_id) {
                 Some(name.clone())
             } else {
@@ -1059,7 +1059,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 {
                     // Each variant case has exactly one payload.
                     let payload_is_unit = matches!(
-                        self.type_table.borrow().get(case_data.payload),
+                        self.tysys.type_table.borrow().get(case_data.payload),
                         ResolvedType::Unit
                     );
                     let expected_args = usize::from(!payload_is_unit);
@@ -1128,8 +1128,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Newtypes share the same representation as their base type, so this is a Cast.
         if static_call.method == "from" && args.len() == 1 {
             let arg_type = args[0].type_id;
-            let base_of_target = self.type_table.borrow().get_newtype_base(target_type_id);
-            let base_of_arg = self.type_table.borrow().get_newtype_base(arg_type);
+            let base_of_target = self.tysys.type_table.borrow().get_newtype_base(target_type_id);
+            let base_of_arg = self.tysys.type_table.borrow().get_newtype_base(arg_type);
             if base_of_target == Some(arg_type) || base_of_arg == Some(target_type_id) {
                 let arg = args.into_iter().next().unwrap();
                 return TirExpr::new(
@@ -1144,7 +1144,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
 
         let (struct_name, struct_module, mangled_struct_name, struct_type_args) =
-            match self.type_table.borrow().get(target_type_id) {
+            match self.tysys.type_table.borrow().get(target_type_id) {
                 ResolvedType::Struct {
                     name,
                     module_source,
@@ -1163,7 +1163,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 } => {
                     let type_arg_names: Vec<String> = type_args
                         .iter()
-                        .map(|t| self.type_table.borrow().mangle_type_name(*t))
+                        .map(|t| self.tysys.type_table.borrow().mangle_type_name(*t))
                         .collect();
                     let mangled = format!("{}<{}>", name, type_arg_names.join(","));
                     (
@@ -1193,7 +1193,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     // Build mangled name for generic type: Array<i32>
                     let type_arg_names: Vec<String> = type_args
                         .iter()
-                        .map(|t| self.type_table.borrow().mangle_type_name(*t))
+                        .map(|t| self.tysys.type_table.borrow().mangle_type_name(*t))
                         .collect();
                     let mangled = format!("{}<{}>", name, type_arg_names.join(","));
                     (
@@ -1217,7 +1217,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         (newtype_name.clone(), newtype_module, newtype_name, vec![])
                     } else {
                         // Fall back to the base type for inherited methods
-                        match self.type_table.borrow().get(*base_type).clone() {
+                        match self.tysys.type_table.borrow().get(*base_type).clone() {
                             ResolvedType::Struct {
                                 name,
                                 module_source,
@@ -1230,7 +1230,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             } => {
                                 let type_arg_names: Vec<String> = type_args
                                     .iter()
-                                    .map(|t| self.type_table.borrow().mangle_type_name(*t))
+                                    .map(|t| self.tysys.type_table.borrow().mangle_type_name(*t))
                                     .collect();
                                 let mangled = format!("{}<{}>", name, type_arg_names.join(","));
                                 (name, module_source, mangled, type_args)
@@ -1241,7 +1241,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             } => {
                                 let mut current = inner_base;
                                 loop {
-                                    match self.type_table.borrow().get(current).clone() {
+                                    match self.tysys.type_table.borrow().get(current).clone() {
                                         ResolvedType::Struct {
                                             name,
                                             module_source,
@@ -1306,7 +1306,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let arg_type_hint = if (static_call.method == "from" || static_call.method == "try_from")
             && args.len() == 1
         {
-            Some(self.type_table.borrow().type_name(args[0].type_id))
+            Some(self.tysys.type_table.borrow().type_name(args[0].type_id))
         } else {
             None
         };
@@ -1353,7 +1353,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 subst_ctx = subst_ctx.with_method_args(&method_type_args, impl_offset);
             }
             if !subst_ctx.is_empty() {
-                return_type = subst_ctx.substitute(return_type, &mut self.type_table.borrow_mut());
+                return_type = subst_ctx.substitute(return_type, &mut self.tysys.type_table.borrow_mut());
             }
         }
 
@@ -1376,11 +1376,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         let method_type_arg_names: Vec<String> = method_type_args
             .iter()
-            .map(|t| self.type_table.borrow().mangle_type_name(*t))
+            .map(|t| self.tysys.type_table.borrow().mangle_type_name(*t))
             .collect();
         let impl_only_type_arg_names: Vec<String> = struct_type_args
             .iter()
-            .map(|t| self.type_table.borrow().mangle_type_name(*t))
+            .map(|t| self.tysys.type_table.borrow().mangle_type_name(*t))
             .collect();
 
         let param_is_mut = struct_name_for_lookup
@@ -1567,7 +1567,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                             let name = &named.name;
                                             if !scope.trait_ctx.type_params.contains_key(name) {
                                                 let type_id = scope
-                                                    .type_table
+                                                    .tysys.type_table
                                                     .borrow_mut()
                                                     .make_type_param(name.clone(), i as u32);
                                                 scope
@@ -1593,12 +1593,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                     let idx = (m_offset + i) as u32;
                                     let type_id = if tp.is_pack {
                                         scope
-                                            .type_table
+                                            .tysys.type_table
                                             .borrow_mut()
                                             .make_type_pack(tp.name.clone(), idx)
                                     } else {
                                         scope
-                                            .type_table
+                                            .tysys.type_table
                                             .borrow_mut()
                                             .make_type_param(tp.name.clone(), idx)
                                     };
@@ -1642,7 +1642,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 let name = &param.name;
                                 if !scope.trait_ctx.type_params.contains_key(name) {
                                     let type_id = scope
-                                        .type_table
+                                        .tysys.type_table
                                         .borrow_mut()
                                         .make_type_param(name.clone(), i as u32);
                                     scope
@@ -1672,9 +1672,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let static_key = self.canonical_decl_key(struct_name);
         // Materialise the impl-block info out of the index borrow before
         // entering the inherited type-param scope, so the borrow on
-        // `self.trait_env` releases before we touch `self` mutably.
+        // `self.tysys.trait_env` releases before we touch `self` mutably.
         let indexed: Option<(ModuleSource, ast::Type, ast::Function)> =
-            if let Some(methods) = self.trait_env.static_method_index.get(&static_key) {
+            if let Some(methods) = self.tysys.trait_env.static_method_index.get(&static_key) {
                 methods.iter().find_map(|(name, ms, item_idx, method_idx)| {
                     if name != method_name {
                         return None;
@@ -1703,7 +1703,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         let name = &named.name;
                         if !scope.trait_ctx.type_params.contains_key(name) {
                             let type_id = scope
-                                .type_table
+                                .tysys.type_table
                                 .borrow_mut()
                                 .make_type_param(name.clone(), i as u32);
                             scope
@@ -1729,12 +1729,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 let idx = (m_offset + i) as u32;
                 let type_id = if tp.is_pack {
                     scope
-                        .type_table
+                        .tysys.type_table
                         .borrow_mut()
                         .make_type_pack(tp.name.clone(), idx)
                 } else {
                     scope
-                        .type_table
+                        .tysys.type_table
                         .borrow_mut()
                         .make_type_param(tp.name.clone(), idx)
                 };
@@ -1758,7 +1758,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Search resource declarations via pre-built index. Same canonical
         // key disambiguation as the inherent-impl path above.
-        if let Some(methods) = self.trait_env.resource_static_method_index.get(&static_key) {
+        if let Some(methods) = self.tysys.trait_env.resource_static_method_index.get(&static_key) {
             for (name, ms, item_idx, method_idx) in methods {
                 if name == method_name
                     && let Some(module) = self.loaded_modules.get(ms)
@@ -1774,7 +1774,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         let name = &param.name;
                         if !scope.trait_ctx.type_params.contains_key(name) {
                             let type_id = scope
-                                .type_table
+                                .tysys.type_table
                                 .borrow_mut()
                                 .make_type_param(name.clone(), i as u32);
                             scope
@@ -1882,7 +1882,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         if let Some(found) = scan(self.current_module_items) {
             return found;
         }
-        if let Some(entries) = self.trait_env.impl_index.get(struct_name) {
+        if let Some(entries) = self.tysys.trait_env.impl_index.get(struct_name) {
             for (module_source, item_idx) in entries {
                 if let Some(module) = self.loaded_modules.get(module_source)
                     && let Item::Impl(impl_block) = &module.items[*item_idx]
@@ -1962,7 +1962,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // a static method's signature references types the impl module
         // imports, not the caller's.
         let indexed: Option<(ModuleSource, ast::Type, ast::Function)> = if let Some(methods) =
-            self.trait_env.static_method_index.get(&static_key)
+            self.tysys.trait_env.static_method_index.get(&static_key)
         {
             let mut found = None;
             for (name, module_source, item_idx, method_idx) in methods {
@@ -2025,7 +2025,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     && !scope.trait_ctx.type_params.contains_key(&named.name)
                 {
                     let type_id = scope
-                        .type_table
+                        .tysys.type_table
                         .borrow_mut()
                         .make_type_param(named.name.clone(), i as u32);
                     scope
@@ -2050,12 +2050,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             let idx = (offset + i) as u32;
             let type_id = if tp.is_pack {
                 scope
-                    .type_table
+                    .tysys.type_table
                     .borrow_mut()
                     .make_type_pack(tp.name.clone(), idx)
             } else {
                 scope
-                    .type_table
+                    .tysys.type_table
                     .borrow_mut()
                     .make_type_param(tp.name.clone(), idx)
             };
@@ -2117,7 +2117,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
         // Check indexed modules — index keyed by canonical decl key.
         let static_key = self.canonical_decl_key(struct_name);
-        if let Some(methods) = self.trait_env.static_method_index.get(&static_key) {
+        if let Some(methods) = self.tysys.trait_env.static_method_index.get(&static_key) {
             for (name, module_source, item_idx, method_idx) in methods {
                 if name == method_name
                     && let Some(module) = self.loaded_modules.get(module_source)
@@ -2213,9 +2213,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         arg_type_id: &crate::tir::TypeId,
     ) -> bool {
         let target_name = Self::get_type_name_static(target_type);
-        let arg_type_name = self.type_table.borrow().type_name(*arg_type_id);
+        let arg_type_name = self.tysys.type_table.borrow().type_name(*arg_type_id);
         let from_trait_name = self
-            .type_table
+            .tysys.type_table
             .borrow()
             .compiler_items()
             .trait_name(crate::compiler_item::CompilerItem::From)
@@ -2290,7 +2290,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         arg_type_name: Option<&str>,
     ) -> Option<StaticMethodRef> {
         let from_trait_name = self
-            .type_table
+            .tysys.type_table
             .borrow()
             .compiler_items()
             .trait_name(crate::compiler_item::CompilerItem::From)
@@ -2375,7 +2375,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
 
         // Use trait_env.impl_index for O(1) lookup instead of scanning all modules
-        if let Some(entries) = self.trait_env.impl_index.get(struct_name) {
+        if let Some(entries) = self.tysys.trait_env.impl_index.get(struct_name) {
             for (module_source, item_idx) in entries {
                 if let Some(module) = self.loaded_modules.get(module_source)
                     && let Item::Impl(impl_block) = &module.items[*item_idx]
@@ -2395,7 +2395,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // the synthesis pass emits one in the struct's own module.
         if method_name == "default" && self.auto_derive_default_struct_type(struct_name).is_some() {
             let default_trait_name = self
-                .type_table
+                .tysys.type_table
                 .borrow()
                 .compiler_items()
                 .trait_name(crate::compiler_item::CompilerItem::Default)
@@ -2424,7 +2424,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Canonicalise so a same-named struct in another module doesn't
         // accidentally claim this name.
         let static_key = self.canonical_decl_key(struct_name);
-        if let Some(methods) = self.trait_env.static_method_index.get(&static_key)
+        if let Some(methods) = self.tysys.trait_env.static_method_index.get(&static_key)
             && methods.iter().any(|(name, ..)| name == method_name)
         {
             return true;
@@ -2450,7 +2450,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // O(1) lookup via pre-built resource static method index.
         // Same canonical-key disambiguation.
-        if let Some(methods) = self.trait_env.resource_static_method_index.get(&static_key)
+        if let Some(methods) = self.tysys.trait_env.resource_static_method_index.get(&static_key)
             && methods.iter().any(|(name, ..)| name == method_name)
         {
             return true;
@@ -2458,9 +2458,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // For newtypes/flags, check if the base type has the static method
         if let Some(newtype_id) = self.lookup_newtype(struct_name) {
-            let base_name = match self.type_table.borrow().get(newtype_id).clone() {
+            let base_name = match self.tysys.type_table.borrow().get(newtype_id).clone() {
                 ResolvedType::Newtype { base_type, .. } => {
-                    Some(self.type_table.borrow().type_name(base_type))
+                    Some(self.tysys.type_table.borrow().type_name(base_type))
                 }
                 ResolvedType::Flags { .. } => Some("u32".to_string()),
                 _ => None,
@@ -2527,7 +2527,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 if self.has_static_method_direct(struct_name, method_name) {
                     (struct_name.to_string(), mangled_func_name.to_string())
                 } else {
-                    let base_name = match self.type_table.borrow().get(newtype_id).clone() {
+                    let base_name = match self.tysys.type_table.borrow().get(newtype_id).clone() {
                         ResolvedType::Newtype { base_type, .. } => {
                             Some(self.get_ultimate_base_struct_name(base_type))
                         }
@@ -2551,7 +2551,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // rather than the default `ModuleSource::primitive()` for `i32`.
         let arg_type_hint =
             if (method_name == "from" || method_name == "try_from") && args.len() == 1 {
-                Some(self.type_table.borrow().type_name(args[0].type_id))
+                Some(self.tysys.type_table.borrow().type_name(args[0].type_id))
             } else {
                 None
             };

--- a/wado-compiler/src/elaborator/method_call.rs
+++ b/wado-compiler/src/elaborator/method_call.rs
@@ -467,7 +467,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Check each argument against expected parameter type
         for (i, (arg, &expected_type)) in args.iter().zip(expected_param_types.iter()).enumerate() {
             let arg_span = args_ast.get(i).map_or(span, super::ast::Expr::span);
-            self.typecheck(arg.type_id, expected_type, arg_span);
+            self.tysys.typecheck(self.logger, arg.type_id, expected_type, arg_span);
         }
 
         // Substitute return type for inherited newtype methods
@@ -582,7 +582,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             self.recoerce_literal_args(args_ast, &mut args, &substituted_param_types);
             for (i, arg) in args.iter().enumerate() {
                 if let Some(&expected) = substituted_param_types.get(i) {
-                    self.typecheck(
+                    self.tysys.typecheck(self.logger, 
                         arg.type_id,
                         expected,
                         args_ast.get(i).map_or(span, super::ast::Expr::span),
@@ -1081,7 +1081,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             .args
                             .first()
                             .map_or(static_call.span, super::ast::Expr::span);
-                        self.typecheck(args[0].type_id, expected_type, span);
+                        self.tysys.typecheck(self.logger, args[0].type_id, expected_type, span);
                     }
 
                     // Payload was already resolved with the correct expected type

--- a/wado-compiler/src/elaborator/method_call.rs
+++ b/wado-compiler/src/elaborator/method_call.rs
@@ -479,8 +479,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Check each argument against expected parameter type
         for (i, (arg, &expected_type)) in args.iter().zip(expected_param_types.iter()).enumerate() {
             let arg_span = args_ast.get(i).map_or(span, super::ast::Expr::span);
-            self.tysys
-                .typecheck(self.logger, arg.type_id, expected_type, arg_span);
+            self.typecheck(arg.type_id, expected_type, arg_span);
         }
 
         // Substitute return type for inherited newtype methods
@@ -597,8 +596,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             self.recoerce_literal_args(args_ast, &mut args, &substituted_param_types);
             for (i, arg) in args.iter().enumerate() {
                 if let Some(&expected) = substituted_param_types.get(i) {
-                    self.tysys.typecheck(
-                        self.logger,
+                    self.typecheck(
                         arg.type_id,
                         expected,
                         args_ast.get(i).map_or(span, super::ast::Expr::span),
@@ -1104,8 +1102,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             .args
                             .first()
                             .map_or(static_call.span, super::ast::Expr::span);
-                        self.tysys
-                            .typecheck(self.logger, args[0].type_id, expected_type, span);
+                        self.typecheck(args[0].type_id, expected_type, span);
                     }
 
                     // Payload was already resolved with the correct expected type

--- a/wado-compiler/src/elaborator/method_lookup.rs
+++ b/wado-compiler/src/elaborator/method_lookup.rs
@@ -94,7 +94,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// Returns lightweight `ImplBlockRef` values instead of cloning impl block data.
     fn collect_trait_impl_refs(&self, type_name: &str) -> Vec<ImplBlockRef> {
         let mut refs = Vec::new();
-        if let Some(entries) = self.trait_env.impl_index.get(type_name) {
+        if let Some(entries) = self.tysys.trait_env.impl_index.get(type_name) {
             for (module_src, item_idx) in entries {
                 let module = &self.loaded_modules[module_src];
                 if let Item::Impl(impl_block) = &module.items[*item_idx]
@@ -119,7 +119,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     fn collect_trait_impl_refs_multi(&self, type_names: &[String]) -> Vec<ImplBlockRef> {
         let mut refs = Vec::new();
         for name in type_names {
-            if let Some(entries) = self.trait_env.impl_index.get(name.as_str()) {
+            if let Some(entries) = self.tysys.trait_env.impl_index.get(name.as_str()) {
                 for (module_src, item_idx) in entries {
                     let module = &self.loaded_modules[module_src];
                     if let Item::Impl(impl_block) = &module.items[*item_idx]
@@ -185,7 +185,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             BinaryOp::Shl => Some(("Shl".to_string(), "shl")),
             BinaryOp::Shr => Some(("Shr".to_string(), "shr")),
             BinaryOp::Eq | BinaryOp::NotEq => Some((
-                self.type_table
+                self.tysys.type_table
                     .borrow()
                     .compiler_items()
                     .trait_name(CompilerItem::Eq)
@@ -193,7 +193,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 "eq",
             )),
             BinaryOp::Lt | BinaryOp::LtEq | BinaryOp::Gt | BinaryOp::GtEq => Some((
-                self.type_table
+                self.tysys.type_table
                     .borrow()
                     .compiler_items()
                     .trait_name(CompilerItem::Ord)
@@ -206,7 +206,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
     /// Get the struct name from a type ID, if it's a struct, generic instance, newtype, or flags.
     pub(super) fn struct_name_for_type(&self, type_id: TypeId) -> Option<String> {
-        match self.type_table.borrow().get(type_id) {
+        match self.tysys.type_table.borrow().get(type_id) {
             ResolvedType::Struct { name, .. }
             | ResolvedType::GenericInstance { name, .. }
             | ResolvedType::Newtype { name, .. }
@@ -218,7 +218,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// For newtypes, get the base type name and ID for trait impl lookup fallback.
     /// Returns (`base_name`, `base_type_id`) if the type is a newtype; otherwise returns the same name/id.
     pub(super) fn newtype_base_lookup(&self, name: &str, type_id: TypeId) -> (String, TypeId) {
-        let tt = self.type_table.borrow();
+        let tt = self.tysys.type_table.borrow();
         if let Some(base_id) = tt.get_newtype_base(type_id) {
             drop(tt);
             if let Some(base_name) = self.struct_name_for_type(base_id) {
@@ -231,7 +231,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// Check if a name refers to a known type (struct, variant, enum, flags, newtype, or primitive).
     /// Uses pre-built cache for O(1) lookup instead of scanning all module maps.
     pub(super) fn is_known_type_name(&self, name: &str) -> bool {
-        self.known_type_names_cache.contains(name)
+        self.tysys.known_type_names_cache.contains(name)
     }
 
     /// Find the rhs parameter type for an operator trait on a struct type.
@@ -247,7 +247,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             self.find_arithmetic_trait_impl(&struct_name, self_type_id, &trait_name, method_name)?;
         // Unwrap the &T reference wrapper if present (e.g., rhs: &Self → return Self)
         trait_info.rhs_type.map(|t| {
-            let resolved = self.type_table.borrow().get(t).clone();
+            let resolved = self.tysys.type_table.borrow().get(t).clone();
             match resolved {
                 ResolvedType::Ref(inner) => inner,
                 _ => t,
@@ -285,12 +285,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     pub(super) fn get_ultimate_base_struct_name(&self, type_id: TypeId) -> String {
         let mut current = type_id;
         loop {
-            match self.type_table.borrow().get(current).clone() {
+            match self.tysys.type_table.borrow().get(current).clone() {
                 ResolvedType::Struct { name, .. } => return name,
                 ResolvedType::GenericInstance { name, .. } => return name,
                 ResolvedType::Newtype { base_type, .. } => current = base_type,
                 ResolvedType::Flags { .. } => return "u32".to_string(),
-                _ => return self.type_table.borrow().type_name(current),
+                _ => return self.tysys.type_table.borrow().type_name(current),
             }
         }
     }
@@ -318,7 +318,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             return None;
         }
         let (n, src) = (info.name.clone(), info.module_source.clone());
-        Some(self.type_table.borrow_mut().make_struct(n, src))
+        Some(self.tysys.type_table.borrow_mut().make_struct(n, src))
     }
 
     /// Find the module source for a struct by name.
@@ -384,7 +384,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Check newtypes/flags — the impl block may live in the module that defines the type
         if let Some(type_id) = self.lookup_newtype(struct_name) {
-            let ms = match self.type_table.borrow().get(type_id).clone() {
+            let ms = match self.tysys.type_table.borrow().get(type_id).clone() {
                 ResolvedType::Newtype { module_source, .. }
                 | ResolvedType::Flags { module_source, .. } => Some(module_source),
                 _ => None,
@@ -445,7 +445,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         base_type_id: TypeId,
         method_name: &str,
     ) -> Option<MethodInfo> {
-        let base_type = self.type_table.borrow().get(base_type_id).clone();
+        let base_type = self.tysys.type_table.borrow().get(base_type_id).clone();
 
         // Get the struct name, module source, and type args from the base type
         // For primitives, module_source is None to trigger "search all loaded modules" logic
@@ -490,7 +490,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         }
                         let inner_arities: Vec<Vec<TypeId>> = elems
                             .iter()
-                            .filter_map(|e| self.type_table.borrow().as_tuple(*e))
+                            .filter_map(|e| self.tysys.type_table.borrow().as_tuple(*e))
                             .collect();
                         if inner_arities.len() != elems.len() {
                             return None;
@@ -503,10 +503,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         for col in 0..arity {
                             let col_types: Vec<TypeId> =
                                 inner_arities.iter().map(|row| row[col]).collect();
-                            let col_tuple = self.type_table.borrow_mut().make_tuple(col_types);
+                            let col_tuple = self.tysys.type_table.borrow_mut().make_tuple(col_types);
                             transposed.push(col_tuple);
                         }
-                        let return_type = self.type_table.borrow_mut().make_tuple(transposed);
+                        let return_type = self.tysys.type_table.borrow_mut().make_tuple(transposed);
                         return Some(MethodInfo {
                             return_type,
                             self_kind: ast::SelfKind::Ref,
@@ -675,7 +675,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                     // These get TypeParam types that will be substituted at call sites
                                     for (i, type_param) in method.type_params.iter().enumerate() {
                                         let index = impl_offset + i as u32;
-                                        let type_param_id = scope.type_table.borrow_mut().intern(
+                                        let type_param_id = scope.tysys.type_table.borrow_mut().intern(
                                             ResolvedType::TypeParam {
                                                 name: type_param.name.clone(),
                                                 index,
@@ -806,7 +806,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                     // These get TypeParam types that will be substituted at call sites
                                     for (i, type_param) in method.type_params.iter().enumerate() {
                                         let index = impl_offset + i as u32;
-                                        let type_param_id = scope.type_table.borrow_mut().intern(
+                                        let type_param_id = scope.tysys.type_table.borrow_mut().intern(
                                             ResolvedType::TypeParam {
                                                 name: type_param.name.clone(),
                                                 index,
@@ -1111,7 +1111,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             && !scope.trait_ctx.type_params.contains_key(&named.name)
                         {
                             let type_id = scope
-                                .type_table
+                                .tysys.type_table
                                 .borrow_mut()
                                 .make_type_param(named.name.clone(), i as u32);
                             scope
@@ -1162,7 +1162,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     let (type_id, consumed_index) = if tp.is_pack {
                         (
                             scope
-                                .type_table
+                                .tysys.type_table
                                 .borrow_mut()
                                 .make_type_pack(tp.name.clone(), idx),
                             true,
@@ -1172,7 +1172,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     } else {
                         (
                             scope
-                                .type_table
+                                .tysys.type_table
                                 .borrow_mut()
                                 .make_type_param(tp.name.clone(), idx),
                             true,
@@ -1227,7 +1227,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         base_type: TypeId,
         newtype: TypeId,
     ) -> TypeId {
-        let ty = self.type_table.borrow().get(type_id).clone();
+        let ty = self.tysys.type_table.borrow().get(type_id).clone();
         match ty {
             // Direct match: base type -> newtype
             _ if type_id == base_type => newtype,
@@ -1238,7 +1238,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 if new_inner == inner {
                     type_id
                 } else {
-                    self.type_table
+                    self.tysys.type_table
                         .borrow_mut()
                         .intern(ResolvedType::Ref(new_inner))
                 }
@@ -1248,7 +1248,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 if new_inner == inner {
                     type_id
                 } else {
-                    self.type_table
+                    self.tysys.type_table
                         .borrow_mut()
                         .intern(ResolvedType::MutRef(new_inner))
                 }
@@ -1267,7 +1267,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 if new_args == type_args {
                     type_id
                 } else {
-                    self.type_table
+                    self.tysys.type_table
                         .borrow_mut()
                         .intern(ResolvedType::GenericInstance {
                             name,
@@ -1319,7 +1319,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         } = input;
 
         let base_type_id = self.get_base_type(receiver_type);
-        let base_type = self.type_table.borrow().get(base_type_id).clone();
+        let base_type = self.tysys.type_table.borrow().get(base_type_id).clone();
 
         // Locate the method's AST just to recover the list of type parameter
         // names (excluding effect params). We use these names together with
@@ -1357,7 +1357,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         };
 
         let method_type_param_ids: Vec<TypeId> = {
-            let mut tt = self.type_table.borrow_mut();
+            let mut tt = self.tysys.type_table.borrow_mut();
             method_type_param_names
                 .iter()
                 .enumerate()
@@ -1365,7 +1365,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 .collect()
         };
 
-        let mut infer = InferCtx::new(&self.type_table, method_type_param_ids);
+        let mut infer = InferCtx::new(&self.tysys.type_table, method_type_param_ids);
         for (i, (&param_type, arg)) in param_types.iter().zip(args.iter()).enumerate() {
             if Self::is_literal_number_arg(raw_args.get(i)) {
                 infer.add_deferred(param_type, arg.type_id);
@@ -1412,7 +1412,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     .filter(|&((_, has_fn_bound), &tid)| {
                         !has_fn_bound
                             && matches!(
-                                self.type_table.borrow().get(tid),
+                                self.tysys.type_table.borrow().get(tid),
                                 ResolvedType::TypeParam { .. } | ResolvedType::TypePack { .. }
                             )
                             && !scope_params.contains(&tid)
@@ -1630,7 +1630,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     pub(super) fn get_base_type(&self, type_id: TypeId) -> TypeId {
         let mut current = type_id;
         loop {
-            match self.type_table.borrow().get(current).clone() {
+            match self.tysys.type_table.borrow().get(current).clone() {
                 ResolvedType::Ref(inner) | ResolvedType::MutRef(inner) => {
                     current = inner;
                 }
@@ -1656,7 +1656,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // The receiver is already &T, so we need to add an extra reference layer.
             return match self_kind {
                 ast::SelfKind::Ref => {
-                    let ref_type = self.type_table.borrow_mut().make_ref(receiver.type_id);
+                    let ref_type = self.tysys.type_table.borrow_mut().make_ref(receiver.type_id);
                     TirExpr::new(
                         TirExprKind::Unary {
                             op: TirUnaryOp::Ref,
@@ -1667,7 +1667,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     )
                 }
                 ast::SelfKind::MutRef => {
-                    let mut_ref_type = self.type_table.borrow_mut().make_mut_ref(receiver.type_id);
+                    let mut_ref_type = self.tysys.type_table.borrow_mut().make_mut_ref(receiver.type_id);
                     TirExpr::new(
                         TirExprKind::Unary {
                             op: TirUnaryOp::MutRef,
@@ -1681,7 +1681,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             };
         }
 
-        let receiver_type = self.type_table.borrow().get(receiver.type_id).clone();
+        let receiver_type = self.tysys.type_table.borrow().get(receiver.type_id).clone();
 
         match self_kind {
             ast::SelfKind::None => {
@@ -1701,7 +1701,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     }
                     _ => {
                         // Value T, need to add &
-                        let ref_type = self.type_table.borrow_mut().make_ref(receiver.type_id);
+                        let ref_type = self.tysys.type_table.borrow_mut().make_ref(receiver.type_id);
                         TirExpr::new(
                             TirExprKind::Unary {
                                 op: TirUnaryOp::Ref,
@@ -1720,7 +1720,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     receiver
                 } else {
                     // Value T, need to add &mut
-                    let mut_ref_type = self.type_table.borrow_mut().make_mut_ref(receiver.type_id);
+                    let mut_ref_type = self.tysys.type_table.borrow_mut().make_mut_ref(receiver.type_id);
                     TirExpr::new(
                         TirExprKind::Unary {
                             op: TirUnaryOp::MutRef,
@@ -1737,7 +1737,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// Dereference a receiver until it's a value (non-reference) type
     pub(super) fn deref_to_value(&self, mut receiver: TirExpr, span: Span) -> TirExpr {
         loop {
-            match self.type_table.borrow().get(receiver.type_id).clone() {
+            match self.tysys.type_table.borrow().get(receiver.type_id).clone() {
                 ResolvedType::Ref(inner) | ResolvedType::MutRef(inner) => {
                     receiver = TirExpr::new(
                         TirExprKind::Unary {
@@ -1779,9 +1779,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             if let Some(newtype_id) = self.lookup_newtype(struct_name) {
                 let mut current = newtype_id;
                 loop {
-                    match self.type_table.borrow().get(current).clone() {
+                    match self.tysys.type_table.borrow().get(current).clone() {
                         ResolvedType::Newtype { base_type, .. } => {
-                            let base_name = self.type_table.borrow().type_name(base_type);
+                            let base_name = self.tysys.type_table.borrow().type_name(base_type);
                             names.push(base_name);
                             current = base_type;
                         }
@@ -1802,7 +1802,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Blanket impl fallback: check `impl<T: Bound> Trait for T` where the receiver
         // type satisfies the bound.  e.g., `impl<I: Iterator> IntoIterator for I` matches
         // any concrete type that implements Iterator.
-        for (module_src, item_idx) in &self.trait_env.blanket_impl_index {
+        for (module_src, item_idx) in &self.tysys.trait_env.blanket_impl_index {
             let module = &self.loaded_modules[module_src];
             if let Item::Impl(impl_block) = &module.items[*item_idx]
                 && impl_block.trait_type.is_some()
@@ -1872,7 +1872,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     _ => None,
                 };
                 if let Some(impl_inner) = impl_inner_outer {
-                    let receiver_outer = match self.type_table.borrow().get(rt) {
+                    let receiver_outer = match self.tysys.type_table.borrow().get(rt) {
                         ResolvedType::GenericInstance { name, .. }
                         | ResolvedType::Struct { name, .. }
                         | ResolvedType::Enum { name, .. }
@@ -1970,7 +1970,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         self.with_module_perspective(impl_module, imports, originals, |s| {
                             s.resolve_type(&impl_ty_clone)
                         });
-                    let tt = self.type_table.borrow();
+                    let tt = self.tysys.type_table.borrow();
                     let target = tt.peel_refs(impl_recv_id);
                     // Walk the receiver's newtype chain so an impl on a
                     // base struct stays reachable through `type
@@ -2098,7 +2098,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 // For variadic pack params (..T in impl<..T> Trait for [..T]),
                 // map the pack to a TypePack so that the method body can reference it.
                 if let Some((pack_name, pack_idx)) = &variadic_pack_entry {
-                    let pack_type = scope.type_table.borrow_mut().make_tuple(type_args.to_vec());
+                    let pack_type = scope.tysys.type_table.borrow_mut().make_tuple(type_args.to_vec());
                     scope
                         .trait_ctx
                         .type_params
@@ -2118,7 +2118,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         .insert(name.clone(), (0, recv_id));
                 } else {
                     let type_id = scope
-                        .type_table
+                        .tysys.type_table
                         .borrow_mut()
                         .make_type_param(name.clone(), 0);
                     scope
@@ -2197,7 +2197,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     let index = impl_offset + i as u32;
                     let type_param_id =
                         scope
-                            .type_table
+                            .tysys.type_table
                             .borrow_mut()
                             .intern(ResolvedType::TypeParam {
                                 name: type_param.name.clone(),
@@ -2331,7 +2331,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 let index = impl_offset + i as u32;
                                 let type_param_id =
                                     scope
-                                        .type_table
+                                        .tysys.type_table
                                         .borrow_mut()
                                         .intern(ResolvedType::TypeParam {
                                             name: type_param.name.clone(),
@@ -2545,7 +2545,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     ) -> Option<TypeId> {
         let concrete_type_args: Vec<TypeId> =
             if let ResolvedType::GenericInstance { type_args, .. } =
-                self.type_table.borrow().get(base_type_id).clone()
+                self.tysys.type_table.borrow().get(base_type_id).clone()
             {
                 type_args
             } else {
@@ -2580,7 +2580,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 &impl_block.ty,
                 &concrete_type_args,
                 &declared_type_params,
-                &self.type_table,
+                &self.tysys.type_table,
             ) {
                 continue;
             }
@@ -2756,7 +2756,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Get concrete type arguments from the base type (for generic instances)
         let concrete_type_args: Vec<TypeId> =
             if let ResolvedType::GenericInstance { type_args, .. } =
-                self.type_table.borrow().get(base_type_id).clone()
+                self.tysys.type_table.borrow().get(base_type_id).clone()
             {
                 type_args
             } else {
@@ -2804,7 +2804,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             && let Some(&type_arg) = concrete_type_args.get(i)
                         {
                             if matches!(
-                                self.type_table.borrow().get(type_arg),
+                                self.tysys.type_table.borrow().get(type_arg),
                                 ResolvedType::TypeParam { .. }
                             ) {
                                 continue;
@@ -2970,7 +2970,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
     /// Convert a `TypeId` to a human-readable string for error messages
     pub(super) fn type_id_to_string(&self, type_id: TypeId) -> String {
-        let resolved = self.type_table.borrow().get(type_id).clone();
+        let resolved = self.tysys.type_table.borrow().get(type_id).clone();
         match resolved {
             ResolvedType::Primitive(prim) => format!("{prim:?}").to_lowercase(),
             ResolvedType::Struct { name, .. } => name,
@@ -3044,7 +3044,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Get concrete type arguments from the base type (for generic instances like Triple<i32>)
         let concrete_type_args: Vec<TypeId> =
             if let ResolvedType::GenericInstance { type_args, .. } =
-                self.type_table.borrow().get(base_type_id).clone()
+                self.tysys.type_table.borrow().get(base_type_id).clone()
             {
                 type_args
             } else {
@@ -3105,7 +3105,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 &impl_block.ty,
                 &concrete_type_args,
                 &declared_type_params,
-                &self.type_table,
+                &self.tysys.type_table,
             ) {
                 continue;
             }
@@ -3198,7 +3198,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 let base_name = &g.name;
                 if base_name == "Option" {
                     let inner = resolved_args.first().copied().unwrap_or(TypeTable::UNKNOWN);
-                    self.type_table.borrow_mut().make_option(inner)
+                    self.tysys.type_table.borrow_mut().make_option(inner)
                 } else {
                     // For generic types, create a generic instance.
                     // Use the defining module source of the struct/variant to ensure the
@@ -3213,7 +3213,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 .map(|info| info.module_source.clone())
                         })
                         .unwrap_or_else(|| self.current_module_source.clone());
-                    self.type_table
+                    self.tysys.type_table
                         .borrow_mut()
                         .intern(ResolvedType::GenericInstance {
                             name: base_name.clone(),
@@ -3224,11 +3224,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             }
             Type::Reference(inner) => {
                 let inner_id = self.resolve_type_with_param_mapping(inner, type_param_mapping);
-                self.type_table.borrow_mut().make_ref(inner_id)
+                self.tysys.type_table.borrow_mut().make_ref(inner_id)
             }
             Type::MutReference(inner) => {
                 let inner_id = self.resolve_type_with_param_mapping(inner, type_param_mapping);
-                self.type_table.borrow_mut().make_mut_ref(inner_id)
+                self.tysys.type_table.borrow_mut().make_mut_ref(inner_id)
             }
             Type::NamespacedGeneric(n) => {
                 // T::AssocType where T maps to a concrete type → resolve the assoc type
@@ -3256,7 +3256,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let struct_name = self.struct_name_for_type(type_id)?;
         let concrete_type_args: Vec<TypeId> =
             if let ResolvedType::GenericInstance { type_args, .. } =
-                self.type_table.borrow().get(type_id).clone()
+                self.tysys.type_table.borrow().get(type_id).clone()
             {
                 type_args
             } else {
@@ -3287,7 +3287,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 &impl_block.ty,
                 &concrete_type_args,
                 &declared_type_params,
-                &self.type_table,
+                &self.tysys.type_table,
             ) {
                 continue;
             }
@@ -3312,7 +3312,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Check if this is an Array type (Arrays use optimized direct access, not traits)
         let is_array = self
-            .type_table
+            .tysys.type_table
             .borrow()
             .as_array(container_expr.type_id)
             .is_some();
@@ -3321,13 +3321,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
 
         // Get base type (unwrap reference if needed)
-        let base_type_id = match self.type_table.borrow().get(container_expr.type_id) {
+        let base_type_id = match self.tysys.type_table.borrow().get(container_expr.type_id) {
             ResolvedType::Ref(inner) | ResolvedType::MutRef(inner) => *inner,
             _ => container_expr.type_id,
         };
 
         // Get struct name from base type
-        let struct_name = match self.type_table.borrow().get(base_type_id).clone() {
+        let struct_name = match self.tysys.type_table.borrow().get(base_type_id).clone() {
             ResolvedType::Struct { name, .. } => name,
             ResolvedType::GenericInstance { name, .. } => name,
             _ => return None, // Not a struct type
@@ -3343,13 +3343,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Now we need to check if the method being called requires &mut self
         // First, look up method info on the OUTPUT type (what IndexMut returns)
         let output_type = index_mut_info.output_type;
-        let output_base_type_id = match self.type_table.borrow().get(output_type) {
+        let output_base_type_id = match self.tysys.type_table.borrow().get(output_type) {
             ResolvedType::Ref(inner) | ResolvedType::MutRef(inner) => *inner,
             _ => output_type,
         };
 
         let (output_struct_name, output_module_source, output_type_args) =
-            match self.type_table.borrow().get(output_base_type_id).clone() {
+            match self.tysys.type_table.borrow().get(output_base_type_id).clone() {
                 ResolvedType::Struct {
                     name,
                     module_source,
@@ -3369,7 +3369,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     },
                 ),
                 _ => (
-                    self.type_table
+                    self.tysys.type_table
                         .borrow()
                         .mangle_type_name(output_base_type_id),
                     self.current_module_source.clone(),
@@ -3428,7 +3428,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // IndexMut returns &mut Output
         let mut_ref_output_type = self
-            .type_table
+            .tysys.type_table
             .borrow_mut()
             .make_mut_ref(index_mut_info.output_type);
 

--- a/wado-compiler/src/elaborator/method_lookup.rs
+++ b/wado-compiler/src/elaborator/method_lookup.rs
@@ -2,9 +2,8 @@
 
 use crate::hashmap::{IndexMap, IndexSet};
 
-use crate::ast::{self, BinaryOp, Expr, Item, Literal, Type, UnaryOp};
+use crate::ast::{self, BinaryOp, Expr, Item, Type};
 use crate::compiler_host::CompilerHost;
-use crate::compiler_item::CompilerItem;
 use crate::module_source::ModuleSource;
 use crate::name::{LocalMethodName, MethodName};
 use crate::tir::{
@@ -149,12 +148,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             .type_params
             .iter()
             .map(|p| p.name.clone())
-            .filter(|name| !self.is_known_type_name(name))
+            .filter(|name| !self.tysys.is_known_type_name(name))
             .collect();
         if let Type::Generic(g) = &impl_block.ty {
             for arg in &g.args {
                 if let Type::Named(n) = arg
-                    && !self.is_known_type_name(&n.name)
+                    && !self.tysys.is_known_type_name(&n.name)
                 {
                     declared.insert(n.name.clone());
                 }
@@ -163,46 +162,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         declared
     }
 
-    /// Map a binary operator to its `(trait_name, method_name)` pair, or
-    /// `None` when the operator does not dispatch through a trait.
-    ///
-    /// For operators that dispatch through a [`CompilerItem`] trait
-    /// (`Eq` for `==` / `!=`), the trait name is resolved through the
-    /// compiler-item registry so a rename on the stdlib side stays
-    /// transparent. For traits that don't yet have a `CompilerItem`
-    /// anchor (`Add`, `Sub`, …, `Ord`), the canonical stdlib name is
-    /// returned as a literal.
-    pub(super) fn operator_trait_method(&self, op: &BinaryOp) -> Option<(String, &'static str)> {
-        match op {
-            BinaryOp::Add => Some(("Add".to_string(), "add")),
-            BinaryOp::Sub => Some(("Sub".to_string(), "sub")),
-            BinaryOp::Mul => Some(("Mul".to_string(), "mul")),
-            BinaryOp::Div => Some(("Div".to_string(), "div")),
-            BinaryOp::Mod => Some(("Rem".to_string(), "rem")),
-            BinaryOp::BitAnd => Some(("BitAnd".to_string(), "bitand")),
-            BinaryOp::BitOr => Some(("BitOr".to_string(), "bitor")),
-            BinaryOp::BitXor => Some(("BitXor".to_string(), "bitxor")),
-            BinaryOp::Shl => Some(("Shl".to_string(), "shl")),
-            BinaryOp::Shr => Some(("Shr".to_string(), "shr")),
-            BinaryOp::Eq | BinaryOp::NotEq => Some((
-                self.tysys.type_table
-                    .borrow()
-                    .compiler_items()
-                    .trait_name(CompilerItem::Eq)
-                    .to_string(),
-                "eq",
-            )),
-            BinaryOp::Lt | BinaryOp::LtEq | BinaryOp::Gt | BinaryOp::GtEq => Some((
-                self.tysys.type_table
-                    .borrow()
-                    .compiler_items()
-                    .trait_name(CompilerItem::Ord)
-                    .to_string(),
-                "cmp",
-            )),
-            _ => None,
-        }
-    }
 
     /// Get the struct name from a type ID, if it's a struct, generic instance, newtype, or flags.
     pub(super) fn struct_name_for_type(&self, type_id: TypeId) -> Option<String> {
@@ -228,11 +187,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         (name.to_string(), type_id)
     }
 
-    /// Check if a name refers to a known type (struct, variant, enum, flags, newtype, or primitive).
-    /// Uses pre-built cache for O(1) lookup instead of scanning all module maps.
-    pub(super) fn is_known_type_name(&self, name: &str) -> bool {
-        self.tysys.known_type_names_cache.contains(name)
-    }
 
     /// Find the rhs parameter type for an operator trait on a struct type.
     /// Used to determine what type a literal rhs should be coerced to.
@@ -242,7 +196,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         op: &BinaryOp,
     ) -> Option<TypeId> {
         let struct_name = self.struct_name_for_type(self_type_id)?;
-        let (trait_name, method_name) = self.operator_trait_method(op)?;
+        let (trait_name, method_name) = self.tysys.operator_trait_method(op)?;
         let trait_info =
             self.find_arithmetic_trait_impl(&struct_name, self_type_id, &trait_name, method_name)?;
         // Unwrap the &T reference wrapper if present (e.g., rhs: &Self → return Self)
@@ -264,22 +218,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         op: &BinaryOp,
     ) -> Option<TypeId> {
         let struct_name = self.struct_name_for_type(rhs_type_id)?;
-        let (trait_name, method_name) = self.operator_trait_method(op)?;
+        let (trait_name, method_name) = self.tysys.operator_trait_method(op)?;
         // Verify the trait impl exists; the self type is the struct type itself
         self.find_arithmetic_trait_impl(&struct_name, rhs_type_id, &trait_name, method_name)?;
         Some(rhs_type_id)
     }
 
-    /// Check if an expression is a numeric literal
-    pub(super) fn is_numeric_literal(&self, expr: &Expr) -> bool {
-        match expr {
-            Expr::Literal(lit) => matches!(lit.value, Literal::Number(_)),
-            Expr::Unary(unary) if unary.op == UnaryOp::Neg => {
-                matches!(&unary.expr, Expr::Literal(lit) if matches!(lit.value, Literal::Number(_)))
-            }
-            _ => false,
-        }
-    }
 
     /// Check if a qualified name `struct_name::method_name` is a static method
     pub(super) fn get_ultimate_base_struct_name(&self, type_id: TypeId) -> String {
@@ -1834,7 +1778,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             let impl_block = self.get_impl_block(impl_ref);
             let impl_struct_name = self.get_type_name(&impl_block.ty);
             // Accept if the type matches by name, or if it's a blanket impl type parameter.
-            let is_blanket_type_param = matches!(&impl_block.ty, Type::Named(named) if !self.is_known_type_name(&named.name));
+            let is_blanket_type_param = matches!(&impl_block.ty, Type::Named(named) if !self.tysys.is_known_type_name(&named.name));
             if !names_to_check.contains(&impl_struct_name) && !is_blanket_type_param {
                 continue;
             }
@@ -1864,7 +1808,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 let impl_inner_outer = match &impl_block.ty {
                     Type::Reference(inner) | Type::MutReference(inner) => match inner.as_ref() {
                         Type::Generic(g) => Some(g.name.clone()),
-                        Type::Named(named) if self.is_known_type_name(&named.name) => {
+                        Type::Named(named) if self.tysys.is_known_type_name(&named.name) => {
                             Some(named.name.clone())
                         }
                         _ => None, // blanket `&T` form — handled by the bound check
@@ -1929,7 +1873,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     let impl_block = self.get_impl_block(impl_ref);
                     let is_blanket_tp = matches!(
                         &impl_block.ty,
-                        Type::Named(named) if !self.is_known_type_name(&named.name)
+                        Type::Named(named) if !self.tysys.is_known_type_name(&named.name)
                     );
                     // Skip the filter for impls whose receiver is
                     // intentionally widely-applicable: blanket impls
@@ -2109,7 +2053,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // For blanket impls where impl_ty is a free type parameter
             if let Some(ref name) = blanket_name
                 && !scope.trait_ctx.type_params.contains_key(name)
-                && !scope.is_known_type_name(name)
+                && !scope.tysys.is_known_type_name(name)
             {
                 if let Some(recv_id) = receiver_type_id {
                     scope

--- a/wado-compiler/src/elaborator/method_lookup.rs
+++ b/wado-compiler/src/elaborator/method_lookup.rs
@@ -162,7 +162,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         declared
     }
 
-
     /// Get the struct name from a type ID, if it's a struct, generic instance, newtype, or flags.
     pub(super) fn struct_name_for_type(&self, type_id: TypeId) -> Option<String> {
         match self.tysys.type_table.borrow().get(type_id) {
@@ -186,7 +185,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
         (name.to_string(), type_id)
     }
-
 
     /// Find the rhs parameter type for an operator trait on a struct type.
     /// Used to determine what type a literal rhs should be coerced to.
@@ -223,7 +221,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         self.find_arithmetic_trait_impl(&struct_name, rhs_type_id, &trait_name, method_name)?;
         Some(rhs_type_id)
     }
-
 
     /// Check if a qualified name `struct_name::method_name` is a static method
     pub(super) fn get_ultimate_base_struct_name(&self, type_id: TypeId) -> String {
@@ -447,7 +444,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         for col in 0..arity {
                             let col_types: Vec<TypeId> =
                                 inner_arities.iter().map(|row| row[col]).collect();
-                            let col_tuple = self.tysys.type_table.borrow_mut().make_tuple(col_types);
+                            let col_tuple =
+                                self.tysys.type_table.borrow_mut().make_tuple(col_types);
                             transposed.push(col_tuple);
                         }
                         let return_type = self.tysys.type_table.borrow_mut().make_tuple(transposed);
@@ -619,12 +617,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                     // These get TypeParam types that will be substituted at call sites
                                     for (i, type_param) in method.type_params.iter().enumerate() {
                                         let index = impl_offset + i as u32;
-                                        let type_param_id = scope.tysys.type_table.borrow_mut().intern(
-                                            ResolvedType::TypeParam {
-                                                name: type_param.name.clone(),
-                                                index,
-                                            },
-                                        );
+                                        let type_param_id =
+                                            scope.tysys.type_table.borrow_mut().intern(
+                                                ResolvedType::TypeParam {
+                                                    name: type_param.name.clone(),
+                                                    index,
+                                                },
+                                            );
                                         scope.trait_ctx.type_params.insert(
                                             type_param.name.clone(),
                                             (index, type_param_id),
@@ -750,12 +749,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                     // These get TypeParam types that will be substituted at call sites
                                     for (i, type_param) in method.type_params.iter().enumerate() {
                                         let index = impl_offset + i as u32;
-                                        let type_param_id = scope.tysys.type_table.borrow_mut().intern(
-                                            ResolvedType::TypeParam {
-                                                name: type_param.name.clone(),
-                                                index,
-                                            },
-                                        );
+                                        let type_param_id =
+                                            scope.tysys.type_table.borrow_mut().intern(
+                                                ResolvedType::TypeParam {
+                                                    name: type_param.name.clone(),
+                                                    index,
+                                                },
+                                            );
                                         scope.trait_ctx.type_params.insert(
                                             type_param.name.clone(),
                                             (index, type_param_id),
@@ -1055,7 +1055,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             && !scope.trait_ctx.type_params.contains_key(&named.name)
                         {
                             let type_id = scope
-                                .tysys.type_table
+                                .tysys
+                                .type_table
                                 .borrow_mut()
                                 .make_type_param(named.name.clone(), i as u32);
                             scope
@@ -1106,7 +1107,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     let (type_id, consumed_index) = if tp.is_pack {
                         (
                             scope
-                                .tysys.type_table
+                                .tysys
+                                .type_table
                                 .borrow_mut()
                                 .make_type_pack(tp.name.clone(), idx),
                             true,
@@ -1116,7 +1118,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     } else {
                         (
                             scope
-                                .tysys.type_table
+                                .tysys
+                                .type_table
                                 .borrow_mut()
                                 .make_type_param(tp.name.clone(), idx),
                             true,
@@ -1182,7 +1185,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 if new_inner == inner {
                     type_id
                 } else {
-                    self.tysys.type_table
+                    self.tysys
+                        .type_table
                         .borrow_mut()
                         .intern(ResolvedType::Ref(new_inner))
                 }
@@ -1192,7 +1196,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 if new_inner == inner {
                     type_id
                 } else {
-                    self.tysys.type_table
+                    self.tysys
+                        .type_table
                         .borrow_mut()
                         .intern(ResolvedType::MutRef(new_inner))
                 }
@@ -1211,7 +1216,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 if new_args == type_args {
                     type_id
                 } else {
-                    self.tysys.type_table
+                    self.tysys
+                        .type_table
                         .borrow_mut()
                         .intern(ResolvedType::GenericInstance {
                             name,
@@ -1600,7 +1606,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // The receiver is already &T, so we need to add an extra reference layer.
             return match self_kind {
                 ast::SelfKind::Ref => {
-                    let ref_type = self.tysys.type_table.borrow_mut().make_ref(receiver.type_id);
+                    let ref_type = self
+                        .tysys
+                        .type_table
+                        .borrow_mut()
+                        .make_ref(receiver.type_id);
                     TirExpr::new(
                         TirExprKind::Unary {
                             op: TirUnaryOp::Ref,
@@ -1611,7 +1621,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     )
                 }
                 ast::SelfKind::MutRef => {
-                    let mut_ref_type = self.tysys.type_table.borrow_mut().make_mut_ref(receiver.type_id);
+                    let mut_ref_type = self
+                        .tysys
+                        .type_table
+                        .borrow_mut()
+                        .make_mut_ref(receiver.type_id);
                     TirExpr::new(
                         TirExprKind::Unary {
                             op: TirUnaryOp::MutRef,
@@ -1645,7 +1659,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     }
                     _ => {
                         // Value T, need to add &
-                        let ref_type = self.tysys.type_table.borrow_mut().make_ref(receiver.type_id);
+                        let ref_type = self
+                            .tysys
+                            .type_table
+                            .borrow_mut()
+                            .make_ref(receiver.type_id);
                         TirExpr::new(
                             TirExprKind::Unary {
                                 op: TirUnaryOp::Ref,
@@ -1664,7 +1682,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     receiver
                 } else {
                     // Value T, need to add &mut
-                    let mut_ref_type = self.tysys.type_table.borrow_mut().make_mut_ref(receiver.type_id);
+                    let mut_ref_type = self
+                        .tysys
+                        .type_table
+                        .borrow_mut()
+                        .make_mut_ref(receiver.type_id);
                     TirExpr::new(
                         TirExprKind::Unary {
                             op: TirUnaryOp::MutRef,
@@ -2042,7 +2064,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 // For variadic pack params (..T in impl<..T> Trait for [..T]),
                 // map the pack to a TypePack so that the method body can reference it.
                 if let Some((pack_name, pack_idx)) = &variadic_pack_entry {
-                    let pack_type = scope.tysys.type_table.borrow_mut().make_tuple(type_args.to_vec());
+                    let pack_type = scope
+                        .tysys
+                        .type_table
+                        .borrow_mut()
+                        .make_tuple(type_args.to_vec());
                     scope
                         .trait_ctx
                         .type_params
@@ -2062,7 +2088,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         .insert(name.clone(), (0, recv_id));
                 } else {
                     let type_id = scope
-                        .tysys.type_table
+                        .tysys
+                        .type_table
                         .borrow_mut()
                         .make_type_param(name.clone(), 0);
                     scope
@@ -2141,7 +2168,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     let index = impl_offset + i as u32;
                     let type_param_id =
                         scope
-                            .tysys.type_table
+                            .tysys
+                            .type_table
                             .borrow_mut()
                             .intern(ResolvedType::TypeParam {
                                 name: type_param.name.clone(),
@@ -2273,14 +2301,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             let impl_offset = scope.trait_ctx.type_params.len() as u32;
                             for (i, type_param) in default_method.type_params.iter().enumerate() {
                                 let index = impl_offset + i as u32;
-                                let type_param_id =
-                                    scope
-                                        .tysys.type_table
-                                        .borrow_mut()
-                                        .intern(ResolvedType::TypeParam {
-                                            name: type_param.name.clone(),
-                                            index,
-                                        });
+                                let type_param_id = scope.tysys.type_table.borrow_mut().intern(
+                                    ResolvedType::TypeParam {
+                                        name: type_param.name.clone(),
+                                        index,
+                                    },
+                                );
                                 scope
                                     .trait_ctx
                                     .type_params
@@ -3157,7 +3183,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 .map(|info| info.module_source.clone())
                         })
                         .unwrap_or_else(|| self.current_module_source.clone());
-                    self.tysys.type_table
+                    self.tysys
+                        .type_table
                         .borrow_mut()
                         .intern(ResolvedType::GenericInstance {
                             name: base_name.clone(),
@@ -3256,7 +3283,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Check if this is an Array type (Arrays use optimized direct access, not traits)
         let is_array = self
-            .tysys.type_table
+            .tysys
+            .type_table
             .borrow()
             .as_array(container_expr.type_id)
             .is_some();
@@ -3292,34 +3320,40 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             _ => output_type,
         };
 
-        let (output_struct_name, output_module_source, output_type_args) =
-            match self.tysys.type_table.borrow().get(output_base_type_id).clone() {
-                ResolvedType::Struct {
-                    name,
-                    module_source,
-                    ..
-                } => (name, module_source, None),
-                ResolvedType::GenericInstance {
-                    name,
-                    module_source,
-                    type_args,
-                } => (
-                    name,
-                    module_source,
-                    if type_args.is_empty() {
-                        None
-                    } else {
-                        Some(type_args)
-                    },
-                ),
-                _ => (
-                    self.tysys.type_table
-                        .borrow()
-                        .mangle_type_name(output_base_type_id),
-                    self.current_module_source.clone(),
-                    None,
-                ),
-            };
+        let (output_struct_name, output_module_source, output_type_args) = match self
+            .tysys
+            .type_table
+            .borrow()
+            .get(output_base_type_id)
+            .clone()
+        {
+            ResolvedType::Struct {
+                name,
+                module_source,
+                ..
+            } => (name, module_source, None),
+            ResolvedType::GenericInstance {
+                name,
+                module_source,
+                type_args,
+            } => (
+                name,
+                module_source,
+                if type_args.is_empty() {
+                    None
+                } else {
+                    Some(type_args)
+                },
+            ),
+            _ => (
+                self.tysys
+                    .type_table
+                    .borrow()
+                    .mangle_type_name(output_base_type_id),
+                self.current_module_source.clone(),
+                None,
+            ),
+        };
 
         // Look up method info to check if it needs &mut self
         let mut method_info = self.lookup_method_info(output_type, &method_call.method);
@@ -3372,7 +3406,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // IndexMut returns &mut Output
         let mut_ref_output_type = self
-            .tysys.type_table
+            .tysys
+            .type_table
             .borrow_mut()
             .make_mut_ref(index_mut_info.output_type);
 

--- a/wado-compiler/src/elaborator/module.rs
+++ b/wado-compiler/src/elaborator/module.rs
@@ -37,7 +37,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     } else if self.lookup_newtype(&newtype_decl.name).is_none() {
                         // Concrete newtype: resolve immediately
                         let base_type_id = self.resolve_type(&newtype_decl.ty);
-                        let newtype_id = self.type_table.borrow_mut().make_newtype(
+                        let newtype_id = self.tysys.type_table.borrow_mut().make_newtype(
                             newtype_decl.name.clone(),
                             module_source.clone(),
                             base_type_id,
@@ -109,7 +109,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         .enumerate()
                         .map(|(i, param)| {
                             scope
-                                .type_table
+                                .tysys.type_table
                                 .borrow_mut()
                                 .make_type_param(param.name.clone(), i as u32)
                         })
@@ -135,7 +135,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     if newtype_decl.type_params.is_empty() {
                         // Concrete newtype: resolve immediately
                         let base_type_id = self.resolve_type(&newtype_decl.ty);
-                        let newtype_id = self.type_table.borrow_mut().make_newtype(
+                        let newtype_id = self.tysys.type_table.borrow_mut().make_newtype(
                             newtype_decl.name.clone(),
                             self.current_module_source.clone(),
                             base_type_id,
@@ -210,7 +210,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     );
 
                     super::item::register_variant_compiler_item(
-                        &scope.type_table,
+                        &scope.tysys.type_table,
                         &variant_decl.attrs,
                         &variant_decl.name,
                         &module_source,
@@ -220,7 +220,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
                     for (case_index, case) in variant_decl.cases.iter().enumerate() {
                         super::item::register_variant_case_compiler_item(
-                            &scope.type_table,
+                            &scope.tysys.type_table,
                             &case.attrs,
                             &variant_decl.name,
                             &case.name,
@@ -260,7 +260,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     // first-pass walk in `orchestration.rs`) still lands in
                     // the registry.
                     super::item::register_enum_compiler_item(
-                        &self.type_table,
+                        &self.tysys.type_table,
                         &enum_decl.attrs,
                         &enum_decl.name,
                         &self.current_module_source,
@@ -269,7 +269,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     );
                     for (case_index, case) in enum_decl.cases.iter().enumerate() {
                         super::item::register_enum_case_compiler_item(
-                            &self.type_table,
+                            &self.tysys.type_table,
                             &case.attrs,
                             &enum_decl.name,
                             &case.name,
@@ -283,7 +283,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 Item::Flags(flags_decl) => {
                     // Create a distinct Flags type (not a newtype over u32)
                     let flags_type = self
-                        .type_table
+                        .tysys.type_table
                         .borrow_mut()
                         .make_flags(flags_decl.name.clone(), self.current_module_source.clone());
                     // Add to newtypes so it can be used as a type name
@@ -311,7 +311,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 }
                 Item::Trait(trait_decl) => {
                     super::item::register_trait_compiler_item(
-                        &self.type_table,
+                        &self.tysys.type_table,
                         &trait_decl.attrs,
                         &trait_decl.name,
                         &trait_decl.methods,
@@ -369,12 +369,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         }
                         let type_id = if param.is_pack {
                             scope
-                                .type_table
+                                .tysys.type_table
                                 .borrow_mut()
                                 .make_type_pack(param.name.clone(), actual_idx)
                         } else {
                             scope
-                                .type_table
+                                .tysys.type_table
                                 .borrow_mut()
                                 .make_type_param(param.name.clone(), actual_idx)
                         };
@@ -414,7 +414,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 {
                                     let index = (offset + i) as u32;
                                     let type_id = scope
-                                        .type_table
+                                        .tysys.type_table
                                         .borrow_mut()
                                         .make_type_param(name.clone(), index);
                                     scope
@@ -464,7 +464,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     // simultaneously in scope.
                     for method in &impl_block.methods {
                         super::item::register_method_compiler_item(
-                            &scope.type_table,
+                            &scope.tysys.type_table,
                             &method.attrs,
                             &method.name,
                             &scope.get_type_name(&impl_block.ty),
@@ -482,7 +482,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         for (i, param) in method.type_params.iter().enumerate() {
                             let idx = (offset + i) as u32;
                             let type_id = scope
-                                .type_table
+                                .tysys.type_table
                                 .borrow_mut()
                                 .make_type_param(param.name.clone(), idx);
                             scope

--- a/wado-compiler/src/elaborator/module.rs
+++ b/wado-compiler/src/elaborator/module.rs
@@ -109,7 +109,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         .enumerate()
                         .map(|(i, param)| {
                             scope
-                                .tysys.type_table
+                                .tysys
+                                .type_table
                                 .borrow_mut()
                                 .make_type_param(param.name.clone(), i as u32)
                         })
@@ -283,7 +284,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 Item::Flags(flags_decl) => {
                     // Create a distinct Flags type (not a newtype over u32)
                     let flags_type = self
-                        .tysys.type_table
+                        .tysys
+                        .type_table
                         .borrow_mut()
                         .make_flags(flags_decl.name.clone(), self.current_module_source.clone());
                     // Add to newtypes so it can be used as a type name
@@ -369,12 +371,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         }
                         let type_id = if param.is_pack {
                             scope
-                                .tysys.type_table
+                                .tysys
+                                .type_table
                                 .borrow_mut()
                                 .make_type_pack(param.name.clone(), actual_idx)
                         } else {
                             scope
-                                .tysys.type_table
+                                .tysys
+                                .type_table
                                 .borrow_mut()
                                 .make_type_param(param.name.clone(), actual_idx)
                         };
@@ -414,7 +418,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 {
                                     let index = (offset + i) as u32;
                                     let type_id = scope
-                                        .tysys.type_table
+                                        .tysys
+                                        .type_table
                                         .borrow_mut()
                                         .make_type_param(name.clone(), index);
                                     scope
@@ -482,7 +487,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         for (i, param) in method.type_params.iter().enumerate() {
                             let idx = (offset + i) as u32;
                             let type_id = scope
-                                .tysys.type_table
+                                .tysys
+                                .type_table
                                 .borrow_mut()
                                 .make_type_param(param.name.clone(), idx);
                             scope

--- a/wado-compiler/src/elaborator/module.rs
+++ b/wado-compiler/src/elaborator/module.rs
@@ -364,7 +364,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     // (e.g., `impl<i32, T> IndexValue<i32> for Triple<T>` — skip "i32").
                     let mut actual_idx = 0u32;
                     for param in &impl_block.type_params {
-                        if scope.is_known_type_name(&param.name) {
+                        if scope.tysys.is_known_type_name(&param.name) {
                             continue;
                         }
                         let type_id = if param.is_pack {
@@ -410,7 +410,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             if let ast::Type::Named(named) = arg {
                                 let name = &named.name;
                                 if !scope.trait_ctx.type_params.contains_key(name)
-                                    && !scope.is_known_type_name(name)
+                                    && !scope.tysys.is_known_type_name(name)
                                 {
                                     let index = (offset + i) as u32;
                                     let type_id = scope

--- a/wado-compiler/src/elaborator/operators.rs
+++ b/wado-compiler/src/elaborator/operators.rs
@@ -80,7 +80,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         if left_is_numeric_literal && !right_is_numeric_literal {
             // Resolve right first, then coerce left
             let right = self.resolve_expr(right_ast, ctx, expected_type);
-            let coerce_type = if self.type_table.borrow().is_numeric(right.type_id) {
+            let coerce_type = if self.tysys.type_table.borrow().is_numeric(right.type_id) {
                 // Primitive type: coerce literal to the same type
                 Some(right.type_id)
             } else {
@@ -92,7 +92,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         } else if right_is_numeric_literal && !left_is_numeric_literal {
             // Resolve left first, then coerce right
             let left = self.resolve_expr(left_ast, ctx, expected_type);
-            let coerce_type = if self.type_table.borrow().is_numeric(left.type_id) {
+            let coerce_type = if self.tysys.type_table.borrow().is_numeric(left.type_id) {
                 // Primitive type: coerce literal to the same type
                 Some(left.type_id)
             } else {
@@ -132,12 +132,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     ) -> TirExpr {
         // Check if this is a comparison operation on a non-primitive type
         // Non-primitives use Eq/Ord traits instead of direct Wasm instructions
-        let left_type = self.type_table.borrow().get(left.type_id).clone();
+        let left_type = self.tysys.type_table.borrow().get(left.type_id).clone();
 
         // Reference types (&T, &mut T): only == and != are allowed (identity via ref.eq).
         // All other operators (ordering, arithmetic, bitwise) are rejected.
         if matches!(&left_type, ResolvedType::Ref(_) | ResolvedType::MutRef(_)) {
-            let right_type = self.type_table.borrow().get(right.type_id).clone();
+            let right_type = self.tysys.type_table.borrow().get(right.type_id).clone();
             let both_refs = matches!(
                 (&left_type, &right_type),
                 (ResolvedType::Ref(_), ResolvedType::Ref(_))
@@ -149,7 +149,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     && left.type_id != TypeTable::ERROR
                     && right.type_id != TypeTable::ERROR
                 {
-                    let type_table = self.type_table.borrow();
+                    let type_table = self.tysys.type_table.borrow();
                     let left_name = type_table.type_name(left.type_id);
                     let right_name = type_table.type_name(right.type_id);
                     if left_name != right_name {
@@ -176,7 +176,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 );
             } else if both_refs {
                 // All operators other than == and != are invalid on reference types
-                let type_name = self.type_table.borrow().type_name(left.type_id);
+                let type_name = self.tysys.type_table.borrow().type_name(left.type_id);
                 let op_str = match op {
                     BinaryOp::Lt => "<",
                     BinaryOp::LtEq => "<=",
@@ -224,7 +224,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 ResolvedType::Struct { name, .. } => Some(name.clone()),
                 ResolvedType::GenericInstance { name, .. } => Some(name.clone()),
                 ResolvedType::Newtype { base_type, .. } => {
-                    let tt = self.type_table.borrow();
+                    let tt = self.tysys.type_table.borrow();
                     let ultimate = tt.get_ultimate_base_type(*base_type);
                     match tt.get(ultimate) {
                         ResolvedType::Struct { .. } | ResolvedType::GenericInstance { .. } => {
@@ -240,14 +240,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             if let Some(struct_name) = struct_name {
                 // For newtypes, use the base type ID for trait lookup
                 let lookup_type_id = {
-                    let tt = self.type_table.borrow();
+                    let tt = self.tysys.type_table.borrow();
                     tt.get_newtype_base(left.type_id).unwrap_or(left.type_id)
                 };
 
                 // Handle Eq trait (== and !=)
                 if matches!(op, BinaryOp::Eq | BinaryOp::NotEq) {
                     let eq_trait_name = self
-                        .type_table
+                        .tysys.type_table
                         .borrow()
                         .compiler_items()
                         .trait_name(CompilerItem::Eq)
@@ -259,7 +259,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         "eq",
                         false,
                     ) else {
-                        let type_name = self.type_table.borrow().type_name(left.type_id);
+                        let type_name = self.tysys.type_table.borrow().type_name(left.type_id);
                         let op_str = if op == BinaryOp::Eq { "==" } else { "!=" };
                         let _ = self.logger.error(TypeError::InvalidPattern {
                             message: format!(
@@ -294,7 +294,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     BinaryOp::Lt | BinaryOp::Gt | BinaryOp::LtEq | BinaryOp::GtEq
                 ) {
                     let ord_trait_name = self
-                        .type_table
+                        .tysys.type_table
                         .borrow()
                         .compiler_items()
                         .trait_name(CompilerItem::Ord)
@@ -306,7 +306,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         "cmp",
                         false,
                     ) else {
-                        let type_name = self.type_table.borrow().type_name(left.type_id);
+                        let type_name = self.tysys.type_table.borrow().type_name(left.type_id);
                         let op_str = match op {
                             BinaryOp::Lt => "<",
                             BinaryOp::Gt => ">",
@@ -353,7 +353,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         self.find_method_in_trait_bounds(&bound_names, "eq", left.type_id)
                 {
                     let eq_trait_name = self
-                        .type_table
+                        .tysys.type_table
                         .borrow()
                         .compiler_items()
                         .trait_name(CompilerItem::Eq)
@@ -392,7 +392,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     self.find_method_in_trait_bounds(&bound_names, "cmp", left.type_id)
                 {
                     let ord_trait_name = self
-                        .type_table
+                        .tysys.type_table
                         .borrow()
                         .compiler_items()
                         .trait_name(CompilerItem::Ord)
@@ -603,7 +603,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Check for arithmetic on flags types: only bitwise ops are allowed
         {
-            let left_resolved = self.type_table.borrow().get(left.type_id).clone();
+            let left_resolved = self.tysys.type_table.borrow().get(left.type_id).clone();
             let is_flags_arith = matches!(
                 op,
                 BinaryOp::Add | BinaryOp::Sub | BinaryOp::Mul | BinaryOp::Div | BinaryOp::Mod
@@ -630,7 +630,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Check for modulo on float types: Wasm has no float remainder instruction.
         // Users should use f64::fmod() or f32::fmod() instead.
         {
-            let left_resolved = self.type_table.borrow().get(left.type_id).clone();
+            let left_resolved = self.tysys.type_table.borrow().get(left.type_id).clone();
             if matches!(op, BinaryOp::Mod)
                 && matches!(
                     left_resolved,
@@ -662,7 +662,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             let requires_trait = match &left_type {
                 ResolvedType::Struct { .. } | ResolvedType::GenericInstance { .. } => true,
                 ResolvedType::Newtype { base_type, .. } => {
-                    let tt = self.type_table.borrow();
+                    let tt = self.tysys.type_table.borrow();
                     let ultimate = tt.get_ultimate_base_type(*base_type);
                     matches!(
                         tt.get(ultimate),
@@ -685,7 +685,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 && left.type_id != TypeTable::ERROR
                 && right.type_id != TypeTable::ERROR
             {
-                let type_table = self.type_table.borrow();
+                let type_table = self.tysys.type_table.borrow();
                 let type_name = type_table.type_name(left.type_id);
                 let op_char = match op {
                     BinaryOp::Add => "+",
@@ -754,7 +754,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             && left.type_id != TypeTable::NEVER
             && right.type_id != TypeTable::NEVER
         {
-            let type_table = self.type_table.borrow();
+            let type_table = self.tysys.type_table.borrow();
             let left_name = type_table.type_name(left.type_id);
             let right_name = type_table.type_name(right.type_id);
             if left_name != right_name {
@@ -804,7 +804,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // way a bare `identity` to a `fn(...)` parameter would.
         let inner_expected = if matches!(unary.op, UnaryOp::Ref | UnaryOp::MutRef) {
             expected_type.and_then(|expected| {
-                let table = self.type_table.borrow();
+                let table = self.tysys.type_table.borrow();
                 match table.get(expected) {
                     ResolvedType::Ref(inner) | ResolvedType::MutRef(inner) => Some(*inner),
                     _ => None,
@@ -841,12 +841,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // For GC reference types (struct, String, Array, etc.), struct.get returns
         // the shared reference, so &mut field works correctly.
         if unary.op == UnaryOp::MutRef && matches!(&expr.kind, TirExprKind::FieldAccess { .. }) {
-            let field_type = self.type_table.borrow().get(expr.type_id).clone();
+            let field_type = self.tysys.type_table.borrow().get(expr.type_id).clone();
             let base_type = self
-                .type_table
+                .tysys.type_table
                 .borrow()
                 .get(
-                    self.type_table
+                    self.tysys.type_table
                         .borrow()
                         .get_ultimate_base_type(expr.type_id),
                 )
@@ -870,7 +870,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             UnaryOp::BitNot => Some(("BitNot", "bitnot")),
             _ => None,
         } {
-            let expr_type = self.type_table.borrow().get(expr.type_id).clone();
+            let expr_type = self.tysys.type_table.borrow().get(expr.type_id).clone();
             let struct_name = match &expr_type {
                 ResolvedType::Struct { name, .. } => Some(name.clone()),
                 ResolvedType::GenericInstance { name, .. } => Some(name.clone()),
@@ -969,18 +969,18 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         let type_id = match unary.op {
             UnaryOp::Not => TypeTable::BOOL,
-            UnaryOp::Ref => self.type_table.borrow_mut().make_ref(expr.type_id),
-            UnaryOp::MutRef => self.type_table.borrow_mut().make_mut_ref(expr.type_id),
+            UnaryOp::Ref => self.tysys.type_table.borrow_mut().make_ref(expr.type_id),
+            UnaryOp::MutRef => self.tysys.type_table.borrow_mut().make_mut_ref(expr.type_id),
             UnaryOp::Deref => {
-                let outer = self.type_table.borrow().get(expr.type_id).clone();
+                let outer = self.tysys.type_table.borrow().get(expr.type_id).clone();
                 match outer {
                     ResolvedType::MutRef(inner) => inner,
                     ResolvedType::Ref(inner) => {
                         // Dereffing a shared reference: &(&mut T) yields &T, not &mut T.
                         // Mutability cannot propagate outward through a shared reference.
-                        let inner_resolved = self.type_table.borrow().get(inner).clone();
+                        let inner_resolved = self.tysys.type_table.borrow().get(inner).clone();
                         if let ResolvedType::MutRef(u) = inner_resolved {
-                            self.type_table.borrow_mut().make_ref(u)
+                            self.tysys.type_table.borrow_mut().make_ref(u)
                         } else {
                             inner
                         }
@@ -988,7 +988,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     _ => {
                         let _ = self.logger.error(TypeError::TypeMismatch {
                             expected: "reference type".to_string(),
-                            found: self.type_table.borrow().type_name(expr.type_id),
+                            found: self.tysys.type_table.borrow().type_name(expr.type_id),
                             span: unary.span,
                         });
                         TypeTable::ERROR
@@ -1043,7 +1043,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             let indexed_expr = self.resolve_expr(&index_expr.expr, ctx, None);
 
             // Get base type (unwrap reference if needed)
-            let base_type_id = match self.type_table.borrow().get(indexed_expr.type_id) {
+            let base_type_id = match self.tysys.type_table.borrow().get(indexed_expr.type_id) {
                 ResolvedType::Ref(inner) | ResolvedType::MutRef(inner) => *inner,
                 _ => indexed_expr.type_id,
             };
@@ -1052,7 +1052,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // Arrays now use IndexAssign trait like other types
             {
                 // Check for IndexAssign trait implementation
-                let struct_name = match self.type_table.borrow().get(base_type_id).clone() {
+                let struct_name = match self.tysys.type_table.borrow().get(base_type_id).clone() {
                     ResolvedType::Struct { name, .. } => name,
                     ResolvedType::GenericInstance { name, .. } => name,
                     ResolvedType::Newtype { name, .. } | ResolvedType::Flags { name, .. } => name,
@@ -1068,7 +1068,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     let index_type = index_resolved.type_id;
 
                     // Reject &T/&mut T used as index expression (would ICE in codegen)
-                    let derefed_index_type = match self.type_table.borrow().get(index_type) {
+                    let derefed_index_type = match self.tysys.type_table.borrow().get(index_type) {
                         ResolvedType::Ref(inner) | ResolvedType::MutRef(inner) => Some(*inner),
                         _ => None,
                     };
@@ -1202,7 +1202,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 expr,
                 ..
             } => {
-                let inner_type = self.type_table.borrow().get(expr.type_id).clone();
+                let inner_type = self.tysys.type_table.borrow().get(expr.type_id).clone();
                 if matches!(inner_type, ResolvedType::Ref(_)) {
                     let _ = self.logger.error(TypeError::CannotAssign {
                         message: "cannot assign through immutable reference".to_string(),
@@ -1455,7 +1455,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let mut wrap_flags: Vec<bool> = Vec::with_capacity(args.len());
         for (arg, &param_ty) in args.iter().zip(resolved.param_types.iter()) {
             let wrap = matches!(
-                self.type_table.borrow().get(param_ty),
+                self.tysys.type_table.borrow().get(param_ty),
                 ResolvedType::Ref(_) | ResolvedType::MutRef(_)
             );
             // For `&Self` parameters the "value-level" expected type is
@@ -1477,7 +1477,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             .map(|(arg, wrap)| {
                 let arg_expr = if wrap {
                     let arg_ref_type = self
-                        .type_table
+                        .tysys.type_table
                         .borrow_mut()
                         .intern(ResolvedType::Ref(arg.type_id));
                     TirExpr::new(
@@ -1529,14 +1529,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// `<=`  → `cmp != Greater`, `>=` → `cmp != Less`.
     fn ord_bool_from_cmp(&mut self, cmp_call: TirExpr, op: BinaryOp, span: Span) -> TirExpr {
         let ordering_type_id = self
-            .type_table
+            .tysys.type_table
             .borrow_mut()
             .make_compiler_enum(CompilerItem::Ordering);
         // Look up Ordering's `Less` / `Greater` cases through the
         // `CompilerItem` registry so a stdlib rename of either case
         // flows here without touching the operator-lowering path.
         let (less_name, less_index, greater_name, greater_index) = {
-            let tt = self.type_table.borrow();
+            let tt = self.tysys.type_table.borrow();
             let items = tt.compiler_items();
             let (_, _, less_name, less_index) = items.require_enum_case(CompilerItem::OrderingLess);
             let (_, _, greater_name, greater_index) =

--- a/wado-compiler/src/elaborator/operators.rs
+++ b/wado-compiler/src/elaborator/operators.rs
@@ -74,8 +74,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         ctx: &mut FunctionContext,
         expected_type: Option<TypeId>,
     ) -> (TirExpr, TirExpr) {
-        let left_is_numeric_literal = self.is_numeric_literal(left_ast);
-        let right_is_numeric_literal = self.is_numeric_literal(right_ast);
+        let left_is_numeric_literal = self.tysys.is_numeric_literal(left_ast);
+        let right_is_numeric_literal = self.tysys.is_numeric_literal(right_ast);
 
         if left_is_numeric_literal && !right_is_numeric_literal {
             // Resolve right first, then coerce left
@@ -1073,7 +1073,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         _ => None,
                     };
                     if let Some(expected) = derefed_index_type {
-                        self.typecheck(index_type, expected, index_expr.index.span());
+                        self.tysys.typecheck(self.logger, index_type, expected, index_expr.index.span());
                     }
 
                     let assign_info = self
@@ -1096,7 +1096,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         };
 
                         // Check: reject &T/&mut T assigned where non-ref expected
-                        self.typecheck(value_tir.type_id, trait_info.input_type, value_span);
+                        self.tysys.typecheck(self.logger, value_tir.type_id, trait_info.input_type, value_span);
 
                         let receiver = self.adjust_receiver_for_self_kind(
                             indexed_expr,
@@ -1148,7 +1148,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         };
 
         // Reject &T assigned where non-ref T expected
-        self.typecheck(value_tir.type_id, target.type_id, value_span);
+        self.tysys.typecheck(self.logger, value_tir.type_id, target.type_id, value_span);
 
         // Handle assignment to global variables
         if let TirExprKind::GlobalVarGet {
@@ -1464,7 +1464,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // For concrete parameter types (e.g. `rhs: u32` on
             // `Shl::shl`) the expected type is the parameter type itself.
             let expected = if wrap { receiver.type_id } else { param_ty };
-            self.typecheck(arg.type_id, expected, span);
+            self.tysys.typecheck(self.logger, arg.type_id, expected, span);
             wrap_flags.push(wrap);
         }
 

--- a/wado-compiler/src/elaborator/operators.rs
+++ b/wado-compiler/src/elaborator/operators.rs
@@ -1083,12 +1083,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         _ => None,
                     };
                     if let Some(expected) = derefed_index_type {
-                        self.tysys.typecheck(
-                            self.logger,
-                            index_type,
-                            expected,
-                            index_expr.index.span(),
-                        );
+                        self.typecheck(index_type, expected, index_expr.index.span());
                     }
 
                     let assign_info = self
@@ -1111,12 +1106,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         };
 
                         // Check: reject &T/&mut T assigned where non-ref expected
-                        self.tysys.typecheck(
-                            self.logger,
-                            value_tir.type_id,
-                            trait_info.input_type,
-                            value_span,
-                        );
+                        self.typecheck(value_tir.type_id, trait_info.input_type, value_span);
 
                         let receiver = self.adjust_receiver_for_self_kind(
                             indexed_expr,
@@ -1168,8 +1158,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         };
 
         // Reject &T assigned where non-ref T expected
-        self.tysys
-            .typecheck(self.logger, value_tir.type_id, target.type_id, value_span);
+        self.typecheck(value_tir.type_id, target.type_id, value_span);
 
         // Handle assignment to global variables
         if let TirExprKind::GlobalVarGet {
@@ -1485,8 +1474,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // For concrete parameter types (e.g. `rhs: u32` on
             // `Shl::shl`) the expected type is the parameter type itself.
             let expected = if wrap { receiver.type_id } else { param_ty };
-            self.tysys
-                .typecheck(self.logger, arg.type_id, expected, span);
+            self.typecheck(arg.type_id, expected, span);
             wrap_flags.push(wrap);
         }
 

--- a/wado-compiler/src/elaborator/operators.rs
+++ b/wado-compiler/src/elaborator/operators.rs
@@ -247,7 +247,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 // Handle Eq trait (== and !=)
                 if matches!(op, BinaryOp::Eq | BinaryOp::NotEq) {
                     let eq_trait_name = self
-                        .tysys.type_table
+                        .tysys
+                        .type_table
                         .borrow()
                         .compiler_items()
                         .trait_name(CompilerItem::Eq)
@@ -294,7 +295,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     BinaryOp::Lt | BinaryOp::Gt | BinaryOp::LtEq | BinaryOp::GtEq
                 ) {
                     let ord_trait_name = self
-                        .tysys.type_table
+                        .tysys
+                        .type_table
                         .borrow()
                         .compiler_items()
                         .trait_name(CompilerItem::Ord)
@@ -353,7 +355,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         self.find_method_in_trait_bounds(&bound_names, "eq", left.type_id)
                 {
                     let eq_trait_name = self
-                        .tysys.type_table
+                        .tysys
+                        .type_table
                         .borrow()
                         .compiler_items()
                         .trait_name(CompilerItem::Eq)
@@ -392,7 +395,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     self.find_method_in_trait_bounds(&bound_names, "cmp", left.type_id)
                 {
                     let ord_trait_name = self
-                        .tysys.type_table
+                        .tysys
+                        .type_table
                         .borrow()
                         .compiler_items()
                         .trait_name(CompilerItem::Ord)
@@ -843,10 +847,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         if unary.op == UnaryOp::MutRef && matches!(&expr.kind, TirExprKind::FieldAccess { .. }) {
             let field_type = self.tysys.type_table.borrow().get(expr.type_id).clone();
             let base_type = self
-                .tysys.type_table
+                .tysys
+                .type_table
                 .borrow()
                 .get(
-                    self.tysys.type_table
+                    self.tysys
+                        .type_table
                         .borrow()
                         .get_ultimate_base_type(expr.type_id),
                 )
@@ -970,7 +976,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let type_id = match unary.op {
             UnaryOp::Not => TypeTable::BOOL,
             UnaryOp::Ref => self.tysys.type_table.borrow_mut().make_ref(expr.type_id),
-            UnaryOp::MutRef => self.tysys.type_table.borrow_mut().make_mut_ref(expr.type_id),
+            UnaryOp::MutRef => self
+                .tysys
+                .type_table
+                .borrow_mut()
+                .make_mut_ref(expr.type_id),
             UnaryOp::Deref => {
                 let outer = self.tysys.type_table.borrow().get(expr.type_id).clone();
                 match outer {
@@ -1073,7 +1083,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         _ => None,
                     };
                     if let Some(expected) = derefed_index_type {
-                        self.tysys.typecheck(self.logger, index_type, expected, index_expr.index.span());
+                        self.tysys.typecheck(
+                            self.logger,
+                            index_type,
+                            expected,
+                            index_expr.index.span(),
+                        );
                     }
 
                     let assign_info = self
@@ -1096,7 +1111,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         };
 
                         // Check: reject &T/&mut T assigned where non-ref expected
-                        self.tysys.typecheck(self.logger, value_tir.type_id, trait_info.input_type, value_span);
+                        self.tysys.typecheck(
+                            self.logger,
+                            value_tir.type_id,
+                            trait_info.input_type,
+                            value_span,
+                        );
 
                         let receiver = self.adjust_receiver_for_self_kind(
                             indexed_expr,
@@ -1148,7 +1168,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         };
 
         // Reject &T assigned where non-ref T expected
-        self.tysys.typecheck(self.logger, value_tir.type_id, target.type_id, value_span);
+        self.tysys
+            .typecheck(self.logger, value_tir.type_id, target.type_id, value_span);
 
         // Handle assignment to global variables
         if let TirExprKind::GlobalVarGet {
@@ -1464,7 +1485,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // For concrete parameter types (e.g. `rhs: u32` on
             // `Shl::shl`) the expected type is the parameter type itself.
             let expected = if wrap { receiver.type_id } else { param_ty };
-            self.tysys.typecheck(self.logger, arg.type_id, expected, span);
+            self.tysys
+                .typecheck(self.logger, arg.type_id, expected, span);
             wrap_flags.push(wrap);
         }
 
@@ -1477,7 +1499,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             .map(|(arg, wrap)| {
                 let arg_expr = if wrap {
                     let arg_ref_type = self
-                        .tysys.type_table
+                        .tysys
+                        .type_table
                         .borrow_mut()
                         .intern(ResolvedType::Ref(arg.type_id));
                     TirExpr::new(
@@ -1529,7 +1552,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// `<=`  → `cmp != Greater`, `>=` → `cmp != Less`.
     fn ord_bool_from_cmp(&mut self, cmp_call: TirExpr, op: BinaryOp, span: Span) -> TirExpr {
         let ordering_type_id = self
-            .tysys.type_table
+            .tysys
+            .type_table
             .borrow_mut()
             .make_compiler_enum(CompilerItem::Ordering);
         // Look up Ordering's `Less` / `Greater` cases through the

--- a/wado-compiler/src/elaborator/orchestration.rs
+++ b/wado-compiler/src/elaborator/orchestration.rs
@@ -35,10 +35,10 @@ use crate::module_source::{ModuleSource, ModuleSourceInterner};
 use crate::name::{self as name};
 use crate::symbol::{Symbol, SymbolKey, SymbolTable};
 use crate::tir::{ResolvedType, TirModule, TypeId, TypeTable};
-use crate::world_registry::WorldRegistry;
 
 use super::Elaborator;
 use super::trait_env::TraitEnv;
+use super::tysys::TypeSystem;
 use super::types::{
     EnumCaseData, EnumInfo, FlagsInfo, FlagsMemberData, GenericNewtypeInfo, ResourceInfo,
     StructFieldInfo, TypeError, TypeLookup, VariantCaseData, VariantInfo,
@@ -59,31 +59,15 @@ use super::types::{
 /// (pipeline-wide), per-module [`super::sem::ModuleSemantics`] instances,
 /// and cross-cutting driver state.
 pub(crate) struct AnnotateState {
-    // MIGRATION: → TypeSystem (arena).
-    pub(crate) type_table: Rc<RefCell<TypeTable>>,
-    // MIGRATION: → TypeSystem.
-    pub(crate) trait_env: Arc<TraitEnv>,
-    // MIGRATION: cross-cutting driver state (topological order of modules).
+    /// Pipeline-wide type knowledge: the type arena, decl-interned type
+    /// tables, registries, included-files map, and read-only caches
+    /// built once at annotate time. See [`TypeSystem`].
+    pub(crate) tysys: TypeSystem,
+    /// Topological order of modules; the per-module body walk in
+    /// [`Elaborator::build_tir_from_state`] visits sources in this order
+    /// so a `TirModule`'s position in the result map matches the
+    /// dependency order downstream phases expect.
     pub(crate) sorted_sources: Vec<ModuleSource>,
-    // MIGRATION: → TypeSystem (decl-interned type tables, all 7 below).
-    pub(crate) all_newtypes: Rc<IndexMap<ModuleSource, IndexMap<String, TypeId>>>,
-    pub(crate) all_generic_newtypes:
-        Rc<IndexMap<ModuleSource, IndexMap<String, GenericNewtypeInfo>>>,
-    pub(crate) all_struct_fields: Rc<IndexMap<ModuleSource, IndexMap<String, StructFieldInfo>>>,
-    pub(crate) all_variant_cases: Rc<IndexMap<ModuleSource, IndexMap<String, VariantInfo>>>,
-    pub(crate) all_enum_cases: Rc<IndexMap<ModuleSource, IndexMap<String, EnumInfo>>>,
-    pub(crate) all_flags_cases: Rc<IndexMap<ModuleSource, IndexMap<String, FlagsInfo>>>,
-    pub(crate) all_resource_types: Rc<IndexMap<ModuleSource, IndexMap<String, ResourceInfo>>>,
-    // MIGRATION: → TypeSystem (registry).
-    pub(crate) wasi_registry: &'static WasiRegistry,
-    // MIGRATION: → TypeSystem (registry).
-    pub(crate) world_registry: &'static WorldRegistry,
-    // MIGRATION: → TypeSystem (registry).
-    pub(crate) builtin_registry: BuiltinRegistry,
-    // MIGRATION: → TypeSystem.
-    pub(crate) global_known_type_names: IndexSet<String>,
-    // MIGRATION: → TypeSystem (pipeline-wide func-name index over loaded modules).
-    pub(crate) all_module_func_indices: IndexMap<ModuleSource, IndexMap<String, usize>>,
     /// Use→def map for local variables: `(module, IdentExpr.id)` →
     /// `(module, defining AstId)`. Populated by [`Elaborator::resolve_ident`]
     /// whenever a name resolves to a local binding. Consumed by LSP
@@ -128,7 +112,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         modules: &'a IndexMap<ModuleSource, Module>,
         entry_module_source: ModuleSource,
         logger: &'a Logger<'a, H>,
-        included_files: &'a IndexMap<[String; 2], Vec<u8>>,
+        included_files: Rc<IndexMap<[String; 2], Vec<u8>>>,
         invocations: crate::kiln::InvocationIndex,
         interner: Rc<RefCell<ModuleSourceInterner>>,
     ) -> Result<(IndexMap<ModuleSource, TirModule>, Arc<TraitEnv>), Bail> {
@@ -137,18 +121,18 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             modules,
             &entry_module_source,
             logger,
+            included_files,
             invocations,
             interner,
             None,
         )?;
-        let trait_env = state.trait_env.clone();
+        let trait_env = state.tysys.trait_env.clone();
         let tir_modules = Self::build_tir_from_state(
             &state,
             symbols,
             modules,
             entry_module_source,
             logger,
-            included_files,
             None,
         )?;
         Ok((tir_modules, trait_env))
@@ -163,6 +147,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         modules: &'a IndexMap<ModuleSource, Module>,
         entry_module_source: &ModuleSource,
         logger: &'a Logger<'a, H>,
+        included_files: Rc<IndexMap<[String; 2], Vec<u8>>>,
         invocations: crate::kiln::InvocationIndex,
         interner: Rc<RefCell<ModuleSourceInterner>>,
         snapshot: Option<&crate::semantics::Semantics>,
@@ -188,30 +173,30 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                 .expect("stdlib snapshot must have a populated annotate state")
         });
         let mut all_newtypes: IndexMap<ModuleSource, IndexMap<String, TypeId>> = snapshot_state
-            .map(|s| (*s.all_newtypes).clone())
+            .map(|s| (*s.tysys.all_newtypes).clone())
             .unwrap_or_default();
         let mut all_generic_newtypes: IndexMap<ModuleSource, IndexMap<String, GenericNewtypeInfo>> =
             snapshot_state
-                .map(|s| (*s.all_generic_newtypes).clone())
+                .map(|s| (*s.tysys.all_generic_newtypes).clone())
                 .unwrap_or_default();
         let mut all_struct_fields: IndexMap<ModuleSource, IndexMap<String, StructFieldInfo>> =
             snapshot_state
-                .map(|s| (*s.all_struct_fields).clone())
+                .map(|s| (*s.tysys.all_struct_fields).clone())
                 .unwrap_or_default();
         let mut all_variant_cases: IndexMap<ModuleSource, IndexMap<String, VariantInfo>> =
             snapshot_state
-                .map(|s| (*s.all_variant_cases).clone())
+                .map(|s| (*s.tysys.all_variant_cases).clone())
                 .unwrap_or_default();
         let mut all_enum_cases: IndexMap<ModuleSource, IndexMap<String, EnumInfo>> = snapshot_state
-            .map(|s| (*s.all_enum_cases).clone())
+            .map(|s| (*s.tysys.all_enum_cases).clone())
             .unwrap_or_default();
         let mut all_flags_cases: IndexMap<ModuleSource, IndexMap<String, FlagsInfo>> =
             snapshot_state
-                .map(|s| (*s.all_flags_cases).clone())
+                .map(|s| (*s.tysys.all_flags_cases).clone())
                 .unwrap_or_default();
         let mut all_resource_types: IndexMap<ModuleSource, IndexMap<String, ResourceInfo>> =
             snapshot_state
-                .map(|s| (*s.all_resource_types).clone())
+                .map(|s| (*s.tysys.all_resource_types).clone())
                 .unwrap_or_default();
 
         // First pass: collect struct, variant, enum, and resource names from all modules (for forward references)
@@ -660,7 +645,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                 // The snapshot's registry is bound to the snapshot's
                 // `TypeTable`, whose entries we cloned into `type_table`
                 // above — so the registered `TypeId`s remain valid.
-                snap_state.builtin_registry.clone()
+                (*snap_state.tysys.builtin_registry).clone()
             } else {
                 BuiltinRegistry::build_from_stdlib(&type_table)
             };
@@ -765,7 +750,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         // Pre-build function name → index maps for all loaded modules (O(1) lookup)
         let all_module_func_indices: IndexMap<ModuleSource, IndexMap<String, usize>> = {
             let mut indices: IndexMap<ModuleSource, IndexMap<String, usize>> = snapshot_state
-                .map(|s| s.all_module_func_indices.clone())
+                .map(|s| (*s.tysys.loaded_module_func_indices).clone())
                 .unwrap_or_default();
             for (src, module) in modules {
                 if stdlib_set.contains(src) {
@@ -809,10 +794,8 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             snapshot.map(|s| s.local_types.clone()).unwrap_or_default(),
         ));
 
-        Ok(AnnotateState {
+        let tysys = TypeSystem {
             type_table,
-            trait_env,
-            sorted_sources,
             all_newtypes,
             all_generic_newtypes,
             all_struct_fields,
@@ -820,11 +803,17 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             all_enum_cases,
             all_flags_cases,
             all_resource_types,
+            trait_env,
             wasi_registry,
             world_registry,
-            builtin_registry,
-            global_known_type_names,
-            all_module_func_indices,
+            builtin_registry: Rc::new(builtin_registry),
+            included_files,
+            known_type_names_cache: Rc::new(global_known_type_names),
+            loaded_module_func_indices: Rc::new(all_module_func_indices),
+        };
+        Ok(AnnotateState {
+            tysys,
+            sorted_sources,
             references,
             local_symbols,
             local_types,
@@ -842,7 +831,6 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         modules: &'a IndexMap<ModuleSource, Module>,
         entry_module_source: ModuleSource,
         logger: &'a Logger<'a, H>,
-        included_files: &'a IndexMap<[String; 2], Vec<u8>>,
         snapshot: Option<&crate::semantics::Semantics>,
     ) -> Result<IndexMap<ModuleSource, TirModule>, Bail> {
         let mut result = IndexMap::default();
@@ -882,7 +870,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                     module_source.clone(),
                     crate::stdlib_snapshot::rehydrate_tir_module(
                         snap_module,
-                        &state.type_table,
+                        &state.tysys.type_table,
                         &mut fn_remap,
                     ),
                 );
@@ -913,13 +901,13 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                     current_module_source: module_source,
                     imported_type_sources: &imported_type_sources,
                     import_original_names: &import_original_names,
-                    all_newtypes: &state.all_newtypes,
-                    all_struct_fields: &state.all_struct_fields,
-                    all_variant_cases: &state.all_variant_cases,
-                    all_enum_cases: &state.all_enum_cases,
-                    all_flags_cases: &state.all_flags_cases,
-                    all_resource_types: &state.all_resource_types,
-                    all_generic_newtypes: &state.all_generic_newtypes,
+                    all_newtypes: &state.tysys.all_newtypes,
+                    all_struct_fields: &state.tysys.all_struct_fields,
+                    all_variant_cases: &state.tysys.all_variant_cases,
+                    all_enum_cases: &state.tysys.all_enum_cases,
+                    all_flags_cases: &state.tysys.all_flags_cases,
+                    all_resource_types: &state.tysys.all_resource_types,
+                    all_generic_newtypes: &state.tysys.all_generic_newtypes,
                     local_struct_fields: &empty_struct,
                     local_newtypes: &empty_newtype,
                     local_enum_cases: &empty_enum,
@@ -932,7 +920,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                         let return_type = if let Some(ret_ty) = &func.return_type {
                             Self::resolve_type_static(
                                 ret_ty,
-                                &mut state.type_table.borrow_mut(),
+                                &mut state.tysys.type_table.borrow_mut(),
                                 &lookup,
                             )
                         } else {
@@ -989,16 +977,9 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             }
 
             let mut elaborator = Elaborator {
-                type_table: Rc::clone(&state.type_table),
+                tysys: state.tysys.clone(),
                 symbols,
                 loaded_modules: modules,
-                all_newtypes: Rc::clone(&state.all_newtypes),
-                all_generic_newtypes: Rc::clone(&state.all_generic_newtypes),
-                all_struct_fields: Rc::clone(&state.all_struct_fields),
-                all_variant_cases: Rc::clone(&state.all_variant_cases),
-                all_enum_cases: Rc::clone(&state.all_enum_cases),
-                all_flags_cases: Rc::clone(&state.all_flags_cases),
-                all_resource_types: Rc::clone(&state.all_resource_types),
                 imported_type_sources,
                 import_original_names,
                 local_struct_fields: IndexMap::default(),
@@ -1024,20 +1005,14 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                 generic_function_resolved_return_types: IndexMap::default(),
                 generic_method_params: IndexMap::default(),
                 generic_method_resolved_param_types: IndexMap::default(),
-                wasi_registry: state.wasi_registry,
-                builtin_registry: &state.builtin_registry,
                 current_module_globals: IndexMap::default(),
                 imported_globals: IndexMap::default(),
                 associated_constants: IndexMap::default(),
-                trait_env: Arc::clone(&state.trait_env),
-                included_files,
-                known_type_names_cache: state.global_known_type_names.clone(),
                 indexing_trait_cache: IndexMap::default(),
                 trait_check_stack: RefCell::new(Vec::new()),
                 method_info_cache: IndexMap::default(),
                 pending_anonymous_structs: Vec::new(),
                 current_module_func_index: IndexMap::default(), // Built in resolve_module
-                loaded_module_func_indices: state.all_module_func_indices.clone(),
                 references: Rc::clone(&state.references),
                 local_symbols: Rc::clone(&state.local_symbols),
                 local_types: Rc::clone(&state.local_types),
@@ -1045,7 +1020,6 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                 invocations: Rc::clone(&state.invocations),
                 interner: Rc::clone(&state.interner),
             };
-            // known_type_names_cache is pre-computed globally; no per-module rebuild needed
 
             // Set file context so diagnostics emitted during resolution
             // carry the correct module filename (not the entry module).

--- a/wado-compiler/src/elaborator/orchestration.rs
+++ b/wado-compiler/src/elaborator/orchestration.rs
@@ -664,7 +664,8 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             // loader-synthesised wasm-asset modules so calls into a
             // wat/wasm asset's exports lower through the same TirImport
             // path as `core:builtin` declarations.  Stdlib wasm assets
-            // (e.g. `core:libm.wat`) are already in `snap.state.builtin_registry`.
+            // (e.g. `core:libm.wat`) are already in
+            // `snapshot.state.tysys.builtin_registry`.
             for (ms, module) in modules {
                 if matches!(ms, ModuleSource::Wasm { .. }) && !stdlib_set.contains(ms) {
                     registry.register_wasm_module(module, &type_table);
@@ -701,7 +702,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         let all_generic_newtypes = Rc::new(all_generic_newtypes);
 
         // Pre-compute the global known type names cache once (shared across all modules)
-        let global_known_type_names = {
+        let known_type_names_cache = {
             let mut cache = IndexSet::default();
             for m in all_struct_fields.values() {
                 for name in m.keys() {
@@ -743,7 +744,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         // At this point all type names from all modules are known, so any unrecognized
         // Named type is truly undefined. This catches undefined types that would silently
         // become UNKNOWN in static pre-resolution.
-        // Resource type names are kept separate from global_known_type_names because
+        // Resource type names are kept separate from known_type_names_cache because
         // adding them would break is_known_type_name() used in impl block type parameter
         // inference (e.g., `impl Request { ... }` would stop recognizing Request's methods).
         let resource_type_names: IndexSet<String> = all_resource_types
@@ -752,14 +753,14 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             .collect();
         Self::validate_type_definitions(
             modules,
-            &global_known_type_names,
+            &known_type_names_cache,
             &resource_type_names,
             logger,
             &stdlib_set,
         )?;
 
         // Pre-build function name → index maps for all loaded modules (O(1) lookup)
-        let all_module_func_indices: IndexMap<ModuleSource, IndexMap<String, usize>> = {
+        let loaded_module_func_indices: IndexMap<ModuleSource, IndexMap<String, usize>> = {
             let mut indices: IndexMap<ModuleSource, IndexMap<String, usize>> = snapshot_state
                 .map(|s| (*s.tysys.loaded_module_func_indices).clone())
                 .unwrap_or_default();
@@ -818,8 +819,8 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             wasi_registry,
             builtin_registry: Rc::new(builtin_registry),
             included_files,
-            known_type_names_cache: Rc::new(global_known_type_names),
-            loaded_module_func_indices: Rc::new(all_module_func_indices),
+            known_type_names_cache: Rc::new(known_type_names_cache),
+            loaded_module_func_indices: Rc::new(loaded_module_func_indices),
         };
         Ok(AnnotateState {
             tysys,
@@ -1003,10 +1004,10 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                 imported_functions,
                 namespace_imports,
                 logger,
-                current_module_source: ModuleSource::entry_point_uninitialized(), // Set in resolve_module
+                current_module_source: ModuleSource::entry_point_uninitialized(), // Set in Elaborator::resolve_module
                 entry_module_source: entry_module_source.clone(),
-                current_module_items: &[], // Set in resolve_module
-                effect_sources: IndexMap::default(), // Populated per-module in resolve_module
+                current_module_items: &[], // Set in Elaborator::resolve_module
+                effect_sources: IndexMap::default(), // Populated per-module in Elaborator::resolve_module
                 current_effect_params: IndexSet::default(),
                 current_effect_param_decls: IndexMap::default(),
                 trait_ctx: super::trait_env::TraitContext::default(),

--- a/wado-compiler/src/elaborator/orchestration.rs
+++ b/wado-compiler/src/elaborator/orchestration.rs
@@ -35,6 +35,7 @@ use crate::module_source::{ModuleSource, ModuleSourceInterner};
 use crate::name::{self as name};
 use crate::symbol::{Symbol, SymbolKey, SymbolTable};
 use crate::tir::{ResolvedType, TirModule, TypeId, TypeTable};
+use crate::world_registry::WorldRegistry;
 
 use super::Elaborator;
 use super::trait_env::TraitEnv;
@@ -63,6 +64,16 @@ pub(crate) struct AnnotateState {
     /// tables, registries, included-files map, and read-only caches
     /// built once at annotate time. See [`TypeSystem`].
     pub(crate) tysys: TypeSystem,
+    /// Component-Model world specifications. Built by the same
+    /// [`WasiRegistry::build_from_stdlib`] call that populates
+    /// [`TypeSystem::wasi_registry`], but lives here rather than on
+    /// `TypeSystem`: the elaborator never asks "what does world X
+    /// export?" — only post-elaborator stages (link, synthesis, DCE,
+    /// world-existence validation in [`crate::lib`]) do. Keeping it on
+    /// the driver state respects the `TypeSystem` membership rule
+    /// ("would this fit the type system itself?" — see
+    /// [`super::tysys`] module docs).
+    pub(crate) world_registry: &'static WorldRegistry,
     /// Topological order of modules; the per-module body walk in
     /// [`Elaborator::build_tir_from_state`] visits sources in this order
     /// so a `TirModule`'s position in the result map matches the
@@ -805,7 +816,6 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             all_resource_types,
             trait_env,
             wasi_registry,
-            world_registry,
             builtin_registry: Rc::new(builtin_registry),
             included_files,
             known_type_names_cache: Rc::new(global_known_type_names),
@@ -813,6 +823,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         };
         Ok(AnnotateState {
             tysys,
+            world_registry,
             sorted_sources,
             references,
             local_symbols,

--- a/wado-compiler/src/elaborator/orchestration.rs
+++ b/wado-compiler/src/elaborator/orchestration.rs
@@ -768,7 +768,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                     // Pre-populated from snapshot.
                     continue;
                 }
-                indices.insert(src.clone(), Self::build_func_index(&module.items));
+                indices.insert(src.clone(), super::build_func_index(&module.items));
             }
             indices
         };
@@ -1023,7 +1023,6 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                 trait_check_stack: RefCell::new(Vec::new()),
                 method_info_cache: IndexMap::default(),
                 pending_anonymous_structs: Vec::new(),
-                current_module_func_index: IndexMap::default(), // Built in resolve_module
                 references: Rc::clone(&state.references),
                 local_symbols: Rc::clone(&state.local_symbols),
                 local_types: Rc::clone(&state.local_types),

--- a/wado-compiler/src/elaborator/orchestration.rs
+++ b/wado-compiler/src/elaborator/orchestration.rs
@@ -52,10 +52,20 @@ use super::types::{
 /// underlying data. The [`TypeTable`] itself is behind `Rc<RefCell<…>>`
 /// because lowering interns additional types (anonymous structs,
 /// monomorphized instances) into the same table.
+///
+/// Migration markers on each field below trace the WEP 2026-05-26
+/// elaborator re-architecture. `AnnotateState` itself disappears after
+/// Stage 7 — its contents redistribute into [`super::tysys::TypeSystem`]
+/// (pipeline-wide), per-module [`super::sem::ModuleSemantics`] instances,
+/// and cross-cutting driver state.
 pub(crate) struct AnnotateState {
+    // MIGRATION: → TypeSystem (arena).
     pub(crate) type_table: Rc<RefCell<TypeTable>>,
+    // MIGRATION: → TypeSystem.
     pub(crate) trait_env: Arc<TraitEnv>,
+    // MIGRATION: cross-cutting driver state (topological order of modules).
     pub(crate) sorted_sources: Vec<ModuleSource>,
+    // MIGRATION: → TypeSystem (decl-interned type tables, all 7 below).
     pub(crate) all_newtypes: Rc<IndexMap<ModuleSource, IndexMap<String, TypeId>>>,
     pub(crate) all_generic_newtypes:
         Rc<IndexMap<ModuleSource, IndexMap<String, GenericNewtypeInfo>>>,
@@ -64,19 +74,27 @@ pub(crate) struct AnnotateState {
     pub(crate) all_enum_cases: Rc<IndexMap<ModuleSource, IndexMap<String, EnumInfo>>>,
     pub(crate) all_flags_cases: Rc<IndexMap<ModuleSource, IndexMap<String, FlagsInfo>>>,
     pub(crate) all_resource_types: Rc<IndexMap<ModuleSource, IndexMap<String, ResourceInfo>>>,
+    // MIGRATION: → TypeSystem (registry).
     pub(crate) wasi_registry: &'static WasiRegistry,
+    // MIGRATION: → TypeSystem (registry).
     pub(crate) world_registry: &'static WorldRegistry,
+    // MIGRATION: → TypeSystem (registry).
     pub(crate) builtin_registry: BuiltinRegistry,
+    // MIGRATION: → TypeSystem.
     pub(crate) global_known_type_names: IndexSet<String>,
+    // MIGRATION: → TypeSystem (pipeline-wide func-name index over loaded modules).
     pub(crate) all_module_func_indices: IndexMap<ModuleSource, IndexMap<String, usize>>,
     /// Use→def map for local variables: `(module, IdentExpr.id)` →
     /// `(module, defining AstId)`. Populated by [`Elaborator::resolve_ident`]
     /// whenever a name resolves to a local binding. Consumed by LSP
     /// `definition` / `hover` to jump to the defining pattern / parameter.
+    // MIGRATION: → ModuleSemantics::bindings (per-module after Stage 3;
+    //   the `Rc<RefCell<…>>` plumbing collapses into `&mut ModuleSemantics`).
     pub(crate) references: Rc<RefCell<IndexMap<SymbolKey, SymbolKey>>>,
     /// Locally-defined [`Symbol`]s (let bindings, parameters, closure
     /// parameters). Keyed by the binding's defining [`SymbolKey`]. Populated
     /// alongside [`Self::references`] as the elaborator walks function bodies.
+    // MIGRATION: → ModuleSemantics::bindings (per-module after Stage 3).
     pub(crate) local_symbols: Rc<RefCell<IndexMap<SymbolKey, Symbol>>>,
     /// Resolved [`TypeId`] for each local binding, keyed by the binding's
     /// defining [`SymbolKey`]. Populated alongside [`Self::local_symbols`]
@@ -84,13 +102,18 @@ pub(crate) struct AnnotateState {
     /// `let x = 1` can render the inferred `: i32` annotation without
     /// reaching into TIR (which is `pub(crate)` and mixes resolver-synth
     /// temporaries into the local namespace).
+    // MIGRATION: → ModuleSemantics::types (TypeId per binding-AstId fits the
+    //   "per-`AstId` type annotations" rule). LSP consumer
+    //   `Semantics::local_type_name` hides the placement.
     pub(crate) local_types: Rc<RefCell<IndexMap<SymbolKey, TypeId>>>,
     /// Kiln invocation redirects consulted by `resolve_import` call sites
     /// when walking `use` declarations. Populated from [`crate::loader::LoadResult`].
+    // MIGRATION: cross-cutting input (loader-provided redirect map).
     pub(crate) invocations: Rc<crate::kiln::InvocationIndex>,
     /// `ModuleSource` interner shared across phases. `Rc<RefCell<>>` so
     /// `&self` elaborator methods can `borrow_mut()` it when constructing
     /// new module sources during name resolution.
+    // MIGRATION: cross-cutting input (shared interner).
     pub(crate) interner: Rc<RefCell<ModuleSourceInterner>>,
 }
 

--- a/wado-compiler/src/elaborator/orchestration.rs
+++ b/wado-compiler/src/elaborator/orchestration.rs
@@ -38,11 +38,11 @@ use crate::tir::{ResolvedType, TirModule, TypeId, TypeTable};
 
 use super::Elaborator;
 use super::trait_env::TraitEnv;
-use super::tysys::TypeSystem;
 use super::types::{
     EnumCaseData, EnumInfo, FlagsInfo, FlagsMemberData, GenericNewtypeInfo, ResourceInfo,
     StructFieldInfo, TypeError, TypeLookup, VariantCaseData, VariantInfo,
 };
+use super::tysys::TypeSystem;
 
 /// Analysis state produced by [`Elaborator::annotate_modules`] and consumed by
 /// [`Elaborator::build_tir_from_state`].

--- a/wado-compiler/src/elaborator/sem.rs
+++ b/wado-compiler/src/elaborator/sem.rs
@@ -1,0 +1,53 @@
+//! [`ModuleSemantics`] — per-module semantic facts produced by the elaborator.
+//!
+//! Stage 1 skeleton introduced by
+//! [`wep-2026-05-26-elaborator-rearchitecture.md`]. The four sub-structs
+//! are empty at this stage; the migration plan populates them across
+//! stages 3-5 by moving fields off [`super::Elaborator`] and
+//! [`super::orchestration::AnnotateState`].
+//!
+//! # Future ownership (per the WEP)
+//!
+//! One instance per loaded module, owned by [`crate::semantics::Semantics`]
+//! in an `IndexMap<ModuleSource, ModuleSemantics>`. `annotate_bodies` takes
+//! `&mut ModuleSemantics` for the module it is processing; every other phase
+//! (including `reify`) takes `&ModuleSemantics`.
+//!
+//! # Decomposition
+//!
+//! Membership is split into four sub-structs with explicit responsibility
+//! rules. Each sub-struct lives in its own file because the
+//! "does this fit the sub-struct's responsibility?" question is what gates
+//! adding a new field; a single file per rule keeps the question reviewable.
+//!
+//! - [`bindings::ModuleBindings`] — `use → def` edges and locally defined
+//!   symbols (the data the LSP reads to answer go-to-definition,
+//!   find-references, and hover-on-local).
+//! - [`imports::ModuleImports`] — per-module name resolution context derived
+//!   from `use` declarations.
+//! - [`types::TypeAnnotations`] — per-[`crate::ast::AstId`] type annotations
+//!   and dispatch decisions recorded during the body walk; consumed by
+//!   `reify`.
+//! - [`decls::ModuleDecls`] — module-internal declarations confirmed by
+//!   elaboration.
+
+pub(crate) mod bindings;
+pub(crate) mod decls;
+pub(crate) mod imports;
+pub(crate) mod types;
+
+pub(crate) use bindings::ModuleBindings;
+pub(crate) use decls::ModuleDecls;
+pub(crate) use imports::ModuleImports;
+pub(crate) use types::TypeAnnotations;
+
+#[expect(
+    dead_code,
+    reason = "Stage 1 skeleton; populated by stages 3-5 of the elaborator re-architecture."
+)]
+pub(crate) struct ModuleSemantics {
+    pub(crate) bindings: ModuleBindings,
+    pub(crate) imports: ModuleImports,
+    pub(crate) types: TypeAnnotations,
+    pub(crate) decls: ModuleDecls,
+}

--- a/wado-compiler/src/elaborator/sem/bindings.rs
+++ b/wado-compiler/src/elaborator/sem/bindings.rs
@@ -1,0 +1,35 @@
+//! [`ModuleBindings`] — `use → def` edges and locally defined symbols.
+//!
+//! Stage 1 skeleton introduced by
+//! [`wep-2026-05-26-elaborator-rearchitecture.md`]. Empty at this stage.
+//!
+//! # Membership rule
+//!
+//! Add a field here when it answers a question the LSP poses for
+//! go-to-definition, find-references, or hover-on-local — and only when
+//! that question depends on a use-site / def-site pair within a single
+//! module. Per-`AstId` type facts go to [`super::types::TypeAnnotations`],
+//! not here.
+//!
+//! # Planned contents
+//!
+//! - **`references`** — `(module, IdentExpr.id) → (module, defining AstId)`.
+//!   Populated by `resolve_ident` / `resolve_call` / etc. as the body walk
+//!   reaches each identifier. Today lives on
+//!   [`super::super::Elaborator::references`] (shared via `Rc<RefCell<…>>`
+//!   with [`super::super::orchestration::AnnotateState::references`]).
+//! - **`local_symbols`** — locally-defined [`crate::symbol::Symbol`]s
+//!   (let bindings, parameters, closure parameters) keyed by the binding's
+//!   defining [`crate::symbol::SymbolKey`]. Today lives on
+//!   [`super::super::Elaborator::local_symbols`] (shared via
+//!   `Rc<RefCell<…>>` with
+//!   [`super::super::orchestration::AnnotateState::local_symbols`]).
+//!
+//! # Planned API
+//!
+//! - `record_reference(use_id, def_id)`
+//! - `record_local_symbol(def_id, symbol)`
+//! - Reference-resolution helpers used by `Semantics::referenced_symbol`
+//!   and `Semantics::references_to_def`.
+
+pub(crate) struct ModuleBindings {}

--- a/wado-compiler/src/elaborator/sem/decls.rs
+++ b/wado-compiler/src/elaborator/sem/decls.rs
@@ -1,0 +1,70 @@
+//! [`ModuleDecls`] — module-internal declarations confirmed by elaboration.
+//!
+//! Stage 1 skeleton introduced by
+//! [`wep-2026-05-26-elaborator-rearchitecture.md`]. Empty at this stage.
+//!
+//! # Membership rule
+//!
+//! Add a field here when it summarises a *declaration* in this module
+//! after elaboration has resolved its signature: function return types,
+//! generic parameter tables, global variable types, associated constants,
+//! synthesised structures. If the fact is a *use-site* decision
+//! (annotation on an [`crate::ast::AstId`]) it belongs in
+//! [`super::types::TypeAnnotations`]; if it is an *import* fact derived
+//! from a `use` declaration it belongs in [`super::imports::ModuleImports`].
+//!
+//! # Planned contents
+//!
+//! Function / global tables:
+//!
+//! - **`function_return_types`** — `func_name → return TypeId` for
+//!   functions defined in this module. Today on
+//!   [`super::super::Elaborator::function_return_types`].
+//! - **`imported_functions`** — names visible via `use`. Today on
+//!   [`super::super::Elaborator::imported_functions`].
+//! - **`current_module_globals`** — `name → (TypeId, is_mut)` for globals
+//!   declared in this module. Today on
+//!   [`super::super::Elaborator::current_module_globals`].
+//! - **`imported_globals`** — `local_name → (source, original_name, TypeId,
+//!   is_mut)` for globals brought in by `use`. Today on
+//!   [`super::super::Elaborator::imported_globals`].
+//! - **`associated_constants`** — `"Type::CONST" → (ast::Type, ast::Expr)`,
+//!   inlined at every use site during resolution. Today on
+//!   [`super::super::Elaborator::associated_constants`].
+//!
+//! Generic-parameter tables (the elaborator's resolution memo for generic
+//! functions / methods / structs):
+//!
+//! - **`generic_struct_names`** — Today on
+//!   [`super::super::Elaborator::generic_struct_names`].
+//! - **`generic_function_params`**,
+//!   **`generic_function_resolved_param_types`**,
+//!   **`generic_function_resolved_return_types`** — Today on the
+//!   corresponding [`super::super::Elaborator`] fields.
+//! - **`generic_method_params`**,
+//!   **`generic_method_resolved_param_types`** — Today on the
+//!   corresponding [`super::super::Elaborator`] fields.
+//!
+//! Per-module local additions to the cross-module decl tables (anonymous
+//! structs synthesised from struct literals, and any decl the elaborator
+//! discovered while walking this module):
+//!
+//! - **`pending_anonymous_structs`** — Today on
+//!   [`super::super::Elaborator::pending_anonymous_structs`]; flushed into
+//!   the [`crate::tir::TirModule`] at the end of `resolve_module`.
+//! - **`local_struct_fields`**, **`local_newtypes`**,
+//!   **`local_generic_newtypes`**, **`local_enum_cases`**,
+//!   **`local_flags_cases`**, **`local_variant_cases`** — Today on the
+//!   corresponding [`super::super::Elaborator`] fields. Stage 2/3 will
+//!   revisit whether these stay here or graduate into
+//!   [`super::super::tysys::TypeSystem`] as a per-module view.
+//!
+//! # Planned API
+//!
+//! - `function_return_type(name) -> Option<TypeId>`
+//! - `generic_function_params(name) -> Option<&[…]>`, …
+//! - `imported_global(name) -> Option<&ImportedGlobal>`
+//! - `associated_constant(key) -> Option<&(ast::Type, ast::Expr)>`
+//! - `pending_anonymous_structs()` drain.
+
+pub(crate) struct ModuleDecls {}

--- a/wado-compiler/src/elaborator/sem/imports.rs
+++ b/wado-compiler/src/elaborator/sem/imports.rs
@@ -1,0 +1,36 @@
+//! [`ModuleImports`] — per-module name resolution context derived from
+//! `use` declarations.
+//!
+//! Stage 1 skeleton introduced by
+//! [`wep-2026-05-26-elaborator-rearchitecture.md`]. Empty at this stage.
+//!
+//! # Membership rule
+//!
+//! Add a field here when it carries a fact derived from this module's
+//! `use` declarations (or its local declarations that participate in
+//! same-name resolution, like `interface` / `resource`). If the fact is
+//! the canonicalisation of an *imported* name to its *declaring* module,
+//! it belongs here. If the fact is a *local* declaration's body, it
+//! belongs in [`super::decls::ModuleDecls`].
+//!
+//! # Planned contents
+//!
+//! - **`imported_type_sources`** — `local_name → defining ModuleSource`,
+//!   from `use { Foo as Bar } from "..."`. Today on
+//!   [`super::super::Elaborator::imported_type_sources`].
+//! - **`import_original_names`** — `local_name → original_decl_name`, so
+//!   aliased imports canonicalise to their original declaration name.
+//!   Today on [`super::super::Elaborator::import_original_names`].
+//! - **`namespace_imports`** — namespace-alias map (`use helper from "..."`).
+//!   Today on [`super::super::Elaborator::namespace_imports`].
+//! - **`effect_sources`** — effect name → module-source map built from
+//!   import declarations and local `interface` / `resource` declarations.
+//!   Today on [`super::super::Elaborator::effect_sources`].
+//!
+//! # Planned API
+//!
+//! - `lookup(local_name) -> Option<ModuleSource>`
+//! - `canonical_decl_key(name) -> (ModuleSource, String)`
+//! - effect-source map / namespace-alias map accessors.
+
+pub(crate) struct ModuleImports {}

--- a/wado-compiler/src/elaborator/sem/types.rs
+++ b/wado-compiler/src/elaborator/sem/types.rs
@@ -1,0 +1,50 @@
+//! [`TypeAnnotations`] — per-[`crate::ast::AstId`] type annotations and
+//! dispatch decisions recorded during the body walk.
+//!
+//! Stage 1 skeleton introduced by
+//! [`wep-2026-05-26-elaborator-rearchitecture.md`]. Empty at this stage.
+//!
+//! # Membership rule
+//!
+//! Add a field here when it stores a fact keyed by an [`crate::ast::AstId`]
+//! (or [`crate::symbol::SymbolKey`]) produced as a *decision* by the
+//! body-level elaborator: the resolved type of an expression, the chosen
+//! method dispatch target, the chosen coercion, the desugar kind of a
+//! TIR-direct rewrite. This is what [`super::super::reify`] (Stage 5) reads
+//! in lieu of re-running inference.
+//!
+//! Facts that derive purely from the AST (spans, position lookup) belong
+//! on [`crate::ast_index::AstIndex`], not here. Decl-level facts (function
+//! return types, generic-parameter tables) belong on
+//! [`super::decls::ModuleDecls`].
+//!
+//! # Planned contents
+//!
+//! New facts introduced by Stage 4 — none of these exist on the current
+//! [`super::super::Elaborator`] yet:
+//!
+//! - The [`crate::tir::TypeId`] of every typed expression.
+//! - The resolved target of each method call (impl block + method name).
+//! - The chosen coercion at each conversion site.
+//! - The desugar kind for each TIR-direct rewrite (`assert`, `matches`,
+//!   comparison chain, for-of, while, compound assignment).
+//!
+//! Existing fields migrating in from [`super::super::Elaborator`]:
+//!
+//! - **`local_types`** — [`crate::tir::TypeId`] for each local binding,
+//!   keyed by the binding's defining [`crate::symbol::SymbolKey`]. Today
+//!   on [`super::super::Elaborator::local_types`] (shared via
+//!   `Rc<RefCell<…>>` with
+//!   [`super::super::orchestration::AnnotateState::local_types`]). Consumed
+//!   by LSP inlay hints via [`crate::semantics::Semantics::local_type_name`]
+//!   — the consumer API layer hides the placement, so moving this here
+//!   does not affect LSP callers.
+//!
+//! # Planned API
+//!
+//! - `set(ast_id, type_id)` / `get(ast_id) -> Option<TypeId>`
+//! - `dispatch_target(ast_id) -> Option<MethodTarget>`
+//! - `coercion_at(ast_id) -> Option<Coercion>`
+//! - `desugar_kind(ast_id) -> Option<DesugarKind>`
+
+pub(crate) struct TypeAnnotations {}

--- a/wado-compiler/src/elaborator/stmt.rs
+++ b/wado-compiler/src/elaborator/stmt.rs
@@ -161,7 +161,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 let expected = expected_elem_types.get(i).copied();
                                 let resolved = self.resolve_expr(elem, ctx, expected);
                                 if let Some(expected_type) = expected {
-                                    self.typecheck(resolved.type_id, expected_type, elem.span());
+                                    self.tysys.typecheck(self.logger, resolved.type_id, expected_type, elem.span());
                                 }
                                 resolved
                             })
@@ -953,7 +953,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Check return value type matches function return type
         if let Some(value) = &value {
-            self.typecheck_return(value.type_id, return_type, ret_stmt.span);
+            self.tysys.typecheck_return(self.logger, value.type_id, return_type, ret_stmt.span);
         }
 
         TirStmt::new(TirStmtKind::Return { value }, ret_stmt.span)

--- a/wado-compiler/src/elaborator/stmt.rs
+++ b/wado-compiler/src/elaborator/stmt.rs
@@ -151,7 +151,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // Special case: tuple literal with Tuple type annotation
             if let ast::Expr::TupleLiteral(tuple_lit) = ast_value {
                 {
-                    let tuple_elems = self.type_table.borrow().as_tuple(target_type);
+                    let tuple_elems = self.tysys.type_table.borrow().as_tuple(target_type);
                     if let Some(expected_elem_types) = tuple_elems {
                         let elements: Vec<TirExpr> = tuple_lit
                             .elements
@@ -194,7 +194,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 // Handle implicit struct literal: let p: Point = { x: 1, y: 2 }
                 if struct_lit.name.is_none() {
                     // Check if target type is a struct
-                    let target_resolved = self.type_table.borrow().get(target_type).clone();
+                    let target_resolved = self.tysys.type_table.borrow().get(target_type).clone();
                     if let ResolvedType::Struct {
                         name,
                         module_source,
@@ -273,7 +273,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         (coerced, target_type)
                     } else {
                         // Target type does not implement KeyValueLiteral
-                        let type_name = self.type_table.borrow().type_name(target_type);
+                        let type_name = self.tysys.type_table.borrow().type_name(target_type);
                         let _ = self.logger.error(TypeError::MissingTraitImpl {
                             type_name,
                             trait_name: "KeyValueLiteral".to_string(),
@@ -309,7 +309,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         {
             // Allow null (Option<unknown>) to be assigned to Option<T>
             let is_null_to_option = {
-                let type_table = self.type_table.borrow();
+                let type_table = self.tysys.type_table.borrow();
                 type_table
                     .as_option(value.type_id)
                     .is_some_and(|inner| inner == TypeTable::UNKNOWN)
@@ -327,7 +327,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // accepts identical generic shapes that differ only in effects
             // without admitting any type-param-to-concrete mismatches.
             let is_compatible_fn_type = {
-                let type_table = self.type_table.borrow();
+                let type_table = self.tysys.type_table.borrow();
                 if let (
                     ResolvedType::Function {
                         params: actual_params,
@@ -359,8 +359,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             };
             if !is_null_to_option && !is_compatible_fn_type {
                 let _ = self.logger.error(TypeError::TypeMismatch {
-                    expected: self.type_table.borrow().type_name(type_id),
-                    found: self.type_table.borrow().type_name(value.type_id),
+                    expected: self.tysys.type_table.borrow().type_name(type_id),
+                    found: self.tysys.type_table.borrow().type_name(value.type_id),
                     span: ast_value.span(),
                 });
             }
@@ -587,7 +587,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         if !self.pattern_qualifier_matches_scrutinee(type_id, qualifier) {
             return false;
         }
-        let resolved = self.type_table.borrow().get(type_id).clone();
+        let resolved = self.tysys.type_table.borrow().get(type_id).clone();
         match &resolved {
             ResolvedType::Enum { name, .. } => self
                 .lookup_enum_case(name)
@@ -610,7 +610,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let Some(qualifier) = qualifier else {
             return true;
         };
-        let scrutinee_resolved = self.type_table.borrow().get(scrutinee_type).clone();
+        let scrutinee_resolved = self.tysys.type_table.borrow().get(scrutinee_type).clone();
         let (scrutinee_name, scrutinee_module, scrutinee_arg_len) = match &scrutinee_resolved {
             ResolvedType::Enum {
                 name,
@@ -697,7 +697,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 let mut current = type_id;
                 let mut rb = RefBinding::None;
                 while let resolved @ (ResolvedType::Ref(_) | ResolvedType::MutRef(_)) =
-                    self.type_table.borrow().get(current).clone()
+                    self.tysys.type_table.borrow().get(current).clone()
                 {
                     match resolved {
                         ResolvedType::Ref(inner) => {
@@ -743,11 +743,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 let pat_mut = is_mut || matches!(pattern, ast::Pattern::MutIdent { .. });
                 let binding_type = match ref_binding {
                     RefBinding::Ref => self
-                        .type_table
+                        .tysys.type_table
                         .borrow_mut()
                         .intern(ResolvedType::Ref(type_id)),
                     RefBinding::MutRef => self
-                        .type_table
+                        .tysys.type_table
                         .borrow_mut()
                         .intern(ResolvedType::MutRef(type_id)),
                     RefBinding::None => type_id,
@@ -763,7 +763,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             ast::Pattern::Tuple(patterns, has_rest) => {
                 // Get element types from the tuple type
                 let elem_types = {
-                    let type_table = self.type_table.borrow();
+                    let type_table = self.tysys.type_table.borrow();
                     if let Some(elem_types) = type_table.as_tuple(type_id) {
                         elem_types
                     } else {
@@ -817,7 +817,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             } => {
                 // Get struct name from type
                 let struct_name = {
-                    let type_table = self.type_table.borrow();
+                    let type_table = self.tysys.type_table.borrow();
                     match type_table.get(type_id) {
                         ResolvedType::Struct { name, .. } => Some(name.clone()),
                         _ => None,
@@ -837,7 +837,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     if actual_short != expected_short {
                         let _ = self.logger.error(TypeError::PatternTypeMismatch {
                             expected: expected_name.clone(),
-                            found: self.type_table.borrow().type_name(type_id),
+                            found: self.tysys.type_table.borrow().type_name(type_id),
                             span: *pat_span,
                         });
                     }
@@ -846,7 +846,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 if struct_name.is_none() {
                     let _ = self.logger.error(TypeError::PatternTypeMismatch {
                         expected: "struct type".to_string(),
-                        found: self.type_table.borrow().type_name(type_id),
+                        found: self.tysys.type_table.borrow().type_name(type_id),
                         span: *pat_span,
                     });
                     return TirPattern::Wildcard;
@@ -1208,7 +1208,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let mut peeled_type = scrutinee_type;
         let mut ref_binding = RefBinding::None;
         while let resolved @ (ResolvedType::Ref(_) | ResolvedType::MutRef(_)) =
-            self.type_table.borrow().get(peeled_type).clone()
+            self.tysys.type_table.borrow().get(peeled_type).clone()
         {
             match resolved {
                 ResolvedType::Ref(inner) => {
@@ -1309,11 +1309,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 let is_mut = matches!(pattern, Pattern::MutIdent { .. });
                 let binding_type = match ref_binding {
                     RefBinding::Ref => self
-                        .type_table
+                        .tysys.type_table
                         .borrow_mut()
                         .intern(ResolvedType::Ref(scrutinee_type)),
                     RefBinding::MutRef => self
-                        .type_table
+                        .tysys.type_table
                         .borrow_mut()
                         .intern(ResolvedType::MutRef(scrutinee_type)),
                     RefBinding::None => scrutinee_type,
@@ -1340,7 +1340,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         }
                         // Check if scrutinee type is unsigned
                         let scrutinee_resolved =
-                            self.type_table.borrow().get(scrutinee_type).clone();
+                            self.tysys.type_table.borrow().get(scrutinee_type).clone();
                         let is_unsigned = matches!(
                             scrutinee_resolved,
                             ResolvedType::Primitive(
@@ -1388,12 +1388,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             Pattern::Tuple(patterns, has_rest) => {
                 // For tuple patterns, extract element types
                 let element_types =
-                    if let Some(types) = self.type_table.borrow().as_tuple(scrutinee_type) {
+                    if let Some(types) = self.tysys.type_table.borrow().as_tuple(scrutinee_type) {
                         types
                     } else {
                         let _ = self.logger.error(TypeError::PatternTypeMismatch {
                             expected: "tuple type".to_string(),
-                            found: self.type_table.borrow().type_name(scrutinee_type),
+                            found: self.tysys.type_table.borrow().type_name(scrutinee_type),
                             span,
                         });
                         vec![TypeTable::UNKNOWN; patterns.len()]
@@ -1454,7 +1454,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         match &resolved.kind {
                             TirExprKind::IntLiteral { repr, .. } => {
                                 let scrutinee_resolved =
-                                    self.type_table.borrow().get(scrutinee_type).clone();
+                                    self.tysys.type_table.borrow().get(scrutinee_type).clone();
                                 let is_unsigned = matches!(
                                     scrutinee_resolved,
                                     ResolvedType::Primitive(
@@ -1491,11 +1491,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
                     let binding_type = match ref_binding {
                         RefBinding::Ref => self
-                            .type_table
+                            .tysys.type_table
                             .borrow_mut()
                             .intern(ResolvedType::Ref(scrutinee_type)),
                         RefBinding::MutRef => self
-                            .type_table
+                            .tysys.type_table
                             .borrow_mut()
                             .intern(ResolvedType::MutRef(scrutinee_type)),
                         RefBinding::None => scrutinee_type,
@@ -1509,7 +1509,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     };
                 }
 
-                let resolved_type = self.type_table.borrow().get(scrutinee_type).clone();
+                let resolved_type = self.tysys.type_table.borrow().get(scrutinee_type).clone();
                 if !self
                     .pattern_qualifier_matches_scrutinee(scrutinee_type, variant_qualifier.as_ref())
                 {
@@ -1694,7 +1694,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             } => {
                 // Verify type if named
                 if let Some(expected_name) = type_name {
-                    let resolved = self.type_table.borrow().get(scrutinee_type).clone();
+                    let resolved = self.tysys.type_table.borrow().get(scrutinee_type).clone();
                     if let ResolvedType::Struct { ref name, .. } = resolved {
                         let expected_short = self
                             .strip_ns_prefix(expected_name)
@@ -1703,7 +1703,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         if actual_short != expected_short {
                             let _ = self.logger.error(TypeError::PatternTypeMismatch {
                                 expected: expected_name.clone(),
-                                found: self.type_table.borrow().type_name(scrutinee_type),
+                                found: self.tysys.type_table.borrow().type_name(scrutinee_type),
                                 span: *pat_span,
                             });
                         }
@@ -1731,7 +1731,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 // Exhaustiveness check
                 if !has_rest {
                     let struct_name = {
-                        let type_table = self.type_table.borrow();
+                        let type_table = self.tysys.type_table.borrow();
                         match type_table.get(scrutinee_type) {
                             ResolvedType::Struct { name, .. } => Some(name.clone()),
                             _ => None,
@@ -1875,7 +1875,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// If the scrutinee is a variant type that has a `None` case, return
     /// a `TirPattern::Variant` for `None`. Otherwise return `None`.
     fn try_null_as_none_pattern(&self, scrutinee_type: TypeId) -> Option<TirPattern> {
-        let resolved = self.type_table.borrow().get(scrutinee_type).clone();
+        let resolved = self.tysys.type_table.borrow().get(scrutinee_type).clone();
         let variant_name = match &resolved {
             ResolvedType::Variant { name, .. } => Some(name.clone()),
             ResolvedType::GenericInstance { name, .. } if self.contains_variant(name) => {
@@ -1885,7 +1885,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }?;
         let variant_info = self.lookup_variant_case(&variant_name)?;
         let none_case_name = self
-            .type_table
+            .tysys.type_table
             .borrow()
             .compiler_items()
             .variant_case_name(crate::compiler_item::CompilerItem::OptionNone)
@@ -1911,7 +1911,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         scrutinee_type: TypeId,
         span: Span,
     ) -> TirPattern {
-        let scrutinee_resolved = self.type_table.borrow().get(scrutinee_type).clone();
+        let scrutinee_resolved = self.tysys.type_table.borrow().get(scrutinee_type).clone();
         let is_unsigned = matches!(
             scrutinee_resolved,
             ResolvedType::Primitive(
@@ -2109,7 +2109,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Check if it's a tuple type
         let tuple_info = {
-            let type_table = self.type_table.borrow();
+            let type_table = self.tysys.type_table.borrow();
             if let Some(elems) = type_table.as_tuple(iterable_type_id) {
                 let has_type_pack = elems
                     .iter()
@@ -2138,18 +2138,18 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // Check that the iterable type implements IntoIterator
             let mut inner_type_id = iterable_type_id;
             while let ResolvedType::Ref(t) | ResolvedType::MutRef(t) =
-                self.type_table.borrow().get(inner_type_id).clone()
+                self.tysys.type_table.borrow().get(inner_type_id).clone()
             {
                 inner_type_id = t;
             }
             if !self.type_implements_trait(iterable_type_id, "IntoIterator")
                 && !self.type_implements_trait(inner_type_id, "IntoIterator")
                 && !matches!(
-                    self.type_table.borrow().get(iterable_type_id),
+                    self.tysys.type_table.borrow().get(iterable_type_id),
                     ResolvedType::Unknown | ResolvedType::TypeParam { .. }
                 )
             {
-                let type_name = self.type_table.borrow().type_name(iterable_type_id);
+                let type_name = self.tysys.type_table.borrow().type_name(iterable_type_id);
                 let _ = self.logger.error(TypeError::MissingTraitImpl {
                     type_name,
                     trait_name: "IntoIterator".to_string(),
@@ -2205,7 +2205,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // For direct TypePack: iterable is Tuple([TypePack{T}]), binding type is TypePack.
         // For TupleZip: iterable is Tuple([Tuple([TypePack, TypePack])]), binding type is the inner tuple.
         let binding_type = {
-            let type_table = self.type_table.borrow();
+            let type_table = self.tysys.type_table.borrow();
             if let Some(elems) = type_table.as_tuple(iterable.type_id) {
                 // Prefer a direct TypePack element
                 if let Some(tp) = elems
@@ -2249,7 +2249,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let mut destruct_stmts = Vec::new();
         if is_destructured && let crate::ast::Pattern::Tuple(tp, _) = &for_of.binding {
             let inner_elems = self
-                .type_table
+                .tysys.type_table
                 .borrow()
                 .as_tuple(binding_type)
                 .unwrap_or_else(|| vec![binding_type]);
@@ -2396,7 +2396,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     span,
                 );
                 let enum_tuple_type = self
-                    .type_table
+                    .tysys.type_table
                     .borrow_mut()
                     .make_tuple(vec![i32_type, elem_type]);
                 let enum_tuple = TirExpr::new(
@@ -2582,11 +2582,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // surface error.
         if !self.type_implements_trait(iter_type, "Iterator")
             && !matches!(
-                self.type_table.borrow().get(iter_type),
+                self.tysys.type_table.borrow().get(iter_type),
                 ResolvedType::Unknown | ResolvedType::TypeParam { .. }
             )
         {
-            let type_name = self.type_table.borrow().type_name(iter_type);
+            let type_name = self.tysys.type_table.borrow().type_name(iter_type);
             let _ = self.logger.error(TypeError::MissingTraitImpl {
                 type_name,
                 trait_name: "Iterator".to_string(),
@@ -2648,7 +2648,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // `Some` token has no source position, so giving it one would be
         // misleading.
         let some_case_name = self
-            .type_table
+            .tysys.type_table
             .borrow()
             .compiler_items()
             .variant_case_name(crate::compiler_item::CompilerItem::OptionSome)
@@ -2657,7 +2657,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // for the binding scrutinee. Bind out of the borrow first so the
         // `get_variant_case_payload_type` call below can re-borrow `&mut self`.
         let option_shape: Option<(String, Vec<TypeId>)> =
-            match self.type_table.borrow().get(option_type).clone() {
+            match self.tysys.type_table.borrow().get(option_type).clone() {
                 ResolvedType::GenericInstance {
                     name, type_args, ..
                 } if self.contains_variant(&name) => Some((name, type_args)),

--- a/wado-compiler/src/elaborator/stmt.rs
+++ b/wado-compiler/src/elaborator/stmt.rs
@@ -161,12 +161,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 let expected = expected_elem_types.get(i).copied();
                                 let resolved = self.resolve_expr(elem, ctx, expected);
                                 if let Some(expected_type) = expected {
-                                    self.tysys.typecheck(
-                                        self.logger,
-                                        resolved.type_id,
-                                        expected_type,
-                                        elem.span(),
-                                    );
+                                    self.typecheck(resolved.type_id, expected_type, elem.span());
                                 }
                                 resolved
                             })
@@ -960,8 +955,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Check return value type matches function return type
         if let Some(value) = &value {
-            self.tysys
-                .typecheck_return(self.logger, value.type_id, return_type, ret_stmt.span);
+            self.typecheck_return(value.type_id, return_type, ret_stmt.span);
         }
 
         TirStmt::new(TirStmtKind::Return { value }, ret_stmt.span)

--- a/wado-compiler/src/elaborator/stmt.rs
+++ b/wado-compiler/src/elaborator/stmt.rs
@@ -161,7 +161,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 let expected = expected_elem_types.get(i).copied();
                                 let resolved = self.resolve_expr(elem, ctx, expected);
                                 if let Some(expected_type) = expected {
-                                    self.tysys.typecheck(self.logger, resolved.type_id, expected_type, elem.span());
+                                    self.tysys.typecheck(
+                                        self.logger,
+                                        resolved.type_id,
+                                        expected_type,
+                                        elem.span(),
+                                    );
                                 }
                                 resolved
                             })
@@ -743,11 +748,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 let pat_mut = is_mut || matches!(pattern, ast::Pattern::MutIdent { .. });
                 let binding_type = match ref_binding {
                     RefBinding::Ref => self
-                        .tysys.type_table
+                        .tysys
+                        .type_table
                         .borrow_mut()
                         .intern(ResolvedType::Ref(type_id)),
                     RefBinding::MutRef => self
-                        .tysys.type_table
+                        .tysys
+                        .type_table
                         .borrow_mut()
                         .intern(ResolvedType::MutRef(type_id)),
                     RefBinding::None => type_id,
@@ -953,7 +960,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Check return value type matches function return type
         if let Some(value) = &value {
-            self.tysys.typecheck_return(self.logger, value.type_id, return_type, ret_stmt.span);
+            self.tysys
+                .typecheck_return(self.logger, value.type_id, return_type, ret_stmt.span);
         }
 
         TirStmt::new(TirStmtKind::Return { value }, ret_stmt.span)
@@ -1309,11 +1317,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 let is_mut = matches!(pattern, Pattern::MutIdent { .. });
                 let binding_type = match ref_binding {
                     RefBinding::Ref => self
-                        .tysys.type_table
+                        .tysys
+                        .type_table
                         .borrow_mut()
                         .intern(ResolvedType::Ref(scrutinee_type)),
                     RefBinding::MutRef => self
-                        .tysys.type_table
+                        .tysys
+                        .type_table
                         .borrow_mut()
                         .intern(ResolvedType::MutRef(scrutinee_type)),
                     RefBinding::None => scrutinee_type,
@@ -1491,11 +1501,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
                     let binding_type = match ref_binding {
                         RefBinding::Ref => self
-                            .tysys.type_table
+                            .tysys
+                            .type_table
                             .borrow_mut()
                             .intern(ResolvedType::Ref(scrutinee_type)),
                         RefBinding::MutRef => self
-                            .tysys.type_table
+                            .tysys
+                            .type_table
                             .borrow_mut()
                             .intern(ResolvedType::MutRef(scrutinee_type)),
                         RefBinding::None => scrutinee_type,
@@ -1885,7 +1897,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }?;
         let variant_info = self.lookup_variant_case(&variant_name)?;
         let none_case_name = self
-            .tysys.type_table
+            .tysys
+            .type_table
             .borrow()
             .compiler_items()
             .variant_case_name(crate::compiler_item::CompilerItem::OptionNone)
@@ -2249,7 +2262,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let mut destruct_stmts = Vec::new();
         if is_destructured && let crate::ast::Pattern::Tuple(tp, _) = &for_of.binding {
             let inner_elems = self
-                .tysys.type_table
+                .tysys
+                .type_table
                 .borrow()
                 .as_tuple(binding_type)
                 .unwrap_or_else(|| vec![binding_type]);
@@ -2396,7 +2410,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     span,
                 );
                 let enum_tuple_type = self
-                    .tysys.type_table
+                    .tysys
+                    .type_table
                     .borrow_mut()
                     .make_tuple(vec![i32_type, elem_type]);
                 let enum_tuple = TirExpr::new(
@@ -2648,7 +2663,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // `Some` token has no source position, so giving it one would be
         // misleading.
         let some_case_name = self
-            .tysys.type_table
+            .tysys
+            .type_table
             .borrow()
             .compiler_items()
             .variant_case_name(crate::compiler_item::CompilerItem::OptionSome)

--- a/wado-compiler/src/elaborator/trait_env.rs
+++ b/wado-compiler/src/elaborator/trait_env.rs
@@ -994,7 +994,8 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             };
             let (type_id, consumed_index) = if tp.is_pack {
                 (
-                    self.tysys.type_table
+                    self.tysys
+                        .type_table
                         .borrow_mut()
                         .make_type_pack(tp.name.clone(), idx),
                     true,
@@ -1003,7 +1004,8 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                 (self.resolve_type(&ast::Type::Function(sig.clone())), false)
             } else {
                 (
-                    self.tysys.type_table
+                    self.tysys
+                        .type_table
                         .borrow_mut()
                         .make_type_param(tp.name.clone(), idx),
                     true,

--- a/wado-compiler/src/elaborator/trait_env.rs
+++ b/wado-compiler/src/elaborator/trait_env.rs
@@ -994,7 +994,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             };
             let (type_id, consumed_index) = if tp.is_pack {
                 (
-                    self.type_table
+                    self.tysys.type_table
                         .borrow_mut()
                         .make_type_pack(tp.name.clone(), idx),
                     true,
@@ -1003,7 +1003,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                 (self.resolve_type(&ast::Type::Function(sig.clone())), false)
             } else {
                 (
-                    self.type_table
+                    self.tysys.type_table
                         .borrow_mut()
                         .make_type_param(tp.name.clone(), idx),
                     true,

--- a/wado-compiler/src/elaborator/trait_query.rs
+++ b/wado-compiler/src/elaborator/trait_query.rs
@@ -24,7 +24,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // two modules with same-named traits never collide at the lookup
         // step.
         let canonical_key = self.canonical_decl_key(trait_name);
-        if let Some((module_src, item_idx)) = self.trait_env.decl_index.get(&canonical_key) {
+        if let Some((module_src, item_idx)) = self.tysys.trait_env.decl_index.get(&canonical_key) {
             let module = &self.loaded_modules[module_src];
             if let Item::Trait(trait_decl) = &module.items[*item_idx] {
                 return Some(trait_decl.methods.clone());
@@ -47,7 +47,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         trait_name: &str,
     ) -> Option<Vec<ast::GenericParam>> {
         let canonical_key = self.canonical_decl_key(trait_name);
-        if let Some((module_src, item_idx)) = self.trait_env.decl_index.get(&canonical_key) {
+        if let Some((module_src, item_idx)) = self.tysys.trait_env.decl_index.get(&canonical_key) {
             let module = &self.loaded_modules[module_src];
             if let Item::Trait(trait_decl) = &module.items[*item_idx] {
                 return Some(trait_decl.type_params.clone());
@@ -65,7 +65,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
     /// Check if a type implements a specific trait (for trait bound checking)
     pub(super) fn type_implements_trait(&self, type_id: TypeId, trait_name: &str) -> bool {
-        let resolved = self.type_table.borrow().get(type_id).clone();
+        let resolved = self.tysys.type_table.borrow().get(type_id).clone();
 
         // Recursion guard: if we're already checking this (type, trait) pair,
         // optimistically return true to break infinite recursion on recursive types.
@@ -106,7 +106,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // stay aligned with the actual stdlib decls (and a rename of
         // `Eq` / `Ord` / `Default` does not silently disable auto-impl).
         let (eq_name, ord_name, default_name) = {
-            let tt = self.type_table.borrow();
+            let tt = self.tysys.type_table.borrow();
             let items = tt.compiler_items();
             (
                 items.trait_name(CompilerItem::Eq).to_string(),
@@ -322,7 +322,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         type_args: Option<&[TypeId]>,
     ) -> bool {
         // Use pre-built index for O(1) lookup by type name.
-        if let Some(entries) = self.trait_env.impl_index.get(type_name) {
+        if let Some(entries) = self.tysys.trait_env.impl_index.get(type_name) {
             for (module_src, item_idx) in entries {
                 let module = &self.loaded_modules[module_src];
                 if let Item::Impl(impl_block) = &module.items[*item_idx]
@@ -355,7 +355,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Blanket impl fallback: check `impl<T: Bound> Trait for T` where the
         // concrete type satisfies the bound.
-        for (module_src, item_idx) in &self.trait_env.blanket_impl_index {
+        for (module_src, item_idx) in &self.tysys.trait_env.blanket_impl_index {
             let module = &self.loaded_modules[module_src];
             if let Item::Impl(impl_block) = &module.items[*item_idx]
                 && let Some(trait_type) = &impl_block.trait_type
@@ -400,7 +400,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let mut bindings = Vec::new();
         let Some(type_param_name) = self_type_param_name else {
             // Also handle AssocTypeProjection self_type: propagate bindings from its bindings
-            let resolved = self.type_table.borrow().get(self_type_id).clone();
+            let resolved = self.tysys.type_table.borrow().get(self_type_id).clone();
             if let ResolvedType::AssocTypeProjection {
                 assoc_type_bindings,
                 ..
@@ -514,7 +514,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 // associated type chains.
                 // Determine the TypeParam name for Self, if self_type is a TypeParam.
                 let self_type_param_name = {
-                    let resolved = scope.type_table.borrow().get(self_type_id).clone();
+                    let resolved = scope.tysys.type_table.borrow().get(self_type_id).clone();
                     if let ResolvedType::TypeParam { name, .. } = resolved {
                         Some(name)
                     } else {
@@ -525,7 +525,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     // Check if self_type has a direct assoc_type_binding for this name.
                     // This handles the case: self_type = I::Iter which has ("Item", u8_typeid).
                     let directly_bound = {
-                        let resolved = scope.type_table.borrow().get(self_type_id).clone();
+                        let resolved = scope.tysys.type_table.borrow().get(self_type_id).clone();
                         if let ResolvedType::AssocTypeProjection {
                             assoc_type_bindings,
                             ..
@@ -550,7 +550,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             self_type_param_name.as_deref(),
                             &assoc_decl.bounds,
                         );
-                        scope.type_table.borrow_mut().make_assoc_type_projection(
+                        scope.tysys.type_table.borrow_mut().make_assoc_type_projection(
                             self_type_id,
                             assoc_decl.name.clone(),
                             bound_names,
@@ -572,7 +572,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 let mut method_type_param_ids: Vec<TypeId> = Vec::new();
                 for (index, param) in method.type_params.iter().enumerate() {
                     let type_id = scope
-                        .type_table
+                        .tysys.type_table
                         .borrow_mut()
                         .make_type_param(param.name.clone(), index as u32);
                     scope
@@ -695,7 +695,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     // skip the bounds check. Within a bounded impl block, type params are assumed
                     // to satisfy bounds; concrete types are checked at call sites.
                     if matches!(
-                        self.type_table.borrow().get(type_arg),
+                        self.tysys.type_table.borrow().get(type_arg),
                         ResolvedType::TypeParam { .. }
                     ) {
                         continue;
@@ -713,7 +713,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             if let Some(bounds) = bounds_map.get(inner_name)
                 && let Some(&type_arg) = type_args.first()
                 && !matches!(
-                    self.type_table.borrow().get(type_arg),
+                    self.tysys.type_table.borrow().get(type_arg),
                     ResolvedType::TypeParam { .. }
                 )
             {
@@ -786,7 +786,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // but registration (below) still uses concrete_type_id so the monomorphizer can
         // resolve e.g. `MyBytes::Iter` when `MyBytes` is a newtype over `Array<u8>`.
         let (type_name, concrete_type_args) = {
-            let tt = self.type_table.borrow();
+            let tt = self.tysys.type_table.borrow();
             let effective_id = tt.get_ultimate_base_type(concrete_type_id);
             let array_name = tt
                 .compiler_items()
@@ -816,7 +816,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
         let impl_infos: Vec<ImplInfo> = {
             let mut result = vec![];
-            if let Some(entries) = self.trait_env.impl_index.get(&type_name) {
+            if let Some(entries) = self.tysys.trait_env.impl_index.get(&type_name) {
                 let entries = entries.clone();
                 for (module_src, item_idx) in entries {
                     let module = &self.loaded_modules[&module_src];
@@ -880,9 +880,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // Resolve and register each associated type in this substituted context
             for binding in &info.assoc_types {
                 let resolved_id = scope.resolve_type(&binding.ty);
-                if !scope.type_table.borrow().contains_type_param(resolved_id) {
+                if !scope.tysys.type_table.borrow().contains_type_param(resolved_id) {
                     scope
-                        .type_table
+                        .tysys.type_table
                         .borrow_mut()
                         .register_assoc_type_resolution(
                             concrete_type_id,
@@ -904,7 +904,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
         let blanket_infos: Vec<BlanketImplInfo> = {
             let mut result = vec![];
-            for (module_src, item_idx) in &self.trait_env.blanket_impl_index {
+            for (module_src, item_idx) in &self.tysys.trait_env.blanket_impl_index {
                 let module = &self.loaded_modules[module_src];
                 if let Item::Impl(impl_block) = &module.items[*item_idx]
                     && let Some(trait_type) = &impl_block.trait_type
@@ -953,9 +953,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // Resolve and register each associated type
             for binding in &info.assoc_types {
                 let resolved_id = scope.resolve_type(&binding.ty);
-                if !scope.type_table.borrow().contains_type_param(resolved_id) {
+                if !scope.tysys.type_table.borrow().contains_type_param(resolved_id) {
                     scope
-                        .type_table
+                        .tysys.type_table
                         .borrow_mut()
                         .register_assoc_type_resolution(
                             concrete_type_id,
@@ -1109,7 +1109,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // `output_type` to the receiver type when no `type Output` is
         // declared.
         let (eq_name, ord_name) = {
-            let tt = self.type_table.borrow();
+            let tt = self.tysys.type_table.borrow();
             let items = tt.compiler_items();
             (
                 items.trait_name(CompilerItem::Eq).to_string(),
@@ -1124,7 +1124,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             let return_type = if is_eq {
                 TypeTable::BOOL
             } else if is_ord {
-                self.type_table
+                self.tysys.type_table
                     .borrow_mut()
                     .make_compiler_enum(CompilerItem::Ordering)
             } else {
@@ -1134,13 +1134,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             (info.trait_name, info.self_kind, param_types, return_type)
         } else if (is_eq || is_ord) && self.type_implements_trait(lookup_type_id, trait_name) {
             let ref_self_ty = self
-                .type_table
+                .tysys.type_table
                 .borrow_mut()
                 .intern(ResolvedType::Ref(lookup_type_id));
             let return_type = if is_eq {
                 TypeTable::BOOL
             } else {
-                self.type_table
+                self.tysys.type_table
                     .borrow_mut()
                     .make_compiler_enum(CompilerItem::Ordering)
             };
@@ -1208,7 +1208,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         receiver_type_id: TypeId,
     ) -> Option<TraitMethodMatch> {
         let (eq_name, ord_name) = {
-            let tt = self.type_table.borrow();
+            let tt = self.tysys.type_table.borrow();
             let items = tt.compiler_items();
             (
                 items.trait_name(CompilerItem::Eq).to_string(),
@@ -1228,14 +1228,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             return None;
         }
         let ref_self_ty = self
-            .type_table
+            .tysys.type_table
             .borrow_mut()
             .intern(ResolvedType::Ref(base_type_id));
         let is_eq_match = trait_name == eq_name;
         let return_type = if is_eq_match {
             TypeTable::BOOL
         } else {
-            self.type_table
+            self.tysys.type_table
                 .borrow_mut()
                 .make_compiler_enum(CompilerItem::Ordering)
         };
@@ -1269,7 +1269,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// rather than a callable method.
     fn auto_derive_eligible_kind(&self, type_id: TypeId) -> bool {
         matches!(
-            self.type_table.borrow().get(type_id),
+            self.tysys.type_table.borrow().get(type_id),
             ResolvedType::Struct { .. }
                 | ResolvedType::Variant { .. }
                 | ResolvedType::Enum { .. }

--- a/wado-compiler/src/elaborator/trait_query.rs
+++ b/wado-compiler/src/elaborator/trait_query.rs
@@ -550,12 +550,16 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             self_type_param_name.as_deref(),
                             &assoc_decl.bounds,
                         );
-                        scope.tysys.type_table.borrow_mut().make_assoc_type_projection(
-                            self_type_id,
-                            assoc_decl.name.clone(),
-                            bound_names,
-                            atb,
-                        )
+                        scope
+                            .tysys
+                            .type_table
+                            .borrow_mut()
+                            .make_assoc_type_projection(
+                                self_type_id,
+                                assoc_decl.name.clone(),
+                                bound_names,
+                                atb,
+                            )
                     });
                     scope
                         .trait_ctx
@@ -572,7 +576,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 let mut method_type_param_ids: Vec<TypeId> = Vec::new();
                 for (index, param) in method.type_params.iter().enumerate() {
                     let type_id = scope
-                        .tysys.type_table
+                        .tysys
+                        .type_table
                         .borrow_mut()
                         .make_type_param(param.name.clone(), index as u32);
                     scope
@@ -880,9 +885,15 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // Resolve and register each associated type in this substituted context
             for binding in &info.assoc_types {
                 let resolved_id = scope.resolve_type(&binding.ty);
-                if !scope.tysys.type_table.borrow().contains_type_param(resolved_id) {
+                if !scope
+                    .tysys
+                    .type_table
+                    .borrow()
+                    .contains_type_param(resolved_id)
+                {
                     scope
-                        .tysys.type_table
+                        .tysys
+                        .type_table
                         .borrow_mut()
                         .register_assoc_type_resolution(
                             concrete_type_id,
@@ -953,9 +964,15 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // Resolve and register each associated type
             for binding in &info.assoc_types {
                 let resolved_id = scope.resolve_type(&binding.ty);
-                if !scope.tysys.type_table.borrow().contains_type_param(resolved_id) {
+                if !scope
+                    .tysys
+                    .type_table
+                    .borrow()
+                    .contains_type_param(resolved_id)
+                {
                     scope
-                        .tysys.type_table
+                        .tysys
+                        .type_table
                         .borrow_mut()
                         .register_assoc_type_resolution(
                             concrete_type_id,
@@ -1124,7 +1141,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             let return_type = if is_eq {
                 TypeTable::BOOL
             } else if is_ord {
-                self.tysys.type_table
+                self.tysys
+                    .type_table
                     .borrow_mut()
                     .make_compiler_enum(CompilerItem::Ordering)
             } else {
@@ -1134,13 +1152,15 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             (info.trait_name, info.self_kind, param_types, return_type)
         } else if (is_eq || is_ord) && self.type_implements_trait(lookup_type_id, trait_name) {
             let ref_self_ty = self
-                .tysys.type_table
+                .tysys
+                .type_table
                 .borrow_mut()
                 .intern(ResolvedType::Ref(lookup_type_id));
             let return_type = if is_eq {
                 TypeTable::BOOL
             } else {
-                self.tysys.type_table
+                self.tysys
+                    .type_table
                     .borrow_mut()
                     .make_compiler_enum(CompilerItem::Ordering)
             };
@@ -1228,14 +1248,16 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             return None;
         }
         let ref_self_ty = self
-            .tysys.type_table
+            .tysys
+            .type_table
             .borrow_mut()
             .intern(ResolvedType::Ref(base_type_id));
         let is_eq_match = trait_name == eq_name;
         let return_type = if is_eq_match {
             TypeTable::BOOL
         } else {
-            self.tysys.type_table
+            self.tysys
+                .type_table
                 .borrow_mut()
                 .make_compiler_enum(CompilerItem::Ordering)
         };

--- a/wado-compiler/src/elaborator/type_resolution.rs
+++ b/wado-compiler/src/elaborator/type_resolution.rs
@@ -78,7 +78,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     .collect();
                 // Resolve effect names in function type position
                 let effects = self.resolve_effects(&func_ty.effects, &func_ty.effect_ids);
-                self.type_table.borrow_mut().make_function_with_mut(
+                self.tysys.type_table.borrow_mut().make_function_with_mut(
                     func_ty.is_mut,
                     params,
                     return_type,
@@ -89,21 +89,21 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             Type::Tuple(elements) => {
                 let elem_types: Vec<TypeId> =
                     elements.iter().map(|e| self.resolve_type(e)).collect();
-                self.type_table.borrow_mut().make_tuple(elem_types)
+                self.tysys.type_table.borrow_mut().make_tuple(elem_types)
             }
             Type::Reference(inner) => {
                 let inner_type = self.resolve_type(inner);
-                self.type_table.borrow_mut().make_ref(inner_type)
+                self.tysys.type_table.borrow_mut().make_ref(inner_type)
             }
             Type::MutReference(inner) => {
                 let inner_type = self.resolve_type(inner);
-                self.type_table.borrow_mut().make_mut_ref(inner_type)
+                self.tysys.type_table.borrow_mut().make_mut_ref(inner_type)
             }
             Type::NamespacedGeneric(namespaced) => self.resolve_namespaced_generic_type(namespaced),
             Type::TypePackSpread(name, span) => {
                 // Look up the type pack parameter
                 if let Some((index, _type_id)) = self.trait_ctx.type_params.get(name) {
-                    self.type_table
+                    self.tysys.type_table
                         .borrow_mut()
                         .make_type_pack(name.clone(), *index)
                 } else {
@@ -142,11 +142,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // type from the TypeTable directly. This handles cases like blanket impl resolution
             // where we temporarily bind e.g. I = StrUtf8ByteIter (concrete struct), and
             // I::Item should resolve to u8 via (StrUtf8ByteIter, "Item") → u8.
-            let param_is_concrete = !self.type_table.borrow().contains_type_param(param_type_id);
+            let param_is_concrete = !self.tysys.type_table.borrow().contains_type_param(param_type_id);
             if param_is_concrete {
                 // First try pre-registered concrete associated type resolution.
                 if let Some(resolved) = self
-                    .type_table
+                    .tysys.type_table
                     .borrow()
                     .resolve_assoc_type(param_type_id, &namespaced.name)
                 {
@@ -157,7 +157,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 // is generic — resolve_assoc_type won't find a pre-registered entry, but
                 // resolve_generic_assoc_type can derive i32 from ("ArrayIter", "Item") → TypeParam(0).
                 if let Some(resolved) = self
-                    .type_table
+                    .tysys.type_table
                     .borrow()
                     .resolve_generic_assoc_type(param_type_id, &namespaced.name)
                 {
@@ -184,7 +184,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             let assoc_type_bindings =
                 self.compute_assoc_type_bindings(&namespaced.namespace.clone(), &assoc_bounds);
 
-            return self.type_table.borrow_mut().make_assoc_type_projection(
+            return self.tysys.type_table.borrow_mut().make_assoc_type_projection(
                 param_type_id,
                 namespaced.name.clone(),
                 bound_names,
@@ -203,7 +203,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     return TypeTable::ERROR;
                 }
                 let element_type = self.resolve_type(&namespaced.args[0]);
-                self.type_table
+                self.tysys.type_table
                     .borrow_mut()
                     .make_builtin_array(element_type)
             } else {
@@ -263,22 +263,22 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 } else if let Some(struct_info) = self.lookup_struct_fields(name) {
                     // Use canonical name (not import alias) so interning produces the same TypeId
                     let (n, src) = (struct_info.name.clone(), struct_info.module_source.clone());
-                    self.type_table.borrow_mut().make_struct(n, src)
+                    self.tysys.type_table.borrow_mut().make_struct(n, src)
                 } else if let Some(variant_info) = self.lookup_variant_case(name) {
                     let (n, src) = (
                         variant_info.name.clone(),
                         variant_info.module_source.clone(),
                     );
-                    self.type_table.borrow_mut().make_variant(n, src)
+                    self.tysys.type_table.borrow_mut().make_variant(n, src)
                 } else if let Some(enum_info) = self.lookup_enum_case(name) {
                     let (n, src) = (enum_info.name.clone(), enum_info.module_source.clone());
-                    self.type_table.borrow_mut().make_enum(n, src)
+                    self.tysys.type_table.borrow_mut().make_enum(n, src)
                 } else if let Some(resource_info) = self.lookup_resource_type(name) {
                     let (n, src) = (
                         resource_info.name.clone(),
                         resource_info.module_source.clone(),
                     );
-                    self.type_table.borrow_mut().make_resource(n, src)
+                    self.tysys.type_table.borrow_mut().make_resource(n, src)
                 } else {
                     // Unknown type
                     TypeTable::UNKNOWN
@@ -313,35 +313,35 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     .first()
                     .map(|t| self.resolve_type(t))
                     .unwrap_or(TypeTable::UNKNOWN);
-                self.type_table.borrow_mut().make_option(inner)
+                self.tysys.type_table.borrow_mut().make_option(inner)
             }
             "Stream" => {
                 let elem = args
                     .first()
                     .map(|t| self.resolve_type(t))
                     .unwrap_or(TypeTable::UNKNOWN);
-                self.type_table.borrow_mut().make_stream(elem)
+                self.tysys.type_table.borrow_mut().make_stream(elem)
             }
             "StreamWritable" => {
                 let elem = args
                     .first()
                     .map(|t| self.resolve_type(t))
                     .unwrap_or(TypeTable::UNKNOWN);
-                self.type_table.borrow_mut().make_stream_writable(elem)
+                self.tysys.type_table.borrow_mut().make_stream_writable(elem)
             }
             "Future" => {
                 let elem = args
                     .first()
                     .map(|t| self.resolve_type(t))
                     .unwrap_or(TypeTable::UNKNOWN);
-                self.type_table.borrow_mut().make_future(elem)
+                self.tysys.type_table.borrow_mut().make_future(elem)
             }
             "FutureWritable" => {
                 let elem = args
                     .first()
                     .map(|t| self.resolve_type(t))
                     .unwrap_or(TypeTable::UNKNOWN);
-                self.type_table.borrow_mut().make_future_writable(elem)
+                self.tysys.type_table.borrow_mut().make_future_writable(elem)
             }
             _ => {
                 // Check if it's a user-defined generic struct
@@ -379,7 +379,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     }
 
                     // Create a GenericInstance type
-                    self.type_table.borrow_mut().make_generic_instance(
+                    self.tysys.type_table.borrow_mut().make_generic_instance(
                         name.to_string(),
                         module_source,
                         type_args,
@@ -391,7 +391,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     } else {
                         let type_args: Vec<TypeId> =
                             args.iter().map(|t| self.resolve_type(t)).collect();
-                        self.type_table.borrow_mut().make_generic_instance(
+                        self.tysys.type_table.borrow_mut().make_generic_instance(
                             name.to_string(),
                             variant_info.module_source,
                             type_args,
@@ -411,7 +411,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         .map(|&tid| self.type_id_to_string(tid))
                         .collect();
                     let display_name = format!("{}<{}>", name, arg_names.join(", "));
-                    self.type_table.borrow_mut().make_newtype(
+                    self.tysys.type_table.borrow_mut().make_newtype(
                         display_name,
                         gn_info.module_source,
                         base_type_id,
@@ -431,7 +431,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         param_id: TypeId,
         assoc_name: &str,
     ) -> Vec<crate::ast::TraitBound> {
-        let param_type = self.type_table.borrow().get(param_id).clone();
+        let param_type = self.tysys.type_table.borrow().get(param_id).clone();
         if !matches!(param_type, ResolvedType::TypeParam { .. }) {
             return Vec::new();
         }

--- a/wado-compiler/src/elaborator/type_resolution.rs
+++ b/wado-compiler/src/elaborator/type_resolution.rs
@@ -103,7 +103,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             Type::TypePackSpread(name, span) => {
                 // Look up the type pack parameter
                 if let Some((index, _type_id)) = self.trait_ctx.type_params.get(name) {
-                    self.tysys.type_table
+                    self.tysys
+                        .type_table
                         .borrow_mut()
                         .make_type_pack(name.clone(), *index)
                 } else {
@@ -142,11 +143,16 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // type from the TypeTable directly. This handles cases like blanket impl resolution
             // where we temporarily bind e.g. I = StrUtf8ByteIter (concrete struct), and
             // I::Item should resolve to u8 via (StrUtf8ByteIter, "Item") → u8.
-            let param_is_concrete = !self.tysys.type_table.borrow().contains_type_param(param_type_id);
+            let param_is_concrete = !self
+                .tysys
+                .type_table
+                .borrow()
+                .contains_type_param(param_type_id);
             if param_is_concrete {
                 // First try pre-registered concrete associated type resolution.
                 if let Some(resolved) = self
-                    .tysys.type_table
+                    .tysys
+                    .type_table
                     .borrow()
                     .resolve_assoc_type(param_type_id, &namespaced.name)
                 {
@@ -157,7 +163,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 // is generic — resolve_assoc_type won't find a pre-registered entry, but
                 // resolve_generic_assoc_type can derive i32 from ("ArrayIter", "Item") → TypeParam(0).
                 if let Some(resolved) = self
-                    .tysys.type_table
+                    .tysys
+                    .type_table
                     .borrow()
                     .resolve_generic_assoc_type(param_type_id, &namespaced.name)
                 {
@@ -184,12 +191,16 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             let assoc_type_bindings =
                 self.compute_assoc_type_bindings(&namespaced.namespace.clone(), &assoc_bounds);
 
-            return self.tysys.type_table.borrow_mut().make_assoc_type_projection(
-                param_type_id,
-                namespaced.name.clone(),
-                bound_names,
-                assoc_type_bindings,
-            );
+            return self
+                .tysys
+                .type_table
+                .borrow_mut()
+                .make_assoc_type_projection(
+                    param_type_id,
+                    namespaced.name.clone(),
+                    bound_names,
+                    assoc_type_bindings,
+                );
         }
 
         if namespaced.namespace.as_str() == "builtin" {
@@ -203,7 +214,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     return TypeTable::ERROR;
                 }
                 let element_type = self.resolve_type(&namespaced.args[0]);
-                self.tysys.type_table
+                self.tysys
+                    .type_table
                     .borrow_mut()
                     .make_builtin_array(element_type)
             } else {
@@ -327,7 +339,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     .first()
                     .map(|t| self.resolve_type(t))
                     .unwrap_or(TypeTable::UNKNOWN);
-                self.tysys.type_table.borrow_mut().make_stream_writable(elem)
+                self.tysys
+                    .type_table
+                    .borrow_mut()
+                    .make_stream_writable(elem)
             }
             "Future" => {
                 let elem = args
@@ -341,7 +356,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     .first()
                     .map(|t| self.resolve_type(t))
                     .unwrap_or(TypeTable::UNKNOWN);
-                self.tysys.type_table.borrow_mut().make_future_writable(elem)
+                self.tysys
+                    .type_table
+                    .borrow_mut()
+                    .make_future_writable(elem)
             }
             _ => {
                 // Check if it's a user-defined generic struct

--- a/wado-compiler/src/elaborator/typecheck.rs
+++ b/wado-compiler/src/elaborator/typecheck.rs
@@ -8,8 +8,8 @@ use crate::logger::Logger;
 use crate::tir::{ResolvedType, TypeId, TypeTable};
 use crate::token::Span;
 
-use super::tysys::TypeSystem;
 use super::types::TypeError;
+use super::tysys::TypeSystem;
 
 /// Result of checking whether `actual` is assignable to `expected`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/wado-compiler/src/elaborator/typecheck.rs
+++ b/wado-compiler/src/elaborator/typecheck.rs
@@ -2,12 +2,33 @@
 //!
 //! This module is the single source of truth for "can type A be used where
 //! type B is expected?". All type mismatch checks route through here.
+//!
+//! # Layering
+//!
+//! The check is split across three layers, each more host-aware than the
+//! last:
+//!
+//! 1. [`check_assignable`] — pure function over the type table. Returns
+//!    [`TypeCheckResult`] (`Compatible` / `Deferred` / `Incompatible`).
+//!    No diagnostics, no host.
+//! 2. [`TypeSystem::typecheck`] / [`TypeSystem::typecheck_return`] —
+//!    type-system operations that build a [`TypeMismatchPayload`] (the
+//!    pretty-printed `expected` / `found` names) on rejection. Still
+//!    host-agnostic — `TypeSystem` does not carry `<H: CompilerHost>`.
+//! 3. [`Elaborator::typecheck`] / [`Elaborator::typecheck_return`] —
+//!    thin wrappers that call (2) and emit a [`TypeError::TypeMismatch`]
+//!    diagnostic via `self.logger` on rejection. This is the layer
+//!    callers in the body walk use.
+//!
+//! Keeping the `<H>` plumbing confined to layer 3 means future
+//! `TypeSystem` operations that report errors can mirror this split
+//! without bleeding the host trait into the type-system API.
 
 use crate::compiler_host::CompilerHost;
-use crate::logger::Logger;
 use crate::tir::{ResolvedType, TypeId, TypeTable};
 use crate::token::Span;
 
+use super::Elaborator;
 use super::types::TypeError;
 use super::tysys::TypeSystem;
 
@@ -219,45 +240,87 @@ fn unwrap_ref(type_id: TypeId, type_table: &TypeTable) -> (TypeId, bool) {
     }
 }
 
+/// Pretty-printed payload carried when [`TypeSystem::typecheck`] /
+/// [`TypeSystem::typecheck_return`] rejects an assignment.
+///
+/// The strings are materialised at the rejection site (while the
+/// [`TypeTable`] is still borrowed) so the caller can drop the type
+/// table before emitting the diagnostic. Both fields use the same
+/// [`TypeTable::type_name`] formatting that the original
+/// `TypeError::TypeMismatch` diagnostic used.
+#[derive(Debug, Clone)]
+pub(crate) struct TypeMismatchPayload {
+    pub(crate) expected: String,
+    pub(crate) found: String,
+}
+
 impl TypeSystem {
-    /// Check type mismatch and emit a [`TypeError::TypeMismatch`] diagnostic
-    /// via `logger` if incompatible. Pure type-system operation — uses only
-    /// the shared type table and the caller-supplied diagnostic sink.
-    pub(crate) fn typecheck<H: CompilerHost>(
+    /// Host-agnostic type-mismatch check. Returns `Ok(())` if `actual`
+    /// is assignable to `expected` (or if the answer is deferred —
+    /// unknown types, unresolved generics — which the body walk
+    /// re-checks once the type is known); returns `Err` with the
+    /// pretty-printed `expected` / `found` names on a definite reject.
+    ///
+    /// This is layer 2 of [the typecheck stack](self): callers that
+    /// want a diagnostic emitted should go through
+    /// [`Elaborator::typecheck`].
+    pub(crate) fn typecheck(
         &self,
-        logger: &Logger<H>,
         actual: TypeId,
         expected: TypeId,
-        span: Span,
-    ) {
+    ) -> Result<(), TypeMismatchPayload> {
         let type_table = self.type_table.borrow();
-        let result = check_assignable(actual, expected, &type_table);
-        if result == TypeCheckResult::Incompatible {
-            let expected_name = type_table.type_name(expected);
-            let found_name = type_table.type_name(actual);
-            drop(type_table);
-            let _ = logger.error(TypeError::TypeMismatch {
-                expected: expected_name,
-                found: found_name,
+        match check_assignable(actual, expected, &type_table) {
+            TypeCheckResult::Incompatible => Err(TypeMismatchPayload {
+                expected: type_table.type_name(expected),
+                found: type_table.type_name(actual),
+            }),
+            TypeCheckResult::Compatible | TypeCheckResult::Deferred => Ok(()),
+        }
+    }
+
+    /// Host-agnostic return-type check. `UNIT` expected always succeeds
+    /// (void returns); otherwise delegates to [`TypeSystem::typecheck`].
+    pub(crate) fn typecheck_return(
+        &self,
+        actual: TypeId,
+        expected: TypeId,
+    ) -> Result<(), TypeMismatchPayload> {
+        if expected == TypeTable::UNIT {
+            return Ok(());
+        }
+        self.typecheck(actual, expected)
+    }
+}
+
+impl<H: CompilerHost> Elaborator<'_, H> {
+    /// Check type mismatch and emit a [`TypeError::TypeMismatch`]
+    /// diagnostic via [`Self::logger`] on rejection.
+    ///
+    /// Layer 3 wrapper over [`TypeSystem::typecheck`]: confines the
+    /// `<H: CompilerHost>` plumbing to the `Elaborator` boundary so
+    /// `TypeSystem` itself stays host-agnostic.
+    pub(super) fn typecheck(&self, actual: TypeId, expected: TypeId, span: Span) {
+        if let Err(payload) = self.tysys.typecheck(actual, expected) {
+            let _ = self.logger.error(TypeError::TypeMismatch {
+                expected: payload.expected,
+                found: payload.found,
                 span,
             });
         }
     }
 
-    /// Check return type mismatch and emit error if incompatible.
+    /// Check return type mismatch and emit a diagnostic on rejection.
     ///
-    /// Additional allowance: `UNIT` expected is always compatible (void
-    /// returns).
-    pub(crate) fn typecheck_return<H: CompilerHost>(
-        &self,
-        logger: &Logger<H>,
-        actual: TypeId,
-        expected: TypeId,
-        span: Span,
-    ) {
-        if expected == TypeTable::UNIT {
-            return;
+    /// `UNIT` expected is always compatible (void returns); otherwise
+    /// delegates to [`Self::typecheck`]'s emit path.
+    pub(super) fn typecheck_return(&self, actual: TypeId, expected: TypeId, span: Span) {
+        if let Err(payload) = self.tysys.typecheck_return(actual, expected) {
+            let _ = self.logger.error(TypeError::TypeMismatch {
+                expected: payload.expected,
+                found: payload.found,
+                span,
+            });
         }
-        self.typecheck(logger, actual, expected, span);
     }
 }

--- a/wado-compiler/src/elaborator/typecheck.rs
+++ b/wado-compiler/src/elaborator/typecheck.rs
@@ -221,7 +221,7 @@ fn unwrap_ref(type_id: TypeId, type_table: &TypeTable) -> (TypeId, bool) {
 impl<H: CompilerHost> Elaborator<'_, H> {
     /// Check type mismatch and emit error if incompatible.
     pub(super) fn typecheck(&mut self, actual: TypeId, expected: TypeId, span: Span) {
-        let type_table = self.type_table.borrow();
+        let type_table = self.tysys.type_table.borrow();
         let result = check_assignable(actual, expected, &type_table);
         if result == TypeCheckResult::Incompatible {
             let expected_name = type_table.type_name(expected);

--- a/wado-compiler/src/elaborator/typecheck.rs
+++ b/wado-compiler/src/elaborator/typecheck.rs
@@ -4,10 +4,11 @@
 //! type B is expected?". All type mismatch checks route through here.
 
 use crate::compiler_host::CompilerHost;
+use crate::logger::Logger;
 use crate::tir::{ResolvedType, TypeId, TypeTable};
 use crate::token::Span;
 
-use super::Elaborator;
+use super::tysys::TypeSystem;
 use super::types::TypeError;
 
 /// Result of checking whether `actual` is assignable to `expected`.
@@ -218,16 +219,24 @@ fn unwrap_ref(type_id: TypeId, type_table: &TypeTable) -> (TypeId, bool) {
     }
 }
 
-impl<H: CompilerHost> Elaborator<'_, H> {
-    /// Check type mismatch and emit error if incompatible.
-    pub(super) fn typecheck(&mut self, actual: TypeId, expected: TypeId, span: Span) {
-        let type_table = self.tysys.type_table.borrow();
+impl TypeSystem {
+    /// Check type mismatch and emit a [`TypeError::TypeMismatch`] diagnostic
+    /// via `logger` if incompatible. Pure type-system operation — uses only
+    /// the shared type table and the caller-supplied diagnostic sink.
+    pub(crate) fn typecheck<H: CompilerHost>(
+        &self,
+        logger: &Logger<H>,
+        actual: TypeId,
+        expected: TypeId,
+        span: Span,
+    ) {
+        let type_table = self.type_table.borrow();
         let result = check_assignable(actual, expected, &type_table);
         if result == TypeCheckResult::Incompatible {
             let expected_name = type_table.type_name(expected);
             let found_name = type_table.type_name(actual);
             drop(type_table);
-            let _ = self.logger.error(TypeError::TypeMismatch {
+            let _ = logger.error(TypeError::TypeMismatch {
                 expected: expected_name,
                 found: found_name,
                 span,
@@ -237,11 +246,18 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
     /// Check return type mismatch and emit error if incompatible.
     ///
-    /// Additional allowance: UNIT expected is always compatible (void returns).
-    pub(super) fn typecheck_return(&mut self, actual: TypeId, expected: TypeId, span: Span) {
+    /// Additional allowance: `UNIT` expected is always compatible (void
+    /// returns).
+    pub(crate) fn typecheck_return<H: CompilerHost>(
+        &self,
+        logger: &Logger<H>,
+        actual: TypeId,
+        expected: TypeId,
+        span: Span,
+    ) {
         if expected == TypeTable::UNIT {
             return;
         }
-        self.typecheck(actual, expected, span);
+        self.typecheck(logger, actual, expected, span);
     }
 }

--- a/wado-compiler/src/elaborator/tysys.rs
+++ b/wado-compiler/src/elaborator/tysys.rs
@@ -133,18 +133,49 @@ impl TypeSystem {
     }
 
     /// Check if an expression is a numeric literal (possibly negated).
+    ///
+    /// The non-numeric arms are enumerated explicitly rather than a
+    /// catch-all `_` so that adding a new [`Expr`] variant produces a
+    /// compile error here, forcing a deliberate decision about whether
+    /// the new shape should participate in numeric-literal coercion.
     pub(crate) fn is_numeric_literal(&self, expr: &Expr) -> bool {
         match expr {
             Expr::Literal(lit) => matches!(lit.value, Literal::Number(_)),
             Expr::Unary(unary) if unary.op == UnaryOp::Neg => {
                 matches!(&unary.expr, Expr::Literal(lit) if matches!(lit.value, Literal::Number(_)))
             }
-            _ => false,
+            Expr::Unary(_)
+            | Expr::Ident(_)
+            | Expr::Binary(_)
+            | Expr::Assign(_)
+            | Expr::CompoundAssign(_)
+            | Expr::ComparisonChain(_)
+            | Expr::Call(_)
+            | Expr::MethodCall(_)
+            | Expr::StaticMethodCall(_)
+            | Expr::FieldAccess(_)
+            | Expr::Index(_)
+            | Expr::Block(_)
+            | Expr::If(_)
+            | Expr::Match(_)
+            | Expr::Matches(_)
+            | Expr::Closure(_)
+            | Expr::TemplateString(_)
+            | Expr::Cast(_)
+            | Expr::StructLiteral(_)
+            | Expr::TupleLiteral(_)
+            | Expr::LabeledBlock(_)
+            | Expr::TryOp(_)
+            | Expr::Spread(..)
+            | Expr::Range(_)
+            | Expr::WithHandler(_)
+            | Expr::Resume(_) => false,
         }
     }
 
     /// Map a binary operator to its `(trait_name, method_name)` pair, or
-    /// `None` when the operator does not dispatch through a trait.
+    /// `None` for short-circuit operators that don't dispatch through a
+    /// trait.
     ///
     /// For operators that dispatch through a [`CompilerItem`] trait
     /// (`Eq` for `==` / `!=`), the trait name is resolved through the
@@ -152,6 +183,10 @@ impl TypeSystem {
     /// transparent. For traits that don't yet have a `CompilerItem`
     /// anchor (`Add`, `Sub`, …, `Ord`), the canonical stdlib name is
     /// returned as a literal.
+    ///
+    /// The non-trait arms (`And` / `Or`) are explicit rather than a
+    /// catch-all `_` so that adding a new [`BinaryOp`] variant produces
+    /// a compile error here instead of silently returning `None`.
     pub(crate) fn operator_trait_method(&self, op: &BinaryOp) -> Option<(String, &'static str)> {
         match op {
             BinaryOp::Add => Some(("Add".to_string(), "add")),
@@ -180,7 +215,8 @@ impl TypeSystem {
                     .to_string(),
                 "cmp",
             )),
-            _ => None,
+            // Logical `&&` / `||` short-circuit on `bool`; no trait dispatch.
+            BinaryOp::And | BinaryOp::Or => None,
         }
     }
 }

--- a/wado-compiler/src/elaborator/tysys.rs
+++ b/wado-compiler/src/elaborator/tysys.rs
@@ -62,7 +62,6 @@ use crate::component_model::WasiRegistry;
 use crate::hashmap::{IndexMap, IndexSet};
 use crate::module_source::ModuleSource;
 use crate::tir::{TypeId, TypeTable};
-use crate::world_registry::WorldRegistry;
 
 use super::trait_env::TraitEnv;
 use super::types::{
@@ -101,9 +100,12 @@ pub(crate) struct TypeSystem {
     /// across every per-module elaborator via `Arc`.
     pub(crate) trait_env: Arc<TraitEnv>,
 
-    /// Registries.
+    /// Registries the elaborator queries. The Component-Model
+    /// `WorldRegistry` is built by the same `WasiRegistry::build_from_stdlib`
+    /// call but lives on [`super::orchestration::AnnotateState`] instead
+    /// of here — the elaborator never asks "what does world X export?",
+    /// only post-elaborator stages (link, synthesis, DCE) do.
     pub(crate) wasi_registry: &'static WasiRegistry,
-    pub(crate) world_registry: &'static WorldRegistry,
     pub(crate) builtin_registry: Rc<BuiltinRegistry>,
 
     /// Pre-loaded file contents for `#include_str` / `#include_bytes`.

--- a/wado-compiler/src/elaborator/tysys.rs
+++ b/wado-compiler/src/elaborator/tysys.rs
@@ -37,7 +37,9 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
 
+use crate::ast::{BinaryOp, Expr, Literal, UnaryOp};
 use crate::builtin_registry::BuiltinRegistry;
+use crate::compiler_item::CompilerItem;
 use crate::component_model::WasiRegistry;
 use crate::hashmap::{IndexMap, IndexSet};
 use crate::module_source::ModuleSource;
@@ -100,4 +102,68 @@ pub(crate) struct TypeSystem {
     /// for O(1) lookup. Built globally during annotate; read-only
     /// afterwards.
     pub(crate) loaded_module_func_indices: Rc<IndexMap<ModuleSource, IndexMap<String, usize>>>,
+}
+
+impl TypeSystem {
+    /// Check if a name refers to a known type (struct, variant, enum,
+    /// flags, newtype, or primitive). Uses the pre-built cache for O(1)
+    /// lookup instead of scanning all module maps.
+    pub(crate) fn is_known_type_name(&self, name: &str) -> bool {
+        self.known_type_names_cache.contains(name)
+    }
+
+    /// Check if an expression is a numeric literal (possibly negated).
+    pub(crate) fn is_numeric_literal(&self, expr: &Expr) -> bool {
+        match expr {
+            Expr::Literal(lit) => matches!(lit.value, Literal::Number(_)),
+            Expr::Unary(unary) if unary.op == UnaryOp::Neg => {
+                matches!(&unary.expr, Expr::Literal(lit) if matches!(lit.value, Literal::Number(_)))
+            }
+            _ => false,
+        }
+    }
+
+    /// Map a binary operator to its `(trait_name, method_name)` pair, or
+    /// `None` when the operator does not dispatch through a trait.
+    ///
+    /// For operators that dispatch through a [`CompilerItem`] trait
+    /// (`Eq` for `==` / `!=`), the trait name is resolved through the
+    /// compiler-item registry so a rename on the stdlib side stays
+    /// transparent. For traits that don't yet have a `CompilerItem`
+    /// anchor (`Add`, `Sub`, …, `Ord`), the canonical stdlib name is
+    /// returned as a literal.
+    pub(crate) fn operator_trait_method(
+        &self,
+        op: &BinaryOp,
+    ) -> Option<(String, &'static str)> {
+        match op {
+            BinaryOp::Add => Some(("Add".to_string(), "add")),
+            BinaryOp::Sub => Some(("Sub".to_string(), "sub")),
+            BinaryOp::Mul => Some(("Mul".to_string(), "mul")),
+            BinaryOp::Div => Some(("Div".to_string(), "div")),
+            BinaryOp::Mod => Some(("Rem".to_string(), "rem")),
+            BinaryOp::BitAnd => Some(("BitAnd".to_string(), "bitand")),
+            BinaryOp::BitOr => Some(("BitOr".to_string(), "bitor")),
+            BinaryOp::BitXor => Some(("BitXor".to_string(), "bitxor")),
+            BinaryOp::Shl => Some(("Shl".to_string(), "shl")),
+            BinaryOp::Shr => Some(("Shr".to_string(), "shr")),
+            BinaryOp::Eq | BinaryOp::NotEq => Some((
+                self.type_table
+                    .borrow()
+                    .compiler_items()
+                    .trait_name(CompilerItem::Eq)
+                    .to_string(),
+                "eq",
+            )),
+            BinaryOp::Lt | BinaryOp::LtEq | BinaryOp::Gt | BinaryOp::GtEq => Some((
+                self.type_table
+                    .borrow()
+                    .compiler_items()
+                    .trait_name(CompilerItem::Ord)
+                    .to_string(),
+                "cmp",
+            )),
+            _ => None,
+        }
+    }
 }

--- a/wado-compiler/src/elaborator/tysys.rs
+++ b/wado-compiler/src/elaborator/tysys.rs
@@ -23,15 +23,33 @@
 //!
 //! # Deferred fields
 //!
-//! Three [`super::Elaborator`] fields are marked
+//! Two [`super::Elaborator`] fields are marked
 //! `MIGRATION: → TypeSystem` but **stay on `Elaborator` through Stage 2**:
-//! `indexing_trait_cache`, `method_info_cache`, `trait_check_stack`. They
-//! carry per-Elaborator mutable state today (constructed fresh per
-//! module, populated by the body walk), and moving them to a shared
-//! `TypeSystem` requires either making them pipeline-wide caches (a
-//! behaviour change) or interior-mutability plumbing. The migration
-//! markers on those fields point at this future home; the move itself is
-//! deferred to a later stage where the cache lifetime story is settled.
+//! `indexing_trait_cache` and `method_info_cache`. They are genuine
+//! type-system caches (lookup `(TypeId, name) → MethodInfo` or
+//! `(struct_name, base_type, trait, method, assoc_type) → impl info`)
+//! whose keys live entirely in the shared type domain, so they belong on
+//! `TypeSystem` in spirit. But they carry per-Elaborator mutable state
+//! today (constructed fresh per module, populated by the body walk), and
+//! moving them to a shared `TypeSystem` requires either making them
+//! pipeline-wide caches (a behaviour change) or interior-mutability
+//! plumbing. The migration markers on those fields point at this future
+//! home; the move itself is deferred to a later stage where the cache
+//! lifetime story is settled.
+//!
+//! [`super::Elaborator::trait_check_stack`] looks superficially similar
+//! — `RefCell<Vec<…>>` mutable state on `Elaborator` — but is **not** a
+//! cache. It is the per-call frame stack used by
+//! `Elaborator::type_implements_trait` to break recursion on recursive
+//! types (e.g. a variant case whose payload eventually contains itself):
+//! frames are pushed on entry, popped on return, and the stack is empty
+//! at every quiescent point. Moving it to a shared `TypeSystem` would
+//! either leak stale frames across module walks (producing wrong
+//! "recursive, optimistically true" answers in trait resolution — a
+//! soundness bug) or require per-call save/restore plumbing that
+//! defeats the move. The migration marker on that field accordingly
+//! targets the same "transient annotate-time scope" bucket as
+//! [`super::Elaborator::trait_ctx`], not `TypeSystem`.
 
 use std::cell::RefCell;
 use std::rc::Rc;

--- a/wado-compiler/src/elaborator/tysys.rs
+++ b/wado-compiler/src/elaborator/tysys.rs
@@ -1,0 +1,43 @@
+//! [`TypeSystem`] — pipeline-wide type knowledge.
+//!
+//! Stage 1 skeleton introduced by
+//! [`wep-2026-05-26-elaborator-rearchitecture.md`]. The type is empty at this
+//! stage; the migration plan populates it across stages 2-7 by moving fields
+//! off [`super::Elaborator`] and [`super::orchestration::AnnotateState`].
+//!
+//! # Future ownership and shape (per the WEP)
+//!
+//! `TypeSystem` is owned by the batch driver and by
+//! [`crate::semantics::Semantics`]; per-module phases (`annotate_bodies`,
+//! `reify`) take `&mut TypeSystem`. It does **not** know about
+//! [`crate::ast::Module`], [`crate::ast::AstId`], or any
+//! [`crate::module_source::ModuleSource`]-keyed per-module state — those
+//! belong to [`super::sem::ModuleSemantics`].
+//!
+//! # Membership rule
+//!
+//! A field belongs on `TypeSystem` only when the answer to
+//! "would this fit the type system itself?" is yes. The criterion is
+//! mechanical and gates drift back toward the God-Object pattern that
+//! motivated the WEP.
+//!
+//! # Planned contents
+//!
+//! - **Arenas / registries**: the shared [`crate::tir::TypeTable`], the
+//!   [`super::trait_env::TraitEnv`], the builtin / WASI / world registries,
+//!   the included-files map.
+//! - **Decl-interned type tables**: the cross-module `all_newtypes`,
+//!   `all_generic_newtypes`, `all_struct_fields`, `all_variant_cases`,
+//!   `all_enum_cases`, `all_flags_cases`, `all_resource_types` maps.
+//! - **Type-system caches**: `method_info_cache`, `indexing_trait_cache`,
+//!   `trait_check_stack`, the global known-type-name set, the per-module
+//!   function-index maps.
+//! - **Operations**: interning, coercion, inference, type checking, trait
+//!   queries, method lookup — taking only [`crate::tir::TypeId`]s and decl
+//!   indices, never per-module flat maps.
+
+#[expect(
+    dead_code,
+    reason = "Stage 1 skeleton; populated by stages 2-7 of the elaborator re-architecture."
+)]
+pub(crate) struct TypeSystem {}

--- a/wado-compiler/src/elaborator/tysys.rs
+++ b/wado-compiler/src/elaborator/tysys.rs
@@ -1,18 +1,18 @@
 //! [`TypeSystem`] — pipeline-wide type knowledge.
 //!
-//! Stage 1 skeleton introduced by
-//! [`wep-2026-05-26-elaborator-rearchitecture.md`]. The type is empty at this
-//! stage; the migration plan populates it across stages 2-7 by moving fields
-//! off [`super::Elaborator`] and [`super::orchestration::AnnotateState`].
+//! Introduced by [`wep-2026-05-26-elaborator-rearchitecture.md`]. Stage 1
+//! placed the empty skeleton; Stage 2 fills it with the cross-module type
+//! tables, registries, and read-only caches that the WEP §"`TypeSystem`
+//! surface" requires.
 //!
-//! # Future ownership and shape (per the WEP)
+//! # Ownership
 //!
-//! `TypeSystem` is owned by the batch driver and by
-//! [`crate::semantics::Semantics`]; per-module phases (`annotate_bodies`,
-//! `reify`) take `&mut TypeSystem`. It does **not** know about
-//! [`crate::ast::Module`], [`crate::ast::AstId`], or any
-//! [`crate::module_source::ModuleSource`]-keyed per-module state — those
-//! belong to [`super::sem::ModuleSemantics`].
+//! Every field is either `'static`, [`Arc`]-wrapped, or [`Rc`]-wrapped, so
+//! `TypeSystem` is `Clone` (a shallow Rc/Arc copy) and can be handed out
+//! cheaply to per-module phases. The driver builds one `TypeSystem`
+//! during [`super::orchestration::Elaborator::annotate_modules`]; each
+//! per-module [`super::Elaborator`] holds a clone in its
+//! [`super::Elaborator::tysys`] field.
 //!
 //! # Membership rule
 //!
@@ -21,23 +21,83 @@
 //! mechanical and gates drift back toward the God-Object pattern that
 //! motivated the WEP.
 //!
-//! # Planned contents
+//! # Deferred fields
 //!
-//! - **Arenas / registries**: the shared [`crate::tir::TypeTable`], the
-//!   [`super::trait_env::TraitEnv`], the builtin / WASI / world registries,
-//!   the included-files map.
-//! - **Decl-interned type tables**: the cross-module `all_newtypes`,
-//!   `all_generic_newtypes`, `all_struct_fields`, `all_variant_cases`,
-//!   `all_enum_cases`, `all_flags_cases`, `all_resource_types` maps.
-//! - **Type-system caches**: `method_info_cache`, `indexing_trait_cache`,
-//!   `trait_check_stack`, the global known-type-name set, the per-module
-//!   function-index maps.
-//! - **Operations**: interning, coercion, inference, type checking, trait
-//!   queries, method lookup — taking only [`crate::tir::TypeId`]s and decl
-//!   indices, never per-module flat maps.
+//! Three [`super::Elaborator`] fields are marked
+//! `MIGRATION: → TypeSystem` but **stay on `Elaborator` through Stage 2**:
+//! `indexing_trait_cache`, `method_info_cache`, `trait_check_stack`. They
+//! carry per-Elaborator mutable state today (constructed fresh per
+//! module, populated by the body walk), and moving them to a shared
+//! `TypeSystem` requires either making them pipeline-wide caches (a
+//! behaviour change) or interior-mutability plumbing. The migration
+//! markers on those fields point at this future home; the move itself is
+//! deferred to a later stage where the cache lifetime story is settled.
 
-#[expect(
-    dead_code,
-    reason = "Stage 1 skeleton; populated by stages 2-7 of the elaborator re-architecture."
-)]
-pub(crate) struct TypeSystem {}
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::Arc;
+
+use crate::builtin_registry::BuiltinRegistry;
+use crate::component_model::WasiRegistry;
+use crate::hashmap::{IndexMap, IndexSet};
+use crate::module_source::ModuleSource;
+use crate::tir::{TypeId, TypeTable};
+use crate::world_registry::WorldRegistry;
+
+use super::trait_env::TraitEnv;
+use super::types::{
+    EnumInfo, FlagsInfo, GenericNewtypeInfo, ResourceInfo, StructFieldInfo, VariantInfo,
+};
+
+/// Pipeline-wide type knowledge — the type arena, the cross-module decl
+/// indices, the registries, and the read-only caches built once at
+/// `annotate_modules` time.
+///
+/// See the module-level documentation for the membership rule and the
+/// migration plan around the deferred `Elaborator` caches.
+#[derive(Clone)]
+pub(crate) struct TypeSystem {
+    /// Shared type arena. Anonymous structs synthesised from struct
+    /// literals and monomorphised instances created during reify intern
+    /// through this same table; the `Rc<RefCell<…>>` is the one piece of
+    /// shared interior mutability the WEP explicitly preserves.
+    pub(crate) type_table: Rc<RefCell<TypeTable>>,
+
+    /// Decl-interned type tables (one per loaded module). Built during
+    /// the annotate-decls pass; read-only afterwards. [`super::types::TypeLookup`]
+    /// resolves type names against these without cloning into per-module
+    /// flat maps.
+    pub(crate) all_newtypes: Rc<IndexMap<ModuleSource, IndexMap<String, TypeId>>>,
+    pub(crate) all_generic_newtypes:
+        Rc<IndexMap<ModuleSource, IndexMap<String, GenericNewtypeInfo>>>,
+    pub(crate) all_struct_fields: Rc<IndexMap<ModuleSource, IndexMap<String, StructFieldInfo>>>,
+    pub(crate) all_variant_cases: Rc<IndexMap<ModuleSource, IndexMap<String, VariantInfo>>>,
+    pub(crate) all_enum_cases: Rc<IndexMap<ModuleSource, IndexMap<String, EnumInfo>>>,
+    pub(crate) all_flags_cases: Rc<IndexMap<ModuleSource, IndexMap<String, FlagsInfo>>>,
+    pub(crate) all_resource_types: Rc<IndexMap<ModuleSource, IndexMap<String, ResourceInfo>>>,
+
+    /// Immutable trait knowledge base: impl indices, trait declarations,
+    /// and blanket impls. Built once by [`TraitEnv::build`] and shared
+    /// across every per-module elaborator via `Arc`.
+    pub(crate) trait_env: Arc<TraitEnv>,
+
+    /// Registries.
+    pub(crate) wasi_registry: &'static WasiRegistry,
+    pub(crate) world_registry: &'static WorldRegistry,
+    pub(crate) builtin_registry: Rc<BuiltinRegistry>,
+
+    /// Pre-loaded file contents for `#include_str` / `#include_bytes`.
+    /// Key: `[module_source_display, raw_path]`, value: raw bytes.
+    pub(crate) included_files: Rc<IndexMap<[String; 2], Vec<u8>>>,
+
+    /// Flat set of every name that resolves to a declared type
+    /// (primitive, struct, enum, variant, flags, newtype, resource).
+    /// Built globally during annotate; read-only afterwards. Powers fast
+    /// `is_known_type_name` lookups in the body walk.
+    pub(crate) known_type_names_cache: Rc<IndexSet<String>>,
+
+    /// Per-module index from function name → position in `module.items`
+    /// for O(1) lookup. Built globally during annotate; read-only
+    /// afterwards.
+    pub(crate) loaded_module_func_indices: Rc<IndexMap<ModuleSource, IndexMap<String, usize>>>,
+}

--- a/wado-compiler/src/elaborator/tysys.rs
+++ b/wado-compiler/src/elaborator/tysys.rs
@@ -132,10 +132,7 @@ impl TypeSystem {
     /// transparent. For traits that don't yet have a `CompilerItem`
     /// anchor (`Add`, `Sub`, …, `Ord`), the canonical stdlib name is
     /// returned as a literal.
-    pub(crate) fn operator_trait_method(
-        &self,
-        op: &BinaryOp,
-    ) -> Option<(String, &'static str)> {
+    pub(crate) fn operator_trait_method(&self, op: &BinaryOp) -> Option<(String, &'static str)> {
         match op {
             BinaryOp::Add => Some(("Add".to_string(), "add")),
             BinaryOp::Sub => Some(("Sub".to_string(), "sub")),

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -396,6 +396,7 @@ fn compile_after_load<H: CompilerHost>(
     // degrade gracefully — it would surface as a panic deep inside
     // synthesis. The `debug_assert!` below makes that contract loud at
     // the leak site instead of one stage later.
+    let world_registry = state.world_registry;
     let tysys = state.tysys;
     debug_assert_eq!(
         std::sync::Arc::strong_count(&tysys.trait_env),
@@ -423,7 +424,7 @@ fn compile_after_load<H: CompilerHost>(
         implicit_modules,
         module_name,
         tysys.wasi_registry,
-        tysys.world_registry,
+        world_registry,
         builtin_registry,
         interner,
     );

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -387,20 +387,23 @@ fn compile_after_load<H: CompilerHost>(
     // is populated.
     let state = state.expect("elaborator state present when is_complete");
 
+    // Move trait_env out of `state.tysys` rather than cloning the `Arc`,
+    // so that `Package` is the unique owner. `synthesize` later relies
+    // on `Arc::try_unwrap` succeeding to swap layers in place; a stray
+    // clone here would force a deep `TraitEnv` clone instead.
+    let tysys = state.tysys;
+    let builtin_registry = std::rc::Rc::try_unwrap(tysys.builtin_registry)
+        .unwrap_or_else(|rc| (*rc).clone());
     let package = Package::new(
         entry_module_source,
         tir_modules,
         symbols,
-        // Move trait_env out of `state` rather than cloning the `Arc`,
-        // so that `Package` is the unique owner. `synthesize` later relies
-        // on `Arc::try_unwrap` succeeding to swap layers in place; a stray
-        // clone here would force a deep `TraitEnv` clone instead.
-        state.trait_env,
+        tysys.trait_env,
         implicit_modules,
         module_name,
-        state.wasi_registry,
-        state.world_registry,
-        state.builtin_registry,
+        tysys.wasi_registry,
+        tysys.world_registry,
+        builtin_registry,
         interner,
     );
 
@@ -761,7 +764,7 @@ pub async fn dump_with_host_and_world<H: CompilerHost>(
             &load_result.modules,
             load_result.entry_module_source.clone(),
             &logger,
-            &load_result.included_files,
+            std::rc::Rc::new(load_result.included_files.clone()),
             load_result.invocations.clone(),
             interner.clone(),
         )

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -392,8 +392,8 @@ fn compile_after_load<H: CompilerHost>(
     // on `Arc::try_unwrap` succeeding to swap layers in place; a stray
     // clone here would force a deep `TraitEnv` clone instead.
     let tysys = state.tysys;
-    let builtin_registry = std::rc::Rc::try_unwrap(tysys.builtin_registry)
-        .unwrap_or_else(|rc| (*rc).clone());
+    let builtin_registry =
+        std::rc::Rc::try_unwrap(tysys.builtin_registry).unwrap_or_else(|rc| (*rc).clone());
     let package = Package::new(
         entry_module_source,
         tir_modules,

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -388,10 +388,31 @@ fn compile_after_load<H: CompilerHost>(
     let state = state.expect("elaborator state present when is_complete");
 
     // Move trait_env out of `state.tysys` rather than cloning the `Arc`,
-    // so that `Package` is the unique owner. `synthesize` later relies
-    // on `Arc::try_unwrap` succeeding to swap layers in place; a stray
-    // clone here would force a deep `TraitEnv` clone instead.
+    // so that `Package` is the unique owner. `synthesize` later calls
+    // `TraitEnv::extend_with_synthesised`, which `Arc::try_unwrap`s the
+    // `trait_env` and **panics** if the `Arc` has more than one strong
+    // reference (see `trait_env.rs::extend_with_synthesised`). `TraitEnv`
+    // does not implement `Clone`, so a stray clone at this point cannot
+    // degrade gracefully — it would surface as a panic deep inside
+    // synthesis. The `debug_assert!` below makes that contract loud at
+    // the leak site instead of one stage later.
     let tysys = state.tysys;
+    debug_assert_eq!(
+        std::sync::Arc::strong_count(&tysys.trait_env),
+        1,
+        "Package::new must be the unique `Arc<TraitEnv>` owner; a leftover \
+         per-module clone would panic in extend_with_synthesised"
+    );
+    // `Rc::try_unwrap` for `builtin_registry` is the same uniqueness
+    // contract; `BuiltinRegistry` *does* implement `Clone`, so the
+    // fallback path is sound but quietly deep-copies — the debug-assert
+    // catches the leak before that happens.
+    debug_assert_eq!(
+        std::rc::Rc::strong_count(&tysys.builtin_registry),
+        1,
+        "Package::new must be the unique `Rc<BuiltinRegistry>` owner; a \
+         leftover per-module clone would silently fall back to a deep clone"
+    );
     let builtin_registry =
         std::rc::Rc::try_unwrap(tysys.builtin_registry).unwrap_or_else(|rc| (*rc).clone());
     let package = Package::new(

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -779,6 +779,12 @@ pub async fn dump_with_host_and_world<H: CompilerHost>(
     };
 
     // === Phase 7: Resolve all modules to TIR ===
+    // Hand `load_result.included_files` to the elaborator via partial
+    // move + `Rc::new`, matching the `semantics_with_logger` pattern.
+    // The map can be megabytes for projects that bundle binary assets
+    // via `#include_bytes`, and nothing below this line reads
+    // `load_result.included_files` again.
+    let included_files = std::rc::Rc::new(load_result.included_files);
     let resolve_output = {
         let _span = logger.span("elaborate");
         Elaborator::elaborate_all_modules(
@@ -786,7 +792,7 @@ pub async fn dump_with_host_and_world<H: CompilerHost>(
             &load_result.modules,
             load_result.entry_module_source.clone(),
             &logger,
-            std::rc::Rc::new(load_result.included_files.clone()),
+            included_files,
             load_result.invocations.clone(),
             interner.clone(),
         )

--- a/wado-compiler/src/optimize/elide_box_local.rs
+++ b/wado-compiler/src/optimize/elide_box_local.rs
@@ -558,7 +558,7 @@ fn walk_children_pure<'a>(
         match walk_expr_for_leftmost(c, candidate, field_name) {
             LeftmostWalk::Found => return LeftmostWalk::Found,
             LeftmostWalk::Blocked => return LeftmostWalk::Blocked,
-            LeftmostWalk::Pure => continue,
+            LeftmostWalk::Pure => {}
         }
     }
     LeftmostWalk::Pure

--- a/wado-compiler/src/semantics.rs
+++ b/wado-compiler/src/semantics.rs
@@ -664,6 +664,7 @@ pub(crate) fn semantics_with_logger<H: CompilerHost>(
         );
     }
 
+    let included_files = std::rc::Rc::new(load_result.included_files);
     let state = {
         let _span = logger.span("elaborate/annotate");
         Elaborator::annotate_modules(
@@ -671,6 +672,7 @@ pub(crate) fn semantics_with_logger<H: CompilerHost>(
             &load_result.modules,
             &load_result.entry_module_source,
             logger,
+            included_files,
             load_result.invocations.clone(),
             interner.clone(),
             snapshot.as_deref(),
@@ -710,7 +712,6 @@ pub(crate) fn semantics_with_logger<H: CompilerHost>(
             &load_result.modules,
             load_result.entry_module_source.clone(),
             logger,
-            &load_result.included_files,
             snapshot.as_deref(),
         ) {
             Ok(m) => (m, true),
@@ -722,7 +723,7 @@ pub(crate) fn semantics_with_logger<H: CompilerHost>(
     // LSP queries read this snapshot; any further lowering (none today) would
     // continue interning into the shared `Rc<RefCell<TypeTable>>` held by
     // `state.type_table`.
-    let types = state.type_table.borrow().clone();
+    let types = state.tysys.type_table.borrow().clone();
 
     // Drain the elaborator's shared reference / local maps into owned IndexMaps
     // so LSP queries can hand out `&Symbol` references without juggling

--- a/wado-compiler/src/semantics.rs
+++ b/wado-compiler/src/semantics.rs
@@ -722,7 +722,7 @@ pub(crate) fn semantics_with_logger<H: CompilerHost>(
     // Take an immutable snapshot of the type table at the end of lowering.
     // LSP queries read this snapshot; any further lowering (none today) would
     // continue interning into the shared `Rc<RefCell<TypeTable>>` held by
-    // `state.type_table`.
+    // `state.tysys.type_table`.
     let types = state.tysys.type_table.borrow().clone();
 
     // Drain the elaborator's shared reference / local maps into owned IndexMaps


### PR DESCRIPTION
First two stages of the elaborator re-architecture described in
[`docs/wep-2026-05-26-elaborator-rearchitecture.md`](../blob/main/docs/wep-2026-05-26-elaborator-rearchitecture.md):
the elaborator God Object loses its type-system half to a new
`TypeSystem` struct, and the WEP's `ModuleSemantics` skeleton lands in
place so stages 3-5 have a fixed physical target to migrate fields
into.

## Summary

- **Stage 1 (skeleton).** Empty `TypeSystem` + `ModuleSemantics`
  (with four sub-structs `bindings` / `decls` / `imports` / `types`)
  introduced alongside the existing `Elaborator` / `AnnotateState`.
  Every existing field on those two structs gained a
  `// MIGRATION:` marker naming its future destination, so the
  later stages move logic without re-litigating placement.
- **Stage 2a (TypeSystem fields).** 15 pipeline-wide fields move
  off `Elaborator` / `AnnotateState` onto `TypeSystem`: the
  `TypeTable` arena, the seven cross-module decl-interned tables,
  `trait_env`, the WASI / builtin registries, the included-files
  map, and the two read-only caches (`known_type_names_cache`,
  `loaded_module_func_indices`). `TypeSystem` is `Clone` over
  shallow `Rc` / `Arc` handles, so per-module elaborators get a
  cheap view via `state.tysys.clone()`.
- **Stage 2b (pure helpers move).** Five host-agnostic helpers
  migrate to `impl TypeSystem`: `is_known_type_name`,
  `is_numeric_literal`, `operator_trait_method`, `typecheck`,
  `typecheck_return`. `typecheck` is split three layers
  (`check_assignable` pure / `TypeSystem::typecheck` returning
  `Result<(), TypeMismatchPayload>` / `Elaborator::typecheck`
  emitting via `Logger<H>`) so `TypeSystem` stays free of the
  `<H: CompilerHost>` plumbing.
- **Review pass (#1-#14).** All 13 actionable findings from the
  branch-review pass are addressed in this PR — see "Review
  findings addressed" below.
- **WEP refresh.** A new "Status" section in the WEP marks Stage 1
  / Stage 2 done and records the design refinements that emerged
  during implementation (host-agnostic discipline, membership rule
  in code, three deferred caches with `trait_check_stack`
  re-classified as a per-call recursion guard rather than a cache,
  `debug_assert!` on `Arc` / `Rc` strong-counts at the Package
  hand-off).

Stages 3-7 of the WEP remain open and will land as separate PRs.

## Review findings addressed

Branch review ran 9 angles + verification; this PR addresses every
non-refuted finding except #11 (the empty `sem/*` skeletons — kept
intentionally as Stage 1 deliverables, to be populated in Stage 3).

| # | Commit | Change |
|---|---|---|
| #1 | `fdeccea4` | Replace inline `is_numeric_literal` in `expr.rs:3241` with `self.tysys.is_numeric_literal(...)` |
| #2 | `d69f2ffc` | Delete dead legacy `pub fn resolve_module` + `Elaborator::new` (no callers; deleting one made the other dead) |
| #3 | `fdeccea4` | Re-classify `trait_check_stack` migration marker — it's a per-call recursion guard, not a type-system cache; sharing it would be a soundness bug |
| #4 | `fdeccea4` | Fix stale `lib.rs` comment about `Arc::try_unwrap` (panics, doesn't deep-clone) and add `debug_assert!` for the `Arc<TraitEnv>` / `Rc<BuiltinRegistry>` uniqueness contracts |
| #5 | `ca1c237b` | `typecheck` host-agnostic via Result + Elaborator wrapper (full rationale above) |
| #6 | `95c8bf1d` | Move `world_registry` off `TypeSystem` to `AnnotateState` — the elaborator never queries it, only post-elaborator stages do |
| #7 | `c1988d40` | Drop wasteful `included_files.clone()` in `lib.rs` dump path; partial-move into `Rc::new` matching `semantics.rs` |
| #8 | `31fa1127` | Drop `current_module_func_index` field — redundant with the pre-built `tysys.loaded_module_func_indices` |
| #10 | `2ecd9b10` | Replace `_ => …` wildcards in `tysys.rs` helpers with exhaustive arms so a new `BinaryOp` / `Expr` variant triggers a compile error |
| #12 / #13 / #14 | `53f196d9` | Stale doc comments (`state.type_table`, `snap.state.builtin_registry`), ambiguous `// Set in resolve_module` references, and local-var names not matching their `TypeSystem` field names |
| — | `245f7bd1` | Drop stale `#[allow(dead_code)]` from `symbols` / `loaded_modules` (both have live readers) |

## Architecture notes

- `TypeSystem` membership rule (recorded in `tysys.rs` module
  docs): a field belongs only if the elaborator queries it while
  making type decisions. `wasi_registry` qualifies (`call.rs` uses
  it for effect signature lookups); `world_registry` does not
  (only post-elaborator stages read it).
- Three deferred-to-later-stage `Elaborator` caches:
  `indexing_trait_cache` and `method_info_cache` are genuine
  type-system caches awaiting the pipeline-wide cache-lifetime
  story; `trait_check_stack` is **not** a cache despite the
  superficial shape and migrates to the per-function transient
  scope bucket alongside `trait_ctx`.
- The pre-existing `9f1161f0 fix(optimize): remove needless
  continue` commit on this branch is unrelated to the elaborator
  refactor; it predates Stage 1 and is included here only because
  the branch was created from it. Safe to squash or carry through.

## Test plan

- [x] `cargo clippy -p wado-compiler --all-targets -- -D warnings`
      clean
- [x] `mise run test` green (49 / 49 test groups, 2920 e2e
      fixtures passed) — re-run after each commit in the review
      pass
- [x] `mise run on-task-done` full pipeline (compile 971 / 971,
      load 971 / 971, test 2920 / 2920) green
- [ ] CI confirms the same on the PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01TtZ2fxddyKSS2ApRnWTsEh)_