### PR TITLE
chore(logger): name previously-unmeasured spans in loader / semantics

### DIFF
--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -1021,7 +1021,10 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         self.logger.span_end(&format!("load {entry_name}"));
 
         // Load all dependencies iteratively
-        let core_cache = cached_stdlib();
+        let core_cache = {
+            let _span = self.logger.span("stdlib_cache_init");
+            cached_stdlib()
+        };
         while let Some((from_module_source, module_source)) = pending.pop_front() {
             // Skip if already loaded
             if self.loaded.contains_key(&module_source) {
@@ -1081,7 +1084,10 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         }
 
         // Load implicit modules (for compiler-generated code)
-        self.load_implicit_modules()?;
+        self.logger.span_start("load/implicit_modules");
+        let implicit_result = self.load_implicit_modules();
+        self.logger.span_end("load/implicit_modules");
+        implicit_result?;
 
         // Drain any wasm asset imports surfaced by implicit modules (e.g.
         // `core:builtin` declaring `use _ from "./libm.wat" with { type: "wat" };`).
@@ -1091,7 +1097,10 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         }
 
         // Collect and load files referenced by #include_str / #include_bytes
-        let included_files = self.load_included_files().await?;
+        let included_files = {
+            let _span = self.logger.span("load/included_files");
+            self.load_included_files().await?
+        };
 
         Ok(LoadResult {
             modules: self.loaded,
@@ -1171,17 +1180,21 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
             ModuleSource::Wasm { path, .. } => path.clone(),
             _ => unreachable!(),
         };
-        let raw_bytes = self.fetch_wasm_asset_bytes(&source, &path).await?;
-        let core_wasm_bytes = match kind {
-            WasmAssetKind::Wat => wat::parse_bytes(&raw_bytes)
-                .map_err(|e| LoadError::WasmImport {
-                    module_source: source.clone(),
-                    message: format!("failed to parse .wat: {e}"),
-                })?
-                .into_owned(),
-            WasmAssetKind::Wasm => raw_bytes,
+        let (core_wasm_bytes, function_exports) = {
+            let _span = self.logger.span(&format!("load_wasm_asset {namespace}"));
+            let raw_bytes = self.fetch_wasm_asset_bytes(&source, &path).await?;
+            let core_wasm_bytes = match kind {
+                WasmAssetKind::Wat => wat::parse_bytes(&raw_bytes)
+                    .map_err(|e| LoadError::WasmImport {
+                        module_source: source.clone(),
+                        message: format!("failed to parse .wat: {e}"),
+                    })?
+                    .into_owned(),
+                WasmAssetKind::Wasm => raw_bytes,
+            };
+            let function_exports = parse_wasm_module_exports(&source, &core_wasm_bytes)?;
+            (core_wasm_bytes, function_exports)
         };
-        let function_exports = parse_wasm_module_exports(&source, &core_wasm_bytes)?;
 
         // Synthesize a Wado AST module from the asset's exports and run
         // it through the regular parse/bind pipeline so that

--- a/wado-compiler/src/semantics.rs
+++ b/wado-compiler/src/semantics.rs
@@ -628,7 +628,10 @@ pub(crate) fn semantics_with_logger<H: CompilerHost>(
     // the ~28 s of CPU otherwise duplicated across a typical `wado test`
     // run.  Returns `None` when called from inside the snapshot builder
     // itself (re-entry guard); a fresh full pipeline runs in that case.
-    let snapshot = crate::stdlib_snapshot::get_or_init_snapshot();
+    let snapshot = {
+        let _span = logger.span("stdlib_snapshot");
+        crate::stdlib_snapshot::get_or_init_snapshot()
+    };
 
     let (symbols, analyze_ok) = {
         let _span = logger.span("analyze");


### PR DESCRIPTION
## Summary

Five chunks of work in the compile pipeline ran outside any
`logger.span()`, so `--log-level DEBUG` output showed them as unexplained
gaps between adjacent spans. This PR wraps each with its own span so the
log is fully accounted for.

Spans added:

- `stdlib_cache_init` — first-call initialization of `cached_stdlib()`
  in the loader (parses+binds every stdlib `.wado` once per process).
- `load/implicit_modules` — `Loader::load_implicit_modules`.
- `load_wasm_asset {namespace}` — wasm asset fetch +
  `wat::parse_bytes` + `parse_wasm_module_exports` in
  `Loader::handle_wasm_import`, before the existing `synthesize` span.
- `load/included_files` — `Loader::load_included_files` async fetch.
- `stdlib_snapshot` — `stdlib_snapshot::get_or_init_snapshot()` in
  `semantics_of`.

After this change, every gap in `wado run --log-level DEBUG` is named.

For example, on `example/hello.wado` (debug build), the previously
unexplained ~60 ms gap between `<< load example/hello.wado` and the
first `>> load core:cli (cached)` now reads:

```
[00:00:00.0036] >> stdlib_cache_init
[00:00:00.0494] << stdlib_cache_init
```

No behavior change; only adds spans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)