### PR TITLE
elaborator: move per-module state to ModuleSemantics (Stage 3)

### DIFF
--- a/docs/wep-2026-05-26-elaborator-rearchitecture.md
+++ b/docs/wep-2026-05-26-elaborator-rearchitecture.md
@@ -387,11 +387,87 @@ migration; see Trade-offs.
   - The legacy `pub fn resolve_module` single-module wrapper and
     `Elaborator::new` were removed as dead code; all entry now goes
     through `annotate_modules` + `build_tir_from_state`.
-- [ ] **Stage 3 — `ModuleSemantics` population.**
+- [x] **Stage 3 — `ModuleSemantics` population.**
+  - The four sub-structs (`bindings`, `imports`, `types`, `decls`) gained
+    their concrete fields, replacing the flat per-module fields that
+    previously lived on `Elaborator` and the `Rc<RefCell<…>>` maps that
+    `AnnotateState` shared with the body walk.
+  - `Elaborator` now owns a single `sem: ModuleSemantics`; the per-module
+    body walk's `&mut sem` access stays disjoint across modules and the
+    shared-mutability plumbing is gone.
+  - `AnnotateState.module_semantics: IndexMap<ModuleSource, ModuleSemantics>`
+    replaces `references` / `local_symbols` / `local_types`
+    `Rc<RefCell<…>>`. The snapshot's flat maps are split by `key.module`
+    during seeding; `semantics_with_logger` flattens back at the end so
+    the LSP-facing `Semantics` API (keyed by full `SymbolKey`) is
+    unchanged.
+  - `Elaborator::build_tir_from_state` now takes `&mut AnnotateState` so
+    it can swap each module's `ModuleSemantics` out for the body walk
+    and reinstall the populated instance afterwards.
 - [ ] **Stage 4 — Per-`AstId` annotation storage.**
 - [ ] **Stage 5 — `annotate_bodies` / `reify` split.**
 - [ ] **Stage 6 — Liveness and DCE.**
 - [ ] **Stage 7 — Cleanup.**
+
+### Stage 3 design notes
+
+#### `Elaborator` owns `ModuleSemantics`, not `&mut`
+
+The WEP's Decision sketch had the per-module elaborator hold
+`&mut ModuleSemantics`. The implementation diverges: `Elaborator` owns a
+`sem: ModuleSemantics` by value, populated from `state.module_semantics`
+on entry to `resolve_module` and re-installed on exit.
+
+The motivation is the same — keep the body walk's mutable access
+disjoint across modules — but ownership turned out to be the lighter
+shape:
+
+- No second lifetime parameter on `Elaborator<'a, H>`, which already
+  threads `'a` through `symbols` / `loaded_modules` / `logger` /
+  `current_module_items`. Adding `'sem` would touch every `impl<'a, H>`
+  block and the existing extension methods on `TypeParamScope`.
+- Same `Clone`-by-shallow-Rc handoff pattern as
+  [`tysys::TypeSystem`] already uses — moving a per-module value out of
+  the driver, into the per-module worker, and back at completion. The
+  call site reads as one symmetric pair (`swap_remove` + `insert`)
+  around the body walk.
+- `&mut ModuleSemantics` would have forced the driver to keep
+  `state.module_semantics` borrowed across `resolve_module`, conflicting
+  with the iteration over `state.sorted_sources` (cloned out of the
+  same `state`). Owning the value sidesteps that.
+
+The decision is structural, not policy: the membership rule and the
+sub-struct boundaries from the Decision section all stand.
+
+#### `module_semantics` is the storage location, `Semantics` keeps its flat API
+
+`AnnotateState.module_semantics: IndexMap<ModuleSource, ModuleSemantics>`
+replaces three `Rc<RefCell<…>>` fields (`references`, `local_symbols`,
+`local_types`). `semantics_with_logger` flattens it back into the
+existing `Semantics` flat maps after `build_tir_from_state` returns,
+keeping the LSP-facing query surface (`Semantics::referenced_symbol`,
+`iter_references`, `local_type_name`, …) byte-for-byte compatible with
+Stage 2.
+
+The snapshot seeds module_semantics by splitting its own flat maps by
+`key.module`. The split is O(snapshot size) and happens once per
+compile; the alternative — storing per-module data on the snapshot
+itself — is a Stage 7 cleanup, not a Stage 3 requirement.
+
+The two layouts (per-module on `AnnotateState`, flat on `Semantics`)
+buy the work the elaborator needs from per-module ownership without
+churning the LSP API. A future Stage 7 refactor that promotes
+`module_semantics` to `Semantics` directly can do so without touching
+the LSP query call sites — they go through `Semantics`'s methods.
+
+#### `build_tir_from_state` now takes `&mut AnnotateState`
+
+The per-module body walk needs to swap each `ModuleSemantics` out of
+`state.module_semantics` and back in, which requires unique access to
+the map. `build_tir_from_state`'s signature changes from
+`&AnnotateState` to `&mut AnnotateState` accordingly. The two callers
+(`elaborate_all_modules`, `semantics_with_logger`) own their state by
+value at that point, so threading `&mut` through is mechanical.
 
 ### Stage 2 design notes
 

--- a/docs/wep-2026-05-26-elaborator-rearchitecture.md
+++ b/docs/wep-2026-05-26-elaborator-rearchitecture.md
@@ -370,182 +370,108 @@ migration; see Trade-offs.
 ## Status
 
 - [x] **Stage 1 — Skeleton.** Empty `TypeSystem` + `ModuleSemantics`
-      (`bindings`, `decls`, `imports`, `types`) introduced alongside the
-      existing `Elaborator` / `AnnotateState`. Every existing field
-      annotated with its future destination via `// MIGRATION:` markers.
-      No method or field moved.
-- [x] **Stage 2 — Pure type-system operations on `TypeSystem`.**
-  - Stage 2a: 15 pipeline-wide fields hoisted onto `TypeSystem`
-    (type arena, decl-interned tables, registries, included-files
-    map, read-only caches). `AnnotateState` and `Elaborator` each
-    hold one `tysys: TypeSystem` field; `TypeSystem` is `Clone`
-    (shallow `Rc` / `Arc` copy) so per-module elaborators get a
-    cheap view.
-  - Stage 2b: five host-agnostic helpers moved to `impl TypeSystem`:
-    `is_known_type_name`, `is_numeric_literal`,
-    `operator_trait_method`, `typecheck`, `typecheck_return`.
-  - The legacy `pub fn resolve_module` single-module wrapper and
-    `Elaborator::new` were removed as dead code; all entry now goes
-    through `annotate_modules` + `build_tir_from_state`.
-- [x] **Stage 3 — `ModuleSemantics` population.**
-  - The four sub-structs (`bindings`, `imports`, `types`, `decls`) gained
-    their concrete fields, replacing the flat per-module fields that
-    previously lived on `Elaborator` and the `Rc<RefCell<…>>` maps that
-    `AnnotateState` shared with the body walk.
-  - `Elaborator` now owns a single `sem: ModuleSemantics`; the per-module
-    body walk's `&mut sem` access stays disjoint across modules and the
-    shared-mutability plumbing is gone.
-  - `AnnotateState.module_semantics: IndexMap<ModuleSource, ModuleSemantics>`
-    replaces `references` / `local_symbols` / `local_types`
-    `Rc<RefCell<…>>`. The snapshot's flat maps are split by `key.module`
-    during seeding; `semantics_with_logger` flattens back at the end so
-    the LSP-facing `Semantics` API (keyed by full `SymbolKey`) is
-    unchanged.
-  - `Elaborator::build_tir_from_state` now takes `&mut AnnotateState` so
-    it can swap each module's `ModuleSemantics` out for the body walk
-    and reinstall the populated instance afterwards.
+      sub-structs introduced alongside the existing `Elaborator` /
+      `AnnotateState`; every existing field annotated with its future
+      destination via `// MIGRATION:` markers.
+- [x] **Stage 2 — Pure type-system operations on `TypeSystem`.** 15
+      pipeline-wide fields (type arena, decl-interned tables, registries,
+      included-files map, read-only caches) and five host-agnostic
+      helpers (`is_known_type_name`, `is_numeric_literal`,
+      `operator_trait_method`, `typecheck`, `typecheck_return`) now live
+      on `TypeSystem`. Both `AnnotateState` and `Elaborator` hold one
+      `tysys: TypeSystem` (shallow `Rc`/`Arc` clone). Legacy
+      `pub fn resolve_module` + `Elaborator::new` removed as dead code.
+- [x] **Stage 3 — `ModuleSemantics` population.** The four sub-structs
+      hold the per-module state previously flat on `Elaborator`.
+      `Elaborator` owns one `sem: ModuleSemantics`;
+      `AnnotateState.module_semantics: IndexMap<ModuleSource, ModuleSemantics>`
+      replaces the trio of `Rc<RefCell<…>>` maps (`references` /
+      `local_symbols` / `local_types`). `build_tir_from_state` takes
+      `&mut AnnotateState` and swaps each module's instance around the
+      body walk; `semantics_with_logger` flattens back so `Semantics`'s
+      flat-map API is unchanged.
 - [ ] **Stage 4 — Per-`AstId` annotation storage.**
 - [ ] **Stage 5 — `annotate_bodies` / `reify` split.**
 - [ ] **Stage 6 — Liveness and DCE.**
 - [ ] **Stage 7 — Cleanup.**
 
-### Stage 3 design notes
+### Design notes (Stages 1–3)
 
-#### `Elaborator` owns `ModuleSemantics`, not `&mut`
+#### TypeSystem membership rule
 
-The WEP's Decision sketch had the per-module elaborator hold
-`&mut ModuleSemantics`. The implementation diverges: `Elaborator` owns a
-`sem: ModuleSemantics` by value, populated from `state.module_semantics`
-on entry to `resolve_module` and re-installed on exit.
+A field belongs on `TypeSystem` iff the elaborator's body walk queries
+it while making a type decision. `world_registry` lives on
+`AnnotateState`, not `TypeSystem`: only post-elaborator stages (`link`,
+`synthesis`, `optimize/dce`, world-existence validation in `lib.rs`)
+read it.
 
-The motivation is the same — keep the body walk's mutable access
-disjoint across modules — but ownership turned out to be the lighter
-shape:
-
-- No second lifetime parameter on `Elaborator<'a, H>`, which already
-  threads `'a` through `symbols` / `loaded_modules` / `logger` /
-  `current_module_items`. Adding `'sem` would touch every `impl<'a, H>`
-  block and the existing extension methods on `TypeParamScope`.
-- Same `Clone`-by-shallow-Rc handoff pattern as
-  [`tysys::TypeSystem`] already uses — moving a per-module value out of
-  the driver, into the per-module worker, and back at completion. The
-  call site reads as one symmetric pair (`swap_remove` + `insert`)
-  around the body walk.
-- `&mut ModuleSemantics` would have forced the driver to keep
-  `state.module_semantics` borrowed across `resolve_module`, conflicting
-  with the iteration over `state.sorted_sources` (cloned out of the
-  same `state`). Owning the value sidesteps that.
-
-The decision is structural, not policy: the membership rule and the
-sub-struct boundaries from the Decision section all stand.
-
-#### `module_semantics` is the storage location, `Semantics` keeps its flat API
-
-`AnnotateState.module_semantics: IndexMap<ModuleSource, ModuleSemantics>`
-replaces three `Rc<RefCell<…>>` fields (`references`, `local_symbols`,
-`local_types`). `semantics_with_logger` flattens it back into the
-existing `Semantics` flat maps after `build_tir_from_state` returns,
-keeping the LSP-facing query surface (`Semantics::referenced_symbol`,
-`iter_references`, `local_type_name`, …) byte-for-byte compatible with
-Stage 2.
-
-The snapshot seeds module_semantics by splitting its own flat maps by
-`key.module`. The split is O(snapshot size) and happens once per
-compile; the alternative — storing per-module data on the snapshot
-itself — is a Stage 7 cleanup, not a Stage 3 requirement.
-
-The two layouts (per-module on `AnnotateState`, flat on `Semantics`)
-buy the work the elaborator needs from per-module ownership without
-churning the LSP API. A future Stage 7 refactor that promotes
-`module_semantics` to `Semantics` directly can do so without touching
-the LSP query call sites — they go through `Semantics`'s methods.
-
-#### `build_tir_from_state` now takes `&mut AnnotateState`
-
-The per-module body walk needs to swap each `ModuleSemantics` out of
-`state.module_semantics` and back in, which requires unique access to
-the map. `build_tir_from_state`'s signature changes from
-`&AnnotateState` to `&mut AnnotateState` accordingly. The two callers
-(`elaborate_all_modules`, `semantics_with_logger`) own their state by
-value at that point, so threading `&mut` through is mechanical.
-
-### Stage 2 design notes
-
-The following decisions emerged while moving the type system out
-from under `Elaborator`. They refine — and in a few cases narrow
-— the surface sketched in "TypeSystem surface" above.
+`indexing_trait_cache` / `method_info_cache` are genuine type-system
+caches but stay on `Elaborator` until the pipeline-wide cache lifetime
+story is decided. `trait_check_stack` is a per-call frame stack (not a
+cache); sharing it would either leak stale frames (soundness bug) or
+need save/restore that defeats the move — it stays with `trait_ctx`.
 
 #### TypeSystem stays host-agnostic
 
-`TypeSystem` operations that need to report a type error return
-`Result<(), TypeMismatchPayload>` (or analogous payload), never
-`&Logger<H>`. The `<H: CompilerHost>` parameter is confined to a
-thin wrapper on `Elaborator` that emits the diagnostic. Without
-this discipline `<H>` is contagious — every `TypeSystem` method
-that errors would propagate it, eventually pulling the host trait
-into the type-system API.
-
-The pattern in `typecheck.rs` is the template for the rest of the
-operations the WEP plans to move (`coerce`, method-lookup core,
-trait queries):
-
-1. A pure helper over `&TypeTable` (e.g. `check_assignable`).
-2. `impl TypeSystem { fn op(&self, …) -> Result<…, Payload> }`.
-3. `impl Elaborator { fn op(&self, …) { logger.error(payload) } }`.
-
-#### TypeSystem membership rule, in code
-
-`TypeSystem` only holds fields the elaborator queries while making
-type decisions. Concretely:
-
-- `wasi_registry` belongs (`call.rs` queries WASI function
-  signatures through it).
-- `world_registry` does **not** belong on `TypeSystem`, even
-  though it is built by the same `WasiRegistry::build_from_stdlib`
-  call. Only post-elaborator stages (`link`, `synthesis`,
-  `optimize/dce`, `lib.rs` world-existence validation) read it.
-  It lives on `AnnotateState` (driver state).
-
-The mechanical question to ask when adding a field: "does the
-elaborator's body walk query this field?" If no, it does not
-belong on `TypeSystem`.
-
-#### Three caches are deferred
-
-`indexing_trait_cache` and `method_info_cache` are genuine
-type-system caches whose keys are pure `TypeId` / name tuples;
-their move to `TypeSystem` is deferred only because the
-pipeline-wide cache lifetime story (today they are per-Elaborator
-mutable state, populated by the body walk) is not yet decided.
-
-`trait_check_stack` _looks_ similar — `RefCell<Vec<…>>` mutable
-state on `Elaborator` — but it is **not** a cache. It is the
-per-call frame stack used by `type_implements_trait` to break
-recursion on recursive types; sharing it across modules would
-either leak stale frames (a soundness bug — wrong "recursive,
-optimistically true" answers) or require per-call save/restore
-plumbing that defeats the move. Its migration target is the
-transient annotate-time scope bucket alongside `trait_ctx`, not
-`TypeSystem`.
+`TypeSystem` operations return `Result<(), Payload>`, never
+`&Logger<H>`. The `<H: CompilerHost>` parameter is confined to a thin
+wrapper on `Elaborator` that emits the diagnostic. The pattern in
+`typecheck.rs` is the template: pure helper over `&TypeTable` →
+`impl TypeSystem` returning payload → `impl Elaborator` calling
+`logger.error`. Pure `TypeSystem` helpers enumerate enum variants
+exhaustively (no `_ => …`) so a new variant surfaces as a compile
+error.
 
 #### Unique-ownership contracts surface at the leak site
 
-`compile_after_load` consumes `Arc<TraitEnv>` and
-`Rc<BuiltinRegistry>` out of `state.tysys`. Both must be uniquely
-owned at that point — `synthesize`'s `extend_with_synthesised`
-panics on a shared `Arc<TraitEnv>`, and a shared
-`Rc<BuiltinRegistry>` silently falls back to a deep clone. The
-handoff uses `debug_assert_eq!` on `Arc::strong_count` /
-`Rc::strong_count` so a stray clone introduced by a later refactor
-surfaces at the leak site instead of in a downstream phase.
+`compile_after_load` consumes `Arc<TraitEnv>` and `Rc<BuiltinRegistry>`
+out of `state.tysys` and `debug_assert_eq!`s their strong counts. A
+stray clone in a later refactor surfaces at the handoff rather than in
+a downstream phase (`synthesize` panics on shared `Arc<TraitEnv>`;
+shared `Rc<BuiltinRegistry>` silently deep-clones).
 
-#### Exhaustive matches over enum kinds
+#### `Elaborator` owns `sem` by value, not `&mut ModuleSemantics`
 
-Pure `TypeSystem` helpers (`is_numeric_literal`,
-`operator_trait_method`) enumerate every `Expr` / `BinaryOp`
-variant rather than using `_ => …`. A new variant added to either
-enum surfaces here as a compile error, forcing a deliberate
-decision instead of silently falling into the catch-all.
+The Decision sketch had the elaborator hold `&mut ModuleSemantics`;
+the implementation owns `sem: ModuleSemantics` instead. Same goal
+(disjoint mutable access per module), lighter shape: no second
+lifetime parameter, same `Clone`-by-shallow-Rc handoff as `TypeSystem`
+already uses, and the driver iterates a cloned `sorted_sources` while
+mutating `state.module_semantics` without borrow conflict. The body
+walk is bracketed by `swap_remove(ms)` → `resolve_module` →
+`insert(ms, elaborator.sem)`.
+
+#### `Semantics` keeps its flat API
+
+`semantics_with_logger` drains `state.module_semantics.values_mut()`
+into the existing flat `references` / `locals` / `local_types` maps,
+so the LSP query surface (`referenced_symbol`, `iter_references`,
+`local_type_name`, …) is unchanged. Promoting per-module storage onto
+`Semantics` itself is a Stage 7 cleanup.
+
+#### Snapshot seeding asserts the loaded-set invariant
+
+The snapshot's flat maps are split by `key.module` into per-module
+`ModuleSemantics`. Seeding uses `get_mut` + `debug_assert!` rather
+than `entry().or_default()`: an invariant break (snapshot module not
+in current `modules.keys()`) surfaces in debug builds instead of
+silently creating phantom entries that the flatten would leak into
+`Semantics::references` as edges into unloaded modules.
+
+`build_tir_from_state` mirrors the invariant with
+`.expect("module_semantics is pre-populated by annotate_modules")`
+instead of `unwrap_or_default()` at `swap_remove`.
+
+#### `ModuleBindings` has a transient cross-module exception
+
+`with_module_perspective` swaps `current_module_source` without
+swapping `self.sem`, so record calls inside its body tag the use-key
+with the foreign module while writing into the outer module's
+`sem.bindings`. Today's flatten reconciles by full `SymbolKey`;
+Stage 5's reify will need to either extend `with_module_perspective`
+to swap `bindings`/`types` too or accept these maps as
+flat-store-by-construction. Same note next to the type in
+`sem/bindings.rs`.
 
 ## Consequences
 

--- a/wado-compiler/src/elaborator.rs
+++ b/wado-compiler/src/elaborator.rs
@@ -104,90 +104,34 @@ pub struct Elaborator<'a, H: CompilerHost> {
     /// tables, registries, included-files map, and the read-only caches
     /// built once during `annotate_modules`. See [`tysys::TypeSystem`].
     pub(crate) tysys: tysys::TypeSystem,
+    /// Per-module semantic facts (imports, decls, bindings, type
+    /// annotations). The elaborator takes ownership of one
+    /// [`sem::ModuleSemantics`] at the start of [`Self::resolve_module`]
+    /// and the driver re-installs it into
+    /// [`orchestration::AnnotateState::module_semantics`] afterwards. See
+    /// the [`sem`] module-level documentation for the membership rules.
+    pub(crate) sem: sem::ModuleSemantics,
     /// Symbol table from analyzer
-    // MIGRATION: cross-cutting input (stays on the driver).
     symbols: &'a SymbolTable,
     /// Loaded modules from analyzer
-    // MIGRATION: cross-cutting input (stays on the driver).
     loaded_modules: &'a IndexMap<ModuleSource, Module>,
-    /// Per-module import context (consumed by [`TypeLookup`]). Built once per
-    /// module from `use` declarations; replaces the 7 flat maps the elaborator
-    /// used to clone for each module.
-    // MIGRATION: → ModuleSemantics::imports (both fields below).
-    imported_type_sources: IndexMap<String, ModuleSource>,
-    import_original_names: IndexMap<String, String>,
-    /// Locally discovered additions to the type tables. Anonymous structs
-    /// (synthesized from struct literals) and the elaborator's own walk of
-    /// `module.items` insert here so [`TypeLookup`] can find them at the
-    /// highest priority. Always empty unless the current module has a
-    /// reason to override / extend the shared tables.
-    // MIGRATION: → ModuleSemantics::decls (per-module decl overrides, all 6 below).
-    //   Stage 2/3 may instead promote these into a per-module view on TypeSystem;
-    //   decided at the move site.
-    local_struct_fields: IndexMap<String, StructFieldInfo>,
-    local_newtypes: IndexMap<String, TypeId>,
-    local_generic_newtypes: IndexMap<String, GenericNewtypeInfo>,
-    local_enum_cases: IndexMap<String, EnumInfo>,
-    local_flags_cases: IndexMap<String, FlagsInfo>,
-    local_variant_cases: IndexMap<String, VariantInfo>,
-    /// Function return types (name -> return type)
-    // MIGRATION: → ModuleSemantics::decls.
-    function_return_types: IndexMap<String, TypeId>,
-    /// Imported function names for the current module
-    // MIGRATION: → ModuleSemantics::decls.
-    imported_functions: IndexSet<String>,
     /// Logger for emitting diagnostics
-    // MIGRATION: cross-cutting input (stays on the driver).
     logger: &'a Logger<'a, H>,
     /// Current module source being resolved (for struct type `module_source`)
     // MIGRATION: identifies the active `ModuleSemantics` — the driver swaps
     //   modules via the `IndexMap<ModuleSource, ModuleSemantics>` key, so this
-    //   field disappears after Stage 3.
+    //   field eventually disappears (Stage 5 carries it as an explicit
+    //   argument to the per-module walker).
     current_module_source: ModuleSource,
     /// Entry module source (for cross-module import dedup)
-    // MIGRATION: cross-cutting input (stays on the driver).
     entry_module_source: ModuleSource,
     /// Current module items (for local function parameter lookup)
-    // MIGRATION: cross-cutting input (the active module's AST is passed
-    //   alongside its `ModuleSemantics`).
     current_module_items: &'a [Item],
     /// Mutable trait resolution context: type params, bounds, associated type bindings, self type.
     /// Grouped together so scope entry/exit can save/restore the whole context at once.
     // MIGRATION: transient annotate-time scope (Stage 5 carries it as an
     //   explicit argument to `annotate_*` walkers).
     trait_ctx: trait_env::TraitContext,
-    /// Generic struct definitions (name -> type param count)
-    /// Used to determine if a struct is generic
-    // MIGRATION: → ModuleSemantics::decls.
-    generic_struct_names: IndexSet<String>,
-    /// Generic function type parameters (`func_name` -> `type_params`)
-    /// Used for substituting type parameters in return types
-    // MIGRATION: → ModuleSemantics::decls.
-    generic_function_params: IndexMap<String, Vec<(String, TypeId)>>,
-    /// Resolved param types for generic functions (`func_name` -> `param TypeIds`)
-    /// Resolved in the function's own type param scope so `TypeParams` have correct ids.
-    // MIGRATION: → ModuleSemantics::decls.
-    generic_function_resolved_param_types: IndexMap<String, Vec<TypeId>>,
-    /// Resolved return type for generic functions (`func_name` -> `return TypeId`)
-    /// Resolved in the function's own type param scope; used for expected-return
-    /// driven back-inference by [`infer::InferCtx::add_expected_return`].
-    // MIGRATION: → ModuleSemantics::decls.
-    generic_function_resolved_return_types: IndexMap<String, TypeId>,
-    /// Generic method type parameters (`mangled_name` -> `type_params`)
-    /// Used for substituting type parameters in method return types
-    // MIGRATION: → ModuleSemantics::decls.
-    generic_method_params: IndexMap<String, Vec<(String, TypeId)>>,
-    /// Resolved param types for generic methods (`mangled_name` -> `param TypeIds`)
-    /// Resolved in the method's own type param scope so `TypeParams` have correct ids.
-    // MIGRATION: → ModuleSemantics::decls.
-    generic_method_resolved_param_types: IndexMap<String, Vec<TypeId>>,
-    /// Namespace import aliases (e.g., "helper" -> module source for `use helper from "..."`)
-    // MIGRATION: → ModuleSemantics::imports.
-    namespace_imports: IndexMap<String, ModuleSource>,
-    /// Effect name to source module mapping (e.g., "Stdout" -> wasi:cli module source)
-    /// Built from import declarations and local interface declarations.
-    // MIGRATION: → ModuleSemantics::imports.
-    effect_sources: IndexMap<String, ModuleSource>,
     /// Effect parameter names currently in scope (from enclosing function's `<effect E>`)
     // MIGRATION: transient annotate-time scope (per-function, not per-module).
     current_effect_params: IndexSet<String>,
@@ -195,20 +139,6 @@ pub struct Elaborator<'a, H: CompilerHost> {
     /// Used to record use→def edges for effect parameter references in `with` clauses.
     // MIGRATION: transient annotate-time scope (per-function, not per-module).
     current_effect_param_decls: IndexMap<String, crate::ast::AstId>,
-    /// Global variables in the current module (name -> (type, `is_mutable`))
-    // MIGRATION: → ModuleSemantics::decls.
-    current_module_globals: IndexMap<String, (TypeId, bool)>,
-    /// Imported globals (local name -> (source module, original name, type, `is_mutable`))
-    // MIGRATION: → ModuleSemantics::decls.
-    imported_globals: IndexMap<String, (ModuleSource, String, TypeId, bool)>,
-    /// Associated constants from impl blocks ("`TypeName::CONST`" -> (type, expr))
-    /// These are inlined at every use site during resolution.
-    // MIGRATION: → ModuleSemantics::decls.
-    associated_constants: IndexMap<String, (ast::Type, ast::Expr)>,
-    /// Anonymous structs created during expression resolution.
-    /// Flushed into the `TirModule` at the end of `resolve_module`.
-    // MIGRATION: → ModuleSemantics::decls.
-    pending_anonymous_structs: Vec<crate::tir::TirStruct>,
     /// Cache for `find_indexing_trait_impl` results.
     /// Key: (`struct_name`, `base_type_id`, `trait_base_name`, `method_name`, `assoc_type_name`)
     // MIGRATION: → TypeSystem (type-system cache); deferred — needs the
@@ -237,26 +167,6 @@ pub struct Elaborator<'a, H: CompilerHost> {
     // MIGRATION: → TypeSystem (type-system cache); deferred — needs the
     //   pipeline-wide cache lifetime story.
     method_info_cache: IndexMap<(TypeId, String), Option<types::MethodInfo>>,
-    /// Use→def map for local variables. Shared via `Rc<RefCell<…>>` with
-    /// [`crate::elaborator::orchestration::AnnotateState`] so LSP queries see
-    /// references as soon as the elaborator has walked the body.
-    // MIGRATION: → ModuleSemantics::bindings (drops the `Rc<RefCell<…>>`;
-    //   the body walk takes `&mut ModuleSemantics`).
-    references: Rc<RefCell<IndexMap<SymbolKey, SymbolKey>>>,
-    /// Local binding [`Symbol`]s emitted alongside `references`. Populated at
-    /// every `ctx.add_local(...)` call that carries a user-visible defining
-    /// `AstId`. Shared via `Rc<RefCell<…>>` with `AnnotateState`.
-    // MIGRATION: → ModuleSemantics::bindings (drops the `Rc<RefCell<…>>`).
-    local_symbols: Rc<RefCell<IndexMap<SymbolKey, Symbol>>>,
-    /// Resolved [`TypeId`] for each local binding, keyed by the binding's
-    /// defining [`SymbolKey`]. Populated alongside `local_symbols` at every
-    /// `record_local_symbol` call. Shared via `Rc<RefCell<…>>` with
-    /// `AnnotateState` and ultimately drained into `Semantics::local_types`
-    /// for LSP inlay-hint consumption.
-    // MIGRATION: → ModuleSemantics::types (TypeId per binding-AstId fits the
-    //   "per-`AstId` type annotations" rule). LSP consumer
-    //   `Semantics::local_type_name` hides the placement.
-    local_types: Rc<RefCell<IndexMap<SymbolKey, TypeId>>>,
     /// When resolving a default-expression AST at a call site, fall back to
     /// looking up unresolved identifiers in this module's global scope. This
     /// preserves the callee's lexical scope for defaults that reference
@@ -266,13 +176,11 @@ pub struct Elaborator<'a, H: CompilerHost> {
     /// Kiln invocation redirects consulted by `use` resolution sites. Shared
     /// by `Rc` so per-module Elaborator instances can read the single
     /// compilation-unit-wide redirect map cheaply.
-    // MIGRATION: cross-cutting input (loader-provided redirect map).
     pub(super) invocations: Rc<crate::kiln::InvocationIndex>,
     /// `ModuleSource` interner shared with the loader and downstream
     /// phases. Wrapped in `Rc<RefCell<>>` so per-module elaborator
     /// instances can `borrow_mut()` it from `&self` contexts (e.g.
     /// `record_use_specifier_references`).
-    // MIGRATION: cross-cutting input (shared interner).
     pub(super) interner: Rc<RefCell<ModuleSourceInterner>>,
 }
 
@@ -283,8 +191,8 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
     pub(crate) fn type_lookup(&self) -> TypeLookup<'_> {
         TypeLookup {
             current_module_source: &self.current_module_source,
-            imported_type_sources: &self.imported_type_sources,
-            import_original_names: &self.import_original_names,
+            imported_type_sources: &self.sem.imports.imported_type_sources,
+            import_original_names: &self.sem.imports.import_original_names,
             all_newtypes: &self.tysys.all_newtypes,
             all_struct_fields: &self.tysys.all_struct_fields,
             all_variant_cases: &self.tysys.all_variant_cases,
@@ -292,12 +200,12 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             all_flags_cases: &self.tysys.all_flags_cases,
             all_resource_types: &self.tysys.all_resource_types,
             all_generic_newtypes: &self.tysys.all_generic_newtypes,
-            local_struct_fields: &self.local_struct_fields,
-            local_newtypes: &self.local_newtypes,
-            local_enum_cases: &self.local_enum_cases,
-            local_flags_cases: &self.local_flags_cases,
-            local_generic_newtypes: &self.local_generic_newtypes,
-            local_variant_cases: &self.local_variant_cases,
+            local_struct_fields: &self.sem.decls.local_struct_fields,
+            local_newtypes: &self.sem.decls.local_newtypes,
+            local_enum_cases: &self.sem.decls.local_enum_cases,
+            local_flags_cases: &self.sem.decls.local_flags_cases,
+            local_generic_newtypes: &self.sem.decls.local_generic_newtypes,
+            local_variant_cases: &self.sem.decls.local_variant_cases,
         }
     }
 
@@ -318,7 +226,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         if suffix.contains("::") {
             return None;
         }
-        if !self.namespace_imports.contains_key(prefix) {
+        if !self.sem.imports.namespace_imports.contains_key(prefix) {
             return None;
         }
         Some(suffix)
@@ -371,44 +279,58 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         body: impl FnOnce(&mut Self) -> R,
     ) -> R {
         let saved_src = std::mem::replace(&mut self.current_module_source, module_source);
-        let saved_imp = std::mem::replace(&mut self.imported_type_sources, imported_type_sources);
-        let saved_orig = std::mem::replace(&mut self.import_original_names, import_original_names);
-        let saved_local_struct = std::mem::take(&mut self.local_struct_fields);
-        let saved_local_newtypes = std::mem::take(&mut self.local_newtypes);
-        let saved_local_enum = std::mem::take(&mut self.local_enum_cases);
-        let saved_local_flags = std::mem::take(&mut self.local_flags_cases);
-        let saved_local_gnt = std::mem::take(&mut self.local_generic_newtypes);
-        let saved_local_variant = std::mem::take(&mut self.local_variant_cases);
+        let saved_imp = std::mem::replace(
+            &mut self.sem.imports.imported_type_sources,
+            imported_type_sources,
+        );
+        let saved_orig = std::mem::replace(
+            &mut self.sem.imports.import_original_names,
+            import_original_names,
+        );
+        let saved_local_struct = std::mem::take(&mut self.sem.decls.local_struct_fields);
+        let saved_local_newtypes = std::mem::take(&mut self.sem.decls.local_newtypes);
+        let saved_local_enum = std::mem::take(&mut self.sem.decls.local_enum_cases);
+        let saved_local_flags = std::mem::take(&mut self.sem.decls.local_flags_cases);
+        let saved_local_gnt = std::mem::take(&mut self.sem.decls.local_generic_newtypes);
+        let saved_local_variant = std::mem::take(&mut self.sem.decls.local_variant_cases);
 
         let result = body(self);
 
         self.current_module_source = saved_src;
-        self.imported_type_sources = saved_imp;
-        self.import_original_names = saved_orig;
-        self.local_struct_fields = saved_local_struct;
-        self.local_newtypes = saved_local_newtypes;
-        self.local_enum_cases = saved_local_enum;
-        self.local_flags_cases = saved_local_flags;
-        self.local_generic_newtypes = saved_local_gnt;
-        self.local_variant_cases = saved_local_variant;
+        self.sem.imports.imported_type_sources = saved_imp;
+        self.sem.imports.import_original_names = saved_orig;
+        self.sem.decls.local_struct_fields = saved_local_struct;
+        self.sem.decls.local_newtypes = saved_local_newtypes;
+        self.sem.decls.local_enum_cases = saved_local_enum;
+        self.sem.decls.local_flags_cases = saved_local_flags;
+        self.sem.decls.local_generic_newtypes = saved_local_gnt;
+        self.sem.decls.local_variant_cases = saved_local_variant;
         result
     }
 
     /// Record that an identifier resolved to a local binding in the current
     /// module. Both `use_id` and `def_id` live in `current_module_source`.
-    pub(super) fn record_reference(&self, use_id: crate::ast::AstId, def_id: crate::ast::AstId) {
+    pub(super) fn record_reference(
+        &mut self,
+        use_id: crate::ast::AstId,
+        def_id: crate::ast::AstId,
+    ) {
         let use_key = SymbolKey::new(self.current_module_source.clone(), use_id);
         let def_key = SymbolKey::new(self.current_module_source.clone(), def_id);
-        self.references.borrow_mut().insert(use_key, def_key);
+        self.sem.bindings.references.insert(use_key, def_key);
     }
 
     /// Record a use→def reference when the definition lives in a (possibly
     /// different) module identified directly by a [`SymbolKey`]. Prefer
     /// [`Self::record_reference_to_decl`] when the call site is constructing
     /// the key from `(module, ast_id)` parts.
-    pub(super) fn record_reference_to_key(&self, use_id: crate::ast::AstId, def_key: SymbolKey) {
+    pub(super) fn record_reference_to_key(
+        &mut self,
+        use_id: crate::ast::AstId,
+        def_key: SymbolKey,
+    ) {
         let use_key = SymbolKey::new(self.current_module_source.clone(), use_id);
-        self.references.borrow_mut().insert(use_key, def_key);
+        self.sem.bindings.references.insert(use_key, def_key);
     }
 
     /// Record a use→def reference where the defining declaration is
@@ -417,7 +339,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
     /// otherwise construct a [`SymbolKey`] inline — keeps `SymbolKey::new`
     /// confined to a single place.
     pub(super) fn record_reference_to_decl(
-        &self,
+        &mut self,
         use_id: crate::ast::AstId,
         decl_module: &ModuleSource,
         decl_ast_id: crate::ast::AstId,
@@ -429,7 +351,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
     /// the current module under `name` (local item, imported item, imported
     /// namespace member, etc.). Looks up the defining [`SymbolKey`] through
     /// the symbol table; no-op if the name is not declared.
-    pub(super) fn record_item_reference_by_name(&self, use_id: crate::ast::AstId, name: &str) {
+    pub(super) fn record_item_reference_by_name(&mut self, use_id: crate::ast::AstId, name: &str) {
         let Some(sym) = self
             .symbols
             .lookup_in_module(&self.current_module_source, name)
@@ -438,8 +360,9 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             return;
         };
         let use_key = SymbolKey::new(self.current_module_source.clone(), use_id);
-        self.references
-            .borrow_mut()
+        self.sem
+            .bindings
+            .references
             .insert(use_key, sym.defined_at.clone());
     }
 
@@ -451,7 +374,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
     /// Used for variant cases, enum cases, and flags members reached via
     /// a two-segment qualified ident.
     pub(super) fn record_qualified_case(
-        &self,
+        &mut self,
         ident: &crate::ast::IdentExpr,
         type_name: &str,
         case_module: &ModuleSource,
@@ -469,7 +392,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
     /// namespace-qualified case path. The leading `ns` and `Type`
     /// segments are left to existing namespace-import edges.
     pub(super) fn record_namespaced_case(
-        &self,
+        &mut self,
         ident: &crate::ast::IdentExpr,
         case_module: &ModuleSource,
         case_ast_id: crate::ast::AstId,
@@ -483,7 +406,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
     /// module) when the defining id is known. Convenience for sites that
     /// receive an `Option<AstId>` from a local variable lookup.
     pub(super) fn record_reference_opt(
-        &self,
+        &mut self,
         use_id: crate::ast::AstId,
         def_id: Option<crate::ast::AstId>,
     ) {
@@ -498,7 +421,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
     /// the `<T>` declaration rather than on a top-level item that happens
     /// to share the name. Falls through to the symbol-table lookup
     /// otherwise.
-    pub(super) fn record_type_name_reference(&self, use_id: crate::ast::AstId, name: &str) {
+    pub(super) fn record_type_name_reference(&mut self, use_id: crate::ast::AstId, name: &str) {
         if let Some(&decl_id) = self.trait_ctx.type_param_decls.get(name) {
             self.record_reference(use_id, decl_id);
         } else {
@@ -541,7 +464,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
     /// and inlay hints can surface the inferred type. Called at each site
     /// where a user-visible local is introduced.
     pub(super) fn record_local_symbol(
-        &self,
+        &mut self,
         def_id: crate::ast::AstId,
         name: &str,
         span: crate::token::Span,
@@ -558,8 +481,8 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             defined_at: key.clone(),
             span: Some(span),
         };
-        self.local_symbols.borrow_mut().insert(key.clone(), symbol);
-        self.local_types.borrow_mut().insert(key, type_id);
+        self.sem.bindings.local_symbols.insert(key.clone(), symbol);
+        self.sem.types.local_types.insert(key, type_id);
     }
 
     /// Look up a function by name in a loaded module, returning the Item at that index.
@@ -608,7 +531,9 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         name: &str,
         module_source: &ModuleSource,
     ) -> Option<&StructFieldInfo> {
-        self.local_struct_fields
+        self.sem
+            .decls
+            .local_struct_fields
             .get(name)
             .filter(|info| info.module_source == *module_source)
             .or_else(|| {
@@ -706,8 +631,10 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         if is_primitive_type_name(name) {
             return (ModuleSource::primitive(), name.to_string());
         }
-        if let Some(src) = self.imported_type_sources.get(name) {
+        if let Some(src) = self.sem.imports.imported_type_sources.get(name) {
             let original = self
+                .sem
+                .imports
                 .import_original_names
                 .get(name)
                 .cloned()
@@ -719,7 +646,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                 .unwrap_or_else(|| src.clone());
             return (canonical, original);
         }
-        if let Some(src) = self.effect_sources.get(name) {
+        if let Some(src) = self.sem.imports.effect_sources.get(name) {
             // `effect_sources` carries either a local effect / resource
             // declaration (no alias possible — the local name IS the
             // declaration name) or a non-aliased import that
@@ -774,7 +701,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
     /// works on effect references in `with` clauses. An empty slice skips recording
     /// (used by synthetic/internal effect lists with no source identifiers).
     pub(crate) fn resolve_effects(
-        &self,
+        &mut self,
         effects: &[String],
         effect_ids: &[(crate::ast::AstId, crate::token::Span)],
     ) -> Vec<tir::EffectRef> {
@@ -788,14 +715,14 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                         self.record_reference(use_id, decl_id);
                     }
                     tir::EffectRef::Param { name: name.clone() }
-                } else if let Some(source) = self.effect_sources.get(name) {
+                } else if let Some(source) = self.sem.imports.effect_sources.get(name).cloned() {
                     // Canonicalize: re-exports point at the importing module, but
                     // identity must match the defining module so two `with Stdout`
                     // clauses (one importing from `core:cli`, one from `wasi:cli`)
                     // refer to the same effect.
                     let canonical = self
                         .symbols
-                        .lookup_in_module(source, name)
+                        .lookup_in_module(&source, name)
                         .map(|sym| {
                             if let Some(use_id) = use_id {
                                 self.record_reference_to_key(use_id, sym.defined_at.clone());
@@ -838,7 +765,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
     /// Record use→def edges for each imported name in `use { a, b as c } from "..."`
     /// declarations. The cursor landing on an imported name inside a `use`
     /// specifier list should jump to the defining symbol in the source module.
-    fn record_use_specifier_references(&self, module: &Module) {
+    fn record_use_specifier_references(&mut self, module: &Module) {
         for item in &module.items {
             let Item::Use(use_decl) = item else { continue };
             let source = name::resolve_import_with_invocations(
@@ -880,7 +807,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         // Clear trait lookup caches (current_module_items changed)
         self.indexing_trait_cache.clear();
         // Build effect source map from imports
-        self.effect_sources = Self::build_effect_sources(
+        self.sem.imports.effect_sources = Self::build_effect_sources(
             &mut self.interner.borrow_mut(),
             module,
             &module_source,
@@ -905,12 +832,14 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         }
 
         // Collect global variable names and types (before resolving functions that may reference them)
-        self.current_module_globals.clear();
-        self.imported_globals.clear();
+        self.sem.decls.current_module_globals.clear();
+        self.sem.decls.imported_globals.clear();
         for item in &module.items {
             if let Item::Global(global_decl) = item {
                 let ty = self.resolve_type(&global_decl.ty);
-                self.current_module_globals
+                self.sem
+                    .decls
+                    .current_module_globals
                     .insert(global_decl.name.clone(), (ty, global_decl.mutable));
             }
         }
@@ -942,7 +871,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                                     {
                                         let ty = self.resolve_type(&global_decl.ty);
                                         let local_name = alias.as_ref().unwrap_or(name).clone();
-                                        self.imported_globals.insert(
+                                        self.sem.decls.imported_globals.insert(
                                             local_name,
                                             (
                                                 source_module_source.clone(),
@@ -962,7 +891,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         }
 
         // Collect associated constants from loaded modules and current module
-        self.associated_constants.clear();
+        self.sem.decls.associated_constants.clear();
         for module_items in self
             .loaded_modules
             .values()
@@ -974,7 +903,9 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                     let type_name = self.get_type_name(&impl_block.ty);
                     for assoc_const in &impl_block.constants {
                         let key = MethodName::format_local(&type_name, None, &assoc_const.name);
-                        self.associated_constants
+                        self.sem
+                            .decls
+                            .associated_constants
                             .insert(key, (assoc_const.ty.clone(), assoc_const.value.clone()));
                     }
                 }
@@ -1325,7 +1256,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         }
 
         // Add anonymous structs created during expression resolution
-        for anon_struct in self.pending_anonymous_structs.drain(..) {
+        for anon_struct in self.sem.decls.pending_anonymous_structs.drain(..) {
             tir_module.add_struct(anon_struct);
         }
 

--- a/wado-compiler/src/elaborator/call.rs
+++ b/wado-compiler/src/elaborator/call.rs
@@ -737,7 +737,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             }
             // Namespace import: `use ns from "..."` then `ns::Type::method()`
             // or `ns::VariantType::Case(...)`.
-            else if let Some(ns_source) = self.namespace_imports.get(prefix).cloned() {
+            else if let Some(ns_source) = self.sem.imports.namespace_imports.get(prefix).cloned()
+            {
                 // suffix may be "Type::method" or plain "func"
                 if let Some(inner_pos) = suffix.find("::") {
                     let type_name = &suffix[..inner_pos];
@@ -909,17 +910,24 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // The four constructor names flow through the
         // `CompilerItem` registry so a stdlib rename of any of
         // them is picked up here without re-editing the literal set.
-        else if self.function_return_types.contains_key(effective_name) || {
-            let tt = self.tysys.type_table.borrow();
-            let items = tt.compiler_items();
-            effective_name == items.variant_case_name(crate::compiler_item::CompilerItem::ResultOk)
-                || effective_name
-                    == items.variant_case_name(crate::compiler_item::CompilerItem::ResultErr)
-                || effective_name
-                    == items.variant_case_name(crate::compiler_item::CompilerItem::OptionSome)
-                || effective_name
-                    == items.variant_case_name(crate::compiler_item::CompilerItem::OptionNone)
-        } {
+        else if self
+            .sem
+            .decls
+            .function_return_types
+            .contains_key(effective_name)
+            || {
+                let tt = self.tysys.type_table.borrow();
+                let items = tt.compiler_items();
+                effective_name
+                    == items.variant_case_name(crate::compiler_item::CompilerItem::ResultOk)
+                    || effective_name
+                        == items.variant_case_name(crate::compiler_item::CompilerItem::ResultErr)
+                    || effective_name
+                        == items.variant_case_name(crate::compiler_item::CompilerItem::OptionSome)
+                    || effective_name
+                        == items.variant_case_name(crate::compiler_item::CompilerItem::OptionNone)
+            }
+        {
             self.record_item_reference_by_name(ident.id, effective_name);
             (
                 Some(CalleeRef::local(
@@ -941,7 +949,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // We go through the `Symbol` directly so both the use→def edge
         // and the `CalleeRef` come from the same resolution — this is
         // the single place the alias→defining-name translation happens.
-        else if self.imported_functions.contains(effective_name) {
+        else if self.sem.decls.imported_functions.contains(effective_name) {
             if let Some(symbol) = self.symbols.lookup(effective_name) {
                 self.record_reference_to_key(ident.id, symbol.defined_at.clone());
                 (
@@ -1163,7 +1171,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // First, try local functions (entry point module)
         if callee_module.is_entry_point()
-            && let Some(&return_type) = self.function_return_types.get(func_name)
+            && let Some(&return_type) = self.sem.decls.function_return_types.get(func_name)
         {
             return return_type;
         }
@@ -1358,7 +1366,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             base_type,
                         );
                         // Cache the newtype for future lookups
-                        self.local_newtypes.insert(named.name.clone(), newtype_id);
+                        self.sem
+                            .decls
+                            .local_newtypes
+                            .insert(named.name.clone(), newtype_id);
                         newtype_id
                     } else if self
                         .tysys
@@ -1656,7 +1667,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
 
         // Check if it's a local function (defined in this module)
-        if self.function_return_types.contains_key(name) {
+        if self.sem.decls.function_return_types.contains_key(name) {
             // Clone params and type_params to avoid borrow issues
             let func_info: Option<(Vec<ast::Param>, Vec<ast::GenericParam>)> = self
                 .lookup_current_func(name)
@@ -1822,7 +1833,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         if let Some(defaults) = ctx.closure_defaults.get(&ident.name) {
             return (defaults.clone(), None);
         }
-        if self.function_return_types.contains_key(&ident.name)
+        if self
+            .sem
+            .decls
+            .function_return_types
+            .contains_key(&ident.name)
             && let Some(func) = self.lookup_current_func(&ident.name)
         {
             return (
@@ -1867,7 +1882,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
 
         // Local function
-        if self.function_return_types.contains_key(&ident.name)
+        if self
+            .sem
+            .decls
+            .function_return_types
+            .contains_key(&ident.name)
             && let Some(func) = self.lookup_current_func(&ident.name)
         {
             return func.params.iter().map(|p| p.is_mut).collect();
@@ -1962,12 +1981,20 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Fast path: current-module cache (populated during item resolution).
         let cached = if let (Some(tp), Some(rp)) = (
-            self.generic_function_params.get(func_name).cloned(),
-            self.generic_function_resolved_param_types
+            self.sem
+                .decls
+                .generic_function_params
+                .get(func_name)
+                .cloned(),
+            self.sem
+                .decls
+                .generic_function_resolved_param_types
                 .get(func_name)
                 .cloned(),
         ) {
             let decl_return = self
+                .sem
+                .decls
                 .generic_function_resolved_return_types
                 .get(func_name)
                 .copied();
@@ -2290,23 +2317,27 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             return Vec::new();
         };
 
-        let func_info: Option<(Vec<ast::GenericParam>, Vec<ast::Param>)> =
-            if self.function_return_types.contains_key(&ident.name) {
-                self.lookup_current_func(&ident.name)
-                    .map(|func| (func.type_params.clone(), func.params.clone()))
-            } else if let Some(symbol) = self.symbols.lookup(&ident.name) {
-                let src = symbol.module_source().clone();
-                let name = symbol.name.clone();
-                Self::lookup_func_in_loaded_module(
-                    self.loaded_modules,
-                    &self.tysys.loaded_module_func_indices,
-                    &src,
-                    &name,
-                )
+        let func_info: Option<(Vec<ast::GenericParam>, Vec<ast::Param>)> = if self
+            .sem
+            .decls
+            .function_return_types
+            .contains_key(&ident.name)
+        {
+            self.lookup_current_func(&ident.name)
                 .map(|func| (func.type_params.clone(), func.params.clone()))
-            } else {
-                None
-            };
+        } else if let Some(symbol) = self.symbols.lookup(&ident.name) {
+            let src = symbol.module_source().clone();
+            let name = symbol.name.clone();
+            Self::lookup_func_in_loaded_module(
+                self.loaded_modules,
+                &self.tysys.loaded_module_func_indices,
+                &src,
+                &name,
+            )
+            .map(|func| (func.type_params.clone(), func.params.clone()))
+        } else {
+            None
+        };
 
         let Some((fn_type_params, fn_params)) = func_info else {
             return Vec::new();

--- a/wado-compiler/src/elaborator/expr.rs
+++ b/wado-compiler/src/elaborator/expr.rs
@@ -572,7 +572,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
 
         // Check for associated constants (e.g., f64::PI, i32::MAX)
-        if let Some((const_ty, const_expr)) = self.associated_constants.get(&ident.name).cloned() {
+        if let Some((const_ty, const_expr)) = self
+            .sem
+            .decls
+            .associated_constants
+            .get(&ident.name)
+            .cloned()
+        {
             let type_id = self.resolve_type(&const_ty);
             let resolved = self.resolve_expr(&const_expr, ctx, Some(type_id));
             return TirExpr::new(resolved.kind, type_id, ident.span);
@@ -690,7 +696,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             }
 
             // Check for namespace import: ns::Type::Case or ns::Enum::Case
-            if let Some(ns_source) = self.namespace_imports.get(prefix).cloned()
+            if let Some(ns_source) = self.sem.imports.namespace_imports.get(prefix).cloned()
                 && let Some(inner_pos) = suffix.find("::")
             {
                 let type_name = &suffix[..inner_pos];
@@ -811,7 +817,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
 
         // Check for global variables in current module
-        if let Some(&(ty, _mutable)) = self.current_module_globals.get(&ident.name) {
+        if let Some(&(ty, _mutable)) = self.sem.decls.current_module_globals.get(&ident.name) {
             self.record_item_reference_by_name(ident.id, &ident.name);
             return TirExpr::new(
                 TirExprKind::GlobalVarGet {
@@ -824,23 +830,31 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
 
         // Check for imported global variables
-        if let Some((source_module, original_name, ty, _mutable)) =
-            self.imported_globals.get(&ident.name)
+        if let Some((source_module, original_name, ty)) = self
+            .sem
+            .decls
+            .imported_globals
+            .get(&ident.name)
+            .map(|(src, orig, ty, _mut)| (src.clone(), orig.clone(), *ty))
         {
             self.record_item_reference_by_name(ident.id, &ident.name);
             return TirExpr::new(
                 TirExprKind::GlobalVarGet {
-                    module_source: source_module.clone(),
-                    name: original_name.clone(),
+                    module_source: source_module,
+                    name: original_name,
                 },
-                *ty,
+                ty,
                 ident.span,
             );
         }
 
         // Check if it's a known function (function reference)
-        if self.function_return_types.contains_key(&ident.name)
-            || self.imported_functions.contains(&ident.name)
+        if self
+            .sem
+            .decls
+            .function_return_types
+            .contains_key(&ident.name)
+            || self.sem.decls.imported_functions.contains(&ident.name)
         {
             return self.resolve_func_ref_ident(ident, expected_type);
         }
@@ -1053,7 +1067,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         else {
             // Fallback: known function but its AST is unreachable (shouldn't
             // normally happen). Emit a stub FuncRef so downstream stays sane.
-            let module_source = if self.function_return_types.contains_key(&ident.name) {
+            let module_source = if self
+                .sem
+                .decls
+                .function_return_types
+                .contains_key(&ident.name)
+            {
                 self.current_module_source.clone()
             } else {
                 self.symbols
@@ -3380,6 +3399,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Check if this is a generic struct and infer type arguments
         let (struct_type, mangled_struct_name, fields) = if self
+            .sem
+            .decls
             .generic_struct_names
             .contains(&struct_name)
         {
@@ -3567,7 +3588,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             type_param_bounds: Vec::new(),
             type_param_type_ids: Vec::new(),
         };
-        self.local_struct_fields
+        self.sem
+            .decls
+            .local_struct_fields
             .insert(anon_name.clone(), field_info);
 
         // Create TirStruct definition for codegen
@@ -3587,7 +3610,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             })
             .collect();
 
-        self.pending_anonymous_structs.push(TirStruct {
+        self.sem.decls.pending_anonymous_structs.push(TirStruct {
             name: anon_name.clone(),
             module_source: self.current_module_source.clone(),
             is_pub: false,

--- a/wado-compiler/src/elaborator/item.rs
+++ b/wado-compiler/src/elaborator/item.rs
@@ -949,11 +949,17 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             .as_ref()
             .map(|t| self.resolve_type(t))
             .unwrap_or(TypeTable::UNIT);
-        self.generic_function_params
+        self.sem
+            .decls
+            .generic_function_params
             .insert(func.name.clone(), type_param_list);
-        self.generic_function_resolved_param_types
+        self.sem
+            .decls
+            .generic_function_resolved_param_types
             .insert(func.name.clone(), resolved_param_types);
-        self.generic_function_resolved_return_types
+        self.sem
+            .decls
+            .generic_function_resolved_return_types
             .insert(func.name.clone(), declared_return_type);
         declared_return_type
     }
@@ -1054,6 +1060,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Update the function_return_types with the resolved return type
         // (This replaces the potentially incorrect type from static resolution)
         scope
+            .sem
+            .decls
             .function_return_types
             .insert(func.name.clone(), return_type);
 
@@ -1610,6 +1618,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // (This replaces the potentially incorrect type from static resolution)
         let mangled_name = MethodName::format_local(struct_name, trait_name, &func.name);
         scope
+            .sem
+            .decls
             .function_return_types
             .insert(mangled_name.clone(), return_type);
 
@@ -1766,9 +1776,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Store type parameters for generic methods (for call site substitution)
         if !func.type_params.is_empty() {
-            self.generic_method_params
+            self.sem
+                .decls
+                .generic_method_params
                 .insert(mangled_name.clone(), type_param_list);
-            self.generic_method_resolved_param_types
+            self.sem
+                .decls
+                .generic_method_resolved_param_types
                 .insert(mangled_name, method_resolved_param_types);
         }
 

--- a/wado-compiler/src/elaborator/method_call.rs
+++ b/wado-compiler/src/elaborator/method_call.rs
@@ -1486,14 +1486,19 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// Check if a static method exists directly for a given type name (no newtype fallback).
     fn has_static_method_direct(&self, struct_name: &str, method_name: &str) -> bool {
         let mangled = MethodName::format_local(struct_name, None, method_name);
-        if self.function_return_types.contains_key(&mangled) {
+        if self.sem.decls.function_return_types.contains_key(&mangled) {
             return true;
         }
         // Also check with trait-qualified name
         if let Some(trait_name) = self.find_static_method_trait(struct_name, method_name) {
             let trait_mangled =
                 MethodName::format_local(struct_name, Some(&trait_name), method_name);
-            if self.function_return_types.contains_key(&trait_mangled) {
+            if self
+                .sem
+                .decls
+                .function_return_types
+                .contains_key(&trait_mangled)
+            {
                 return true;
             }
         }
@@ -1546,13 +1551,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let struct_module = &method_ref.module;
         let method_name = method_ref.method_name.as_str();
         // First check locally registered function_return_types
-        if let Some(&return_type) = self.function_return_types.get(mangled_func_name) {
+        if let Some(&return_type) = self.sem.decls.function_return_types.get(mangled_func_name) {
             return return_type;
         }
 
         // Also try with just StructName::method (for non-generic types)
         let simple_name = MethodName::format_local(struct_name, None, method_name);
-        if let Some(&return_type) = self.function_return_types.get(&simple_name) {
+        if let Some(&return_type) = self.sem.decls.function_return_types.get(&simple_name) {
             return return_type;
         }
 
@@ -1560,7 +1565,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         if let Some(trait_name) = self.find_static_method_trait(struct_name, method_name) {
             let trait_mangled =
                 MethodName::format_local(struct_name, Some(&trait_name), method_name);
-            if let Some(&return_type) = self.function_return_types.get(&trait_mangled) {
+            if let Some(&return_type) = self.sem.decls.function_return_types.get(&trait_mangled) {
                 return return_type;
             }
         }
@@ -2461,7 +2466,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let mangled_name = MethodName::format_local(struct_name, None, method_name);
 
         // Check if it's registered in function_return_types (static methods are registered there)
-        if self.function_return_types.contains_key(&mangled_name) {
+        if self
+            .sem
+            .decls
+            .function_return_types
+            .contains_key(&mangled_name)
+        {
             return true;
         }
 

--- a/wado-compiler/src/elaborator/method_lookup.rs
+++ b/wado-compiler/src/elaborator/method_lookup.rs
@@ -353,7 +353,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // synthesized lookups (e.g. `String^Inspect`) must still resolve
         // through their well-known modules, which the full chain might
         // route elsewhere.
-        if let Some(src) = self.imported_type_sources.get(struct_name) {
+        if let Some(src) = self.sem.imports.imported_type_sources.get(struct_name) {
             return src.clone();
         }
         // Default to current module source
@@ -536,7 +536,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         };
 
         let mangled_name = MethodName::format_local(&struct_name, None, method_name);
-        if let Some(&return_type) = self.function_return_types.get(&mangled_name) {
+        if let Some(&return_type) = self.sem.decls.function_return_types.get(&mangled_name) {
             // For locally registered methods, find self_kind and param_types from the AST
             // Also checks that bounded impl block constraints are satisfied
             if let Some((self_kind, param_types, param_is_mut, param_defaults, param_names)) = self

--- a/wado-compiler/src/elaborator/module.rs
+++ b/wado-compiler/src/elaborator/module.rs
@@ -25,7 +25,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 .iter()
                                 .map(|p| p.name.clone())
                                 .collect();
-                            self.local_generic_newtypes.insert(
+                            self.sem.decls.local_generic_newtypes.insert(
                                 newtype_decl.name.clone(),
                                 GenericNewtypeInfo {
                                     module_source: module_source.clone(),
@@ -42,7 +42,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             module_source.clone(),
                             base_type_id,
                         );
-                        self.local_newtypes
+                        self.sem
+                            .decls
+                            .local_newtypes
                             .insert(newtype_decl.name.clone(), newtype_id);
                     }
                 }
@@ -55,7 +57,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 if let Item::Struct(struct_decl) = item
                     && !struct_decl.type_params.is_empty()
                 {
-                    self.generic_struct_names.insert(struct_decl.name.clone());
+                    self.sem
+                        .decls
+                        .generic_struct_names
+                        .insert(struct_decl.name.clone());
                 }
             }
         }
@@ -65,7 +70,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             if let Item::Struct(struct_decl) = item
                 && !struct_decl.type_params.is_empty()
             {
-                self.generic_struct_names.insert(struct_decl.name.clone());
+                self.sem
+                    .decls
+                    .generic_struct_names
+                    .insert(struct_decl.name.clone());
             }
         }
 
@@ -117,7 +125,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         .collect();
 
                     let module_source = scope.current_module_source.clone();
-                    scope.local_struct_fields.insert(
+                    scope.sem.decls.local_struct_fields.insert(
                         struct_decl.name.clone(),
                         StructFieldInfo {
                             name: struct_decl.name.clone(),
@@ -141,7 +149,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             self.current_module_source.clone(),
                             base_type_id,
                         );
-                        self.local_newtypes
+                        self.sem
+                            .decls
+                            .local_newtypes
                             .insert(newtype_decl.name.clone(), newtype_id);
                     } else {
                         // Generic newtype: store definition for lazy instantiation
@@ -150,7 +160,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             .iter()
                             .map(|p| p.name.clone())
                             .collect();
-                        self.local_generic_newtypes.insert(
+                        self.sem.decls.local_generic_newtypes.insert(
                             newtype_decl.name.clone(),
                             GenericNewtypeInfo {
                                 module_source: self.current_module_source.clone(),
@@ -199,7 +209,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     }
 
                     let module_source = scope.current_module_source.clone();
-                    scope.local_variant_cases.insert(
+                    scope.sem.decls.local_variant_cases.insert(
                         variant_decl.name.clone(),
                         VariantInfo {
                             name: variant_decl.name.clone(),
@@ -246,7 +256,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             ast_id: case.id,
                         })
                         .collect();
-                    self.local_enum_cases.insert(
+                    self.sem.decls.local_enum_cases.insert(
                         enum_decl.name.clone(),
                         EnumInfo::new(
                             enum_decl.name.clone(),
@@ -289,7 +299,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         .borrow_mut()
                         .make_flags(flags_decl.name.clone(), self.current_module_source.clone());
                     // Add to newtypes so it can be used as a type name
-                    self.local_newtypes
+                    self.sem
+                        .decls
+                        .local_newtypes
                         .insert(flags_decl.name.clone(), flags_type);
                     // Store member info with bitmask values (1 << index)
                     let members: Vec<FlagsMemberData> = flags_decl
@@ -302,7 +314,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             ast_id: m.id,
                         })
                         .collect();
-                    self.local_flags_cases.insert(
+                    self.sem.decls.local_flags_cases.insert(
                         flags_decl.name.clone(),
                         FlagsInfo {
                             type_id: flags_type,
@@ -348,7 +360,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         .map(|t| scope.resolve_type(t))
                         .unwrap_or(TypeTable::UNIT);
                     drop(scope);
-                    self.function_return_types
+                    self.sem
+                        .decls
+                        .function_return_types
                         .insert(func.name.clone(), return_type);
                 }
                 Item::Impl(impl_block) => {
@@ -526,6 +540,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             &method.name,
                         );
                         scope
+                            .sem
+                            .decls
                             .function_return_types
                             .insert(mangled_name, return_type);
                     }

--- a/wado-compiler/src/elaborator/operators.rs
+++ b/wado-compiler/src/elaborator/operators.rs
@@ -1168,13 +1168,17 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         {
             // Check if the global is mutable (check both local and imported globals)
             let is_mutable = self
+                .sem
+                .decls
                 .current_module_globals
                 .get(name)
                 .map(|(_, m)| *m)
                 .or_else(|| {
                     // For imported globals, the name in the TIR is the original name from source
                     // We need to find it by iterating through imported_globals
-                    self.imported_globals
+                    self.sem
+                        .decls
+                        .imported_globals
                         .values()
                         .find(|(src, orig_name, _, _)| src == module_source && orig_name == name)
                         .map(|(_, _, _, m)| *m)

--- a/wado-compiler/src/elaborator/orchestration.rs
+++ b/wado-compiler/src/elaborator/orchestration.rs
@@ -818,7 +818,9 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                     debug_assert!(false, "{snapshot_invariant}: {:?}", use_key.module);
                     continue;
                 };
-                sem.bindings.references.insert(use_key.clone(), def_key.clone());
+                sem.bindings
+                    .references
+                    .insert(use_key.clone(), def_key.clone());
             }
             for (key, sym) in &snap.locals {
                 let Some(sem) = module_semantics.get_mut(&key.module) else {

--- a/wado-compiler/src/elaborator/orchestration.rs
+++ b/wado-compiler/src/elaborator/orchestration.rs
@@ -806,29 +806,33 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             module_semantics.entry(ms.clone()).or_default();
         }
         if let Some(snap) = snapshot {
+            // Snapshot keys must always reference modules in the current
+            // compile's `modules` set — the loader's implicit-modules pass
+            // pulls in the snapshot's stdlib closure on every compile. Use
+            // `get_mut` so a divergence shows up as a `debug_assert` failure
+            // rather than silently creating phantom `ModuleSemantics` entries
+            // that LSP would later flatten into `Semantics::references`.
+            let snapshot_invariant = "snapshot module must be in the current compile's loaded set";
             for (use_key, def_key) in &snap.references {
-                module_semantics
-                    .entry(use_key.module.clone())
-                    .or_default()
-                    .bindings
-                    .references
-                    .insert(use_key.clone(), def_key.clone());
+                let Some(sem) = module_semantics.get_mut(&use_key.module) else {
+                    debug_assert!(false, "{snapshot_invariant}: {:?}", use_key.module);
+                    continue;
+                };
+                sem.bindings.references.insert(use_key.clone(), def_key.clone());
             }
             for (key, sym) in &snap.locals {
-                module_semantics
-                    .entry(key.module.clone())
-                    .or_default()
-                    .bindings
-                    .local_symbols
-                    .insert(key.clone(), sym.clone());
+                let Some(sem) = module_semantics.get_mut(&key.module) else {
+                    debug_assert!(false, "{snapshot_invariant}: {:?}", key.module);
+                    continue;
+                };
+                sem.bindings.local_symbols.insert(key.clone(), sym.clone());
             }
             for (key, type_id) in &snap.local_types {
-                module_semantics
-                    .entry(key.module.clone())
-                    .or_default()
-                    .types
-                    .local_types
-                    .insert(key.clone(), *type_id);
+                let Some(sem) = module_semantics.get_mut(&key.module) else {
+                    debug_assert!(false, "{snapshot_invariant}: {:?}", key.module);
+                    continue;
+                };
+                sem.types.local_types.insert(key.clone(), *type_id);
             }
         }
 
@@ -1018,14 +1022,18 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
 
             // Take this module's `ModuleSemantics` out of `state` so the
             // elaborator can own it for the body walk. The map entry was
-            // pre-populated in `annotate_modules`; any bindings the snapshot
+            // pre-populated in `annotate_modules` for every `modules.keys()`
+            // (and `sorted_sources` is derived from `modules`), so the entry
+            // is guaranteed to exist; `expect` rather than `unwrap_or_default`
+            // surfaces any future divergence between `sorted_sources` and
+            // `module_semantics.keys()` loudly. Any bindings the snapshot
             // contributed survive in the taken instance. We seed the
             // imports / decls populated above and reinstall the populated
             // instance after `resolve_module` returns.
             let mut sem = state
                 .module_semantics
                 .swap_remove(module_source)
-                .unwrap_or_default();
+                .expect("module_semantics is pre-populated by annotate_modules");
             sem.imports.imported_type_sources = imported_type_sources;
             sem.imports.import_original_names = import_original_names;
             sem.imports.namespace_imports = namespace_imports;

--- a/wado-compiler/src/elaborator/orchestration.rs
+++ b/wado-compiler/src/elaborator/orchestration.rs
@@ -10,9 +10,11 @@
 //!   without running TIR lowering. The output is an [`AnnotateState`] that
 //!   both `build_tir` and the LSP consume.
 //! - [`Elaborator::build_tir_from_state`] reads that state and produces one
-//!   [`TirModule`] per source module. It does not mutate the annotate
-//!   output; all new types created during lowering (anonymous structs,
-//!   monomorphic instances) are written through the shared
+//!   [`TirModule`] per source module. It also extends the per-module
+//!   [`super::sem::ModuleSemantics`] entries on `state.module_semantics`
+//!   with the body-walk results (use→def edges, local symbols, local
+//!   types), and new types created during lowering (anonymous structs,
+//!   monomorphic instances) are interned through the shared
 //!   `Rc<RefCell<TypeTable>>`.
 //!
 //! This split keeps the annotate phase self-contained and cheap enough to
@@ -33,7 +35,7 @@ use crate::component_model::WasiRegistry;
 use crate::logger::{Bail, Logger};
 use crate::module_source::{ModuleSource, ModuleSourceInterner};
 use crate::name::{self as name};
-use crate::symbol::{Symbol, SymbolKey, SymbolTable};
+use crate::symbol::SymbolTable;
 use crate::tir::{ResolvedType, TirModule, TypeId, TypeTable};
 use crate::world_registry::WorldRegistry;
 
@@ -48,11 +50,18 @@ use super::tysys::TypeSystem;
 /// Analysis state produced by [`Elaborator::annotate_modules`] and consumed by
 /// [`Elaborator::build_tir_from_state`].
 ///
-/// All expensive maps are stored behind `Rc` so the state is cheap to share
-/// between LSP queries and the lowering pipeline without cloning the
-/// underlying data. The [`TypeTable`] itself is behind `Rc<RefCell<…>>`
-/// because lowering interns additional types (anonymous structs,
-/// monomorphized instances) into the same table.
+/// The shared [`TypeSystem`] internals (type arena, decl maps, registries)
+/// are reference-counted so per-module elaborators can clone them cheaply.
+/// The [`TypeTable`] itself remains behind `Rc<RefCell<…>>` because lowering
+/// interns additional types (anonymous structs, monomorphic instances) into
+/// the same table.
+///
+/// Per-module semantic facts (use→def edges, local symbols, decl tables,
+/// import context) live in [`Self::module_semantics`] as a `IndexMap` of
+/// [`super::sem::ModuleSemantics`]. Each entry is owned by exactly one
+/// place at a time — the driver hands the entry to the body walk via
+/// `swap_remove` + `insert`, so no shared-mutability plumbing is needed
+/// (WEP 2026-05-26, Stage 3).
 ///
 /// Migration markers on each field below trace the WEP 2026-05-26
 /// elaborator re-architecture. `AnnotateState` itself disappears after
@@ -79,28 +88,17 @@ pub(crate) struct AnnotateState {
     /// so a `TirModule`'s position in the result map matches the
     /// dependency order downstream phases expect.
     pub(crate) sorted_sources: Vec<ModuleSource>,
-    /// Use→def map for local variables: `(module, IdentExpr.id)` →
-    /// `(module, defining AstId)`. Populated by [`Elaborator::resolve_ident`]
-    /// whenever a name resolves to a local binding. Consumed by LSP
-    /// `definition` / `hover` to jump to the defining pattern / parameter.
-    // MIGRATION: → ModuleSemantics::bindings (per-module after Stage 3;
-    //   the `Rc<RefCell<…>>` plumbing collapses into `&mut ModuleSemantics`).
-    pub(crate) references: Rc<RefCell<IndexMap<SymbolKey, SymbolKey>>>,
-    /// Locally-defined [`Symbol`]s (let bindings, parameters, closure
-    /// parameters). Keyed by the binding's defining [`SymbolKey`]. Populated
-    /// alongside [`Self::references`] as the elaborator walks function bodies.
-    // MIGRATION: → ModuleSemantics::bindings (per-module after Stage 3).
-    pub(crate) local_symbols: Rc<RefCell<IndexMap<SymbolKey, Symbol>>>,
-    /// Resolved [`TypeId`] for each local binding, keyed by the binding's
-    /// defining [`SymbolKey`]. Populated alongside [`Self::local_symbols`]
-    /// at every `record_local_symbol` call. Consumed by LSP inlay hints so
-    /// `let x = 1` can render the inferred `: i32` annotation without
-    /// reaching into TIR (which is `pub(crate)` and mixes resolver-synth
-    /// temporaries into the local namespace).
-    // MIGRATION: → ModuleSemantics::types (TypeId per binding-AstId fits the
-    //   "per-`AstId` type annotations" rule). LSP consumer
-    //   `Semantics::local_type_name` hides the placement.
-    pub(crate) local_types: Rc<RefCell<IndexMap<SymbolKey, TypeId>>>,
+    /// Per-module semantic facts produced by the elaborator. One entry per
+    /// loaded module. Stdlib entries are seeded from the snapshot in
+    /// [`Self::annotate_modules`]; per-compile entries are produced by the
+    /// body walk in [`Self::build_tir_from_state`].
+    ///
+    /// Replaces the previous trio of `Rc<RefCell<…>>` maps
+    /// (`references` / `local_symbols` / `local_types`) — each module's
+    /// data now lives in its own owned [`super::sem::ModuleSemantics`], so
+    /// the body walk's `&mut` access stays disjoint across modules and the
+    /// shared-mutability plumbing disappears (WEP 2026-05-26, Stage 3).
+    pub(crate) module_semantics: IndexMap<ModuleSource, super::sem::ModuleSemantics>,
     /// Kiln invocation redirects consulted by `resolve_import` call sites
     /// when walking `use` declarations. Populated from [`crate::loader::LoadResult`].
     // MIGRATION: cross-cutting input (loader-provided redirect map).
@@ -127,7 +125,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         invocations: crate::kiln::InvocationIndex,
         interner: Rc<RefCell<ModuleSourceInterner>>,
     ) -> Result<(IndexMap<ModuleSource, TirModule>, Arc<TraitEnv>), Bail> {
-        let state = Self::annotate_modules(
+        let mut state = Self::annotate_modules(
             symbols,
             modules,
             &entry_module_source,
@@ -139,7 +137,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         )?;
         let trait_env = state.tysys.trait_env.clone();
         let tir_modules = Self::build_tir_from_state(
-            &state,
+            &mut state,
             symbols,
             modules,
             entry_module_source,
@@ -793,18 +791,46 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         // lower phase.
         Self::register_symbol_key_type_indices(symbols, &type_table);
 
-        // Seed the use→def reference map and the local-symbol map with the
-        // snapshot's pre-resolved stdlib entries so the LSP edges remain
-        // consistent and user-module body resolution can extend on top.
-        let references = Rc::new(RefCell::new(
-            snapshot.map(|s| s.references.clone()).unwrap_or_default(),
-        ));
-        let local_symbols = Rc::new(RefCell::new(
-            snapshot.map(|s| s.locals.clone()).unwrap_or_default(),
-        ));
-        let local_types = Rc::new(RefCell::new(
-            snapshot.map(|s| s.local_types.clone()).unwrap_or_default(),
-        ));
+        // Seed per-module semantics with the snapshot's pre-resolved stdlib
+        // entries so the LSP edges remain consistent and the body walk on
+        // user modules can extend on top. The snapshot stores `references` /
+        // `locals` / `local_types` as flat maps keyed by `SymbolKey`; we
+        // split them by `key.module` because each module's data now lives in
+        // its own [`super::sem::ModuleSemantics`].
+        let mut module_semantics: IndexMap<ModuleSource, super::sem::ModuleSemantics> =
+            IndexMap::default();
+        // Ensure every loaded module has an entry; the body walk in
+        // `build_tir_from_state` requires a `ModuleSemantics` to swap in
+        // for each user module it processes.
+        for ms in modules.keys() {
+            module_semantics.entry(ms.clone()).or_default();
+        }
+        if let Some(snap) = snapshot {
+            for (use_key, def_key) in &snap.references {
+                module_semantics
+                    .entry(use_key.module.clone())
+                    .or_default()
+                    .bindings
+                    .references
+                    .insert(use_key.clone(), def_key.clone());
+            }
+            for (key, sym) in &snap.locals {
+                module_semantics
+                    .entry(key.module.clone())
+                    .or_default()
+                    .bindings
+                    .local_symbols
+                    .insert(key.clone(), sym.clone());
+            }
+            for (key, type_id) in &snap.local_types {
+                module_semantics
+                    .entry(key.module.clone())
+                    .or_default()
+                    .types
+                    .local_types
+                    .insert(key.clone(), *type_id);
+            }
+        }
 
         let tysys = TypeSystem {
             type_table,
@@ -826,9 +852,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             tysys,
             world_registry,
             sorted_sources,
-            references,
-            local_symbols,
-            local_types,
+            module_semantics,
             invocations,
             interner,
         })
@@ -838,7 +862,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
     /// produced by [`Elaborator::annotate_modules`]. Errors are collected in the
     /// logger; the function returns [`Bail`] if any module failed.
     pub(crate) fn build_tir_from_state(
-        state: &AnnotateState,
+        state: &mut AnnotateState,
         symbols: &'a SymbolTable,
         modules: &'a IndexMap<ModuleSource, Module>,
         entry_module_source: ModuleSource,
@@ -865,7 +889,11 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         // are emitted to the logger; we keep going so one broken module
         // doesn't mask others.
         let _span = logger.span("elaborate/modules");
-        for module_source in &state.sorted_sources {
+        // Iterate a snapshot of the source order: we need `&mut state` to
+        // swap each module's `ModuleSemantics` in and out, which would
+        // otherwise conflict with borrowing `state.sorted_sources`.
+        let sorted_sources = state.sorted_sources.clone();
+        for module_source in &sorted_sources {
             // Cache hit: deep-clone the cached `TirModule` into the
             // per-compile shared type table.  Only `Core` / `Wasi` /
             // `Wasm` variants are eligible — `ModuleSource::EntryPoint`
@@ -988,45 +1016,37 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                 }
             }
 
+            // Take this module's `ModuleSemantics` out of `state` so the
+            // elaborator can own it for the body walk. The map entry was
+            // pre-populated in `annotate_modules`; any bindings the snapshot
+            // contributed survive in the taken instance. We seed the
+            // imports / decls populated above and reinstall the populated
+            // instance after `resolve_module` returns.
+            let mut sem = state
+                .module_semantics
+                .swap_remove(module_source)
+                .unwrap_or_default();
+            sem.imports.imported_type_sources = imported_type_sources;
+            sem.imports.import_original_names = import_original_names;
+            sem.imports.namespace_imports = namespace_imports;
+            sem.decls.function_return_types = function_return_types;
+            sem.decls.imported_functions = imported_functions;
+
             let mut elaborator = Elaborator {
                 tysys: state.tysys.clone(),
+                sem,
                 symbols,
                 loaded_modules: modules,
-                imported_type_sources,
-                import_original_names,
-                local_struct_fields: IndexMap::default(),
-                local_newtypes: IndexMap::default(),
-                local_generic_newtypes: IndexMap::default(),
-                local_enum_cases: IndexMap::default(),
-                local_flags_cases: IndexMap::default(),
-                local_variant_cases: IndexMap::default(),
-                function_return_types,
-                imported_functions,
-                namespace_imports,
                 logger,
                 current_module_source: ModuleSource::entry_point_uninitialized(), // Set in Elaborator::resolve_module
                 entry_module_source: entry_module_source.clone(),
                 current_module_items: &[], // Set in Elaborator::resolve_module
-                effect_sources: IndexMap::default(), // Populated per-module in Elaborator::resolve_module
                 current_effect_params: IndexSet::default(),
                 current_effect_param_decls: IndexMap::default(),
                 trait_ctx: super::trait_env::TraitContext::default(),
-                generic_struct_names: IndexSet::default(),
-                generic_function_params: IndexMap::default(),
-                generic_function_resolved_param_types: IndexMap::default(),
-                generic_function_resolved_return_types: IndexMap::default(),
-                generic_method_params: IndexMap::default(),
-                generic_method_resolved_param_types: IndexMap::default(),
-                current_module_globals: IndexMap::default(),
-                imported_globals: IndexMap::default(),
-                associated_constants: IndexMap::default(),
                 indexing_trait_cache: IndexMap::default(),
                 trait_check_stack: RefCell::new(Vec::new()),
                 method_info_cache: IndexMap::default(),
-                pending_anonymous_structs: Vec::new(),
-                references: Rc::clone(&state.references),
-                local_symbols: Rc::clone(&state.local_symbols),
-                local_types: Rc::clone(&state.local_types),
                 default_scope_module: None,
                 invocations: Rc::clone(&state.invocations),
                 interner: Rc::clone(&state.interner),
@@ -1038,7 +1058,14 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
 
             // Errors are emitted to the logger; if resolve_module returns Bail,
             // we continue to resolve remaining modules to collect more errors
-            if let Ok(tir_module) = elaborator.resolve_module(module, module_source.clone()) {
+            let resolve_result = elaborator.resolve_module(module, module_source.clone());
+            // Re-install the (now-populated) `ModuleSemantics` even on bail
+            // so the LSP can answer cursor queries against whatever bindings
+            // the elaborator did reach before bailing.
+            state
+                .module_semantics
+                .insert(module_source.clone(), elaborator.sem);
+            if let Ok(tir_module) = resolve_result {
                 result.insert(module_source.clone(), tir_module);
             }
         }

--- a/wado-compiler/src/elaborator/sem.rs
+++ b/wado-compiler/src/elaborator/sem.rs
@@ -1,17 +1,19 @@
 //! [`ModuleSemantics`] — per-module semantic facts produced by the elaborator.
 //!
-//! Stage 1 skeleton introduced by
-//! [`wep-2026-05-26-elaborator-rearchitecture.md`]. The four sub-structs
-//! are empty at this stage; the migration plan populates them across
-//! stages 3-5 by moving fields off [`super::Elaborator`] and
-//! [`super::orchestration::AnnotateState`].
+//! Introduced by [`wep-2026-05-26-elaborator-rearchitecture.md`]. Stage 1
+//! placed the empty skeleton; Stage 3 populates the four sub-structs with
+//! the per-module state that previously lived as flat fields on
+//! [`super::Elaborator`] (and as `Rc<RefCell<…>>`-shared maps on
+//! [`super::orchestration::AnnotateState`]).
 //!
-//! # Future ownership (per the WEP)
+//! # Ownership
 //!
-//! One instance per loaded module, owned by [`crate::semantics::Semantics`]
-//! in an `IndexMap<ModuleSource, ModuleSemantics>`. `annotate_bodies` takes
-//! `&mut ModuleSemantics` for the module it is processing; every other phase
-//! (including `reify`) takes `&ModuleSemantics`.
+//! One instance per loaded module, owned by
+//! [`super::orchestration::AnnotateState::module_semantics`]. The per-module
+//! [`super::Elaborator`] takes ownership of the instance for the duration
+//! of [`super::Elaborator::resolve_module`] and the driver re-installs it
+//! into the map afterwards; every other phase (including the future
+//! `reify`) takes `&ModuleSemantics`.
 //!
 //! # Decomposition
 //!
@@ -41,10 +43,9 @@ pub(crate) use decls::ModuleDecls;
 pub(crate) use imports::ModuleImports;
 pub(crate) use types::TypeAnnotations;
 
-#[expect(
-    dead_code,
-    reason = "Stage 1 skeleton; populated by stages 3-5 of the elaborator re-architecture."
-)]
+/// Per-module semantic facts. See the module-level documentation for the
+/// membership rules and ownership story.
+#[derive(Default, Clone)]
 pub(crate) struct ModuleSemantics {
     pub(crate) bindings: ModuleBindings,
     pub(crate) imports: ModuleImports,

--- a/wado-compiler/src/elaborator/sem/bindings.rs
+++ b/wado-compiler/src/elaborator/sem/bindings.rs
@@ -28,14 +28,33 @@ use crate::hashmap::IndexMap;
 use crate::symbol::{Symbol, SymbolKey};
 
 /// `use → def` edges and locally defined symbols for one module.
+///
+/// # Caveat: transient cross-module entries
+///
+/// The keys *almost always* belong to the owning module: every record site
+/// (`Elaborator::record_reference` etc.) builds the use-side key from
+/// `self.current_module_source`. The exception is
+/// [`super::super::Elaborator::with_module_perspective`], which swaps
+/// `current_module_source` to a foreign module while leaving `self.sem`
+/// pointing at the outer module's `ModuleSemantics`. Any record calls inside
+/// that scope tag their use-key with the foreign module but still write into
+/// the outer module's bindings.
+///
+/// Today's only consumer ([`crate::semantics::semantics_with_logger`]) flattens
+/// every module's bindings into a single `Semantics::references` map keyed by
+/// the full `SymbolKey`, so the cross-module entries land in the right place
+/// regardless of which `ModuleBindings` they passed through. The future
+/// per-module reify pass (Stage 5) will need to either teach
+/// `with_module_perspective` to swap `bindings` / `types` too, or accept that
+/// these maps are a flat-store-by-construction.
 #[derive(Default, Clone)]
 pub(crate) struct ModuleBindings {
-    /// `(module, IdentExpr.id) → (module, defining AstId)`. The use-site key
-    /// always lives in this module's `ModuleSource`; the def-site key may
-    /// point at a different module (e.g. an imported function).
+    /// `(module, IdentExpr.id) → (module, defining AstId)`. See the
+    /// struct-level "Caveat: transient cross-module entries" note for when
+    /// the use-side key's module does not match the owning module.
     pub(crate) references: IndexMap<SymbolKey, SymbolKey>,
     /// Locally-defined [`Symbol`]s (let bindings, parameters, closure
-    /// parameters) keyed by the binding's defining [`SymbolKey`]. The key's
-    /// `module` field always equals this `ModuleBindings`'s owning module.
+    /// parameters) keyed by the binding's defining [`SymbolKey`]. See the
+    /// struct-level "Caveat: transient cross-module entries" note.
     pub(crate) local_symbols: IndexMap<SymbolKey, Symbol>,
 }

--- a/wado-compiler/src/elaborator/sem/bindings.rs
+++ b/wado-compiler/src/elaborator/sem/bindings.rs
@@ -1,7 +1,9 @@
 //! [`ModuleBindings`] — `use → def` edges and locally defined symbols.
 //!
-//! Stage 1 skeleton introduced by
-//! [`wep-2026-05-26-elaborator-rearchitecture.md`]. Empty at this stage.
+//! Populated by the body walk (Stage 3 of
+//! [`wep-2026-05-26-elaborator-rearchitecture.md`]) — every call site that
+//! resolves an identifier to its defining symbol writes here, and every
+//! site that introduces a user-visible local binding registers it here.
 //!
 //! # Membership rule
 //!
@@ -11,25 +13,29 @@
 //! module. Per-`AstId` type facts go to [`super::types::TypeAnnotations`],
 //! not here.
 //!
-//! # Planned contents
+//! # Ownership
 //!
-//! - **`references`** — `(module, IdentExpr.id) → (module, defining AstId)`.
-//!   Populated by `resolve_ident` / `resolve_call` / etc. as the body walk
-//!   reaches each identifier. Today lives on
-//!   [`super::super::Elaborator::references`] (shared via `Rc<RefCell<…>>`
-//!   with [`super::super::orchestration::AnnotateState::references`]).
-//! - **`local_symbols`** — locally-defined [`crate::symbol::Symbol`]s
-//!   (let bindings, parameters, closure parameters) keyed by the binding's
-//!   defining [`crate::symbol::SymbolKey`]. Today lives on
-//!   [`super::super::Elaborator::local_symbols`] (shared via
-//!   `Rc<RefCell<…>>` with
-//!   [`super::super::orchestration::AnnotateState::local_symbols`]).
-//!
-//! # Planned API
-//!
-//! - `record_reference(use_id, def_id)`
-//! - `record_local_symbol(def_id, symbol)`
-//! - Reference-resolution helpers used by `Semantics::referenced_symbol`
-//!   and `Semantics::references_to_def`.
+//! One instance per loaded module, owned by [`super::ModuleSemantics`].
+//! Plain owned [`crate::hashmap::IndexMap`]s replace the previous
+//! `Rc<RefCell<…>>` plumbing the elaborator shared with
+//! [`super::super::orchestration::AnnotateState`]: each module's body walk
+//! has exclusive `&mut` access to its own [`ModuleBindings`] for the
+//! duration of [`super::super::Elaborator::resolve_module`], and the
+//! driver re-installs the populated instance back into
+//! `state.module_semantics` afterwards.
 
-pub(crate) struct ModuleBindings {}
+use crate::hashmap::IndexMap;
+use crate::symbol::{Symbol, SymbolKey};
+
+/// `use → def` edges and locally defined symbols for one module.
+#[derive(Default, Clone)]
+pub(crate) struct ModuleBindings {
+    /// `(module, IdentExpr.id) → (module, defining AstId)`. The use-site key
+    /// always lives in this module's `ModuleSource`; the def-site key may
+    /// point at a different module (e.g. an imported function).
+    pub(crate) references: IndexMap<SymbolKey, SymbolKey>,
+    /// Locally-defined [`Symbol`]s (let bindings, parameters, closure
+    /// parameters) keyed by the binding's defining [`SymbolKey`]. The key's
+    /// `module` field always equals this `ModuleBindings`'s owning module.
+    pub(crate) local_symbols: IndexMap<SymbolKey, Symbol>,
+}

--- a/wado-compiler/src/elaborator/sem/decls.rs
+++ b/wado-compiler/src/elaborator/sem/decls.rs
@@ -1,7 +1,8 @@
 //! [`ModuleDecls`] — module-internal declarations confirmed by elaboration.
 //!
-//! Stage 1 skeleton introduced by
-//! [`wep-2026-05-26-elaborator-rearchitecture.md`]. Empty at this stage.
+//! Stage 3 of [`wep-2026-05-26-elaborator-rearchitecture.md`] populates the
+//! fields below by relocating per-module state off
+//! [`super::super::Elaborator`].
 //!
 //! # Membership rule
 //!
@@ -12,59 +13,65 @@
 //! (annotation on an [`crate::ast::AstId`]) it belongs in
 //! [`super::types::TypeAnnotations`]; if it is an *import* fact derived
 //! from a `use` declaration it belongs in [`super::imports::ModuleImports`].
-//!
-//! # Planned contents
-//!
-//! Function / global tables:
-//!
-//! - **`function_return_types`** — `func_name → return TypeId` for
-//!   functions defined in this module. Today on
-//!   [`super::super::Elaborator::function_return_types`].
-//! - **`imported_functions`** — names visible via `use`. Today on
-//!   [`super::super::Elaborator::imported_functions`].
-//! - **`current_module_globals`** — `name → (TypeId, is_mut)` for globals
-//!   declared in this module. Today on
-//!   [`super::super::Elaborator::current_module_globals`].
-//! - **`imported_globals`** — `local_name → (source, original_name, TypeId,
-//!   is_mut)` for globals brought in by `use`. Today on
-//!   [`super::super::Elaborator::imported_globals`].
-//! - **`associated_constants`** — `"Type::CONST" → (ast::Type, ast::Expr)`,
-//!   inlined at every use site during resolution. Today on
-//!   [`super::super::Elaborator::associated_constants`].
-//!
-//! Generic-parameter tables (the elaborator's resolution memo for generic
-//! functions / methods / structs):
-//!
-//! - **`generic_struct_names`** — Today on
-//!   [`super::super::Elaborator::generic_struct_names`].
-//! - **`generic_function_params`**,
-//!   **`generic_function_resolved_param_types`**,
-//!   **`generic_function_resolved_return_types`** — Today on the
-//!   corresponding [`super::super::Elaborator`] fields.
-//! - **`generic_method_params`**,
-//!   **`generic_method_resolved_param_types`** — Today on the
-//!   corresponding [`super::super::Elaborator`] fields.
-//!
-//! Per-module local additions to the cross-module decl tables (anonymous
-//! structs synthesised from struct literals, and any decl the elaborator
-//! discovered while walking this module):
-//!
-//! - **`pending_anonymous_structs`** — Today on
-//!   [`super::super::Elaborator::pending_anonymous_structs`]; flushed into
-//!   the [`crate::tir::TirModule`] at the end of `resolve_module`.
-//! - **`local_struct_fields`**, **`local_newtypes`**,
-//!   **`local_generic_newtypes`**, **`local_enum_cases`**,
-//!   **`local_flags_cases`**, **`local_variant_cases`** — Today on the
-//!   corresponding [`super::super::Elaborator`] fields. Stage 2/3 will
-//!   revisit whether these stay here or graduate into
-//!   [`super::super::tysys::TypeSystem`] as a per-module view.
-//!
-//! # Planned API
-//!
-//! - `function_return_type(name) -> Option<TypeId>`
-//! - `generic_function_params(name) -> Option<&[…]>`, …
-//! - `imported_global(name) -> Option<&ImportedGlobal>`
-//! - `associated_constant(key) -> Option<&(ast::Type, ast::Expr)>`
-//! - `pending_anonymous_structs()` drain.
 
-pub(crate) struct ModuleDecls {}
+use crate::ast;
+use crate::hashmap::{IndexMap, IndexSet};
+use crate::module_source::ModuleSource;
+use crate::tir::TypeId;
+
+use super::super::types::{EnumInfo, FlagsInfo, GenericNewtypeInfo, StructFieldInfo, VariantInfo};
+
+/// Per-module declaration tables produced by elaboration.
+#[derive(Default, Clone)]
+pub(crate) struct ModuleDecls {
+    /// `func_name → return TypeId` for functions defined in this module.
+    pub(crate) function_return_types: IndexMap<String, TypeId>,
+    /// Names visible via `use` declarations in this module (the union of
+    /// imported function names, effect function names, and namespace-import
+    /// members), used by call resolution to recognise non-local names.
+    pub(crate) imported_functions: IndexSet<String>,
+    /// `name → (TypeId, is_mut)` for globals declared in this module.
+    pub(crate) current_module_globals: IndexMap<String, (TypeId, bool)>,
+    /// `local_name → (source, original_name, TypeId, is_mut)` for globals
+    /// brought in by `use`.
+    pub(crate) imported_globals: IndexMap<String, (ModuleSource, String, TypeId, bool)>,
+    /// `"Type::CONST" → (type, expr)`. Inlined at every use site during
+    /// resolution. Built from impl blocks across all loaded modules plus
+    /// this module's own impls.
+    pub(crate) associated_constants: IndexMap<String, (ast::Type, ast::Expr)>,
+
+    /// Names of generic structs declared in this module (used to decide
+    /// whether a struct reference needs generic-instance handling).
+    pub(crate) generic_struct_names: IndexSet<String>,
+    /// `func_name → type_params` for generic functions in this module.
+    pub(crate) generic_function_params: IndexMap<String, Vec<(String, TypeId)>>,
+    /// `func_name → resolved param TypeIds` for generic functions. The
+    /// `TypeIds` are resolved in the function's own type-param scope so
+    /// `TypeParam` ids match.
+    pub(crate) generic_function_resolved_param_types: IndexMap<String, Vec<TypeId>>,
+    /// `func_name → resolved return TypeId` for generic functions. Used for
+    /// expected-return back-inference.
+    pub(crate) generic_function_resolved_return_types: IndexMap<String, TypeId>,
+    /// `mangled_name → type_params` for generic methods.
+    pub(crate) generic_method_params: IndexMap<String, Vec<(String, TypeId)>>,
+    /// `mangled_name → resolved param TypeIds` for generic methods. Resolved
+    /// in the method's own type-param scope.
+    pub(crate) generic_method_resolved_param_types: IndexMap<String, Vec<TypeId>>,
+
+    /// Anonymous structs synthesised from struct literals during expression
+    /// resolution. Flushed into the [`crate::tir::TirModule`] at the end of
+    /// [`super::super::Elaborator::resolve_module`].
+    pub(crate) pending_anonymous_structs: Vec<crate::tir::TirStruct>,
+
+    /// Per-module additions to the type tables, consulted by
+    /// [`super::super::types::TypeLookup`] before the shared `all_*` tables.
+    /// Populated by [`super::super::Elaborator::collect_types`] and by call
+    /// sites that intern an anonymous struct or instantiate a generic
+    /// newtype on demand.
+    pub(crate) local_struct_fields: IndexMap<String, StructFieldInfo>,
+    pub(crate) local_newtypes: IndexMap<String, TypeId>,
+    pub(crate) local_generic_newtypes: IndexMap<String, GenericNewtypeInfo>,
+    pub(crate) local_enum_cases: IndexMap<String, EnumInfo>,
+    pub(crate) local_flags_cases: IndexMap<String, FlagsInfo>,
+    pub(crate) local_variant_cases: IndexMap<String, VariantInfo>,
+}

--- a/wado-compiler/src/elaborator/sem/imports.rs
+++ b/wado-compiler/src/elaborator/sem/imports.rs
@@ -1,8 +1,10 @@
 //! [`ModuleImports`] — per-module name resolution context derived from
 //! `use` declarations.
 //!
-//! Stage 1 skeleton introduced by
-//! [`wep-2026-05-26-elaborator-rearchitecture.md`]. Empty at this stage.
+//! Populated by [`super::super::orchestration::Elaborator::build_tir_from_state`]
+//! before the body walk starts, and consulted by name-resolution sites in
+//! the elaborator (Stage 3 of
+//! [`wep-2026-05-26-elaborator-rearchitecture.md`]).
 //!
 //! # Membership rule
 //!
@@ -12,25 +14,29 @@
 //! the canonicalisation of an *imported* name to its *declaring* module,
 //! it belongs here. If the fact is a *local* declaration's body, it
 //! belongs in [`super::decls::ModuleDecls`].
-//!
-//! # Planned contents
-//!
-//! - **`imported_type_sources`** — `local_name → defining ModuleSource`,
-//!   from `use { Foo as Bar } from "..."`. Today on
-//!   [`super::super::Elaborator::imported_type_sources`].
-//! - **`import_original_names`** — `local_name → original_decl_name`, so
-//!   aliased imports canonicalise to their original declaration name.
-//!   Today on [`super::super::Elaborator::import_original_names`].
-//! - **`namespace_imports`** — namespace-alias map (`use helper from "..."`).
-//!   Today on [`super::super::Elaborator::namespace_imports`].
-//! - **`effect_sources`** — effect name → module-source map built from
-//!   import declarations and local `interface` / `resource` declarations.
-//!   Today on [`super::super::Elaborator::effect_sources`].
-//!
-//! # Planned API
-//!
-//! - `lookup(local_name) -> Option<ModuleSource>`
-//! - `canonical_decl_key(name) -> (ModuleSource, String)`
-//! - effect-source map / namespace-alias map accessors.
 
-pub(crate) struct ModuleImports {}
+use crate::hashmap::IndexMap;
+use crate::module_source::ModuleSource;
+
+/// Per-module name-resolution context derived from `use` declarations.
+#[derive(Default, Clone)]
+pub(crate) struct ModuleImports {
+    /// `local_name → defining ModuleSource`, populated from
+    /// `use { Foo as Bar } from "..."` declarations. `Bar` (the local name)
+    /// is the key.
+    pub(crate) imported_type_sources: IndexMap<String, ModuleSource>,
+    /// `local_name → original_decl_name`. Populated only for aliased
+    /// imports (`use { Foo as Bar }`), so [`super::super::Elaborator::canonical_decl_key`]
+    /// can canonicalise an aliased name to its original declaration.
+    pub(crate) import_original_names: IndexMap<String, String>,
+    /// Namespace-alias map. `use helper from "..."` registers `helper →
+    /// resolved("...")` so `helper::foo` paths in identifiers resolve
+    /// against the namespace's module.
+    pub(crate) namespace_imports: IndexMap<String, ModuleSource>,
+    /// Effect name → module-source map built from import declarations and
+    /// local `interface` / `resource` declarations. Consulted by
+    /// [`super::super::Elaborator::resolve_effects`] and
+    /// [`super::super::Elaborator::canonical_decl_key`] when resolving
+    /// effect references in `with` clauses.
+    pub(crate) effect_sources: IndexMap<String, ModuleSource>,
+}

--- a/wado-compiler/src/elaborator/sem/types.rs
+++ b/wado-compiler/src/elaborator/sem/types.rs
@@ -1,50 +1,38 @@
 //! [`TypeAnnotations`] — per-[`crate::ast::AstId`] type annotations and
 //! dispatch decisions recorded during the body walk.
 //!
-//! Stage 1 skeleton introduced by
-//! [`wep-2026-05-26-elaborator-rearchitecture.md`]. Empty at this stage.
-//!
 //! # Membership rule
 //!
 //! Add a field here when it stores a fact keyed by an [`crate::ast::AstId`]
 //! (or [`crate::symbol::SymbolKey`]) produced as a *decision* by the
 //! body-level elaborator: the resolved type of an expression, the chosen
 //! method dispatch target, the chosen coercion, the desugar kind of a
-//! TIR-direct rewrite. This is what [`super::super::reify`] (Stage 5) reads
-//! in lieu of re-running inference.
+//! TIR-direct rewrite. This is what [`super::super::reify`] (Stage 5) will
+//! read in lieu of re-running inference.
 //!
 //! Facts that derive purely from the AST (spans, position lookup) belong
 //! on [`crate::ast_index::AstIndex`], not here. Decl-level facts (function
 //! return types, generic-parameter tables) belong on
 //! [`super::decls::ModuleDecls`].
 //!
-//! # Planned contents
-//!
-//! New facts introduced by Stage 4 — none of these exist on the current
-//! [`super::super::Elaborator`] yet:
-//!
-//! - The [`crate::tir::TypeId`] of every typed expression.
-//! - The resolved target of each method call (impl block + method name).
-//! - The chosen coercion at each conversion site.
-//! - The desugar kind for each TIR-direct rewrite (`assert`, `matches`,
-//!   comparison chain, for-of, while, compound assignment).
-//!
-//! Existing fields migrating in from [`super::super::Elaborator`]:
-//!
-//! - **`local_types`** — [`crate::tir::TypeId`] for each local binding,
-//!   keyed by the binding's defining [`crate::symbol::SymbolKey`]. Today
-//!   on [`super::super::Elaborator::local_types`] (shared via
-//!   `Rc<RefCell<…>>` with
-//!   [`super::super::orchestration::AnnotateState::local_types`]). Consumed
-//!   by LSP inlay hints via [`crate::semantics::Semantics::local_type_name`]
-//!   — the consumer API layer hides the placement, so moving this here
-//!   does not affect LSP callers.
-//!
-//! # Planned API
-//!
-//! - `set(ast_id, type_id)` / `get(ast_id) -> Option<TypeId>`
-//! - `dispatch_target(ast_id) -> Option<MethodTarget>`
-//! - `coercion_at(ast_id) -> Option<Coercion>`
-//! - `desugar_kind(ast_id) -> Option<DesugarKind>`
+//! Stage 3 of [`wep-2026-05-26-elaborator-rearchitecture.md`] populates
+//! `local_types` (the only field that exists on
+//! [`super::super::Elaborator`] today and feeds LSP inlay hints). The
+//! per-expression `TypeId` map, dispatch targets, coercion choices, and
+//! desugar-kind annotations land in Stage 4.
 
-pub(crate) struct TypeAnnotations {}
+use crate::hashmap::IndexMap;
+use crate::symbol::SymbolKey;
+use crate::tir::TypeId;
+
+/// Per-`AstId` type annotations recorded by the body walk.
+#[derive(Default, Clone)]
+pub(crate) struct TypeAnnotations {
+    /// Resolved [`TypeId`] for each local binding, keyed by the binding's
+    /// defining [`SymbolKey`]. Populated alongside
+    /// [`super::bindings::ModuleBindings::local_symbols`] at every
+    /// `record_local_symbol` call. Consumed by LSP inlay hints via
+    /// [`crate::semantics::Semantics::local_type_name`] so `let x = 1` can
+    /// render the inferred `: i32` annotation without reaching into TIR.
+    pub(crate) local_types: IndexMap<SymbolKey, TypeId>,
+}

--- a/wado-compiler/src/elaborator/stmt.rs
+++ b/wado-compiler/src/elaborator/stmt.rs
@@ -638,6 +638,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 ns.name == scrutinee_name
                     && scrutinee_arg_len.is_none_or(|n| n == ns.args.len())
                     && self
+                        .sem
+                        .imports
                         .namespace_imports
                         .get(&ns.namespace)
                         .is_some_and(|m| m == scrutinee_module)
@@ -1278,7 +1280,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 }
                 // Check if the identifier refers to an immutable global constant
                 if !matches!(pattern, Pattern::MutIdent { .. }) {
-                    if let Some(&(ty, mutable)) = self.current_module_globals.get(name)
+                    if let Some(&(ty, mutable)) = self.sem.decls.current_module_globals.get(name)
                         && !mutable
                     {
                         return TirPattern::ConstantValue {
@@ -1293,7 +1295,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         };
                     }
                     if let Some((source_module, original_name, ty, mutable)) =
-                        self.imported_globals.get(name)
+                        self.sem.decls.imported_globals.get(name)
                         && !*mutable
                     {
                         return TirPattern::ConstantValue {
@@ -1448,8 +1450,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     let assoc_const_key =
                         Self::format_assoc_const_key(variant_name, variant_qualifier.as_ref());
                     // Resolve to literal patterns when possible for switch optimization.
-                    if let Some((const_ty, const_expr)) =
-                        self.associated_constants.get(&assoc_const_key).cloned()
+                    if let Some((const_ty, const_expr)) = self
+                        .sem
+                        .decls
+                        .associated_constants
+                        .get(&assoc_const_key)
+                        .cloned()
                     {
                         let type_id = self.resolve_type(&const_ty);
                         let resolved = self.resolve_expr(&const_expr, ctx, Some(type_id));

--- a/wado-compiler/src/elaborator/type_resolution.rs
+++ b/wado-compiler/src/elaborator/type_resolution.rs
@@ -363,7 +363,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             }
             _ => {
                 // Check if it's a user-defined generic struct
-                if self.generic_struct_names.contains(name) {
+                if self.sem.decls.generic_struct_names.contains(name) {
                     // Resolve type arguments
                     let type_args: Vec<TypeId> =
                         args.iter().map(|t| self.resolve_type(t)).collect();

--- a/wado-compiler/src/semantics.rs
+++ b/wado-compiler/src/semantics.rs
@@ -679,7 +679,7 @@ pub(crate) fn semantics_with_logger<H: CompilerHost>(
         )
         .ok()
     };
-    let Some(state) = state else {
+    let Some(mut state) = state else {
         return Semantics::partial(
             load_result.entry_module_source,
             load_result.modules,
@@ -695,11 +695,11 @@ pub(crate) fn semantics_with_logger<H: CompilerHost>(
         );
     };
 
-    // Run the full body-level resolve pass so `state.references` and
-    // `state.local_symbols` are populated by the real elaborator. This is the
-    // single source of truth for use→def edges — LSP and batch compilation
-    // both consume what the elaborator recorded here, with no separate lexical
-    // re-scan to drift out of sync.
+    // Run the full body-level resolve pass so each module's
+    // `ModuleSemantics::bindings` is populated by the real elaborator. This
+    // is the single source of truth for use→def edges — LSP and batch
+    // compilation both consume what the elaborator recorded here, with no
+    // separate lexical re-scan to drift out of sync.
     //
     // On Bail we still drain the partial reference / local maps so the LSP
     // can answer cursor queries against whatever bodies the elaborator did
@@ -707,7 +707,7 @@ pub(crate) fn semantics_with_logger<H: CompilerHost>(
     let (tir_modules, lower_ok) = {
         let _span = logger.span("elaborate/build_tir");
         match Elaborator::build_tir_from_state(
-            &state,
+            &mut state,
             &symbols,
             &load_result.modules,
             load_result.entry_module_source.clone(),
@@ -725,12 +725,18 @@ pub(crate) fn semantics_with_logger<H: CompilerHost>(
     // `state.tysys.type_table`.
     let types = state.tysys.type_table.borrow().clone();
 
-    // Drain the elaborator's shared reference / local maps into owned IndexMaps
-    // so LSP queries can hand out `&Symbol` references without juggling
-    // `RefCell` borrows.
-    let references = std::mem::take(&mut *state.references.borrow_mut());
-    let locals = std::mem::take(&mut *state.local_symbols.borrow_mut());
-    let local_types = std::mem::take(&mut *state.local_types.borrow_mut());
+    // Flatten the per-module `ModuleSemantics` into the maps LSP queries
+    // consume directly. The Semantics API stays keyed by `SymbolKey`; the
+    // per-module storage on `AnnotateState` is the elaborator-side detail
+    // that replaces the previous `Rc<RefCell<…>>` plumbing.
+    let mut references: IndexMap<SymbolKey, SymbolKey> = IndexMap::default();
+    let mut locals: IndexMap<SymbolKey, Symbol> = IndexMap::default();
+    let mut local_types: IndexMap<SymbolKey, TypeId> = IndexMap::default();
+    for sem in state.module_semantics.values_mut() {
+        references.extend(std::mem::take(&mut sem.bindings.references));
+        locals.extend(std::mem::take(&mut sem.bindings.local_symbols));
+        local_types.extend(std::mem::take(&mut sem.types.local_types));
+    }
 
     Semantics {
         entry_module_source: load_result.entry_module_source,


### PR DESCRIPTION
Populate the four `ModuleSemantics` sub-structs (`bindings`, `imports`,
`types`, `decls`) with the per-module fields that previously lived as
flat fields on `Elaborator` and as `Rc<RefCell<…>>`-shared maps on
`AnnotateState`. `Elaborator` now owns a single `sem: ModuleSemantics`
and the driver swaps each module's instance in/out of
`AnnotateState.module_semantics` around the body walk, removing the
shared-mutability plumbing for `references` / `local_symbols` /
`local_types`.

`build_tir_from_state` takes `&mut AnnotateState` so it can swap each
module's `ModuleSemantics` around the per-module Elaborator;
`semantics_with_logger` flattens the per-module bindings back into the
existing `Semantics` flat maps so the LSP-facing query surface remains
unchanged. Stdlib snapshot seeding splits its flat maps by
`key.module` once at seed time.

See `docs/wep-2026-05-26-elaborator-rearchitecture.md` for the updated
Status section and Stage 3 design notes (in particular, why
`Elaborator` owns its `sem` by value instead of holding `&mut
ModuleSemantics`).