### PR TITLE
wado-compiler: parse stdlib modules lazily

### DIFF
--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -1040,15 +1040,6 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         self.logger.span_end(&format!("load {entry_name}"));
 
         // Load all dependencies iteratively
-<<<<<<< HEAD
-||||||| 53618ba2
-        let core_cache = cached_stdlib();
-=======
-        let core_cache = {
-            let _span = self.logger.span("stdlib_cache_init");
-            cached_stdlib()
-        };
->>>>>>> origin/main
         while let Some((from_module_source, module_source)) = pending.pop_front() {
             // Skip if already loaded
             if self.loaded.contains_key(&module_source) {

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -822,9 +822,13 @@ mod tests {
     }
 }
 
-/// Cached AST modules for all stdlib modules (core + WASI).
+/// Per-module lazy cache for stdlib AST.
 ///
-/// Each module is parsed and bound exactly once per process.
+/// Each module is parsed and bound at most once per process. The slot
+/// table (path → slot) is built eagerly on first access — that walk is
+/// just `HashMap` inserts of empty [`OnceLock`]s, no parsing — and then
+/// each module's actual parse runs only when [`cached_stdlib_module`]
+/// is called for that import path.
 ///
 /// Keyed by the canonical display form (`"core:foo"`, `"wasi:bar/baz.wado"`)
 /// rather than by `ModuleSource` value. The cache is process-global, but
@@ -833,29 +837,44 @@ mod tests {
 /// content-addressed and avoids forcing the cache to share an interner
 /// with every loader. See [`stdlib_cache_key`] for how callers compute
 /// the lookup string from a `ModuleSource`.
-fn cached_stdlib() -> &'static IndexMap<String, Module> {
+struct StdlibSlot {
+    source: &'static str,
+    module: std::sync::OnceLock<Module>,
+}
+
+type StdlibSlotMap = std::collections::HashMap<&'static str, StdlibSlot, FxBuildHasher>;
+
+fn stdlib_slots() -> &'static StdlibSlotMap {
     use std::sync::OnceLock;
 
-    static CACHE: OnceLock<IndexMap<String, Module>> = OnceLock::new();
-    CACHE.get_or_init(|| {
-        let total_count = stdlib::ALL_CORE_MODULES.len() + stdlib::ALL_WASI_MODULES.len();
-        let mut cache = IndexMap::with_capacity_and_hasher(total_count, FxBuildHasher);
-
-        for &(import_path, source) in stdlib::ALL_CORE_MODULES
+    static SLOTS: OnceLock<StdlibSlotMap> = OnceLock::new();
+    SLOTS.get_or_init(|| {
+        let total = stdlib::ALL_CORE_MODULES.len() + stdlib::ALL_WASI_MODULES.len();
+        let mut slots: StdlibSlotMap =
+            std::collections::HashMap::with_capacity_and_hasher(total, FxBuildHasher);
+        for &(path, source) in stdlib::ALL_CORE_MODULES
             .iter()
             .chain(stdlib::ALL_WASI_MODULES.iter())
         {
-            cache.insert(
-                import_path.to_string(),
-                parse_bind_stdlib(import_path, source),
+            slots.insert(
+                path,
+                StdlibSlot {
+                    source,
+                    module: OnceLock::new(),
+                },
             );
         }
-
-        cache
+        slots
     })
 }
 
-/// Compute the cache key string used by [`cached_stdlib`] for a
+/// Return the cached AST for a stdlib module, parsing it on first access.
+fn cached_stdlib_module(import_path: &str) -> Option<&'static Module> {
+    let (key, slot) = stdlib_slots().get_key_value(import_path)?;
+    Some(slot.module.get_or_init(|| parse_bind_stdlib(key, slot.source)))
+}
+
+/// Compute the cache key string used by [`cached_stdlib_module`] for a
 /// `ModuleSource`. Returns `None` for variants that the stdlib cache
 /// never holds (Local / Remote / `EntryPoint` / Redirected / Wasm).
 fn stdlib_cache_key(ms: &ModuleSource) -> Option<String> {
@@ -1021,7 +1040,6 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         self.logger.span_end(&format!("load {entry_name}"));
 
         // Load all dependencies iteratively
-        let core_cache = cached_stdlib();
         while let Some((from_module_source, module_source)) = pending.pop_front() {
             // Skip if already loaded
             if self.loaded.contains_key(&module_source) {
@@ -1038,7 +1056,8 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
             let mod_name = module_source.to_string();
 
             // Use cached parsed module for core stdlib
-            if let Some(cached) = stdlib_cache_key(&module_source).and_then(|k| core_cache.get(&k))
+            if let Some(cached) =
+                stdlib_cache_key(&module_source).and_then(|k| cached_stdlib_module(&k))
             {
                 let span_name = format!("load {mod_name} (cached)");
                 self.logger.span_start(&span_name);
@@ -1235,8 +1254,6 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
 
     /// Load implicit modules required by the compiler
     fn load_implicit_modules(&mut self) -> Result<(), LoadError> {
-        let cache = cached_stdlib();
-
         let implicit_module_sources = [
             ModuleSource::builtin(),
             ModuleSource::string(),
@@ -1250,7 +1267,9 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
                 continue;
             }
 
-            if let Some(cached) = stdlib_cache_key(&module_source).and_then(|k| cache.get(&k)) {
+            if let Some(cached) =
+                stdlib_cache_key(&module_source).and_then(|k| cached_stdlib_module(&k))
+            {
                 // Load transitive dependencies from cache
                 let mut pending = VecDeque::new();
                 let mut wasm_imports = Vec::new();
@@ -1265,7 +1284,8 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
                     if self.loaded.contains_key(&dep_ms) {
                         continue;
                     }
-                    if let Some(dep_cached) = stdlib_cache_key(&dep_ms).and_then(|k| cache.get(&k))
+                    if let Some(dep_cached) =
+                        stdlib_cache_key(&dep_ms).and_then(|k| cached_stdlib_module(&k))
                     {
                         let _ = self.collect_imports(
                             dep_cached,

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -871,7 +871,10 @@ fn stdlib_slots() -> &'static StdlibSlotMap {
 /// Return the cached AST for a stdlib module, parsing it on first access.
 fn cached_stdlib_module(import_path: &str) -> Option<&'static Module> {
     let (key, slot) = stdlib_slots().get_key_value(import_path)?;
-    Some(slot.module.get_or_init(|| parse_bind_stdlib(key, slot.source)))
+    Some(
+        slot.module
+            .get_or_init(|| parse_bind_stdlib(key, slot.source)),
+    )
 }
 
 /// Compute the cache key string used by [`cached_stdlib_module`] for a

--- a/wado-compiler/src/stdlib.rs
+++ b/wado-compiler/src/stdlib.rs
@@ -116,7 +116,7 @@ pub const WASI_TLS_WORLDS: &str = include_str!("../lib/wasi/tls/worlds.wado");
 /// Each entry is `(import_path, source)` where `import_path` matches
 /// what users write in `from "core:..."` expressions. This is the
 /// single source of truth for the set of core stdlib modules: the
-/// loader's `cached_stdlib`, `get_stdlib_module`, and the
+/// loader's `cached_stdlib_module`, `get_stdlib_module`, and the
 /// `ModuleSourceInterner` well-known arc set all derive from it.
 pub const ALL_CORE_MODULES: &[(&str, &str)] = &[
     ("core:allocator", CORE_ALLOCATOR),

--- a/wado-compiler/src/stdlib_snapshot.rs
+++ b/wado-compiler/src/stdlib_snapshot.rs
@@ -131,7 +131,7 @@ fn build_snapshot() -> Semantics {
     // `wado-compiler` has no async runtime dependency (it must compile
     // to `wasm32-unknown-unknown`, see crate-level `CLAUDE.md`).  The
     // loader future is driven by hand with a no-op waker: every `await`
-    // inside it bottoms out either at a `cached_stdlib()` lookup or at
+    // inside it bottoms out either at a `cached_stdlib_module()` lookup or at
     // `SnapshotHost::load_source` (which returns immediately), so a
     // single poll completes the whole pipeline.  No actual suspension
     // can occur — if `Poll::Pending` ever surfaces it means an
@@ -177,7 +177,7 @@ fn poll_to_completion<F: Future>(fut: F) -> F::Output {
 ///
 /// Only modules with names that are stable across compiles in the same
 /// process can be served from the cache — that is exactly the set of
-/// stdlib modules served from `cached_stdlib()` plus the `core:libm.wat`
+/// stdlib modules served from `cached_stdlib_module()` plus the `core:libm.wat`
 /// Wasm asset module. Returns the subset of `snap.tir_modules` whose
 /// keys match.
 pub(crate) fn stdlib_sources(snap: &Semantics) -> IndexSet<ModuleSource> {
@@ -244,14 +244,14 @@ fn clone_fn_rc(
 
 /// In-memory [`CompilerHost`] used solely for building the stdlib
 /// snapshot.  The entry source is empty and every transitively-loaded
-/// module is a stdlib module served from `cached_stdlib()`, so
+/// module is a stdlib module served from `cached_stdlib_module()`, so
 /// `load_source` is unreachable in steady state.
 struct SnapshotHost;
 
 impl CompilerHost for SnapshotHost {
     async fn load_source(&self, path: &str) -> Result<Vec<u8>, SourceError> {
         // The snapshot's closure is the stdlib only; the loader resolves
-        // those via `cached_stdlib()` without touching this method. A
+        // those via `cached_stdlib_module()` without touching this method. A
         // call here would mean the loader tried to pull in a non-stdlib
         // module, which is a regression we want surfaced clearly.
         Err(SourceError::NotFound {


### PR DESCRIPTION
## Summary

- Replace the all-at-once stdlib cache (`OnceLock<IndexMap<String, Module>>`) with per-module `OnceLock` slots.
- The slot table is built eagerly on first access — just `HashMap` inserts of empty `OnceLock`s, no parsing — and each module's parse+bind runs only when first looked up by import path.
- For `example/hello.wado` on a debug build, the ~110 ms unconditional stdlib parse gap (after entry-module load, before the first cached lookup) is essentially eliminated. Only ~15 of the 76 bundled stdlib modules are actually touched by hello.

## Motivation

The goal is faster local edit/compile turnaround. `cached_stdlib()` previously parsed all 76 bundled modules (~40k lines of stdlib source) on first access regardless of what the user program imported. Both callers (`load_all`'s main loop and `load_implicit_modules`) only ever look modules up by string key, so per-module lazy slots are a drop-in replacement.

## Measurement

Debug build (`cargo build --bin wado`), `./target/debug/wado run --log-level debug example/hello.wado`, 4 runs each.

| Phase | Baseline avg | Lazy avg | Δ |
|---|---|---|---|
| `<< load example/hello.wado` (entry done) | ~1.2 ms | ~1.0 ms | ~0 |
| First `>> load X (cached)` | ~111.9 ms | ~1.7 ms | **−110 ms** |
| **stdlib eager-parse gap** | **~110.7 ms** | **~0.7 ms** | **−110 ms** |
| `>> synthesize wasm:core:libm.wat` | ~175.9 ms | ~106.0 ms | −70 ms |
| `>> analyze` | ~801.5 ms | ~704.3 ms | −97 ms |
| **Total `<< codegen`** | **~1283 ms** | **~1186 ms** | **−97 ms (~7.6%)** |

The thread-local `stdlib_snapshot` builder (which drives the loader over an empty entry source) also benefits — it no longer parses unrelated modules that `core:prelude`'s transitive closure doesn't pull in.

## Test plan

- [x] `cargo test -p wado-compiler --lib` — 558/558 pass
- [ ] `mise run test` (Rust e2e)
- [ ] `mise run test-wado` (Wado module tests)
- [ ] `cargo build -p wado-compiler --target wasm32-unknown-unknown`


---
_Generated by [Claude Code](https://claude.ai/code/session_012CuycmUX9S2ZdZbLGs7GkN)_