### PR TITLE
docs(agents): note that the dev profile is tuned; avoid `--release` in the inner loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ mise run report-wasm-size  # hello_world, pi_approx, zlib, and so on
 - A compiler bug is always P0 — no exceptions. Stop, write a minimal reproducible e2e fixture, and fix it before continuing if it blocks the current task.
 - A pre-existing issue — whether you find it or a reviewer points it out — must be fixed, with TDD when practical.
 - Don't pipe long-running commands (`mise run …`, `cargo test`, etc.) into `tail` or `head`. Redirect to a file and inspect it afterwards if you need to trim output.
+- Use plain `cargo build` / `cargo run` / `cargo test` (the `dev` profile) for iteration. `Cargo.toml` raises `opt-level` on `wado-compiler`, `wado-dev-tools`, and `cranelift-codegen` so dev-build runtime is close to release for the parts that matter, while compile time stays much lower. `--release` is for distributing binaries, not for the inner dev loop.
 - Use the `rust` skill when writing Rust.
 - Use the `wado` skill when writing Wado code or designing Wado language features.
 


### PR DESCRIPTION
## Summary

`Cargo.toml` raises `opt-level` on `wado-compiler`, `wado-dev-tools`,
and `cranelift-codegen` so a plain `cargo build` (dev profile) runs
close to release speed for the parts that dominate the test loop,
while staying much cheaper to compile than `--release`. AGENTS.md
didn't say this, so an LLM (or a new contributor) reading the file
top-to-bottom will reach for `cargo run --release --bin wado -- test
…` out of Rust habit — paying the ~8-minute first-build cost for no
runtime gain.

One-line note added to "General Rules" right next to the existing
"don't pipe long-running commands" guidance.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTMFpr9c1UAakZ9AnZzuQ4)_