### PR TITLE
refactor(gale): replace wildcard arms with explicit variant enumeration on IR transforms

### DIFF
--- a/package-gale/src/lower.wado
+++ b/package-gale/src/lower.wado
@@ -950,7 +950,17 @@ fn rebind_self_ref_min_prec(op: Op, prec: i32) -> Op {
             inner: rebind_self_ref_min_prec(ll.inner, prec),
             dedup_base: ll.dedup_base,
         }),
-        other => other,
+        // The caller (`stamp_lr_self_ref_min_prec`) only invokes this
+        // when `find_self_ref_rule_call` already matched the top op,
+        // so non-self-ref / container arms are unreachable in practice.
+        // Listed explicitly so a new `Op` variant fails to compile
+        // here instead of inheriting the silent passthrough.
+        Token(t) => Op::Token(t),
+        Literal(l) => Op::Literal(l),
+        Wildcard(wop) => Op::Wildcard(wop),
+        Excluded(e) => Op::Excluded(e),
+        Repeat(r) => Op::Repeat(r),
+        Group(g) => Op::Group(g),
     };
 }
 
@@ -1674,7 +1684,15 @@ fn element_is_self_ref(elem: &Element, rule_name: &String) -> bool {
     return match *elem {
         RuleRef(r) => r.name == *rule_name,
         Label(lab) => element_is_self_ref(&lab.element, rule_name),
-        _ => false,
+        // Listed explicitly so a new `Element` variant that could
+        // wrap a self-ref (e.g. a future `Annotated(Element)`) fails
+        // to compile here rather than silently returning false.
+        TokenRef(_) => false,
+        Literal(_) => false,
+        Group(_) => false,
+        Repeat(_) => false,
+        Wildcard(_) => false,
+        Not(_) => false,
     };
 }
 
@@ -3429,7 +3447,15 @@ fn try_optional_scan_guard(inner: &Element, ctx: &mut GenContext) -> Option<Repe
     let needs_guard = match *inner {
         Group(_) => true,
         RuleRef(_) => true,
-        _ => false,
+        // Leaf or non-scannable inners — `Plain` strategy handles them.
+        // Listed explicitly so a new `Element` variant is a compile
+        // error here rather than defaulting to "no scan guard".
+        TokenRef(_) => false,
+        Literal(_) => false,
+        Wildcard(_) => false,
+        Not(_) => false,
+        Label(_) => false,
+        Repeat(_) => false,
     };
     if !needs_guard {
         return null;

--- a/package-gale/src/lower.wado
+++ b/package-gale/src/lower.wado
@@ -950,11 +950,6 @@ fn rebind_self_ref_min_prec(op: Op, prec: i32) -> Op {
             inner: rebind_self_ref_min_prec(ll.inner, prec),
             dedup_base: ll.dedup_base,
         }),
-        // The caller (`stamp_lr_self_ref_min_prec`) only invokes this
-        // when `find_self_ref_rule_call` already matched the top op,
-        // so non-self-ref / container arms are unreachable in practice.
-        // Listed explicitly so a new `Op` variant fails to compile
-        // here instead of inheriting the silent passthrough.
         Token(t) => Op::Token(t),
         Literal(l) => Op::Literal(l),
         Wildcard(wop) => Op::Wildcard(wop),
@@ -1684,9 +1679,6 @@ fn element_is_self_ref(elem: &Element, rule_name: &String) -> bool {
     return match *elem {
         RuleRef(r) => r.name == *rule_name,
         Label(lab) => element_is_self_ref(&lab.element, rule_name),
-        // Listed explicitly so a new `Element` variant that could
-        // wrap a self-ref (e.g. a future `Annotated(Element)`) fails
-        // to compile here rather than silently returning false.
         TokenRef(_) => false,
         Literal(_) => false,
         Group(_) => false,
@@ -3447,9 +3439,6 @@ fn try_optional_scan_guard(inner: &Element, ctx: &mut GenContext) -> Option<Repe
     let needs_guard = match *inner {
         Group(_) => true,
         RuleRef(_) => true,
-        // Leaf or non-scannable inners — `Plain` strategy handles them.
-        // Listed explicitly so a new `Element` variant is a compile
-        // error here rather than defaulting to "no scan guard".
         TokenRef(_) => false,
         Literal(_) => false,
         Wildcard(_) => false,

--- a/package-gale/src/parser_gen.wado
+++ b/package-gale/src/parser_gen.wado
@@ -2150,7 +2150,13 @@ fn inner_walker_follow_for_repeat(rep: &RepeatElement, rep_op: &RepeatOp, elemen
 fn op_is_leaf(op: &Op) -> bool {
     return match op {
         Token(_) | Literal(_) | RuleCall(_) | Wildcard(_) | Excluded(_) => true,
-        _ => false,
+        // Listed explicitly so a new leaf-shape `Op` variant must
+        // be classified here rather than silently inheriting
+        // "non-leaf" and being routed through the container emit
+        // helpers that would panic on it.
+        Repeat(_) => false,
+        Group(_) => false,
+        ListLabel(_) => false,
     };
 }
 

--- a/package-gale/src/parser_gen.wado
+++ b/package-gale/src/parser_gen.wado
@@ -2150,10 +2150,6 @@ fn inner_walker_follow_for_repeat(rep: &RepeatElement, rep_op: &RepeatOp, elemen
 fn op_is_leaf(op: &Op) -> bool {
     return match op {
         Token(_) | Literal(_) | RuleCall(_) | Wildcard(_) | Excluded(_) => true,
-        // Listed explicitly so a new leaf-shape `Op` variant must
-        // be classified here rather than silently inheriting
-        // "non-leaf" and being routed through the container emit
-        // helpers that would panic on it.
         Repeat(_) => false,
         Group(_) => false,
         ListLabel(_) => false,

--- a/package-gale/tests/generated/antlr4/ANTLRv4Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4/ANTLRv4Lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6fd58782d32cfb10",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/ANTLRv4Lexer.g4",
     "hash": "30bd52b58a5916a63041f501c2d45358431c5c379f1ed3e8a3fbbb311f3572bd"

--- a/package-gale/tests/generated/antlr4_compat_a/FullContextParsing/FullContextIF_THEN_ELSEParse_1/FullContextIF_THEN_ELSEParse_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/FullContextParsing/FullContextIF_THEN_ELSEParse_1/FullContextIF_THEN_ELSEParse_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-638680e10de193b9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/FullContextParsing/FullContextIF_THEN_ELSEParse_1.g4",
     "hash": "741538d9d6c17ba04aef378568b4ab2abdfbffd161000d9ab169b2a4d9abf5d0"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_1/AmbigLR_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_1/AmbigLR_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-aa54d1f54c3c3397",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/AmbigLR_1.g4",
     "hash": "24d8561b0961d6320b98bd4cfaff5fdf42796f8247fb92c253a205a5937f6edd"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_2/AmbigLR_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_2/AmbigLR_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-00a06ace4397e1c2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/AmbigLR_2.g4",
     "hash": "24d8561b0961d6320b98bd4cfaff5fdf42796f8247fb92c253a205a5937f6edd"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_3/AmbigLR_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_3/AmbigLR_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-46a15312ac52c3a2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/AmbigLR_3.g4",
     "hash": "24d8561b0961d6320b98bd4cfaff5fdf42796f8247fb92c253a205a5937f6edd"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_4/AmbigLR_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_4/AmbigLR_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-beadf766755ec773",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/AmbigLR_4.g4",
     "hash": "24d8561b0961d6320b98bd4cfaff5fdf42796f8247fb92c253a205a5937f6edd"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_5/AmbigLR_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_5/AmbigLR_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-aac47e3f7ad2f611",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/AmbigLR_5.g4",
     "hash": "24d8561b0961d6320b98bd4cfaff5fdf42796f8247fb92c253a205a5937f6edd"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a6ec2b8f2ddde283",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_1.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-61c5e70fcdb6da1f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_10.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-699ecb3a8f815e27",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_2.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-262e54587e9044c3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_3.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a998eaa06c653a5b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_4.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fc22b0fc36d36630",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_5.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2852af861801de26",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_6.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-320d631a0baf5c0b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_7.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3bd4c5ea00e5572f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_8.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-49d484703a919155",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_9.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-713ef5230fbaf9f1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_1.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-558b311b80c4da10",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_2.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c369756dc031bf12",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_3.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-abed1c70b5e6c53f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_1.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a1b502206053bf7a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_2.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-68045ae831d55159",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_3.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-678c469712c8fc23",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_4.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-16bc5e2c231c2ba8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_5.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c116bb1cfe62a2a8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_6.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0484794f535b91f2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_7.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fe2840241e9172a0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_1.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-235cd53ca8f4663a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_10.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ed84013859c673b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_11.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-739357c31b4c8ca4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_12.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-70a21a8410fad983",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_2.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_3/JavaExpressions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_3/JavaExpressions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-84ac2f3f46fb93bc",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_3.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_4/JavaExpressions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_4/JavaExpressions_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-21d6144f1ef80bed",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_4.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-99bcc333174e8ead",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_5.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2f290cf17eba13e0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_6.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bd943cd5ec077b75",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_7.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6ad535192ef3e12f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_8.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-43dcc5eba0df7ec4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_9.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-112c4a21992a04ed",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_1.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-459d0b754845c21f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_2.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1181507cda20d45b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_3.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4b506a26b7b7c7b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_1.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-34e6293e9d4c3e83",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_2.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b2467e37954af95c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_3.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-be8254158e713214",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_1.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4fc8261d73da648f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_2.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-93334f393b16d8e0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_3.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_1/MultipleAlternativesWithCommonLabel_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_1/MultipleAlternativesWithCommonLabel_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f8f837edca2c89e7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_1.g4",
     "hash": "ae1955a63072b61bfb19d308ec36275bae7fd4ca41cb570ddcd3113f86f61d81"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_2/MultipleAlternativesWithCommonLabel_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_2/MultipleAlternativesWithCommonLabel_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e9a04fe0052b621e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_2.g4",
     "hash": "ae1955a63072b61bfb19d308ec36275bae7fd4ca41cb570ddcd3113f86f61d81"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_3/MultipleAlternativesWithCommonLabel_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_3/MultipleAlternativesWithCommonLabel_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1105f32afc8cf90d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_3.g4",
     "hash": "ae1955a63072b61bfb19d308ec36275bae7fd4ca41cb570ddcd3113f86f61d81"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_4/MultipleAlternativesWithCommonLabel_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_4/MultipleAlternativesWithCommonLabel_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-689fb2e6742c4014",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_4.g4",
     "hash": "ae1955a63072b61bfb19d308ec36275bae7fd4ca41cb570ddcd3113f86f61d81"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_5/MultipleAlternativesWithCommonLabel_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_5/MultipleAlternativesWithCommonLabel_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bba1df3c39861ac6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_5.g4",
     "hash": "ae1955a63072b61bfb19d308ec36275bae7fd4ca41cb570ddcd3113f86f61d81"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e522638eb5f62a2f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrecedenceFilterConsidersContext.g4",
     "hash": "c92df3158f9ed1c1b43de581aedaf3b0918fa525ff0258f855022b78585b860b"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-709c12dbc0d22c0c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrefixAndOtherAlt_1.g4",
     "hash": "f946ec43c09928b2aae968a817d4ff315478257d5700925eab82fd22d94714d8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1f6f1364b2571756",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrefixAndOtherAlt_2.g4",
     "hash": "f946ec43c09928b2aae968a817d4ff315478257d5700925eab82fd22d94714d8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixOpWithActionAndLabel_1/PrefixOpWithActionAndLabel_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixOpWithActionAndLabel_1/PrefixOpWithActionAndLabel_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1bceb663d8f72bbc",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrefixOpWithActionAndLabel_1.g4",
     "hash": "277dfd7e556da18b06db5bf0fccd85fe10f7a2e1f0229f7a11d5580da4f5fc38"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixOpWithActionAndLabel_2/PrefixOpWithActionAndLabel_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixOpWithActionAndLabel_2/PrefixOpWithActionAndLabel_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f66f69768ea9b073",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrefixOpWithActionAndLabel_2.g4",
     "hash": "277dfd7e556da18b06db5bf0fccd85fe10f7a2e1f0229f7a11d5580da4f5fc38"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixOpWithActionAndLabel_3/PrefixOpWithActionAndLabel_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixOpWithActionAndLabel_3/PrefixOpWithActionAndLabel_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-39c67a17295485a8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrefixOpWithActionAndLabel_3.g4",
     "hash": "277dfd7e556da18b06db5bf0fccd85fe10f7a2e1f0229f7a11d5580da4f5fc38"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_1/ReturnValueAndActionsAndLabels_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_1/ReturnValueAndActionsAndLabels_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5692d6e3f456dfbc",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsAndLabels_1.g4",
     "hash": "8598d942da23d2752eeb86358ab94f137ea6ecbd4536dad7a93253b6dbba2583"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_2/ReturnValueAndActionsAndLabels_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_2/ReturnValueAndActionsAndLabels_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5c5ed2412472f210",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsAndLabels_2.g4",
     "hash": "8598d942da23d2752eeb86358ab94f137ea6ecbd4536dad7a93253b6dbba2583"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_3/ReturnValueAndActionsAndLabels_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_3/ReturnValueAndActionsAndLabels_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-37625c9ce8fecf22",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsAndLabels_3.g4",
     "hash": "8598d942da23d2752eeb86358ab94f137ea6ecbd4536dad7a93253b6dbba2583"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_4/ReturnValueAndActionsAndLabels_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_4/ReturnValueAndActionsAndLabels_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-25e049ca5b917254",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsAndLabels_4.g4",
     "hash": "8598d942da23d2752eeb86358ab94f137ea6ecbd4536dad7a93253b6dbba2583"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_1/ReturnValueAndActionsList1_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_1/ReturnValueAndActionsList1_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-98215ef7f217d444",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList1_1.g4",
     "hash": "97ed3cba25571f64d3b3f1ada1225af38693f6353aa699ec825c47886f968b1e"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_2/ReturnValueAndActionsList1_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_2/ReturnValueAndActionsList1_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4b874ab98e1307f7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList1_2.g4",
     "hash": "97ed3cba25571f64d3b3f1ada1225af38693f6353aa699ec825c47886f968b1e"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_3/ReturnValueAndActionsList1_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_3/ReturnValueAndActionsList1_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d3f80bba204a6230",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList1_3.g4",
     "hash": "97ed3cba25571f64d3b3f1ada1225af38693f6353aa699ec825c47886f968b1e"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_4/ReturnValueAndActionsList1_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_4/ReturnValueAndActionsList1_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b49376635cb5520f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList1_4.g4",
     "hash": "97ed3cba25571f64d3b3f1ada1225af38693f6353aa699ec825c47886f968b1e"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_1/ReturnValueAndActionsList2_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_1/ReturnValueAndActionsList2_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fe2931b7e3ce7624",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList2_1.g4",
     "hash": "d020b96fea143032cbc0f3f58b543f99e6ee62a9921e2c0c402a721dfeb8e67c"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_2/ReturnValueAndActionsList2_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_2/ReturnValueAndActionsList2_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-38b61cfa75fd52d2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList2_2.g4",
     "hash": "d020b96fea143032cbc0f3f58b543f99e6ee62a9921e2c0c402a721dfeb8e67c"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_3/ReturnValueAndActionsList2_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_3/ReturnValueAndActionsList2_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-292efe417a055f21",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList2_3.g4",
     "hash": "d020b96fea143032cbc0f3f58b543f99e6ee62a9921e2c0c402a721dfeb8e67c"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_4/ReturnValueAndActionsList2_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_4/ReturnValueAndActionsList2_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a83798d7b64b39bf",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList2_4.g4",
     "hash": "d020b96fea143032cbc0f3f58b543f99e6ee62a9921e2c0c402a721dfeb8e67c"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_1/ReturnValueAndActions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_1/ReturnValueAndActions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-21861166aaabb459",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActions_1.g4",
     "hash": "b75cc6b1b5387a38b7faf0c7f28b2278e632d380687b5cfbd93d691d753d4dfc"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_2/ReturnValueAndActions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_2/ReturnValueAndActions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-baee6ffe2906a543",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActions_2.g4",
     "hash": "b75cc6b1b5387a38b7faf0c7f28b2278e632d380687b5cfbd93d691d753d4dfc"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_3/ReturnValueAndActions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_3/ReturnValueAndActions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7ac903d674117074",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActions_3.g4",
     "hash": "b75cc6b1b5387a38b7faf0c7f28b2278e632d380687b5cfbd93d691d753d4dfc"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_4/ReturnValueAndActions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_4/ReturnValueAndActions_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e520c27c5b2a98e7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActions_4.g4",
     "hash": "b75cc6b1b5387a38b7faf0c7f28b2278e632d380687b5cfbd93d691d753d4dfc"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/SemPred/SemPred.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/SemPred/SemPred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-960ef5ffa9d45556",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/SemPred.g4",
     "hash": "a19c17fc308f32463fe399a657b189a837ad4fa52afc1206ab0d1d8a38dcbe04"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5d3495c986bff9bd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_1.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-33ccce79b79bf5e2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_2.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6dcbc071fc2f601e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_3.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-741313c066ff2cd5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_1.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-381677e2c28357d8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_2.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4d665f3c7d50cbb6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_3.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-18d85335cd7b6ba7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_4.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6c0e1c831530f504",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_5.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d5dda292b3d95344",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_6.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bc586f7b630f85cb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_7.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b8fe4abc43e4380d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_8.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ddd4f8db5f21632f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_9.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1a2ad3adca9a2a07",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_1.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-eed4df03ca7a51f5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_2.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bfcc2ec63de46569",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_3.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-20cd1bcceb40fb33",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_4.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-cfe1fc1849a20141",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_5.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-88482992acd5509f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_6.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-78bbab6b273081fa",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_7.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-03918ec747b14ad6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_8.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a66253165de20181",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_9.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/DFAToATNThatFailsBackToDFA/DFAToATNThatFailsBackToDFA.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/DFAToATNThatFailsBackToDFA/DFAToATNThatFailsBackToDFA.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-43662820cd720381",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerErrors/DFAToATNThatFailsBackToDFA.g4",
     "hash": "48db67da6df9caa67f3e56b39408023058c363703e5eac58a74bea22a92f0066"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/DFAToATNThatMatchesThenFailsInATN/DFAToATNThatMatchesThenFailsInATN.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/DFAToATNThatMatchesThenFailsInATN/DFAToATNThatMatchesThenFailsInATN.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-92639b4998fdb6d8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerErrors/DFAToATNThatMatchesThenFailsInATN.g4",
     "hash": "ce03131129eb8147280be2cb5319ce363f7a4184ab6b871b761128c49ce4edb3"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/EnforcedGreedyNestedBraces_1/EnforcedGreedyNestedBraces_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/EnforcedGreedyNestedBraces_1/EnforcedGreedyNestedBraces_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ab2dc616bbf25ced",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerErrors/EnforcedGreedyNestedBraces_1.g4",
     "hash": "492b2ecee9f08f105799b38ff8e81a375902fbb29ec5d849b5f6459f2abc26a5"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/EnforcedGreedyNestedBraces_2/EnforcedGreedyNestedBraces_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/EnforcedGreedyNestedBraces_2/EnforcedGreedyNestedBraces_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-11f55d79f5b51619",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerErrors/EnforcedGreedyNestedBraces_2.g4",
     "hash": "492b2ecee9f08f105799b38ff8e81a375902fbb29ec5d849b5f6459f2abc26a5"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/ErrorInMiddle/ErrorInMiddle.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/ErrorInMiddle/ErrorInMiddle.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-32e6c8d04a1f19dc",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerErrors/ErrorInMiddle.g4",
     "hash": "ca5afb8c050f2d8b96fd19595dc603645d812846f62c9d767d56f7d0a0c5a0d9"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharAtStart/InvalidCharAtStart.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharAtStart/InvalidCharAtStart.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4ef9785e331127f4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerErrors/InvalidCharAtStart.g4",
     "hash": "97fcf7891b064a11fbcda1b83696ecfa795d3917c98f4efc47dfef9d8781364d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharAtStartAfterDFACache/InvalidCharAtStartAfterDFACache.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharAtStartAfterDFACache/InvalidCharAtStartAfterDFACache.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-85823d9f7794aa53",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerErrors/InvalidCharAtStartAfterDFACache.g4",
     "hash": "97fcf7891b064a11fbcda1b83696ecfa795d3917c98f4efc47dfef9d8781364d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharInToken/InvalidCharInToken.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharInToken/InvalidCharInToken.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a6221528b7ed7b0f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerErrors/InvalidCharInToken.g4",
     "hash": "97fcf7891b064a11fbcda1b83696ecfa795d3917c98f4efc47dfef9d8781364d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharInTokenAfterDFACache/InvalidCharInTokenAfterDFACache.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharInTokenAfterDFACache/InvalidCharInTokenAfterDFACache.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-583a97ab9cabd77e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerErrors/InvalidCharInTokenAfterDFACache.g4",
     "hash": "97fcf7891b064a11fbcda1b83696ecfa795d3917c98f4efc47dfef9d8781364d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/LexerExecDFA/LexerExecDFA.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/LexerExecDFA/LexerExecDFA.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0993dfa42831103f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerErrors/LexerExecDFA.g4",
     "hash": "9082786e9c7fc41aaf4fdfc2878c546039534e8b4ce83af668f95a9189b005d8"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/StringsEmbeddedInActions_1/StringsEmbeddedInActions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/StringsEmbeddedInActions_1/StringsEmbeddedInActions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-799e43fbadd97c49",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerErrors/StringsEmbeddedInActions_1.g4",
     "hash": "5e54d404efadb816a1078633ba2ec12083f375115c60fb0a60fab0de281a428e"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/StringsEmbeddedInActions_2/StringsEmbeddedInActions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/StringsEmbeddedInActions_2/StringsEmbeddedInActions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-16583a74c70842a2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerErrors/StringsEmbeddedInActions_2.g4",
     "hash": "5e54d404efadb816a1078633ba2ec12083f375115c60fb0a60fab0de281a428e"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/ActionPlacement/ActionPlacement.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/ActionPlacement/ActionPlacement.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0b7d7ee907eff28d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/ActionPlacement.g4",
     "hash": "d2e2766e7a6e95053b231cd43aca1fe4f764aee1d333e2302d278b5b067e209c"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSet/CharSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSet/CharSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ec6a82f66661d3b2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/CharSet.g4",
     "hash": "8e650ba32b5a406d9b26183b2d8bedcce9c1db181bdb411ad7c5839dcf4b228d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetInSet/CharSetInSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetInSet/CharSetInSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-059a913c8f048685",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/CharSetInSet.g4",
     "hash": "b5e383c044a1563de26a51b2d6b7cb2248fd55be0e3964e1d14b3610562eec1b"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetNot/CharSetNot.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetNot/CharSetNot.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6b134e988acd6363",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/CharSetNot.g4",
     "hash": "69cca11dfc28d919af7dc2ee9fe3723a7cd21d664d0be3beac4731d55c756c1c"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetPlus/CharSetPlus.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetPlus/CharSetPlus.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bf99cbf4ca947742",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/CharSetPlus.g4",
     "hash": "0cbc99fa0bac4ead651732b006ec8eb8eeca91cf996b2f879d7b0169d1ea3d1d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetRange/CharSetRange.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetRange/CharSetRange.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c934afe8d6fb12c3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/CharSetRange.g4",
     "hash": "3e05d18b49d5c8c36a07be0bfad40393aad4dbfd51a4236754351f81326709b1"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithEscapedChar/CharSetWithEscapedChar.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithEscapedChar/CharSetWithEscapedChar.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-beee1b790da6eca8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/CharSetWithEscapedChar.g4",
     "hash": "5223c3ae6c31d174c32451245dd1b500378e5db8269d2436d6c3e13348c843a1"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithMissingEscapeChar/CharSetWithMissingEscapeChar.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithMissingEscapeChar/CharSetWithMissingEscapeChar.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6d0d4b989a50e1d8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/CharSetWithMissingEscapeChar.g4",
     "hash": "50af99ded636823b3572ef557e472106e875b6a577bfce40a5a9f136e02a5425"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithQuote1/CharSetWithQuote1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithQuote1/CharSetWithQuote1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-86d2205ba2955dc2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/CharSetWithQuote1.g4",
     "hash": "be53ac24d9dde8c37359d79d1cc412859db4f7c36ea7d8994a7e41abb529735e"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithQuote2/CharSetWithQuote2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithQuote2/CharSetWithQuote2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8069a3abadd3121d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/CharSetWithQuote2.g4",
     "hash": "9abf142b50b105db8ba755c0a77ed4d38d3f00173bf0b86e12df3eb7f3d9f869"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/EOFSuffixInFirstRule_2/EOFSuffixInFirstRule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/EOFSuffixInFirstRule_2/EOFSuffixInFirstRule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-aea1b38951921107",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/EOFSuffixInFirstRule_2.g4",
     "hash": "441bbb7e472213eb37da15d9b0992d1c4d399644b0fa057762e0b579ae06e531"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/EscapedCharacters/EscapedCharacters.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/EscapedCharacters/EscapedCharacters.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e8300fe6f4844494",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/EscapedCharacters.g4",
     "hash": "88a4f34355fb87e7adbc718fcfe030c51f5c362d158b4cce6a5796189ba1cd4a"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyClosure/GreedyClosure.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyClosure/GreedyClosure.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b0942d820fcbb7cd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/GreedyClosure.g4",
     "hash": "d1458a9fc1db2a1bc64866ee5b621bdea6b8aca8fd321a6053f7b64c496bf279"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyConfigs/GreedyConfigs.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyConfigs/GreedyConfigs.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3de5a17518246534",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/GreedyConfigs.g4",
     "hash": "bdd0480bbe82e2296561739001674c10fb887a4867707fe2de4f1c1eb323655b"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyOptional/GreedyOptional.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyOptional/GreedyOptional.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6a5d57f15ad9cc05",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/GreedyOptional.g4",
     "hash": "0e2acf0a59884a4de77f9b74b30c2dc30770c78b1a11db4db50b1cea97df2d4d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyPositiveClosure/GreedyPositiveClosure.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyPositiveClosure/GreedyPositiveClosure.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-19156932f057309b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/GreedyPositiveClosure.g4",
     "hash": "5d96b0c62fad69596130c0cfe142462b2dffa59bcc399e1decfd28cd0ad2ac03"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/HexVsID/HexVsID.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/HexVsID/HexVsID.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8abb80787ab55f9c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/HexVsID.g4",
     "hash": "a1aa12f4fe19f66adc2b83628e3806eb535b11a974c9e7173202674b57eb3bf2"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/KeywordID/KeywordID.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/KeywordID/KeywordID.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9ea33c5c30fad565",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/KeywordID.g4",
     "hash": "5eec334a6818219de3e310c919f6fa92ee282ea3d98561d1e53fa586df4b7645"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyClosure/NonGreedyClosure.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyClosure/NonGreedyClosure.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c329de00201a662b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/NonGreedyClosure.g4",
     "hash": "919895cc80becbaa85e86b313156de11fb8cc30e641612bb47a295326f546a2c"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyConfigs/NonGreedyConfigs.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyConfigs/NonGreedyConfigs.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6e481196977fb897",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/NonGreedyConfigs.g4",
     "hash": "ccf5c3efabd0e9fb90790d1eecb50a96b56642cb5f696121dbebe686a03d9c66"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyOptional/NonGreedyOptional.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyOptional/NonGreedyOptional.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-98a2517cd6de3281",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/NonGreedyOptional.g4",
     "hash": "611a3d559cf19bd50743e764270d813639b924662b03e7075f24f3ac3520ac9d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyPositiveClosure/NonGreedyPositiveClosure.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyPositiveClosure/NonGreedyPositiveClosure.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7f8b9d47090908f8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/NonGreedyPositiveClosure.g4",
     "hash": "a19bcb18c02be6721bf1028a7c1335d28291e3e247dbd8e5fa2fcbc88d716fe4"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyTermination1/NonGreedyTermination1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyTermination1/NonGreedyTermination1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-544276065b3f5292",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/NonGreedyTermination1.g4",
     "hash": "5841fcdcd5adf818f59bf6e0f6a29db4d1027ce77dcc476160b96079fcf35a8b"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyTermination2/NonGreedyTermination2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyTermination2/NonGreedyTermination2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-69c6ed615346bda3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/NonGreedyTermination2.g4",
     "hash": "9ea5e3f0fd959bb4a51b464e3c49d7f20e95f5189bab762287847163d70a5960"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/Parentheses/Parentheses.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/Parentheses/Parentheses.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c6d5ce9be675555a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/Parentheses.g4",
     "hash": "10a47eed1b802ff2274c0d7ffffc1a145b6142f25340091ecdb1176446429acc"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/QuoteTranslation/QuoteTranslation.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/QuoteTranslation/QuoteTranslation.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c3104f60588afc47",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/QuoteTranslation.g4",
     "hash": "fd454e5ff551c86e4eab1e50e2375a62b8246aae8b700f386202c3fbc795225f"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/RecursiveLexerRuleRefWithWildcardPlus_1/RecursiveLexerRuleRefWithWildcardPlus_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/RecursiveLexerRuleRefWithWildcardPlus_1/RecursiveLexerRuleRefWithWildcardPlus_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a70c0ee99123e3c1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/RecursiveLexerRuleRefWithWildcardPlus_1.g4",
     "hash": "ccf3affeed08d41932ee1b94716d414b1bae3d229b6c7f3f4d17e62300e91492"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/RecursiveLexerRuleRefWithWildcardStar_1/RecursiveLexerRuleRefWithWildcardStar_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/RecursiveLexerRuleRefWithWildcardStar_1/RecursiveLexerRuleRefWithWildcardStar_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ff63ca508475ca7d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/RecursiveLexerRuleRefWithWildcardStar_1.g4",
     "hash": "7b6ed71096a57f601b91ad9c0bee2e6b2fc376dcf23c80eb7430b84c165be764"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/RefToRuleDoesNotSetTokenNorEmitAnother/RefToRuleDoesNotSetTokenNorEmitAnother.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/RefToRuleDoesNotSetTokenNorEmitAnother/RefToRuleDoesNotSetTokenNorEmitAnother.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-dfeb7d6ff29cae4e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/RefToRuleDoesNotSetTokenNorEmitAnother.g4",
     "hash": "95a088465b495a7bfbf61a77ce9bb6ae79caa9288236175927e10273cca715f1"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/ReservedWordsEscaping/ReservedWordsEscaping.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/ReservedWordsEscaping/ReservedWordsEscaping.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-943ecf575772c038",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/ReservedWordsEscaping.g4",
     "hash": "66600b7a97e9750d7527d65b8f6799e6e8f39806bf1a1bc70f349d2d79549d04"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/ReservedWordsEscaping_NULL/ReservedWordsEscaping_NULL.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/ReservedWordsEscaping_NULL/ReservedWordsEscaping_NULL.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-cca11faf9eb972a7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/ReservedWordsEscaping_NULL.g4",
     "hash": "c0512ddd17eb85b03ec5ee0bdfbd91e04bf5186ea196a43c6699b55bf350e582"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/Slashes/Slashes.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/Slashes/Slashes.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5b895275cf797a70",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/Slashes.g4",
     "hash": "8542b8d313ce35cd690e1408d548786844016931b7659852bbcb1af80919f7df"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/StackoverflowDueToNotEscapedHyphen/StackoverflowDueToNotEscapedHyphen.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/StackoverflowDueToNotEscapedHyphen/StackoverflowDueToNotEscapedHyphen.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2644dac05d6694ee",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/StackoverflowDueToNotEscapedHyphen.g4",
     "hash": "8ac36d903f20ad5d1c01d8de6e7555e7095b62f80282b91c7309cb119f6e0e81"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/UnicodeCharSet/UnicodeCharSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/UnicodeCharSet/UnicodeCharSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-43a5a4f219cff449",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/UnicodeCharSet.g4",
     "hash": "be6380e8ca1f1838a7908f37fc269bbfe32d7522dff990274bfc144c90d5a73f"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/ZeroLengthToken/ZeroLengthToken.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/ZeroLengthToken/ZeroLengthToken.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8ed7f21c46440147",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LexerExec/ZeroLengthToken.g4",
     "hash": "602fefbd71118c707ee514a7eb2d6eeac92032b2009e51b705b154429bffd5ea"

--- a/package-gale/tests/generated/antlr4_compat_a/ParseTrees/RuleRef/RuleRef.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParseTrees/RuleRef/RuleRef.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-169bf906f921e598",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParseTrees/RuleRef.g4",
     "hash": "94e77d3cf0e835f48dfd591d6b9b625e723dc68af632bce754d64e7a83682e5f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParseTrees/Token2/Token2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParseTrees/Token2/Token2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0ba95439abba4779",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParseTrees/Token2.g4",
     "hash": "7f89f3118adb112f187ec9a91475c3230eb8d3e0f11d5f98649b5ca5cd018210"

--- a/package-gale/tests/generated/antlr4_compat_a/ParseTrees/TwoAltLoop/TwoAltLoop.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParseTrees/TwoAltLoop/TwoAltLoop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-dfb4bb64c6c70d96",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParseTrees/TwoAltLoop.g4",
     "hash": "01ee51d71cecc10fa33d0b88dd68d026e6e3e811ceaa04d124aaf32b943836ef"

--- a/package-gale/tests/generated/antlr4_compat_a/ParseTrees/TwoAlts/TwoAlts.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParseTrees/TwoAlts/TwoAlts.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7e35452b6694c6ca",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParseTrees/TwoAlts.g4",
     "hash": "18ff657616b51f930ed3ce29a3df32d447b93f1ff9f857f30f3eb53458857f94"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ConjuringUpToken/ConjuringUpToken.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ConjuringUpToken/ConjuringUpToken.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-88b2932f5ec4fe02",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserErrors/ConjuringUpToken.g4",
     "hash": "cec24d194020155bc5c53585d2a955c7d39e697e652fa11acaf3efc1a7589fb7"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ConjuringUpTokenFromSet/ConjuringUpTokenFromSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ConjuringUpTokenFromSet/ConjuringUpTokenFromSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-949514c025c718e0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserErrors/ConjuringUpTokenFromSet.g4",
     "hash": "b56e1ba56f51bf544a254459dcc27c19e3f719f8eafae34e005aef07581e6517"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ContextListGetters/ContextListGetters.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ContextListGetters/ContextListGetters.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c046d2e955ea50d7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserErrors/ContextListGetters.g4",
     "hash": "b7f98ec81bd992592439948185bb23c69116c968bf6f2529cf779cfa9801366f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_1/DuplicatedLeftRecursiveCall_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_1/DuplicatedLeftRecursiveCall_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-14e4c615c6247171",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserErrors/DuplicatedLeftRecursiveCall_1.g4",
     "hash": "cb574c6c608fb07e3c875b5c7561874060c04e7a280293a55ab819142ffe274f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_2/DuplicatedLeftRecursiveCall_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_2/DuplicatedLeftRecursiveCall_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6fa8c086a7f8b385",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserErrors/DuplicatedLeftRecursiveCall_2.g4",
     "hash": "cb574c6c608fb07e3c875b5c7561874060c04e7a280293a55ab819142ffe274f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_3/DuplicatedLeftRecursiveCall_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_3/DuplicatedLeftRecursiveCall_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-38daa485fd706c29",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserErrors/DuplicatedLeftRecursiveCall_3.g4",
     "hash": "cb574c6c608fb07e3c875b5c7561874060c04e7a280293a55ab819142ffe274f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_4/DuplicatedLeftRecursiveCall_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_4/DuplicatedLeftRecursiveCall_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3f74525ca7ce7306",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserErrors/DuplicatedLeftRecursiveCall_4.g4",
     "hash": "cb574c6c608fb07e3c875b5c7561874060c04e7a280293a55ab819142ffe274f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ExtraneousInput/ExtraneousInput.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ExtraneousInput/ExtraneousInput.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-69d327b1ce53e23e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserErrors/ExtraneousInput.g4",
     "hash": "d65f706ca2451405802574364ae8d3d7abf995b07027e8a4625c575ee48c919b"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/InvalidATNStateRemoval/InvalidATNStateRemoval.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/InvalidATNStateRemoval/InvalidATNStateRemoval.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-35f2301c1e275a74",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserErrors/InvalidATNStateRemoval.g4",
     "hash": "264f98bcea9cc9d12c0c89782381318f9404f87e10f26da3a6762a42f6738109"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LL1ErrorInfo/LL1ErrorInfo.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LL1ErrorInfo/LL1ErrorInfo.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3630e43f048325ae",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserErrors/LL1ErrorInfo.g4",
     "hash": "894561cdd0b332fdb9c86599422d88ee6f45086a452209a385b14df01e56f8aa"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LL2/LL2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LL2/LL2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-27275e28a7283862",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserErrors/LL2.g4",
     "hash": "2aaa2b6a34f4a4348b34477ca85e32d712d0090ea04767439f00a52c9e369525"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LL3/LL3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LL3/LL3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2c02059c81383bdf",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserErrors/LL3.g4",
     "hash": "c71f82724eba5c68a8618a7e086bdd6d4945e4a769695822a02a3e560fc12d76"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LLStar/LLStar.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LLStar/LLStar.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c58b4a7f2470bfbd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserErrors/LLStar.g4",
     "hash": "3e937ce2ce494c4be9f9c68d8901657bf961c2323261dd30954d25990d001418"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionBeforeLoop/MultiTokenDeletionBeforeLoop.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionBeforeLoop/MultiTokenDeletionBeforeLoop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-11c428dc92bce342",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserErrors/MultiTokenDeletionBeforeLoop.g4",
     "hash": "e85e3274b80d9927fac0d6f6fd84f36c85e3495b5c8288e0dcb1117c16f07173"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionBeforeLoop2/MultiTokenDeletionBeforeLoop2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionBeforeLoop2/MultiTokenDeletionBeforeLoop2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5c85c00cf85bcd7f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserErrors/MultiTokenDeletionBeforeLoop2.g4",
     "hash": "51530a0ee95353c6b0fb35a295e36225ea546f7677798f9ce2d4671ba35b7edd"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionDuringLoop/MultiTokenDeletionDuringLoop.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionDuringLoop/MultiTokenDeletionDuringLoop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f956579d72cda75b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserErrors/MultiTokenDeletionDuringLoop.g4",
     "hash": "bb77678589d1936b056f87c3eafaa90d32f55c9a10beee93b8160102affad30f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionDuringLoop2/MultiTokenDeletionDuringLoop2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionDuringLoop2/MultiTokenDeletionDuringLoop2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4b2726c798a3f404",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserErrors/MultiTokenDeletionDuringLoop2.g4",
     "hash": "e425f4fea0c6671792c777df6308de1546711741603dfcde04e0cf3ebebf6b9f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/NoViableAltAvoidance/NoViableAltAvoidance.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/NoViableAltAvoidance/NoViableAltAvoidance.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d86bb14016285c15",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserErrors/NoViableAltAvoidance.g4",
     "hash": "b28914eab8290e79724e3e1b2ac223e8b6c5021ac6ca3c564ee873762146bbfc"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleSetInsertion/SingleSetInsertion.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleSetInsertion/SingleSetInsertion.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a740dc5de6aa9be1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserErrors/SingleSetInsertion.g4",
     "hash": "5c5213e807e10eac992c2dd076d8f12a8df33bb71c1803ee039588b15da2782b"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletion/SingleTokenDeletion.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletion/SingleTokenDeletion.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5567b7a22ba37d48",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserErrors/SingleTokenDeletion.g4",
     "hash": "25554c7741a77a1d8537817aac67e64f061017ef4c7c06a01596c0279a6b03ec"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforeAlt/SingleTokenDeletionBeforeAlt.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforeAlt/SingleTokenDeletionBeforeAlt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8bc2797041d59085",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserErrors/SingleTokenDeletionBeforeAlt.g4",
     "hash": "8620c2090497e410ec32e4c6556c760c41ffe1a00ca410ee8a598dfdd77baf3c"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforeLoop/SingleTokenDeletionBeforeLoop.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforeLoop/SingleTokenDeletionBeforeLoop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-955b5c33d9e7273a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserErrors/SingleTokenDeletionBeforeLoop.g4",
     "hash": "981912e9f61c0e8e34da6607456532112011597125c30dcbddf0125401041f85"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforeLoop2/SingleTokenDeletionBeforeLoop2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforeLoop2/SingleTokenDeletionBeforeLoop2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-db65a1054c5e73e1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserErrors/SingleTokenDeletionBeforeLoop2.g4",
     "hash": "959f4e3f298f227e7e5c734f8325acfb023db1858bc5f3c11f1236c771316b55"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforePredict/SingleTokenDeletionBeforePredict.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforePredict/SingleTokenDeletionBeforePredict.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6a740074fa5af7c4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserErrors/SingleTokenDeletionBeforePredict.g4",
     "hash": "3e937ce2ce494c4be9f9c68d8901657bf961c2323261dd30954d25990d001418"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionDuringLoop/SingleTokenDeletionDuringLoop.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionDuringLoop/SingleTokenDeletionDuringLoop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-add885d747200bef",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserErrors/SingleTokenDeletionDuringLoop.g4",
     "hash": "bb77678589d1936b056f87c3eafaa90d32f55c9a10beee93b8160102affad30f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionDuringLoop2/SingleTokenDeletionDuringLoop2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionDuringLoop2/SingleTokenDeletionDuringLoop2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-792ed25474d04331",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserErrors/SingleTokenDeletionDuringLoop2.g4",
     "hash": "e425f4fea0c6671792c777df6308de1546711741603dfcde04e0cf3ebebf6b9f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionExpectingSet/SingleTokenDeletionExpectingSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionExpectingSet/SingleTokenDeletionExpectingSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ed06340b010d215f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserErrors/SingleTokenDeletionExpectingSet.g4",
     "hash": "82fab2ac95de6f83693cfada43a42fb29c81c33276e86a92c9ffe512e0619240"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenInsertion/SingleTokenInsertion.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenInsertion/SingleTokenInsertion.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b22c89bcb3a2b88e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserErrors/SingleTokenInsertion.g4",
     "hash": "4153af41f9ffb8e3498f2f8624598a75ecb726bce94b85532bc26a2f9a553a93"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/TokenMismatch/TokenMismatch.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/TokenMismatch/TokenMismatch.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e68ef4bce9bbab9b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserErrors/TokenMismatch.g4",
     "hash": "25554c7741a77a1d8537817aac67e64f061017ef4c7c06a01596c0279a6b03ec"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/TokenMismatch2/TokenMismatch2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/TokenMismatch2/TokenMismatch2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6e1085f00c2900ad",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserErrors/TokenMismatch2.g4",
     "hash": "4bd0badd70e068efac023f2f42dff67c8439fb46b31ad4ecffa908f2eb619d18"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/APlus/APlus.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/APlus/APlus.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-728d3d84fcf455c3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/APlus.g4",
     "hash": "2b0dbbd74f199abf2352f0d10d69380a3efa3415df6e4766c0ec28607af19cda"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/AStar_2/AStar_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/AStar_2/AStar_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1a756c9763de62cf",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/AStar_2.g4",
     "hash": "a92a7a73eaf0898b23dda4615fc26ca13df1545ef078fde29cdf8c3bc9cbb95e"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorAPlus/AorAPlus.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorAPlus/AorAPlus.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c42842cac56908aa",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/AorAPlus.g4",
     "hash": "d4aee965be5cd3da519492b2a33a77762e9b3679da9f616bc2e85a73f2202fae"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorAStar_2/AorAStar_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorAStar_2/AorAStar_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5549786fa4e45e89",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/AorAStar_2.g4",
     "hash": "6d4d8fd0f1b4d3dc3e2e8faf8ea35103229eb6c35779eaccc5d82b1628327b23"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorB/AorB.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorB/AorB.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-af2d4db1d1c41fa2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/AorB.g4",
     "hash": "a5be6ae4578376bc6ce8bc8244b8547a686c023b8288b7ee1b788e3109641aef"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorBPlus/AorBPlus.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorBPlus/AorBPlus.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e9cba1c238b58c8f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/AorBPlus.g4",
     "hash": "513f4bbe3648eb8ee7cda9846f4decf54510992284d1f855c91d3ff63f4eb561"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorBStar_2/AorBStar_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorBStar_2/AorBStar_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-62a21287c929c510",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/AorBStar_2.g4",
     "hash": "30bd8a0630f5fee2c9cdd84358bb4330bdbbef41ce747fb918a5317b26d72094"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Basic/Basic.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Basic/Basic.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6478199efe55bc2a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/Basic.g4",
     "hash": "12d9ef272c7c1189094b1667f57d2434ee01e7390bde72fef40bbd2c39c655ad"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/BuildParseTree_FALSE/BuildParseTree_FALSE.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/BuildParseTree_FALSE/BuildParseTree_FALSE.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-481eced579ea16c7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/BuildParseTree_FALSE.g4",
     "hash": "2a131cc48cdbfa4950f7c16ef0fcb51f4679926cabf71d403883a9fc01e9cb99"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1d1b100d63f04166",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/BuildParseTree_TRUE.g4",
     "hash": "2a131cc48cdbfa4950f7c16ef0fcb51f4679926cabf71d403883a9fc01e9cb99"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseGreedyBinding1/IfIfElseGreedyBinding1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseGreedyBinding1/IfIfElseGreedyBinding1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-178da7119841f92f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/IfIfElseGreedyBinding1.g4",
     "hash": "87cddc954cc58d91bcee872b5e1136ec8db7cdba27d288e3158f1263465e1c68"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseGreedyBinding2/IfIfElseGreedyBinding2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseGreedyBinding2/IfIfElseGreedyBinding2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f862b65924b584c3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/IfIfElseGreedyBinding2.g4",
     "hash": "9961fd76deec1ff3f156b53cae19057402f659774e286b5109f317f9099548bf"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseNonGreedyBinding2/IfIfElseNonGreedyBinding2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseNonGreedyBinding2/IfIfElseNonGreedyBinding2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e177ceb86d9657b8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/IfIfElseNonGreedyBinding2.g4",
     "hash": "82b13e026c76cbd8d6e148ff6b07a4afcaff767d281341b009acb47f2177fa99"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_1/Keyword_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_1/Keyword_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ab26a078dce4ba4d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/Keyword_1.g4",
     "hash": "ce8b6e86f90fd838f389c969f26848a74f12cedfc2269000d54013aefc9d7cfd"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_2/Keyword_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_2/Keyword_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-71926d55e62dc139",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/Keyword_2.g4",
     "hash": "4901211c2a6d24bc31faad4232c52b1076c788c30ca1626ee8189f377298edb3"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_3/Keyword_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_3/Keyword_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2dfb8df028c35315",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/Keyword_3.g4",
     "hash": "be54343e5d0af2db673e19012a397a002684ea46cbfae40b2d7283c34d120aaf"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_4/Keyword_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_4/Keyword_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6f611c6ff41ad4b7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/Keyword_4.g4",
     "hash": "f093c2f32b839973701e676ff0a7ac42b07bde81fe26d0dd62242d5bddea35df"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_5/Keyword_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_5/Keyword_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-77b6fe2367098780",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/Keyword_5.g4",
     "hash": "288f969b08c50c65a8fe90dca09e2900316e61a1e643ed8dffe19f0baf33caeb"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_6/Keyword_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_6/Keyword_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-208d3031e87fb60b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/Keyword_6.g4",
     "hash": "f1f23150782692a30fca3499f09edc2d8b32615fe4158fdd496ca236f257abfd"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/LL1OptionalBlock_2/LL1OptionalBlock_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/LL1OptionalBlock_2/LL1OptionalBlock_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9d45b4605cb12aa1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/LL1OptionalBlock_2.g4",
     "hash": "a2b9873d31df6aa521f495b2f4f63cbcb01917154e56af08ec8162e66ec4b375"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/LabelAliasingAcrossLabeledAlternatives/LabelAliasingAcrossLabeledAlternatives.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/LabelAliasingAcrossLabeledAlternatives/LabelAliasingAcrossLabeledAlternatives.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7407b4e055dc9668",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/LabelAliasingAcrossLabeledAlternatives.g4",
     "hash": "10da0f9ef1418b4e7996ee9ca537b6eb00e24cd75a5e9cadcf6a0f2cd05403d8"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/ListLabelForClosureContext/ListLabelForClosureContext.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/ListLabelForClosureContext/ListLabelForClosureContext.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fd388b2fbd095aaf",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/ListLabelForClosureContext.g4",
     "hash": "b74922c349f6fd54727a73a9292ac1aa7379006a6b5858b2120f09137b8f5220"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/ListLabelsOnRuleRefStartOfAlt/ListLabelsOnRuleRefStartOfAlt.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/ListLabelsOnRuleRefStartOfAlt/ListLabelsOnRuleRefStartOfAlt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b6e9d57c79d09026",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/ListLabelsOnRuleRefStartOfAlt.g4",
     "hash": "936dbddefbedcc17fb63d1cebd59dba273f24001d8510aa9e4584026b3a77a47"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/MultipleEOFHandling/MultipleEOFHandling.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/MultipleEOFHandling/MultipleEOFHandling.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bfbb91211458856c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/MultipleEOFHandling.g4",
     "hash": "f1cb5bab46a024203403073ff94ae02fed6987c2e63b627edf697a7d299b08c6"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/OpenDeviceStatement_Case1/OpenDeviceStatement_Case1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/OpenDeviceStatement_Case1/OpenDeviceStatement_Case1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b78910bf9bf158f2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/OpenDeviceStatement_Case1.g4",
     "hash": "e7e0d629d700077ba7d1c73b090f445f1d1e6a71e05a0ec865a1119f159c0689"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/OpenDeviceStatement_Case2/OpenDeviceStatement_Case2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/OpenDeviceStatement_Case2/OpenDeviceStatement_Case2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e5674944ed003268",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/OpenDeviceStatement_Case2.g4",
     "hash": "3e809216e16c70dfb0f29110bb04e4f17b9cc8df65e343e657587db8125919d1"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/OpenDeviceStatement_Case3/OpenDeviceStatement_Case3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/OpenDeviceStatement_Case3/OpenDeviceStatement_Case3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3e764b7acdb12698",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/OpenDeviceStatement_Case3.g4",
     "hash": "3e809216e16c70dfb0f29110bb04e4f17b9cc8df65e343e657587db8125919d1"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_1/Optional_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_1/Optional_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c274b4f5c3986095",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/Optional_1.g4",
     "hash": "81da3d25df801643a2b8b428b72db781e2a8d51f46e90fe17e5c4d569460040c"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_2/Optional_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_2/Optional_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-aedb0aa92cf17a71",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/Optional_2.g4",
     "hash": "81da3d25df801643a2b8b428b72db781e2a8d51f46e90fe17e5c4d569460040c"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_3/Optional_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_3/Optional_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9167a5251f4b8f7b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/Optional_3.g4",
     "hash": "81da3d25df801643a2b8b428b72db781e2a8d51f46e90fe17e5c4d569460040c"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_4/Optional_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_4/Optional_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fb9e364a1f321866",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/Optional_4.g4",
     "hash": "81da3d25df801643a2b8b428b72db781e2a8d51f46e90fe17e5c4d569460040c"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/OrderingPredicates/OrderingPredicates.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/OrderingPredicates/OrderingPredicates.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-eb23dd6200692539",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/OrderingPredicates.g4",
     "hash": "9e1c1b5e4eb5492597f2e750d5935cb9a2fad092868471a4a1244f39f05c60e5"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredicatedIfIfElse/PredicatedIfIfElse.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredicatedIfIfElse/PredicatedIfIfElse.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2adf50b71d6b26eb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/PredicatedIfIfElse.g4",
     "hash": "440287edf9ce1d9d35ced00c525bdf5620ab0d710872d6c3df66275a20b6a6b7"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-94c0b5df15a69680",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/PredictionIssue334.g4",
     "hash": "05f509013c98f1d1ef907d23c43aa328f3c9ee0ad9166b21ac03dbc715ee8542"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3ebf8faf7a4261df",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/PredictionMode_LL.g4",
     "hash": "8542495134a20f622112aa07fc5cd71fcc1b8e3669f41ff329126b355c4df7f4"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/ReferenceToATN_2/ReferenceToATN_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/ReferenceToATN_2/ReferenceToATN_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7cb38e03f3cad365",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/ReferenceToATN_2.g4",
     "hash": "51acdad9c9d5ac16101b107cd251308154503481b21347eba16ed71c07207cf8"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/TokenOffset/TokenOffset.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/TokenOffset/TokenOffset.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c220c68df172fdc8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/TokenOffset.g4",
     "hash": "e74488674b6ea2a5b0c7c5c0da5c63c5f40e5cbd3659293737c5f866eec3dadb"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Wildcard/Wildcard.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Wildcard/Wildcard.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-38fea6538d89f39e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/Wildcard.g4",
     "hash": "443ea5e8b3a600f483f353e7b727214ae7b46b07d48a05209575e59a4e5f87ff"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape/uStartingCharDoesNotCauseIllegalUnicodeEscape.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape/uStartingCharDoesNotCauseIllegalUnicodeEscape.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2339d2f209eeb675",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape.g4",
     "hash": "2ddf63624620f170bb9fc4afce010caed86e03e13c5841514ae5f185dda39973"

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_1/DropLoopEntryBranchInLRRule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_1/DropLoopEntryBranchInLRRule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-52627404e5640445",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Performance/DropLoopEntryBranchInLRRule_1.g4",
     "hash": "b939eb6c32ee7ec29a924f62f15dbcc4185a8e719a264dc0f73c4b0abccc59bd"

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_2/DropLoopEntryBranchInLRRule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_2/DropLoopEntryBranchInLRRule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-59b8af4a0fa6b3ee",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Performance/DropLoopEntryBranchInLRRule_2.g4",
     "hash": "b939eb6c32ee7ec29a924f62f15dbcc4185a8e719a264dc0f73c4b0abccc59bd"

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_3/DropLoopEntryBranchInLRRule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_3/DropLoopEntryBranchInLRRule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f5521d38c0216647",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Performance/DropLoopEntryBranchInLRRule_3.g4",
     "hash": "b939eb6c32ee7ec29a924f62f15dbcc4185a8e719a264dc0f73c4b0abccc59bd"

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_4/DropLoopEntryBranchInLRRule_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_4/DropLoopEntryBranchInLRRule_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c5ad84645f427a7d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Performance/DropLoopEntryBranchInLRRule_4.g4",
     "hash": "b939eb6c32ee7ec29a924f62f15dbcc4185a8e719a264dc0f73c4b0abccc59bd"

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_5/DropLoopEntryBranchInLRRule_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_5/DropLoopEntryBranchInLRRule_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e4e42c238a991ee1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Performance/DropLoopEntryBranchInLRRule_5.g4",
     "hash": "b939eb6c32ee7ec29a924f62f15dbcc4185a8e719a264dc0f73c4b0abccc59bd"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/DisableRule/DisableRule.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/DisableRule/DisableRule.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-86a2ab3396aab386",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/SemPredEvalLexer/DisableRule.g4",
     "hash": "5b1574a02354c266f21fd591064fe38a2e504dc819f17e3926537f3a06d4fc7f"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/EnumNotID/EnumNotID.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/EnumNotID/EnumNotID.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-913cec3fde51b4e9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/SemPredEvalLexer/EnumNotID.g4",
     "hash": "85fe205c1e5199d59ecdfde76be2b554d5417cf4f3044467d2c3c2bc6be62a38"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/IDnotEnum/IDnotEnum.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/IDnotEnum/IDnotEnum.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-62b49dae9cdfa1e9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/SemPredEvalLexer/IDnotEnum.g4",
     "hash": "6931892d68c03b3e5aa6440e19df4ec4d482979716d8265bb90d754b4ef6ef7a"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/IDvsEnum/IDvsEnum.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/IDvsEnum/IDvsEnum.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-99254c1dc443e2ed",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/SemPredEvalLexer/IDvsEnum.g4",
     "hash": "56ae33e82f989514e362fec8cc72a6550b7a4460f7cf651186c0fc5577e2596d"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/Indent/Indent.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/Indent/Indent.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-cd7a12324cae4154",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/SemPredEvalLexer/Indent.g4",
     "hash": "ae673bead61ac8db918560678d525133be3f118e57d3af6dc6170f0a5f59854a"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/LexerInputPositionSensitivePredicates/LexerInputPositionSensitivePredicates.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/LexerInputPositionSensitivePredicates/LexerInputPositionSensitivePredicates.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-55720fd860adaf84",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/SemPredEvalLexer/LexerInputPositionSensitivePredicates.g4",
     "hash": "3b657b482bf4474734371c82bad60577eab45adcb768b00be1f1332976f573a7"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/PredicatedKeywords/PredicatedKeywords.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/PredicatedKeywords/PredicatedKeywords.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-469bc7973b79e9b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/SemPredEvalLexer/PredicatedKeywords.g4",
     "hash": "2d282eb6b99756b6a78e5b9350752b0e8a9c44853cd80fc99024cca551f2c8a2"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/RuleSempredFunction/RuleSempredFunction.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/RuleSempredFunction/RuleSempredFunction.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-06588ae5e8ac8f6e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/SemPredEvalLexer/RuleSempredFunction.g4",
     "hash": "afb90011be3fc07f2b609aab80113b4cdc176601aa78430bdc8af851cd096c57"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ActionHidesPreds/ActionHidesPreds.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ActionHidesPreds/ActionHidesPreds.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5ebe2ee47798d213",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/ActionHidesPreds.g4",
     "hash": "7176de59d1c79178e55d5e86f1c9d45d2a84c42d0306624c059f6291b7bef8aa"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ActionsHidePredsInGlobalFOLLOW/ActionsHidePredsInGlobalFOLLOW.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ActionsHidePredsInGlobalFOLLOW/ActionsHidePredsInGlobalFOLLOW.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a94c1b64bd13fbed",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/ActionsHidePredsInGlobalFOLLOW.g4",
     "hash": "ccdf783cb1b30be5a7b33fa50258508b6fa6564ffc640f83cdd701860cefceab"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/AtomWithClosureInTranslatedLRRule/AtomWithClosureInTranslatedLRRule.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/AtomWithClosureInTranslatedLRRule/AtomWithClosureInTranslatedLRRule.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5a178af823f9ac9a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/AtomWithClosureInTranslatedLRRule.g4",
     "hash": "92e1a1f0924ff1342f55dce399ac903cbd1ee449cb61b490823161e0100e84ea"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/DepedentPredsInGlobalFOLLOW/DepedentPredsInGlobalFOLLOW.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/DepedentPredsInGlobalFOLLOW/DepedentPredsInGlobalFOLLOW.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-692f131977ac56a3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/DepedentPredsInGlobalFOLLOW.g4",
     "hash": "23c2d14982503d975310e5e3c23f6d5acf82bdea14758b8edf43a21de15fc46b"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored/DependentPredNotInOuterCtxShouldBeIgnored.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored/DependentPredNotInOuterCtxShouldBeIgnored.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3fe42b4ce1e78640",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored.g4",
     "hash": "9d9906068c7233613cbd6b5d1291c8c6fcb0cd0cdc09eb46491a16d77043a351"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/DisabledAlternative/DisabledAlternative.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/DisabledAlternative/DisabledAlternative.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a255bb34009ec064",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/DisabledAlternative.g4",
     "hash": "dd7e12c1c8029e091a0a98c9844b768fe2beb66e2dd4499affa4dd42426bbebb"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/IndependentPredNotPassedOuterCtxToAvoidCastException/IndependentPredNotPassedOuterCtxToAvoidCastException.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/IndependentPredNotPassedOuterCtxToAvoidCastException/IndependentPredNotPassedOuterCtxToAvoidCastException.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8d1b342c55cae162",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/IndependentPredNotPassedOuterCtxToAvoidCastException.g4",
     "hash": "7750e6dc3c86efd7c47184ad7f428310bd808cbee7cc760d88cbf6c76aed00ea"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/Order/Order.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/Order/Order.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b0cb8abb4f972c24",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/Order.g4",
     "hash": "fe5bc85134bb1581bdcae00261221a4d8d5cf7fc66861514c518c932db73927c"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7f162199fbfa5a4d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/PredFromAltTestedInLoopBack_2.g4",
     "hash": "b6144b334167648d1e1560be8a7590525c8b34cbba2e27d040c41026fa7c9323"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredTestedEvenWhenUnAmbig_1/PredTestedEvenWhenUnAmbig_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredTestedEvenWhenUnAmbig_1/PredTestedEvenWhenUnAmbig_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3b39341559a48cc1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/PredTestedEvenWhenUnAmbig_1.g4",
     "hash": "e612218883337369509a10795a6c896ed4fd346099904bcdea49689b70eacb58"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredicateDependentOnArg/PredicateDependentOnArg.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredicateDependentOnArg/PredicateDependentOnArg.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f608cd4c953fcc54",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/PredicateDependentOnArg.g4",
     "hash": "63ad05004eaa3eae497c7ac7b869f512be40e3b08c490a4edefce0a7bfd03be4"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredicateDependentOnArg2/PredicateDependentOnArg2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredicateDependentOnArg2/PredicateDependentOnArg2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d0d8e7243a5ed8fa",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/PredicateDependentOnArg2.g4",
     "hash": "54d5032bc72d9ef84bb3c836a5c580fad72122817b40fc5380affd8a13521f6c"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredsInGlobalFOLLOW/PredsInGlobalFOLLOW.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredsInGlobalFOLLOW/PredsInGlobalFOLLOW.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d3df6d6bd95a1bd9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/PredsInGlobalFOLLOW.g4",
     "hash": "5bc8badde05794d30336979aa4a8e376565246e39e74e5e79ffcc7d3640896ab"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/RewindBeforePredEval/RewindBeforePredEval.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/RewindBeforePredEval/RewindBeforePredEval.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-83aa6f01e7804f87",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/RewindBeforePredEval.g4",
     "hash": "1e8283c5161522a98e12bd6b9c0b904b195ed3b305a7cd1104d32111a16230ac"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/Simple/Simple.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/Simple/Simple.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-677df452d792bc67",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/Simple.g4",
     "hash": "35ff1d3690b2d9d2c179b9064ac1f19102b739667e99e936dc923f266be1a29b"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ToLeft/ToLeft.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ToLeft/ToLeft.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-be444147c4503b8c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/ToLeft.g4",
     "hash": "4663e60c7732087dc2db2c9b615d6a9d091258c9088e5494ada4888d59fe97ed"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ToLeftWithVaryingPredicate/ToLeftWithVaryingPredicate.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ToLeftWithVaryingPredicate/ToLeftWithVaryingPredicate.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-210346e30f72367f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/ToLeftWithVaryingPredicate.g4",
     "hash": "660b45f425c3ed090eab8100788e1b44cea8e8acf7a3a7df551673b469969613"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/UnpredicatedPathsInAlt/UnpredicatedPathsInAlt.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/UnpredicatedPathsInAlt/UnpredicatedPathsInAlt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-35f1c77265d94b3d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/UnpredicatedPathsInAlt.g4",
     "hash": "b92936412d8caa3aa5e0a9f0859db4db2dbd59b422445fc0ac7646ad9de7e7b5"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/CharSetLiteral/CharSetLiteral.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/CharSetLiteral/CharSetLiteral.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-071abee69c5f8b99",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Sets/CharSetLiteral.g4",
     "hash": "06e8171bff5cb8897907a7253d3622ee2b3fe0046ae8d0b91af1e53eea95199a"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/LexerOptionalSet/LexerOptionalSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/LexerOptionalSet/LexerOptionalSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f34fde4990cf3527",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Sets/LexerOptionalSet.g4",
     "hash": "805d183407ee6d3e197aa59c47746f31a3a876616ba81d2796b4eade4fd0cb1a"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/LexerPlusSet/LexerPlusSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/LexerPlusSet/LexerPlusSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0a05f3c65ac671fe",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Sets/LexerPlusSet.g4",
     "hash": "82d73edf927d0b41773a2aed77c24eb6c1e15ae757745711744a98d92a30ba9f"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/LexerStarSet/LexerStarSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/LexerStarSet/LexerStarSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-067c6d0cdaeafd72",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Sets/LexerStarSet.g4",
     "hash": "5fc2408d6d827c200d5f3dda95c90ca51c0304141e1966710e5ba3ee4e8c9c62"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/NotChar/NotChar.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/NotChar/NotChar.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-df532a39582b5252",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Sets/NotChar.g4",
     "hash": "ea4e829495a2862424c660528e60b42538171fd98c4add9d59de52bfebb03636"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/NotCharSet/NotCharSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/NotCharSet/NotCharSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f06d5349b86b506d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Sets/NotCharSet.g4",
     "hash": "e746afb6f30a6057ad02472688eed14093eb3c3667bdf9e3c181886b47e78837"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/NotCharSetWithRuleRef3/NotCharSetWithRuleRef3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/NotCharSetWithRuleRef3/NotCharSetWithRuleRef3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d4da046f1e65bec9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Sets/NotCharSetWithRuleRef3.g4",
     "hash": "13b313e51177c018f7ae34ebaa84db67e86a0d4b36209ad3fd1711f2ad2fb7c7"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/OptionalLexerSingleElement/OptionalLexerSingleElement.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/OptionalLexerSingleElement/OptionalLexerSingleElement.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ca7134f26228c2de",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Sets/OptionalLexerSingleElement.g4",
     "hash": "3921de873d86bac58271a10481e3c0e015c69cd9d31da1c2278263a953b16c45"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/OptionalSet/OptionalSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/OptionalSet/OptionalSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3d68ae8128fb39ab",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Sets/OptionalSet.g4",
     "hash": "c13dc8792637b8734bddc522d5c7eb48f4d40806f34c7540b36f59d70a45db0b"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/OptionalSingleElement/OptionalSingleElement.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/OptionalSingleElement/OptionalSingleElement.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-efeddf2f7e9b125b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Sets/OptionalSingleElement.g4",
     "hash": "6ed40cb1f8e0cf841fa0926ccc6a4d62bc3164537ac07270baaf99e7bff650ed"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/ParserNotSet/ParserNotSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/ParserNotSet/ParserNotSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3b9f8eb9e42815a6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Sets/ParserNotSet.g4",
     "hash": "5cd8c64df8a97020ac5413953d3f986284c2d0d02ecffa78f56e74501fd843a4"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/ParserNotToken/ParserNotToken.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/ParserNotToken/ParserNotToken.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-aad9720a02ffb8dc",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Sets/ParserNotToken.g4",
     "hash": "f3628c394dba3dcf943da3c57ae49f9638ad607d2889b3c93a404ffdee955bdd"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/ParserNotTokenWithLabel/ParserNotTokenWithLabel.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/ParserNotTokenWithLabel/ParserNotTokenWithLabel.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-769f62ca417d9ed5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Sets/ParserNotTokenWithLabel.g4",
     "hash": "0a93f8b72d55e95661fd29f1dc20be1ba499092a4627974f10deafbabfc1902d"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/ParserSet/ParserSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/ParserSet/ParserSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-20c70a227c9554ea",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Sets/ParserSet.g4",
     "hash": "9f4a6537aa3fabe41aabda8b6dceb0b110ae6dc2c1ca606d1bb6a4c17bc0523f"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/PlusLexerSingleElement/PlusLexerSingleElement.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/PlusLexerSingleElement/PlusLexerSingleElement.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9e32c82dca8baf2a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Sets/PlusLexerSingleElement.g4",
     "hash": "308fe96545620a9956a16a0b905efbd6838f91f1380d112f59c8f5e7ec847df6"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/PlusSet/PlusSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/PlusSet/PlusSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-27c278babd34c7f1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Sets/PlusSet.g4",
     "hash": "e22104935432d1ef1346e156287f6ffc20f7a823a3a6fc35eead1aa59f7e5bff"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/RuleAsSet/RuleAsSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/RuleAsSet/RuleAsSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8d93a0978fbdee9f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Sets/RuleAsSet.g4",
     "hash": "b292a08285fc28948b206aa219a2c5707f54b8d7d059e4b9435a685e35604a0f"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/SeqDoesNotBecomeSet/SeqDoesNotBecomeSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/SeqDoesNotBecomeSet/SeqDoesNotBecomeSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-56cef52f926ea67e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Sets/SeqDoesNotBecomeSet.g4",
     "hash": "1e9c5a53f120329c72dade19fb74f37b769fa3e8620ce55c964187b4b31afa04"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/StarLexerSingleElement_1/StarLexerSingleElement_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/StarLexerSingleElement_1/StarLexerSingleElement_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-dae05255d7087267",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Sets/StarLexerSingleElement_1.g4",
     "hash": "9ef8e31aeee6cc982752fab2eb2bc1f24a2c1c941b2188809dfd5924be72e052"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/StarLexerSingleElement_2/StarLexerSingleElement_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/StarLexerSingleElement_2/StarLexerSingleElement_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e43de691a19bfcc5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Sets/StarLexerSingleElement_2.g4",
     "hash": "9ef8e31aeee6cc982752fab2eb2bc1f24a2c1c941b2188809dfd5924be72e052"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/StarSet/StarSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/StarSet/StarSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-df2617285346a8e4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Sets/StarSet.g4",
     "hash": "b6e8bd3225682605f4be8329a1ae6a16abcad1fcd59e904ef3b62582e975e58c"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedBMPRangeSet/UnicodeEscapedBMPRangeSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedBMPRangeSet/UnicodeEscapedBMPRangeSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0005566e799dba7a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Sets/UnicodeEscapedBMPRangeSet.g4",
     "hash": "91d810085adf2f3357827ce10f4bbad8b3e368cee7f7cb7a3f7a1de5dcd9fb25"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedBMPSet/UnicodeEscapedBMPSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedBMPSet/UnicodeEscapedBMPSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0060929253ada741",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Sets/UnicodeEscapedBMPSet.g4",
     "hash": "1ebdc64bc0460ae535aeffbdc92a3f5761026b451f53b16a67a1e4ca5c5adfd0"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedSMPRangeSet/UnicodeEscapedSMPRangeSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedSMPRangeSet/UnicodeEscapedSMPRangeSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e54a3fb3292bae9f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Sets/UnicodeEscapedSMPRangeSet.g4",
     "hash": "315c93a355628ed83d531af6a8acae7963652887c8317e90194f639f487a1454"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedSMPSet/UnicodeEscapedSMPSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedSMPSet/UnicodeEscapedSMPSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6165c080cf12dd08",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Sets/UnicodeEscapedSMPSet.g4",
     "hash": "537c313c2d870d0c4e8fd6353c23f77e4510a436510e08e010dadf6674649f67"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeNegatedBMPSetIncludesSMPCodePoints/UnicodeNegatedBMPSetIncludesSMPCodePoints.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeNegatedBMPSetIncludesSMPCodePoints/UnicodeNegatedBMPSetIncludesSMPCodePoints.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-353a1e6aa47b228f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Sets/UnicodeNegatedBMPSetIncludesSMPCodePoints.g4",
     "hash": "466941b1536dede6ac3205c0840ef6d5769d6ebbb02068e3078667aa3b723bf0"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints/UnicodeNegatedSMPSetIncludesBMPCodePoints.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints/UnicodeNegatedSMPSetIncludesBMPCodePoints.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bd7acbaa64d536c9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints.g4",
     "hash": "69ab5aeb81e985edb26b848195ad01840cbc068de1413e0dc41dc606755f5d85"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeUnescapedBMPRangeSet/UnicodeUnescapedBMPRangeSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeUnescapedBMPRangeSet/UnicodeUnescapedBMPRangeSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-080df775962946d3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Sets/UnicodeUnescapedBMPRangeSet.g4",
     "hash": "f35a7b066983f55034da8d5bb525e9f4265b04e208656d8bf80e2647ec315064"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeUnescapedBMPSet/UnicodeUnescapedBMPSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeUnescapedBMPSet/UnicodeUnescapedBMPSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-da721cd708e5efb0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/Sets/UnicodeUnescapedBMPSet.g4",
     "hash": "116c1a706a18422d1b24ff9c3f8cc3e9c183c8047ace31fbbb1b2e4e3b9d2b89"

--- a/package-gale/tests/generated/antlr4_compat_b/FullContextParsing/ExprAmbiguity_1/ExprAmbiguity_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/FullContextParsing/ExprAmbiguity_1/ExprAmbiguity_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9e6a660e962943cf",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/FullContextParsing/ExprAmbiguity_1.g4",
     "hash": "14b8e903ab55457ab6f1ff7095b057b77680cdb6892d993f7509940795fdfec1"

--- a/package-gale/tests/generated/antlr4_compat_b/FullContextParsing/ExprAmbiguity_2/ExprAmbiguity_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/FullContextParsing/ExprAmbiguity_2/ExprAmbiguity_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a241ad7263b0316c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/FullContextParsing/ExprAmbiguity_2.g4",
     "hash": "14b8e903ab55457ab6f1ff7095b057b77680cdb6892d993f7509940795fdfec1"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a6ec2b8f2ddde283",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_1.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-61c5e70fcdb6da1f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_10.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-699ecb3a8f815e27",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_2.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-262e54587e9044c3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_3.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a998eaa06c653a5b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_4.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fc22b0fc36d36630",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_5.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2852af861801de26",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_6.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-320d631a0baf5c0b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_7.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3bd4c5ea00e5572f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_8.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-49d484703a919155",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_9.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-713ef5230fbaf9f1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_1.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-558b311b80c4da10",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_2.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c369756dc031bf12",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_3.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-abed1c70b5e6c53f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_1.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a1b502206053bf7a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_2.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-68045ae831d55159",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_3.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-678c469712c8fc23",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_4.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-16bc5e2c231c2ba8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_5.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c116bb1cfe62a2a8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_6.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0484794f535b91f2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_7.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fe2840241e9172a0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_1.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-235cd53ca8f4663a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_10.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ed84013859c673b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_11.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-739357c31b4c8ca4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_12.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-70a21a8410fad983",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_2.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-99bcc333174e8ead",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_5.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2f290cf17eba13e0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_6.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bd943cd5ec077b75",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_7.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6ad535192ef3e12f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_8.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-43dcc5eba0df7ec4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_9.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-112c4a21992a04ed",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_1.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-459d0b754845c21f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_2.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1181507cda20d45b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_3.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4b506a26b7b7c7b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_1.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-34e6293e9d4c3e83",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_2.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b2467e37954af95c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_3.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-be8254158e713214",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_1.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4fc8261d73da648f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_2.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-93334f393b16d8e0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_3.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e522638eb5f62a2f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrecedenceFilterConsidersContext.g4",
     "hash": "c92df3158f9ed1c1b43de581aedaf3b0918fa525ff0258f855022b78585b860b"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-709c12dbc0d22c0c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrefixAndOtherAlt_1.g4",
     "hash": "f946ec43c09928b2aae968a817d4ff315478257d5700925eab82fd22d94714d8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1f6f1364b2571756",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrefixAndOtherAlt_2.g4",
     "hash": "f946ec43c09928b2aae968a817d4ff315478257d5700925eab82fd22d94714d8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList1_1/ReturnValueAndActionsList1_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList1_1/ReturnValueAndActionsList1_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-98215ef7f217d444",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList1_1.g4",
     "hash": "97ed3cba25571f64d3b3f1ada1225af38693f6353aa699ec825c47886f968b1e"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList1_3/ReturnValueAndActionsList1_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList1_3/ReturnValueAndActionsList1_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d3f80bba204a6230",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList1_3.g4",
     "hash": "97ed3cba25571f64d3b3f1ada1225af38693f6353aa699ec825c47886f968b1e"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList2_1/ReturnValueAndActionsList2_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList2_1/ReturnValueAndActionsList2_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fe2931b7e3ce7624",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList2_1.g4",
     "hash": "d020b96fea143032cbc0f3f58b543f99e6ee62a9921e2c0c402a721dfeb8e67c"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList2_3/ReturnValueAndActionsList2_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList2_3/ReturnValueAndActionsList2_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-292efe417a055f21",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList2_3.g4",
     "hash": "d020b96fea143032cbc0f3f58b543f99e6ee62a9921e2c0c402a721dfeb8e67c"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/SemPred/SemPred.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/SemPred/SemPred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-960ef5ffa9d45556",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/SemPred.g4",
     "hash": "a19c17fc308f32463fe399a657b189a837ad4fa52afc1206ab0d1d8a38dcbe04"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/SemPredFailOption/SemPredFailOption.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/SemPredFailOption/SemPredFailOption.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a26551c8d0a65a59",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/SemPredFailOption.g4",
     "hash": "baacd97f45a8e197f2d9363c57506eebffd7f8862b34984e659ed317ac48a7d5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5d3495c986bff9bd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_1.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-33ccce79b79bf5e2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_2.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6dcbc071fc2f601e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_3.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-741313c066ff2cd5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_1.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-381677e2c28357d8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_2.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4d665f3c7d50cbb6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_3.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-18d85335cd7b6ba7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_4.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6c0e1c831530f504",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_5.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d5dda292b3d95344",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_6.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bc586f7b630f85cb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_7.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b8fe4abc43e4380d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_8.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ddd4f8db5f21632f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_9.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1a2ad3adca9a2a07",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_1.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-eed4df03ca7a51f5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_2.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bfcc2ec63de46569",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_3.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-20cd1bcceb40fb33",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_4.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-cfe1fc1849a20141",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_5.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-88482992acd5509f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_6.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-78bbab6b273081fa",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_7.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-03918ec747b14ad6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_8.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a66253165de20181",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_9.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/ExtraToken/ExtraToken.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/ExtraToken/ExtraToken.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f98287cee6b90751",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParseTrees/ExtraToken.g4",
     "hash": "156ed9b936c29311886ba71c031dac87cd4b6840001fee2eb9fe68aaa966ecb6"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/NoViableAlt/NoViableAlt.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/NoViableAlt/NoViableAlt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-dac7a0991b16026a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParseTrees/NoViableAlt.g4",
     "hash": "9231f03d8ef47e85e3d2852cfafaddcc6f66c6b8c974af0a13924510275448b7"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/RuleRef/RuleRef.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/RuleRef/RuleRef.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-169bf906f921e598",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParseTrees/RuleRef.g4",
     "hash": "94e77d3cf0e835f48dfd591d6b9b625e723dc68af632bce754d64e7a83682e5f"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/Sync/Sync.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/Sync/Sync.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-47349b342118b43c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParseTrees/Sync.g4",
     "hash": "7f0cc226fbcaf40b919d6fabc5b7e88c8fe92ed6637415b5c5a4be42addac7e8"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/Token2/Token2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/Token2/Token2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0ba95439abba4779",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParseTrees/Token2.g4",
     "hash": "7f89f3118adb112f187ec9a91475c3230eb8d3e0f11d5f98649b5ca5cd018210"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/TwoAltLoop/TwoAltLoop.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/TwoAltLoop/TwoAltLoop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-dfb4bb64c6c70d96",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParseTrees/TwoAltLoop.g4",
     "hash": "01ee51d71cecc10fa33d0b88dd68d026e6e3e811ceaa04d124aaf32b943836ef"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/TwoAlts/TwoAlts.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/TwoAlts/TwoAlts.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7e35452b6694c6ca",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParseTrees/TwoAlts.g4",
     "hash": "18ff657616b51f930ed3ce29a3df32d447b93f1ff9f857f30f3eb53458857f94"

--- a/package-gale/tests/generated/antlr4_compat_b/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1d1b100d63f04166",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/BuildParseTree_TRUE.g4",
     "hash": "2a131cc48cdbfa4950f7c16ef0fcb51f4679926cabf71d403883a9fc01e9cb99"

--- a/package-gale/tests/generated/antlr4_compat_b/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-94c0b5df15a69680",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/PredictionIssue334.g4",
     "hash": "05f509013c98f1d1ef907d23c43aa328f3c9ee0ad9166b21ac03dbc715ee8542"

--- a/package-gale/tests/generated/antlr4_compat_b/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3ebf8faf7a4261df",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/ParserExec/PredictionMode_LL.g4",
     "hash": "8542495134a20f622112aa07fc5cd71fcc1b8e3669f41ff329126b355c4df7f4"

--- a/package-gale/tests/generated/antlr4_compat_b/SemPredEvalParser/PredFromAltTestedInLoopBack_1/PredFromAltTestedInLoopBack_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/SemPredEvalParser/PredFromAltTestedInLoopBack_1/PredFromAltTestedInLoopBack_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3c84aa606fbeb863",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/PredFromAltTestedInLoopBack_1.g4",
     "hash": "b6144b334167648d1e1560be8a7590525c8b34cbba2e27d040c41026fa7c9323"

--- a/package-gale/tests/generated/antlr4_compat_b/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7f162199fbfa5a4d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/PredFromAltTestedInLoopBack_2.g4",
     "hash": "b6144b334167648d1e1560be8a7590525c8b34cbba2e27d040c41026fa7c9323"

--- a/package-gale/tests/generated/at_end_alt_gaps/at_end_alt_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/at_end_alt_gaps/at_end_alt_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-105bcd36568c5dd8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/at_end_alt_gaps.g4",
     "hash": "9cd47ca80f5762b4107f87ae05f1bce472bbfb8aca3c06ef0bdbf501ac519f82"

--- a/package-gale/tests/generated/calculator/calculator.g4.kiln.json
+++ b/package-gale/tests/generated/calculator/calculator.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7fbe69e34c931e16",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/calculator.g4",
     "hash": "67431dad6dcc459fea7d4c448fb04944de2c4cf61ecd75d546aeccd93b4564d7"

--- a/package-gale/tests/generated/ci_rule_override/ci_rule_override.g4.kiln.json
+++ b/package-gale/tests/generated/ci_rule_override/ci_rule_override.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-66c270910e5642be",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/ci_rule_override.g4",
     "hash": "6efdfe55ecb215bf526900a32a11c664a57c9e14d61c6a67758f870adc73d09b"

--- a/package-gale/tests/generated/ci_sql/ci_sql.g4.kiln.json
+++ b/package-gale/tests/generated/ci_sql/ci_sql.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b9bfa38391d7f122",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/ci_sql.g4",
     "hash": "41b72934417dd2f6fa0359722ce53ca05cd10cccde08fd9f3d0d58018f2137fe"

--- a/package-gale/tests/generated/css3/css3Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/css3/css3Lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fa4a5fa8cced30ae",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/css3Lexer.g4",
     "hash": "4733198f782344f0d3dbd2456ee9f6db955f53c688d14334fb403985551c963c"

--- a/package-gale/tests/generated/html/HTMLLexer.g4.kiln.json
+++ b/package-gale/tests/generated/html/HTMLLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c6b3fd168a1b47a8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/HTMLLexer.g4",
     "hash": "1d3b243228b182ddeca45bf2c7f9ec6512c176bcec126444bce7cbe7a8e93052"

--- a/package-gale/tests/generated/json/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/json/JSON.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-deb9206518cd2a6f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/JSON.g4",
     "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"

--- a/package-gale/tests/generated/json_highlight/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/json_highlight/JSON.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-deb9206518cd2a6f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/JSON.g4",
     "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"

--- a/package-gale/tests/generated/label_gaps/label_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/label_gaps/label_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6e9e12ac993603d7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/label_gaps.g4",
     "hash": "8e2049cd7baf82750b8e242018ffdc1f8e684226f8e27fe8068ad7838d6da425"

--- a/package-gale/tests/generated/label_list_collision/label_list_collision.g4.kiln.json
+++ b/package-gale/tests/generated/label_list_collision/label_list_collision.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-46e32ac3c676e666",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/label_list_collision.g4",
     "hash": "245eac983b4d16903ac917751c3f59e886be8be3e55623cdb25e40c782b58d44"

--- a/package-gale/tests/generated/lexer_command_gaps/lexer_command_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/lexer_command_gaps/lexer_command_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c1bc56a77b40e824",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/lexer_command_gaps.g4",
     "hash": "253a32f9908895a3ffaa23ac8e32eaa12f43998f25d7d2b73637ddf11a3cb3c9"

--- a/package-gale/tests/generated/lexer_greedy_suffix/lexer_greedy_suffix.g4.kiln.json
+++ b/package-gale/tests/generated/lexer_greedy_suffix/lexer_greedy_suffix.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6d59efe1924c9daa",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/lexer_greedy_suffix.g4",
     "hash": "2286e1ce4403101b6a2c197a88b3ba06ef185d7c31e99ad55033185275953d1a"

--- a/package-gale/tests/generated/ll_basic/ll_basic.g4.kiln.json
+++ b/package-gale/tests/generated/ll_basic/ll_basic.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1206cd75cc164570",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/ll_basic.g4",
     "hash": "13868e6cd6d82823b75c7c4c47196769892a7455d2a5708059eda73d059fa079"

--- a/package-gale/tests/generated/ll_ctx_follow/ll_ctx_follow.g4.kiln.json
+++ b/package-gale/tests/generated/ll_ctx_follow/ll_ctx_follow.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b6ecd573d27c61b4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/ll_ctx_follow.g4",
     "hash": "dfd02fd3f5e412a278dd35d357b67bd1b5c3ee832a93ead373965a1ea4caa7ed"

--- a/package-gale/tests/generated/ll_lr_atom/ll_lr_atom.g4.kiln.json
+++ b/package-gale/tests/generated/ll_lr_atom/ll_lr_atom.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-57755379135c6d22",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/ll_lr_atom.g4",
     "hash": "a03827fb8ff2576a6b7eb0997c60f88f94b45f673cc5ef743531000f7441227a"

--- a/package-gale/tests/generated/ll_multi_alt/ll_multi_alt.g4.kiln.json
+++ b/package-gale/tests/generated/ll_multi_alt/ll_multi_alt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4ba2b45344ba5494",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/ll_multi_alt.g4",
     "hash": "16387da958668ca8bfdc3a1502dec2180c703bb9affd3b19c2e669b8be9197a6"

--- a/package-gale/tests/generated/ll_multi_alt_overlap/ll_multi_alt_overlap.g4.kiln.json
+++ b/package-gale/tests/generated/ll_multi_alt_overlap/ll_multi_alt_overlap.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e527efdc825ca74e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/ll_multi_alt_overlap.g4",
     "hash": "570115cb7ce13e54d54def090f3ec3c79f9d8fcde7a904ce0043cace1a35336a"

--- a/package-gale/tests/generated/ll_multi_token_tail/ll_multi_token_tail.g4.kiln.json
+++ b/package-gale/tests/generated/ll_multi_token_tail/ll_multi_token_tail.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-467a302512739408",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/ll_multi_token_tail.g4",
     "hash": "5b3c6e9762dfdcb510a7454132f535cb903673dc4c85d38e903d48cdcea40a5b"

--- a/package-gale/tests/generated/ll_nullable_suffix/ll_nullable_suffix.g4.kiln.json
+++ b/package-gale/tests/generated/ll_nullable_suffix/ll_nullable_suffix.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f9a69797fc3574b8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/ll_nullable_suffix.g4",
     "hash": "d66de357f8340f6036dea6270e51c73a58b209b0a07685a7df03b2d18d218fe4"

--- a/package-gale/tests/generated/ll_wildcard_alt/ll_wildcard_alt.g4.kiln.json
+++ b/package-gale/tests/generated/ll_wildcard_alt/ll_wildcard_alt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b7f46d8d9ce550a7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/ll_wildcard_alt.g4",
     "hash": "5679207b4c2a4bdb85056206fff12aef1cb8c4998f099751195b3e09aea7047d"

--- a/package-gale/tests/generated/mode_gaps/mode_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/mode_gaps/mode_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-934b67223a7d4708",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/mode_gaps.g4",
     "hash": "2129310ea345f84328b61531ce102c6306fda62ef4fa71d7c64d1dc4bb9f1d14"

--- a/package-gale/tests/generated/multiple_eof/multiple_eof.g4.kiln.json
+++ b/package-gale/tests/generated/multiple_eof/multiple_eof.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-eca210b3fbc81812",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/multiple_eof.g4",
     "hash": "2b097a4cde773ec14e56e4222cd34af3735931774e74c4c77ca7b37f41afaa43"

--- a/package-gale/tests/generated/non_greedy_gaps/non_greedy_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/non_greedy_gaps/non_greedy_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a7aa34c1db2fca6a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/non_greedy_gaps.g4",
     "hash": "b7ebb6e1d962ee295bf43cc5a13f167cbd270ef3d9e15a052d2eb060eefb012c"

--- a/package-gale/tests/generated/parser_gaps/parser_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/parser_gaps/parser_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8eb28e22b79ba2bd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/parser_gaps.g4",
     "hash": "8262a9d7c10805db35e063564eaea6deb43e8de540af19d0969551d042b6d03a"

--- a/package-gale/tests/generated/parser_set_group_dispatch/parser_set_group_dispatch.g4.kiln.json
+++ b/package-gale/tests/generated/parser_set_group_dispatch/parser_set_group_dispatch.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ed667626677cf0f6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/parser_set_group_dispatch.g4",
     "hash": "c36bfab5dcc4c7f598aa83ca22dca3fd716225387804db2223b3c47986b73355"

--- a/package-gale/tests/generated/recursive_lexer/recursive_lexer.g4.kiln.json
+++ b/package-gale/tests/generated/recursive_lexer/recursive_lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b23078c163edb700",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/recursive_lexer.g4",
     "hash": "3bba2a980c91c247bfa081040a71e8349ebd29cec177d15cf69feb75f40e705f"

--- a/package-gale/tests/generated/right_assoc_gaps/right_assoc_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/right_assoc_gaps/right_assoc_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7382226003c5d9e1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/right_assoc_gaps.g4",
     "hash": "7632fce865fe8aa2c3c460beea14a27a0a020b9ccb2312fb59a2c980f12f639a"

--- a/package-gale/tests/generated/rust/RustLexer.g4.kiln.json
+++ b/package-gale/tests/generated/rust/RustLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-28566ce8c3b8a5b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/RustLexer.g4",
     "hash": "a9069b6b1a5650b0f5f115897eaa0edaddc42007b262c5096b59eb1de15323d3"

--- a/package-gale/tests/generated/sexpression/sexpression.g4.kiln.json
+++ b/package-gale/tests/generated/sexpression/sexpression.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1847ef51d5668bfd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/sexpression.g4",
     "hash": "74549e6167e186b754886880a5d473ad3361bee8440368f99e1b233e2c1c7bdb"

--- a/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-880d9db12a6d7521",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/SQLite.g4",
     "hash": "72e3fa9877777afa5a4f9e8196d4cb194bb599e719d43b7b29d09eeed3e4c5e0"

--- a/package-gale/tests/generated/sqlite_highlight/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite_highlight/SQLite.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-880d9db12a6d7521",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/SQLite.g4",
     "hash": "72e3fa9877777afa5a4f9e8196d4cb194bb599e719d43b7b29d09eeed3e4c5e0"

--- a/package-gale/tests/generated/typescript/TypeScriptLexer.g4.kiln.json
+++ b/package-gale/tests/generated/typescript/TypeScriptLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b6f068637d3275ff",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/TypeScriptLexer.g4",
     "hash": "f7089740f7e82bbb90a6c4b13c75959b6ceaf3003be0dd0657c52b9eb6a594b7"

--- a/package-gale/tests/generated/unicode_props/unicode_props.g4.kiln.json
+++ b/package-gale/tests/generated/unicode_props/unicode_props.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f37fa830f2a0df13",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "016d569266af9a5281173e7c7df644035b750a753f75939d702fb9647b24c51d",
+  "generator_source_hash": "05b7eace84047f4e219922a3d43c3fac3c919fad1375647f08bd8ba054c4211a",
   "primary": {
     "path": "grammars/unicode_props.g4",
     "hash": "7559b99d20b67597cdc99b2e9e0eaeea1ad4b0931d40859c1dbb600e20d1c5c0"


### PR DESCRIPTION
## Summary

`_ =>` / `other => other` arms on `Op` / `Element` matches in
IR-transformation paths silently absorb new variant additions. If a
future container variant is added, the wildcard would mis-handle it
instead of letting the compiler flag the call sites that need
updating.

This is the same class of gap as the
`ScanElement::OptionalLookahead` miss in the recent LR self-ref
walker — a wildcard `other => other` hid a real container case. The
fix there listed the leaf variants explicitly; this PR applies the
same treatment to the other IR-transform call sites where a wildcard
would mishandle (rather than safely default) a new variant.

## Replaced

| Site | Was | Risk if new variant added |
| --- | --- | --- |
| `lower::rebind_self_ref_min_prec` | `other => other` | New container `Op` would inherit silent passthrough; the caller guards via `find_self_ref_rule_call` so the arms are unreachable today — explicit enumeration makes the future addition a compile error. |
| `lower::element_is_self_ref` | `_ => false` | A new `Element` variant that could wrap a self-ref would be misclassified. |
| `lower::try_optional_scan_guard` | `_ => false` | A new scannable-requiring `Element` would default to "no scan guard". |
| `parser_gen::op_is_leaf` | `_ => false` | A new leaf-shape `Op` variant would silently route through the container emit helpers and panic at run time. |

## Kept

Other wildcards in the same files keep their `_`:

- Panic arms enforcing an invariant (`lower::lr_prefix_field_decl`,
  `lower::lower_token_only_leaf`, `parser_gen::single_token_first`,
  `lower::collect_excluded_kinds`, …) — `_ => panic(…)` IS the
  intent.
- Terminal-vs-non-terminal priority / name-fallback defaults
  (`lower.wado:1622`, `gen_util::not_element_field_name`,
  `gen_util::element_base_name`) — the wildcard SEMANTICS are the
  design.

A broader "lint against wildcard match on IR variants" policy would
catch the same class of bug at scale, but Gale doesn't ship a lint
framework today — that's a separate discussion.

## Verification

- 462 src tests + 47 codegen tests + 95 LR stage-A tests all pass.
- Generated kiln cache hashes refresh (no observable change in
  generated parsers — verified by diff on `t.wado` outputs).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTMFpr9c1UAakZ9AnZzuQ4)_