### PR TITLE
fix(zlib): decode gzip FNAME/FCOMMENT as UTF-8

### DIFF
--- a/docs/stdlib-core-zlib.md
+++ b/docs/stdlib-core-zlib.md
@@ -261,6 +261,34 @@ _Fields are private._
 
 Creates a header with all fields cleared (`os` set to `0xFF` = unknown).
 
+#### `pub fn text(&self) -> bool`
+
+Returns true if the FTEXT flag is set (payload is probably ASCII text).
+
+#### `pub fn time(&self) -> u32`
+
+Returns MTIME (modification time as a Unix timestamp; 0 = unset).
+
+#### `pub fn os(&self) -> i32`
+
+Returns the OS byte (`0xFF` = unknown).
+
+#### `pub fn extra(&self) -> Array<u8>`
+
+Returns the FEXTRA payload (empty = none).
+
+#### `pub fn name(&self) -> String`
+
+Returns the FNAME (original file name; empty = none).
+
+#### `pub fn comment(&self) -> String`
+
+Returns the FCOMMENT (empty = none).
+
+#### `pub fn hcrc(&self) -> bool`
+
+Returns true if the FHCRC flag is set (header CRC16 is present).
+
 #### `pub fn set_text(&mut self, text: bool)`
 
 Sets the FTEXT flag, indicating the payload is probably ASCII text.

--- a/wado-compiler/lib/core/zlib.wado
+++ b/wado-compiler/lib/core/zlib.wado
@@ -3255,6 +3255,41 @@ impl GzipHeader {
         };
     }
 
+    /// Returns true if the FTEXT flag is set (payload is probably ASCII text).
+    pub fn text(&self) -> bool {
+        return self.text;
+    }
+
+    /// Returns MTIME (modification time as a Unix timestamp; 0 = unset).
+    pub fn time(&self) -> u32 {
+        return self.time;
+    }
+
+    /// Returns the OS byte (`0xFF` = unknown).
+    pub fn os(&self) -> i32 {
+        return self.os;
+    }
+
+    /// Returns the FEXTRA payload (empty = none).
+    pub fn extra(&self) -> Array<u8> {
+        return self.extra;
+    }
+
+    /// Returns the FNAME (original file name; empty = none).
+    pub fn name(&self) -> String {
+        return self.name;
+    }
+
+    /// Returns the FCOMMENT (empty = none).
+    pub fn comment(&self) -> String {
+        return self.comment;
+    }
+
+    /// Returns true if the FHCRC flag is set (header CRC16 is present).
+    pub fn hcrc(&self) -> bool {
+        return self.hcrc;
+    }
+
     /// Sets the FTEXT flag, indicating the payload is probably ASCII text.
     pub fn set_text(&mut self, text: bool) {
         self.text = text;
@@ -3398,14 +3433,18 @@ pub fn gzip_compress_with_header(input: &Array<u8>, level: i32, header: &GzipHea
     return output;
 }
 
-// Helper: build a string from bytes in an array
+// Decode a gzip header byte range (FNAME/FCOMMENT) as a String.
+//
+// RFC 1952 specifies ISO-8859-1 for these fields, but we deliberately decode
+// as UTF-8 to match the bytes the compress side emits and to support
+// non-Latin-1 names. Invalid sequences are replaced with U+FFFD rather than
+// failing the parse, since these fields are best-effort metadata.
 fn bytes_to_string(buf: &Array<u8>, offset: i32, len: i32) -> String {
-    let mut s = String::with_capacity(len);
-    // FIXME: UTF-8 handling
+    let mut slice: Array<u8> = Array::with_capacity(len);
     for let mut i = 0; i < len; i += 1 {
-        s.push(buf[offset + i] as char);
+        slice.push(buf[offset + i]);
     }
-    return s;
+    return String::from_utf8_lossy(slice);
 }
 
 /// Parses and returns the gzip header without decompressing the body.

--- a/wado-compiler/lib/core/zlib_test.wado
+++ b/wado-compiler/lib/core/zlib_test.wado
@@ -41,7 +41,10 @@ use {
     deflate_raw,
     inflate_raw,
     gzip_compress,
+    gzip_compress_with_header,
     inflate_gzip,
+    inflate_get_gzip_header,
+    GzipHeader,
     uncompress,
     DeflateStream,
     InflateStream,
@@ -624,4 +627,20 @@ test "inflate_zlib error on invalid data" {
 test "inflate_gzip error on invalid data" {
     let bad: Array<u8> = [0, 0];
     assert inflate_gzip(&bad) matches { Err(_) };
+}
+
+test "gzip header preserves UTF-8 name and comment" {
+    let mut header = GzipHeader::new();
+    header.set_name("café_日本語.txt");
+    header.set_comment("コメント 😀");
+
+    let data = string_to_bytes("payload");
+    let compressed = gzip_compress_with_header(&data, Z_DEFAULT_COMPRESSION, &header);
+
+    let parsed = inflate_get_gzip_header(&compressed).unwrap();
+    assert parsed.name() == "café_日本語.txt", "FNAME must round-trip as UTF-8";
+    assert parsed.comment() == "コメント 😀", "FCOMMENT must round-trip as UTF-8";
+
+    // The body still inflates correctly with non-ASCII header fields present.
+    assert bytes_equal(&data, &inflate_gzip(&compressed).unwrap());
 }


### PR DESCRIPTION
## Problem

`bytes_to_string` (used by `inflate_get_gzip_header`) decoded each gzip header byte as a Unicode scalar — an implicit ISO-8859-1 read — while the compress side emits the `String`'s raw UTF-8 bytes. Any non-ASCII gzip file name or comment therefore round-tripped into mojibake (e.g. `"café"` → `"cafÃ©"`). This was the `// FIXME: UTF-8 handling` in `wado-compiler/lib/core/zlib.wado`.

## Fix

- Decode the FNAME/FCOMMENT byte range as UTF-8 via `String::from_utf8_lossy`, matching the bytes the compress side writes. Invalid sequences are replaced with U+FFFD rather than aborting an otherwise-valid header parse, since these fields are best-effort metadata.
- Note: RFC 1952 specifies ISO-8859-1 for these fields; we deliberately use UTF-8 to keep the round trip lossless and support non-Latin-1 (CJK/emoji) names. This is documented at the decode site.
- Add `GzipHeader` getters (`text`/`time`/`os`/`extra`/`name`/`comment`/`hcrc`). The header returned by `inflate_get_gzip_header` previously had only private fields and no accessors, so the parsed name/comment were unreadable from other modules.
- Regenerate `docs/stdlib-core-zlib.md`.

## Tests

Adds a round-trip test (`gzip header preserves UTF-8 name and comment`) covering a UTF-8 file name and comment plus body inflation. Verified red (mojibake) before the fix and green after; the full `wado test` suite passes (2925 passed, 0 failed).

https://claude.ai/code/session_01KYsTy3W76z5NwuqLUpkSdi

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYsTy3W76z5NwuqLUpkSdi)_