### PR TITLE
ci(tidy): apply parallel-job patches with --3way

### DIFF
--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -95,9 +95,9 @@ jobs:
   # Tasks that require `wado` / `wado-dev-tools` binaries to be built.
   # `wado doc -f markdown` is itself dprint-stable (see wado-cli/src/doc.rs),
   # so the regenerated `docs/stdlib-*.md` files do not need a follow-up
-  # format pass — committed stdlib docs are always dprint-stable, so the
-  # `format-md` step in tidy-rust is a no-op against them and the two
-  # parallel patches do not conflict on `docs/stdlib-*.md`.
+  # format pass from tidy-rust. Where the two parallel jobs do touch the
+  # same file (e.g. `Cargo.lock`), the aggregator's `--3way` apply merges
+  # the overlapping patches — see the "Apply patches" step.
   tidy-wado:
     name: Tidy (Wado)
     needs: precheck
@@ -215,12 +215,29 @@ jobs:
         if: needs.precheck.outputs.should-run == 'true'
         run: |
           set -e
-          if [ -s tidy-rust.patch ]; then
-            git apply --index --whitespace=nowarn tidy-rust.patch
-          fi
-          if [ -s tidy-wado.patch ]; then
-            git apply --index --whitespace=nowarn tidy-wado.patch
-          fi
+          # Both patches are full diffs taken from the same HEAD by two
+          # parallel jobs, so any file touched by both makes a plain
+          # `git apply` of the second patch reject ("patch does not apply").
+          # This happens whenever the jobs converge on the same file — most
+          # commonly `Cargo.lock`, which both `clippy-fix`/`cargo fmt`
+          # (tidy-rust) and `cargo build` (tidy-wado) regenerate identically
+          # once it is stale, but also any doc both jobs rewrite.
+          #
+          # `--3way` falls back to a 3-way merge against the blob ids recorded
+          # in the patch (the HEAD blobs, present because the aggregator checked
+          # out the same ref): identical or non-overlapping edits merge cleanly,
+          # and only a genuine content conflict between the two tidy jobs fails
+          # — which is a real bug worth surfacing red. `--3way` implies `--index`.
+          apply_patch() {
+            local patch="$1"
+            [ -s "$patch" ] || return 0
+            if ! git apply --3way --whitespace=nowarn "$patch"; then
+              echo "::error::Failed to apply ${patch}: the two parallel tidy jobs produced conflicting edits to the same file."
+              exit 1
+            fi
+          }
+          apply_patch tidy-rust.patch
+          apply_patch tidy-wado.patch
 
       - name: Detect changes
         id: changes

--- a/docs/stdlib-core-simd.md
+++ b/docs/stdlib-core-simd.md
@@ -10,11 +10,11 @@ All types are newtypes of the primitive `v128` and can be freely reinterpreted v
 
 ## Types
 
-| Category | Types |
-|----------|-------|
-| Signed integer | `i8x16`, `i16x8`, `i32x4`, `i64x2` |
+| Category         | Types                              |
+| ---------------- | ---------------------------------- |
+| Signed integer   | `i8x16`, `i16x8`, `i32x4`, `i64x2` |
 | Unsigned integer | `u8x16`, `u16x8`, `u32x4`, `u64x2` |
-| Floating-point | `f32x4`, `f64x2` |
+| Floating-point   | `f32x4`, `f64x2`                   |
 
 ## Construction
 


### PR DESCRIPTION
The aggregator concatenated the two parallel tidy patches with plain
`git apply --index`. Both patches are full diffs taken from the same
HEAD, so the second apply rejects ("patch does not apply") the moment a
file is touched by both jobs — most commonly `Cargo.lock`, regenerated
identically by tidy-rust's `cargo fmt`/`clippy-fix` and tidy-wado's
`cargo build` once it is stale. This is what reddened Tidy on the v0.0.7
release PR (#1172), whose merged dep bumps left Cargo.lock stale.

Switch to `git apply --3way`, which falls back to a 3-way merge against
the blob ids recorded in each patch: identical or non-overlapping edits
merge cleanly, and only a genuine conflict between the two jobs fails
(correctly surfaced red). `--3way` implies `--index`.

https://claude.ai/code/session_01Sod4EWjkVjqCniQvscz3Bo