### PR TITLE
bench: denominate light benchmarks; refresh results (best-of-three, whole-ms) and skill

### DIFF
--- a/.claude/hooks/mise-setup.sh
+++ b/.claude/hooks/mise-setup.sh
@@ -102,7 +102,6 @@ if [ -n "$CLAUDE_ENV_FILE" ]; then
 export PATH="$HOME/.local/bin:$PATH"
 export MISE_YES=true
 export MISE_TRUSTED_CONFIG_PATHS="$HOME:$PWD"
-export MISE_GITHUB_TOKEN=$(gh auth token)
 eval "$(mise activate bash)"
 EOF
     log "Environment persisted to CLAUDE_ENV_FILE"
@@ -120,6 +119,20 @@ if mise install; then
     log "Project tools installed successfully"
 else
     log "Warning: Some tools may have failed to install"
+fi
+
+# Initialize the wasmtime submodule. wado-compiler has a path dependency on
+# vendor/wasmtime/crates/wasmtime (see [workspace.dependencies] in Cargo.toml),
+# so any cargo build/test/benchmark fails without it. Only this submodule is
+# needed for builds; the rest of vendor/ holds reference specs that can be
+# initialized on demand. --recommend-shallow keeps the checkout small.
+if [ -f .gitmodules ] && [ ! -f vendor/wasmtime/Cargo.toml ]; then
+    log "Initializing vendor/wasmtime submodule..."
+    if git submodule update --init --recommend-shallow vendor/wasmtime; then
+        log "vendor/wasmtime initialized"
+    else
+        log "Warning: failed to initialize vendor/wasmtime submodule"
+    fi
 fi
 
 log "mise setup complete"

--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -5,52 +5,77 @@ description: Run performance benchmarks and wasm size reports, then update READM
 
 # Benchmark
 
-Run all benchmarks and wasm size comparison, then update the README files.
+Run all benchmarks (compute, JSON, compression, parsing, HTTP routing) and
+the wasm size comparison, then update the README files.
 
 ## Prerequisites
 
 ```sh
-mise run on-task-started                                      # install mise and project tools
-rustup target add wasm32-wasip1                           # for wasm-size Rust builds
-curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash  # for wasm-size Moonbit builds
+mise run on-task-started   # install mise and project tools
 ```
 
-After installing Moonbit, run `moon update` in each wasm-size program directory to fetch dependencies:
+The `wado-compiler` build needs the `vendor/wasmtime` submodule. The
+SessionStart hook initializes it automatically; if a build fails with a
+missing `vendor/wasmtime/.../Cargo.toml`, run:
 
 ```sh
+git submodule update --init --recommend-shallow vendor/wasmtime
+```
+
+For the **http-routing** benchmark only:
+
+```sh
+cargo install oha   # HTTP load generator (compiles from source, ~minutes)
+```
+
+`bun` is mise-managed (installed by the benchmark's own `mise.toml`); `taskset`
+is used for CPU pinning when available. The Bun row is skipped gracefully if
+`bun` is missing.
+
+For the **wasm-size** report only:
+
+```sh
+rustup target add wasm32-wasip1                                # Rust wasm builds
+curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash  # Moonbit builds
 export PATH="$HOME/.moon/bin:$PATH"
 cd wasm-size/hello_world && moon update
 cd ../pi_approx && moon update
-```
-
-If `mise trust` errors appear for `wasm-size/mise.toml`, run:
-
-```sh
-mise trust wasm-size/mise.toml
+# If `mise trust` errors appear: mise trust wasm-size/mise.toml
 ```
 
 ## Procedure
 
-### 1. Run benchmarks (at least twice)
-
-The first run may be slow due to cold compilation caches. Run at least twice and use the run with the most internally consistent numbers.
+### 1. Run `benchmark-all` three times (best of three)
 
 ```sh
-mise run benchmark-all   # 1st run (warmup)
-mise run benchmark-all   # 2nd run (use these numbers)
+mise run benchmark-all   # run 1 (cold caches — warmup)
+mise run benchmark-all   # run 2
+mise run benchmark-all   # run 3
 ```
 
-Benchmarks compare Wado against C and JavaScript (plus Rust/Zig for fts, zlib-rs for zlib).
+`benchmark-all` runs these **10** benchmarks serially (`MISE_JOBS=1`):
+count-prime, mandelbrot, sieve, zlib, fts, json-twitter, json-canada,
+json-catalog, sqlite-parse, syntax-highlight.
 
-### 2. Extract results
+Take the **best (fastest) value per implementation** across the three runs
+(run 1 is effectively a warmup and usually loses). Cloud VMs throttle, and
+throttling only ever lowers throughput, so the fastest run is the cleanest
+estimate of true capacity.
 
-Parse the output for each benchmark:
+### 2. Run the http-routing benchmark (separate)
 
-- **count-prime**: `Elapsed: NNN ms` for C, JavaScript, Wado
-- **mandelbrot**: `Elapsed: NNN.NN ms` for C, JavaScript, Wado
-- **sieve**: `Elapsed: NNN ms` for C, JavaScript, Wado
-- **zlib**: `Compress: NNN ms`, `Decompress: NNN ms`, `Elapsed: NNN ms` for zlib-rs and Wado
-- **fts**: `Elapsed: NNN ms` for Zig, Rust, C, Wado
+http-routing is **not** part of `benchmark-all` (it needs `oha` + pinned
+cores). Run it on its own:
+
+```sh
+SLICE=4 ROUNDS=5 CONNECTIONS=50 mise run benchmark-http-routing
+```
+
+Tunables (env vars): `SLICE` (seconds per slice, default 3), `ROUNDS`
+(rotation rounds, per-server max is kept, default 3), `CONNECTIONS`
+(concurrent connections, default 50), `OHA_CORE_COUNT` (load-generator core
+budget, default `nproc/4`). It already keeps the per-(server,request) max
+over rounds internally, so a single invocation suffices.
 
 ### 3. Get tool versions
 
@@ -63,27 +88,71 @@ cc --version | head -1
 
 ### 4. Update benchmark/README.md
 
-Update the "Recent Results" section:
+- **Environment line**: update the Wado date and any changed tool versions.
+- **Result tables**: update times and `vs best` ratios (baseline is the
+  fastest = 1.00x). Sort each table fastest-first. Use commas for thousands
+  (`3,140`). Round ratios to 2 decimals (compute ratios from the raw
+  values, then round the displayed time).
+- The http-routing table is **throughput (req/s, higher is better)** and
+  shows a curated 5-row subset of the 7 measured requests — keep the same 5
+  rows, just refresh the numbers (and the prose ranges below it).
 
-- **Environment table**: Update Wado date and any changed tool versions
-- **Result tables**: Update times and relative ratios (baseline is always the fastest, 1.00x)
-- Sort each table by time (fastest first)
-- Format large numbers with commas (e.g., `3,140`)
-- Round relative to 2 decimal places
-
-### 5. Run wasm size report
+### 5. wasm-size report (optional, when asked)
 
 ```sh
 mise run report-wasm-size
 ```
 
-### 6. Update wasm-size/README.md
+Then update `wasm-size/README.md` size tables for all languages.
 
-Update the size tables with new values for all languages.
+## Reading benchmark output
+
+All time tables are in **whole milliseconds**. Parse these lines per run:
+
+| Benchmark        | Implementations                                                  | Line to parse                                      |
+| ---------------- | ---------------------------------------------------------------- | -------------------------------------------------- |
+| count-prime      | C, JavaScript, Wado                                              | `Elapsed: N ms` (Wado: `Elapsed: N.NNN ms`)        |
+| mandelbrot       | C, JavaScript, Wado                                              | `Elapsed: N.NN ms`                                 |
+| sieve            | C, JavaScript, Wado                                              | `Elapsed: N ms`                                    |
+| fts              | Zig, Rust, C, Wado                                               | `Elapsed: N ms`                                    |
+| zlib             | zlib-rs, Wado                                                    | `Compress:`, `Decompress:`, total (`Elapsed:`/sum) |
+| json-twitter     | serde_json, JSON.parse, Wado                                     | `Elapsed: N ms` (Wado: `... ms total`)             |
+| json-canada      | serde_json, JSON.parse, Wado                                     | `Elapsed: N ms total`                              |
+| json-catalog     | serde_json, JSON.parse, Wado v2, Wado core:json                  | `Elapsed: N ms total`                              |
+| sqlite-parse     | sqlparser-rs, Wado (Gale)                                        | `Elapsed: N ms (100 iterations)` / `... ms total`  |
+| syntax-highlight | Prism, Lezer, tree-sitter (native + JS/WASM), Shiki, Wado (Gale) | `Elapsed: N ms (100 iterations)`                   |
+| http-routing     | wado serve, Hono (Node/Bun), Axum                                | results table, req/s per request                   |
+
+Round Wado's `N.NNN ms` to whole ms for the table. For looped benchmarks
+report the **total** over the iterations (matching the existing tables).
+
+## Denomination (keeping every result in whole ms)
+
+The lightest workloads are scaled so integer-ms rounding never loses signal.
+The scale factor is **baked into the benchmark programs** — just run and
+report; do not multiply by hand:
+
+- **sieve** counts to **100M** (problem size; one allocation, so no
+  GC-churn artifact from looping).
+- **fts** does **5M** conversions (problem size).
+- **JSON** (twitter/canada/catalog, incl. v2/v3) iterate **×10** — the
+  iteration count lives in `iterations` (Rust/JS) / `b.iterations` (Wado).
+- **zlib** iterates **×100**.
+
+JSON/zlib totals are warm steady-state (the Wado framework auto-warms 1 of
+N), not a single cold parse. count-prime, mandelbrot, sqlite-parse, and
+syntax-highlight are already heavy enough and are not scaled.
+
+If a benchmark still reads too coarse (e.g. serde_json twitter ≈ 9 ms at
+×10), bump its factor (×10 → ×100) in the program and re-measure. To change
+a factor, edit the `iterations` / `b.iterations` (JSON, zlib) or the problem
+size (sieve `limit`, fts `n`) consistently across **all** language
+implementations of that benchmark.
 
 ## Notes
 
 - Benchmarks use mise-managed tool versions, not system versions.
-- Cloud VMs have noisy performance. Absolute times vary across runs but relative ratios are fairly stable. Choose the run with the most internally consistent numbers.
-- `mise run benchmark-all` runs: count-prime, mandelbrot, sieve, zlib, fts serially (MISE_JOBS=1).
-- `mise run report-wasm-size` builds all language targets with size-optimized flags and reports `.wasm` file sizes.
+- Cloud VMs are noisy: absolute times drift, but within-run ratios are
+  fairly stable. Best-of-three handles the drift.
+- `mise run report-wasm-size` builds all language targets with
+  size-optimized flags and reports `.wasm` file sizes.

--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -5,154 +5,60 @@ description: Run performance benchmarks and wasm size reports, then update READM
 
 # Benchmark
 
-Run all benchmarks (compute, JSON, compression, parsing, HTTP routing) and
-the wasm size comparison, then update the README files.
+Run the benchmarks and update `benchmark/README.md` (and `wasm-size/README.md`).
 
 ## Prerequisites
 
 ```sh
-mise run on-task-started   # install mise and project tools
+mise run on-task-started
 ```
 
-The `wado-compiler` build needs the `vendor/wasmtime` submodule. The
-SessionStart hook initializes it automatically; if a build fails with a
-missing `vendor/wasmtime/.../Cargo.toml`, run:
-
-```sh
-git submodule update --init --recommend-shallow vendor/wasmtime
-```
-
-For the **http-routing** benchmark only:
-
-```sh
-cargo install oha   # HTTP load generator (compiles from source, ~minutes)
-```
-
-`bun` is mise-managed (installed by the benchmark's own `mise.toml`); `taskset`
-is used for CPU pinning when available. The Bun row is skipped gracefully if
-`bun` is missing.
-
-For the **wasm-size** report only:
-
-```sh
-rustup target add wasm32-wasip1                                # Rust wasm builds
-curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash  # Moonbit builds
-export PATH="$HOME/.moon/bin:$PATH"
-cd wasm-size/hello_world && moon update
-cd ../pi_approx && moon update
-# If `mise trust` errors appear: mise trust wasm-size/mise.toml
-```
+- `vendor/wasmtime` submodule must exist (the SessionStart hook handles it;
+  otherwise `git submodule update --init --recommend-shallow vendor/wasmtime`).
+- http-routing needs `oha` (`cargo install oha`); `bun` is mise-managed.
+- wasm-size needs `rustup target add wasm32-wasip1` and Moonbit
+  (`curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash`, then
+  `moon update` in each `wasm-size/*` dir).
 
 ## Procedure
 
-### 1. Run `benchmark-all` three times (best of three)
+1. Run `mise run benchmark-all` **three times**; per implementation keep the
+   fastest value (throttling only ever slows things down). It runs 10
+   benchmarks serially: count-prime, mandelbrot, sieve, zlib, fts,
+   json-{twitter,canada,catalog}, sqlite-parse, syntax-highlight.
+2. Run http-routing separately (needs `oha` + pinned cores):
+   `SLICE=4 ROUNDS=5 CONNECTIONS=50 mise run benchmark-http-routing`. It keeps
+   the per-(server, request) max internally, so one invocation suffices.
+3. Refresh the README Environment line versions: `mise exec -- node --version`,
+   `mise exec -- zig version`, `wasmtime --version`, `rustc --version`,
+   `cc --version | head -1`.
+4. Update the tables, following README.md's existing layout. http-routing is
+   req/s (higher is better) and lists a curated subset of the measured requests.
+5. wasm-size, when asked: `mise run report-wasm-size`, then update
+   `wasm-size/README.md`.
 
-```sh
-mise run benchmark-all   # run 1 (cold caches — warmup)
-mise run benchmark-all   # run 2
-mise run benchmark-all   # run 3
-```
+## Reading output
 
-`benchmark-all` runs these **10** benchmarks serially (`MISE_JOBS=1`):
-count-prime, mandelbrot, sieve, zlib, fts, json-twitter, json-canada,
-json-catalog, sqlite-parse, syntax-highlight.
+Each program prints `Elapsed: … ms` (zlib also `Compress:`/`Decompress:`).
+Round Wado's fractional ms to whole; report the total for looped benchmarks.
+Implementations per benchmark:
 
-Take the **best (fastest) value per implementation** across the three runs
-(run 1 is effectively a warmup and usually loses). Cloud VMs throttle, and
-throttling only ever lowers throughput, so the fastest run is the cleanest
-estimate of true capacity.
+- count-prime / mandelbrot / sieve: C, JavaScript, Wado
+- fts: Zig, Rust, C, Wado
+- zlib: zlib-rs, Wado
+- json-\*: serde_json, JSON.parse, Wado (catalog also Wado v2)
+- sqlite-parse: sqlparser-rs, Wado
+- syntax-highlight: Prism, Lezer, tree-sitter, Shiki, Wado
+- http-routing: wado serve, Hono (Node/Bun), Axum
 
-### 2. Run the http-routing benchmark (separate)
+## Denomination
 
-http-routing is **not** part of `benchmark-all` (it needs `oha` + pinned
-cores). Run it on its own:
-
-```sh
-SLICE=4 ROUNDS=5 CONNECTIONS=50 mise run benchmark-http-routing
-```
-
-Tunables (env vars): `SLICE` (seconds per slice, default 3), `ROUNDS`
-(rotation rounds, per-server max is kept, default 3), `CONNECTIONS`
-(concurrent connections, default 50), `OHA_CORE_COUNT` (load-generator core
-budget, default `nproc/4`). It already keeps the per-(server,request) max
-over rounds internally, so a single invocation suffices.
-
-### 3. Get tool versions
-
-```sh
-cd benchmark && mise exec -- node --version && mise exec -- zig version
-wasmtime --version
-rustc --version
-cc --version | head -1
-```
-
-### 4. Update benchmark/README.md
-
-- **Environment line**: update the Wado date and any changed tool versions.
-- **Result tables**: update times and `vs best` ratios (baseline is the
-  fastest = 1.00x). Sort each table fastest-first. Use commas for thousands
-  (`3,140`). Round ratios to 2 decimals (compute ratios from the raw
-  values, then round the displayed time).
-- The http-routing table is **throughput (req/s, higher is better)** and
-  shows a curated 5-row subset of the 7 measured requests — keep the same 5
-  rows, just refresh the numbers (and the prose ranges below it).
-
-### 5. wasm-size report (optional, when asked)
-
-```sh
-mise run report-wasm-size
-```
-
-Then update `wasm-size/README.md` size tables for all languages.
-
-## Reading benchmark output
-
-All time tables are in **whole milliseconds**. Parse these lines per run:
-
-| Benchmark        | Implementations                                                  | Line to parse                                      |
-| ---------------- | ---------------------------------------------------------------- | -------------------------------------------------- |
-| count-prime      | C, JavaScript, Wado                                              | `Elapsed: N ms` (Wado: `Elapsed: N.NNN ms`)        |
-| mandelbrot       | C, JavaScript, Wado                                              | `Elapsed: N.NN ms`                                 |
-| sieve            | C, JavaScript, Wado                                              | `Elapsed: N ms`                                    |
-| fts              | Zig, Rust, C, Wado                                               | `Elapsed: N ms`                                    |
-| zlib             | zlib-rs, Wado                                                    | `Compress:`, `Decompress:`, total (`Elapsed:`/sum) |
-| json-twitter     | serde_json, JSON.parse, Wado                                     | `Elapsed: N ms` (Wado: `... ms total`)             |
-| json-canada      | serde_json, JSON.parse, Wado                                     | `Elapsed: N ms total`                              |
-| json-catalog     | serde_json, JSON.parse, Wado v2, Wado core:json                  | `Elapsed: N ms total`                              |
-| sqlite-parse     | sqlparser-rs, Wado (Gale)                                        | `Elapsed: N ms (100 iterations)` / `... ms total`  |
-| syntax-highlight | Prism, Lezer, tree-sitter (native + JS/WASM), Shiki, Wado (Gale) | `Elapsed: N ms (100 iterations)`                   |
-| http-routing     | wado serve, Hono (Node/Bun), Axum                                | results table, req/s per request                   |
-
-Round Wado's `N.NNN ms` to whole ms for the table. For looped benchmarks
-report the **total** over the iterations (matching the existing tables).
-
-## Denomination (keeping every result in whole ms)
-
-The lightest workloads are scaled so integer-ms rounding never loses signal.
-The scale factor is **baked into the benchmark programs** — just run and
-report; do not multiply by hand:
-
-- **sieve** counts to **100M** (problem size; one allocation, so no
-  GC-churn artifact from looping).
-- **fts** does **5M** conversions (problem size).
-- **JSON** (twitter/canada/catalog, incl. v2/v3) iterate **×10** — the
-  iteration count lives in `iterations` (Rust/JS) / `b.iterations` (Wado).
-- **zlib** iterates **×100**.
-
-JSON/zlib totals are warm steady-state (the Wado framework auto-warms 1 of
-N), not a single cold parse. count-prime, mandelbrot, sqlite-parse, and
-syntax-highlight are already heavy enough and are not scaled.
-
-If a benchmark still reads too coarse (e.g. serde_json twitter ≈ 9 ms at
-×10), bump its factor (×10 → ×100) in the program and re-measure. To change
-a factor, edit the `iterations` / `b.iterations` (JSON, zlib) or the problem
-size (sieve `limit`, fts `n`) consistently across **all** language
-implementations of that benchmark.
+Light workloads are scaled in-program so results land in whole ms — just run
+and report. sieve → 100M, fts → 5M (problem size); JSON → ×10, zlib → ×100
+(`iterations` / `b.iterations`). JSON/zlib totals are warm steady-state. To
+retune, change the factor across every language implementation of that benchmark.
 
 ## Notes
 
-- Benchmarks use mise-managed tool versions, not system versions.
-- Cloud VMs are noisy: absolute times drift, but within-run ratios are
-  fairly stable. Best-of-three handles the drift.
-- `mise run report-wasm-size` builds all language targets with
-  size-optimized flags and reports `.wasm` file sizes.
+- Tool versions come from mise, not the system.
+- Cloud VMs are noisy; best-of-three absorbs the drift.

--- a/benchmark/AGENTS.md
+++ b/benchmark/AGENTS.md
@@ -15,7 +15,7 @@ C compiler (`cc`) and Rust (`cargo`) are expected from the system.
 ```sh
 mise run count-prime   # integer arithmetic (count primes to 10M)
 mise run mandelbrot    # float arithmetic (1024x768 fractal)
-mise run sieve         # array operations (sieve of Eratosthenes to 10M)
+mise run sieve         # array operations (sieve of Eratosthenes to 100M)
 mise run zlib          # compression (zlib-rs native vs Wado)
 mise run fts           # float-to-string conversion
 mise run json-twitter  # JSON deserialization (twitter.json)

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -4,13 +4,11 @@ Performance comparison of Wado (Wasm/wasmtime) against native compilers.
 
 Environment: Wado 2026-05-29, wasmtime 44.0.0, gcc 13.3.0, rustc 1.95.0, Zig 0.15.2, Node.js v24.14.1, Linux x86_64.
 
-All figures are the **best of three runs** per implementation (cloud VMs
-are noisy; the fastest run is the cleanest estimate of true capacity).
-To keep every result in whole milliseconds, the lightest workloads are
-scaled up: the sieve runs to 100M, float-to-string does 5M conversions,
-the JSON parsers iterate ×10, and zlib iterates ×100. JSON and zlib
-figures are totals over those iterations, so they reflect warm
-steady-state throughput rather than a single cold parse.
+All figures are the **best of three runs** per implementation. To keep
+every result in whole milliseconds, the lightest workloads are scaled up:
+sieve to 100M, float-to-string to 5M conversions, the JSON parsers ×10,
+and zlib ×100. JSON/zlib figures are totals over those iterations (warm
+steady-state, not a single cold parse).
 
 ## Prime Counting
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -156,19 +156,20 @@ Throughput (requests/sec, higher is better):
 
 | Request                         | `wado serve` | Hono (Node) | Hono (Bun) | Axum (native) |
 | ------------------------------- | -----------: | ----------: | ---------: | ------------: |
-| `GET /user`                     |       54,106 |      40,486 |     71,401 |        93,103 |
-| `GET /user/lookup/username/hey` |       51,752 |      42,260 |     64,678 |        95,552 |
-| `GET /event/abcd1234/comments`  |       50,771 |      42,425 |     66,314 |        92,374 |
-| `POST /event/abcd1234/comment`  |       50,780 |      33,452 |     66,137 |        92,109 |
-| `GET /static/index.html`        |       50,553 |      41,972 |     66,981 |        94,257 |
+| `GET /user`                     |       52,979 |      30,595 |     61,858 |        98,406 |
+| `GET /user/lookup/username/hey` |       49,963 |      30,536 |     54,222 |       100,359 |
+| `GET /event/abcd1234/comments`  |       51,269 |      30,646 |     54,752 |       100,362 |
+| `POST /event/abcd1234/comment`  |       50,210 |      21,421 |     53,639 |        99,944 |
+| `GET /static/index.html`        |       50,816 |      28,582 |     55,317 |        98,739 |
 
-`wado serve` leads Hono on Node on every request (~50k–54k vs ~33k–45k
-req/s) but trails Hono on Bun (~65k–73k) — Bun's HTTP server is
+`wado serve` leads Hono on Node on every request (~50k–53k vs ~21k–31k
+req/s) but trails Hono on Bun (~54k–62k) — Bun's HTTP server is
 markedly faster than Node's. Native-Rust Axum is the ceiling; its
 figure here is load-generator-limited (`oha` saturates before Axum
-does). `wado serve` runs a `wasi:http/service` component on wasmtime,
-dispatching through `core:router`, with pooled instance reuse +
-periodic recycling. A cross-runtime comparison (Wasm component on
+does, staying flat at ~98k–100k). `wado serve` runs a
+`wasi:http/service` component on wasmtime, dispatching through
+`core:router`, with pooled instance reuse + periodic recycling. A
+cross-runtime comparison (Wasm component on
 wasmtime vs JS on Node.js/Bun vs native Rust). See
 `http_routing/README.md` for the full table and methodology.
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -4,6 +4,14 @@ Performance comparison of Wado (Wasm/wasmtime) against native compilers.
 
 Environment: Wado 2026-05-29, wasmtime 44.0.0, gcc 13.3.0, rustc 1.95.0, Zig 0.15.2, Node.js v24.14.1, Linux x86_64.
 
+All figures are the **best of three runs** per implementation (cloud VMs
+are noisy; the fastest run is the cleanest estimate of true capacity).
+To keep every result in whole milliseconds, the lightest workloads are
+scaled up: the sieve runs to 100M, float-to-string does 5M conversions,
+the JSON parsers iterate ×10, and zlib iterates ×100. JSON and zlib
+figures are totals over those iterations, so they reflect warm
+steady-state throughput rather than a single cold parse.
+
 ## Prime Counting
 
 Count primes up to 10M (integer arithmetic).
@@ -11,8 +19,8 @@ Count primes up to 10M (integer arithmetic).
 | Implementation    |     Time | vs best |
 | ----------------- | -------: | ------: |
 | C (gcc -O3)       | 3,208 ms |   1.00x |
-| **Wado**          | 3,252 ms |   1.01x |
-| JavaScript (Node) | 3,311 ms |   1.03x |
+| **Wado**          | 3,245 ms |   1.01x |
+| JavaScript (Node) | 3,288 ms |   1.02x |
 
 ## Mandelbrot
 
@@ -20,70 +28,70 @@ Count primes up to 10M (integer arithmetic).
 
 | Implementation    |   Time | vs best |
 | ----------------- | -----: | ------: |
-| **Wado**          | 195 ms |   1.00x |
-| JavaScript (Node) | 196 ms |   1.01x |
-| C (gcc -O3)       | 197 ms |   1.01x |
+| **Wado**          | 194 ms |   1.00x |
+| JavaScript (Node) | 194 ms |   1.00x |
+| C (gcc -O3)       | 197 ms |   1.02x |
 
 ## Sieve
 
-Sieve of Eratosthenes up to 10M (array operations).
+Sieve of Eratosthenes up to 100M (array operations).
 
-| Implementation    |  Time | vs best |
-| ----------------- | ----: | ------: |
-| C (gcc -O3)       | 37 ms |   1.00x |
-| JavaScript (Node) | 61 ms |   1.65x |
-| **Wado**          | 71 ms |   1.92x |
+| Implementation    |     Time | vs best |
+| ----------------- | -------: | ------: |
+| C (gcc -O3)       | 1,423 ms |   1.00x |
+| JavaScript (Node) | 1,541 ms |   1.08x |
+| **Wado**          | 1,864 ms |   1.31x |
 
 ## Float-to-String
 
-500K f64 conversions to fixed-point string.
+5M f64 conversions to fixed-point string.
 
-| Implementation |  Time | vs best |
-| -------------- | ----: | ------: |
-| Zig (RelFast)  | 31 ms |   1.00x |
-| Rust (native)  | 38 ms |   1.23x |
-| **Wado**       | 57 ms |   1.84x |
-| C (gcc -O3)    | 67 ms |   2.16x |
+| Implementation |   Time | vs best |
+| -------------- | -----: | ------: |
+| Zig (RelFast)  | 334 ms |   1.00x |
+| Rust (native)  | 497 ms |   1.49x |
+| **Wado**       | 702 ms |   2.10x |
+| C (gcc -O3)    | 877 ms |   2.63x |
 
 ## Compression
 
-zlib compress/decompress of twitter.json (631 KB) x 10 iterations.
+zlib compress/decompress of twitter.json (631 KB) x 100 iterations.
 
-| Implementation        | Compress | Decompress |  Total | vs best |
-| --------------------- | -------: | ---------: | -----: | ------: |
-| zlib-rs (Rust native) |    29 ms |       4 ms |  32 ms |   1.00x |
-| **Wado** core:zlib    |   201 ms |     116 ms | 317 ms |   9.86x |
+| Implementation        | Compress | Decompress |    Total | vs best |
+| --------------------- | -------: | ---------: | -------: | ------: |
+| zlib-rs (Rust native) |   402 ms |      44 ms |   446 ms |   1.00x |
+| **Wado** core:zlib    | 2,568 ms |   1,560 ms | 4,128 ms |   9.26x |
 
 ## JSON: twitter
 
-Deserialize twitter.json (631 KB).
+Deserialize twitter.json (631 KB), ×10.
 
-| Implementation           |    Time | vs best |
-| ------------------------ | ------: | ------: |
-| serde_json (Rust native) | 0.90 ms |   1.00x |
-| JSON.parse (Node)        | 1.77 ms |   1.97x |
-| **Wado** core:json       | 4.46 ms |   4.97x |
+| Implementation           |  Time | vs best |
+| ------------------------ | ----: | ------: |
+| serde_json (Rust native) |  9 ms |   1.00x |
+| JSON.parse (Node)        | 24 ms |   2.66x |
+| **Wado** core:json       | 57 ms |   6.20x |
 
 ## JSON: canada
 
-Deserialize canada.json (2.3 MB, geographic coordinates).
+Deserialize canada.json (2.3 MB, geographic coordinates), ×10.
 
-| Implementation           |      Time | vs best |
-| ------------------------ | --------: | ------: |
-| serde_json (Rust native) |   8.39 ms |   1.00x |
-| JSON.parse (Node)        |  12.25 ms |   1.46x |
-| **Wado** core:json       | 117.73 ms |  14.03x |
+| Implementation           |   Time | vs best |
+| ------------------------ | -----: | ------: |
+| serde_json (Rust native) | 111 ms |   1.00x |
+| JSON.parse (Node)        | 138 ms |   1.24x |
+| **Wado** core:json       | 426 ms |   3.84x |
 
 ## JSON: catalog
 
-Deserialize citm_catalog.json (1.7 MB, event catalog).
+Deserialize citm_catalog.json (1.7 MB, event catalog), ×10.
 
-| Implementation             |     Time | vs best |
-| -------------------------- | -------: | ------: |
-| serde_json (Rust native)   |  2.39 ms |   1.00x |
-| JSON.parse (Node)          |  4.50 ms |   1.88x |
-| **Wado** v2 (hand-rolled¹) |  6.42 ms |   2.69x |
-| **Wado** core:json         | 17.09 ms |   7.15x |
+| Implementation             |   Time | vs best |
+| -------------------------- | -----: | ------: |
+| serde_json (Rust native)   |  27 ms |   1.00x |
+| JSON.parse (Node)          |  49 ms |   1.80x |
+| **Wado** v2 (hand-rolled¹) | 107 ms |   3.98x |
+| **Wado** core:json         | 224 ms |   8.30x |
 
 ¹ `json_catalog/json_catalog_v2.wado` is a hand-rolled CitmCatalog parser
 PoC (no `core:json` / `core:serde`). Kept as a marker of the upper bound
@@ -93,8 +101,6 @@ sub-access-struct architecture. See its source for design notes.
 ## SQL Parse
 
 Parse 81 SQL statements (13 KB) x 100 iterations. Gale-generated parser vs sqlparser-rs.
-
-Best of three runs per implementation:
 
 | Implementation             |   Time | vs best |
 | -------------------------- | -----: | ------: |
@@ -114,8 +120,6 @@ highlighter vs four reference SQL highlighters:
 - **tree-sitter (web-tree-sitter)** — official JS WASM binding, same
   `@derekstride/tree-sitter-sql` grammar as the Rust row
 - **Shiki (JS engine)** — TextMate grammars, VSCode-quality output
-
-Best of three runs per implementation:
 
 | Implementation            |     Time | vs best |
 | ------------------------- | -------: | ------: |

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -2,7 +2,7 @@
 
 Performance comparison of Wado (Wasm/wasmtime) against native compilers.
 
-Environment: Wado 2026-05-26, wasmtime 44.0.0, gcc 13.3.0, rustc 1.95.0, Zig 0.15.2, Node.js v24.14.1, Linux x86_64.
+Environment: Wado 2026-05-29, wasmtime 44.0.0, gcc 13.3.0, rustc 1.95.0, Zig 0.15.2, Node.js v24.14.1, Linux x86_64.
 
 ## Prime Counting
 
@@ -10,9 +10,9 @@ Count primes up to 10M (integer arithmetic).
 
 | Implementation    |     Time | vs best |
 | ----------------- | -------: | ------: |
-| C (gcc -O3)       | 3,738 ms |   1.00x |
-| **Wado**          | 3,755 ms |   1.00x |
-| JavaScript (Node) | 4,370 ms |   1.17x |
+| C (gcc -O3)       | 3,208 ms |   1.00x |
+| **Wado**          | 3,252 ms |   1.01x |
+| JavaScript (Node) | 3,311 ms |   1.03x |
 
 ## Mandelbrot
 
@@ -20,9 +20,9 @@ Count primes up to 10M (integer arithmetic).
 
 | Implementation    |   Time | vs best |
 | ----------------- | -----: | ------: |
-| C (gcc -O3)       | 168 ms |   1.00x |
-| JavaScript (Node) | 177 ms |   1.06x |
-| **Wado**          | 191 ms |   1.14x |
+| **Wado**          | 195 ms |   1.00x |
+| JavaScript (Node) | 196 ms |   1.01x |
+| C (gcc -O3)       | 197 ms |   1.01x |
 
 ## Sieve
 
@@ -30,9 +30,9 @@ Sieve of Eratosthenes up to 10M (array operations).
 
 | Implementation    |  Time | vs best |
 | ----------------- | ----: | ------: |
-| C (gcc -O3)       | 44 ms |   1.00x |
-| JavaScript (Node) | 68 ms |   1.55x |
-| **Wado**          | 78 ms |   1.77x |
+| C (gcc -O3)       | 37 ms |   1.00x |
+| JavaScript (Node) | 61 ms |   1.65x |
+| **Wado**          | 71 ms |   1.92x |
 
 ## Float-to-String
 
@@ -40,10 +40,10 @@ Sieve of Eratosthenes up to 10M (array operations).
 
 | Implementation |  Time | vs best |
 | -------------- | ----: | ------: |
-| Zig (RelFast)  | 28 ms |   1.00x |
-| Rust (native)  | 40 ms |   1.43x |
-| **Wado**       | 49 ms |   1.75x |
-| C (gcc -O3)    | 64 ms |   2.29x |
+| Zig (RelFast)  | 31 ms |   1.00x |
+| Rust (native)  | 38 ms |   1.23x |
+| **Wado**       | 57 ms |   1.84x |
+| C (gcc -O3)    | 67 ms |   2.16x |
 
 ## Compression
 
@@ -51,8 +51,8 @@ zlib compress/decompress of twitter.json (631 KB) x 10 iterations.
 
 | Implementation        | Compress | Decompress |  Total | vs best |
 | --------------------- | -------: | ---------: | -----: | ------: |
-| zlib-rs (Rust native) |    32 ms |       4 ms |  36 ms |   1.00x |
-| **Wado** core:zlib    |   217 ms |     113 ms | 330 ms |   9.17x |
+| zlib-rs (Rust native) |    29 ms |       4 ms |  32 ms |   1.00x |
+| **Wado** core:zlib    |   201 ms |     116 ms | 317 ms |   9.86x |
 
 ## JSON: twitter
 
@@ -60,9 +60,9 @@ Deserialize twitter.json (631 KB).
 
 | Implementation           |    Time | vs best |
 | ------------------------ | ------: | ------: |
-| serde_json (Rust native) | 0.77 ms |   1.00x |
-| JSON.parse (Node)        | 1.76 ms |   2.27x |
-| **Wado** core:json       | 8.03 ms |  10.38x |
+| serde_json (Rust native) | 0.90 ms |   1.00x |
+| JSON.parse (Node)        | 1.77 ms |   1.97x |
+| **Wado** core:json       | 4.46 ms |   4.97x |
 
 ## JSON: canada
 
@@ -70,9 +70,9 @@ Deserialize canada.json (2.3 MB, geographic coordinates).
 
 | Implementation           |      Time | vs best |
 | ------------------------ | --------: | ------: |
-| serde_json (Rust native) |   8.93 ms |   1.00x |
-| JSON.parse (Node)        |  12.39 ms |   1.39x |
-| **Wado** core:json       | 108.27 ms |  12.12x |
+| serde_json (Rust native) |   8.39 ms |   1.00x |
+| JSON.parse (Node)        |  12.25 ms |   1.46x |
+| **Wado** core:json       | 117.73 ms |  14.03x |
 
 ## JSON: catalog
 
@@ -80,10 +80,10 @@ Deserialize citm_catalog.json (1.7 MB, event catalog).
 
 | Implementation             |     Time | vs best |
 | -------------------------- | -------: | ------: |
-| serde_json (Rust native)   |  2.28 ms |   1.00x |
-| JSON.parse (Node)          |  4.32 ms |   1.90x |
-| **Wado** v2 (hand-rolled¹) | 12.37 ms |   5.43x |
-| **Wado** core:json         | 40.65 ms |  17.83x |
+| serde_json (Rust native)   |  2.39 ms |   1.00x |
+| JSON.parse (Node)          |  4.50 ms |   1.88x |
+| **Wado** v2 (hand-rolled¹) |  6.42 ms |   2.69x |
+| **Wado** core:json         | 17.09 ms |   7.15x |
 
 ¹ `json_catalog/json_catalog_v2.wado` is a hand-rolled CitmCatalog parser
 PoC (no `core:json` / `core:serde`). Kept as a marker of the upper bound
@@ -98,8 +98,8 @@ Best of three runs per implementation:
 
 | Implementation             |   Time | vs best |
 | -------------------------- | -----: | ------: |
-| sqlparser-rs (Rust native) | 190 ms |   1.00x |
-| **Wado** (Gale)            | 635 ms |   3.34x |
+| sqlparser-rs (Rust native) | 175 ms |   1.00x |
+| **Wado** (Gale)            | 190 ms |   1.08x |
 
 ## Syntax Highlight
 
@@ -119,17 +119,20 @@ Best of three runs per implementation:
 
 | Implementation            |     Time | vs best |
 | ------------------------- | -------: | ------: |
-| Prism.js                  |   177 ms |   1.00x |
-| Lezer (CodeMirror)        |   499 ms |   2.82x |
-| tree-sitter (Rust native) |   512 ms |   2.89x |
-| tree-sitter (JS / WASM)   |   809 ms |   4.57x |
-| **Wado** (Gale)           |   982 ms |   5.55x |
-| Shiki (JS engine)         | 2,055 ms |  11.61x |
+| Prism.js                  |   171 ms |   1.00x |
+| **Wado** (Gale)           |   410 ms |   2.40x |
+| tree-sitter (Rust native) |   500 ms |   2.92x |
+| Lezer (CodeMirror)        |   525 ms |   3.07x |
+| tree-sitter (JS / WASM)   |   874 ms |   5.11x |
+| Shiki (JS engine)         | 2,126 ms |  12.43x |
 
 Notes:
 
 - Regex-based Prism.js wins on raw speed for a token-poor language
   like SQL.
+- The Wado (Gale) highlighter now lands second overall, ahead of the
+  tree-sitter Rust native parser and Lezer — only the regex-based
+  Prism.js is faster.
 - Pure-JS Lezer is essentially on par with tree-sitter's Rust native
   parser, and clearly beats the same tree-sitter grammar accessed
   through its JS WASM binding — V8 optimises plain JS more aggressively

--- a/benchmark/fts/fts.c
+++ b/benchmark/fts/fts.c
@@ -1,5 +1,5 @@
 // Float-to-string benchmark
-// Converts 500K random f64 values to decimal strings using %.6f format.
+// Converts 5M random f64 values to decimal strings using %.6f format.
 // Uses a linear congruential generator for deterministic float sequence.
 //
 // How to run:
@@ -9,7 +9,7 @@
 #include <time.h>
 
 int main(void) {
-    const int n = 500000;
+    const int n = 5000000;
     unsigned int state = 42;
     char buf[32];
     long total_bytes = 0;
@@ -32,7 +32,7 @@ int main(void) {
     long elapsed_ms = (t1.tv_sec - t0.tv_sec) * 1000 +
                       (t1.tv_nsec - t0.tv_nsec) / 1000000;
 
-    printf("fts: 500000 f64 conversions (%%.6f)\n");
+    printf("fts: 5000000 f64 conversions (%%.6f)\n");
     printf("Total bytes: %ld, byte sum: %lu\n", total_bytes, byte_sum);
     printf("Elapsed: %ld ms\n", elapsed_ms);
     return 0;

--- a/benchmark/fts/fts.rs
+++ b/benchmark/fts/fts.rs
@@ -1,5 +1,5 @@
 // Float-to-string benchmark
-// Converts 500K random f64 values to decimal strings using {:.6} format.
+// Converts 5M random f64 values to decimal strings using {:.6} format.
 // Uses a linear congruential generator for deterministic float sequence.
 //
 // How to run:
@@ -9,7 +9,7 @@ use std::fmt::Write;
 use std::time::Instant;
 
 fn main() {
-    let n = 500_000u32;
+    let n = 5_000_000u32;
     let mut state: u32 = 42;
     let mut total_bytes: u64 = 0;
     let mut byte_sum: u64 = 0;

--- a/benchmark/fts/fts.wado
+++ b/benchmark/fts/fts.wado
@@ -1,5 +1,5 @@
 // Float-to-string benchmark
-// Converts 500K random f64 values to decimal strings using :0.6f format.
+// Converts 5M random f64 values to decimal strings using :0.6f format.
 // Uses a linear congruential generator for deterministic float sequence.
 //
 // How to run:
@@ -38,7 +38,7 @@ test "smoke" {
 }
 
 export fn run() with Stdout, MonotonicClock {
-    let n = 500000;
+    let n = 5000000;
     let mut b = Benchmark::new(`fts: {n} f64 conversions (%.6f)`);
     let r = b.run("", || fts_run(n));
     b.println(`total bytes = {r.total_bytes}, byte sum = {r.byte_sum}`);

--- a/benchmark/fts/fts.zig
+++ b/benchmark/fts/fts.zig
@@ -1,5 +1,5 @@
 // Float-to-string benchmark
-// Converts 500K random f64 values to decimal strings using {d:.6} format.
+// Converts 5M random f64 values to decimal strings using {d:.6} format.
 // Uses a linear congruential generator for deterministic float sequence.
 //
 // How to run:
@@ -8,7 +8,7 @@
 const std = @import("std");
 
 pub fn main() !void {
-    const n: u32 = 500_000;
+    const n: u32 = 5_000_000;
     var state: u32 = 42;
     var total_bytes: u64 = 0;
     var byte_sum: u64 = 0;

--- a/benchmark/json_canada/json_canada.js
+++ b/benchmark/json_canada/json_canada.js
@@ -11,7 +11,7 @@ const jsonData = fs.readFileSync(
   path.join(__dirname, "canada.json"),
   "utf-8",
 );
-const iterations = 1;
+const iterations = 10;
 
 console.log(`json-canada: ${jsonData.length} bytes, ${iterations} iterations`);
 

--- a/benchmark/json_canada/json_canada.wado
+++ b/benchmark/json_canada/json_canada.wado
@@ -86,6 +86,7 @@ export fn run() with Stdout, MonotonicClock, Preopens {
     let json_data = read_file("json_canada/canada.json");
     let mut b = Benchmark::new("json-canada");
     b.input_size = Option::Some(json_data.len());
+    b.iterations = 10;
 
     let total_points = b.run("", || count_points(json_data));
     assert total_points == 55563;

--- a/benchmark/json_canada/serde_json.rs
+++ b/benchmark/json_canada/serde_json.rs
@@ -38,7 +38,7 @@ struct FeatureCollection {
 fn main() {
     let json_data = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/canada.json"))
         .expect("Failed to read canada.json");
-    let iterations = 1;
+    let iterations = 10;
 
     println!(
         "json-canada: {} bytes, {} iterations",

--- a/benchmark/json_catalog/json_catalog.js
+++ b/benchmark/json_catalog/json_catalog.js
@@ -11,7 +11,7 @@ const jsonData = fs.readFileSync(
   path.join(__dirname, "citm_catalog.json"),
   "utf-8",
 );
-const iterations = 1;
+const iterations = 10;
 
 console.log(`json-catalog: ${jsonData.length} bytes, ${iterations} iterations`);
 

--- a/benchmark/json_catalog/json_catalog.wado
+++ b/benchmark/json_catalog/json_catalog.wado
@@ -148,6 +148,7 @@ export fn run() with Stdout, MonotonicClock, Preopens {
     let json_data = read_file("json_catalog/citm_catalog.json");
     let mut b = Benchmark::new("json-catalog");
     b.input_size = Option::Some(json_data.len());
+    b.iterations = 10;
 
     let counts = b.run("", || parse_counts(json_data));
     assert counts.events == 184;

--- a/benchmark/json_catalog/json_catalog_v2.wado
+++ b/benchmark/json_catalog/json_catalog_v2.wado
@@ -1157,7 +1157,7 @@ export fn run() with Stdout, MonotonicClock, Preopens {
     let json_data = read_file("json_catalog/citm_catalog.json");
     let mut b = Benchmark::new("json-catalog-v2");
     b.input_size = Option::Some(json_data.len());
-    b.iterations = 5;
+    b.iterations = 10;
 
     let counts = b.run("", || parse_counts_v2(json_data));
     assert counts.events == 184;

--- a/benchmark/json_catalog/json_catalog_v3.wado
+++ b/benchmark/json_catalog/json_catalog_v3.wado
@@ -849,7 +849,7 @@ export fn run() with Stdout, MonotonicClock, Preopens {
     let json_data = read_file("json_catalog/citm_catalog.json");
     let mut b = Benchmark::new("json-catalog-v3");
     b.input_size = Option::Some(json_data.len());
-    b.iterations = 5;
+    b.iterations = 10;
 
     let counts = b.run("", || parse_counts_v3(json_data));
     assert counts.events == 184;

--- a/benchmark/json_catalog/serde_json.rs
+++ b/benchmark/json_catalog/serde_json.rs
@@ -97,7 +97,7 @@ struct CitmCatalog {
 fn main() {
     let json_data = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/citm_catalog.json"))
         .expect("Failed to read citm_catalog.json");
-    let iterations = 1;
+    let iterations = 10;
 
     println!(
         "json-catalog: {} bytes, {} iterations",

--- a/benchmark/json_twitter/json_twitter.js
+++ b/benchmark/json_twitter/json_twitter.js
@@ -11,7 +11,7 @@ const jsonData = fs.readFileSync(
   path.join(__dirname, "twitter.json"),
   "utf-8",
 );
-const iterations = 1;
+const iterations = 10;
 
 console.log(`json-twitter: ${jsonData.length} bytes, ${iterations} iterations`);
 

--- a/benchmark/json_twitter/json_twitter.wado
+++ b/benchmark/json_twitter/json_twitter.wado
@@ -180,6 +180,7 @@ export fn run() with Stdout, MonotonicClock, Preopens {
     let json_data = read_file("json_twitter/twitter.json");
     let mut b = Benchmark::new("json-twitter");
     b.input_size = Option::Some(json_data.len());
+    b.iterations = 10;
 
     let count = b.run("", || parse_statuses(json_data));
     assert count == 100;

--- a/benchmark/json_twitter/serde_json.rs
+++ b/benchmark/json_twitter/serde_json.rs
@@ -114,7 +114,7 @@ struct TwitterResponse {
 fn main() {
     let json_data = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/twitter.json"))
         .expect("Failed to read twitter.json");
-    let iterations = 1;
+    let iterations = 10;
 
     println!(
         "json-twitter: {} bytes, {} iterations",

--- a/benchmark/sieve/sieve.c
+++ b/benchmark/sieve/sieve.c
@@ -1,6 +1,6 @@
 // Sieve of Eratosthenes benchmark for C
 // Counts primes up to LIMIT using the sieve algorithm
-// Reference: π(10,000,000) = 664,579
+// Reference: π(100,000,000) = 5,761,455
 //
 // How to run:
 //   mise run benchmark-sieve
@@ -53,7 +53,7 @@ int sieve_count(int limit) {
 }
 
 int main() {
-    int limit = 10000000;
+    int limit = 100000000;
 
     struct timespec start, end;
     clock_gettime(CLOCK_MONOTONIC, &start);

--- a/benchmark/sieve/sieve.js
+++ b/benchmark/sieve/sieve.js
@@ -1,6 +1,6 @@
 // Sieve of Eratosthenes benchmark for JavaScript
 // Counts primes up to LIMIT using the sieve algorithm
-// Reference: π(10,000,000) = 664,579
+// Reference: π(100,000,000) = 5,761,455
 //
 // How to run:
 //   mise run benchmark-sieve
@@ -39,7 +39,7 @@ function sieveCount(limit) {
 }
 
 function main() {
-    const limit = 10000000;
+    const limit = 100000000;
 
     const start = performance.now();
     const count = sieveCount(limit);

--- a/benchmark/sieve/sieve.wado
+++ b/benchmark/sieve/sieve.wado
@@ -1,6 +1,6 @@
 // Sieve of Eratosthenes benchmark for Wado
 // Counts primes up to LIMIT using the sieve algorithm
-// Reference: π(10,000,000) = 664,579
+// Reference: π(100,000,000) = 5,761,455
 //
 // How to run:
 //   mise run benchmark-sieve
@@ -49,7 +49,7 @@ test "smoke" {
 }
 
 export fn run() with Stdout, MonotonicClock {
-    let limit = 10000000;
+    let limit = 100000000;
     let mut b = Benchmark::new(`sieve up to {limit}`);
     let count = b.run("", || sieve_count(limit));
     b.println(`count = {count}`);

--- a/benchmark/zlib/zlib_bench.wado
+++ b/benchmark/zlib/zlib_bench.wado
@@ -53,7 +53,7 @@ test "smoke" {
 export fn run() with Stdout, MonotonicClock, Preopens {
     let data = read_file_bytes("json_twitter/twitter.json");
     let mut b = Benchmark::new("zlib");
-    b.iterations = 10;
+    b.iterations = 100;
     b.input_size = Option::Some(data.len());
 
     let compressed = b.run("compress", || zlib_compress(&data));

--- a/benchmark/zlib/zlib_rs.rs
+++ b/benchmark/zlib/zlib_rs.rs
@@ -9,7 +9,7 @@ fn main() {
     let data = std::fs::read("json_twitter/twitter.json")
         .expect("failed to read json_twitter/twitter.json");
     let size = data.len();
-    let iterations = 10;
+    let iterations = 100;
 
     println!("zlib {size} bytes x {iterations} iterations");
 

--- a/mise.toml
+++ b/mise.toml
@@ -15,10 +15,6 @@ wasmtime = "44"
 # Node.js - required for VS Code extension development
 node = "24"
 
-# Optional tools below are NOT in [tools] because mise doesn't support per-tool
-# optional flag. They are installed best-effort via `mise run on-task-started`.
-#   github:cli/cli = "latest"  # GitHub CLI
-
 [settings]
 auto_install = true
 lockfile = true
@@ -33,7 +29,6 @@ run = """
 #!/usr/bin/env bash
 set -xe -o pipefail
 mise install
-mise install github:cli/cli@latest 2>&1 || true
 """
 
 [tasks.on-task-done]


### PR DESCRIPTION
## What

Refreshes the benchmark suite results and reporting, and scales the lightest workloads so every result reports in whole milliseconds without integer rounding swallowing real signal.

### Denomination (program changes)

The lightest workloads are scaled up; the factor lives in each program and is applied consistently across **every** language implementation:

- **sieve**: count to **100M** (was 10M) — problem-size scaling, one allocation (looping would have re-allocated the array and folded GC churn into the measurement).
- **fts**: **5M** conversions (was 500K) — problem-size scaling.
- **JSON** twitter/canada/catalog (+v2/v3): iterate **×10** (was ×1 / ×5).
- **zlib**: iterate **×100** (was ×10).

Per-iteration verification outputs (prime count, byte sums, event counts) are unchanged; benchmark smoke tests still pass.

### Results & docs

- `benchmark/README.md`: every table refreshed from **best-of-three** runs, all times now in **whole milliseconds**. Added a methodology note (best-of-three; which workloads are scaled and why). Because the denominated JSON/zlib figures are warm steady-state totals, some ratios shift from the earlier cold single-shot numbers — e.g. json-canada `14.0x → 3.8x` once cold-start tiering is excluded, and sieve `1.9x → 1.3x` in the memory-bound 100M regime.
- `.claude/skills/benchmark/SKILL.md`: now covers all 10 `benchmark-all` benchmarks plus the separate `http-routing` run (oha prerequisite, tunables, req/s, curated subset), documents the best-of-three and whole-ms conventions, and explains the denomination factors and how to retune them.
- Earlier commits on this branch also refreshed the HTTP-routing results and the `benchmark-all` tables, dropped `gh` from the dev environment, and made the SessionStart hook initialize the `vendor/wasmtime` submodule.

## Testing

- Ran each changed benchmark three times; report the best per implementation.
- `wado test` over the changed benchmark dirs: 9 smoke tests pass, all compile.
- `mise run format` clean.

## Follow-ups (filed, not fixed here)

While scaling `fts` to 5M I uncovered two pre-existing bugs, filed separately:

- #1229 — fixed-point `{:.Nf}` under-rounds small-magnitude values (causes the `fts` Wado `byte_sum` to be off-by-one vs native; benchmark itself is correct).
- #1230 — `core:cli::println` leaks a stream resource per call.

https://claude.ai/code/session_01PELiaHkTZv9VhWpBpJuDub

---
_Generated by [Claude Code](https://claude.ai/code/session_01PELiaHkTZv9VhWpBpJuDub)_