### PR TITLE
feat: recover from parser syntax errors for the LSP

### DIFF
--- a/wado-cli/src/doc.rs
+++ b/wado-cli/src/doc.rs
@@ -228,6 +228,7 @@ fn load_doc(input: &str) -> Result<DocModule, CliExit> {
         .map_err(|e| CliExit::error(format!("reading '{}': {e}", path.display())))?;
 
     let parsed = wado_compiler::parse(&source)
+        .and_then(wado_compiler::ParseResult::into_fail_fast)
         .map_err(|e| CliExit::error(format!("parsing '{}': {e:?}", path.display())))?;
 
     let module_name = path

--- a/wado-compiler/src/analyze.rs
+++ b/wado-compiler/src/analyze.rs
@@ -549,6 +549,10 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
                 Item::TupleTypeDecl(_) => {
                     // Tuple type family declaration — handled in orchestration
                 }
+
+                Item::Error(_) => {
+                    // Error-recovery placeholder; no symbol to define.
+                }
             }
         }
     }

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -458,6 +458,7 @@ pub fn walk_item<V: AstVisitor>(v: &mut V, item: &Item) {
             v.visit_type(&g.ty);
             v.visit_expr(&g.initializer);
         }
+        Item::Error(e) => v.visit_id(e.id, e.span),
     }
 }
 
@@ -904,6 +905,16 @@ pub enum Item {
     World(WorldDecl),
     Test(TestDecl),
     Global(GlobalDecl),
+    /// Unparsable token run, emitted by error recovery so one syntax error
+    /// doesn't discard the rest of the module.
+    Error(ErrorItem),
+}
+
+/// Placeholder for a token run that failed to parse as an item. See [`Item::Error`].
+#[derive(Debug, Clone)]
+pub struct ErrorItem {
+    pub id: AstId,
+    pub span: Span,
 }
 
 /// Test declaration: `test "name" { ... }` or `test { ... }`

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -2988,9 +2988,7 @@ mod ast_id_tests {
     fn parse(source: &str) -> Module {
         let tokens = Lexer::new(source).tokenize().expect("lex");
         let mut parser = Parser::new(tokens);
-        let module = parser.parse();
-        assert!(parser.take_errors().is_empty(), "parse");
-        module
+        parser.parse_strict().expect("parse")
     }
 
     /// Collect every `(AstId, Span)` emitted while walking `items` using the

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -99,6 +99,11 @@ pub struct Module {
     /// Total number of [`AstId`]s allocated for this module during parsing.
     /// Ids occupy the range `0..ast_id_count`.
     ast_id_count: u32,
+    /// True if error recovery ran during parsing (any syntax error, including
+    /// block-internal ones that leave no `Item::Error`). Travels with the AST
+    /// so `Semantics::is_complete` can refuse to treat a partial parse as
+    /// complete.
+    has_syntax_errors: bool,
 }
 
 /// Inner attribute like `#![no_prelude]`, `#![wasm_module("mem")]`, or
@@ -155,6 +160,7 @@ impl Module {
             data_section: None,
             include_paths: IndexSet::default(),
             ast_id_count: 0,
+            has_syntax_errors: false,
         }
     }
 
@@ -166,6 +172,7 @@ impl Module {
         data_section: Option<String>,
         include_paths: IndexSet<String>,
         ast_id_count: u32,
+        has_syntax_errors: bool,
     ) -> Self {
         Self {
             items,
@@ -174,7 +181,13 @@ impl Module {
             data_section,
             include_paths,
             ast_id_count,
+            has_syntax_errors,
         }
+    }
+
+    /// True if parsing recovered from one or more syntax errors.
+    pub fn has_syntax_errors(&self) -> bool {
+        self.has_syntax_errors
     }
 
     /// Returns the total number of [`AstId`]s allocated for this module.
@@ -2975,7 +2988,9 @@ mod ast_id_tests {
     fn parse(source: &str) -> Module {
         let tokens = Lexer::new(source).tokenize().expect("lex");
         let mut parser = Parser::new(tokens);
-        parser.parse().expect("parse")
+        let module = parser.parse();
+        assert!(parser.take_errors().is_empty(), "parse");
+        module
     }
 
     /// Collect every `(AstId, Span)` emitted while walking `items` using the

--- a/wado-compiler/src/ast_index.rs
+++ b/wado-compiler/src/ast_index.rs
@@ -374,9 +374,7 @@ mod tests {
     fn parse(source: &str) -> Module {
         let tokens = Lexer::new(source).tokenize().expect("lex");
         let mut parser = Parser::new(tokens);
-        let module = parser.parse();
-        assert!(parser.take_errors().is_empty(), "parse");
-        module
+        parser.parse_strict().expect("parse")
     }
 
     #[test]

--- a/wado-compiler/src/ast_index.rs
+++ b/wado-compiler/src/ast_index.rs
@@ -374,7 +374,9 @@ mod tests {
     fn parse(source: &str) -> Module {
         let tokens = Lexer::new(source).tokenize().expect("lex");
         let mut parser = Parser::new(tokens);
-        parser.parse().expect("parse")
+        let module = parser.parse();
+        assert!(parser.take_errors().is_empty(), "parse");
+        module
     }
 
     #[test]

--- a/wado-compiler/src/ast_index.rs
+++ b/wado-compiler/src/ast_index.rs
@@ -307,6 +307,9 @@ fn record_item_name_spans(index: &mut AstIndex, item: &Item) {
         }
         Item::Impl(imp) => record_impl_name_spans(index, imp),
         Item::Use(_) | Item::World(_) | Item::Test(_) | Item::TupleTypeDecl(_) => {}
+        // Error-recovery placeholder; its own span is the only fact to record,
+        // handled by the generic item-span pass, not here.
+        Item::Error(_) => {}
     }
 }
 

--- a/wado-compiler/src/bind.rs
+++ b/wado-compiler/src/bind.rs
@@ -1247,9 +1247,7 @@ mod tests {
         let mut lexer = Lexer::new(source);
         let tokens = lexer.tokenize().unwrap();
         let mut parser = Parser::new(tokens);
-        let module = parser.parse();
-        assert!(parser.take_errors().is_empty(), "parse error");
-        module
+        parser.parse_strict().expect("parse error")
     }
 
     fn bind_and_check(module: &Module) -> (bool, Vec<crate::compiler_host::Diagnostic>) {

--- a/wado-compiler/src/bind.rs
+++ b/wado-compiler/src/bind.rs
@@ -1247,7 +1247,9 @@ mod tests {
         let mut lexer = Lexer::new(source);
         let tokens = lexer.tokenize().unwrap();
         let mut parser = Parser::new(tokens);
-        parser.parse().unwrap()
+        let module = parser.parse();
+        assert!(parser.take_errors().is_empty(), "parse error");
+        module
     }
 
     fn bind_and_check(module: &Module) -> (bool, Vec<crate::compiler_host::Diagnostic>) {

--- a/wado-compiler/src/builtin_registry.rs
+++ b/wado-compiler/src/builtin_registry.rs
@@ -66,7 +66,12 @@ impl BuiltinRegistry {
             let mut lexer = Lexer::new(source);
             let tokens = lexer.tokenize().expect("lexer error in core:builtin");
             let mut parser = Parser::new(tokens);
-            parser.parse().expect("parser error in core:builtin")
+            let module = parser.parse();
+            assert!(
+                parser.take_errors().is_empty(),
+                "parser error in core:builtin"
+            );
+            module
         });
 
         let mut registry = Self::new();
@@ -447,7 +452,8 @@ mod tests {
         let mut lexer = Lexer::new(CORE_BUILTIN);
         let tokens = lexer.tokenize().expect("lexer error");
         let mut parser = Parser::new(tokens);
-        let module = parser.parse().expect("parser error");
+        let module = parser.parse();
+        assert!(parser.take_errors().is_empty(), "parser error");
 
         // Build registry with type table
         let type_table = make_type_table();

--- a/wado-compiler/src/builtin_registry.rs
+++ b/wado-compiler/src/builtin_registry.rs
@@ -66,12 +66,7 @@ impl BuiltinRegistry {
             let mut lexer = Lexer::new(source);
             let tokens = lexer.tokenize().expect("lexer error in core:builtin");
             let mut parser = Parser::new(tokens);
-            let module = parser.parse();
-            assert!(
-                parser.take_errors().is_empty(),
-                "parser error in core:builtin"
-            );
-            module
+            parser.parse_strict().expect("parser error in core:builtin")
         });
 
         let mut registry = Self::new();
@@ -452,8 +447,7 @@ mod tests {
         let mut lexer = Lexer::new(CORE_BUILTIN);
         let tokens = lexer.tokenize().expect("lexer error");
         let mut parser = Parser::new(tokens);
-        let module = parser.parse();
-        assert!(parser.take_errors().is_empty(), "parser error");
+        let module = parser.parse_strict().expect("parser error");
 
         // Build registry with type table
         let type_table = make_type_table();

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -902,9 +902,7 @@ impl CmInterfaceRegistry {
             let mut lexer = Lexer::new(source);
             let tokens = lexer.tokenize().expect("lexer error in stdlib");
             let mut parser = Parser::new(tokens);
-            let module = parser.parse();
-            assert!(parser.take_errors().is_empty(), "parser error in stdlib");
-            module
+            parser.parse_strict().expect("parser error in stdlib")
         }
 
         // Two-pass bootstrap so every stdlib `Type::Named` reference carries

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -902,7 +902,9 @@ impl CmInterfaceRegistry {
             let mut lexer = Lexer::new(source);
             let tokens = lexer.tokenize().expect("lexer error in stdlib");
             let mut parser = Parser::new(tokens);
-            parser.parse().expect("parser error in stdlib")
+            let module = parser.parse();
+            assert!(parser.take_errors().is_empty(), "parser error in stdlib");
+            module
         }
 
         // Two-pass bootstrap so every stdlib `Type::Named` reference carries

--- a/wado-compiler/src/doc.rs
+++ b/wado-compiler/src/doc.rs
@@ -565,6 +565,7 @@ fn is_pub_or_export(item: &Item) -> bool {
         Item::Impl(_) => true,
         Item::TupleTypeDecl(d) => d.is_pub,
         Item::Use(_) | Item::World(_) | Item::Test(_) => false,
+        Item::Error(_) => false,
     }
 }
 

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -1021,8 +1021,6 @@ pub struct ParseResult {
     pub trivia: comment::TriviaMap,
     /// Syntax errors recovered during parsing, in source order.
     pub errors: Vec<parser::ParseError>,
-    /// `#![TODO]` present in the parsed inner attributes.
-    pub had_todo: bool,
 }
 
 impl ParseResult {
@@ -1037,7 +1035,7 @@ impl ParseResult {
                 line: e.span.line,
                 column: e.span.column,
                 filename: None,
-                is_todo_module: self.had_todo,
+                is_todo_module: self.ast.has_todo(),
             });
         }
         Ok(self)
@@ -1085,7 +1083,6 @@ pub fn parse(source: &str) -> Result<ParseResult, CompileError> {
     // `ParseResult::errors` and `into_fail_fast` for callers that need them.
     let ast = parser.parse();
     let errors = parser.take_errors();
-    let had_todo = parser.has_todo();
     let mut trivia = parser.take_trivia();
     comment::populate_trailing(&mut trivia, &ast);
     comment::populate_inner_tail(&mut trivia, &ast);
@@ -1093,7 +1090,6 @@ pub fn parse(source: &str) -> Result<ParseResult, CompileError> {
         ast,
         trivia,
         errors,
-        had_todo,
     })
 }
 

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -63,7 +63,8 @@ pub use compiler_host::{
 };
 pub use logger::{Bail, Logger};
 pub use semantics::{
-    Cursor, Definition, Semantics, parse_failure_diagnostic, semantics, semantics_of,
+    Cursor, Definition, Semantics, parse_error_diagnostic, parse_failure_diagnostic, semantics,
+    semantics_of,
 };
 
 #[cfg(test)]
@@ -742,10 +743,11 @@ pub async fn dump_with_host_and_world<H: CompilerHost>(
     let (ast, trivia) = {
         let _span = logger.span("parse");
         let mut parser = Parser::with_trivia(tokens, shebang, data_section, comments);
-        let ast = parser.parse().map_err(|e| {
+        let ast = parser.parse();
+        if let Some(e) = parser.take_errors().into_iter().next() {
             let _ = logger.error(e);
-            Bail
-        })?;
+            return Err(Bail);
+        }
         let mut trivia = parser.take_trivia();
         comment::populate_trailing(&mut trivia, &ast);
         comment::populate_inner_tail(&mut trivia, &ast);
@@ -988,13 +990,17 @@ pub fn format(source: &str) -> Result<String, CompileError> {
     // Parser (with shebang, data section, and the comment stream so it
     // can attach leading comments to AST nodes as it allocates ids).
     let mut parser = Parser::with_trivia(tokens, shebang, data_section, comments);
-    let ast = parser.parse().map_err(|e| CompileError::Parser {
-        message: e.message,
-        line: e.span.line,
-        column: e.span.column,
-        filename: None,
-        is_todo_module: parser.has_todo(),
-    })?;
+    // Formatting requires a clean parse: reject the first recovered error.
+    let ast = parser.parse();
+    if let Some(e) = parser.take_errors().first() {
+        return Err(CompileError::Parser {
+            message: e.message.clone(),
+            line: e.span.line,
+            column: e.span.column,
+            filename: None,
+            is_todo_module: parser.has_todo(),
+        });
+    }
     let mut trivia = parser.take_trivia();
     comment::populate_trailing(&mut trivia, &ast);
     comment::populate_inner_tail(&mut trivia, &ast);
@@ -1004,10 +1010,38 @@ pub fn format(source: &str) -> Result<String, CompileError> {
     Ok(unparser.unparse(&ast))
 }
 
-/// Result of parsing a source file (AST + AstId-keyed trivia, no compilation)
+/// Result of parsing a source file (AST + AstId-keyed trivia, no compilation).
+///
+/// The parser is error-recovering: `ast` always covers the whole input, and
+/// any syntax errors are collected in `errors` (empty on a clean parse).
+/// Batch/format/doc callers that need the old fail-fast behavior call
+/// [`ParseResult::into_fail_fast`]; the LSP path uses the partial `ast`.
 pub struct ParseResult {
     pub ast: ast::Module,
     pub trivia: comment::TriviaMap,
+    /// Syntax errors recovered during parsing, in source order.
+    pub errors: Vec<parser::ParseError>,
+    /// `#![TODO]` present in the parsed inner attributes.
+    pub had_todo: bool,
+}
+
+impl ParseResult {
+    /// Fail-fast adapter: if parsing recovered any syntax error, return the
+    /// first as the `CompileError::Parser` the parser used to produce;
+    /// otherwise yield the result unchanged. Used by batch compilation,
+    /// `wado doc`, and the formatter, which must reject malformed input.
+    pub fn into_fail_fast(self) -> Result<ParseResult, CompileError> {
+        if let Some(e) = self.errors.first() {
+            return Err(CompileError::Parser {
+                message: e.message.clone(),
+                line: e.span.line,
+                column: e.span.column,
+                filename: None,
+                is_todo_module: self.had_todo,
+            });
+        }
+        Ok(self)
+    }
 }
 
 /// Resolve every transitive import of `parsed` and return the loaded
@@ -1046,17 +1080,21 @@ pub fn parse(source: &str) -> Result<ParseResult, CompileError> {
     })?;
     let (data_section, comments, shebang) = lexer.into_parts();
     let mut parser = Parser::with_trivia(tokens, shebang, data_section, comments);
-    let ast = parser.parse().map_err(|e| CompileError::Parser {
-        message: e.message,
-        line: e.span.line,
-        column: e.span.column,
-        filename: None,
-        is_todo_module: parser.has_todo(),
-    })?;
+    // The parser is error-recovering and always returns a Module; lexing
+    // remains fail-fast (the `?` above). Syntax errors are surfaced via
+    // `ParseResult::errors` and `into_fail_fast` for callers that need them.
+    let ast = parser.parse();
+    let errors = parser.take_errors();
+    let had_todo = parser.has_todo();
     let mut trivia = parser.take_trivia();
     comment::populate_trailing(&mut trivia, &ast);
     comment::populate_inner_tail(&mut trivia, &ast);
-    Ok(ParseResult { ast, trivia })
+    Ok(ParseResult {
+        ast,
+        trivia,
+        errors,
+        had_todo,
+    })
 }
 
 /// Compilation error with structured location info

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -723,7 +723,10 @@ fn parse_bind_stdlib(label: &str, source: &str) -> Module {
     });
     let (data_section, _comments, shebang) = lexer.into_parts();
     let mut parser = Parser::with_metadata(tokens, shebang, data_section);
-    let ast = parser.parse().unwrap_or_else(|e| {
+    let ast = parser.parse();
+    if let Some(e) = parser.take_errors().first() {
+        // Bundled stdlib must always parse cleanly; a syntax error here is a
+        // compiler bug, so fail loudly rather than degrade.
         panic!(
             "{}",
             format_stdlib_error(
@@ -735,8 +738,8 @@ fn parse_bind_stdlib(label: &str, source: &str) -> Module {
                 Some(e.span.end_column),
                 &e.message,
             )
-        )
-    });
+        );
+    }
     {
         let bind_host = crate::compiler_host::InMemoryCompilerHost::new();
         let bind_logger = Logger::new(&bind_host, LogLevel::Off);
@@ -807,7 +810,9 @@ mod tests {
         let tokens = lexer.tokenize().expect("test source must lex");
         let (data_section, _comments, shebang) = lexer.into_parts();
         let mut parser = Parser::with_metadata(tokens, shebang, data_section);
-        parser.parse().expect("test source must parse")
+        let ast = parser.parse();
+        assert!(parser.take_errors().is_empty(), "test source must parse");
+        ast
     }
 
     #[test]
@@ -1532,12 +1537,18 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         let (data_section, _comments, shebang) = lexer.into_parts();
 
         let mut parser = Parser::with_metadata(tokens, shebang, data_section);
-        parser.parse().map_err(|e| LoadError::ParseError {
-            module_source: module_source.clone(),
-            message: e.message,
-            line: e.span.line,
-            column: e.span.column,
-        })
+        // Batch loading is fail-fast: report the first recovered syntax error
+        // as a load error so compilation never proceeds on a partial AST.
+        let ast = parser.parse();
+        if let Some(e) = parser.take_errors().first() {
+            return Err(LoadError::ParseError {
+                module_source: module_source.clone(),
+                message: e.message.clone(),
+                line: e.span.line,
+                column: e.span.column,
+            });
+        }
+        Ok(ast)
     }
 
     /// Bind a module (local name resolution and scope checking)

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -810,9 +810,7 @@ mod tests {
         let tokens = lexer.tokenize().expect("test source must lex");
         let (data_section, _comments, shebang) = lexer.into_parts();
         let mut parser = Parser::with_metadata(tokens, shebang, data_section);
-        let ast = parser.parse();
-        assert!(parser.take_errors().is_empty(), "test source must parse");
-        ast
+        parser.parse_strict().expect("test source must parse")
     }
 
     #[test]

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -160,6 +160,18 @@ impl Parser {
         std::mem::take(&mut self.errors)
     }
 
+    /// Parse fail-fast: return the [`Module`] only if no syntax error was
+    /// recovered, otherwise the first error. For callers that require a clean
+    /// parse (stdlib loading, expression-snippet tests) and want the old
+    /// `Result`-returning shape.
+    pub fn parse_strict(&mut self) -> ParseResult<Module> {
+        let module = self.parse();
+        match self.take_errors().into_iter().next() {
+            Some(e) => Err(e),
+            None => Ok(module),
+        }
+    }
+
     /// Allocate a fresh [`AstId`] for an AST node currently being constructed.
     /// Ids are dense in `0..next_ast_id` and assigned in parse order.
     ///
@@ -240,7 +252,8 @@ impl Parser {
     }
 
     /// Returns true if the parsed inner attributes include `#![TODO]`.
-    /// Valid even after a parse error, since inner attributes are parsed first.
+    /// Valid even after a parse error: each inner attribute is recorded as it
+    /// parses, so the valid ones survive a later malformed attribute or item.
     pub fn has_todo(&self) -> bool {
         self.parsed_inner_attributes
             .iter()
@@ -296,16 +309,12 @@ impl Parser {
     /// `self.errors`, drained by [`Parser::take_errors`]. The returned module
     /// covers the whole input — broken regions become [`Item::Error`] nodes.
     pub fn parse(&mut self) -> Module {
-        // Parse inner attributes at the start of the module.
-        // Store them so has_todo() works even if item parsing fails later.
-        let inner_attributes = match self.parse_inner_attributes() {
-            Ok(attrs) => attrs,
-            Err(e) => {
-                self.errors.push(e);
-                Vec::new()
-            }
-        };
-        self.parsed_inner_attributes.clone_from(&inner_attributes);
+        // `parse_inner_attributes` records each attribute as it parses, so a
+        // malformed one only loses itself; the rest stay in the module.
+        if let Err(e) = self.parse_inner_attributes() {
+            self.errors.push(e);
+        }
+        let inner_attributes = self.parsed_inner_attributes.clone();
 
         let mut items = Vec::new();
 
@@ -341,21 +350,22 @@ impl Parser {
     /// attribute-start `#` (also begins `#include_str(...)`), and the
     /// contextual `test` keyword (an ordinary identifier, e.g. `test(1, 2)`).
     fn at_hard_item_keyword(&self) -> bool {
-        use TokenKind::*;
+        use TokenKind as T;
         matches!(
             self.peek_kind(),
-            Use | Fn
-                | Interface
-                | Struct
-                | Enum
-                | Variant
-                | Impl
-                | Trait
-                | Resource
-                | World
-                | Global
-                | Pub
-                | Export
+            T::Use
+                | T::Fn
+                | T::Interface
+                | T::Struct
+                | T::Enum
+                | T::Variant
+                | T::Impl
+                | T::Trait
+                | T::Resource
+                | T::World
+                | T::Global
+                | T::Pub
+                | T::Export
         )
     }
 
@@ -364,8 +374,8 @@ impl Parser {
     /// block) every item keyword — including the contextual `flags` / `type` /
     /// `test` and the attribute-start `#` — unambiguously starts the next item.
     fn at_item_start(&self) -> bool {
-        use TokenKind::*;
-        if self.at_hard_item_keyword() || matches!(self.peek_kind(), Flags | Type | Hash) {
+        use TokenKind as T;
+        if self.at_hard_item_keyword() || matches!(self.peek_kind(), T::Flags | T::Type | T::Hash) {
             return true;
         }
         matches!(self.peek_kind(), TokenKind::Ident(name) if name == "test")
@@ -393,7 +403,7 @@ impl Parser {
     }
 
     /// Skip tokens after a failed statement until a statement/block boundary:
-    /// a `;` (consumed), or `}` / an item-start token / EOF (left in place).
+    /// a `;` (consumed), or `}` / a hard item keyword / EOF (left in place).
     /// Guarantees forward progress.
     fn recover_in_block(&mut self, before: usize) {
         if self.pos == before {
@@ -858,14 +868,16 @@ impl Parser {
     }
 
     /// Parse inner attributes at the start of a module: `#![name]`
-    fn parse_inner_attributes(&mut self) -> ParseResult<Vec<InnerAttribute>> {
-        let mut attrs = Vec::new();
-
+    /// Parse the run of `#![...]` inner attributes at the module start. Each
+    /// attribute is recorded in `parsed_inner_attributes` as soon as it parses,
+    /// so a later malformed attribute does not discard the valid ones already
+    /// seen — `has_todo()` stays correct across recovery.
+    fn parse_inner_attributes(&mut self) -> ParseResult<()> {
         while self.check(&TokenKind::Hash) && self.peek_nth(1).kind == TokenKind::Not {
-            attrs.push(self.parse_inner_attribute()?);
+            let attr = self.parse_inner_attribute()?;
+            self.parsed_inner_attributes.push(attr);
         }
-
-        Ok(attrs)
+        Ok(())
     }
 
     /// Parse a single inner attribute: `#![name]`, `#![name("arg")]`, or
@@ -1644,7 +1656,10 @@ impl Parser {
         // here rather than letting the body swallow the next item. Only hard
         // keywords qualify — `flags`/`type` as identifiers, `test(...)`, and
         // `#include_str(...)` are all valid statements, so `at_hard_item_keyword`
-        // (not `at_item_start`) is correct.
+        // (not `at_item_start`) is correct. The trade-off: a brace-less block
+        // immediately before a `#[attr]`-prefixed item still over-reads (the `#`
+        // parses as a compile-time literal and fails), so that one case yields a
+        // less precise diagnostic. The following item itself still recovers.
         while !self.check(&TokenKind::RBrace) && !self.is_at_end() && !self.at_hard_item_keyword() {
             let before = self.pos;
             match self.parse_stmt_in_block() {
@@ -5503,11 +5518,7 @@ mod tests {
         let tokens = lexer.tokenize().expect("lexer error");
         let (data_section, _comments, shebang) = lexer.into_parts();
         let mut parser = Parser::with_metadata(tokens, shebang, data_section);
-        let module = parser.parse();
-        match parser.take_errors().into_iter().next() {
-            Some(e) => Err(e),
-            None => Ok(module),
-        }
+        parser.parse_strict()
     }
 
     /// Parse helper that exposes the full recovery result: the (always
@@ -7178,6 +7189,63 @@ line 2
         assert!(
             errors.is_empty(),
             "speculative backtracking must not leak errors: {errors:?}",
+        );
+    }
+
+    #[test]
+    fn recovery_resyncs_to_every_item_keyword() {
+        // Guards `at_item_start` against drifting from `parse_item`: a leading
+        // garbage token forces recovery, and each item kind that follows must
+        // still parse (i.e. its start token is in the recovery sync set). If a
+        // new item keyword is added to `parse_item` without updating
+        // `at_item_start`, recovery would swallow it and this test fails.
+        let item_sources = [
+            "use { x } from \"core:cli\";",
+            "fn a() {}",
+            "interface I { fn m(); }",
+            "struct S { x: i32 }",
+            "enum E { A, B }",
+            "variant V { A(i32), B }",
+            "flags F { A, B }",
+            "type T = i32;",
+            "impl S {}",
+            "trait Tr {}",
+            "resource R {}",
+            "world W {}",
+            "global G: i32 = 0;",
+            "test \"t\" {}",
+            "pub fn b() {}",
+        ];
+        for src in item_sources {
+            let full = format!("] {src}\n");
+            let (module, errors) = parse_recovering(&full);
+            assert!(!errors.is_empty(), "leading `]` should error: {src}");
+            let recovered = module.items.iter().any(|i| !matches!(i, Item::Error(_)));
+            assert!(
+                recovered,
+                "recovery must re-sync to and parse the item: {src}",
+            );
+        }
+    }
+
+    #[test]
+    fn has_todo_survives_a_failing_later_inner_attribute() {
+        // `#![TODO]` parses fine but the next inner attribute is malformed. The
+        // valid `#![TODO]` must not be discarded by recovery, so has_todo() and
+        // the module's inner attributes still see it.
+        let mut lexer = Lexer::new("#![TODO]\n#![wasm_module(\n");
+        let tokens = lexer.tokenize().expect("lexer error");
+        let (data_section, _comments, shebang) = lexer.into_parts();
+        let mut parser = Parser::with_metadata(tokens, shebang, data_section);
+        let module = parser.parse();
+        assert!(
+            !parser.take_errors().is_empty(),
+            "malformed attr is an error"
+        );
+        assert!(parser.has_todo(), "has_todo() must still see #![TODO]");
+        assert!(
+            module.has_todo(),
+            "module must retain #![TODO] despite the later failure",
         );
     }
 }

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -55,6 +55,9 @@ pub struct Parser {
     /// Trivia attached to AST nodes during parsing. Exposed via
     /// [`Parser::take_trivia`] for the formatter pipeline.
     trivia: crate::comment::TriviaMap,
+    /// Syntax errors collected during error recovery. Drained via
+    /// [`Parser::take_errors`] after [`Parser::parse`].
+    errors: Vec<ParseError>,
 }
 
 #[derive(Debug)]
@@ -86,6 +89,7 @@ struct ParserCheckpoint {
     comment_cursor: usize,
     next_ast_id: u32,
     pending_gt: bool,
+    errors_len: usize,
 }
 
 /// Groups of comparison operators for chain validation
@@ -147,7 +151,13 @@ impl Parser {
             comments,
             comment_cursor: 0,
             trivia: crate::comment::TriviaMap::new(),
+            errors: Vec::new(),
         }
+    }
+
+    /// Drain the syntax errors collected during error recovery.
+    pub fn take_errors(&mut self) -> Vec<ParseError> {
+        std::mem::take(&mut self.errors)
     }
 
     /// Allocate a fresh [`AstId`] for an AST node currently being constructed.
@@ -215,6 +225,7 @@ impl Parser {
             comment_cursor: self.comment_cursor,
             next_ast_id: self.next_ast_id,
             pending_gt: self.pending_gt,
+            errors_len: self.errors.len(),
         }
     }
 
@@ -224,6 +235,8 @@ impl Parser {
         self.trivia.discard_from(crate::ast::AstId(cp.next_ast_id));
         self.next_ast_id = cp.next_ast_id;
         self.pending_gt = cp.pending_gt;
+        // Drop errors recorded inside the speculative branch being rolled back.
+        self.errors.truncate(cp.errors_len);
     }
 
     /// Returns true if the parsed inner attributes include `#![TODO]`.
@@ -278,26 +291,124 @@ impl Parser {
         }
     }
 
-    pub fn parse(&mut self) -> ParseResult<Module> {
+    /// Parse the token stream into a [`Module`]. Always succeeds: syntax
+    /// errors are recovered (see [`Parser::recover_item`]) and collected into
+    /// `self.errors`, drained by [`Parser::take_errors`]. The returned module
+    /// covers the whole input — broken regions become [`Item::Error`] nodes.
+    pub fn parse(&mut self) -> Module {
         // Parse inner attributes at the start of the module.
         // Store them so has_todo() works even if item parsing fails later.
-        let inner_attributes = self.parse_inner_attributes()?;
+        let inner_attributes = match self.parse_inner_attributes() {
+            Ok(attrs) => attrs,
+            Err(e) => {
+                self.errors.push(e);
+                Vec::new()
+            }
+        };
         self.parsed_inner_attributes.clone_from(&inner_attributes);
 
         let mut items = Vec::new();
 
         while !self.is_at_end() {
-            items.push(self.parse_item()?);
+            let before = self.pos;
+            match self.parse_item() {
+                Ok(item) => items.push(item),
+                Err(e) => {
+                    self.errors.push(e);
+                    items.push(self.recover_item(before));
+                }
+            }
         }
 
-        Ok(Module::with_metadata(
+        let has_syntax_errors = !self.errors.is_empty();
+        Module::with_metadata(
             items,
             inner_attributes,
             self.shebang.take(),
             self.data_section.take(),
             std::mem::take(&mut self.include_paths),
             self.next_ast_id,
-        ))
+            has_syntax_errors,
+        )
+    }
+
+    /// True when the current token is a *hard* item keyword: a reserved word
+    /// that can only begin a top-level item and never appears as an identifier
+    /// or statement start. This is the safe sync set for *block* termination —
+    /// a missing `}` is recovered by ending the block here. It deliberately
+    /// excludes the contextual keywords `flags` and `type` (both valid as
+    /// identifiers, e.g. `flags = flags | 1;` or `type` as a name), the
+    /// attribute-start `#` (also begins `#include_str(...)`), and the
+    /// contextual `test` keyword (an ordinary identifier, e.g. `test(1, 2)`).
+    fn at_hard_item_keyword(&self) -> bool {
+        use TokenKind::*;
+        matches!(
+            self.peek_kind(),
+            Use | Fn
+                | Interface
+                | Struct
+                | Enum
+                | Variant
+                | Impl
+                | Trait
+                | Resource
+                | World
+                | Global
+                | Pub
+                | Export
+        )
+    }
+
+    /// True when the current token can begin a top-level item. This is the sync
+    /// set for the item-loop's panic-mode recovery, where (unlike inside a
+    /// block) every item keyword — including the contextual `flags` / `type` /
+    /// `test` and the attribute-start `#` — unambiguously starts the next item.
+    fn at_item_start(&self) -> bool {
+        use TokenKind::*;
+        if self.at_hard_item_keyword() || matches!(self.peek_kind(), Flags | Type | Hash) {
+            return true;
+        }
+        matches!(self.peek_kind(), TokenKind::Ident(name) if name == "test")
+    }
+
+    /// Skip the unparsable token run starting at `before` up to (but not
+    /// including) the next item-start token or EOF, and return an
+    /// [`Item::Error`] covering it. Guarantees forward progress: if no token
+    /// was consumed before the failure, consume one here so the caller's loop
+    /// cannot spin.
+    fn recover_item(&mut self, before: usize) -> Item {
+        let id = self.alloc_ast_id();
+        let start = self.tokens[before].span;
+        if self.pos == before {
+            self.advance();
+        }
+        while !self.is_at_end() && !self.at_item_start() {
+            self.advance();
+        }
+        let end = self.tokens[self.pos.saturating_sub(1)].span;
+        Item::Error(crate::ast::ErrorItem {
+            id,
+            span: start.merge(&end),
+        })
+    }
+
+    /// Skip tokens after a failed statement until a statement/block boundary:
+    /// a `;` (consumed), or `}` / an item-start token / EOF (left in place).
+    /// Guarantees forward progress.
+    fn recover_in_block(&mut self, before: usize) {
+        if self.pos == before {
+            self.advance();
+        }
+        loop {
+            if self.is_at_end() || self.check(&TokenKind::RBrace) || self.at_hard_item_keyword() {
+                break;
+            }
+            if self.check(&TokenKind::Semicolon) {
+                self.advance();
+                break;
+            }
+            self.advance();
+        }
     }
 
     // Token handling
@@ -1529,13 +1640,34 @@ impl Parser {
 
         let mut stmts = Vec::new();
 
-        while !self.check(&TokenKind::RBrace) && !self.is_at_end() {
-            // Try to parse a statement, allowing optional trailing semicolon for final expression
-            let stmt = self.parse_stmt_in_block()?;
-            stmts.push(stmt);
+        // Stop at a hard item keyword too: a missing `}` should close the block
+        // here rather than letting the body swallow the next item. Only hard
+        // keywords qualify — `flags`/`type` as identifiers, `test(...)`, and
+        // `#include_str(...)` are all valid statements, so `at_hard_item_keyword`
+        // (not `at_item_start`) is correct.
+        while !self.check(&TokenKind::RBrace) && !self.is_at_end() && !self.at_hard_item_keyword() {
+            let before = self.pos;
+            match self.parse_stmt_in_block() {
+                Ok(stmt) => stmts.push(stmt),
+                Err(e) => {
+                    // Drop the broken statement (no Stmt::Error node yet) and
+                    // recover to the next boundary so the rest of the block,
+                    // and any following items, still parse.
+                    self.errors.push(e);
+                    self.recover_in_block(before);
+                }
+            }
         }
 
-        let end_span = self.expect(&TokenKind::RBrace)?.span;
+        // Close the block. A missing `}` is reported but recovered: the block
+        // ends at the previous token so following items are unaffected.
+        let end_span = if self.check(&TokenKind::RBrace) {
+            self.advance().span
+        } else {
+            self.errors
+                .push(self.error_at_span(self.peek().span, "expected `}`"));
+            self.tokens[self.pos.saturating_sub(1)].span
+        };
 
         Ok(Block {
             id,
@@ -5363,12 +5495,31 @@ mod tests {
     use super::*;
     use crate::lexer::Lexer;
 
+    /// Parse helper for tests: maps the error-recovering parser back to a
+    /// `Result` (first recovered error as `Err`) so existing `.unwrap()` /
+    /// `.unwrap_err()` call sites keep working.
     fn parse(source: &str) -> ParseResult<Module> {
         let mut lexer = Lexer::new(source);
         let tokens = lexer.tokenize().expect("lexer error");
         let (data_section, _comments, shebang) = lexer.into_parts();
         let mut parser = Parser::with_metadata(tokens, shebang, data_section);
-        parser.parse()
+        let module = parser.parse();
+        match parser.take_errors().into_iter().next() {
+            Some(e) => Err(e),
+            None => Ok(module),
+        }
+    }
+
+    /// Parse helper that exposes the full recovery result: the (always
+    /// produced) module plus every recovered syntax error.
+    fn parse_recovering(source: &str) -> (Module, Vec<ParseError>) {
+        let mut lexer = Lexer::new(source);
+        let tokens = lexer.tokenize().expect("lexer error");
+        let (data_section, _comments, shebang) = lexer.into_parts();
+        let mut parser = Parser::with_metadata(tokens, shebang, data_section);
+        let module = parser.parse();
+        let errors = parser.take_errors();
+        (module, errors)
     }
 
     #[test]
@@ -6927,6 +7078,106 @@ line 2
             brk.span.end_column < 28,
             "break span should not include `}}`: end_column={}",
             brk.span.end_column
+        );
+    }
+
+    fn fn_name(item: &Item) -> Option<&str> {
+        match item {
+            Item::Function(f) => Some(&f.name),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn recovery_collects_multiple_top_level_errors() {
+        // Two broken items between two valid ones: each error is collected,
+        // and the surrounding functions survive. The garbage tokens (`)` `]`)
+        // lex fine but can't begin an item.
+        let (module, errors) = parse_recovering("fn a() {}\n) ) )\nfn b() {}\n] ] ]\nfn c() {}\n");
+        assert!(
+            errors.len() >= 2,
+            "expected >= 2 recovered errors, got {}",
+            errors.len()
+        );
+        let names: Vec<&str> = module.items.iter().filter_map(fn_name).collect();
+        assert!(
+            names.contains(&"a") && names.contains(&"b") && names.contains(&"c"),
+            "all valid functions should survive recovery, got {names:?}",
+        );
+        assert!(module.has_syntax_errors());
+    }
+
+    #[test]
+    fn recovery_missing_brace_keeps_following_item() {
+        // `f` is missing its closing brace; `g` must still parse as a full item.
+        let (module, errors) = parse_recovering(
+            "fn f() -> i32 {\n    let x: i32 = 1;\n    return x;\n\nfn g() -> i32 {\n    return 2;\n}\n",
+        );
+        assert!(!errors.is_empty(), "missing brace should be reported");
+        let names: Vec<&str> = module.items.iter().filter_map(fn_name).collect();
+        assert!(
+            names.contains(&"g"),
+            "function g should survive the missing brace in f, got {names:?}",
+        );
+    }
+
+    #[test]
+    fn block_termination_ignores_contextual_keywords() {
+        // `flags` and `type` are item keywords but also valid identifiers; a
+        // statement using them must not trip block-termination recovery. This
+        // well-formed function must parse with zero errors.
+        let (_module, errors) = parse_recovering(
+            "fn f(mut flags: i32) -> i32 {\n    flags = flags | 1;\n    let type: i32 = flags;\n    return type;\n}\n",
+        );
+        assert!(
+            errors.is_empty(),
+            "contextual keywords in statements must not trigger recovery: {errors:?}",
+        );
+    }
+
+    #[test]
+    fn recovery_terminates_on_garbage() {
+        // A stream of stray-but-lexable tokens must not hang; it yields >= 1
+        // error and at least one Item::Error. (Reaching the assertions proves
+        // termination.)
+        let (module, errors) = parse_recovering(") ] } ) ] } , , =\n");
+        assert!(!errors.is_empty());
+        assert!(
+            module.items.iter().any(|i| matches!(i, Item::Error(_))),
+            "garbage should produce an Item::Error",
+        );
+    }
+
+    #[test]
+    fn recovery_block_internal_error_has_no_item_error() {
+        // A broken statement inside an otherwise valid function: the item shape
+        // is intact (no Item::Error), but the syntax error is still recorded.
+        let (module, errors) =
+            parse_recovering("fn f() -> i32 {\n    let x: i32 = ;\n    return 0;\n}\n");
+        assert!(
+            !errors.is_empty(),
+            "block-internal error should be reported"
+        );
+        assert!(
+            module.has_syntax_errors(),
+            "module must remember the block-internal syntax error",
+        );
+        assert!(
+            !module.items.iter().any(|i| matches!(i, Item::Error(_))),
+            "a recovered statement should not produce an Item::Error",
+        );
+    }
+
+    #[test]
+    fn speculative_parse_does_not_leak_errors() {
+        // Valid input that exercises checkpoint/restore (struct-literal vs block
+        // disambiguation in an `if` condition) must parse with zero errors.
+        let (_module, errors) = parse_recovering(
+            "fn f(p: Point) -> i32 {\n    if p.x > 0 {\n        return 1;\n    }\n    return 0;\n}\n",
+        );
+        assert!(
+            errors.is_empty(),
+            "speculative backtracking must not leak errors: {errors:?}",
         );
     }
 }

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -305,9 +305,10 @@ impl Parser {
     }
 
     /// Parse the token stream into a [`Module`]. Always succeeds: syntax
-    /// errors are recovered (see [`Parser::recover_item`]) and collected into
-    /// `self.errors`, drained by [`Parser::take_errors`]. The returned module
-    /// covers the whole input — broken regions become [`Item::Error`] nodes.
+    /// errors are recovered and collected into `self.errors`, drained by
+    /// [`Parser::take_errors`]. An unparsable item becomes an [`Item::Error`]
+    /// node (see [`Parser::recover_item`]); a broken statement inside a block
+    /// is skipped without a node.
     pub fn parse(&mut self) -> Module {
         // `parse_inner_attributes` records each attribute as it parses, so a
         // malformed one only loses itself; the rest stay in the module.
@@ -383,9 +384,8 @@ impl Parser {
 
     /// Skip the unparsable token run starting at `before` up to (but not
     /// including) the next item-start token or EOF, and return an
-    /// [`Item::Error`] covering it. Guarantees forward progress: if no token
-    /// was consumed before the failure, consume one here so the caller's loop
-    /// cannot spin.
+    /// [`Item::Error`] covering it. Guarantees forward progress: if still at
+    /// `before`, consume one token so the caller's loop cannot spin.
     fn recover_item(&mut self, before: usize) -> Item {
         let id = self.alloc_ast_id();
         let start = self.tokens[before].span;
@@ -1652,14 +1652,12 @@ impl Parser {
 
         let mut stmts = Vec::new();
 
-        // Stop at a hard item keyword too: a missing `}` should close the block
-        // here rather than letting the body swallow the next item. Only hard
-        // keywords qualify — `flags`/`type` as identifiers, `test(...)`, and
-        // `#include_str(...)` are all valid statements, so `at_hard_item_keyword`
-        // (not `at_item_start`) is correct. The trade-off: a brace-less block
-        // immediately before a `#[attr]`-prefixed item still over-reads (the `#`
-        // parses as a compile-time literal and fails), so that one case yields a
-        // less precise diagnostic. The following item itself still recovers.
+        // Stop at a hard item keyword too, so a missing `}` closes the block
+        // instead of swallowing the next item. Must be `at_hard_item_keyword`,
+        // not `at_item_start`: see its doc for why `#`/`test`/`flags`/`type` are
+        // excluded. Trade-off: a brace-less block right before a `#[attr]` item
+        // still over-reads `#` as a compile-time literal, blurring that one
+        // diagnostic — the following item still recovers.
         while !self.check(&TokenKind::RBrace) && !self.is_at_end() && !self.at_hard_item_keyword() {
             let before = self.pos;
             match self.parse_stmt_in_block() {

--- a/wado-compiler/src/semantics.rs
+++ b/wado-compiler/src/semantics.rs
@@ -684,7 +684,11 @@ pub async fn semantics<H: CompilerHost>(
         }
     };
     // Surface every recovered syntax error, then analyze the partial AST so
-    // queries still resolve in the regions outside the error.
+    // queries still resolve in the regions outside the error. If load/bind
+    // then fails on the partial AST, the result still collapses to
+    // `Semantics::empty()` below — recovery helps only when binding succeeds,
+    // which holds for the common cases (missing brace, garbage item) where
+    // scopes stay separate.
     for e in &parsed.errors {
         host.emit_diagnostic(parse_error_diagnostic(e, filename));
     }

--- a/wado-compiler/src/semantics.rs
+++ b/wado-compiler/src/semantics.rs
@@ -678,10 +678,16 @@ pub async fn semantics<H: CompilerHost>(
     let parsed = match crate::parse(source) {
         Ok(p) => p,
         Err(e) => {
+            // Lexer failure: no usable AST.
             host.emit_diagnostic(parse_failure_diagnostic(&e, filename));
             return Semantics::empty();
         }
     };
+    // Surface every recovered syntax error, then analyze the partial AST so
+    // queries still resolve in the regions outside the error.
+    for e in &parsed.errors {
+        host.emit_diagnostic(parse_error_diagnostic(e, filename));
+    }
     match crate::load(
         parsed,
         filename,
@@ -740,6 +746,30 @@ pub fn parse_failure_diagnostic(
             column,
             end_line: None,
             end_column: None,
+        }),
+    }
+}
+
+/// Convert a single recovered [`crate::ParseError`] into a `parse error: …`
+/// [`crate::Diagnostic`], attributing the span to `filename`. The
+/// error-recovering parser surfaces one of these per syntax error, so the
+/// LSP can report them all while still analyzing the partial AST.
+#[must_use]
+pub fn parse_error_diagnostic(
+    err: &crate::ParseError,
+    filename: Option<&str>,
+) -> crate::Diagnostic {
+    use crate::{Code, Diagnostic, DiagnosticSpan, Severity};
+    Diagnostic {
+        severity: Severity::Error,
+        code: Code::InvalidSyntax,
+        message: format!("parse error: {}", err.message),
+        span: filename.map(|f| DiagnosticSpan {
+            file: f.to_string(),
+            line: err.span.line,
+            column: err.span.column,
+            end_line: Some(err.span.end_line),
+            end_column: Some(err.span.end_column),
         }),
     }
 }
@@ -991,6 +1021,11 @@ pub(crate) fn semantics_with_logger<H: CompilerHost>(
         );
     }
 
+    // A recovered syntax error anywhere in the loaded set means the parse was
+    // partial (covers block-internal errors that leave no `Item::Error` node),
+    // so the result is never "complete" even if later phases ran clean.
+    let no_syntax_errors = load_result.modules.values().all(|m| !m.has_syntax_errors());
+
     Semantics {
         entry_module_source: load_result.entry_module_source,
         modules: load_result.modules,
@@ -1007,6 +1042,6 @@ pub(crate) fn semantics_with_logger<H: CompilerHost>(
         coercions,
         desugars,
         tir_modules,
-        is_complete: lower_ok,
+        is_complete: lower_ok && no_syntax_errors,
     }
 }

--- a/wado-compiler/src/unparse.rs
+++ b/wado-compiler/src/unparse.rs
@@ -340,6 +340,9 @@ impl<'a> Unparser<'a> {
             Item::Test(t) => self.unparse_test(t),
             Item::Global(g) => self.unparse_global(g),
             Item::TupleTypeDecl(d) => self.unparse_tuple_type_decl(d),
+            // Unreachable in practice: formatting is fail-fast on syntax
+            // errors, so no Item::Error reaches the unparser. Emit nothing.
+            Item::Error(_) => {}
         }
 
         self.emit_trailing_for(id);
@@ -2603,6 +2606,7 @@ pub fn get_item_span(item: &Item) -> Span {
         Item::Test(t) => t.span,
         Item::Global(g) => g.span,
         Item::TupleTypeDecl(d) => d.span,
+        Item::Error(e) => e.span,
     }
 }
 
@@ -2623,6 +2627,7 @@ pub fn get_item_id(item: &Item) -> crate::ast::AstId {
         Item::Test(t) => t.id,
         Item::Global(g) => g.id,
         Item::TupleTypeDecl(d) => d.id,
+        Item::Error(e) => e.id,
     }
 }
 

--- a/wado-compiler/src/unparse.rs
+++ b/wado-compiler/src/unparse.rs
@@ -340,8 +340,8 @@ impl<'a> Unparser<'a> {
             Item::Test(t) => self.unparse_test(t),
             Item::Global(g) => self.unparse_global(g),
             Item::TupleTypeDecl(d) => self.unparse_tuple_type_decl(d),
-            // Unreachable in practice: formatting is fail-fast on syntax
-            // errors, so no Item::Error reaches the unparser. Emit nothing.
+            // The formatter's fail-fast path produces no Item::Error; emit
+            // nothing if one is ever unparsed (e.g. a future partial-AST caller).
             Item::Error(_) => {}
         }
 

--- a/wado-compiler/tests/literals.rs
+++ b/wado-compiler/tests/literals.rs
@@ -18,11 +18,7 @@ fn parse_expr(source: &str) -> Result<wado_compiler::ast::Module, String> {
     let tokens = lexer.tokenize().map_err(|e| e.message)?;
 
     let mut parser = Parser::new(tokens);
-    let module = parser.parse();
-    match parser.take_errors().into_iter().next() {
-        Some(e) => Err(e.message),
-        None => Ok(module),
-    }
+    parser.parse_strict().map_err(|e| e.message)
 }
 
 /// Extract the literal value from a parsed let statement

--- a/wado-compiler/tests/literals.rs
+++ b/wado-compiler/tests/literals.rs
@@ -18,7 +18,11 @@ fn parse_expr(source: &str) -> Result<wado_compiler::ast::Module, String> {
     let tokens = lexer.tokenize().map_err(|e| e.message)?;
 
     let mut parser = Parser::new(tokens);
-    parser.parse().map_err(|e| e.message)
+    let module = parser.parse();
+    match parser.take_errors().into_iter().next() {
+        Some(e) => Err(e.message),
+        None => Ok(module),
+    }
 }
 
 /// Extract the literal value from a parsed let statement

--- a/wado-compiler/tests/string_templates.rs
+++ b/wado-compiler/tests/string_templates.rs
@@ -14,7 +14,11 @@ fn parse_expr(source: &str) -> Result<wado_compiler::ast::Module, String> {
     let tokens = lexer.tokenize().map_err(|e| e.message)?;
 
     let mut parser = Parser::new(tokens);
-    parser.parse().map_err(|e| e.message)
+    let module = parser.parse();
+    match parser.take_errors().into_iter().next() {
+        Some(e) => Err(e.message),
+        None => Ok(module),
+    }
 }
 
 /// Extract the expression from a parsed let statement

--- a/wado-compiler/tests/string_templates.rs
+++ b/wado-compiler/tests/string_templates.rs
@@ -14,11 +14,7 @@ fn parse_expr(source: &str) -> Result<wado_compiler::ast::Module, String> {
     let tokens = lexer.tokenize().map_err(|e| e.message)?;
 
     let mut parser = Parser::new(tokens);
-    let module = parser.parse();
-    match parser.take_errors().into_iter().next() {
-        Some(e) => Err(e.message),
-        None => Ok(module),
-    }
+    parser.parse_strict().map_err(|e| e.message)
 }
 
 /// Extract the expression from a parsed let statement

--- a/wado-lsp/src/lib.rs
+++ b/wado-lsp/src/lib.rs
@@ -447,7 +447,9 @@ async fn build_semantics<H: CompilerHost>(source: &str, filename: &str, host: &H
         }
     };
     // Report each recovered syntax error, then continue with the partial AST
-    // so position queries resolve in the regions outside the error.
+    // so position queries resolve in the regions outside the error. A
+    // load/bind failure on the partial AST still degrades to
+    // `Semantics::empty()` below; recovery helps only when binding succeeds.
     for e in &parsed.errors {
         host.emit_diagnostic(wado_compiler::parse_error_diagnostic(e, Some(filename)));
     }

--- a/wado-lsp/src/lib.rs
+++ b/wado-lsp/src/lib.rs
@@ -441,10 +441,16 @@ async fn build_semantics<H: CompilerHost>(source: &str, filename: &str, host: &H
     let parsed = match wado_compiler::parse(source) {
         Ok(p) => p,
         Err(e) => {
+            // Lexer failure: no usable AST.
             host.emit_diagnostic(wado_compiler::parse_failure_diagnostic(&e, Some(filename)));
             return Semantics::empty();
         }
     };
+    // Report each recovered syntax error, then continue with the partial AST
+    // so position queries resolve in the regions outside the error.
+    for e in &parsed.errors {
+        host.emit_diagnostic(wado_compiler::parse_error_diagnostic(e, Some(filename)));
+    }
     let invocations = kiln::prepare_invocations(filename, &parsed.ast, host);
     match wado_compiler::load(
         parsed,

--- a/wado-lsp/src/semantic_tokens.rs
+++ b/wado-lsp/src/semantic_tokens.rs
@@ -263,6 +263,8 @@ fn visit_item(spans: &mut TypeSpans, item: &Item) {
         | Item::World(_)
         | Item::Test(_)
         | Item::TupleTypeDecl(_) => {}
+        // Error-recovery placeholder; lexer-level highlighting covers it.
+        Item::Error(_) => {}
     }
 }
 

--- a/wado-lsp/tests/parse_error.rs
+++ b/wado-lsp/tests/parse_error.rs
@@ -1,28 +1,27 @@
-//! Behavior of LSP queries when the entry source fails to lex/parse.
+//! Behavior of LSP queries when the entry source has a syntax error.
 //!
-//! The Wado parser is currently fail-fast (no error-recovery), so a
-//! single syntax error in the entry kills the entry's AST. This file
-//! pins the **current** behavior so we notice when it changes:
+//! The Wado parser is error-recovering: a syntax error no longer discards
+//! the whole module. A single broken item (or a missing brace) is recovered,
+//! and the surrounding well-formed regions still analyze. This file pins that
+//! recovery behavior:
 //!
-//! - `Engine::diagnostics` returns exactly one diagnostic: the
-//!   lex/parse error with span attribution to the entry filename.
-//! - Every position-bearing semantic query (`definition`, `hover`,
-//!   `references`, `document_highlight`) returns `None` / empty
-//!   because the snapshot's `Semantics` is empty.
-//! - `semantic_tokens` still produces lexer-level tokens: highlighting
-//!   degrades gracefully and does not blank out on a typo.
+//! - `Engine::diagnostics` reports at least one parse/lex error, each with
+//!   span attribution to the entry filename.
+//! - Position-bearing semantic queries resolve in the healthy regions on
+//!   either side of the error.
+//! - `semantic_tokens` keeps producing lexer-level tokens.
 //!
-//! See the module doc comment for the planned upgrade path.
+//! A lexer error (not a parse error) is still fail-fast; that path is
+//! exercised elsewhere.
 
 use wado_lsp::test_support::MapHost;
 use wado_lsp::{Diagnostic, Engine, Position, Severity};
 
 const PATH: &str = "/test.wado";
 
-/// Source with a deliberate syntax error: missing `}` after the body
-/// of `f`. Everything around it is well-formed, which (under a
-/// future error-recovery parser) would let semantic queries still
-/// resolve in the surrounding regions.
+/// Source with a deliberate syntax error: `f` is missing its closing `}`
+/// before `g`. Error recovery closes `f`'s body at `fn g` so that `g` parses
+/// as a complete item and `f`'s prefix (`let x`, `return x`) survives.
 const BROKEN_SOURCE: &str = "\
 fn f() -> i32 {
     let x: i32 = 1;
@@ -51,70 +50,63 @@ fn errors(diags: &[Diagnostic]) -> Vec<&Diagnostic> {
         .collect()
 }
 
-/// A lex/parse error on the entry surfaces as exactly one
-/// `Severity::Error` diagnostic, attributed to the entry filename.
+/// A syntax error surfaces as at least one `Severity::Error` diagnostic,
+/// attributed to the entry filename and using the `parse error: …` /
+/// `lexer error: …` wire format the loader emits.
 #[test]
-fn parse_error_emits_one_diagnostic_attributed_to_entry() {
+fn parse_error_emits_diagnostics_attributed_to_entry() {
     futures::executor::block_on(async {
         let (engine, host) = engine_with_broken_source();
         let diags = engine.diagnostics(&uri(), &host).await;
         let errs = errors(&diags);
-        assert_eq!(
-            errs.len(),
-            1,
-            "expected exactly one parse error, got {}: {:#?}",
-            errs.len(),
-            errs
-        );
-        // Diagnostic message uses the "parse error: …" / "lexer error: …"
-        // wire format that the loader emits, so editor pane labels match
-        // what `wado compile` shows for the same input.
         assert!(
-            errs[0].message.starts_with("parse error:")
-                || errs[0].message.starts_with("lexer error:"),
-            "unexpected diagnostic message: {}",
-            errs[0].message,
+            !errs.is_empty(),
+            "expected at least one parse error, got none",
         );
+        for e in &errs {
+            assert!(
+                e.message.starts_with("parse error:") || e.message.starts_with("lexer error:"),
+                "unexpected diagnostic message: {}",
+                e.message,
+            );
+        }
     });
 }
 
-/// With no parse, the snapshot has no AST → every position-bearing
-/// query returns the empty answer. This is the current LSP-as-fail-fast
-/// behavior; a future error-recovery parser should let these resolve
-/// in the surviving regions (see module doc).
+/// With error recovery, semantic queries resolve in the well-formed regions
+/// around the syntax error: both `g` (after the broken brace) and `x` (in
+/// `f`'s surviving prefix) hover/resolve.
 #[test]
-fn position_queries_return_empty_on_parse_error() {
+fn position_queries_resolve_in_healthy_regions() {
     futures::executor::block_on(async {
         let (engine, host) = engine_with_broken_source();
-        let pos = Position {
+
+        // `x` in `let x: i32 = 1;` (line 1, col 8) — inside the recovered
+        // prefix of the brace-less `f`.
+        let x_pos = Position {
             line: 1,
             character: 8,
         };
         assert!(
-            engine.definition(&uri(), pos, &host).await.is_none(),
-            "definition should be None when the entry failed to parse",
+            engine.hover(&uri(), x_pos, &host).await.is_some(),
+            "hover on `x` should resolve in f's surviving prefix",
         );
+
+        // `g` in `fn g() -> i32` (line 4, col 3) — a complete item recovered
+        // after the missing brace.
+        let g_pos = Position {
+            line: 4,
+            character: 3,
+        };
         assert!(
-            engine.hover(&uri(), pos, &host).await.is_none(),
-            "hover should be None when the entry failed to parse",
-        );
-        assert!(
-            engine.references(&uri(), pos, true, &host).await.is_empty(),
-            "references should be empty when the entry failed to parse",
-        );
-        assert!(
-            engine
-                .document_highlight(&uri(), pos, &host)
-                .await
-                .is_empty(),
-            "document_highlight should be empty when the entry failed to parse",
+            engine.hover(&uri(), g_pos, &host).await.is_some(),
+            "hover on `g` should resolve after the recovered brace",
         );
     });
 }
 
 /// Semantic tokens degrade gracefully to lexer-level classification.
-/// Highlighting must keep working even when the parser bails, so users
-/// editing toward a missing brace don't see their colours disappear.
+/// Highlighting must keep working even with a syntax error present.
 #[test]
 fn semantic_tokens_survive_parse_error() {
     let mut engine = Engine::new();
@@ -132,15 +124,15 @@ fn semantic_tokens_survive_parse_error() {
     );
 }
 
-/// Re-opening with a fix recovers all semantic features. Sanity check
-/// that the empty-Semantics path doesn't poison the cache.
+/// Re-opening with a fix recovers all semantic features. Sanity check that
+/// the partial-Semantics path doesn't poison the cache.
 #[test]
 fn fixing_the_parse_error_recovers_semantics() {
     futures::executor::block_on(async {
         let host = MapHost::single(PATH, BROKEN_SOURCE);
         let mut engine = Engine::new();
         engine.open_document(&uri(), BROKEN_SOURCE.to_string());
-        // First query: broken.
+        // First query on the broken source still resolves `x`.
         assert!(
             engine
                 .hover(
@@ -152,7 +144,7 @@ fn fixing_the_parse_error_recovers_semantics() {
                     &host,
                 )
                 .await
-                .is_none(),
+                .is_some(),
         );
 
         // Edit to fix the missing brace.


### PR DESCRIPTION
## Summary

The parser was fail-fast: the first syntax error aborted the whole module and returned no AST, so the LSP could not answer any position query (hover, go-to-definition, references) when a file had even a single typo. This adds panic-mode error recovery so a syntax error in one item no longer discards the rest of the file, and the LSP resolves queries in the regions outside the error.

This is the first increment of the recovery design: item-level and block-boundary recovery. Statement/expression-level placeholder nodes and lexer recovery are deliberately out of scope for a later increment.

## Parser

- `Parser::parse` no longer bails on the first error — it always returns a `Module` and collects every recovered `ParseError` (drained via `take_errors`).
- An unparsable item becomes an `Item::Error` node spanning the skipped tokens; recovery re-syncs to the next item-start token. A broken statement inside a block is skipped (no `Stmt::Error` node yet). Both paths guarantee forward progress, so recovery can never spin.
- `parse_block` closes at a *hard* item keyword (`fn`/`struct`/`impl`/…) on a missing `}`, so a function missing its brace no longer swallows the next item. Contextual keywords (`flags`/`type`), the `test` identifier, and `#include_str(...)` stay valid as statements and do not trip recovery.
- `ParserCheckpoint` captures the error count and `restore` truncates it, so speculative parses that roll back don't leak spurious errors. `AstId` density and comment-trivia lockstep are preserved across recovery.
- Inner attributes are recorded incrementally, so a malformed `#[...]` no longer discards a valid earlier `#[TODO]`.

## Public surface

- `ParseResult` gains `errors`; `parse` only `Err`s on lexer failure now. `ParseResult::into_fail_fast` reproduces the old `CompileError::Parser`, so batch compilation, `wado doc`, and the formatter stay fail-fast on syntax errors with unchanged behavior.
- `ast::Module` carries `has_syntax_errors`, set from the parser's error list, so the signal travels with the AST. `Semantics::is_complete` keys on it (covering block-internal errors that leave no `Item::Error`), keeping batch compilation from treating a partial parse as complete.
- `Parser::parse_strict` consolidates the "parse then require a clean result" pattern used by the stdlib loaders and test helpers.

## LSP

- `build_semantics` (and the `semantics` convenience) emit one diagnostic per recovered syntax error and continue analyzing the partial AST, so position queries resolve outside the error. When binding then fails on the partial AST the result still degrades to `Semantics::empty()`; recovery helps when binding succeeds, which holds for the common cases (missing brace, garbage item).
- `tests/parse_error.rs` is flipped from pinning the old fail-fast behavior to asserting recovery: queries resolve in the healthy regions of a file whose first function is missing its closing brace.

## Tests

New parser unit tests cover multi-error collection, missing-brace survival of the following item, garbage-token termination, block-internal errors leaving no `Item::Error`, speculative-backtrack error isolation, contextual-keyword statements not tripping recovery, `#[TODO]` surviving a later malformed attribute, and a drift guard asserting every `parse_item` keyword is in the recovery sync set.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BgMq41YYhYSJWy5gkm7USp)_