### PR TITLE
test: make WASI filesystem fixtures hermetic to fix flaky dir_ops

### DIFF
--- a/wado-compiler/AGENTS.md
+++ b/wado-compiler/AGENTS.md
@@ -44,12 +44,20 @@ The target world is indicated by the top-level key in the JSON:
 | `trapped`             | `bool`               | Whether the program should trap                             |
 | `compile_error`       | `string`             | Expected compile error (substring match)                    |
 | `skip_os`             | `bool`               | Skip this test under `-Os` (e.g. tests relying on names)    |
-| `preopened_dirs`      | `[string, string][]` | Preopened directories `[host_path, guest_path]`             |
+| `preopened_dirs`      | `[string, string][]` | Preopened dirs `[template, guest_path]` (see note below)    |
 | `allocator`           | `string`             | Override allocator: `"bump"` (default) or `"debug"`         |
 | `wir_expect:Ox`       | `string[]`           | Patterns that must appear in WIR at `-Ox` (substring match) |
 | `wir_not_expect:Ox`   | `string[]`           | Patterns that must NOT appear in WIR at `-Ox`               |
 | `outgoing_mocks`      | `object`             | Mock responses for outgoing HTTP requests (see below)       |
 | `tls_mocks`           | `object`             | Mock responses for `wasi:tls` handshakes (see below)        |
+
+Every `preopened_dirs` entry is backed by a fresh temp directory (deleted when
+the test finishes), keeping filesystem tests hermetic across the parallel
+per-optimization-level runs. The first element is a `template` seeding it:
+
+- `""` — empty scratch directory.
+- a workspace-relative path — copied in as a seed corpus (e.g. binary fixtures
+  that cannot be expressed inline, such as `tests/fixtures/testdata`).
 
 HTTP sub-fields (inside `"wasi:http/service": {...}`):
 

--- a/wado-compiler/tests/e2e.rs
+++ b/wado-compiler/tests/e2e.rs
@@ -144,9 +144,9 @@ struct TestSpec {
     #[serde(default)]
     compile_error: Option<String>,
 
-    /// Preopened directories for WASI filesystem tests.
-    /// Each entry is `[host_path, guest_path]`.
-    /// Paths are relative to the workspace root (cargo test working directory).
+    /// Preopened directories, each `[template, guest_path]`. Every preopen is a
+    /// fresh temp dir (see `prepare_preopened_dirs`). `template` seeds it:
+    /// `""` for empty scratch, or a workspace-relative path to copy in.
     #[serde(default)]
     preopened_dirs: Vec<[String; 2]>,
 
@@ -858,12 +858,9 @@ fn run_normal_test(
         });
         verify_result(&result, spec, test_id);
     } else {
-        // Default: wasi:cli/command
-        let dirs: Vec<(String, String)> = spec
-            .preopened_dirs
-            .iter()
-            .map(|[h, g]| (h.clone(), g.clone()))
-            .collect();
+        // Default: wasi:cli/command. `_temp_dirs` must outlive the run: dropping
+        // a `TempDir` deletes it from disk.
+        let (dirs, _temp_dirs) = prepare_preopened_dirs(&spec.preopened_dirs, test_id);
         let result = common::run_wasm_with_full_options(
             compile_result.wasm,
             &dirs,
@@ -907,6 +904,55 @@ fn run_normal_test(
             );
         }
     }
+}
+
+/// Back each `preopened_dirs` entry with a fresh temp dir so filesystem tests
+/// stay hermetic across the parallel per-optimization-level runs. An empty
+/// `template` yields empty scratch; otherwise it is copied in as a seed corpus.
+/// Returns the `(host, guest)` pairs plus the owning `TempDir` guards, which the
+/// caller must keep alive until the guest finishes.
+fn prepare_preopened_dirs(
+    specs: &[[String; 2]],
+    test_id: &str,
+) -> (Vec<(String, String)>, Vec<tempfile::TempDir>) {
+    let mut dirs = Vec::with_capacity(specs.len());
+    let mut temp_dirs = Vec::with_capacity(specs.len());
+
+    for [template, guest_path] in specs {
+        let temp = tempfile::tempdir()
+            .unwrap_or_else(|e| panic!("[{test_id}] failed to create temp preopen dir: {e}"));
+
+        if !template.is_empty() {
+            copy_dir_recursive(Path::new(template), temp.path()).unwrap_or_else(|e| {
+                panic!("[{test_id}] failed to seed preopen dir from {template:?}: {e}")
+            });
+        }
+
+        dirs.push((
+            temp.path().to_string_lossy().into_owned(),
+            guest_path.clone(),
+        ));
+        temp_dirs.push(temp);
+    }
+
+    (dirs, temp_dirs)
+}
+
+/// Recursively copy the contents of `src` into the existing directory `dst`.
+fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            std::fs::create_dir(&to)?;
+            copy_dir_recursive(&from, &to)?;
+        } else {
+            std::fs::copy(&from, &to)?;
+        }
+    }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------

--- a/wado-compiler/tests/fixtures/wasi_filesystem_append_stream.wado
+++ b/wado-compiler/tests/fixtures/wasi_filesystem_append_stream.wado
@@ -65,6 +65,6 @@ export fn run() with Stdout, Stderr, Preopens {
 
 __DATA__
 {
-    "preopened_dirs": [["tests/fixtures/testdata", "testdata"]],
+    "preopened_dirs": [["", "scratch"]],
     "stdout": "Hello, World!\n"
 }

--- a/wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado
+++ b/wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado
@@ -1,11 +1,13 @@
 // Tests: Descriptor::create_directory_at, read_directory, remove_directory_at
 //
 // Verifies that:
-// - create_directory_at creates a new directory
-// - read_directory lists entries including known files
-// - DirectoryEntry has correct type fields
+// - create_directory_at creates a directory, and returns Exist on a duplicate
+// - read_directory lists exactly the entries the fixture created, with correct
+//   DescriptorType fields
 // - remove_directory_at removes an empty directory
-// - create_directory_at on existing directory returns Exist error
+//
+// Uses an empty scratch preopen so the fixture owns the whole directory and the
+// read_directory expectations can be exact.
 
 use { println, eprintln, Stdout, Stderr } from "core:cli";
 use { Preopens, Descriptor, DescriptorType, DescriptorFlags, PathFlags, OpenFlags, DirectoryEntry } from "wasi:filesystem";
@@ -19,10 +21,27 @@ export fn run() with Stdout, Stderr, Preopens {
 
     let dir = dirs[0].0;
 
-    // Clean up any leftover from previous runs
-    dir.remove_directory_at("test_newdir").wait();
+    // Seed the scratch directory with one regular file so read_directory has a
+    // RegularFile entry to report.
+    let file_result = dir.open_at(
+        PathFlags::none(),
+        "alpha.txt",
+        OpenFlags::Create | OpenFlags::Truncate,
+        DescriptorFlags::Write | DescriptorFlags::Read,
+    ).wait();
+    if let Err(_) = file_result {
+        eprintln("setup: failed to create alpha.txt");
+        return;
+    }
 
-    // Create a new directory
+    // Seed a nested directory so read_directory has a pre-existing Directory entry.
+    let nested_result = dir.create_directory_at("nested").wait();
+    if let Err(_) = nested_result {
+        eprintln("setup: failed to create nested");
+        return;
+    }
+
+    // Create a new directory.
     let mkdir_result = dir.create_directory_at("test_newdir").wait();
     if let Ok(_) = mkdir_result {
         println("create_directory_at: succeeded");
@@ -31,7 +50,7 @@ export fn run() with Stdout, Stderr, Preopens {
         return;
     }
 
-    // Creating the same directory again should fail with Exist
+    // Creating the same directory again should fail with Exist.
     let mkdir_dup = dir.create_directory_at("test_newdir").wait();
     if let Err(err) = mkdir_dup {
         if err matches { Exist } {
@@ -43,11 +62,11 @@ export fn run() with Stdout, Stderr, Preopens {
         eprintln("create_directory_at: duplicate should fail");
     }
 
-    // Read directory entries
+    // Read directory entries. The scratch directory now holds exactly:
+    //   alpha.txt (RegularFile), nested (Directory), test_newdir (Directory).
     let [dir_stream, _done] = dir.read_directory();
-    let mut found_hello = false;
-    let mut found_binary = false;
-    let mut found_subdir = false;
+    let mut found_alpha = false;
+    let mut found_nested = false;
     let mut found_newdir = false;
     let mut entry_count = 0;
 
@@ -55,19 +74,16 @@ export fn run() with Stdout, Stderr, Preopens {
         let entries = dir_stream.read(100);
         for let entry of entries {
             entry_count += 1;
-            if entry.name == "hello.txt" {
-                found_hello = true;
+            if entry.name == "alpha.txt" {
+                found_alpha = true;
                 if entry.type matches { RegularFile } {
-                    println("read_directory: hello.txt is RegularFile (correct)");
+                    println("read_directory: alpha.txt is RegularFile (correct)");
                 }
             }
-            if entry.name == "binary.dat" {
-                found_binary = true;
-            }
-            if entry.name == "subdir" {
-                found_subdir = true;
+            if entry.name == "nested" {
+                found_nested = true;
                 if entry.type matches { Directory } {
-                    println("read_directory: subdir is Directory (correct)");
+                    println("read_directory: nested is Directory (correct)");
                 }
             }
             if entry.name == "test_newdir" {
@@ -81,30 +97,28 @@ export fn run() with Stdout, Stderr, Preopens {
     _done.drop();
     dir_stream.drop();
 
-    if found_hello {
-        println("read_directory: found hello.txt");
+    if found_alpha {
+        println("read_directory: found alpha.txt");
     } else {
-        eprintln("read_directory: missing hello.txt");
+        eprintln("read_directory: missing alpha.txt");
     }
-    if found_binary {
-        println("read_directory: found binary.dat");
+    if found_nested {
+        println("read_directory: found nested");
     } else {
-        eprintln("read_directory: missing binary.dat");
-    }
-    if found_subdir {
-        println("read_directory: found subdir");
-    } else {
-        eprintln("read_directory: missing subdir");
+        eprintln("read_directory: missing nested");
     }
     if found_newdir {
         println("read_directory: found test_newdir");
     } else {
         eprintln("read_directory: missing test_newdir");
     }
+    if entry_count == 3 {
+        println("read_directory: entry count is exactly 3 (correct)");
+    } else {
+        eprintln(`read_directory: unexpected entry count = {entry_count}`);
+    }
 
-    println(`read_directory: total entries = {entry_count}`);
-
-    // Remove the created directory
+    // Remove the created directory.
     let rmdir_result = dir.remove_directory_at("test_newdir").wait();
     if let Ok(_) = rmdir_result {
         println("remove_directory_at: succeeded");
@@ -112,7 +126,7 @@ export fn run() with Stdout, Stderr, Preopens {
         eprintln("remove_directory_at: failed");
     }
 
-    // Verify it's gone
+    // Verify it's gone: removing again should fail.
     let rmdir_again = dir.remove_directory_at("test_newdir").wait();
     if let Err(_) = rmdir_again {
         println("remove_directory_at: already removed (correct)");
@@ -125,15 +139,17 @@ export fn run() with Stdout, Stderr, Preopens {
 
 __DATA__
 {
-    
-    "preopened_dirs": [["tests/fixtures/testdata", "testdata"]],
+    "preopened_dirs": [["", "scratch"]],
     "stdout_contains": [
         "create_directory_at: succeeded",
         "create_directory_at: duplicate returns Exist (correct)",
-        "read_directory: found hello.txt",
-        "read_directory: found binary.dat",
-        "read_directory: found subdir",
+        "read_directory: alpha.txt is RegularFile (correct)",
+        "read_directory: nested is Directory (correct)",
+        "read_directory: test_newdir is Directory (correct)",
+        "read_directory: found alpha.txt",
+        "read_directory: found nested",
         "read_directory: found test_newdir",
+        "read_directory: entry count is exactly 3 (correct)",
         "remove_directory_at: succeeded",
         "remove_directory_at: already removed (correct)",
         "all dir_ops tests passed"

--- a/wado-compiler/tests/fixtures/wasi_filesystem_rename_unlink.wado
+++ b/wado-compiler/tests/fixtures/wasi_filesystem_rename_unlink.wado
@@ -127,7 +127,7 @@ export fn run() with Stdout, Stderr, Preopens {
 
 __DATA__
 {
-    "preopened_dirs": [["tests/fixtures/testdata", "testdata"]],
+    "preopened_dirs": [["", "scratch"]],
     "stdout_contains": [
         "rename: source file created",
         "rename: rename_at succeeded",

--- a/wado-compiler/tests/fixtures/wasi_filesystem_set_times.wado
+++ b/wado-compiler/tests/fixtures/wasi_filesystem_set_times.wado
@@ -94,7 +94,7 @@ export fn run() with Stdout, Stderr, Preopens {
 __DATA__
 {
     
-    "preopened_dirs": [["tests/fixtures/testdata", "testdata"]],
+    "preopened_dirs": [["", "scratch"]],
     "stdout_contains": [
         "set_times: Now/Now succeeded",
         "set_times: access timestamp is set",

--- a/wado-compiler/tests/generated/fixtures/wasi_filesystem_dir_ops.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/wasi_filesystem_dir_ops.wir.wado
@@ -96,21 +96,23 @@ struct tuple//[Stream<wasi:filesystem/types.wado/DirectoryEntry>, Future<core:pr
     mut 1: i32,
 }
 
-struct wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado//__Closure_3 {  // TypeId(10)}
+struct wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado//__Closure_4 {  // TypeId(10)}
 
-struct wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado//__Closure_2 {  // TypeId(11)}
+struct wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado//__Closure_3 {  // TypeId(11)}
 
-array builtin::array<wasi:filesystem/types.wado/DirectoryEntry> (mut ref "wasi:filesystem/types.wado//DirectoryEntry");  // TypeId(12)
+struct wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado//__Closure_2 {  // TypeId(12)}
 
-array builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>> (mut ref "tuple//[Descriptor, String]");  // TypeId(13)
+array builtin::array<wasi:filesystem/types.wado/DirectoryEntry> (mut ref "wasi:filesystem/types.wado//DirectoryEntry");  // TypeId(13)
 
-struct core:prelude/array.wado//ArrayIter<wasi:filesystem/types.wado/DirectoryEntry> {  // TypeId(14)
+array builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>> (mut ref "tuple//[Descriptor, String]");  // TypeId(14)
+
+struct core:prelude/array.wado//ArrayIter<wasi:filesystem/types.wado/DirectoryEntry> {  // TypeId(15)
     mut repr: ref "builtin::array<wasi:filesystem/types.wado/DirectoryEntry>",
     mut used: i32,
     mut index: i32,
 }
 
-struct core:prelude/types.wado//AsyncCall<core:prelude/types.wado/Result<(),wasi:filesystem/types.wado/ErrorCode>> {  // TypeId(15)
+struct core:prelude/types.wado//AsyncCall<core:prelude/types.wado/Result<(),wasi:filesystem/types.wado/ErrorCode>> {  // TypeId(16)
     mut __cm_packed: i32,
     mut __cm_outptr: i32,
     mut __cm_size: i32,
@@ -118,150 +120,190 @@ struct core:prelude/types.wado//AsyncCall<core:prelude/types.wado/Result<(),wasi
     mut __cm_lift: ref struct,
 }
 
-struct core:prelude//Array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>> {  // TypeId(16)
+struct core:prelude/types.wado//AsyncCall<core:prelude/types.wado/Result<wasi:filesystem/types.wado/Descriptor,wasi:filesystem/types.wado/ErrorCode>> {  // TypeId(17)
+    mut __cm_packed: i32,
+    mut __cm_outptr: i32,
+    mut __cm_size: i32,
+    mut __cm_align: i32,
+    mut __cm_lift: ref struct,
+}
+
+variant core:prelude/types.wado//Result<wasi:filesystem/types.wado/Descriptor,wasi:filesystem/types.wado/ErrorCode> {  // TypeId(18)
+    Ok(i32),
+    Err(ref "wasi:filesystem/types.wado//ErrorCode"),
+}
+
+struct core:prelude/types.wado//Result<wasi:filesystem/types.wado/Descriptor,wasi:filesystem/types.wado/ErrorCode>::Ok {  // TypeId(19)
+    discriminant: i32,
+    payload_0: i32,
+}
+
+struct core:prelude/types.wado//Result<wasi:filesystem/types.wado/Descriptor,wasi:filesystem/types.wado/ErrorCode>::Err {  // TypeId(20)
+    discriminant: i32,
+    payload_0: ref "wasi:filesystem/types.wado//ErrorCode",
+}
+
+struct core:prelude//Array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>> {  // TypeId(21)
     mut repr: ref "builtin::array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>",
     mut used: i32,
 }
 
-struct core:prelude//Array<wasi:filesystem/types.wado/DirectoryEntry> {  // TypeId(17)
+struct core:prelude//Array<wasi:filesystem/types.wado/DirectoryEntry> {  // TypeId(22)
     mut repr: ref "builtin::array<wasi:filesystem/types.wado/DirectoryEntry>",
     mut used: i32,
 }
 
-enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(18)
+enum core:prelude/format.wado//enum:Alignment { Left = 0, Center = 1, Right = 2 };  // TypeId(23)
 
-type "functype/$canonical_closure_fn_0" = fn(ref null struct, i32) -> ref null "wasi:filesystem/types.wado//ErrorCode";  // TypeId(19)
+type "functype/$canonical_closure_fn_0" = fn(ref null struct, i32) -> ref "core:prelude/types.wado//Result<wasi:filesystem/types.wado/Descriptor,wasi:filesystem/types.wado/ErrorCode>";  // TypeId(24)
 
-struct canonical//CanonicalClosure_0 {  // TypeId(20)
+struct canonical//CanonicalClosure_0 {  // TypeId(25)
     env: ref null struct,
     func: ref "functype/$canonical_closure_fn_0",
 }
 
-type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(21)
+type "functype/$canonical_closure_fn_1" = fn(ref null struct, i32) -> ref null "wasi:filesystem/types.wado//ErrorCode";  // TypeId(26)
 
-type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(22)
+struct canonical//CanonicalClosure_1 {  // TypeId(27)
+    env: ref null struct,
+    func: ref "functype/$canonical_closure_fn_1",
+}
 
-type "functype//wasi/task-return" = fn(i32);  // TypeId(23)
+type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(28)
 
-type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(24)
+type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(29)
 
-type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(25)
+type "functype//wasi/task-return" = fn(i32);  // TypeId(30)
 
-type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(26)
+type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(31)
 
-type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(27)
+type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(32)
 
-type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(28)
+type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(33)
 
-type "functype//wasi/wasi:cli/Stdout::write_via_stream" = fn(i32) -> i32;  // TypeId(29)
+type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(34)
 
-type "functype//wasi/wasi:filesystem/Preopens::get_directories" = fn(i32);  // TypeId(30)
+type "functype//wasi/wasi:cli/Stderr::write_via_stream" = fn(i32) -> i32;  // TypeId(35)
 
-type "functype//wasi/wasi:filesystem/Descriptor::read_directory" = fn(i32, i32);  // TypeId(31)
+type "functype//wasi/wasi:cli/Stdout::write_via_stream" = fn(i32) -> i32;  // TypeId(36)
 
-type "functype//wasi/wasi:filesystem/Descriptor::create_directory_at" = fn(i32, i32, i32, i32) -> i32;  // TypeId(32)
+type "functype//wasi/wasi:filesystem/Preopens::get_directories" = fn(i32);  // TypeId(37)
 
-type "functype//wasi/wasi:filesystem/Descriptor::remove_directory_at" = fn(i32, i32, i32, i32) -> i32;  // TypeId(33)
+type "functype//wasi/wasi:filesystem/Descriptor::read_directory" = fn(i32, i32);  // TypeId(38)
 
-type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/run" = fn();  // TypeId(34)
+type "functype//wasi/wasi:filesystem/Descriptor::create_directory_at" = fn(i32, i32, i32, i32) -> i32;  // TypeId(39)
 
-type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_binding__Stdout_write_via_stream" = fn(i32) -> i32;  // TypeId(35)
+type "functype//wasi/wasi:filesystem/Descriptor::open_at" = fn(i32, i32) -> i32;  // TypeId(40)
 
-type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_binding__Stderr_write_via_stream" = fn(i32) -> i32;  // TypeId(36)
+type "functype//wasi/wasi:filesystem/Descriptor::remove_directory_at" = fn(i32, i32, i32, i32) -> i32;  // TypeId(41)
 
-type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_binding__Preopens_get_directories" = fn() -> ref "core:prelude//Array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";  // TypeId(37)
+type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/run" = fn();  // TypeId(42)
 
-type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_binding__Descriptor_remove_directory_at" = fn(i32, ref "core:prelude/string.wado//String") -> ref "core:prelude/types.wado//AsyncCall<core:prelude/types.wado/Result<(),wasi:filesystem/types.wado/ErrorCode>>";  // TypeId(38)
+type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_binding__Stdout_write_via_stream" = fn(i32) -> i32;  // TypeId(43)
 
-type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_binding__Descriptor_create_directory_at" = fn(i32, ref "core:prelude/string.wado//String") -> ref "core:prelude/types.wado//AsyncCall<core:prelude/types.wado/Result<(),wasi:filesystem/types.wado/ErrorCode>>";  // TypeId(39)
+type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_binding__Stderr_write_via_stream" = fn(i32) -> i32;  // TypeId(44)
 
-type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_binding__Descriptor_read_directory" = fn(i32) -> ref "tuple//[Stream<wasi:filesystem/types.wado/DirectoryEntry>, Future<core:prelude/types.wado/Result<(),wasi:filesystem/types.wado/ErrorCode>>]";  // TypeId(40)
+type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_binding__Preopens_get_directories" = fn() -> ref "core:prelude//Array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";  // TypeId(45)
 
-type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_lift__Descriptor_remove_directory_at" = fn(i32) -> ref null "wasi:filesystem/types.wado//ErrorCode";  // TypeId(41)
+type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_binding__Descriptor_open_at" = fn(i32, i32, ref "core:prelude/string.wado//String", i32, i32) -> ref "core:prelude/types.wado//AsyncCall<core:prelude/types.wado/Result<wasi:filesystem/types.wado/Descriptor,wasi:filesystem/types.wado/ErrorCode>>";  // TypeId(46)
 
-type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_lift__Descriptor_create_directory_at" = fn(i32) -> ref null "wasi:filesystem/types.wado//ErrorCode";  // TypeId(42)
+type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_binding__Descriptor_create_directory_at" = fn(i32, ref "core:prelude/string.wado//String") -> ref "core:prelude/types.wado//AsyncCall<core:prelude/types.wado/Result<(),wasi:filesystem/types.wado/ErrorCode>>";  // TypeId(47)
 
-type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_export__run" = fn();  // TypeId(43)
+type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_binding__Descriptor_read_directory" = fn(i32) -> ref "tuple//[Stream<wasi:filesystem/types.wado/DirectoryEntry>, Future<core:prelude/types.wado/Result<(),wasi:filesystem/types.wado/ErrorCode>>]";  // TypeId(48)
 
-type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_stream_read_DirectoryEntry" = fn(i32, i32) -> ref "core:prelude//Array<wasi:filesystem/types.wado/DirectoryEntry>";  // TypeId(44)
+type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_binding__Descriptor_remove_directory_at" = fn(i32, ref "core:prelude/string.wado//String") -> ref "core:prelude/types.wado//AsyncCall<core:prelude/types.wado/Result<(),wasi:filesystem/types.wado/ErrorCode>>";  // TypeId(49)
 
-type "functype//core:cli/write_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(45)
+type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_lift__Descriptor_open_at" = fn(i32) -> ref "core:prelude/types.wado//Result<wasi:filesystem/types.wado/Descriptor,wasi:filesystem/types.wado/ErrorCode>";  // TypeId(50)
 
-type "functype//core:cli/println" = fn(ref "core:prelude/string.wado//String");  // TypeId(46)
+type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_lift__Descriptor_create_directory_at" = fn(i32) -> ref null "wasi:filesystem/types.wado//ErrorCode";  // TypeId(51)
 
-type "functype//core:cli/eprintln" = fn(ref "core:prelude/string.wado//String");  // TypeId(47)
+type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_lift__Descriptor_remove_directory_at" = fn(i32) -> ref null "wasi:filesystem/types.wado//ErrorCode";  // TypeId(52)
 
-type "functype//core:internal/memory_to_gc_array" = fn(i32, i32) -> ref builtin::array<u8>;  // TypeId(48)
+type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_export__run" = fn();  // TypeId(53)
 
-type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(49)
+type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_stream_read_DirectoryEntry" = fn(i32, i32) -> ref "core:prelude//Array<wasi:filesystem/types.wado/DirectoryEntry>";  // TypeId(54)
 
-type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(50)
+type "functype//core:cli/write_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(55)
 
-type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(51)
+type "functype//core:cli/println" = fn(ref "core:prelude/string.wado//String");  // TypeId(56)
 
-type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(52)
+type "functype//core:cli/eprintln" = fn(ref "core:prelude/string.wado//String");  // TypeId(57)
 
-type "functype//core:internal/cm_lower_string" = fn(ref "core:prelude/string.wado//String") -> i64;  // TypeId(53)
+type "functype//core:internal/memory_to_gc_array" = fn(i32, i32) -> ref builtin::array<u8>;  // TypeId(58)
 
-type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(54)
+type "functype//core:internal/gc_array_to_memory" = fn(ref builtin::array<u8>, i32, i32);  // TypeId(59)
 
-type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(55)
+type "functype//core:internal/write_string_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(60)
 
-type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(56)
+type "functype//core:internal/log_stderr" = fn(ref "core:prelude/string.wado//String");  // TypeId(61)
 
-type "functype//core:internal/cm_waitable_set_wait" = fn(i32) -> [i32, i32, u32];  // TypeId(57)
+type "functype//core:internal/panic" = fn(ref "core:prelude/string.wado//String");  // TypeId(62)
 
-type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(58)
+type "functype//core:internal/cm_lower_string" = fn(ref "core:prelude/string.wado//String") -> i64;  // TypeId(63)
 
-type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(59)
+type "functype//core:internal/cm_lower_list_u8" = fn(ref builtin::array<u8>, i32) -> i64;  // TypeId(64)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(60)
+type "functype//core:internal/wait_for_blocked" = fn(i32) -> i32;  // TypeId(65)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(61)
+type "functype//core:internal/cm_stream_write_raw_u8" = fn(i32, ref builtin::array<u8>, i32);  // TypeId(66)
 
-type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(62)
+type "functype//core:internal/cm_waitable_set_wait" = fn(i32) -> [i32, i32, u32];  // TypeId(67)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(63)
+type "functype//core:prelude/primitive.wado/count_digits_i64" = fn(i64) -> i32;  // TypeId(68)
 
-type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(64)
+type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref builtin::array<u8>, i32, i64, i32);  // TypeId(69)
 
-type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(65)
+type "functype//core:prelude/primitive.wado/i32::fmt_decimal" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(70)
 
-type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(66)
+type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(71)
 
-type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(67)
+type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(72)
 
-type "functype//core:prelude/array.wado/Array<wasi:filesystem/types.wado/DirectoryEntry>::push" = fn(ref "core:prelude//Array<wasi:filesystem/types.wado/DirectoryEntry>", ref "wasi:filesystem/types.wado//DirectoryEntry");  // TypeId(68)
+type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(73)
 
-type "functype//core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>::push" = fn(ref "core:prelude//Array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>", ref "tuple//[Descriptor, String]");  // TypeId(69)
+type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref builtin::array<u8>, ref builtin::array<u8>, i32) -> bool;  // TypeId(74)
 
-type "functype//core:prelude/array.wado/ArrayIter<wasi:filesystem/types.wado/DirectoryEntry>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<wasi:filesystem/types.wado/DirectoryEntry>") -> ref null "wasi:filesystem/types.wado//DirectoryEntry";  // TypeId(70)
+type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(75)
 
-type "functype//core:prelude/types.wado/AsyncCall<core:prelude/types.wado/Result<(),wasi:filesystem/types.wado/ErrorCode>>::wait" = fn(ref "core:prelude/types.wado//AsyncCall<core:prelude/types.wado/Result<(),wasi:filesystem/types.wado/ErrorCode>>") -> ref null "wasi:filesystem/types.wado//ErrorCode";  // TypeId(71)
+type "functype//core:prelude/format.wado/Formatter::write_char_n" = fn(ref "core:prelude/format.wado//Formatter", char, i32);  // TypeId(76)
 
-type "functype//core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>::grow" = fn(ref "core:prelude//Array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>");  // TypeId(72)
+type "functype//core:prelude/format.wado/Formatter::prepare_int_write" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(77)
 
-type "functype//core:prelude/array.wado/Array<wasi:filesystem/types.wado/DirectoryEntry>::grow" = fn(ref "core:prelude//Array<wasi:filesystem/types.wado/DirectoryEntry>");  // TypeId(73)
+type "functype//core:prelude/array.wado/Array<wasi:filesystem/types.wado/DirectoryEntry>::push" = fn(ref "core:prelude//Array<wasi:filesystem/types.wado/DirectoryEntry>", ref "wasi:filesystem/types.wado//DirectoryEntry");  // TypeId(78)
 
-type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__Closure_2::__call" = fn(i32) -> ref null "wasi:filesystem/types.wado//ErrorCode";  // TypeId(74)
+type "functype//core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>::push" = fn(ref "core:prelude//Array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>", ref "tuple//[Descriptor, String]");  // TypeId(79)
 
-type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__Closure_3::__call" = fn(i32) -> ref null "wasi:filesystem/types.wado//ErrorCode";  // TypeId(75)
+type "functype//core:prelude/array.wado/ArrayIter<wasi:filesystem/types.wado/DirectoryEntry>^Iterator::next" = fn(ref "core:prelude/array.wado//ArrayIter<wasi:filesystem/types.wado/DirectoryEntry>") -> ref null "wasi:filesystem/types.wado//DirectoryEntry";  // TypeId(80)
 
-type "functype//wasi/resource-drop:descriptor" = fn(i32);  // TypeId(76)
+type "functype//core:prelude/types.wado/AsyncCall<core:prelude/types.wado/Result<(),wasi:filesystem/types.wado/ErrorCode>>::wait" = fn(ref "core:prelude/types.wado//AsyncCall<core:prelude/types.wado/Result<(),wasi:filesystem/types.wado/ErrorCode>>") -> ref null "wasi:filesystem/types.wado//ErrorCode";  // TypeId(81)
 
-type "functype//wasi/future-drop-readable:transmission-filesystem" = fn(i32);  // TypeId(77)
+type "functype//core:prelude/types.wado/AsyncCall<core:prelude/types.wado/Result<wasi:filesystem/types.wado/Descriptor,wasi:filesystem/types.wado/ErrorCode>>::wait" = fn(ref "core:prelude/types.wado//AsyncCall<core:prelude/types.wado/Result<wasi:filesystem/types.wado/Descriptor,wasi:filesystem/types.wado/ErrorCode>>") -> ref "core:prelude/types.wado//Result<wasi:filesystem/types.wado/Descriptor,wasi:filesystem/types.wado/ErrorCode>";  // TypeId(82)
 
-type "functype//wasi/stream-drop-readable:directory-entry" = fn(i32);  // TypeId(78)
+type "functype//core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>::grow" = fn(ref "core:prelude//Array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>");  // TypeId(83)
 
-type "functype//wasi/stream-read:directory-entry" = fn(i32, i32, i32) -> i32;  // TypeId(79)
+type "functype//core:prelude/array.wado/Array<wasi:filesystem/types.wado/DirectoryEntry>::grow" = fn(ref "core:prelude//Array<wasi:filesystem/types.wado/DirectoryEntry>");  // TypeId(84)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(80)
+type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__Closure_2::__call" = fn(i32) -> ref "core:prelude/types.wado//Result<wasi:filesystem/types.wado/Descriptor,wasi:filesystem/types.wado/ErrorCode>";  // TypeId(85)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(81)
+type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__Closure_3::__call" = fn(i32) -> ref null "wasi:filesystem/types.wado//ErrorCode";  // TypeId(86)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(82)
+type "functype//wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__Closure_4::__call" = fn(i32) -> ref null "wasi:filesystem/types.wado//ErrorCode";  // TypeId(87)
 
-type "functype//wasi/subtask-drop" = fn(i32);  // TypeId(83)
+type "functype//wasi/resource-drop:descriptor" = fn(i32);  // TypeId(88)
+
+type "functype//wasi/future-drop-readable:transmission-filesystem" = fn(i32);  // TypeId(89)
+
+type "functype//wasi/stream-drop-readable:directory-entry" = fn(i32);  // TypeId(90)
+
+type "functype//wasi/stream-read:directory-entry" = fn(i32, i32, i32) -> i32;  // TypeId(91)
+
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(92)
+
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(93)
+
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(94)
+
+type "functype//wasi/subtask-drop" = fn(i32);  // TypeId(95)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -275,6 +317,7 @@ import fn wasi/wasi:cli/Stdout::write_via_stream from "wasi/wasi:cli/Stdout::wri
 import fn wasi/wasi:filesystem/Preopens::get_directories from "wasi/wasi:filesystem/Preopens::get_directories";
 import fn wasi/wasi:filesystem/Descriptor::read_directory from "wasi/wasi:filesystem/Descriptor::read_directory";
 import fn wasi/wasi:filesystem/Descriptor::create_directory_at from "wasi/wasi:filesystem/Descriptor::create_directory_at";
+import fn wasi/wasi:filesystem/Descriptor::open_at from "wasi/wasi:filesystem/Descriptor::open_at";
 import fn wasi/wasi:filesystem/Descriptor::remove_directory_at from "wasi/wasi:filesystem/Descriptor::remove_directory_at";
 import memory (1) from "mem/memory";
 import fn wasi/resource-drop:descriptor from "wasi/resource-drop:descriptor";
@@ -289,34 +332,37 @@ import fn wasi/subtask-drop from "wasi/subtask-drop";
 fn "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/run"() with Stdout, Stderr, Preopens {
     let dirs: ref "core:prelude//Array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>";
     let dir: i32;
+    let file_result: ref "core:prelude/types.wado//Result<wasi:filesystem/types.wado/Descriptor,wasi:filesystem/types.wado/ErrorCode>";
+    let nested_result: ref null "wasi:filesystem/types.wado//ErrorCode";
     let mkdir_result: ref null "wasi:filesystem/types.wado//ErrorCode";
     let mkdir_dup: ref null "wasi:filesystem/types.wado//ErrorCode";
     let err: ref "wasi:filesystem/types.wado//ErrorCode";
     let dir_stream: i32;
     let _done: i32;
-    let found_hello: bool;
-    let found_binary: bool;
-    let found_subdir: bool;
+    let found_alpha: bool;
+    let found_nested: bool;
     let found_newdir: bool;
     let entry_count: i32;
     let entries: ref "core:prelude//Array<wasi:filesystem/types.wado/DirectoryEntry>";
-    let __iter_13: ref "core:prelude/array.wado//ArrayIter<wasi:filesystem/types.wado/DirectoryEntry>";
+    let __iter_14: ref "core:prelude/array.wado//ArrayIter<wasi:filesystem/types.wado/DirectoryEntry>";
     let entry: ref "wasi:filesystem/types.wado//DirectoryEntry";
     let rmdir_result: ref null "wasi:filesystem/types.wado//ErrorCode";
     let rmdir_again: ref null "wasi:filesystem/types.wado//ErrorCode";
-    let __local_17: ref "core:prelude/string.wado//String";
-    let __local_18: ref "core:prelude/format.wado//Formatter";
+    let __local_18: ref "core:prelude/string.wado//String";
+    let __local_19: ref "core:prelude/format.wado//Formatter";
+    let __drop_v_20: i32;
+    let __drop_v_22: i32;
+    let __drop_v_24: i32;
+    let __drop_v_26: i32;
     let __pattern_temp_0: ref "tuple//[Stream<wasi:filesystem/types.wado/DirectoryEntry>, Future<core:prelude/types.wado/Result<(),wasi:filesystem/types.wado/ErrorCode>>]";
-    let __match_20: ref null "wasi:filesystem/types.wado//DirectoryEntry";
-    let other_27: ref "core:prelude/string.wado//String";
-    let len_a_28: i32;
-    let other_30: ref "core:prelude/string.wado//String";
-    let len_a_31: i32;
-    let other_33: ref "core:prelude/string.wado//String";
-    let len_a_34: i32;
+    let __match_29: ref null "wasi:filesystem/types.wado//DirectoryEntry";
     let other_36: ref "core:prelude/string.wado//String";
     let len_a_37: i32;
-    let self_42: i32;
+    let other_39: ref "core:prelude/string.wado//String";
+    let len_a_40: i32;
+    let other_42: ref "core:prelude/string.wado//String";
+    let len_a_43: i32;
+    let self_48: i32;
     dirs = "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_binding__Preopens_get_directories"();
     if dirs.used == 0 {
         "core:cli/eprintln"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("no preopened directories available"), used: 34 });
@@ -326,12 +372,43 @@ fn "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/run"() with Stdout
         "core:internal/panic"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("index out of bounds"), used: 19 });
         unreachable;
     }; builtin::array_get<ref "tuple//[Descriptor, String]">(dirs.repr, 0).0;
-    drop("core:prelude/types.wado/AsyncCall<core:prelude/types.wado/Result<(),wasi:filesystem/types.wado/ErrorCode>>::wait"("wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_binding__Descriptor_remove_directory_at"(dir, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("test_newdir"), used: 11 })));
+    file_result = "core:prelude/types.wado/AsyncCall<core:prelude/types.wado/Result<wasi:filesystem/types.wado/Descriptor,wasi:filesystem/types.wado/ErrorCode>>::wait"("wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_binding__Descriptor_open_at"(dir, 0, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("alpha.txt"), used: 9 }, 9, 3));
+    if ref.test "core:prelude/types.wado//Result<wasi:filesystem/types.wado/Descriptor,wasi:filesystem/types.wado/ErrorCode>::Err"(file_result) {
+        "core:cli/eprintln"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("setup: failed to create alpha.txt"), used: 33 });
+        if ref.test "core:prelude/types.wado//Result<wasi:filesystem/types.wado/Descriptor,wasi:filesystem/types.wado/ErrorCode>::Ok"(file_result) {
+            __drop_v_20 = ref.cast "core:prelude/types.wado//Result<wasi:filesystem/types.wado/Descriptor,wasi:filesystem/types.wado/ErrorCode>::Ok"(file_result).payload_0;
+            "wasi/resource-drop:descriptor"(__drop_v_20);
+        } else {
+            drop(ref.cast "core:prelude/types.wado//Result<wasi:filesystem/types.wado/Descriptor,wasi:filesystem/types.wado/ErrorCode>::Err"(file_result).payload_0);
+        }
+        "wasi/resource-drop:descriptor"(dir);
+        return;
+    } else {
+    }
+    nested_result = "core:prelude/types.wado/AsyncCall<core:prelude/types.wado/Result<(),wasi:filesystem/types.wado/ErrorCode>>::wait"("wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_binding__Descriptor_create_directory_at"(dir, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("nested"), used: 6 }));
+    if ref.is_null(nested_result) == 0 {
+        "core:cli/eprintln"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("setup: failed to create nested"), used: 30 });
+        if ref.test "core:prelude/types.wado//Result<wasi:filesystem/types.wado/Descriptor,wasi:filesystem/types.wado/ErrorCode>::Ok"(file_result) {
+            __drop_v_22 = ref.cast "core:prelude/types.wado//Result<wasi:filesystem/types.wado/Descriptor,wasi:filesystem/types.wado/ErrorCode>::Ok"(file_result).payload_0;
+            "wasi/resource-drop:descriptor"(__drop_v_22);
+        } else {
+            drop(ref.cast "core:prelude/types.wado//Result<wasi:filesystem/types.wado/Descriptor,wasi:filesystem/types.wado/ErrorCode>::Err"(file_result).payload_0);
+        }
+        "wasi/resource-drop:descriptor"(dir);
+        return;
+    } else {
+    }
     mkdir_result = "core:prelude/types.wado/AsyncCall<core:prelude/types.wado/Result<(),wasi:filesystem/types.wado/ErrorCode>>::wait"("wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_binding__Descriptor_create_directory_at"(dir, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("test_newdir"), used: 11 }));
     if ref.is_null(mkdir_result) {
         "core:cli/println"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("create_directory_at: succeeded"), used: 30 });
     } else {
         "core:cli/eprintln"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("create_directory_at: failed"), used: 27 });
+        if ref.test "core:prelude/types.wado//Result<wasi:filesystem/types.wado/Descriptor,wasi:filesystem/types.wado/ErrorCode>::Ok"(file_result) {
+            __drop_v_24 = ref.cast "core:prelude/types.wado//Result<wasi:filesystem/types.wado/Descriptor,wasi:filesystem/types.wado/ErrorCode>::Ok"(file_result).payload_0;
+            "wasi/resource-drop:descriptor"(__drop_v_24);
+        } else {
+            drop(ref.cast "core:prelude/types.wado//Result<wasi:filesystem/types.wado/Descriptor,wasi:filesystem/types.wado/ErrorCode>::Err"(file_result).payload_0);
+        }
         "wasi/resource-drop:descriptor"(dir);
         return;
     }
@@ -349,103 +426,91 @@ fn "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/run"() with Stdout
     __pattern_temp_0 = "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_binding__Descriptor_read_directory"(dir);
     dir_stream = __pattern_temp_0.0;
     _done = __pattern_temp_0.1;
-    found_hello = 0;
-    found_binary = 0;
-    found_subdir = 0;
+    found_alpha = 0;
+    found_nested = 0;
     found_newdir = 0;
     entry_count = 0;
     entries = "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_stream_read_DirectoryEntry"(dir_stream, 100);
-    __iter_13 = struct.new "core:prelude/array.wado//ArrayIter<wasi:filesystem/types.wado/DirectoryEntry>" { repr: entries.repr, used: entries.used, index: 0 };
-    b5: block {
-        l6: loop {
-            __match_20 = "core:prelude/array.wado/ArrayIter<wasi:filesystem/types.wado/DirectoryEntry>^Iterator::next"(__iter_13);
-            if ref.is_null(__match_20) == 0 {
-                entry = ref.as_non_null(__match_20);
+    __iter_14 = struct.new "core:prelude/array.wado//ArrayIter<wasi:filesystem/types.wado/DirectoryEntry>" { repr: entries.repr, used: entries.used, index: 0 };
+    b10: block {
+        l11: loop {
+            __match_29 = "core:prelude/array.wado/ArrayIter<wasi:filesystem/types.wado/DirectoryEntry>^Iterator::next"(__iter_14);
+            if ref.is_null(__match_29) == 0 {
+                entry = ref.as_non_null(__match_29);
                 entry_count = entry_count + 1;
                 if __inline_String_Eq__eq_5: block -> bool {
-                    other_27 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("hello.txt"), used: 9 };
-                    len_a_28 = entry.name.used;
-                    if len_a_28 != other_27.used {
+                    other_36 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("alpha.txt"), used: 9 };
+                    len_a_37 = entry.name.used;
+                    if len_a_37 != other_36.used {
                         break __inline_String_Eq__eq_5: 0;
                     }
-                    break __inline_String_Eq__eq_5: "core:prelude/string.wado/String^Eq::eq_bytes"(entry.name.repr, other_27.repr, len_a_28);
+                    break __inline_String_Eq__eq_5: "core:prelude/string.wado/String^Eq::eq_bytes"(entry.name.repr, other_36.repr, len_a_37);
                 } {
-                    found_hello = 1;
-                    let __match_scrut_4: ref "wasi:filesystem/types.wado//DescriptorType";
-                    __match_scrut_4 = entry.type;
-                    if __match_scrut_4.discriminant == 5 {
-                        "core:cli/println"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("read_directory: hello.txt is RegularFile (correct)"), used: 50 });
+                    found_alpha = 1;
+                    let __match_scrut_9: ref "wasi:filesystem/types.wado//DescriptorType";
+                    __match_scrut_9 = entry.type;
+                    if __match_scrut_9.discriminant == 5 {
+                        "core:cli/println"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("read_directory: alpha.txt is RegularFile (correct)"), used: 50 });
                     }
                 }
                 if __inline_String_Eq__eq_6: block -> bool {
-                    other_30 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("binary.dat"), used: 10 };
-                    len_a_31 = entry.name.used;
-                    if len_a_31 != other_30.used {
+                    other_39 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("nested"), used: 6 };
+                    len_a_40 = entry.name.used;
+                    if len_a_40 != other_39.used {
                         break __inline_String_Eq__eq_6: 0;
                     }
-                    break __inline_String_Eq__eq_6: "core:prelude/string.wado/String^Eq::eq_bytes"(entry.name.repr, other_30.repr, len_a_31);
+                    break __inline_String_Eq__eq_6: "core:prelude/string.wado/String^Eq::eq_bytes"(entry.name.repr, other_39.repr, len_a_40);
                 } {
-                    found_binary = 1;
+                    found_nested = 1;
+                    let __match_scrut_10: ref "wasi:filesystem/types.wado//DescriptorType";
+                    __match_scrut_10 = entry.type;
+                    if __match_scrut_10.discriminant == 2 {
+                        "core:cli/println"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("read_directory: nested is Directory (correct)"), used: 45 });
+                    }
                 }
                 if __inline_String_Eq__eq_7: block -> bool {
-                    other_33 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("subdir"), used: 6 };
-                    len_a_34 = entry.name.used;
-                    if len_a_34 != other_33.used {
+                    other_42 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("test_newdir"), used: 11 };
+                    len_a_43 = entry.name.used;
+                    if len_a_43 != other_42.used {
                         break __inline_String_Eq__eq_7: 0;
                     }
-                    break __inline_String_Eq__eq_7: "core:prelude/string.wado/String^Eq::eq_bytes"(entry.name.repr, other_33.repr, len_a_34);
-                } {
-                    found_subdir = 1;
-                    let __match_scrut_5: ref "wasi:filesystem/types.wado//DescriptorType";
-                    __match_scrut_5 = entry.type;
-                    if __match_scrut_5.discriminant == 2 {
-                        "core:cli/println"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("read_directory: subdir is Directory (correct)"), used: 45 });
-                    }
-                }
-                if __inline_String_Eq__eq_8: block -> bool {
-                    other_36 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("test_newdir"), used: 11 };
-                    len_a_37 = entry.name.used;
-                    if len_a_37 != other_36.used {
-                        break __inline_String_Eq__eq_8: 0;
-                    }
-                    break __inline_String_Eq__eq_8: "core:prelude/string.wado/String^Eq::eq_bytes"(entry.name.repr, other_36.repr, len_a_37);
+                    break __inline_String_Eq__eq_7: "core:prelude/string.wado/String^Eq::eq_bytes"(entry.name.repr, other_42.repr, len_a_43);
                 } {
                     found_newdir = 1;
-                    let __match_scrut_6: ref "wasi:filesystem/types.wado//DescriptorType";
-                    __match_scrut_6 = entry.type;
-                    if __match_scrut_6.discriminant == 2 {
+                    let __match_scrut_11: ref "wasi:filesystem/types.wado//DescriptorType";
+                    __match_scrut_11 = entry.type;
+                    if __match_scrut_11.discriminant == 2 {
                         "core:cli/println"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("read_directory: test_newdir is Directory (correct)"), used: 50 });
                     }
                 }
             } else {
-                break b5;
+                break b10;
             }
-            continue l6;
+            continue l11;
         };
     };
     "wasi/future-drop-readable:transmission-filesystem"(_done);
     "wasi/stream-drop-readable:directory-entry"(dir_stream);
-    if found_hello {
-        "core:cli/println"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("read_directory: found hello.txt"), used: 31 });
+    if found_alpha {
+        "core:cli/println"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("read_directory: found alpha.txt"), used: 31 });
     } else {
-        "core:cli/eprintln"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("read_directory: missing hello.txt"), used: 33 });
+        "core:cli/eprintln"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("read_directory: missing alpha.txt"), used: 33 });
     }
-    if found_binary {
-        "core:cli/println"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("read_directory: found binary.dat"), used: 32 });
+    if found_nested {
+        "core:cli/println"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("read_directory: found nested"), used: 28 });
     } else {
-        "core:cli/eprintln"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("read_directory: missing binary.dat"), used: 34 });
-    }
-    if found_subdir {
-        "core:cli/println"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("read_directory: found subdir"), used: 28 });
-    } else {
-        "core:cli/eprintln"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("read_directory: missing subdir"), used: 30 });
+        "core:cli/eprintln"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("read_directory: missing nested"), used: 30 });
     }
     if found_newdir {
         "core:cli/println"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("read_directory: found test_newdir"), used: 33 });
     } else {
         "core:cli/eprintln"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("read_directory: missing test_newdir"), used: 35 });
     }
-    "core:cli/println"(__local_17 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(48), used: 0 }; "core:prelude/string.wado/String::push_str"(__local_17, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("read_directory: total entries = "), used: 32 }); __local_18 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_17 }; self_42 = entry_count; "core:prelude/primitive.wado/i32::fmt_decimal"(self_42, __local_18); __local_17);
+    if entry_count == 3 {
+        "core:cli/println"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("read_directory: entry count is exactly 3 (correct)"), used: 50 });
+    } else {
+        "core:cli/eprintln"(__local_18 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(57), used: 0 }; "core:prelude/string.wado/String::push_str"(__local_18, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("read_directory: unexpected entry count = "), used: 41 }); __local_19 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_18 }; self_48 = entry_count; "core:prelude/primitive.wado/i32::fmt_decimal"(self_48, __local_19); __local_18);
+    }
     rmdir_result = "core:prelude/types.wado/AsyncCall<core:prelude/types.wado/Result<(),wasi:filesystem/types.wado/ErrorCode>>::wait"("wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_binding__Descriptor_remove_directory_at"(dir, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("test_newdir"), used: 11 }));
     if ref.is_null(rmdir_result) {
         "core:cli/println"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("remove_directory_at: succeeded"), used: 30 });
@@ -459,6 +524,12 @@ fn "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/run"() with Stdout
         "core:cli/eprintln"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("remove_directory_at: should have failed"), used: 39 });
     }
     "core:cli/println"(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("all dir_ops tests passed"), used: 24 });
+    if ref.test "core:prelude/types.wado//Result<wasi:filesystem/types.wado/Descriptor,wasi:filesystem/types.wado/ErrorCode>::Ok"(file_result) {
+        __drop_v_26 = ref.cast "core:prelude/types.wado//Result<wasi:filesystem/types.wado/Descriptor,wasi:filesystem/types.wado/ErrorCode>::Ok"(file_result).payload_0;
+        "wasi/resource-drop:descriptor"(__drop_v_26);
+    } else {
+        drop(ref.cast "core:prelude/types.wado//Result<wasi:filesystem/types.wado/Descriptor,wasi:filesystem/types.wado/ErrorCode>::Err"(file_result).payload_0);
+    }
     "wasi/resource-drop:descriptor"(dir);
 }
 
@@ -488,10 +559,10 @@ fn "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_binding__Preo
     __count = builtin::load_i32(__outptr + 4);
     __result = struct.new "core:prelude//Array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>" { repr: builtin::array_new<ref "tuple//[Descriptor, String]">(__count), used: 0 };
     __i = 0;
-    b25: block {
-        l26: loop {
+    b29: block {
+        l30: loop {
             if __i >= __count {
-                break b25;
+                break b29;
             }
             __elem_addr = __base + (__i * 12);
             __lifted_result_6 = builtin::load_i32(__elem_addr + 0);
@@ -502,7 +573,7 @@ fn "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_binding__Preo
             "core:prelude/array.wado/Array<core:prelude/types.wado/Tuple<wasi:filesystem/types.wado/Descriptor,core:prelude/string.wado/String>>::push"(__result, struct.new "tuple//[Descriptor, String]" { 0: __lifted_result_6, 1: __lifted_result_7 });
             drop("mem/realloc"(builtin::load_i32(__elem_addr + 4), builtin::load_i32((__elem_addr + 4) + 4), 1, 0));
             __i = __i + 1;
-            continue l26;
+            continue l30;
         };
     };
     if __count > 0 {
@@ -512,14 +583,22 @@ fn "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_binding__Preo
     return __result;
 }
 
-fn "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_binding__Descriptor_remove_directory_at"(self, path) with Descriptor {
+fn "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_binding__Descriptor_open_at"(self, path_flags, path, open_flags, flags) with Descriptor {
     let __path_packed: i64;
     let __async_outptr: i32;
+    let __params_buf: i32;
     let __subtask_packed: i32;
     __path_packed = "core:internal/cm_lower_string"(path);
     __async_outptr = "mem/realloc"(0, 0, 4, 20);
-    __subtask_packed = "wasi/wasi:filesystem/Descriptor::remove_directory_at"(self, builtin::i32_wrap_i64(__path_packed), builtin::i32_wrap_i64(__path_packed >> 32_i64), __async_outptr);
-    return struct.new "core:prelude/types.wado//AsyncCall<core:prelude/types.wado/Result<(),wasi:filesystem/types.wado/ErrorCode>>" { __cm_packed: __subtask_packed, __cm_outptr: __async_outptr, __cm_size: 20, __cm_align: 4, __cm_lift: struct.new "canonical//CanonicalClosure_0" { env: struct.new "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado//__Closure_2" {  }, func: ref.func "closure/wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__closure_wrapper_0" } };
+    __params_buf = "mem/realloc"(0, 0, 4, 20);
+    builtin::store_i32(__params_buf, self);
+    builtin::store_u8(__params_buf + 4, path_flags);
+    builtin::store_i32(__params_buf + 8, builtin::i32_wrap_i64(__path_packed));
+    builtin::store_i32(__params_buf + 12, builtin::i32_wrap_i64(__path_packed >> 32_i64));
+    builtin::store_u8(__params_buf + 16, open_flags);
+    builtin::store_u8(__params_buf + 17, flags);
+    __subtask_packed = "wasi/wasi:filesystem/Descriptor::open_at"(__params_buf, __async_outptr);
+    return struct.new "core:prelude/types.wado//AsyncCall<core:prelude/types.wado/Result<wasi:filesystem/types.wado/Descriptor,wasi:filesystem/types.wado/ErrorCode>>" { __cm_packed: __subtask_packed, __cm_outptr: __async_outptr, __cm_size: 20, __cm_align: 4, __cm_lift: struct.new "canonical//CanonicalClosure_0" { env: struct.new "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado//__Closure_2" {  }, func: ref.func "closure/wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__closure_wrapper_0" } };
 }
 
 fn "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_binding__Descriptor_create_directory_at"(self, path) with Descriptor {
@@ -529,7 +608,7 @@ fn "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_binding__Desc
     __path_packed = "core:internal/cm_lower_string"(path);
     __async_outptr = "mem/realloc"(0, 0, 4, 20);
     __subtask_packed = "wasi/wasi:filesystem/Descriptor::create_directory_at"(self, builtin::i32_wrap_i64(__path_packed), builtin::i32_wrap_i64(__path_packed >> 32_i64), __async_outptr);
-    return struct.new "core:prelude/types.wado//AsyncCall<core:prelude/types.wado/Result<(),wasi:filesystem/types.wado/ErrorCode>>" { __cm_packed: __subtask_packed, __cm_outptr: __async_outptr, __cm_size: 20, __cm_align: 4, __cm_lift: struct.new "canonical//CanonicalClosure_0" { env: struct.new "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado//__Closure_3" {  }, func: ref.func "closure/wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__closure_wrapper_1" } };
+    return struct.new "core:prelude/types.wado//AsyncCall<core:prelude/types.wado/Result<(),wasi:filesystem/types.wado/ErrorCode>>" { __cm_packed: __subtask_packed, __cm_outptr: __async_outptr, __cm_size: 20, __cm_align: 4, __cm_lift: struct.new "canonical//CanonicalClosure_1" { env: struct.new "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado//__Closure_3" {  }, func: ref.func "closure/wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__closure_wrapper_1" } };
 }
 
 fn "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_binding__Descriptor_read_directory"(self) with Descriptor {
@@ -544,7 +623,120 @@ fn "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_binding__Desc
     return struct.new "tuple//[Stream<wasi:filesystem/types.wado/DirectoryEntry>, Future<core:prelude/types.wado/Result<(),wasi:filesystem/types.wado/ErrorCode>>]" { 0: __lifted_result_2, 1: __lifted_result_3 };
 }
 
-fn "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_lift__Descriptor_remove_directory_at"(__outptr) {
+fn "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_binding__Descriptor_remove_directory_at"(self, path) with Descriptor {
+    let __path_packed: i64;
+    let __async_outptr: i32;
+    let __subtask_packed: i32;
+    __path_packed = "core:internal/cm_lower_string"(path);
+    __async_outptr = "mem/realloc"(0, 0, 4, 20);
+    __subtask_packed = "wasi/wasi:filesystem/Descriptor::remove_directory_at"(self, builtin::i32_wrap_i64(__path_packed), builtin::i32_wrap_i64(__path_packed >> 32_i64), __async_outptr);
+    return struct.new "core:prelude/types.wado//AsyncCall<core:prelude/types.wado/Result<(),wasi:filesystem/types.wado/ErrorCode>>" { __cm_packed: __subtask_packed, __cm_outptr: __async_outptr, __cm_size: 20, __cm_align: 4, __cm_lift: struct.new "canonical//CanonicalClosure_1" { env: struct.new "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado//__Closure_4" {  }, func: ref.func "closure/wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__closure_wrapper_2" } };
+}
+
+fn "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_lift__Descriptor_open_at"(__outptr) {
+    let __disc_1: i32;
+    let __result_val: ref "core:prelude/types.wado//Result<wasi:filesystem/types.wado/Descriptor,wasi:filesystem/types.wado/ErrorCode>";
+    let __vdisc: i32;
+    let __vresult: ref "wasi:filesystem/types.wado//ErrorCode";
+    let __disc_5: i32;
+    let __option_result: ref null "core:prelude/string.wado//String";
+    let ptr: i32;
+    let len_8: i32;
+    let arr: ref builtin::array<u8>;
+    __disc_1 = builtin::load_u8(__outptr);
+    __result_val = ref.null none;
+    if __disc_1 == 0 {
+        __result_val = struct.new "core:prelude/types.wado//Result<wasi:filesystem/types.wado/Descriptor,wasi:filesystem/types.wado/ErrorCode>::Ok" { discriminant: 0, payload_0: builtin::load_i32(__outptr + 4) };
+    } else {
+        __vdisc = builtin::load_u8(__outptr + 4);
+        __vresult = ref.null none;
+        if __vdisc == 0 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 0 };
+        } else if __vdisc == 1 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 1 };
+        } else if __vdisc == 2 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 2 };
+        } else if __vdisc == 3 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 3 };
+        } else if __vdisc == 4 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 4 };
+        } else if __vdisc == 5 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 5 };
+        } else if __vdisc == 6 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 6 };
+        } else if __vdisc == 7 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 7 };
+        } else if __vdisc == 8 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 8 };
+        } else if __vdisc == 9 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 9 };
+        } else if __vdisc == 10 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 10 };
+        } else if __vdisc == 11 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 11 };
+        } else if __vdisc == 12 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 12 };
+        } else if __vdisc == 13 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 13 };
+        } else if __vdisc == 14 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 14 };
+        } else if __vdisc == 15 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 15 };
+        } else if __vdisc == 16 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 16 };
+        } else if __vdisc == 17 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 17 };
+        } else if __vdisc == 18 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 18 };
+        } else if __vdisc == 19 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 19 };
+        } else if __vdisc == 20 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 20 };
+        } else if __vdisc == 21 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 21 };
+        } else if __vdisc == 22 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 22 };
+        } else if __vdisc == 23 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 23 };
+        } else if __vdisc == 24 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 24 };
+        } else if __vdisc == 25 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 25 };
+        } else if __vdisc == 26 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 26 };
+        } else if __vdisc == 27 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 27 };
+        } else if __vdisc == 28 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 28 };
+        } else if __vdisc == 29 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 29 };
+        } else if __vdisc == 30 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 30 };
+        } else if __vdisc == 31 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 31 };
+        } else if __vdisc == 32 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 32 };
+        } else if __vdisc == 33 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 33 };
+        } else if __vdisc == 34 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 34 };
+        } else if __vdisc == 35 {
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode" { 35 };
+        } else {
+            __disc_5 = builtin::load_u8((__outptr + 4) + 4);
+            __option_result = ref.null none;
+            if __disc_5 != 0 {
+                __option_result = ref.as_non_null(ptr = builtin::load_i32(((__outptr + 4) + 4) + 4); len_8 = builtin::load_i32((((__outptr + 4) + 4) + 4) + 4); arr = "core:internal/memory_to_gc_array"(ptr, len_8); struct.new "core:prelude/string.wado//String" { repr: arr, used: len_8 });
+                drop("mem/realloc"(builtin::load_i32(((__outptr + 4) + 4) + 4), builtin::load_i32((((__outptr + 4) + 4) + 4) + 4), 1, 0));
+            }
+            __vresult = struct.new "wasi:filesystem/types.wado//ErrorCode::Other" { discriminant: 36, payload_0: __option_result };
+        }
+        __result_val = struct.new "core:prelude/types.wado//Result<wasi:filesystem/types.wado/Descriptor,wasi:filesystem/types.wado/ErrorCode>::Err" { discriminant: 1, payload_0: __vresult };
+    }
+    return __result_val;
+}
+
+fn "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_lift__Descriptor_create_directory_at"(__outptr) {
     let __disc_1: i32;
     let __result_val: ref null "wasi:filesystem/types.wado//ErrorCode";
     let __vdisc: i32;
@@ -647,7 +839,7 @@ fn "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_lift__Descrip
     return __result_val;
 }
 
-fn "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_lift__Descriptor_create_directory_at"(__outptr) {
+fn "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_lift__Descriptor_remove_directory_at"(__outptr) {
     let __disc_1: i32;
     let __result_val: ref null "wasi:filesystem/types.wado//ErrorCode";
     let __vdisc: i32;
@@ -784,10 +976,10 @@ fn "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_stream_read_D
     count = result >> 4;
     arr_6 = struct.new "core:prelude//Array<wasi:filesystem/types.wado/DirectoryEntry>" { repr: builtin::array_new<ref "wasi:filesystem/types.wado//DirectoryEntry">(count), used: 0 };
     i = 0;
-    b106: block {
-        l107: loop {
+    b148: block {
+        l149: loop {
             if i >= count {
-                break b106;
+                break b148;
             }
             addr = ptr_3 + (i * 24);
             __vdisc = builtin::load_u8(addr);
@@ -822,7 +1014,7 @@ fn "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_stream_read_D
             __struct_result = struct.new "wasi:filesystem/types.wado//DirectoryEntry" { type: __vresult, name: __lifted_result_13 };
             "core:prelude/array.wado/Array<wasi:filesystem/types.wado/DirectoryEntry>::push"(arr_6, __struct_result);
             i = i + 1;
-            continue l107;
+            continue l149;
         };
     };
     drop("mem/realloc"(ptr_3, byte_count, 4, 0));
@@ -875,14 +1067,14 @@ fn "core:internal/memory_to_gc_array"(ptr, len) {
     let i: i32;
     arr = builtin::array_new<u8>(len);
     i = 0;
-    b118: block {
-        l119: loop {
+    b160: block {
+        l161: loop {
             if i >= len {
-                break b118;
+                break b160;
             }
             builtin::array_set_u8(arr, i, builtin::load_u8(ptr + i));
             i = i + 1;
-            continue l119;
+            continue l161;
         };
     };
     return arr;
@@ -891,14 +1083,14 @@ fn "core:internal/memory_to_gc_array"(ptr, len) {
 fn "core:internal/gc_array_to_memory"(arr, ptr, len) {
     let i: i32;
     i = 0;
-    b121: block {
-        l122: loop {
+    b163: block {
+        l164: loop {
             if i >= len {
-                break b121;
+                break b163;
             }
             builtin::store_u8(ptr + i, builtin::array_get_u8(arr, i));
             i = i + 1;
-            continue l122;
+            continue l164;
         };
     };
 }
@@ -1005,14 +1197,14 @@ fn "core:prelude/primitive.wado/count_digits_i64"(val) {
     }
     n = 0;
     t = val;
-    b127: block {
-        l128: loop {
+    b169: block {
+        l170: loop {
             if t <= 0_i64 {
-                break b127;
+                break b169;
             }
             n = n + 1;
             t = t / 10_i64;
-            continue l128;
+            continue l170;
         };
     };
     return n;
@@ -1026,15 +1218,15 @@ fn "core:prelude/primitive.wado/write_decimal_digits"(arr, offset, abs_val, digi
         builtin::array_set_u8(arr, offset, 48);
     } else {
         temp = abs_val;
-        b131: block {
-            l132: loop {
+        b173: block {
+            l174: loop {
                 if temp <= 0_i64 {
-                    break b131;
+                    break b173;
                 }
                 pos = pos - 1;
                 builtin::array_set_u8(arr, pos, (48 + builtin::i32_wrap_i64(temp % 10_i64)) & 255);
                 temp = temp / 10_i64;
-                continue l132;
+                continue l174;
             };
         };
     }
@@ -1101,16 +1293,16 @@ fn "core:prelude/string.wado/String::push_str"(self, other) {
 fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     let i: i32;
     i = 0;
-    b138: block {
-        l139: loop {
+    b180: block {
+        l181: loop {
             if i >= len {
-                break b138;
+                break b180;
             }
             if builtin::array_get_u8(a, i) != builtin::array_get_u8(b, i) {
                 return 0;
             }
             i = i + 1;
-            continue l139;
+            continue l181;
         };
     };
     return 1;
@@ -1146,14 +1338,14 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
     let _licm_buf_4: ref "core:prelude/string.wado//String";
     i = 0;
     _licm_buf_4 = self.buf;
-    b146: block {
-        l147: loop {
+    b188: block {
+        l189: loop {
             if i >= n {
-                break b146;
+                break b188;
             }
             "core:prelude/string.wado/String::push"(_licm_buf_4, c);
             i = i + 1;
-            continue l147;
+            continue l189;
         };
     };
 }
@@ -1276,22 +1468,54 @@ fn "core:prelude/types.wado/AsyncCall<core:prelude/types.wado/Result<(),wasi:fil
     if handle_1 != 0 {
         ws_3 = "wasi/waitable-set-new"();
         "wasi/waitable-join"(handle_1, ws_3);
-        b170: block {
-            l171: loop {
+        b212: block {
+            l213: loop {
                 let event_mv_code: i32;
                 let event_mv_handle: i32;
                 let event_mv_payload: u32;
                 multivalue_bind [event_mv_code, event_mv_handle, event_mv_payload] = "core:internal/cm_waitable_set_wait"(ws_3);
                 if event_mv_payload == 2 {
-                    break b170;
+                    break b212;
                 }
-                continue l171;
+                continue l213;
             };
         };
         "wasi/subtask-drop"(handle_1);
         "wasi/waitable-set-drop"(ws_3);
     }
     result = block -> ref null "wasi:filesystem/types.wado//ErrorCode" {
+        let __indirect_call_0: ref "canonical//CanonicalClosure_1";
+        __indirect_call_0 = ref.cast "canonical//CanonicalClosure_1"(self.__cm_lift);
+        call_ref "functype/$canonical_closure_fn_1"(__indirect_call_0.func, __indirect_call_0.env, self.__cm_outptr);
+    };
+    drop("mem/realloc"(self.__cm_outptr, self.__cm_size, self.__cm_align, 0));
+    return result;
+}
+
+fn "core:prelude/types.wado/AsyncCall<core:prelude/types.wado/Result<wasi:filesystem/types.wado/Descriptor,wasi:filesystem/types.wado/ErrorCode>>::wait"(self) {
+    let handle_1: i32;
+    let ws_3: i32;
+    let result: ref "core:prelude/types.wado//Result<wasi:filesystem/types.wado/Descriptor,wasi:filesystem/types.wado/ErrorCode>";
+    handle_1 = self.__cm_packed >> 4;
+    if handle_1 != 0 {
+        ws_3 = "wasi/waitable-set-new"();
+        "wasi/waitable-join"(handle_1, ws_3);
+        b217: block {
+            l218: loop {
+                let event_mv_code: i32;
+                let event_mv_handle: i32;
+                let event_mv_payload: u32;
+                multivalue_bind [event_mv_code, event_mv_handle, event_mv_payload] = "core:internal/cm_waitable_set_wait"(ws_3);
+                if event_mv_payload == 2 {
+                    break b217;
+                }
+                continue l218;
+            };
+        };
+        "wasi/subtask-drop"(handle_1);
+        "wasi/waitable-set-drop"(ws_3);
+    }
+    result = block -> ref "core:prelude/types.wado//Result<wasi:filesystem/types.wado/Descriptor,wasi:filesystem/types.wado/ErrorCode>" {
         let __indirect_call_0: ref "canonical//CanonicalClosure_0";
         __indirect_call_0 = ref.cast "canonical//CanonicalClosure_0"(self.__cm_lift);
         call_ref "functype/$canonical_closure_fn_0"(__indirect_call_0.func, __indirect_call_0.env, self.__cm_outptr);
@@ -1327,11 +1551,15 @@ fn "core:prelude/array.wado/Array<wasi:filesystem/types.wado/DirectoryEntry>::gr
 }
 
 fn "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__Closure_2::__call"(__outptr) {
-    return "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_lift__Descriptor_remove_directory_at"(__outptr);
+    return "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_lift__Descriptor_open_at"(__outptr);
 }
 
 fn "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__Closure_3::__call"(__outptr) {
     return "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_lift__Descriptor_create_directory_at"(__outptr);
+}
+
+fn "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__Closure_4::__call"(__outptr) {
+    return "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_lift__Descriptor_remove_directory_at"(__outptr);
 }
 
 fn "closure/wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__closure_wrapper_0"(__env, __p0) {
@@ -1340,6 +1568,10 @@ fn "closure/wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__closure_
 
 fn "closure/wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__closure_wrapper_1"(__env, __p0) {
     return "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__Closure_3::__call"(__p0);
+}
+
+fn "closure/wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__closure_wrapper_2"(__env, __p0) {
+    return "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__Closure_4::__call"(__p0);
 }
 
 export fn "wado-compiler/tests/fixtures/wasi_filesystem_dir_ops.wado/__cm_export__run" as "run"


### PR DESCRIPTION
## Problem

`fixture_test_o2::wasi_filesystem_dir_ops_wado` was flaky. The same fixture runs once per optimization level **in parallel**, and all WASI filesystem fixtures preopened a single checked-in directory (`tests/fixtures/testdata`) and mutated it (mkdir/rmdir, create/unlink, `Create|Exclusive`, rename). Concurrent level runs raced on that shared on-disk state, so `stdout_contains` assertions intermittently failed. `dir_ops` surfaced it first, but the whole class was at risk.

## Fix

Make the preopen contract hermetic rather than patching one fixture:

- **Harness (`e2e.rs`)**: every `preopened_dirs` entry is now backed by a fresh per-invocation `TempDir`, preopened read-write and dropped at test end. The pair's first element is a `template`: `""` for empty scratch, or a workspace-relative path copied in as an immutable seed corpus. This isolates the whole filesystem-test class with no per-fixture opt-in to forget.
- **`dir_ops` fixture**: rewritten to be self-contained — seeds its own `alpha.txt` + `nested/`, creates `test_newdir`, and asserts the exact 3-entry listing, instead of depending on unrelated seed files.
- **Pure-write fixtures** (`set_times`, `append_stream`, `rename_unlink`): switched to empty scratch.
- Doc updated in `wado-compiler/AGENTS.md`.

## Verification

- `dir_ops` green at all 5 opt levels; 5× stress at 16 threads on the mutating fixtures = 25/25 each time (the previously-racing configuration).
- Full `on-task-done` passed (exit 0): clippy-fix, golden regen, format, `mise run test` (e2e suite 2678 passed / 0 failed), `test-wado` (2933 passed / 0 failed).

https://claude.ai/code/session_01QrSRsZeoQScgzFcvUhNXWn

---
_Generated by [Claude Code](https://claude.ai/code/session_01QrSRsZeoQScgzFcvUhNXWn)_