### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   tagpr:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/wado-lang/wado/security/code-scanning/3](https://github.com/wado-lang/wado/security/code-scanning/3)

Add an explicit `permissions` block to the workflow (or job) to restrict the default `GITHUB_TOKEN` to least privilege.  
Best single fix here: add workflow-level:

- `contents: read`

This satisfies CodeQL’s requirement and preserves current behavior, since write actions in this workflow are done with the GitHub App token, not `GITHUB_TOKEN`.  
Change location: `.github/workflows/tagpr.yml`, near the top-level keys (after `on:` and before `jobs:` is a clean placement).  
No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
