### PR TITLE
Constant object globalization: WEP + recursive emit_const_expr

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -113,3 +113,4 @@ It may include TODOs on WIP.
 - [Unused Diagnostics](./wep-2026-05-16-unused-diagnostics.md)
 - [Resource Ownership and a Resource-Scoped Borrow Checker](./wep-2026-05-21-resource-ownership.md)
 - [Elaborator Re-architecture — TypeSystem / Annotate / Reify](./wep-2026-05-26-elaborator-rearchitecture.md)
+- [Constant Object Globalization](./wep-2026-05-31-const-object-globalization.md)

--- a/docs/wep-2026-04-27-nir-interpreter.md
+++ b/docs/wep-2026-04-27-nir-interpreter.md
@@ -404,6 +404,31 @@ heap-aware return values stay deferred (call them Stage 3.5+).
       compile time without re-implementing every NIR construct, and
       without breaking wasm32 compatibility of `wado-compiler`.
 
+### Stage 6 — aggregate global & field/element projection
+
+Status: planned. Independent of Stages 4-5; builds on Phase C's
+heap-aware [`Value`]. Motivated by
+[Constant Object Globalization](./wep-2026-05-31-const-object-globalization.md),
+which turns read-only constant aggregates into immutable module-scope
+globals and needs `niri` to see through them so the fold cascades.
+
+- [ ] Extend `GlobalEnv` beyond scalar `Lattice`: record immutable
+      aggregate globals (`StructLiteral` / `TupleLiteral` / `ArrayLiteral`
+      / `VariantConstruct` initializers) as a structural snapshot keyed by
+      `(ModuleSource, name)`.
+- [ ] Fold `FieldAccess(GlobalVarGet(G), f)` and
+      `Index(GlobalVarGet(G), const)` to the field/element constant — the
+      global analog of the local `field_env` projection, sharing the same
+      `value_to_expr_kind` leaf-rewrite.
+- [ ] Generalize the local `field_env` to project nested aggregate fields
+      (today scalar `Value` only), reusing Phase C's heap-aware
+      `Value::{Struct, Array, Variant}`.
+- [ ] Loop effect: a globalized constant's field/element reads fold to
+      scalars module-wide → `const_global_promotion` / `const_fold` /
+      `const_branch_prune` reduce further → the now-unread global is removed
+      by DCE. This is the cross-function constant propagation that
+      intra-function SROA cannot reach.
+
 ## Cost model
 
 The in-process engine stays sub-quadratic by following the patterns
@@ -449,8 +474,9 @@ incurs one codegen.
 
 - `const_folding.rs` shrinks to a thin glue file, and stays that way.
 - `niri` covers immutable-global folding through Stage 1's
-  `GlobalEnv`. May further absorb parts of `const_branch_prune` and
-  `inline` — to be evaluated as later stages land.
+  `GlobalEnv` (scalars); Stage 6 extends it to aggregate globals and
+  field/element projection. May further absorb parts of
+  `const_branch_prune` and `inline` — to be evaluated as later stages land.
 - Stage 2.5's match-fold is observable in the NIR optimize phase even
   though `lower_patterns` runs before `optimize`: not every match is
   desugared by `lower_patterns` (some shapes survive to optimize

--- a/docs/wep-2026-05-11-nir.md
+++ b/docs/wep-2026-05-11-nir.md
@@ -381,6 +381,41 @@ Out of scope for this WEP:
 - A short window during the transition where both `FlatPackage` and `NirPackage` flow through downstream code. The Phase 2 adapter absorbs this; Phase 5 removes it.
 - One more `wado dump` mode to maintain.
 
+## Normalization Additions
+
+The subtractive stance above ("not a host for new explicit node kinds")
+bars re-introducing _lowered_ concepts as nodes (a distinct `Alloc` for
+boxing, etc.). It does not bar _normalizing_ nodes that give NIR a more
+analyzable canonical form — which is precisely what "Normalized" names.
+
+### `NirExprKind::ArrayLiteral` (proposed)
+
+Array literals are coerced into `SequenceLiteralBuilder` push sequences
+during elaboration (see [Iterator-Based Literal Coercion](./wep-2026-01-18-iterator-based-literal-coercion.md)),
+so an array constant reaches NIR as imperative `with_capacity` + `push`
+statements; a fixed const-array shape only re-materializes at WIR
+(`collapse_array_push_sequences` → `array.new_fixed`). NIR-level analysis
+of constant arrays is therefore impossible today.
+
+Add `NirExprKind::ArrayLiteral { elements }` plus a collapse that
+recognizes the const builder push-sequence and rewrites it to the literal,
+early in the optimize loop. This is normalization, not a lowered-concept
+re-introduction: it gives constant arrays the same first-class, analyzable
+shape `StructLiteral` / `TupleLiteral` already have. It is shared
+infrastructure, not specific to one pass:
+
+- `cse` can deduplicate identical constant arrays (today it returns `None`
+  for aggregates).
+- `niri` / `const_fold` can fold `Index(ArrayLiteral, const)` to the
+  element.
+- Bounds-check elimination knows the static length.
+- [Constant Object Globalization](./wep-2026-05-31-const-object-globalization.md)
+  can globalize constant arrays and strings.
+
+The WIR `collapse_array_push_sequences` should then share the collapse
+helper or be retired once the NIR `ArrayLiteral` subsumes it. Status:
+proposed; land it with its first consumer.
+
 ## See Also
 
 - [WEP 2026-02-14: Wasm IR (WIR) Layer](./wep-2026-02-14-wir-layer.md) — the precedent for a separately-typed body IR. NIR follows WIR's data-sharing conventions (shared type / symbol identity, independent expression enum).

--- a/docs/wep-2026-05-11-nir.md
+++ b/docs/wep-2026-05-11-nir.md
@@ -36,7 +36,6 @@ The content of this Decision is the type boundary, not a shape redesign:
 ### What NIR Is Not
 
 - Not a redesign. This WEP introduces no new node kinds, removes no variants, and changes no semantic behaviour. Wasm output is bit-identical before and after.
-- Not a host for new explicit node kinds. NIR's direction is subtractive: variants that `lower` eliminates lose their place in NIR, and variants that only `lower`'s input needs lose their place in TIR. Adding new node kinds for lowered concepts (e.g., a distinct `Alloc` node for boxing) is a non-goal — type information and metadata on existing nodes are preferred over new variants.
 - Not a CFG or SSA representation. NIR keeps TIR's tree-structured shape. Wado has no borrow check, and Wasm has structured control flow; the tree shape is appropriate.
 - Not the home for sugar removal. Sugar elimination is `desugar`'s responsibility today, on AST. If `desugar` is later removed, sugar elimination moves to `build_tir` (AST → TIR). Neither path produces sugar that flows into NIR.
 - Not a replacement for FlatPackage. FlatPackage continues to be the pre-lower container; NirPackage is the post-lower container. Both exist after this WEP.
@@ -381,12 +380,12 @@ Out of scope for this WEP:
 - A short window during the transition where both `FlatPackage` and `NirPackage` flow through downstream code. The Phase 2 adapter absorbs this; Phase 5 removes it.
 - One more `wado dump` mode to maintain.
 
-## Normalization Additions
+## Additions
 
-The subtractive stance above ("not a host for new explicit node kinds")
-bars re-introducing _lowered_ concepts as nodes (a distinct `Alloc` for
-boxing, etc.). It does not bar _normalizing_ nodes that give NIR a more
-analyzable canonical form — which is precisely what "Normalized" names.
+NIR's node set is not frozen. The migration landed with no new nodes (a
+scoping constraint for the type-boundary work, now lifted); going forward,
+NIR's expression set may grow when a new node makes its canonical form more
+analyzable.
 
 ### `NirExprKind::ArrayLiteral` (proposed)
 

--- a/docs/wep-2026-05-31-const-object-globalization.md
+++ b/docs/wep-2026-05-31-const-object-globalization.md
@@ -10,11 +10,10 @@ function entry — or every loop iteration — is pure waste.
 The compiler already hoists non-constant user `global` initializers into a
 runtime `__initialize_module` / `__initialize_modules` path, guarded by a single
 `__modules_initialized` flag (see [Global Variables](./wep-2026-01-27-global-variables.md)).
-But the Wasm-instantiation-time path is narrow: `is_constant_initializer`
-(`lower/plan/globals.rs`) only accepts scalar literals, and `emit_const_expr`
-(`codegen/emit.rs`) only emits scalar constants and `ref.null`. Even an
-all-constant struct such as `global ORIGIN: GPoint = GPoint { x: 0, y: 0 }` is
-forced onto the runtime path today.
+But the Wasm-instantiation-time path is narrow: `emit_const_expr`
+(`codegen/emit.rs`) only emits scalar constants and `ref.null`, with a
+`_ => i32_const(0)` fallback. Even an all-constant struct such as
+`global ORIGIN: GPoint = GPoint { x: 0, y: 0 }` is forced onto the runtime path.
 
 Wasm 3.0 GC permits aggregate construction in constant init expressions
 (`struct.new`, `struct.new_default`, `array.new`, `array.new_default`,
@@ -22,63 +21,119 @@ Wasm 3.0 GC permits aggregate construction in constant init expressions
 This lets the engine build constant objects once at instantiation, with no init
 function and no flag check on access.
 
+Today "what counts as a constant init" is duplicated across three layers:
+`is_constant_initializer` (`lower/plan/globals.rs`, TIR plan),
+`translate_global_init` (`wir_build`, NIR→WIR), and `emit_const_expr` (codegen).
+The codegen fallback is also a policy decision that violates the crate principle
+"codegen emits the `Package` as is."
+
 ## Decision
 
 Globalize constant, read-only aggregate values into instantiation-time Wasm
-const globals. Two coordinated changes:
+const globals. Implement at the WIR layer, split into a mechanical codegen
+capability and a single optimizer policy pass.
 
-### 1. Widen constant initialization
+### Layering
 
-Grow the recognizer and emitter together so they agree on what is constant:
+- Capability (codegen). `emit_const_expr` becomes a faithful recursive
+  structural emitter of any const-expressible `WirInstr` tree: scalar consts,
+  `ref.null`, `ref.i31`, `ref.func`, `struct.new`, `array.new_fixed`,
+  `array.new_default`, `array.new_data`. It carries no policy — it emits whatever
+  the optimizer placed in `WirGlobal.init`. The `_ => i32_const(0)` fallback
+  becomes an ICE: a non-const instruction in an init slot is an optimizer bug.
+- Policy (optimizer). One WIR pass owns the decision of what becomes a const
+  global and performs the rewrite. `is_constant_initializer` and
+  `translate_global_init` stay scalar-only; aggregates keep flowing through the
+  existing lazy-init path and are promoted by this pass. The constant-shape
+  recognizer then lives once, over `WirInstr`.
 
-- `is_constant_initializer` accepts struct / array / tuple literals whose fields
-  are recursively constant (extending the existing scalar/cast/neg cases).
-- `emit_const_expr` recurses over the `WirInstr` tree, emitting GC const
-  instructions (`struct.new`, `array.new_fixed`, `array.new_data`, …) for the
-  shapes the recognizer now admits.
+Why WIR, not TIR/NIR. `emit_const_expr` produces `wasm-encoder::ConstExpr`
+bytes — a codegen concern that cannot move up. The transformation cannot live at
+TIR/NIR either: array literals only acquire a hoistable const form
+(`array.new_fixed` / `array.new_data`) after the WIR array passes; at NIR they
+are still `SequenceLiteralBuilder` push sequences. WIR is the first layer where
+struct, array, and string constants share a uniform const-expressible shape, and
+where value-copy elision has already settled which uses are read-only (a
+surviving copy is an explicit `struct.new` reconstruction by WIR time).
 
-This alone upgrades existing all-constant `global` declarations from the runtime
-path to instantiation-time const globals.
+### Constant-aggregate predicate
 
-### 2. Globalize constant body expressions
+A `WirInstr` is a const-init expression iff it is recursively one of: scalar
+const (`I32/I64/F32/F64Const`), `RefNull`, `RefI31(const)`, `RefFunc`,
+`StructNew { fields: all const }`, `ArrayNewFixed { elements: all const }`,
+`ArrayNewDefault { len: const }`, `ArrayNewData { offset/len: const }`.
+Everything else (calls, locals, arithmetic beyond extended-const) is non-const.
+`global.get` is deliberately excluded, so a const init never references another
+global — this avoids the core-Wasm restriction (init may reference only imported
+immutable globals) and any global-ordering constraint.
 
-A new NIR pass (sibling to `const_global_promotion`) hoists constant-shaped
-aggregate expressions out of function bodies:
+### Part 1 — lazy-to-const global demotion
 
-- Candidate: any aggregate expression (named binding or inline literal) whose
-  initializer is recursively constant and effect-free, i.e. expressible as a
-  Wasm const init expression.
-- Safety: every use site must be read-only — no field mutation, no `&mut`, no
-  address-taken / closure capture / store aliasing. This reuses the escape
-  analysis already driving `value_copy_elide` / SROA
-  (`has_field_mutation`, `address_taken_locals`, `stores_aliased_locals`).
-- Rewrite: create a synthetic immutable global, replace each occurrence with
-  `global.get`, and deduplicate identical constants into one global.
+Generalizes `const_global_promotion` to aggregates, at WIR. After the array
+passes run, scan each module init function for `GlobalSet { g, value }` where `g`
+is immutable (not user `global mut`) and `value` satisfies the predicate. Move
+`value` into `WirGlobal.init`, clear `lazy_init`, restore the slot to its
+non-null type, and drop the `GlobalSet`. This upgrades all-constant user globals
+(`GPoint { x: 0, y: 0 }`, constant arrays, constant strings) from runtime
+construction to instantiation-time const globals. This part has no aliasing
+hazard: the global was already a shared singleton; only its construction time
+moves.
 
-The read-only requirement is exactly the condition under which `value_copy` is
-elidable, so the defensive copy on each shared read disappears automatically —
-that elision is the payoff that makes sharing one instance observationally
-identical to per-occurrence construction.
+### Part 2 — body constant globalization
+
+Hoist constant aggregate `WirInstr` trees out of function bodies into fresh
+immutable const globals, replace the occurrence with `global.get`, and
+deduplicate identical trees (keyed by a structural hash).
+
+Soundness. Replacing a fresh allocation with a shared reference is valid only
+when the value is used read-only and does not escape into a context that assumes
+freshness (notably `return`, where the caller treats a call result as fresh and
+adds no defensive copy). Value semantics guarantees every mutating or
+freshness-dependent consumer already carries an explicit copy by WIR time, so the
+remaining hazard is in-place mutation or escape of the hoisted value itself. v1
+restricts candidates to constant aggregates bound to a WIR local that the
+existing read-only / escape analysis (the predicates behind
+`elide_*_struct_locals`) proves is never written, never `&mut`-aliased, and never
+returned or stored. The motivating win — a constant object reconstructed each
+loop iteration — falls out as module-scope LICM. Aggressive cases
+(inline-subexpression hoist, cross-function dedup, escape through value-copied
+call args) are staged follow-ups.
+
+Synthetic globals are named via the `name.rs` mangling utilities, internal
+(non-`pub`, not exported), and immutable.
 
 ### Scope boundary
 
-Values whose construction runs user code (constructor logic, computed values,
-effectful or non-deterministic calls) are not constant expressions and are out
-of scope. Those are loop-invariant runtime values, better served by in-function
-hoisting (`licm`, `tmpl_hoist`) than by module globalization. Because
-instantiation-time const globals carry near-zero init cost, no runtime
-init-function path and no hotness heuristic is needed for the in-scope cases.
+Values whose construction runs user code (constructor logic, computed fields,
+effectful or non-deterministic calls) or references another global are not
+const-init expressions and stay on the runtime path. Those are loop-invariant
+runtime values, served by `licm` / `tmpl_hoist`, not module globalization.
+Because const globals carry near-zero init cost, no per-object init flag and no
+hotness heuristic is needed.
 
 ## Consequences
 
-- Constant objects are allocated once at instantiation instead of per call /
-  per iteration; reads become a bare `global.get` with no flag check.
+- Constant objects are built once at instantiation instead of per call / per
+  iteration; reads become a bare `global.get` with no flag check.
 - Identical constants are pooled into a single global.
-- No per-object init flag and no extension of the runtime
-  `__initialize_modules` path is required for this feature.
+- Codegen stays mechanical: policy moves out of `emit_const_expr`, and the
+  constant-shape recognizer is defined once over `WirInstr`.
+- No per-object init flag and no extension of the runtime `__initialize_modules`
+  path is required.
 - Slightly larger global section and a marginal instantiation-time cost for
-  constants that a given execution may never reach — acceptable given the
-  per-use savings and the absence of any access-time overhead.
-- `emit_const_expr` gains a recursive code path; the recognizer and emitter must
-  stay in lockstep, enforced by E2E `wir_expect` fixtures asserting that
-  globalized constants appear as const globals (not in `__initialize_module`).
+  constants a given execution may never reach — acceptable given the per-use
+  savings and the absence of any access-time overhead.
+- Requires confirming the pinned `wasmparser` / `wasmtime` generation accepts GC
+  aggregate constant init expressions; enforced by E2E `wir_expect` fixtures
+  asserting globalized constants appear as const globals (not in
+  `__initialize_module`).
+
+## TODO
+
+- [ ] Make `emit_const_expr` a recursive structural emitter; turn the fallback
+      into an ICE.
+- [ ] Define the `WirInstr` const-aggregate predicate (single source of truth).
+- [ ] Part 1: lazy-to-const global demotion WIR pass.
+- [ ] Part 2: body constant globalization with read-only / escape gating.
+- [ ] E2E fixtures (`wir_expect` / `wir_not_expect`) for structs, arrays, and
+      strings at each `-Ox`.

--- a/docs/wep-2026-05-31-const-object-globalization.md
+++ b/docs/wep-2026-05-31-const-object-globalization.md
@@ -47,14 +47,31 @@ capability and a single optimizer policy pass.
   existing lazy-init path and are promoted by this pass. The constant-shape
   recognizer then lives once, over `WirInstr`.
 
-Why WIR, not TIR/NIR. `emit_const_expr` produces `wasm-encoder::ConstExpr`
-bytes — a codegen concern that cannot move up. The transformation cannot live at
-TIR/NIR either: array literals only acquire a hoistable const form
-(`array.new_fixed` / `array.new_data`) after the WIR array passes; at NIR they
-are still `SequenceLiteralBuilder` push sequences. WIR is the first layer where
-struct, array, and string constants share a uniform const-expressible shape, and
-where value-copy elision has already settled which uses are read-only (a
-surviving copy is an explicit `struct.new` reconstruction by WIR time).
+Layer choice. The capability (`emit_const_expr`) is a codegen concern and stays
+there. The policy's natural layer is not absolute — it differs by data kind and
+by which judgment is needed:
+
+- Struct / tuple / variant / enum constants are first-class at TIR, and the
+  eager/lazy decision for user globals already lives at TIR
+  (`is_constant_initializer`). This subset can be recognized and globalized from
+  TIR onward.
+- Array and string constants are desugared into `SequenceLiteralBuilder` push
+  sequences during elaboration, so they carry no const-recognizable shape at
+  TIR/NIR; a hoistable const form (`array.new_fixed` / `array.new_data`)
+  re-materializes only after the WIR array passes. Recognizing them earlier
+  would mean re-implementing that collapse.
+- Part 2 read-only / escape precision rises toward WIR: `address_taken_locals`
+  is known at TIR, but `stores_aliased_locals` is populated only during
+  lowering, and value-copies become explicit `struct.new` reconstructions
+  (rather than `$value_copy$T` calls) only after NIR optimization.
+
+WIR is therefore chosen as the single home for the policy: it is the first layer
+where struct, array, and string constants share a uniform const-expressible
+shape and where escape facts are fully materialized. A TIR-rooted variant is
+possible for the struct/tuple/enum subset (by widening `is_constant_initializer`)
+but would not cover arrays/strings and would carry weaker escape precision;
+unifying at WIR via the lazy-init → const-demotion path keeps one recognizer for
+all data kinds.
 
 ### Constant-aggregate predicate
 

--- a/docs/wep-2026-05-31-const-object-globalization.md
+++ b/docs/wep-2026-05-31-const-object-globalization.md
@@ -2,194 +2,132 @@
 
 ## Context
 
-Wado has value semantics: a struct/array/tuple literal constructs a fresh heap
-object every time it is evaluated. When such a literal is constant-shaped (all
-fields are recursively constant) and only read, re-constructing it on every
-function entry — or every loop iteration — is pure waste.
+Wado has value semantics: a struct/array/tuple literal builds a fresh heap object
+every time it is evaluated. A constant-shaped, read-only literal rebuilt on every
+call — or loop iteration — is pure waste.
 
-The compiler already hoists non-constant user `global` initializers into a
-runtime `__initialize_module` / `__initialize_modules` path, guarded by a single
-`__modules_initialized` flag (see [Global Variables](./wep-2026-01-27-global-variables.md)).
-The instantiation-time path is narrow: `emit_const_expr` (`codegen/emit.rs`) only
-emits scalar constants and `ref.null` (with an `_ => i32_const(0)` fallback), so
-even an all-constant struct such as `global ORIGIN: GPoint = GPoint { x: 0, y: 0 }`
-is forced onto the runtime path. Wasm 3.0 GC permits aggregate construction in
-constant init expressions (`struct.new`, `array.new_fixed`, `array.new_data`,
-`ref.i31`, `ref.func`, …), so the engine can build such objects once at
-instantiation with no init function and no flag check on access.
+Two problems block fixing this:
 
-NIR is Wado's primary optimizer, run as a fixed-point loop (`optimize.rs`). Two
-facts make NIR the right home for this work:
-
-- The NIR interpreter (`niri`) already carries a `GlobalEnv` that folds
-  `GlobalVarGet` of an immutable scalar global to its constant value, and a
-  per-function `field_env` that folds `FieldAccess(Local, f)` of a struct literal
-  to the field constant. These two environments are not yet connected for global
-  field access.
-- `const_global_promotion` already demotes a runtime-initialized immutable global
-  to a compile-time constant once its initializer folds to a scalar.
-
-Globalizing a constant at NIR is therefore not merely "allocate once": connected
-to `niri`, it becomes a module-wide constant-propagation source that compounds
-with `const_fold`, `const_global_promotion`, `branch_prune`, and DCE in the same
-fixed-point loop. A WIR placement would be terminal — no fixed point, no `niri` —
-and would forgo all of that.
+- Narrow capability. `emit_const_expr` (`codegen/emit.rs`) emitted only scalar
+  consts and `ref.null` (an `_ => i32.const 0` fallback), so even
+  `global ORIGIN: GPoint = GPoint { x: 0, y: 0 }` could not be an
+  instantiation-time const global — though Wasm 3.0 GC allows `struct.new` /
+  `array.new_fixed` / `array.new_data` / … in constant init expressions.
+- Scattered knowledge (smell). "Is this init a Wasm constant?" is encoded
+  redundantly across `is_constant_initializer` (TIR, `lower/plan`),
+  `translate_global_init` (NIR→WIR), `emit_const_expr` (codegen), and
+  `is_scalar_constant` (`const_global_promotion`). The eager/lazy split is decided
+  prematurely in `lower/plan` (syntactic, pre-optimization), then partially undone
+  by `const_global_promotion` — a guess-lazy-then-recover round trip.
 
 ## Decision
 
-Implement constant object globalization as a NIR optimization pass (plus one
-codegen capability and one `niri` keystone extension).
+Three coordinated changes, plus two enablers owned by other WEPs.
 
-### Layering
+### Capability — recursive `emit_const_expr`
 
-- Capability (codegen, layer-agnostic). `emit_const_expr` becomes a faithful
-  recursive structural emitter of any const-expressible `WirInstr` tree (scalar
-  consts, `ref.null`, `ref.i31`, `ref.func`, `struct.new`, `array.new_fixed`,
-  `array.new_default`, `array.new_data`). The `_ => i32_const(0)` fallback becomes
-  an ICE: a non-const instruction in an init slot is an optimizer bug.
-  `translate_global_init` (NIR→WIR build, today scalar-only → `RefNull`
-  placeholder) gains the matching recursive aggregate translation.
-- Policy (NIR). One shared const-aggregate predicate over `NirExpr`, consumed by
-  Part 1 and Part 2; one `niri` keystone extension. Codegen stays mechanical and
-  holds no policy.
+`emit_const_expr` is a faithful recursive emitter of any const-expressible
+`WirInstr` tree (scalar consts, `ref.null` / `ref.i31` / `ref.func`, `struct.new`
+/ `array.new_fixed` / `array.new_default` / `array.new_data`) via
+`ConstExpr::extended`. The fallback is now an ICE: a non-const instruction in an
+init slot is an optimizer bug. Codegen holds no policy — it emits whatever WIR put
+in the slot.
 
-### Enabler: first-class constant arrays at NIR
+### Global initialization — single boundary classifier
 
-Constant arrays and strings reach NIR as `SequenceLiteralBuilder` push
-sequences, so they carry no const-recognizable shape until WIR. Recognizing
-them needs a first-class `NirExprKind::ArrayLiteral` and a collapse of the const
-push-sequence into it, early in the loop. That addition is shared
-infrastructure, not specific to this feature, and is specified in the
-[NIR Layer WEP](./wep-2026-05-11-nir.md) (Additions). This pass
-depends on it for the array/string cases; struct/tuple/variant/enum constants
-need no enabler (they are already first-class in NIR).
+Make the NIR→WIR boundary the sole authority on eager-vs-lazy, via one function:
 
-### Constant-aggregate predicate
+```
+try_const_init(&NirExpr, ctx) -> Option<WirInstr>
+```
 
-A `NirExpr` is a const-init expression iff it is recursively one of: scalar
-literal (`IntLiteral` / `FloatLiteral` / `BoolLiteral` / `CharLiteral`), `Null`,
-`Unit`, `StringLiteral` / `BytesLiteral`, `ArrayLiteral { all const }`,
-`StructLiteral { all fields const }`, `TupleLiteral { all const }`,
-`VariantConstruct { payload const }`, `EnumConstruct`. Everything else (calls,
-locals, arithmetic beyond extended-const) is non-const. `GlobalVarGet` is
-deliberately excluded, so a const init never references another global — avoiding
-the core-Wasm const-expr restriction (init may reference only imported immutable
-globals) and any global-ordering constraint. Defined once and reused by Part 1,
-Part 2, and `translate_global_init`; `emit_const_expr` mirrors it structurally.
+- NIR carries each global as `{ name, type, init-expr }` and optimizes init
+  expressions in place. NIR has no lazy concept and no `__initialize_module`.
+- `Some(tree)` → eager Wasm const global (Wasm-immutable iff the user wrote
+  `global`, not `global mut`).
+- `None` → lazy: `wir_build` synthesizes the runtime init for the residue only —
+  `__initialize_module` / `__initialize_modules`, the `__modules_initialized`
+  guard, dependency topo-sort, and the entry-point call.
 
-### Part 1 — user-global const-init (generalize `const_global_promotion`)
+This is the de-smell. It removes `is_constant_initializer` (TIR),
+`const_global_promotion` (NIR), and `NirGlobal.{lazy_init, is_nullable}`, and
+relocates `extract` / `build_initialize_modules` from `lower/plan` to `wir_build`.
+`try_const_init`'s `Some` set is the single const predicate; `emit_const_expr`
+mirrors it structurally. It accepts, recursively: scalar literals, `Null`, `Unit`,
+`String` / `Bytes`, `StructLiteral` / `TupleLiteral` / `ArrayLiteral` /
+`VariantConstruct` with const children, and `EnumConstruct`. It excludes
+`GlobalVarGet`, so a const init never references another global — sidestepping the
+core-Wasm const-expr restriction and any init ordering.
 
-Extend `const_global_promotion`'s predicate from `is_scalar_constant` to the
-const-aggregate predicate. The pass already scans `__initialize_module` for
-`GlobalVarSet { g, value }` with a constant `value` and demotes `g` to an
-immutable const-init global, dropping the `GlobalSet`. Generalizing the predicate
-upgrades all-constant user globals (`GPoint { x: 0, y: 0 }`, constant arrays,
-constant strings) from runtime construction to instantiation-time const globals,
-with no new pass. This part has no aliasing hazard: the global was already a
-shared singleton; only its construction time moves. (Arrays require the
-`ArrayLiteral` enabler to be recognized at NIR; the collapse runs earlier in the
-loop, and the fixed point lets the demotion fire on a later iteration.)
+Lazy-ness thus becomes a function of how far NIR-optimize simplified the init,
+decided once. Because globals keep their real init expression (never a premature
+placeholder), `-O0` stays correct and unpessimised: literal inits classify eager,
+unfolded ones (`A + 10`, builder-shaped arrays) lazy — exactly "lazy iff optimize
+could not simplify it."
 
-### Part 2 — body constant globalization (new pass)
+### Body globalization — NIR pass
 
 Hoist constant-aggregate `NirExpr` trees out of function bodies into fresh
-immutable globals, replace each occurrence with `GlobalVarGet`, and deduplicate
-identical trees (structural-hash keyed, across functions).
+immutable globals (named via `name.rs`, internal), replacing each occurrence with
+`GlobalVarGet` and deduplicating identical trees across functions.
 
-Placement: late in the fixed-point loop, after the SROA / scalarization passes
-(`container_sroa`, `sroa`) and `const_fold`, so decomposable constants are
-scalarized away first and only the whole-value residue is hoisted.
+- Placement: late in the fixed-point loop, after `container_sroa` / `sroa` /
+  `const_fold`, so decomposable constants are scalarised away first and only
+  whole-value residue is hoisted.
+- Soundness: sharing one instance for a fresh allocation is valid only when the
+  value is read-only and does not escape into a freshness-assuming context
+  (`return`, store into a longer-lived aggregate). Value semantics already inserts
+  an explicit copy at every mutating consumer, so the residual gate is on the
+  hoisted local itself: not in `address_taken_locals` / `stores_aliased_locals`,
+  `has_field_mutation == false`, never reassigned, not returned or stored. v1
+  targets named `let` bindings.
+- Value: a constant used only via field reads in one function already folds away
+  via `niri`'s `field_env`; the pass targets constants used as whole values,
+  duplicated across functions, or rebuilt in loops — the SROA residue and the
+  loop-invariant-construction hole LICM (field reads only) and `tmpl_hoist`
+  (strings only) miss.
 
-Soundness: replacing a fresh allocation with a shared reference is valid only when
-the value is read-only and does not escape into a freshness-assuming context —
-notably `return` (the caller treats a call result as fresh and adds no defensive
-copy) or a store into a longer-lived aggregate. Value semantics guarantees every
-mutating or freshness-dependent consumer already carries an explicit copy, so the
-residual hazard is in-place mutation or escape of the hoisted value itself. Gate
-with the analyses already present at NIR: the bound local is not in
-`address_taken_locals`, not in `stores_aliased_locals`, has
-`has_field_mutation == false` (`value_copy_elide`'s usage analysis), is never
-reassigned, and is not returned or stored. v1 targets named `let` bindings;
-inline-subexpression hoisting and escape-through-value-copied call arguments are
-staged follow-ups.
+### Enablers (other WEPs)
 
-A constant used only via field reads within a single function is already folded
-away by `niri`'s `field_env`, so it needs no global. Part 2's value is for
-constants used as whole values, duplicated across functions, or built inside
-loops — the SROA residue, plus the loop-invariant-construction hole that LICM
-(field reads only) and `tmpl_hoist` (strings only) do not cover.
-
-Synthetic globals are named via the `name.rs` mangling utilities, internal
-(non-`pub`, not exported), and immutable.
-
-### Keystone — fold aggregate-global access in `niri`
-
-What turns globalization from "allocate once" into a cross-function
-constant-propagation source is `niri` folding `FieldAccess(GlobalVarGet(G), f)`
-and `Index(GlobalVarGet(G), const)` on immutable aggregate globals: globalize →
-fold field/element reads to scalars module-wide → feed `const_global_promotion` /
-`const_fold` / `const_branch_prune` → the now-unread global is removed by DCE,
-leaving propagation that intra-function SROA could never reach. This is a `niri`
-capability, specified as Stage 6 in the
-[niri Evolution WEP](./wep-2026-04-27-nir-interpreter.md). Without it, this pass
-still yields cross-function dedup and loop-invariant-construction hoisting, but
-not the compounding cascade.
-
-### Interaction summary
-
-| Interaction                                                      | Effect                                                    | Basis                                                                   |
-| ---------------------------------------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------- |
-| `niri` `GlobalEnv` + `field_env` connected for aggregate globals | strong positive (new cross-function constant propagation) | infrastructure exists, only unconnected                                 |
-| Loop-invariant _construction_ hoisting                           | strong positive (fills a real hole)                       | LICM hoists field reads only; `tmpl_hoist` is string-only               |
-| Cross-function aggregate dedup                                   | strong positive (new capability)                          | `cse` handles scalars/binary only; aggregates return `None`             |
-| `inline` exposes constant constructions (often into loops)       | positive                                                  | place the pass after `inline` in the loop                               |
-| SROA / scalarization tension                                     | neutral via ordering; self-heals via keystone             | run after SROA; field reads on a mis-hoisted global fold + DCE          |
-| Escape precision                                                 | available at NIR                                          | `address_taken_locals` / `stores_aliased_locals` / `has_field_mutation` |
-
-### Scope boundary
-
-Values whose construction runs user code (constructor logic, computed fields,
-effectful or non-deterministic calls) or that reference another global are not
-const-init expressions and stay on the runtime path, served by `licm` /
-`tmpl_hoist`. Because const globals carry near-zero init cost, no per-object init
-flag and no hotness heuristic is needed.
+- `NirExprKind::ArrayLiteral` + const push-sequence collapse — without it,
+  arrays/strings reach NIR as builder push-sequences and stay lazy until WIR. See
+  [NIR Layer WEP](./wep-2026-05-11-nir.md) (Additions).
+- `niri` folding `G.field` / `G[const]` on immutable aggregate globals — turns
+  globalization into a cross-function constant-propagation source (globalize →
+  fold reads to scalars module-wide → DCE removes the now-unread global). See
+  [niri Evolution WEP](./wep-2026-04-27-nir-interpreter.md) (Stage 6).
 
 ## Consequences
 
-- Constant objects are built once at instantiation; reads become a bare
-  `global.get` with no flag check.
-- With the keystone, aggregate-global fields/elements propagate as module-wide
-  constants and compound in the fixed point; objects frequently fold away
-  entirely, leaving cross-function scalar propagation.
-- Identical constants are pooled into a single global across functions.
-- `NirExprKind::ArrayLiteral` and the NIR collapse benefit CSE, constant-index
-  folding, and bounds-check elimination beyond this feature.
-- Codegen stays mechanical: policy is out of `emit_const_expr` (fallback → ICE),
-  and the constant-shape recognizer is defined once over `NirExpr`.
-- Slightly larger global section and a marginal instantiation-time cost for
-  constants a given execution may never reach — acceptable given the per-use
-  savings and the absence of any access-time overhead.
-- Requires confirming the pinned `wasmparser` / `wasmtime` generation accepts GC
-  aggregate constant init expressions; enforced by E2E `wir_expect` fixtures.
+- Constant objects build once at instantiation; reads are a bare `global.get`,
+  no flag check.
+- The const predicate lives once (`try_const_init`), codegen is mechanical, and
+  the guess-lazy round trip plus three of the four duplicated predicates are gone.
+- With the `niri` enabler, aggregate-global fields/elements propagate as
+  module-wide constants and often fold the object away entirely.
+- Cost: a larger global section and a marginal instantiation-time cost for
+  constants a path may never reach — acceptable given no access-time overhead.
+- Relocating `__initialize_module` synthesis to `wir_build` is the main effort;
+  the existing `global_*` e2e fixtures are the safety net. Requires confirming the
+  pinned `wasmparser` / `wasmtime` accepts GC aggregate const init expressions.
 
 ## TODO
 
-This feature (constant-globalization-specific):
+Feature:
 
-- [ ] `emit_const_expr`: recursive structural emitter; fallback → ICE.
-- [ ] `translate_global_init`: recursive aggregate translation (NIR→WIR).
-- [ ] Shared const-aggregate predicate over `NirExpr`.
-- [ ] Part 1: generalize `const_global_promotion` to aggregates.
-- [ ] Part 2: `const_object_globalization` pass — read-only / escape gating,
-      cross-function dedup, placed after SROA / `const_fold` in the loop.
-- [ ] E2E `wir_expect` / `wir_not_expect` fixtures for structs, arrays, and
-      strings at each `-Ox`; assert const globals (not `__initialize_module`), and
-      that field-fold + DCE removes the global where every use is a field read.
+- [x] `emit_const_expr` recursive emitter; fallback → ICE.
+- [ ] `try_const_init` at the NIR→WIR boundary; relocate `extract` /
+      `build_initialize_modules` to `wir_build`; delete `is_constant_initializer`,
+      `const_global_promotion`, `NirGlobal.{lazy_init, is_nullable}`.
+- [ ] Optimize global init expressions in place during NIR optimize.
+- [ ] `const_object_globalization` NIR pass — read-only / escape gating,
+      cross-function dedup, after SROA / `const_fold`.
+- [ ] E2E `wir_expect` / `wir_not_expect` fixtures (struct / array / string, each
+      `-Ox`): const globals are not in `__initialize_module`; field-fold + DCE
+      removes globals whose every use is a field read.
 
-Cross-cutting infrastructure (owned by other WEPs, blocking the array/string and
-cascade cases here):
+Cross-cutting (other WEPs):
 
-- [ ] `NirExprKind::ArrayLiteral` + NIR push-sequence collapse — see
-      [NIR Layer WEP](./wep-2026-05-11-nir.md) (Additions).
-- [ ] `niri` aggregate `GlobalEnv` + `G.field` / `G[const]` projection — see
+- [ ] `NirExprKind::ArrayLiteral` + collapse — [NIR Layer WEP](./wep-2026-05-11-nir.md).
+- [ ] `niri` aggregate `GlobalEnv` + `G.field` / `G[const]` projection —
       [niri Evolution WEP](./wep-2026-04-27-nir-interpreter.md) (Stage 6).

--- a/docs/wep-2026-05-31-const-object-globalization.md
+++ b/docs/wep-2026-05-31-const-object-globalization.md
@@ -1,0 +1,84 @@
+# WEP: Constant Object Globalization
+
+## Context
+
+Wado has value semantics: a struct/array/tuple literal constructs a fresh heap
+object every time it is evaluated. When such a literal is constant-shaped (all
+fields are recursively constant) and only read, re-constructing it on every
+function entry — or every loop iteration — is pure waste.
+
+The compiler already hoists non-constant user `global` initializers into a
+runtime `__initialize_module` / `__initialize_modules` path, guarded by a single
+`__modules_initialized` flag (see [Global Variables](./wep-2026-01-27-global-variables.md)).
+But the Wasm-instantiation-time path is narrow: `is_constant_initializer`
+(`lower/plan/globals.rs`) only accepts scalar literals, and `emit_const_expr`
+(`codegen/emit.rs`) only emits scalar constants and `ref.null`. Even an
+all-constant struct such as `global ORIGIN: GPoint = GPoint { x: 0, y: 0 }` is
+forced onto the runtime path today.
+
+Wasm 3.0 GC permits aggregate construction in constant init expressions
+(`struct.new`, `struct.new_default`, `array.new`, `array.new_default`,
+`array.new_fixed`, `array.new_data`, `array.new_elem`, `ref.i31`, `ref.func`).
+This lets the engine build constant objects once at instantiation, with no init
+function and no flag check on access.
+
+## Decision
+
+Globalize constant, read-only aggregate values into instantiation-time Wasm
+const globals. Two coordinated changes:
+
+### 1. Widen constant initialization
+
+Grow the recognizer and emitter together so they agree on what is constant:
+
+- `is_constant_initializer` accepts struct / array / tuple literals whose fields
+  are recursively constant (extending the existing scalar/cast/neg cases).
+- `emit_const_expr` recurses over the `WirInstr` tree, emitting GC const
+  instructions (`struct.new`, `array.new_fixed`, `array.new_data`, …) for the
+  shapes the recognizer now admits.
+
+This alone upgrades existing all-constant `global` declarations from the runtime
+path to instantiation-time const globals.
+
+### 2. Globalize constant body expressions
+
+A new NIR pass (sibling to `const_global_promotion`) hoists constant-shaped
+aggregate expressions out of function bodies:
+
+- Candidate: any aggregate expression (named binding or inline literal) whose
+  initializer is recursively constant and effect-free, i.e. expressible as a
+  Wasm const init expression.
+- Safety: every use site must be read-only — no field mutation, no `&mut`, no
+  address-taken / closure capture / store aliasing. This reuses the escape
+  analysis already driving `value_copy_elide` / SROA
+  (`has_field_mutation`, `address_taken_locals`, `stores_aliased_locals`).
+- Rewrite: create a synthetic immutable global, replace each occurrence with
+  `global.get`, and deduplicate identical constants into one global.
+
+The read-only requirement is exactly the condition under which `value_copy` is
+elidable, so the defensive copy on each shared read disappears automatically —
+that elision is the payoff that makes sharing one instance observationally
+identical to per-occurrence construction.
+
+### Scope boundary
+
+Values whose construction runs user code (constructor logic, computed values,
+effectful or non-deterministic calls) are not constant expressions and are out
+of scope. Those are loop-invariant runtime values, better served by in-function
+hoisting (`licm`, `tmpl_hoist`) than by module globalization. Because
+instantiation-time const globals carry near-zero init cost, no runtime
+init-function path and no hotness heuristic is needed for the in-scope cases.
+
+## Consequences
+
+- Constant objects are allocated once at instantiation instead of per call /
+  per iteration; reads become a bare `global.get` with no flag check.
+- Identical constants are pooled into a single global.
+- No per-object init flag and no extension of the runtime
+  `__initialize_modules` path is required for this feature.
+- Slightly larger global section and a marginal instantiation-time cost for
+  constants that a given execution may never reach — acceptable given the
+  per-use savings and the absence of any access-time overhead.
+- `emit_const_expr` gains a recursive code path; the recognizer and emitter must
+  stay in lockstep, enforced by E2E `wir_expect` fixtures asserting that
+  globalized constants appear as const globals (not in `__initialize_module`).

--- a/docs/wep-2026-05-31-const-object-globalization.md
+++ b/docs/wep-2026-05-31-const-object-globalization.md
@@ -55,13 +55,14 @@ codegen capability and one `niri` keystone extension).
 
 ### Enabler: first-class constant arrays at NIR
 
-Add `NirExprKind::ArrayLiteral` and collapse `SequenceLiteralBuilder` push
-sequences into it during NIR optimization (porting WIR's
-`collapse_array_push_sequences` earlier in the pipeline). Without this, arrays and
-strings carry no const-recognizable shape until WIR. The collapse runs early in
-the fixed-point loop (alongside `container_sroa`) so later passes see the literal
-form. This pays off beyond this feature: CSE of arrays, constant-index folding,
-and bounds-check elimination all benefit from a first-class constant array.
+Constant arrays and strings reach NIR as `SequenceLiteralBuilder` push
+sequences, so they carry no const-recognizable shape until WIR. Recognizing
+them needs a first-class `NirExprKind::ArrayLiteral` and a collapse of the const
+push-sequence into it, early in the loop. That addition is shared
+infrastructure, not specific to this feature, and is specified in the
+[NIR Layer WEP](./wep-2026-05-11-nir.md) (Normalization Additions). This pass
+depends on it for the array/string cases; struct/tuple/variant/enum constants
+need no enabler (they are already first-class in NIR).
 
 ### Constant-aggregate predicate
 
@@ -123,17 +124,16 @@ Synthetic globals are named via the `name.rs` mangling utilities, internal
 
 ### Keystone — fold aggregate-global access in `niri`
 
-Extend `niri`'s `GlobalEnv` beyond scalar `Lattice` to carry a structural
-snapshot of immutable aggregate globals, and fold
-`FieldAccess(GlobalVarGet(G), f)` and `Index(GlobalVarGet(G), const)` to the
-field/element constant — mirroring `field_env`'s local folding. This converts
-globalization into a cross-function constant-propagation source: globalize → fold
-field/element reads to scalars module-wide → feed `const_global_promotion` /
-`const_fold` / `branch_prune` → the global often becomes dead and DCE removes it,
-leaving pure scalar propagation that SROA (intra-function) could never achieve
-across function boundaries. Without this keystone, NIR globalization still yields
-cross-function dedup and loop-invariant-construction hoisting, but not the
-compounding cascade.
+What turns globalization from "allocate once" into a cross-function
+constant-propagation source is `niri` folding `FieldAccess(GlobalVarGet(G), f)`
+and `Index(GlobalVarGet(G), const)` on immutable aggregate globals: globalize →
+fold field/element reads to scalars module-wide → feed `const_global_promotion` /
+`const_fold` / `const_branch_prune` → the now-unread global is removed by DCE,
+leaving propagation that intra-function SROA could never reach. This is a `niri`
+capability, specified as Stage 6 in the
+[niri Evolution WEP](./wep-2026-04-27-nir-interpreter.md). Without it, this pass
+still yields cross-function dedup and loop-invariant-construction hoisting, but
+not the compounding cascade.
 
 ### Interaction summary
 
@@ -169,22 +169,27 @@ flag and no hotness heuristic is needed.
 - Slightly larger global section and a marginal instantiation-time cost for
   constants a given execution may never reach — acceptable given the per-use
   savings and the absence of any access-time overhead.
-- The NIR collapse duplicates logic currently in WIR
-  (`collapse_array_push_sequences`); the two should share a helper or the WIR pass
-  should be retired once the NIR `ArrayLiteral` subsumes it.
 - Requires confirming the pinned `wasmparser` / `wasmtime` generation accepts GC
   aggregate constant init expressions; enforced by E2E `wir_expect` fixtures.
 
 ## TODO
 
+This feature (constant-globalization-specific):
+
 - [ ] `emit_const_expr`: recursive structural emitter; fallback → ICE.
 - [ ] `translate_global_init`: recursive aggregate translation (NIR→WIR).
-- [ ] `NirExprKind::ArrayLiteral` + NIR push-sequence collapse (early in the loop).
 - [ ] Shared const-aggregate predicate over `NirExpr`.
 - [ ] Part 1: generalize `const_global_promotion` to aggregates.
 - [ ] Part 2: `const_object_globalization` pass — read-only / escape gating,
       cross-function dedup, placed after SROA / `const_fold` in the loop.
-- [ ] Keystone: `niri` `GlobalEnv` aggregate snapshots; fold `G.field` / `G[const]`.
 - [ ] E2E `wir_expect` / `wir_not_expect` fixtures for structs, arrays, and
       strings at each `-Ox`; assert const globals (not `__initialize_module`), and
       that field-fold + DCE removes the global where every use is a field read.
+
+Cross-cutting infrastructure (owned by other WEPs, blocking the array/string and
+cascade cases here):
+
+- [ ] `NirExprKind::ArrayLiteral` + NIR push-sequence collapse — see
+      [NIR Layer WEP](./wep-2026-05-11-nir.md) (Normalization Additions).
+- [ ] `niri` aggregate `GlobalEnv` + `G.field` / `G[const]` projection — see
+      [niri Evolution WEP](./wep-2026-04-27-nir-interpreter.md) (Stage 6).

--- a/docs/wep-2026-05-31-const-object-globalization.md
+++ b/docs/wep-2026-05-31-const-object-globalization.md
@@ -10,147 +10,181 @@ function entry — or every loop iteration — is pure waste.
 The compiler already hoists non-constant user `global` initializers into a
 runtime `__initialize_module` / `__initialize_modules` path, guarded by a single
 `__modules_initialized` flag (see [Global Variables](./wep-2026-01-27-global-variables.md)).
-But the Wasm-instantiation-time path is narrow: `emit_const_expr`
-(`codegen/emit.rs`) only emits scalar constants and `ref.null`, with a
-`_ => i32_const(0)` fallback. Even an all-constant struct such as
-`global ORIGIN: GPoint = GPoint { x: 0, y: 0 }` is forced onto the runtime path.
+The instantiation-time path is narrow: `emit_const_expr` (`codegen/emit.rs`) only
+emits scalar constants and `ref.null` (with an `_ => i32_const(0)` fallback), so
+even an all-constant struct such as `global ORIGIN: GPoint = GPoint { x: 0, y: 0 }`
+is forced onto the runtime path. Wasm 3.0 GC permits aggregate construction in
+constant init expressions (`struct.new`, `array.new_fixed`, `array.new_data`,
+`ref.i31`, `ref.func`, …), so the engine can build such objects once at
+instantiation with no init function and no flag check on access.
 
-Wasm 3.0 GC permits aggregate construction in constant init expressions
-(`struct.new`, `struct.new_default`, `array.new`, `array.new_default`,
-`array.new_fixed`, `array.new_data`, `array.new_elem`, `ref.i31`, `ref.func`).
-This lets the engine build constant objects once at instantiation, with no init
-function and no flag check on access.
+NIR is Wado's primary optimizer, run as a fixed-point loop (`optimize.rs`). Two
+facts make NIR the right home for this work:
 
-Today "what counts as a constant init" is duplicated across three layers:
-`is_constant_initializer` (`lower/plan/globals.rs`, TIR plan),
-`translate_global_init` (`wir_build`, NIR→WIR), and `emit_const_expr` (codegen).
-The codegen fallback is also a policy decision that violates the crate principle
-"codegen emits the `Package` as is."
+- The NIR interpreter (`niri`) already carries a `GlobalEnv` that folds
+  `GlobalVarGet` of an immutable scalar global to its constant value, and a
+  per-function `field_env` that folds `FieldAccess(Local, f)` of a struct literal
+  to the field constant. These two environments are not yet connected for global
+  field access.
+- `const_global_promotion` already demotes a runtime-initialized immutable global
+  to a compile-time constant once its initializer folds to a scalar.
+
+Globalizing a constant at NIR is therefore not merely "allocate once": connected
+to `niri`, it becomes a module-wide constant-propagation source that compounds
+with `const_fold`, `const_global_promotion`, `branch_prune`, and DCE in the same
+fixed-point loop. A WIR placement would be terminal — no fixed point, no `niri` —
+and would forgo all of that.
 
 ## Decision
 
-Globalize constant, read-only aggregate values into instantiation-time Wasm
-const globals. Implement at the WIR layer, split into a mechanical codegen
-capability and a single optimizer policy pass.
+Implement constant object globalization as a NIR optimization pass (plus one
+codegen capability and one `niri` keystone extension).
 
 ### Layering
 
-- Capability (codegen). `emit_const_expr` becomes a faithful recursive
-  structural emitter of any const-expressible `WirInstr` tree: scalar consts,
-  `ref.null`, `ref.i31`, `ref.func`, `struct.new`, `array.new_fixed`,
-  `array.new_default`, `array.new_data`. It carries no policy — it emits whatever
-  the optimizer placed in `WirGlobal.init`. The `_ => i32_const(0)` fallback
-  becomes an ICE: a non-const instruction in an init slot is an optimizer bug.
-- Policy (optimizer). One WIR pass owns the decision of what becomes a const
-  global and performs the rewrite. `is_constant_initializer` and
-  `translate_global_init` stay scalar-only; aggregates keep flowing through the
-  existing lazy-init path and are promoted by this pass. The constant-shape
-  recognizer then lives once, over `WirInstr`.
+- Capability (codegen, layer-agnostic). `emit_const_expr` becomes a faithful
+  recursive structural emitter of any const-expressible `WirInstr` tree (scalar
+  consts, `ref.null`, `ref.i31`, `ref.func`, `struct.new`, `array.new_fixed`,
+  `array.new_default`, `array.new_data`). The `_ => i32_const(0)` fallback becomes
+  an ICE: a non-const instruction in an init slot is an optimizer bug.
+  `translate_global_init` (NIR→WIR build, today scalar-only → `RefNull`
+  placeholder) gains the matching recursive aggregate translation.
+- Policy (NIR). One shared const-aggregate predicate over `NirExpr`, consumed by
+  Part 1 and Part 2; one `niri` keystone extension. Codegen stays mechanical and
+  holds no policy.
 
-Layer choice. The capability (`emit_const_expr`) is a codegen concern and stays
-there. The policy's natural layer is not absolute — it differs by data kind and
-by which judgment is needed:
+### Enabler: first-class constant arrays at NIR
 
-- Struct / tuple / variant / enum constants are first-class at TIR, and the
-  eager/lazy decision for user globals already lives at TIR
-  (`is_constant_initializer`). This subset can be recognized and globalized from
-  TIR onward.
-- Array and string constants are desugared into `SequenceLiteralBuilder` push
-  sequences during elaboration, so they carry no const-recognizable shape at
-  TIR/NIR; a hoistable const form (`array.new_fixed` / `array.new_data`)
-  re-materializes only after the WIR array passes. Recognizing them earlier
-  would mean re-implementing that collapse.
-- Part 2 read-only / escape precision rises toward WIR: `address_taken_locals`
-  is known at TIR, but `stores_aliased_locals` is populated only during
-  lowering, and value-copies become explicit `struct.new` reconstructions
-  (rather than `$value_copy$T` calls) only after NIR optimization.
-
-WIR is therefore chosen as the single home for the policy: it is the first layer
-where struct, array, and string constants share a uniform const-expressible
-shape and where escape facts are fully materialized. A TIR-rooted variant is
-possible for the struct/tuple/enum subset (by widening `is_constant_initializer`)
-but would not cover arrays/strings and would carry weaker escape precision;
-unifying at WIR via the lazy-init → const-demotion path keeps one recognizer for
-all data kinds.
+Add `NirExprKind::ArrayLiteral` and collapse `SequenceLiteralBuilder` push
+sequences into it during NIR optimization (porting WIR's
+`collapse_array_push_sequences` earlier in the pipeline). Without this, arrays and
+strings carry no const-recognizable shape until WIR. The collapse runs early in
+the fixed-point loop (alongside `container_sroa`) so later passes see the literal
+form. This pays off beyond this feature: CSE of arrays, constant-index folding,
+and bounds-check elimination all benefit from a first-class constant array.
 
 ### Constant-aggregate predicate
 
-A `WirInstr` is a const-init expression iff it is recursively one of: scalar
-const (`I32/I64/F32/F64Const`), `RefNull`, `RefI31(const)`, `RefFunc`,
-`StructNew { fields: all const }`, `ArrayNewFixed { elements: all const }`,
-`ArrayNewDefault { len: const }`, `ArrayNewData { offset/len: const }`.
-Everything else (calls, locals, arithmetic beyond extended-const) is non-const.
-`global.get` is deliberately excluded, so a const init never references another
-global — this avoids the core-Wasm restriction (init may reference only imported
-immutable globals) and any global-ordering constraint.
+A `NirExpr` is a const-init expression iff it is recursively one of: scalar
+literal (`IntLiteral` / `FloatLiteral` / `BoolLiteral` / `CharLiteral`), `Null`,
+`Unit`, `StringLiteral` / `BytesLiteral`, `ArrayLiteral { all const }`,
+`StructLiteral { all fields const }`, `TupleLiteral { all const }`,
+`VariantConstruct { payload const }`, `EnumConstruct`. Everything else (calls,
+locals, arithmetic beyond extended-const) is non-const. `GlobalVarGet` is
+deliberately excluded, so a const init never references another global — avoiding
+the core-Wasm const-expr restriction (init may reference only imported immutable
+globals) and any global-ordering constraint. Defined once and reused by Part 1,
+Part 2, and `translate_global_init`; `emit_const_expr` mirrors it structurally.
 
-### Part 1 — lazy-to-const global demotion
+### Part 1 — user-global const-init (generalize `const_global_promotion`)
 
-Generalizes `const_global_promotion` to aggregates, at WIR. After the array
-passes run, scan each module init function for `GlobalSet { g, value }` where `g`
-is immutable (not user `global mut`) and `value` satisfies the predicate. Move
-`value` into `WirGlobal.init`, clear `lazy_init`, restore the slot to its
-non-null type, and drop the `GlobalSet`. This upgrades all-constant user globals
-(`GPoint { x: 0, y: 0 }`, constant arrays, constant strings) from runtime
-construction to instantiation-time const globals. This part has no aliasing
-hazard: the global was already a shared singleton; only its construction time
-moves.
+Extend `const_global_promotion`'s predicate from `is_scalar_constant` to the
+const-aggregate predicate. The pass already scans `__initialize_module` for
+`GlobalVarSet { g, value }` with a constant `value` and demotes `g` to an
+immutable const-init global, dropping the `GlobalSet`. Generalizing the predicate
+upgrades all-constant user globals (`GPoint { x: 0, y: 0 }`, constant arrays,
+constant strings) from runtime construction to instantiation-time const globals,
+with no new pass. This part has no aliasing hazard: the global was already a
+shared singleton; only its construction time moves. (Arrays require the
+`ArrayLiteral` enabler to be recognized at NIR; the collapse runs earlier in the
+loop, and the fixed point lets the demotion fire on a later iteration.)
 
-### Part 2 — body constant globalization
+### Part 2 — body constant globalization (new pass)
 
-Hoist constant aggregate `WirInstr` trees out of function bodies into fresh
-immutable const globals, replace the occurrence with `global.get`, and
-deduplicate identical trees (keyed by a structural hash).
+Hoist constant-aggregate `NirExpr` trees out of function bodies into fresh
+immutable globals, replace each occurrence with `GlobalVarGet`, and deduplicate
+identical trees (structural-hash keyed, across functions).
 
-Soundness. Replacing a fresh allocation with a shared reference is valid only
-when the value is used read-only and does not escape into a context that assumes
-freshness (notably `return`, where the caller treats a call result as fresh and
-adds no defensive copy). Value semantics guarantees every mutating or
-freshness-dependent consumer already carries an explicit copy by WIR time, so the
-remaining hazard is in-place mutation or escape of the hoisted value itself. v1
-restricts candidates to constant aggregates bound to a WIR local that the
-existing read-only / escape analysis (the predicates behind
-`elide_*_struct_locals`) proves is never written, never `&mut`-aliased, and never
-returned or stored. The motivating win — a constant object reconstructed each
-loop iteration — falls out as module-scope LICM. Aggressive cases
-(inline-subexpression hoist, cross-function dedup, escape through value-copied
-call args) are staged follow-ups.
+Placement: late in the fixed-point loop, after the SROA / scalarization passes
+(`container_sroa`, `sroa`) and `const_fold`, so decomposable constants are
+scalarized away first and only the whole-value residue is hoisted.
+
+Soundness: replacing a fresh allocation with a shared reference is valid only when
+the value is read-only and does not escape into a freshness-assuming context —
+notably `return` (the caller treats a call result as fresh and adds no defensive
+copy) or a store into a longer-lived aggregate. Value semantics guarantees every
+mutating or freshness-dependent consumer already carries an explicit copy, so the
+residual hazard is in-place mutation or escape of the hoisted value itself. Gate
+with the analyses already present at NIR: the bound local is not in
+`address_taken_locals`, not in `stores_aliased_locals`, has
+`has_field_mutation == false` (`value_copy_elide`'s usage analysis), is never
+reassigned, and is not returned or stored. v1 targets named `let` bindings;
+inline-subexpression hoisting and escape-through-value-copied call arguments are
+staged follow-ups.
+
+A constant used only via field reads within a single function is already folded
+away by `niri`'s `field_env`, so it needs no global. Part 2's value is for
+constants used as whole values, duplicated across functions, or built inside
+loops — the SROA residue, plus the loop-invariant-construction hole that LICM
+(field reads only) and `tmpl_hoist` (strings only) do not cover.
 
 Synthetic globals are named via the `name.rs` mangling utilities, internal
 (non-`pub`, not exported), and immutable.
 
+### Keystone — fold aggregate-global access in `niri`
+
+Extend `niri`'s `GlobalEnv` beyond scalar `Lattice` to carry a structural
+snapshot of immutable aggregate globals, and fold
+`FieldAccess(GlobalVarGet(G), f)` and `Index(GlobalVarGet(G), const)` to the
+field/element constant — mirroring `field_env`'s local folding. This converts
+globalization into a cross-function constant-propagation source: globalize → fold
+field/element reads to scalars module-wide → feed `const_global_promotion` /
+`const_fold` / `branch_prune` → the global often becomes dead and DCE removes it,
+leaving pure scalar propagation that SROA (intra-function) could never achieve
+across function boundaries. Without this keystone, NIR globalization still yields
+cross-function dedup and loop-invariant-construction hoisting, but not the
+compounding cascade.
+
+### Interaction summary
+
+| Interaction                                                      | Effect                                                    | Basis                                                                   |
+| ---------------------------------------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `niri` `GlobalEnv` + `field_env` connected for aggregate globals | strong positive (new cross-function constant propagation) | infrastructure exists, only unconnected                                 |
+| Loop-invariant _construction_ hoisting                           | strong positive (fills a real hole)                       | LICM hoists field reads only; `tmpl_hoist` is string-only               |
+| Cross-function aggregate dedup                                   | strong positive (new capability)                          | `cse` handles scalars/binary only; aggregates return `None`             |
+| `inline` exposes constant constructions (often into loops)       | positive                                                  | place the pass after `inline` in the loop                               |
+| SROA / scalarization tension                                     | neutral via ordering; self-heals via keystone             | run after SROA; field reads on a mis-hoisted global fold + DCE          |
+| Escape precision                                                 | available at NIR                                          | `address_taken_locals` / `stores_aliased_locals` / `has_field_mutation` |
+
 ### Scope boundary
 
 Values whose construction runs user code (constructor logic, computed fields,
-effectful or non-deterministic calls) or references another global are not
-const-init expressions and stay on the runtime path. Those are loop-invariant
-runtime values, served by `licm` / `tmpl_hoist`, not module globalization.
-Because const globals carry near-zero init cost, no per-object init flag and no
-hotness heuristic is needed.
+effectful or non-deterministic calls) or that reference another global are not
+const-init expressions and stay on the runtime path, served by `licm` /
+`tmpl_hoist`. Because const globals carry near-zero init cost, no per-object init
+flag and no hotness heuristic is needed.
 
 ## Consequences
 
-- Constant objects are built once at instantiation instead of per call / per
-  iteration; reads become a bare `global.get` with no flag check.
-- Identical constants are pooled into a single global.
-- Codegen stays mechanical: policy moves out of `emit_const_expr`, and the
-  constant-shape recognizer is defined once over `WirInstr`.
-- No per-object init flag and no extension of the runtime `__initialize_modules`
-  path is required.
+- Constant objects are built once at instantiation; reads become a bare
+  `global.get` with no flag check.
+- With the keystone, aggregate-global fields/elements propagate as module-wide
+  constants and compound in the fixed point; objects frequently fold away
+  entirely, leaving cross-function scalar propagation.
+- Identical constants are pooled into a single global across functions.
+- `NirExprKind::ArrayLiteral` and the NIR collapse benefit CSE, constant-index
+  folding, and bounds-check elimination beyond this feature.
+- Codegen stays mechanical: policy is out of `emit_const_expr` (fallback → ICE),
+  and the constant-shape recognizer is defined once over `NirExpr`.
 - Slightly larger global section and a marginal instantiation-time cost for
   constants a given execution may never reach — acceptable given the per-use
   savings and the absence of any access-time overhead.
+- The NIR collapse duplicates logic currently in WIR
+  (`collapse_array_push_sequences`); the two should share a helper or the WIR pass
+  should be retired once the NIR `ArrayLiteral` subsumes it.
 - Requires confirming the pinned `wasmparser` / `wasmtime` generation accepts GC
-  aggregate constant init expressions; enforced by E2E `wir_expect` fixtures
-  asserting globalized constants appear as const globals (not in
-  `__initialize_module`).
+  aggregate constant init expressions; enforced by E2E `wir_expect` fixtures.
 
 ## TODO
 
-- [ ] Make `emit_const_expr` a recursive structural emitter; turn the fallback
-      into an ICE.
-- [ ] Define the `WirInstr` const-aggregate predicate (single source of truth).
-- [ ] Part 1: lazy-to-const global demotion WIR pass.
-- [ ] Part 2: body constant globalization with read-only / escape gating.
-- [ ] E2E fixtures (`wir_expect` / `wir_not_expect`) for structs, arrays, and
-      strings at each `-Ox`.
+- [ ] `emit_const_expr`: recursive structural emitter; fallback → ICE.
+- [ ] `translate_global_init`: recursive aggregate translation (NIR→WIR).
+- [ ] `NirExprKind::ArrayLiteral` + NIR push-sequence collapse (early in the loop).
+- [ ] Shared const-aggregate predicate over `NirExpr`.
+- [ ] Part 1: generalize `const_global_promotion` to aggregates.
+- [ ] Part 2: `const_object_globalization` pass — read-only / escape gating,
+      cross-function dedup, placed after SROA / `const_fold` in the loop.
+- [ ] Keystone: `niri` `GlobalEnv` aggregate snapshots; fold `G.field` / `G[const]`.
+- [ ] E2E `wir_expect` / `wir_not_expect` fixtures for structs, arrays, and
+      strings at each `-Ox`; assert const globals (not `__initialize_module`), and
+      that field-fold + DCE removes the global where every use is a field read.

--- a/docs/wep-2026-05-31-const-object-globalization.md
+++ b/docs/wep-2026-05-31-const-object-globalization.md
@@ -60,7 +60,7 @@ sequences, so they carry no const-recognizable shape until WIR. Recognizing
 them needs a first-class `NirExprKind::ArrayLiteral` and a collapse of the const
 push-sequence into it, early in the loop. That addition is shared
 infrastructure, not specific to this feature, and is specified in the
-[NIR Layer WEP](./wep-2026-05-11-nir.md) (Normalization Additions). This pass
+[NIR Layer WEP](./wep-2026-05-11-nir.md) (Additions). This pass
 depends on it for the array/string cases; struct/tuple/variant/enum constants
 need no enabler (they are already first-class in NIR).
 
@@ -190,6 +190,6 @@ Cross-cutting infrastructure (owned by other WEPs, blocking the array/string and
 cascade cases here):
 
 - [ ] `NirExprKind::ArrayLiteral` + NIR push-sequence collapse — see
-      [NIR Layer WEP](./wep-2026-05-11-nir.md) (Normalization Additions).
+      [NIR Layer WEP](./wep-2026-05-11-nir.md) (Additions).
 - [ ] `niri` aggregate `GlobalEnv` + `G.field` / `G[const]` projection — see
       [niri Evolution WEP](./wep-2026-04-27-nir-interpreter.md) (Stage 6).

--- a/wado-compiler/src/codegen/emit.rs
+++ b/wado-compiler/src/codegen/emit.rs
@@ -2637,16 +2637,79 @@ impl<'a> WirEmitter<'a> {
     }
 
     fn emit_const_expr(&self, instr: &WirInstr) -> ConstExpr {
+        let mut instrs = Vec::new();
+        self.push_const_instrs(instr, &mut instrs);
+        ConstExpr::extended(instrs)
+    }
+
+    /// Recursively lower a constant-expressible `WirInstr` tree into the
+    /// instruction sequence of a Wasm constant init expression. Mirrors the
+    /// aggregate-construction arms of [`Self::emit_instr`]; only instructions
+    /// valid in a Wasm 3.0 GC constant expression are accepted (scalar consts,
+    /// `ref.null` / `ref.i31` / `ref.func`, and `struct.new` / `array.new_fixed`
+    /// / `array.new_default` / `array.new_data`). Anything else reaching an init
+    /// slot is an optimizer bug — a non-const initializer should never be placed
+    /// here — so it ICEs rather than silently miscompiling to `i32.const 0`.
+    fn push_const_instrs<'i>(&'i self, instr: &'i WirInstr, out: &mut Vec<Instruction<'i>>) {
         match instr {
-            WirInstr::I32Const(v) => ConstExpr::i32_const(*v),
-            WirInstr::I64Const(v) => ConstExpr::i64_const(*v),
-            WirInstr::F32Const(v) => ConstExpr::f32_const((*v).into()),
-            WirInstr::F64Const(v) => ConstExpr::f64_const((*v).into()),
-            WirInstr::RefNull { .. } => ConstExpr::ref_null(HeapType::Abstract {
-                shared: false,
-                ty: AbstractHeapType::None,
-            }),
-            _ => ConstExpr::i32_const(0), // fallback
+            WirInstr::I32Const(v) => out.push(Instruction::I32Const(*v)),
+            WirInstr::I64Const(v) => out.push(Instruction::I64Const(*v)),
+            WirInstr::F32Const(v) => out.push(Instruction::F32Const((*v).into())),
+            WirInstr::F64Const(v) => out.push(Instruction::F64Const((*v).into())),
+            WirInstr::RefNull { heap_type } => {
+                out.push(Instruction::RefNull(
+                    self.wir_abstract_heap_to_wasm(heap_type),
+                ));
+            }
+            WirInstr::RefI31(inner) => {
+                self.push_const_instrs(inner, out);
+                out.push(Instruction::RefI31);
+            }
+            WirInstr::RefFunc { func_id } => {
+                out.push(Instruction::RefFunc(
+                    self.resolve_func_index(func_id.index()),
+                ));
+            }
+            WirInstr::StructNew { type_id, fields } => {
+                for field in fields {
+                    self.push_const_instrs(field, out);
+                }
+                out.push(Instruction::StructNew(
+                    self.resolve_type_index(type_id.index()),
+                ));
+            }
+            WirInstr::ArrayNewFixed { type_id, elements } => {
+                for elem in elements {
+                    self.push_const_instrs(elem, out);
+                }
+                out.push(Instruction::ArrayNewFixed {
+                    array_type_index: self.resolve_type_index(type_id.index()),
+                    array_size: u32::try_from(elements.len()).unwrap(),
+                });
+            }
+            WirInstr::ArrayNewDefault { type_id, len } => {
+                self.push_const_instrs(len, out);
+                out.push(Instruction::ArrayNewDefault(
+                    self.resolve_type_index(type_id.index()),
+                ));
+            }
+            WirInstr::ArrayNewData {
+                type_id,
+                data_index,
+                offset,
+                len,
+            } => {
+                self.push_const_instrs(offset, out);
+                self.push_const_instrs(len, out);
+                out.push(Instruction::ArrayNewData {
+                    array_type_index: self.resolve_type_index(type_id.index()),
+                    array_data_index: *data_index,
+                });
+            }
+            other => panic!(
+                "non-const instruction in global initializer: {other:?}; \
+                 a non-const init is an optimizer bug"
+            ),
         }
     }
 
@@ -2871,5 +2934,94 @@ impl<'a> WirEmitter<'a> {
         instr.for_each_child(&mut |child| {
             self.scan_ref_func_instr(child, indices);
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::emit_core_module;
+    use crate::hashmap::{IndexMap, IndexSet};
+    use crate::wir::{
+        WirComponent, WirField, WirGlobal, WirInstr, WirMeta, WirName, WirNames, WirPackage,
+        WirStructType, WirType, WirTypeDef, WirTypeId,
+    };
+    use std::rc::Rc;
+
+    fn empty_package() -> WirPackage {
+        WirPackage {
+            types: Vec::new(),
+            imports: Vec::new(),
+            functions: Vec::new(),
+            globals: Vec::new(),
+            exports: Vec::new(),
+            elements: Vec::new(),
+            memories: Vec::new(),
+            data: Vec::new(),
+            names: WirNames::default(),
+            component: WirComponent::default(),
+            variant_case_info: IndexMap::default(),
+            wasm_modules: IndexMap::default(),
+            dead_type_indices: IndexSet::default(),
+            dead_func_indices: IndexSet::default(),
+            dead_global_indices: IndexSet::default(),
+            needed_canonicals: IndexSet::default(),
+            defined_func_base: 0,
+        }
+    }
+
+    fn validate(bytes: &[u8]) -> Result<(), String> {
+        let mut v = wasmparser::Validator::new_with_features(wasmparser::WasmFeatures::all());
+        v.validate_all(bytes).map(|_| ()).map_err(|e| e.to_string())
+    }
+
+    /// A global whose initializer is a constant `struct.new` must be emitted as
+    /// a Wasm GC constant init expression — not the scalar `i32.const 0`
+    /// fallback, which leaves the `(ref $P)` global's init ill-typed.
+    #[test]
+    fn const_struct_global_init_validates() {
+        let tid = WirTypeId::new(0, Rc::from("test//P"));
+        let struct_ty = WirStructType {
+            name: WirName {
+                fq: "test//P".to_string(),
+            },
+            fields: vec![
+                WirField {
+                    name: "x".to_string(),
+                    ty: WirType::I32,
+                    mutable: false,
+                },
+                WirField {
+                    name: "y".to_string(),
+                    ty: WirType::I32,
+                    mutable: false,
+                },
+            ],
+            meta: WirMeta::default(),
+            generic_origin: None,
+            newtype_origin: None,
+            supertype: None,
+        };
+        let global = WirGlobal {
+            name: WirName {
+                fq: "global:ORIGIN".to_string(),
+            },
+            ty: WirType::Ref {
+                type_id: tid.clone(),
+                nullable: false,
+            },
+            mutable: false,
+            init: WirInstr::StructNew {
+                type_id: tid,
+                fields: vec![WirInstr::I32Const(3), WirInstr::I32Const(4)],
+            },
+            lazy_init: false,
+            meta: WirMeta::default(),
+        };
+        let mut pkg = empty_package();
+        pkg.types.push(WirTypeDef::Struct(struct_ty));
+        pkg.globals.push(global);
+
+        let bytes = emit_core_module(&pkg, false);
+        validate(&bytes).expect("const struct global init should validate as Wasm");
     }
 }


### PR DESCRIPTION
## Summary

Lands the design and the first capability for **constant object globalization** — building constant, read-only aggregates once at instantiation as Wasm GC const globals instead of rebuilding them on every call/iteration.

### Design (WEPs)

- **New WEP — [Constant Object Globalization](docs/wep-2026-05-31-const-object-globalization.md).** Built as a NIR optimization. Its core is a **single boundary classifier**: the NIR→WIR boundary is the sole eager/lazy authority via `try_const_init(&NirExpr, ctx) -> Option<WirInstr>`. NIR carries globals as optimized init expressions with no lazy concept; `wir_build` synthesizes `__initialize_module` only for the non-const residue. This de-smells the global-init path — removing `is_constant_initializer` (TIR), `const_global_promotion` (NIR), and `NirGlobal.{lazy_init, is_nullable}` — so lazy-ness becomes purely a function of how far NIR-optimize simplified the init (and `-O0` stays correct without premature extraction).
- **niri Evolution WEP** — adds Stage 6 (fold `G.field` / `G[const]` on immutable aggregate globals), the keystone that turns globalization into a cross-function constant-propagation source.
- **NIR Layer WEP** — drops the migration-era "no new node kinds" constraint and proposes `NirExprKind::ArrayLiteral` as a normalization (shared by CSE / const-fold / bounds-check / this feature).

### Code

- `emit_const_expr` is now a faithful **recursive** structural emitter of any const-expressible `WirInstr` tree (scalar consts, `ref.null` / `ref.i31` / `ref.func`, `struct.new` / `array.new_fixed` / `array.new_default` / `array.new_data`) via `ConstExpr::extended`. The old `_ => i32.const 0` fallback is now an ICE — a non-const instruction in an init slot is an optimizer bug. Codegen holds no policy.

## Scope / status

This PR delivers the **capability** (codegen) plus the agreed design. The remaining `try_const_init` boundary work, the body-globalization NIR pass, and the two enablers (ArrayLiteral, niri Stage 6) are tracked as TODOs in the WEP and are out of scope here.

## Tests

- New unit test (`codegen::emit::tests::const_struct_global_init_validates`): builds a struct global with a `struct.new` initializer and validates the emitted module — red before the change (`type mismatch: expected (ref $type), found i32`), green after.
- `cargo test --lib`: 577 passed. e2e `global` / `array` / `const` / `opt` subsets: 0 failed. The real pipeline output is unchanged today (no global yet carries an aggregate init); the new arms are exercised by the unit test.

https://claude.ai/code/session_01XcXCbMURbExbLHPTHbT78c

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcXCbMURbExbLHPTHbT78c)_