### PR TITLE
feat(lexer): resilient tokenisation with bundled LexResult and per-error recovery

### DIFF
--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -444,9 +444,7 @@ pub fn collect_inline_invocations_for_entry(
     let Ok(source) = fs::read_to_string(entry_file) else {
         return Vec::new();
     };
-    let Ok(parsed) = wado_compiler::parse(&source) else {
-        return Vec::new();
-    };
+    let parsed = wado_compiler::parse(&source);
     let mut modules =
         wado_compiler::hashmap::IndexMap::<String, wado_compiler::ast::Module>::default();
     // Key by the full path so `decl_site.module` here matches the

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -444,7 +444,13 @@ pub fn collect_inline_invocations_for_entry(
     let Ok(source) = fs::read_to_string(entry_file) else {
         return Vec::new();
     };
-    let parsed = wado_compiler::parse(&source);
+    // `parse` is resilient; if the entry has recovered lex or parse errors
+    // the AST is partial. Refuse to harvest kiln invocations from a partial
+    // tree so a mid-edit source can't trigger surprising codegen side
+    // effects — matches the prior fail-on-parse-error behaviour.
+    let Ok(parsed) = wado_compiler::parse(&source).into_fail_fast() else {
+        return Vec::new();
+    };
     let mut modules =
         wado_compiler::hashmap::IndexMap::<String, wado_compiler::ast::Module>::default();
     // Key by the full path so `decl_site.module` here matches the

--- a/wado-cli/src/doc.rs
+++ b/wado-cli/src/doc.rs
@@ -228,7 +228,7 @@ fn load_doc(input: &str) -> Result<DocModule, CliExit> {
         .map_err(|e| CliExit::error(format!("reading '{}': {e}", path.display())))?;
 
     let parsed = wado_compiler::parse(&source)
-        .and_then(wado_compiler::ParseResult::into_fail_fast)
+        .into_fail_fast()
         .map_err(|e| CliExit::error(format!("parsing '{}': {e:?}", path.display())))?;
 
     let module_name = path

--- a/wado-cli/src/kiln_provider.rs
+++ b/wado-cli/src/kiln_provider.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use wado_compiler::kiln::{GeneratorModule, OptionsDescriptor};
-use wado_compiler::lexer::Lexer;
+use wado_compiler::lexer::lex;
 use wado_compiler::token::canonical_token_bytes;
 use wado_compiler::{CompilerHost, CompilerOptions, Diagnostic, LogLevel};
 
@@ -434,26 +434,28 @@ fn hash_source(path: &str, bytes: &[u8]) -> [u8; 32] {
     let Ok(source) = std::str::from_utf8(bytes) else {
         return sha256_of(bytes);
     };
-    let mut lexer = Lexer::new(source);
-    let Ok(tokens) = lexer.tokenize() else {
+    let lex_result = lex(source);
+    // If the lexer recovered any error the source is malformed; fall back to
+    // the byte hash so we don't bake a half-tokenised stream into the cache.
+    if !lex_result.errors.is_empty() {
         return sha256_of(bytes);
-    };
+    }
     // Canonical token bytes ignore spans and (because the lexer peels
     // comments off into a side channel before returning the token list)
     // every line/block/doc comment.
     let mut buf: Vec<u8> = Vec::with_capacity(bytes.len());
     buf.extend_from_slice(b"wado-token-stream-v1\n");
-    for tok in &tokens {
+    for tok in &lex_result.tokens {
         canonical_token_bytes(&mut buf, &tok.kind);
     }
     // Shebang and the `__DATA__` trailer carry semantic content that
     // the parser still sees, so fold them into the hash too.
-    if let Some(shebang) = lexer.shebang() {
+    if let Some(shebang) = &lex_result.shebang {
         buf.push(b'#');
         buf.extend_from_slice(shebang.as_bytes());
         buf.push(0);
     }
-    if let Some(data) = lexer.data_section() {
+    if let Some(data) = &lex_result.data_section {
         buf.push(b'D');
         buf.extend_from_slice(data.as_bytes());
         buf.push(0);

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -2982,12 +2982,13 @@ pub struct ImplBlock {
 mod ast_id_tests {
     use super::*;
     use crate::hashmap::IndexSet;
-    use crate::lexer::Lexer;
+    use crate::lexer::lex;
     use crate::parser::Parser;
 
     fn parse(source: &str) -> Module {
-        let tokens = Lexer::new(source).tokenize().expect("lex");
-        let mut parser = Parser::new(tokens);
+        let r = lex(source);
+        assert!(r.errors.is_empty(), "lex error: {:?}", r.errors);
+        let mut parser = Parser::new(r.tokens);
         parser.parse_strict().expect("parse")
     }
 

--- a/wado-compiler/src/ast_index.rs
+++ b/wado-compiler/src/ast_index.rs
@@ -368,12 +368,13 @@ fn record_impl_name_spans(index: &mut AstIndex, imp: &ImplBlock) {
 mod tests {
     use super::*;
     use crate::ast::Stmt;
-    use crate::lexer::Lexer;
+    use crate::lexer::lex;
     use crate::parser::Parser;
 
     fn parse(source: &str) -> Module {
-        let tokens = Lexer::new(source).tokenize().expect("lex");
-        let mut parser = Parser::new(tokens);
+        let r = lex(source);
+        assert!(r.errors.is_empty(), "lex error: {:?}", r.errors);
+        let mut parser = Parser::new(r.tokens);
         parser.parse_strict().expect("parse")
     }
 

--- a/wado-compiler/src/bind.rs
+++ b/wado-compiler/src/bind.rs
@@ -1240,13 +1240,13 @@ pub fn bind_module<H: CompilerHost>(module: &Module, logger: &Logger<H>) -> Resu
 mod tests {
     use super::*;
     use crate::compiler_host::{InMemoryCompilerHost, LogLevel, Severity};
-    use crate::lexer::Lexer;
+    use crate::lexer::lex;
     use crate::parser::Parser;
 
     fn parse(source: &str) -> Module {
-        let mut lexer = Lexer::new(source);
-        let tokens = lexer.tokenize().unwrap();
-        let mut parser = Parser::new(tokens);
+        let r = lex(source);
+        assert!(r.errors.is_empty(), "lex error: {:?}", r.errors);
+        let mut parser = Parser::new(r.tokens);
         parser.parse_strict().expect("parse error")
     }
 

--- a/wado-compiler/src/builtin_registry.rs
+++ b/wado-compiler/src/builtin_registry.rs
@@ -55,7 +55,6 @@ impl BuiltinRegistry {
         use std::sync::OnceLock;
 
         use crate::ast::Module;
-        use crate::lexer::Lexer;
         use crate::parser::Parser;
         use crate::stdlib;
 
@@ -63,9 +62,13 @@ impl BuiltinRegistry {
 
         let module = PARSED_MODULE.get_or_init(|| {
             let source = stdlib::CORE_BUILTIN;
-            let mut lexer = Lexer::new(source);
-            let tokens = lexer.tokenize().expect("lexer error in core:builtin");
-            let mut parser = Parser::new(tokens);
+            let r = crate::lexer::lex(source);
+            assert!(
+                r.errors.is_empty(),
+                "lexer error in core:builtin: {:?}",
+                r.errors
+            );
+            let mut parser = Parser::new(r.tokens);
             parser.parse_strict().expect("parser error in core:builtin")
         });
 
@@ -439,14 +442,13 @@ mod tests {
     #[test]
     fn test_parse_builtin_wado() {
         use crate::ast::Item;
-        use crate::lexer::Lexer;
         use crate::parser::Parser;
         use crate::stdlib::CORE_BUILTIN;
 
         // Parse the actual builtin.wado
-        let mut lexer = Lexer::new(CORE_BUILTIN);
-        let tokens = lexer.tokenize().expect("lexer error");
-        let mut parser = Parser::new(tokens);
+        let r = crate::lexer::lex(CORE_BUILTIN);
+        assert!(r.errors.is_empty(), "lexer error: {:?}", r.errors);
+        let mut parser = Parser::new(r.tokens);
         let module = parser.parse_strict().expect("parser error");
 
         // Build registry with type table

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -893,15 +893,15 @@ impl CmInterfaceRegistry {
 
     fn build_from_stdlib_inner() -> (Self, crate::world_registry::WorldRegistry) {
         use crate::ast::Module as AstModule;
-        use crate::lexer::Lexer;
+        use crate::lexer::lex;
         use crate::parser::Parser;
         use crate::stdlib;
         use crate::world_registry::WorldRegistry;
 
         fn parse_module(source: &str) -> AstModule {
-            let mut lexer = Lexer::new(source);
-            let tokens = lexer.tokenize().expect("lexer error in stdlib");
-            let mut parser = Parser::new(tokens);
+            let r = lex(source);
+            assert!(r.errors.is_empty(), "lexer error in stdlib: {:?}", r.errors);
+            let mut parser = Parser::new(r.tokens);
             parser.parse_strict().expect("parser error in stdlib")
         }
 

--- a/wado-compiler/src/doc.rs
+++ b/wado-compiler/src/doc.rs
@@ -746,7 +746,7 @@ pub fn resolve_stdlib_source(module_name: &str) -> Option<&'static str> {
 /// Returns `None` if the module name is not a known stdlib module.
 pub fn extract_stdlib_doc(module_name: &str) -> Option<DocModule> {
     let source = stdlib::get_stdlib_module(module_name)?;
-    let parsed = crate::parse(source).ok()?;
+    let parsed = crate::parse(source);
     let mut doc = extract_doc(&parsed.ast, &parsed.trivia, module_name);
 
     // For modules with pub use re-exports, follow them to get the actual items
@@ -754,9 +754,8 @@ pub fn extract_stdlib_doc(module_name: &str) -> Option<DocModule> {
     if !reexport_sources.is_empty() {
         let exported_names = collect_pub_use_names(&parsed.ast);
         for reexport_source in &reexport_sources {
-            if let Some(sub_source) = stdlib::get_stdlib_module(reexport_source)
-                && let Ok(sub_parsed) = crate::parse(sub_source)
-            {
+            if let Some(sub_source) = stdlib::get_stdlib_module(reexport_source) {
+                let sub_parsed = crate::parse(sub_source);
                 let sub_doc = extract_doc(&sub_parsed.ast, &sub_parsed.trivia, reexport_source);
                 merge_reexported_items(&mut doc, &sub_doc, &exported_names);
             }
@@ -766,9 +765,8 @@ pub fn extract_stdlib_doc(module_name: &str) -> Option<DocModule> {
     // Follow `use _ from "..."` (side-effect imports) to collect impl blocks on primitive types
     let side_effect_sources = collect_side_effect_import_sources(&parsed.ast);
     for se_source in &side_effect_sources {
-        if let Some(sub_source) = stdlib::get_stdlib_module(se_source)
-            && let Ok(sub_parsed) = crate::parse(sub_source)
-        {
+        if let Some(sub_source) = stdlib::get_stdlib_module(se_source) {
+            let sub_parsed = crate::parse(sub_source);
             let prim_types =
                 collect_primitive_types_from_module(&sub_parsed.ast, &sub_parsed.trivia);
             merge_primitive_types(&mut doc.primitive_types, prim_types);
@@ -777,15 +775,13 @@ pub fn extract_stdlib_doc(module_name: &str) -> Option<DocModule> {
 
     // Also collect from any pub use re-export sources that may have primitive impls
     for reexport_source in &reexport_sources {
-        if let Some(sub_source) = stdlib::get_stdlib_module(reexport_source)
-            && let Ok(sub_parsed) = crate::parse(sub_source)
-        {
+        if let Some(sub_source) = stdlib::get_stdlib_module(reexport_source) {
+            let sub_parsed = crate::parse(sub_source);
             // Recursively follow side-effect imports from re-exported sub-modules
             let sub_se_sources = collect_side_effect_import_sources(&sub_parsed.ast);
             for sub_se in &sub_se_sources {
-                if let Some(se_source) = stdlib::get_stdlib_module(sub_se)
-                    && let Ok(se_parsed) = crate::parse(se_source)
-                {
+                if let Some(se_source) = stdlib::get_stdlib_module(sub_se) {
+                    let se_parsed = crate::parse(se_source);
                     let prim_types =
                         collect_primitive_types_from_module(&se_parsed.ast, &se_parsed.trivia);
                     merge_primitive_types(&mut doc.primitive_types, prim_types);

--- a/wado-compiler/src/doc.rs
+++ b/wado-compiler/src/doc.rs
@@ -737,6 +737,25 @@ pub fn resolve_stdlib_source(module_name: &str) -> Option<&'static str> {
     stdlib::get_stdlib_module(module_name)
 }
 
+/// Parse a bundled stdlib source. Bundled stdlib must always parse cleanly;
+/// a recovered lex or parse error here is a compiler bug, so fail loudly
+/// rather than silently produce partial docs (matches `parse_bind_stdlib`
+/// in `loader.rs`).
+fn parse_stdlib_for_doc(label: &str, source: &str) -> crate::ParseResult {
+    let parsed = crate::parse(source);
+    assert!(
+        parsed.lex_errors.is_empty(),
+        "stdlib '{label}' must lex cleanly: {:?}",
+        parsed.lex_errors,
+    );
+    assert!(
+        parsed.errors.is_empty(),
+        "stdlib '{label}' must parse cleanly: {:?}",
+        parsed.errors,
+    );
+    parsed
+}
+
 /// Extract documentation from a stdlib module by name.
 ///
 /// For `core:prelude`, follows `pub use` re-exports and merges items from
@@ -746,7 +765,7 @@ pub fn resolve_stdlib_source(module_name: &str) -> Option<&'static str> {
 /// Returns `None` if the module name is not a known stdlib module.
 pub fn extract_stdlib_doc(module_name: &str) -> Option<DocModule> {
     let source = stdlib::get_stdlib_module(module_name)?;
-    let parsed = crate::parse(source);
+    let parsed = parse_stdlib_for_doc(module_name, source);
     let mut doc = extract_doc(&parsed.ast, &parsed.trivia, module_name);
 
     // For modules with pub use re-exports, follow them to get the actual items
@@ -755,7 +774,7 @@ pub fn extract_stdlib_doc(module_name: &str) -> Option<DocModule> {
         let exported_names = collect_pub_use_names(&parsed.ast);
         for reexport_source in &reexport_sources {
             if let Some(sub_source) = stdlib::get_stdlib_module(reexport_source) {
-                let sub_parsed = crate::parse(sub_source);
+                let sub_parsed = parse_stdlib_for_doc(reexport_source, sub_source);
                 let sub_doc = extract_doc(&sub_parsed.ast, &sub_parsed.trivia, reexport_source);
                 merge_reexported_items(&mut doc, &sub_doc, &exported_names);
             }
@@ -766,7 +785,7 @@ pub fn extract_stdlib_doc(module_name: &str) -> Option<DocModule> {
     let side_effect_sources = collect_side_effect_import_sources(&parsed.ast);
     for se_source in &side_effect_sources {
         if let Some(sub_source) = stdlib::get_stdlib_module(se_source) {
-            let sub_parsed = crate::parse(sub_source);
+            let sub_parsed = parse_stdlib_for_doc(se_source, sub_source);
             let prim_types =
                 collect_primitive_types_from_module(&sub_parsed.ast, &sub_parsed.trivia);
             merge_primitive_types(&mut doc.primitive_types, prim_types);
@@ -776,12 +795,12 @@ pub fn extract_stdlib_doc(module_name: &str) -> Option<DocModule> {
     // Also collect from any pub use re-export sources that may have primitive impls
     for reexport_source in &reexport_sources {
         if let Some(sub_source) = stdlib::get_stdlib_module(reexport_source) {
-            let sub_parsed = crate::parse(sub_source);
+            let sub_parsed = parse_stdlib_for_doc(reexport_source, sub_source);
             // Recursively follow side-effect imports from re-exported sub-modules
             let sub_se_sources = collect_side_effect_import_sources(&sub_parsed.ast);
             for sub_se in &sub_se_sources {
                 if let Some(se_source) = stdlib::get_stdlib_module(sub_se) {
-                    let se_parsed = crate::parse(se_source);
+                    let se_parsed = parse_stdlib_for_doc(sub_se, se_source);
                     let prim_types =
                         collect_primitive_types_from_module(&se_parsed.ast, &se_parsed.trivia);
                     merge_primitive_types(&mut doc.primitive_types, prim_types);

--- a/wado-compiler/src/lexer.rs
+++ b/wado-compiler/src/lexer.rs
@@ -1499,7 +1499,7 @@ test data";
         let r = lex(source);
         assert!(r.errors.is_empty(), "unexpected lex errors: {:?}", r.errors);
 
-        let data = r.data_section.clone();
+        let data = r.data_section;
         assert_eq!(data, Some("owned data".to_string()));
     }
 

--- a/wado-compiler/src/lexer.rs
+++ b/wado-compiler/src/lexer.rs
@@ -85,6 +85,12 @@ pub enum LexErrorKind {
     UnterminatedTemplateString,
     /// Character literal lacking its closing `'`.
     UnterminatedChar,
+    /// Character literal with more than one character between the quotes
+    /// (e.g. `'abc'`). The lexer recovers by greedily consuming up to the
+    /// closing quote, so the elaborator still sees a `CharLit` payload — but
+    /// the diagnostic flags the size violation here rather than letting it
+    /// cascade into a tail of follow-on identifier / unterminated-char errors.
+    CharLiteralTooLong,
     /// Empty character literal (`''`).
     EmptyCharLiteral,
     /// Block comment (`/* ... */`) lacking its closing `*/`.
@@ -106,6 +112,9 @@ impl std::fmt::Display for LexError {
             LexErrorKind::UnterminatedString => write!(f, "unterminated string literal"),
             LexErrorKind::UnterminatedTemplateString => write!(f, "unterminated template string"),
             LexErrorKind::UnterminatedChar => write!(f, "unterminated character literal"),
+            LexErrorKind::CharLiteralTooLong => {
+                write!(f, "character literal must contain a single character")
+            }
             LexErrorKind::EmptyCharLiteral => write!(f, "empty character literal"),
             LexErrorKind::UnterminatedBlockComment => write!(f, "unterminated block comment"),
             LexErrorKind::MissingHexDigits => write!(f, "expected hex digit after 0x"),
@@ -182,6 +191,21 @@ impl<'a> Lexer<'a> {
             shebang: self.shebang,
             data_section: self.data_section,
         }
+    }
+
+    /// Build a span from a saved start position to the current cursor.
+    /// Captures `(start, self.pos, start_line, start_column, self.line,
+    /// self.column)` — the recurring pattern at every error site and every
+    /// closing-token site.
+    fn span_from(&self, start: usize, start_line: usize, start_column: usize) -> Span {
+        Span::with_end(
+            start,
+            self.pos,
+            start_line,
+            start_column,
+            self.line,
+            self.column,
+        )
     }
 
     fn next_token(&mut self) -> Token {
@@ -445,14 +469,7 @@ impl<'a> Lexer<'a> {
                 // emit a `TokenKind::Error` carrying its source text so the
                 // parser can step over it without losing forward progress.
                 self.advance();
-                let span = Span::with_end(
-                    start,
-                    self.pos,
-                    start_line,
-                    start_column,
-                    self.line,
-                    self.column,
-                );
+                let span = self.span_from(start, start_line, start_column);
                 self.errors.push(LexError {
                     kind: LexErrorKind::UnexpectedChar(ch),
                     span,
@@ -461,17 +478,7 @@ impl<'a> Lexer<'a> {
             }
         };
 
-        Token::new(
-            kind,
-            Span::with_end(
-                start,
-                self.pos,
-                start_line,
-                start_column,
-                self.line,
-                self.column,
-            ),
-        )
+        Token::new(kind, self.span_from(start, start_line, start_column))
     }
 
     fn peek(&mut self) -> Option<(usize, char)> {
@@ -608,14 +615,7 @@ impl<'a> Lexer<'a> {
         Comment {
             text,
             kind,
-            span: Span::with_end(
-                start,
-                self.pos,
-                start_line,
-                start_column,
-                self.line,
-                self.column,
-            ),
+            span: self.span_from(start, start_line, start_column),
         }
     }
 
@@ -634,14 +634,7 @@ impl<'a> Lexer<'a> {
         loop {
             match self.peek() {
                 None => {
-                    let span = Span::with_end(
-                        start,
-                        self.pos,
-                        start_line,
-                        start_column,
-                        self.line,
-                        self.column,
-                    );
+                    let span = self.span_from(start, start_line, start_column);
                     self.errors.push(LexError {
                         kind: LexErrorKind::UnterminatedBlockComment,
                         span,
@@ -662,14 +655,7 @@ impl<'a> Lexer<'a> {
                         return Comment {
                             text,
                             kind: CommentKind::Block,
-                            span: Span::with_end(
-                                start,
-                                self.pos,
-                                start_line,
-                                start_column,
-                                self.line,
-                                self.column,
-                            ),
+                            span: self.span_from(start, start_line, start_column),
                         };
                     }
                 }
@@ -859,14 +845,7 @@ impl<'a> Lexer<'a> {
             if !matches!(self.peek_char(), Some('0'..='9')) {
                 self.errors.push(LexError {
                     kind: LexErrorKind::MissingExponentDigits,
-                    span: Span::with_end(
-                        start,
-                        self.pos,
-                        start_line,
-                        start_column,
-                        self.line,
-                        self.column,
-                    ),
+                    span: self.span_from(start, start_line, start_column),
                 });
             }
             while let Some((_, ch)) = self.peek() {
@@ -903,14 +882,7 @@ impl<'a> Lexer<'a> {
         if self.pos == digit_start {
             self.errors.push(LexError {
                 kind: LexErrorKind::MissingHexDigits,
-                span: Span::with_end(
-                    start,
-                    self.pos,
-                    start_line,
-                    start_column,
-                    self.line,
-                    self.column,
-                ),
+                span: self.span_from(start, start_line, start_column),
             });
         }
 
@@ -937,14 +909,7 @@ impl<'a> Lexer<'a> {
         if self.pos == digit_start {
             self.errors.push(LexError {
                 kind: LexErrorKind::MissingBinaryDigits,
-                span: Span::with_end(
-                    start,
-                    self.pos,
-                    start_line,
-                    start_column,
-                    self.line,
-                    self.column,
-                ),
+                span: self.span_from(start, start_line, start_column),
             });
         }
 
@@ -970,14 +935,7 @@ impl<'a> Lexer<'a> {
         if self.pos == digit_start {
             self.errors.push(LexError {
                 kind: LexErrorKind::MissingOctalDigits,
-                span: Span::with_end(
-                    start,
-                    self.pos,
-                    start_line,
-                    start_column,
-                    self.line,
-                    self.column,
-                ),
+                span: self.span_from(start, start_line, start_column),
             });
         }
 
@@ -1000,14 +958,7 @@ impl<'a> Lexer<'a> {
                     // cannot break on newline; EOF is the only safe recovery.
                     self.errors.push(LexError {
                         kind: LexErrorKind::UnterminatedString,
-                        span: Span::with_end(
-                            start,
-                            self.pos,
-                            start_line,
-                            start_column,
-                            self.line,
-                            self.column,
-                        ),
+                        span: self.span_from(start, start_line, start_column),
                     });
                     let raw = self.input[content_start..self.pos].to_string();
                     return TokenKind::StringLit(raw);
@@ -1079,14 +1030,7 @@ impl<'a> Lexer<'a> {
                 None => {
                     self.errors.push(LexError {
                         kind: LexErrorKind::UnterminatedTemplateString,
-                        span: Span::with_end(
-                            start,
-                            self.pos,
-                            start_line,
-                            start_column,
-                            self.line,
-                            self.column,
-                        ),
+                        span: self.span_from(start, start_line, start_column),
                     });
                     if !current_literal.is_empty() {
                         parts.push(TemplateTokenPart::Literal(current_literal));
@@ -1194,14 +1138,7 @@ impl<'a> Lexer<'a> {
             let Some((_, ch)) = self.peek() else {
                 self.errors.push(LexError {
                     kind: LexErrorKind::UnterminatedTemplateString,
-                    span: Span::with_end(
-                        start,
-                        self.pos,
-                        start_line,
-                        start_column,
-                        self.line,
-                        self.column,
-                    ),
+                    span: self.span_from(start, start_line, start_column),
                 });
                 return (source, true);
             };
@@ -1259,14 +1196,7 @@ impl<'a> Lexer<'a> {
                 // `'` at EOF: empty content, no closing quote.
                 self.errors.push(LexError {
                     kind: LexErrorKind::UnterminatedChar,
-                    span: Span::with_end(
-                        start,
-                        self.pos,
-                        start_line,
-                        start_column,
-                        self.line,
-                        self.column,
-                    ),
+                    span: self.span_from(start, start_line, start_column),
                 });
                 return TokenKind::CharLit(String::new());
             }
@@ -1276,14 +1206,7 @@ impl<'a> Lexer<'a> {
                 self.advance();
                 self.errors.push(LexError {
                     kind: LexErrorKind::EmptyCharLiteral,
-                    span: Span::with_end(
-                        start,
-                        self.pos,
-                        start_line,
-                        start_column,
-                        self.line,
-                        self.column,
-                    ),
+                    span: self.span_from(start, start_line, start_column),
                 });
                 return TokenKind::CharLit(String::new());
             }
@@ -1296,27 +1219,39 @@ impl<'a> Lexer<'a> {
             }
         }
 
-        let raw = self.input[inner_start..self.pos].to_string();
-
-        if self.peek_char() != Some('\'') {
-            // Missing closing quote: emit the char with what we read so far,
-            // record the error, and leave the cursor where it is so the
-            // surrounding tokens (after this position) can still lex.
-            self.errors.push(LexError {
-                kind: LexErrorKind::UnterminatedChar,
-                span: Span::with_end(
-                    start,
-                    self.pos,
-                    start_line,
-                    start_column,
-                    self.line,
-                    self.column,
-                ),
-            });
+        if self.peek_char() == Some('\'') {
+            let raw = self.input[inner_start..self.pos].to_string();
+            self.advance(); // consume closing '
             return TokenKind::CharLit(raw);
         }
-        self.advance(); // consume closing '
 
+        // No closing quote where one was expected. Scan forward up to the
+        // next `'` (or newline / EOF) so a multi-char literal like `'abc'`
+        // recovers as a single CharLit("abc") + one diagnostic, instead of
+        // cascading into Ident("bc") + a second unterminated char on the
+        // closing quote.
+        while let Some((_, ch)) = self.peek() {
+            if ch == '\'' || ch == '\n' {
+                break;
+            }
+            if ch == '\\' {
+                self.advance();
+                self.skip_escape();
+            } else {
+                self.advance();
+            }
+        }
+        let raw = self.input[inner_start..self.pos].to_string();
+        let kind = if self.peek_char() == Some('\'') {
+            self.advance(); // consume closing '
+            LexErrorKind::CharLiteralTooLong
+        } else {
+            LexErrorKind::UnterminatedChar
+        };
+        self.errors.push(LexError {
+            kind,
+            span: self.span_from(start, start_line, start_column),
+        });
         TokenKind::CharLit(raw)
     }
 }

--- a/wado-compiler/src/lexer.rs
+++ b/wado-compiler/src/lexer.rs
@@ -1,5 +1,11 @@
 // Lexer for Wado
 // This module must be synchronized with syntax.rs (canonical syntax definition).
+//
+// The lexer is *resilient*: malformed input never aborts tokenisation. Every
+// byte of the source is accounted for as a token, comment, whitespace,
+// shebang, or data-section content, and lex errors are surfaced alongside a
+// best-effort token stream via [`LexResult`]. The recommended entry points
+// are the free functions [`lex`] and [`lex_with_line`].
 
 use crate::comment::{Comment, CommentKind};
 use crate::token::{Span, Token, TokenKind};
@@ -15,7 +21,34 @@ pub fn is_valid_ident(s: &str) -> bool {
     chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
-pub struct Lexer<'a> {
+/// Tokenise `source` with full error recovery.
+///
+/// Always returns a complete [`LexResult`] — never fails. Errors are
+/// collected in [`LexResult::errors`]; downstream consumers (parser, LSP)
+/// continue past them using best-effort tokens.
+pub fn lex(source: &str) -> LexResult {
+    Lexer::new(source).run()
+}
+
+/// Like [`lex`] but starts numbering lines at `start_line`. Used by the
+/// parser when re-lexing the inside of a template-string interpolation so
+/// reported spans line up with the outer source.
+pub fn lex_with_line(source: &str, start_line: usize) -> LexResult {
+    Lexer::with_line(source, start_line).run()
+}
+
+/// Resilient lexer output. Every field is final after [`lex`] returns; the
+/// lexer is consumed in the process.
+#[derive(Debug, Default)]
+pub struct LexResult {
+    pub tokens: Vec<Token>,
+    pub errors: Vec<LexError>,
+    pub comments: Vec<Comment>,
+    pub shebang: Option<String>,
+    pub data_section: Option<String>,
+}
+
+pub(crate) struct Lexer<'a> {
     input: &'a str,
     chars: std::iter::Peekable<std::str::CharIndices<'a>>,
     pos: usize,
@@ -27,28 +60,79 @@ pub struct Lexer<'a> {
     comments: Vec<Comment>,
     /// Shebang line, if present (e.g., "#!/usr/bin/env wado")
     shebang: Option<String>,
+    /// Errors collected during tokenisation. The lexer never aborts; instead
+    /// it pushes each problem here and emits a best-effort token.
+    errors: Vec<LexError>,
 }
 
-#[derive(Debug)]
+/// Structured lexer error. Pair with [`LexError::span`] for source location.
+#[derive(Debug, Clone)]
 pub struct LexError {
-    pub message: String,
+    pub kind: LexErrorKind,
     pub span: Span,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LexErrorKind {
+    /// A character that does not begin any valid token. Holds the char itself
+    /// so the error message can render it; the matching [`TokenKind::Error`]
+    /// in the token stream carries the same source text.
+    UnexpectedChar(char),
+    /// String literal lacking a closing `"`. The lexer emitted a `StringLit`
+    /// containing everything from the opening `"` to EOF.
+    UnterminatedString,
+    /// Template string (`` `...` ``) lacking its closing backtick.
+    UnterminatedTemplateString,
+    /// Character literal lacking its closing `'`.
+    UnterminatedChar,
+    /// Empty character literal (`''`).
+    EmptyCharLiteral,
+    /// Block comment (`/* ... */`) lacking its closing `*/`.
+    UnterminatedBlockComment,
+    /// `0x` with no following hex digit.
+    MissingHexDigits,
+    /// `0b` with no following binary digit.
+    MissingBinaryDigits,
+    /// `0o` with no following octal digit.
+    MissingOctalDigits,
+    /// Floating-point exponent (`e` / `E`) with no following digit.
+    MissingExponentDigits,
+}
+
+impl LexError {
+    /// Render a human-readable message. Used by diagnostic conversion and
+    /// logging paths that previously stored the message inline.
+    pub fn message(&self) -> String {
+        match self.kind {
+            LexErrorKind::UnexpectedChar(ch) => format!("unexpected character: '{ch}'"),
+            LexErrorKind::UnterminatedString => "unterminated string literal".to_string(),
+            LexErrorKind::UnterminatedTemplateString => "unterminated template string".to_string(),
+            LexErrorKind::UnterminatedChar => "unterminated character literal".to_string(),
+            LexErrorKind::EmptyCharLiteral => "empty character literal".to_string(),
+            LexErrorKind::UnterminatedBlockComment => "unterminated block comment".to_string(),
+            LexErrorKind::MissingHexDigits => "expected hex digit after 0x".to_string(),
+            LexErrorKind::MissingBinaryDigits => "expected binary digit after 0b".to_string(),
+            LexErrorKind::MissingOctalDigits => "expected octal digit after 0o".to_string(),
+            LexErrorKind::MissingExponentDigits => "expected digit after exponent".to_string(),
+        }
+    }
 }
 
 impl From<LexError> for crate::compiler_host::Diagnostic {
     fn from(e: LexError) -> Self {
         use crate::compiler_host::{Code, DiagnosticSpan, Severity};
+        let message = format!("lexer error: {}", e.message());
         Self {
             severity: Severity::Error,
             code: Code::InvalidSyntax,
-            message: format!("lexer error: {}", e.message),
+            message,
             span: Some(DiagnosticSpan::from_span(&e.span, None)),
         }
     }
 }
 
 impl<'a> Lexer<'a> {
-    pub fn new(input: &'a str) -> Self {
+    fn new(input: &'a str) -> Self {
         Self {
             input,
             chars: input.char_indices().peekable(),
@@ -58,13 +142,14 @@ impl<'a> Lexer<'a> {
             data_section: None,
             comments: Vec::new(),
             shebang: None,
+            errors: Vec::new(),
         }
     }
 
-    /// Create a new lexer with a custom starting line number.
-    /// Useful for parsing embedded expressions (e.g., template string interpolations)
-    /// where the line number should reflect the original source location.
-    pub fn with_line(input: &'a str, line: usize) -> Self {
+    /// Like `new`, but starts numbering lines at `line`. Used when re-lexing
+    /// an embedded sub-expression (e.g. template-string interpolation) so
+    /// reported spans line up with the outer source.
+    fn with_line(input: &'a str, line: usize) -> Self {
         Self {
             input,
             chars: input.char_indices().peekable(),
@@ -74,46 +159,18 @@ impl<'a> Lexer<'a> {
             data_section: None,
             comments: Vec::new(),
             shebang: None,
+            errors: Vec::new(),
         }
     }
 
-    /// Returns the content of the __DATA__ section, if present.
-    /// This is available after calling `tokenize()`.
-    pub fn data_section(&self) -> Option<&str> {
-        self.data_section.as_deref()
-    }
-
-    /// Consumes the lexer and returns the data section content.
-    pub fn into_data_section(self) -> Option<String> {
-        self.data_section
-    }
-
-    pub fn comments(&self) -> &[Comment] {
-        &self.comments
-    }
-
-    pub fn into_comments(self) -> Vec<Comment> {
-        self.comments
-    }
-
-    pub fn into_parts(self) -> (Option<String>, Vec<Comment>, Option<String>) {
-        (self.data_section, self.comments, self.shebang)
-    }
-
-    /// Returns the shebang line, if present.
-    /// This is available after calling `tokenize()`.
-    pub fn shebang(&self) -> Option<&str> {
-        self.shebang.as_deref()
-    }
-
-    pub fn tokenize(&mut self) -> Result<Vec<Token>, LexError> {
-        // Skip shebang if present at the very beginning of the file
+    /// Drive the lexer to completion, returning all collected state. The
+    /// lexer never aborts on malformed input — see [`LexResult`].
+    fn run(mut self) -> LexResult {
         self.skip_shebang();
 
         let mut tokens = Vec::new();
-
         loop {
-            let token = self.next_token()?;
+            let token = self.next_token();
             let is_eof = token.kind == TokenKind::Eof;
             tokens.push(token);
             if is_eof {
@@ -121,10 +178,16 @@ impl<'a> Lexer<'a> {
             }
         }
 
-        Ok(tokens)
+        LexResult {
+            tokens,
+            errors: self.errors,
+            comments: self.comments,
+            shebang: self.shebang,
+            data_section: self.data_section,
+        }
     }
 
-    fn next_token(&mut self) -> Result<Token, LexError> {
+    fn next_token(&mut self) -> Token {
         self.skip_whitespace_and_comments();
 
         let start = self.pos;
@@ -132,10 +195,10 @@ impl<'a> Lexer<'a> {
         let start_column = self.column;
 
         let Some((_, ch)) = self.peek() else {
-            return Ok(Token::new(
+            return Token::new(
                 TokenKind::Eof,
                 Span::new(start, start, start_line, start_column),
-            ));
+            );
         };
 
         let kind = match ch {
@@ -143,16 +206,16 @@ impl<'a> Lexer<'a> {
             'a'..='z' | 'A'..='Z' | '_' => self.lex_ident_or_keyword(),
 
             // Numbers
-            '0'..='9' => self.lex_number()?,
+            '0'..='9' => self.lex_number(),
 
             // Strings
-            '"' => self.lex_string()?,
+            '"' => self.lex_string(),
 
             // Character literals
-            '\'' => self.lex_char()?,
+            '\'' => self.lex_char(),
 
             // Template strings
-            '`' => self.lex_template_string()?,
+            '`' => self.lex_template_string(),
 
             // Punctuation and operators
             '(' => {
@@ -381,14 +444,27 @@ impl<'a> Lexer<'a> {
             }
 
             _ => {
-                return Err(LexError {
-                    message: format!("unexpected character: '{ch}'"),
-                    span: Span::new(start, self.pos + 1, start_line, start_column),
+                // Unrecognised character: consume it, record an error, and
+                // emit a `TokenKind::Error` carrying its source text so the
+                // parser can step over it without losing forward progress.
+                self.advance();
+                let span = Span::with_end(
+                    start,
+                    self.pos,
+                    start_line,
+                    start_column,
+                    self.line,
+                    self.column,
+                );
+                self.errors.push(LexError {
+                    kind: LexErrorKind::UnexpectedChar(ch),
+                    span,
                 });
+                TokenKind::Error(self.input[start..self.pos].to_string())
             }
         };
 
-        Ok(Token::new(
+        Token::new(
             kind,
             Span::with_end(
                 start,
@@ -398,7 +474,7 @@ impl<'a> Lexer<'a> {
                 self.line,
                 self.column,
             ),
-        ))
+        )
     }
 
     fn peek(&mut self) -> Option<(usize, char)> {
@@ -485,18 +561,12 @@ impl<'a> Lexer<'a> {
                         continue;
                     }
                     Some((_, '*')) => {
-                        // Block comment - collect instead of discard
-                        match self.lex_block_comment() {
-                            Ok(comment) => {
-                                self.comments.push(comment);
-                                continue;
-                            }
-                            Err(_) => {
-                                // Error will be caught in next_token when we
-                                // encounter the unterminated block comment again
-                                break;
-                            }
-                        }
+                        // Block comment — always returns a comment, even if
+                        // unterminated. The error (if any) was already pushed
+                        // into `self.errors` by `lex_block_comment`.
+                        let comment = self.lex_block_comment();
+                        self.comments.push(comment);
+                        continue;
                     }
                     _ => {}
                 }
@@ -552,7 +622,10 @@ impl<'a> Lexer<'a> {
         }
     }
 
-    fn lex_block_comment(&mut self) -> Result<Comment, LexError> {
+    /// Lex a block comment. Always returns the comment (possibly unterminated
+    /// to EOF) and records a [`LexErrorKind::UnterminatedBlockComment`] error
+    /// when no closing `*/` was found.
+    fn lex_block_comment(&mut self) -> Comment {
         let start = self.pos;
         let start_line = self.line;
         let start_column = self.column;
@@ -564,17 +637,24 @@ impl<'a> Lexer<'a> {
         loop {
             match self.peek() {
                 None => {
-                    return Err(LexError {
-                        message: "unterminated block comment".to_string(),
-                        span: Span::with_end(
-                            start,
-                            self.pos,
-                            start_line,
-                            start_column,
-                            self.line,
-                            self.column,
-                        ),
+                    let span = Span::with_end(
+                        start,
+                        self.pos,
+                        start_line,
+                        start_column,
+                        self.line,
+                        self.column,
+                    );
+                    self.errors.push(LexError {
+                        kind: LexErrorKind::UnterminatedBlockComment,
+                        span,
                     });
+                    let text = self.input[text_start..self.pos].to_string();
+                    return Comment {
+                        text,
+                        kind: CommentKind::Block,
+                        span,
+                    };
                 }
                 Some((_, '*')) => {
                     self.advance();
@@ -582,7 +662,7 @@ impl<'a> Lexer<'a> {
                         let text_end = self.pos - 1; // before the *
                         self.advance(); // consume /
                         let text = self.input[text_start..text_end].to_string();
-                        return Ok(Comment {
+                        return Comment {
                             text,
                             kind: CommentKind::Block,
                             span: Span::with_end(
@@ -593,7 +673,7 @@ impl<'a> Lexer<'a> {
                                 self.line,
                                 self.column,
                             ),
-                        });
+                        };
                     }
                 }
                 Some(_) => {
@@ -714,7 +794,7 @@ impl<'a> Lexer<'a> {
         }
     }
 
-    fn lex_number(&mut self) -> Result<TokenKind, LexError> {
+    fn lex_number(&mut self) -> TokenKind {
         let start = self.pos;
         let start_line = self.line;
         let start_column = self.column;
@@ -775,10 +855,13 @@ impl<'a> Lexer<'a> {
             if let Some('+' | '-') = self.peek_char() {
                 self.advance();
             }
-            // Must have at least one digit
+            // Must have at least one digit. Resilient behaviour: emit the
+            // partial `NumberLit` (e.g. `1e`) and record an error; the
+            // elaborator already rejects malformed numeric literals, but the
+            // explicit lex-time diagnostic gives the user a precise span.
             if !matches!(self.peek_char(), Some('0'..='9')) {
-                return Err(LexError {
-                    message: "expected digit after exponent".to_string(),
+                self.errors.push(LexError {
+                    kind: LexErrorKind::MissingExponentDigits,
                     span: Span::with_end(
                         start,
                         self.pos,
@@ -801,7 +884,7 @@ impl<'a> Lexer<'a> {
         let text = &self.input[start..self.pos];
 
         // Return string representation; type is determined by context in elaborator
-        Ok(TokenKind::NumberLit(text.to_string()))
+        TokenKind::NumberLit(text.to_string())
     }
 
     fn lex_hex_number(
@@ -809,7 +892,7 @@ impl<'a> Lexer<'a> {
         start: usize,
         start_line: usize,
         start_column: usize,
-    ) -> Result<TokenKind, LexError> {
+    ) -> TokenKind {
         let digit_start = self.pos;
 
         while let Some((_, ch)) = self.peek() {
@@ -821,8 +904,8 @@ impl<'a> Lexer<'a> {
         }
 
         if self.pos == digit_start {
-            return Err(LexError {
-                message: "expected hex digit after 0x".to_string(),
+            self.errors.push(LexError {
+                kind: LexErrorKind::MissingHexDigits,
                 span: Span::with_end(
                     start,
                     self.pos,
@@ -835,8 +918,7 @@ impl<'a> Lexer<'a> {
         }
 
         // Include "0x" prefix in repr; actual parsing happens in elaborator
-        let repr = self.input[start..self.pos].to_string();
-        Ok(TokenKind::NumberLit(repr))
+        TokenKind::NumberLit(self.input[start..self.pos].to_string())
     }
 
     fn lex_binary_number(
@@ -844,7 +926,7 @@ impl<'a> Lexer<'a> {
         start: usize,
         start_line: usize,
         start_column: usize,
-    ) -> Result<TokenKind, LexError> {
+    ) -> TokenKind {
         let digit_start = self.pos;
 
         while let Some((_, ch)) = self.peek() {
@@ -856,8 +938,8 @@ impl<'a> Lexer<'a> {
         }
 
         if self.pos == digit_start {
-            return Err(LexError {
-                message: "expected binary digit after 0b".to_string(),
+            self.errors.push(LexError {
+                kind: LexErrorKind::MissingBinaryDigits,
                 span: Span::with_end(
                     start,
                     self.pos,
@@ -869,9 +951,7 @@ impl<'a> Lexer<'a> {
             });
         }
 
-        // Include "0b" prefix in repr; actual parsing happens in elaborator
-        let repr = self.input[start..self.pos].to_string();
-        Ok(TokenKind::NumberLit(repr))
+        TokenKind::NumberLit(self.input[start..self.pos].to_string())
     }
 
     fn lex_octal_number(
@@ -879,7 +959,7 @@ impl<'a> Lexer<'a> {
         start: usize,
         start_line: usize,
         start_column: usize,
-    ) -> Result<TokenKind, LexError> {
+    ) -> TokenKind {
         let digit_start = self.pos;
 
         while let Some((_, ch)) = self.peek() {
@@ -891,8 +971,8 @@ impl<'a> Lexer<'a> {
         }
 
         if self.pos == digit_start {
-            return Err(LexError {
-                message: "expected octal digit after 0o".to_string(),
+            self.errors.push(LexError {
+                kind: LexErrorKind::MissingOctalDigits,
                 span: Span::with_end(
                     start,
                     self.pos,
@@ -904,12 +984,10 @@ impl<'a> Lexer<'a> {
             });
         }
 
-        // Include "0o" prefix in repr; actual parsing happens in elaborator
-        let repr = self.input[start..self.pos].to_string();
-        Ok(TokenKind::NumberLit(repr))
+        TokenKind::NumberLit(self.input[start..self.pos].to_string())
     }
 
-    fn lex_string(&mut self) -> Result<TokenKind, LexError> {
+    fn lex_string(&mut self) -> TokenKind {
         let start = self.pos;
         let start_line = self.line;
         let start_column = self.column;
@@ -920,8 +998,11 @@ impl<'a> Lexer<'a> {
         loop {
             match self.peek() {
                 None => {
-                    return Err(LexError {
-                        message: "unterminated string literal".to_string(),
+                    // Unterminated: emit a `StringLit` covering everything we
+                    // managed to read. Multi-line strings are legal, so we
+                    // cannot break on newline; EOF is the only safe recovery.
+                    self.errors.push(LexError {
+                        kind: LexErrorKind::UnterminatedString,
                         span: Span::with_end(
                             start,
                             self.pos,
@@ -931,12 +1012,14 @@ impl<'a> Lexer<'a> {
                             self.column,
                         ),
                     });
+                    let raw = self.input[content_start..self.pos].to_string();
+                    return TokenKind::StringLit(raw);
                 }
                 Some((_, '"')) => {
                     let content_end = self.pos;
                     self.advance();
                     let raw = self.input[content_start..content_end].to_string();
-                    return Ok(TokenKind::StringLit(raw));
+                    return TokenKind::StringLit(raw);
                 }
                 Some((_, '\\')) => {
                     self.advance();
@@ -982,7 +1065,7 @@ impl<'a> Lexer<'a> {
         }
     }
 
-    fn lex_template_string(&mut self) -> Result<TokenKind, LexError> {
+    fn lex_template_string(&mut self) -> TokenKind {
         use crate::token::TemplateTokenPart;
 
         let start = self.pos;
@@ -997,8 +1080,8 @@ impl<'a> Lexer<'a> {
         loop {
             match self.peek() {
                 None => {
-                    return Err(LexError {
-                        message: "unterminated template string".to_string(),
+                    self.errors.push(LexError {
+                        kind: LexErrorKind::UnterminatedTemplateString,
                         span: Span::with_end(
                             start,
                             self.pos,
@@ -1008,6 +1091,10 @@ impl<'a> Lexer<'a> {
                             self.column,
                         ),
                     });
+                    if !current_literal.is_empty() {
+                        parts.push(TemplateTokenPart::Literal(current_literal));
+                    }
+                    return TokenKind::TemplateStringLit(parts);
                 }
                 Some((_, '\\')) => {
                     current_literal.push('\\');
@@ -1061,9 +1148,15 @@ impl<'a> Lexer<'a> {
                             &mut current_literal,
                         )));
                     }
-                    let interp =
-                        self.collect_interpolation_source(start, start_line, start_column)?;
+                    let (interp, hit_eof) =
+                        self.collect_interpolation_source(start, start_line, start_column);
                     parts.push(TemplateTokenPart::Interpolation(interp));
+                    if hit_eof {
+                        // Outer template terminated mid-interpolation. The
+                        // error was already recorded; surface whatever parts
+                        // we have so the parser still sees a TemplateString.
+                        return TokenKind::TemplateStringLit(parts);
+                    }
                 }
                 Some((_, '`')) => {
                     self.advance();
@@ -1080,17 +1173,20 @@ impl<'a> Lexer<'a> {
             parts.push(TemplateTokenPart::Literal(current_literal));
         }
 
-        Ok(TokenKind::TemplateStringLit(parts))
+        TokenKind::TemplateStringLit(parts)
     }
 
     /// Collect the raw source text of an interpolation expression.
-    /// Called after consuming the opening `{`. Consumes up to and including the closing `}`.
+    /// Called after consuming the opening `{`. Consumes up to and including
+    /// the closing `}`. Returns `(source, hit_eof)`; when `hit_eof` is true
+    /// the enclosing template string was truncated mid-interpolation and an
+    /// error has been recorded.
     fn collect_interpolation_source(
         &mut self,
         start: usize,
         start_line: usize,
         start_column: usize,
-    ) -> Result<String, LexError> {
+    ) -> (String, bool) {
         let mut source = String::new();
         let mut brace_depth = 1u32;
         let mut in_string = false;
@@ -1099,8 +1195,8 @@ impl<'a> Lexer<'a> {
 
         loop {
             let Some((_, ch)) = self.peek() else {
-                return Err(LexError {
-                    message: "unterminated template string".to_string(),
+                self.errors.push(LexError {
+                    kind: LexErrorKind::UnterminatedTemplateString,
                     span: Span::with_end(
                         start,
                         self.pos,
@@ -1110,6 +1206,7 @@ impl<'a> Lexer<'a> {
                         self.column,
                     ),
                 });
+                return (source, true);
             };
             self.advance();
 
@@ -1141,7 +1238,7 @@ impl<'a> Lexer<'a> {
                 '}' if !in_string && backtick_depth == 0 => {
                     brace_depth -= 1;
                     if brace_depth == 0 {
-                        return Ok(source);
+                        return (source, false);
                     }
                     source.push(ch);
                 }
@@ -1152,7 +1249,7 @@ impl<'a> Lexer<'a> {
         }
     }
 
-    fn lex_char(&mut self) -> Result<TokenKind, LexError> {
+    fn lex_char(&mut self) -> TokenKind {
         let start = self.pos;
         let start_line = self.line;
         let start_column = self.column;
@@ -1162,8 +1259,9 @@ impl<'a> Lexer<'a> {
 
         match self.peek() {
             None => {
-                return Err(LexError {
-                    message: "unterminated character literal".to_string(),
+                // `'` at EOF: empty content, no closing quote.
+                self.errors.push(LexError {
+                    kind: LexErrorKind::UnterminatedChar,
                     span: Span::with_end(
                         start,
                         self.pos,
@@ -1173,10 +1271,14 @@ impl<'a> Lexer<'a> {
                         self.column,
                     ),
                 });
+                return TokenKind::CharLit(String::new());
             }
             Some((_, '\'')) => {
-                return Err(LexError {
-                    message: "empty character literal".to_string(),
+                // `''` — empty char. Consume the closing quote so the lexer
+                // can continue past it cleanly.
+                self.advance();
+                self.errors.push(LexError {
+                    kind: LexErrorKind::EmptyCharLiteral,
                     span: Span::with_end(
                         start,
                         self.pos,
@@ -1186,6 +1288,7 @@ impl<'a> Lexer<'a> {
                         self.column,
                     ),
                 });
+                return TokenKind::CharLit(String::new());
             }
             Some((_, '\\')) => {
                 self.advance();
@@ -1199,8 +1302,11 @@ impl<'a> Lexer<'a> {
         let raw = self.input[inner_start..self.pos].to_string();
 
         if self.peek_char() != Some('\'') {
-            return Err(LexError {
-                message: "unterminated character literal".to_string(),
+            // Missing closing quote: emit the char with what we read so far,
+            // record the error, and leave the cursor where it is so the
+            // surrounding tokens (after this position) can still lex.
+            self.errors.push(LexError {
+                kind: LexErrorKind::UnterminatedChar,
                 span: Span::with_end(
                     start,
                     self.pos,
@@ -1210,16 +1316,26 @@ impl<'a> Lexer<'a> {
                     self.column,
                 ),
             });
+            return TokenKind::CharLit(raw);
         }
         self.advance(); // consume closing '
 
-        Ok(TokenKind::CharLit(raw))
+        TokenKind::CharLit(raw)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Lex a clean (no recovered errors) source and return the token stream.
+    /// Asserts that no lex errors were recorded, since these tests cover the
+    /// happy paths; recovery behaviour is covered by `tests/lexer_recovery.rs`.
+    fn tokens(source: &str) -> Vec<Token> {
+        let r = lex(source);
+        assert!(r.errors.is_empty(), "unexpected lex errors: {:?}", r.errors);
+        r.tokens
+    }
 
     #[test]
     fn test_is_valid_ident() {
@@ -1243,8 +1359,7 @@ mod tests {
 
     #[test]
     fn test_simple_tokens() {
-        let mut lexer = Lexer::new("fn main() { }");
-        let tokens = lexer.tokenize().unwrap();
+        let tokens = tokens("fn main() { }");
 
         assert!(matches!(tokens[0].kind, TokenKind::Fn));
         assert!(matches!(&tokens[1].kind, TokenKind::Ident(s) if s == "main"));
@@ -1258,8 +1373,7 @@ mod tests {
     #[test]
     fn test_use_statement() {
         // Test the new ESM-like import syntax
-        let mut lexer = Lexer::new(r#"use {println} from "core:cli";"#);
-        let tokens = lexer.tokenize().unwrap();
+        let tokens = tokens(r#"use {println} from "core:cli";"#);
 
         assert!(matches!(tokens[0].kind, TokenKind::Use));
         assert!(matches!(tokens[1].kind, TokenKind::LBrace));
@@ -1272,21 +1386,21 @@ mod tests {
 
     #[test]
     fn test_string_literal() {
-        let mut lexer = Lexer::new(r#""Hello, world!""#);
-        let tokens = lexer.tokenize().unwrap();
+        let tokens = tokens(r#""Hello, world!""#);
 
         assert!(matches!(&tokens[0].kind, TokenKind::StringLit(raw) if raw == "Hello, world!"));
     }
 
     #[test]
     fn test_comments() {
-        let mut lexer = Lexer::new("// comment\nfn");
-        let tokens = lexer.tokenize().unwrap();
+        let r = lex("// comment\nfn");
+        assert!(r.errors.is_empty(), "unexpected lex errors: {:?}", r.errors);
+        let tokens = &r.tokens;
 
         assert!(matches!(tokens[0].kind, TokenKind::Fn));
 
         // Comments should be collected, not discarded
-        let comments = lexer.comments();
+        let comments = &r.comments;
         assert_eq!(comments.len(), 1);
         assert_eq!(comments[0].text, " comment");
         assert_eq!(comments[0].kind, CommentKind::Line);
@@ -1294,12 +1408,13 @@ mod tests {
 
     #[test]
     fn test_block_comments() {
-        let mut lexer = Lexer::new("/* block comment */fn");
-        let tokens = lexer.tokenize().unwrap();
+        let r = lex("/* block comment */fn");
+        assert!(r.errors.is_empty(), "unexpected lex errors: {:?}", r.errors);
+        let tokens = &r.tokens;
 
         assert!(matches!(tokens[0].kind, TokenKind::Fn));
 
-        let comments = lexer.comments();
+        let comments = &r.comments;
         assert_eq!(comments.len(), 1);
         assert_eq!(comments[0].text, " block comment ");
         assert_eq!(comments[0].kind, CommentKind::Block);
@@ -1307,12 +1422,13 @@ mod tests {
 
     #[test]
     fn test_multiline_block_comment() {
-        let mut lexer = Lexer::new("/*\n * multi-line\n * comment\n */\nfn");
-        let tokens = lexer.tokenize().unwrap();
+        let r = lex("/*\n * multi-line\n * comment\n */\nfn");
+        assert!(r.errors.is_empty(), "unexpected lex errors: {:?}", r.errors);
+        let tokens = &r.tokens;
 
         assert!(matches!(tokens[0].kind, TokenKind::Fn));
 
-        let comments = lexer.comments();
+        let comments = &r.comments;
         assert_eq!(comments.len(), 1);
         assert!(comments[0].text.contains("multi-line"));
         assert!(comments[0].text.contains("comment"));
@@ -1321,12 +1437,13 @@ mod tests {
 
     #[test]
     fn test_multiple_comments() {
-        let mut lexer = Lexer::new("// first\n/* second */\n// third\nfn");
-        let tokens = lexer.tokenize().unwrap();
+        let r = lex("// first\n/* second */\n// third\nfn");
+        assert!(r.errors.is_empty(), "unexpected lex errors: {:?}", r.errors);
+        let tokens = &r.tokens;
 
         assert!(matches!(tokens[0].kind, TokenKind::Fn));
 
-        let comments = lexer.comments();
+        let comments = &r.comments;
         assert_eq!(comments.len(), 3);
         assert_eq!(comments[0].text, " first");
         assert_eq!(comments[0].kind, CommentKind::Line);
@@ -1338,13 +1455,13 @@ mod tests {
 
     #[test]
     fn test_trailing_comment() {
-        let mut lexer = Lexer::new("fn main() { } // trailing comment");
-        let tokens = lexer.tokenize().unwrap();
+        let r = lex("fn main() { } // trailing comment");
+        assert!(r.errors.is_empty(), "unexpected lex errors: {:?}", r.errors);
 
         // Find the function tokens
-        assert!(matches!(tokens[0].kind, TokenKind::Fn));
+        assert!(matches!(r.tokens[0].kind, TokenKind::Fn));
 
-        let comments = lexer.comments();
+        let comments = &r.comments;
         assert_eq!(comments.len(), 1);
         assert_eq!(comments[0].text, " trailing comment");
         // The comment should be on the same line as the code
@@ -1356,15 +1473,16 @@ mod tests {
         let source = r"fn main() { }
 __DATA__
 hello world";
-        let mut lexer = Lexer::new(source);
-        let tokens = lexer.tokenize().unwrap();
+        let r = lex(source);
+        assert!(r.errors.is_empty(), "unexpected lex errors: {:?}", r.errors);
+        let tokens = &r.tokens;
 
         // Should have parsed the function tokens and EOF
         assert!(matches!(tokens[0].kind, TokenKind::Fn));
         assert!(matches!(tokens.last().unwrap().kind, TokenKind::Eof));
 
         // Should have captured the data section
-        assert_eq!(lexer.data_section(), Some("hello world"));
+        assert_eq!(r.data_section.as_deref(), Some("hello world"));
     }
 
     #[test]
@@ -1374,10 +1492,10 @@ __DATA__
 line 1
 line 2
 line 3";
-        let mut lexer = Lexer::new(source);
-        lexer.tokenize().unwrap();
+        let r = lex(source);
+        assert!(r.errors.is_empty(), "unexpected lex errors: {:?}", r.errors);
 
-        assert_eq!(lexer.data_section(), Some("line 1\nline 2\nline 3"));
+        assert_eq!(r.data_section.as_deref(), Some("line 1\nline 2\nline 3"));
     }
 
     #[test]
@@ -1388,10 +1506,10 @@ __DATA__
   "exit": 0,
   "stdout": "Hello\n"
 }"#;
-        let mut lexer = Lexer::new(source);
-        lexer.tokenize().unwrap();
+        let r = lex(source);
+        assert!(r.errors.is_empty(), "unexpected lex errors: {:?}", r.errors);
 
-        let data = lexer.data_section().unwrap();
+        let data = r.data_section.as_deref().unwrap();
         assert!(data.contains("\"exit\": 0"));
         assert!(data.contains("\"stdout\": \"Hello\\n\""));
     }
@@ -1399,44 +1517,45 @@ __DATA__
     #[test]
     fn test_data_section_empty() {
         let source = "fn main() { }\n__DATA__\n";
-        let mut lexer = Lexer::new(source);
-        lexer.tokenize().unwrap();
+        let r = lex(source);
+        assert!(r.errors.is_empty(), "unexpected lex errors: {:?}", r.errors);
 
         // Empty data section should be Some("")
-        assert_eq!(lexer.data_section(), Some(""));
+        assert_eq!(r.data_section.as_deref(), Some(""));
     }
 
     #[test]
     fn test_no_data_section() {
         let source = "fn main() { }";
-        let mut lexer = Lexer::new(source);
-        lexer.tokenize().unwrap();
+        let r = lex(source);
+        assert!(r.errors.is_empty(), "unexpected lex errors: {:?}", r.errors);
 
-        assert_eq!(lexer.data_section(), None);
+        assert_eq!(r.data_section.as_deref(), None);
     }
 
     #[test]
     fn test_data_section_not_at_start_of_line() {
         // __DATA__ in the middle of a line should not be recognized
         let source = "let x = __DATA__;";
-        let mut lexer = Lexer::new(source);
-        let tokens = lexer.tokenize().unwrap();
+        let r = lex(source);
+        assert!(r.errors.is_empty(), "unexpected lex errors: {:?}", r.errors);
 
         // Should parse __DATA__ as an identifier
         assert!(
-            tokens
+            r.tokens
                 .iter()
                 .any(|t| matches!(&t.kind, TokenKind::Ident(s) if s == "__DATA__"))
         );
-        assert_eq!(lexer.data_section(), None);
+        assert_eq!(r.data_section.as_deref(), None);
     }
 
     #[test]
     fn test_data_section_with_trailing_content() {
         // __DATA__ with content on the same line should not be recognized
         let source = "fn main() { }\n__DATA__ some content";
-        let mut lexer = Lexer::new(source);
-        let tokens = lexer.tokenize().unwrap();
+        let r = lex(source);
+        assert!(r.errors.is_empty(), "unexpected lex errors: {:?}", r.errors);
+        let tokens = &r.tokens;
 
         // Should parse __DATA__ as an identifier since it's not on its own line
         assert!(
@@ -1444,7 +1563,7 @@ __DATA__
                 .iter()
                 .any(|t| matches!(&t.kind, TokenKind::Ident(s) if s == "__DATA__"))
         );
-        assert_eq!(lexer.data_section(), None);
+        assert_eq!(r.data_section.as_deref(), None);
     }
 
     #[test]
@@ -1453,27 +1572,26 @@ __DATA__
 fn main() { }
 __DATA__
 test data";
-        let mut lexer = Lexer::new(source);
-        lexer.tokenize().unwrap();
+        let r = lex(source);
+        assert!(r.errors.is_empty(), "unexpected lex errors: {:?}", r.errors);
 
-        assert_eq!(lexer.data_section(), Some("test data"));
+        assert_eq!(r.data_section.as_deref(), Some("test data"));
     }
 
     #[test]
     fn test_into_data_section() {
         let source = "fn main() { }\n__DATA__\nowned data";
-        let mut lexer = Lexer::new(source);
-        lexer.tokenize().unwrap();
+        let r = lex(source);
+        assert!(r.errors.is_empty(), "unexpected lex errors: {:?}", r.errors);
 
-        let data = lexer.into_data_section();
+        let data = r.data_section.clone();
         assert_eq!(data, Some("owned data".to_string()));
     }
 
     #[test]
     fn test_shebang_basic() {
         let source = "#!/usr/bin/env wado\nfn main() { }";
-        let mut lexer = Lexer::new(source);
-        let tokens = lexer.tokenize().unwrap();
+        let tokens = tokens(source);
 
         // Shebang should be completely skipped
         assert!(matches!(tokens[0].kind, TokenKind::Fn));
@@ -1483,8 +1601,7 @@ test data";
     #[test]
     fn test_shebang_with_args() {
         let source = "#!/usr/bin/wado --some-flag\nfn test() { }";
-        let mut lexer = Lexer::new(source);
-        let tokens = lexer.tokenize().unwrap();
+        let tokens = tokens(source);
 
         assert!(matches!(tokens[0].kind, TokenKind::Fn));
     }
@@ -1493,8 +1610,7 @@ test data";
     fn test_no_shebang() {
         // Regular code without shebang
         let source = "fn main() { }";
-        let mut lexer = Lexer::new(source);
-        let tokens = lexer.tokenize().unwrap();
+        let tokens = tokens(source);
 
         assert!(matches!(tokens[0].kind, TokenKind::Fn));
     }
@@ -1503,8 +1619,7 @@ test data";
     fn test_hash_not_shebang() {
         // Hash on first line but not shebang (no !)
         let source = "#[attr]\nfn main() { }";
-        let mut lexer = Lexer::new(source);
-        let tokens = lexer.tokenize().unwrap();
+        let tokens = tokens(source);
 
         // Should parse # as Hash token, not skip as shebang
         assert!(matches!(tokens[0].kind, TokenKind::Hash));
@@ -1514,8 +1629,7 @@ test data";
     fn test_inner_attribute_not_shebang() {
         // #![ is an inner attribute, not a shebang
         let source = "#![no_prelude]\nfn main() { }";
-        let mut lexer = Lexer::new(source);
-        let tokens = lexer.tokenize().unwrap();
+        let tokens = tokens(source);
 
         // Should parse #, !, [ as tokens, not skip as shebang
         assert!(matches!(tokens[0].kind, TokenKind::Hash));
@@ -1527,8 +1641,7 @@ test data";
     fn test_shebang_not_on_first_line() {
         // #! on second line should be parsed as Hash + Not, not skipped as shebang
         let source = "fn main() { }\n#!/usr/bin/wado";
-        let mut lexer = Lexer::new(source);
-        let tokens = lexer.tokenize().unwrap();
+        let tokens = tokens(source);
 
         // Should find Hash and Not tokens after the function
         let has_hash = tokens.iter().any(|t| matches!(t.kind, TokenKind::Hash));
@@ -1540,32 +1653,29 @@ test data";
     #[test]
     fn test_shebang_with_data_section() {
         let source = "#!/usr/bin/env wado\nfn main() { }\n__DATA__\ntest data";
-        let mut lexer = Lexer::new(source);
-        lexer.tokenize().unwrap();
+        let r = lex(source);
+        assert!(r.errors.is_empty(), "unexpected lex errors: {:?}", r.errors);
 
-        assert_eq!(lexer.data_section(), Some("test data"));
+        assert_eq!(r.data_section.as_deref(), Some("test data"));
     }
 
     #[test]
     fn test_dot_dot_token() {
-        let mut lexer = Lexer::new("..x");
-        let tokens = lexer.tokenize().unwrap();
+        let tokens = tokens("..x");
         assert!(matches!(tokens[0].kind, TokenKind::DotDot));
         assert!(matches!(&tokens[1].kind, TokenKind::Ident(s) if s == "x"));
     }
 
     #[test]
     fn test_dot_dot_dot_token() {
-        let mut lexer = Lexer::new("...x");
-        let tokens = lexer.tokenize().unwrap();
+        let tokens = tokens("...x");
         assert!(matches!(tokens[0].kind, TokenKind::DotDotDot));
         assert!(matches!(&tokens[1].kind, TokenKind::Ident(s) if s == "x"));
     }
 
     #[test]
     fn test_dot_dot_lt_token() {
-        let mut lexer = Lexer::new("0..<10");
-        let tokens = lexer.tokenize().unwrap();
+        let tokens = tokens("0..<10");
         assert!(matches!(&tokens[0].kind, TokenKind::NumberLit(s) if s == "0"));
         assert!(matches!(tokens[1].kind, TokenKind::DotDotLt));
         assert!(matches!(&tokens[2].kind, TokenKind::NumberLit(s) if s == "10"));
@@ -1573,8 +1683,7 @@ test data";
 
     #[test]
     fn test_dot_dot_eq_token() {
-        let mut lexer = Lexer::new("1..=10");
-        let tokens = lexer.tokenize().unwrap();
+        let tokens = tokens("1..=10");
         assert!(matches!(&tokens[0].kind, TokenKind::NumberLit(s) if s == "1"));
         assert!(matches!(tokens[1].kind, TokenKind::DotDotEq));
         assert!(matches!(&tokens[2].kind, TokenKind::NumberLit(s) if s == "10"));
@@ -1582,8 +1691,7 @@ test data";
 
     #[test]
     fn test_dot_dot_lt_with_chars() {
-        let mut lexer = Lexer::new("'a'..='z'");
-        let tokens = lexer.tokenize().unwrap();
+        let tokens = tokens("'a'..='z'");
         assert!(matches!(&tokens[0].kind, TokenKind::CharLit(s) if s == "a"));
         assert!(matches!(tokens[1].kind, TokenKind::DotDotEq));
         assert!(matches!(&tokens[2].kind, TokenKind::CharLit(s) if s == "z"));
@@ -1591,8 +1699,7 @@ test data";
 
     #[test]
     fn test_single_dot_followed_by_ident() {
-        let mut lexer = Lexer::new("a.b");
-        let tokens = lexer.tokenize().unwrap();
+        let tokens = tokens("a.b");
         assert!(matches!(&tokens[0].kind, TokenKind::Ident(s) if s == "a"));
         assert!(matches!(tokens[1].kind, TokenKind::Dot));
         assert!(matches!(&tokens[2].kind, TokenKind::Ident(s) if s == "b"));

--- a/wado-compiler/src/lexer.rs
+++ b/wado-compiler/src/lexer.rs
@@ -21,24 +21,18 @@ pub fn is_valid_ident(s: &str) -> bool {
     chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
-/// Tokenise `source` with full error recovery.
-///
-/// Always returns a complete [`LexResult`] — never fails. Errors are
-/// collected in [`LexResult::errors`]; downstream consumers (parser, LSP)
-/// continue past them using best-effort tokens.
+/// Tokenise `source`. See module docs for the recovery contract.
 pub fn lex(source: &str) -> LexResult {
     Lexer::new(source).run()
 }
 
-/// Like [`lex`] but starts numbering lines at `start_line`. Used by the
-/// parser when re-lexing the inside of a template-string interpolation so
-/// reported spans line up with the outer source.
+/// Like [`lex`] but starts numbering lines at `start_line` — used by the
+/// parser when re-lexing the inside of a template-string interpolation.
 pub fn lex_with_line(source: &str, start_line: usize) -> LexResult {
     Lexer::with_line(source, start_line).run()
 }
 
-/// Resilient lexer output. Every field is final after [`lex`] returns; the
-/// lexer is consumed in the process.
+/// Bundle of tokens + recovered diagnostics + trivia returned by [`lex`].
 #[derive(Debug)]
 pub struct LexResult {
     pub tokens: Vec<Token>,
@@ -60,8 +54,7 @@ pub(crate) struct Lexer<'a> {
     comments: Vec<Comment>,
     /// Shebang line, if present (e.g., "#!/usr/bin/env wado")
     shebang: Option<String>,
-    /// Errors collected during tokenisation. The lexer never aborts; instead
-    /// it pushes each problem here and emits a best-effort token.
+    /// Recovered errors, in source order. Drained into [`LexResult::errors`].
     errors: Vec<LexError>,
 }
 
@@ -74,22 +67,18 @@ pub struct LexError {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LexErrorKind {
-    /// A character that does not begin any valid token. Holds the char itself
-    /// so the error message can render it; the matching [`TokenKind::Error`]
-    /// in the token stream carries the same source text.
+    /// A character that does not begin any valid token. Paired with a
+    /// [`TokenKind::Error`] in the token stream.
     UnexpectedChar(char),
-    /// String literal lacking a closing `"`. The lexer emitted a `StringLit`
-    /// containing everything from the opening `"` to EOF.
+    /// String literal lacking a closing `"`. Paired with a `StringLit`
+    /// holding everything from the opening `"` to EOF.
     UnterminatedString,
     /// Template string (`` `...` ``) lacking its closing backtick.
     UnterminatedTemplateString,
     /// Character literal lacking its closing `'`.
     UnterminatedChar,
     /// Character literal with more than one character between the quotes
-    /// (e.g. `'abc'`). The lexer recovers by greedily consuming up to the
-    /// closing quote, so the elaborator still sees a `CharLit` payload — but
-    /// the diagnostic flags the size violation here rather than letting it
-    /// cascade into a tail of follow-on identifier / unterminated-char errors.
+    /// (e.g. `'abc'`).
     CharLiteralTooLong,
     /// Empty character literal (`''`).
     EmptyCharLiteral,
@@ -152,9 +141,7 @@ impl<'a> Lexer<'a> {
         }
     }
 
-    /// Like `new`, but starts numbering lines at `line`. Used when re-lexing
-    /// an embedded sub-expression (e.g. template-string interpolation) so
-    /// reported spans line up with the outer source.
+    /// Like `new`, but starts numbering lines at `line`.
     fn with_line(input: &'a str, line: usize) -> Self {
         Self {
             input,
@@ -169,8 +156,7 @@ impl<'a> Lexer<'a> {
         }
     }
 
-    /// Drive the lexer to completion, returning all collected state. The
-    /// lexer never aborts on malformed input — see [`LexResult`].
+    /// Drive the lexer to completion and return the bundled [`LexResult`].
     fn run(mut self) -> LexResult {
         self.skip_shebang();
 
@@ -466,8 +452,8 @@ impl<'a> Lexer<'a> {
 
             _ => {
                 // Unrecognised character: consume it, record an error, and
-                // emit a `TokenKind::Error` carrying its source text so the
-                // parser can step over it without losing forward progress.
+                // emit a `TokenKind::Error` so the source text is preserved
+                // for span lookup and LSP semantic-token rendering.
                 self.advance();
                 let span = self.span_from(start, start_line, start_column);
                 self.errors.push(LexError {
@@ -1225,11 +1211,8 @@ impl<'a> Lexer<'a> {
             return TokenKind::CharLit(raw);
         }
 
-        // No closing quote where one was expected. Scan forward up to the
-        // next `'` (or newline / EOF) so a multi-char literal like `'abc'`
-        // recovers as a single CharLit("abc") + one diagnostic, instead of
-        // cascading into Ident("bc") + a second unterminated char on the
-        // closing quote.
+        // Scan forward to the next `'`, newline, or EOF so the literal
+        // recovers as one CharLit + one diagnostic.
         while let Some((_, ch)) = self.peek() {
             if ch == '\'' || ch == '\n' {
                 break;

--- a/wado-compiler/src/lexer.rs
+++ b/wado-compiler/src/lexer.rs
@@ -39,7 +39,7 @@ pub fn lex_with_line(source: &str, start_line: usize) -> LexResult {
 
 /// Resilient lexer output. Every field is final after [`lex`] returns; the
 /// lexer is consumed in the process.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct LexResult {
     pub tokens: Vec<Token>,
     pub errors: Vec<LexError>,
@@ -66,7 +66,7 @@ pub(crate) struct Lexer<'a> {
 }
 
 /// Structured lexer error. Pair with [`LexError::span`] for source location.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct LexError {
     pub kind: LexErrorKind,
     pub span: Span,
@@ -99,21 +99,19 @@ pub enum LexErrorKind {
     MissingExponentDigits,
 }
 
-impl LexError {
-    /// Render a human-readable message. Used by diagnostic conversion and
-    /// logging paths that previously stored the message inline.
-    pub fn message(&self) -> String {
+impl std::fmt::Display for LexError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.kind {
-            LexErrorKind::UnexpectedChar(ch) => format!("unexpected character: '{ch}'"),
-            LexErrorKind::UnterminatedString => "unterminated string literal".to_string(),
-            LexErrorKind::UnterminatedTemplateString => "unterminated template string".to_string(),
-            LexErrorKind::UnterminatedChar => "unterminated character literal".to_string(),
-            LexErrorKind::EmptyCharLiteral => "empty character literal".to_string(),
-            LexErrorKind::UnterminatedBlockComment => "unterminated block comment".to_string(),
-            LexErrorKind::MissingHexDigits => "expected hex digit after 0x".to_string(),
-            LexErrorKind::MissingBinaryDigits => "expected binary digit after 0b".to_string(),
-            LexErrorKind::MissingOctalDigits => "expected octal digit after 0o".to_string(),
-            LexErrorKind::MissingExponentDigits => "expected digit after exponent".to_string(),
+            LexErrorKind::UnexpectedChar(ch) => write!(f, "unexpected character: '{ch}'"),
+            LexErrorKind::UnterminatedString => write!(f, "unterminated string literal"),
+            LexErrorKind::UnterminatedTemplateString => write!(f, "unterminated template string"),
+            LexErrorKind::UnterminatedChar => write!(f, "unterminated character literal"),
+            LexErrorKind::EmptyCharLiteral => write!(f, "empty character literal"),
+            LexErrorKind::UnterminatedBlockComment => write!(f, "unterminated block comment"),
+            LexErrorKind::MissingHexDigits => write!(f, "expected hex digit after 0x"),
+            LexErrorKind::MissingBinaryDigits => write!(f, "expected binary digit after 0b"),
+            LexErrorKind::MissingOctalDigits => write!(f, "expected octal digit after 0o"),
+            LexErrorKind::MissingExponentDigits => write!(f, "expected digit after exponent"),
         }
     }
 }
@@ -121,11 +119,10 @@ impl LexError {
 impl From<LexError> for crate::compiler_host::Diagnostic {
     fn from(e: LexError) -> Self {
         use crate::compiler_host::{Code, DiagnosticSpan, Severity};
-        let message = format!("lexer error: {}", e.message());
         Self {
             severity: Severity::Error,
             code: Code::InvalidSyntax,
-            message,
+            message: format!("lexer error: {e}"),
             span: Some(DiagnosticSpan::from_span(&e.span, None)),
         }
     }

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -63,8 +63,8 @@ pub use compiler_host::{
 };
 pub use logger::{Bail, Logger};
 pub use semantics::{
-    Cursor, Definition, Semantics, lex_error_diagnostic, parse_error_diagnostic,
-    parse_failure_diagnostic, semantics, semantics_of,
+    Cursor, Definition, Semantics, lex_error_diagnostic, parse_error_diagnostic, semantics,
+    semantics_of,
 };
 
 #[cfg(test)]
@@ -982,24 +982,13 @@ pub fn format(source: &str) -> Result<String, CompileError> {
     // `CompileError::Lexer` (the first one wins).
     let lex_result = lexer::lex(source);
     if let Some(e) = lex_result.errors.first() {
-        return Err(CompileError::Lexer {
-            message: e.to_string(),
-            line: e.span.line,
-            column: e.span.column,
-            filename: None,
-        });
+        return Err(CompileError::from_lex_error(e, None));
     }
     let mut parser = Parser::from_lex(lex_result);
     // Formatting requires a clean parse: reject the first recovered error.
     let ast = parser.parse();
     if let Some(e) = parser.take_errors().first() {
-        return Err(CompileError::Parser {
-            message: e.message.clone(),
-            line: e.span.line,
-            column: e.span.column,
-            filename: None,
-            is_todo_module: parser.has_todo(),
-        });
+        return Err(CompileError::from_parse_error(e, None, parser.has_todo()));
     }
     let mut trivia = parser.take_trivia();
     comment::populate_trailing(&mut trivia, &ast);
@@ -1034,21 +1023,10 @@ impl ParseResult {
     /// which must reject malformed input.
     pub fn into_fail_fast(self) -> Result<ParseResult, CompileError> {
         if let Some(e) = self.lex_errors.first() {
-            return Err(CompileError::Lexer {
-                message: e.to_string(),
-                line: e.span.line,
-                column: e.span.column,
-                filename: None,
-            });
+            return Err(CompileError::from_lex_error(e, None));
         }
         if let Some(e) = self.errors.first() {
-            return Err(CompileError::Parser {
-                message: e.message.clone(),
-                line: e.span.line,
-                column: e.span.column,
-                filename: None,
-                is_todo_module: self.ast.has_todo(),
-            });
+            return Err(CompileError::from_parse_error(e, None, self.ast.has_todo()));
         }
         Ok(self)
     }
@@ -1079,24 +1057,24 @@ pub async fn load<H: CompilerHost>(
 }
 
 /// Parse a Wado source file into AST and trivia map.
-/// This is a lightweight operation that only lexes and parses.
-pub fn parse(source: &str) -> Result<ParseResult, CompileError> {
+/// This is a lightweight operation that only lexes and parses; both are
+/// error-recovering, so the call cannot fail. Lex / parse errors are
+/// surfaced via [`ParseResult::lex_errors`] / [`ParseResult::errors`].
+pub fn parse(source: &str) -> ParseResult {
     let mut lex_result = lexer::lex(source);
     let lex_errors = std::mem::take(&mut lex_result.errors);
     let mut parser = Parser::from_lex(lex_result);
-    // Both lexing and parsing are resilient and always produce a `Module`;
-    // callers that need fail-fast call `ParseResult::into_fail_fast`.
     let ast = parser.parse();
     let errors = parser.take_errors();
     let mut trivia = parser.take_trivia();
     comment::populate_trailing(&mut trivia, &ast);
     comment::populate_inner_tail(&mut trivia, &ast);
-    Ok(ParseResult {
+    ParseResult {
         ast,
         trivia,
         lex_errors,
         errors,
-    })
+    }
 }
 
 /// Compilation error with structured location info
@@ -1144,6 +1122,35 @@ impl CompileError {
                 ..
             }
         )
+    }
+
+    /// Build a `CompileError::Lexer` from a recovered [`lexer::LexError`].
+    /// Single projection consulted by every fail-fast site so message /
+    /// line / column extraction lives in one place.
+    pub fn from_lex_error(e: &lexer::LexError, filename: Option<&str>) -> Self {
+        CompileError::Lexer {
+            message: e.to_string(),
+            line: e.span.line,
+            column: e.span.column,
+            filename: filename.map(String::from),
+        }
+    }
+
+    /// Build a `CompileError::Parser` from a recovered
+    /// [`parser::ParseError`]. Mirrors [`Self::from_lex_error`] for the parse
+    /// fail-fast path; `is_todo_module` comes from the surrounding AST.
+    pub fn from_parse_error(
+        e: &parser::ParseError,
+        filename: Option<&str>,
+        is_todo_module: bool,
+    ) -> Self {
+        CompileError::Parser {
+            message: e.message.clone(),
+            line: e.span.line,
+            column: e.span.column,
+            filename: filename.map(String::from),
+            is_todo_module,
+        }
     }
 }
 

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -63,8 +63,8 @@ pub use compiler_host::{
 };
 pub use logger::{Bail, Logger};
 pub use semantics::{
-    Cursor, Definition, Semantics, parse_error_diagnostic, parse_failure_diagnostic, semantics,
-    semantics_of,
+    Cursor, Definition, Semantics, lex_error_diagnostic, parse_error_diagnostic,
+    parse_failure_diagnostic, semantics, semantics_of,
 };
 
 #[cfg(test)]
@@ -72,7 +72,7 @@ pub use compiler_host::InMemoryCompilerHost;
 pub use effect_check::{EffectError, check_default_purity, check_effects, check_stores};
 pub use elaborator::{Elaborator, TypeError};
 pub use flat_package::FlatPackage;
-pub use lexer::{LexError, Lexer};
+pub use lexer::{LexError, LexErrorKind, LexResult, lex, lex_with_line};
 pub use loader::{LoadError, LoadResult, ModuleLoader};
 pub use lower::lower;
 pub use module_source::ModuleSource;
@@ -726,18 +726,26 @@ pub async fn dump_with_host_and_world<H: CompilerHost>(
         logger.set_file(f);
     }
 
-    // === Phase 1: Lexer ===
-    let (tokens, tokens_for_dump, comments, data_section, shebang) = {
+    // === Phase 1: Lexer (resilient — never aborts on its own) ===
+    let (tokens, tokens_for_dump, comments, data_section, shebang, lex_errors) = {
         let _span = logger.span("lex");
-        let mut lexer = Lexer::new(source);
-        let tokens = lexer.tokenize().map_err(|e| {
-            let _ = logger.error(e);
-            Bail
-        })?;
-        let (data_section, comments, shebang) = lexer.into_parts();
-        let tokens_for_dump = tokens.clone();
-        (tokens, tokens_for_dump, comments, data_section, shebang)
+        let lex_result = lexer::lex(source);
+        let tokens_for_dump = lex_result.tokens.clone();
+        (
+            lex_result.tokens,
+            tokens_for_dump,
+            lex_result.comments,
+            lex_result.data_section,
+            lex_result.shebang,
+            lex_result.errors,
+        )
     };
+    // Batch path is fail-fast: report any recovered lex error before parsing
+    // so the wire format keeps the `lexer error: …` prefix.
+    if let Some(e) = lex_errors.into_iter().next() {
+        let _ = logger.error(e);
+        return Err(Bail);
+    }
 
     // === Phase 2: Parser ===
     let (ast, trivia) = {
@@ -977,19 +985,24 @@ pub async fn dump_with_host_and_world<H: CompilerHost>(
 /// assert!(formatted.contains("use { println }"));
 /// ```
 pub fn format(source: &str) -> Result<String, CompileError> {
-    // Lexer (collect comments, shebang, data section)
-    let mut lexer = Lexer::new(source);
-    let tokens = lexer.tokenize().map_err(|e| CompileError::Lexer {
-        message: e.message,
-        line: e.span.line,
-        column: e.span.column,
-        filename: None,
-    })?;
-    let (data_section, comments, shebang) = lexer.into_parts();
-
-    // Parser (with shebang, data section, and the comment stream so it
-    // can attach leading comments to AST nodes as it allocates ids).
-    let mut parser = Parser::with_trivia(tokens, shebang, data_section, comments);
+    // Lexer (collect comments, shebang, data section). Lexer is resilient;
+    // formatting requires clean input, so lex errors are reported via
+    // `CompileError::Lexer` (the first one wins).
+    let lex_result = lexer::lex(source);
+    if let Some(e) = lex_result.errors.into_iter().next() {
+        return Err(CompileError::Lexer {
+            message: e.message(),
+            line: e.span.line,
+            column: e.span.column,
+            filename: None,
+        });
+    }
+    let mut parser = Parser::with_trivia(
+        lex_result.tokens,
+        lex_result.shebang,
+        lex_result.data_section,
+        lex_result.comments,
+    );
     // Formatting requires a clean parse: reject the first recovered error.
     let ast = parser.parse();
     if let Some(e) = parser.take_errors().first() {
@@ -1012,23 +1025,35 @@ pub fn format(source: &str) -> Result<String, CompileError> {
 
 /// Result of parsing a source file (AST + AstId-keyed trivia, no compilation).
 ///
-/// The parser is error-recovering: `ast` always covers the whole input, and
-/// any syntax errors are collected in `errors` (empty on a clean parse).
-/// Batch/format/doc callers that need the old fail-fast behavior call
+/// Lexing and parsing are both error-recovering: `ast` always covers the
+/// whole input. `lex_errors` and `errors` collect recovered problems in
+/// source order; they stay separate so the wire-format diagnostic prefixes
+/// (`lexer error:` / `parse error:`) stay accurate. Batch/format/doc
+/// callers that need the old fail-fast behavior call
 /// [`ParseResult::into_fail_fast`]; the LSP path uses the partial `ast`.
 pub struct ParseResult {
     pub ast: ast::Module,
     pub trivia: comment::TriviaMap,
-    /// Syntax errors recovered during parsing, in source order.
+    /// Lexer errors recovered while tokenising, in source order.
+    pub lex_errors: Vec<lexer::LexError>,
+    /// Parser errors recovered while building the AST, in source order.
     pub errors: Vec<parser::ParseError>,
 }
 
 impl ParseResult {
-    /// Fail-fast adapter: if parsing recovered any syntax error, return the
-    /// first as the `CompileError::Parser` the parser used to produce;
-    /// otherwise yield the result unchanged. Used by batch compilation,
-    /// `wado doc`, and the formatter, which must reject malformed input.
+    /// Fail-fast adapter: if lexing or parsing recovered any syntax error,
+    /// return the first as a `CompileError`; otherwise yield the result
+    /// unchanged. Used by batch compilation, `wado doc`, and the formatter,
+    /// which must reject malformed input.
     pub fn into_fail_fast(self) -> Result<ParseResult, CompileError> {
+        if let Some(e) = self.lex_errors.first() {
+            return Err(CompileError::Lexer {
+                message: e.message(),
+                line: e.span.line,
+                column: e.span.column,
+                filename: None,
+            });
+        }
         if let Some(e) = self.errors.first() {
             return Err(CompileError::Parser {
                 message: e.message.clone(),
@@ -1069,18 +1094,15 @@ pub async fn load<H: CompilerHost>(
 /// Parse a Wado source file into AST and trivia map.
 /// This is a lightweight operation that only lexes and parses.
 pub fn parse(source: &str) -> Result<ParseResult, CompileError> {
-    let mut lexer = Lexer::new(source);
-    let tokens = lexer.tokenize().map_err(|e| CompileError::Lexer {
-        message: e.message,
-        line: e.span.line,
-        column: e.span.column,
-        filename: None,
-    })?;
-    let (data_section, comments, shebang) = lexer.into_parts();
-    let mut parser = Parser::with_trivia(tokens, shebang, data_section, comments);
-    // The parser is error-recovering and always returns a Module; lexing
-    // remains fail-fast (the `?` above). Syntax errors are surfaced via
-    // `ParseResult::errors` and `into_fail_fast` for callers that need them.
+    let lex_result = lexer::lex(source);
+    let mut parser = Parser::with_trivia(
+        lex_result.tokens,
+        lex_result.shebang,
+        lex_result.data_section,
+        lex_result.comments,
+    );
+    // Both lexing and parsing are resilient and always produce a `Module`;
+    // callers that need fail-fast call `ParseResult::into_fail_fast`.
     let ast = parser.parse();
     let errors = parser.take_errors();
     let mut trivia = parser.take_trivia();
@@ -1089,6 +1111,7 @@ pub fn parse(source: &str) -> Result<ParseResult, CompileError> {
     Ok(ParseResult {
         ast,
         trivia,
+        lex_errors: lex_result.errors,
         errors,
     })
 }

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -727,30 +727,22 @@ pub async fn dump_with_host_and_world<H: CompilerHost>(
     }
 
     // === Phase 1: Lexer (resilient — never aborts on its own) ===
-    let (tokens, tokens_for_dump, comments, data_section, shebang, lex_errors) = {
+    let mut lex_result = {
         let _span = logger.span("lex");
-        let lex_result = lexer::lex(source);
-        let tokens_for_dump = lex_result.tokens.clone();
-        (
-            lex_result.tokens,
-            tokens_for_dump,
-            lex_result.comments,
-            lex_result.data_section,
-            lex_result.shebang,
-            lex_result.errors,
-        )
+        lexer::lex(source)
     };
+    let tokens_for_dump = lex_result.tokens.clone();
     // Batch path is fail-fast: report any recovered lex error before parsing
     // so the wire format keeps the `lexer error: …` prefix.
-    if let Some(e) = lex_errors.into_iter().next() {
-        let _ = logger.error(e);
+    if !lex_result.errors.is_empty() {
+        let _ = logger.error(lex_result.errors.remove(0));
         return Err(Bail);
     }
 
     // === Phase 2: Parser ===
     let (ast, trivia) = {
         let _span = logger.span("parse");
-        let mut parser = Parser::with_trivia(tokens, shebang, data_section, comments);
+        let mut parser = Parser::from_lex(lex_result);
         let ast = parser.parse();
         if let Some(e) = parser.take_errors().into_iter().next() {
             let _ = logger.error(e);
@@ -989,20 +981,15 @@ pub fn format(source: &str) -> Result<String, CompileError> {
     // formatting requires clean input, so lex errors are reported via
     // `CompileError::Lexer` (the first one wins).
     let lex_result = lexer::lex(source);
-    if let Some(e) = lex_result.errors.into_iter().next() {
+    if let Some(e) = lex_result.errors.first() {
         return Err(CompileError::Lexer {
-            message: e.message(),
+            message: e.to_string(),
             line: e.span.line,
             column: e.span.column,
             filename: None,
         });
     }
-    let mut parser = Parser::with_trivia(
-        lex_result.tokens,
-        lex_result.shebang,
-        lex_result.data_section,
-        lex_result.comments,
-    );
+    let mut parser = Parser::from_lex(lex_result);
     // Formatting requires a clean parse: reject the first recovered error.
     let ast = parser.parse();
     if let Some(e) = parser.take_errors().first() {
@@ -1048,7 +1035,7 @@ impl ParseResult {
     pub fn into_fail_fast(self) -> Result<ParseResult, CompileError> {
         if let Some(e) = self.lex_errors.first() {
             return Err(CompileError::Lexer {
-                message: e.message(),
+                message: e.to_string(),
                 line: e.span.line,
                 column: e.span.column,
                 filename: None,
@@ -1094,13 +1081,9 @@ pub async fn load<H: CompilerHost>(
 /// Parse a Wado source file into AST and trivia map.
 /// This is a lightweight operation that only lexes and parses.
 pub fn parse(source: &str) -> Result<ParseResult, CompileError> {
-    let lex_result = lexer::lex(source);
-    let mut parser = Parser::with_trivia(
-        lex_result.tokens,
-        lex_result.shebang,
-        lex_result.data_section,
-        lex_result.comments,
-    );
+    let mut lex_result = lexer::lex(source);
+    let lex_errors = std::mem::take(&mut lex_result.errors);
+    let mut parser = Parser::from_lex(lex_result);
     // Both lexing and parsing are resilient and always produce a `Module`;
     // callers that need fail-fast call `ParseResult::into_fail_fast`.
     let ast = parser.parse();
@@ -1111,7 +1094,7 @@ pub fn parse(source: &str) -> Result<ParseResult, CompileError> {
     Ok(ParseResult {
         ast,
         trivia,
-        lex_errors: lex_result.errors,
+        lex_errors,
         errors,
     })
 }

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -726,7 +726,7 @@ pub async fn dump_with_host_and_world<H: CompilerHost>(
         logger.set_file(f);
     }
 
-    // === Phase 1: Lexer (resilient — never aborts on its own) ===
+    // === Phase 1: Lexer ===
     let mut lex_result = {
         let _span = logger.span("lex");
         lexer::lex(source)
@@ -977,9 +977,8 @@ pub async fn dump_with_host_and_world<H: CompilerHost>(
 /// assert!(formatted.contains("use { println }"));
 /// ```
 pub fn format(source: &str) -> Result<String, CompileError> {
-    // Lexer (collect comments, shebang, data section). Lexer is resilient;
-    // formatting requires clean input, so lex errors are reported via
-    // `CompileError::Lexer` (the first one wins).
+    // Formatting requires a clean parse — the first recovered lex error
+    // becomes a `CompileError::Lexer`.
     let lex_result = lexer::lex(source);
     if let Some(e) = lex_result.errors.first() {
         return Err(CompileError::from_lex_error(e, None));

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -13,7 +13,6 @@ use rustc_hash::FxBuildHasher;
 use crate::ast::{Item, Module};
 use crate::bind;
 use crate::compiler_host::{CompilerHost, SourceError};
-use crate::lexer::Lexer;
 use crate::logger::Logger;
 use crate::module_source::{ModuleSource, ModuleSourceInterner, WasmAssetKind};
 use crate::name::{normalize_module_path, resolve_module_path};
@@ -706,8 +705,10 @@ fn format_stdlib_error(
 }
 
 fn parse_bind_stdlib(label: &str, source: &str) -> Module {
-    let mut lexer = Lexer::new(source);
-    let tokens = lexer.tokenize().unwrap_or_else(|e| {
+    let lex_result = crate::lexer::lex(source);
+    if let Some(e) = lex_result.errors.first() {
+        // Bundled stdlib must always lex cleanly; a recovered lex error here
+        // is a compiler bug, so fail loudly rather than degrade.
         panic!(
             "{}",
             format_stdlib_error(
@@ -717,12 +718,15 @@ fn parse_bind_stdlib(label: &str, source: &str) -> Module {
                 e.span.line,
                 e.span.column,
                 Some(e.span.end_column),
-                &e.message,
+                &e.message(),
             )
-        )
-    });
-    let (data_section, _comments, shebang) = lexer.into_parts();
-    let mut parser = Parser::with_metadata(tokens, shebang, data_section);
+        );
+    }
+    let mut parser = Parser::with_metadata(
+        lex_result.tokens,
+        lex_result.shebang,
+        lex_result.data_section,
+    );
     let ast = parser.parse();
     if let Some(e) = parser.take_errors().first() {
         // Bundled stdlib must always parse cleanly; a syntax error here is a
@@ -802,14 +806,13 @@ fn parse_stdlib_identity_attribute(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::lexer::Lexer;
+    use crate::lexer::lex;
     use crate::parser::Parser;
 
     fn parse_test_module(source: &str) -> Module {
-        let mut lexer = Lexer::new(source);
-        let tokens = lexer.tokenize().expect("test source must lex");
-        let (data_section, _comments, shebang) = lexer.into_parts();
-        let mut parser = Parser::with_metadata(tokens, shebang, data_section);
+        let r = lex(source);
+        assert!(r.errors.is_empty(), "test source must lex: {:?}", r.errors);
+        let mut parser = Parser::with_metadata(r.tokens, r.shebang, r.data_section);
         parser.parse_strict().expect("test source must parse")
     }
 
@@ -1525,16 +1528,21 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         source: &str,
         module_source: &ModuleSource,
     ) -> Result<Module, LoadError> {
-        let mut lexer = Lexer::new(source);
-        let tokens = lexer.tokenize().map_err(|e| LoadError::LexError {
-            module_source: module_source.clone(),
-            message: e.message,
-            line: e.span.line,
-            column: e.span.column,
-        })?;
-        let (data_section, _comments, shebang) = lexer.into_parts();
+        let lex_result = crate::lexer::lex(source);
+        if let Some(e) = lex_result.errors.first() {
+            return Err(LoadError::LexError {
+                module_source: module_source.clone(),
+                message: e.message(),
+                line: e.span.line,
+                column: e.span.column,
+            });
+        }
 
-        let mut parser = Parser::with_metadata(tokens, shebang, data_section);
+        let mut parser = Parser::with_metadata(
+            lex_result.tokens,
+            lex_result.shebang,
+            lex_result.data_section,
+        );
         // Batch loading is fail-fast: report the first recovered syntax error
         // as a load error so compilation never proceeds on a partial AST.
         let ast = parser.parse();

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -718,15 +718,11 @@ fn parse_bind_stdlib(label: &str, source: &str) -> Module {
                 e.span.line,
                 e.span.column,
                 Some(e.span.end_column),
-                &e.message(),
+                &e.to_string(),
             )
         );
     }
-    let mut parser = Parser::with_metadata(
-        lex_result.tokens,
-        lex_result.shebang,
-        lex_result.data_section,
-    );
+    let mut parser = Parser::from_lex(lex_result);
     let ast = parser.parse();
     if let Some(e) = parser.take_errors().first() {
         // Bundled stdlib must always parse cleanly; a syntax error here is a
@@ -812,7 +808,7 @@ mod tests {
     fn parse_test_module(source: &str) -> Module {
         let r = lex(source);
         assert!(r.errors.is_empty(), "test source must lex: {:?}", r.errors);
-        let mut parser = Parser::with_metadata(r.tokens, r.shebang, r.data_section);
+        let mut parser = Parser::from_lex(r);
         parser.parse_strict().expect("test source must parse")
     }
 
@@ -1532,17 +1528,13 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         if let Some(e) = lex_result.errors.first() {
             return Err(LoadError::LexError {
                 module_source: module_source.clone(),
-                message: e.message(),
+                message: e.to_string(),
                 line: e.span.line,
                 column: e.span.column,
             });
         }
 
-        let mut parser = Parser::with_metadata(
-            lex_result.tokens,
-            lex_result.shebang,
-            lex_result.data_section,
-        );
+        let mut parser = Parser::from_lex(lex_result);
         // Batch loading is fail-fast: report the first recovered syntax error
         // as a load error so compilation never proceeds on a partial AST.
         let ast = parser.parse();

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -60,6 +60,28 @@ pub enum LoadError {
     },
 }
 
+impl LoadError {
+    /// Build a `LexError` from a recovered [`crate::lexer::LexError`].
+    pub fn from_lex_error(e: &crate::lexer::LexError, module_source: ModuleSource) -> Self {
+        LoadError::LexError {
+            module_source,
+            message: e.to_string(),
+            line: e.span.line,
+            column: e.span.column,
+        }
+    }
+
+    /// Build a `ParseError` from a recovered [`crate::parser::ParseError`].
+    pub fn from_parse_error(e: &crate::parser::ParseError, module_source: ModuleSource) -> Self {
+        LoadError::ParseError {
+            module_source,
+            message: e.message.clone(),
+            line: e.span.line,
+            column: e.span.column,
+        }
+    }
+}
+
 impl std::fmt::Display for LoadError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -722,7 +744,7 @@ fn parse_bind_stdlib(label: &str, source: &str) -> Module {
             )
         );
     }
-    let mut parser = Parser::from_lex(lex_result);
+    let mut parser = Parser::from_lex_no_trivia(lex_result);
     let ast = parser.parse();
     if let Some(e) = parser.take_errors().first() {
         // Bundled stdlib must always parse cleanly; a syntax error here is a
@@ -808,7 +830,7 @@ mod tests {
     fn parse_test_module(source: &str) -> Module {
         let r = lex(source);
         assert!(r.errors.is_empty(), "test source must lex: {:?}", r.errors);
-        let mut parser = Parser::from_lex(r);
+        let mut parser = Parser::from_lex_no_trivia(r);
         parser.parse_strict().expect("test source must parse")
     }
 
@@ -1526,25 +1548,15 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
     ) -> Result<Module, LoadError> {
         let lex_result = crate::lexer::lex(source);
         if let Some(e) = lex_result.errors.first() {
-            return Err(LoadError::LexError {
-                module_source: module_source.clone(),
-                message: e.to_string(),
-                line: e.span.line,
-                column: e.span.column,
-            });
+            return Err(LoadError::from_lex_error(e, module_source.clone()));
         }
 
-        let mut parser = Parser::from_lex(lex_result);
+        let mut parser = Parser::from_lex_no_trivia(lex_result);
         // Batch loading is fail-fast: report the first recovered syntax error
         // as a load error so compilation never proceeds on a partial AST.
         let ast = parser.parse();
         if let Some(e) = parser.take_errors().first() {
-            return Err(LoadError::ParseError {
-                module_source: module_source.clone(),
-                message: e.message.clone(),
-                line: e.span.line,
-                column: e.span.column,
-            });
+            return Err(LoadError::from_parse_error(e, module_source.clone()));
         }
         Ok(ast)
     }

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -111,39 +111,53 @@ impl Parser {
     /// should call [`Parser::from_lex`] instead so shebang / data section /
     /// comments flow through.
     pub fn new(tokens: Vec<Token>) -> Self {
+        Self::build(tokens, None, None, Vec::new())
+    }
+
+    /// Parse a complete [`crate::lexer::LexResult`], keeping the comment
+    /// stream so the formatter / doc / dump paths can attach leading comments
+    /// to AST nodes as ids are allocated. The lexer's errors are not consumed
+    /// here — callers route them through [`crate::ParseResult::lex_errors`]
+    /// so the wire format keeps the `lexer error:` prefix distinct from
+    /// `parse error:`.
+    pub fn from_lex(lex: crate::lexer::LexResult) -> Self {
+        Self::build(lex.tokens, lex.shebang, lex.data_section, lex.comments)
+    }
+
+    /// Like [`Parser::from_lex`] but drops the comment stream. Used by the
+    /// loader and other non-formatter paths where trivia is allocated then
+    /// thrown away — clearing it up front skips the per-AST-id comment-cursor
+    /// walk and `Comment::clone` into [`crate::comment::TriviaMap`].
+    pub fn from_lex_no_trivia(lex: crate::lexer::LexResult) -> Self {
+        Self::build(lex.tokens, lex.shebang, lex.data_section, Vec::new())
+    }
+
+    fn build(
+        tokens: Vec<Token>,
+        shebang: Option<String>,
+        data_section: Option<String>,
+        comments: Vec<crate::comment::Comment>,
+    ) -> Self {
+        // Filter `TokenKind::Error` tokens at construction time so no parser
+        // path can mistake one for an identifier or generate a duplicate
+        // "expected …, found Error(...)" diagnostic. The lex error is already
+        // surfaced through `ParseResult::lex_errors`; the parser has no use
+        // for the recovery sentinel.
+        let tokens: Vec<Token> = tokens
+            .into_iter()
+            .filter(|t| !matches!(t.kind, TokenKind::Error(_)))
+            .collect();
         Self {
             tokens,
             pos: 0,
             pending_gt: false,
             restrict_struct_literals: false,
-            shebang: None,
-            data_section: None,
+            shebang,
+            data_section,
             include_paths: crate::hashmap::IndexSet::default(),
             parsed_inner_attributes: Vec::new(),
             next_ast_id: 0,
-            comments: Vec::new(),
-            comment_cursor: 0,
-            trivia: crate::comment::TriviaMap::new(),
-            errors: Vec::new(),
-        }
-    }
-
-    /// Parse a complete [`crate::lexer::LexResult`]. The lexer's errors are
-    /// not consumed here — callers route them through
-    /// [`crate::ParseResult::lex_errors`] so the wire format keeps the
-    /// `lexer error:` prefix distinct from `parse error:`.
-    pub fn from_lex(lex: crate::lexer::LexResult) -> Self {
-        Self {
-            tokens: lex.tokens,
-            pos: 0,
-            pending_gt: false,
-            restrict_struct_literals: false,
-            shebang: lex.shebang,
-            data_section: lex.data_section,
-            include_paths: crate::hashmap::IndexSet::default(),
-            parsed_inner_attributes: Vec::new(),
-            next_ast_id: 0,
-            comments: lex.comments,
+            comments,
             comment_cursor: 0,
             trivia: crate::comment::TriviaMap::new(),
             errors: Vec::new(),
@@ -315,14 +329,6 @@ impl Parser {
         let mut items = Vec::new();
 
         while !self.is_at_end() {
-            // Skip lexer-emitted error tokens silently — the underlying lex
-            // error was already absorbed via `absorb_lex_errors`, so the
-            // parser would otherwise report a redundant "expected item"
-            // diagnostic for the same span.
-            if matches!(self.peek_kind(), TokenKind::Error(_)) {
-                self.advance();
-                continue;
-            }
             let before = self.pos;
             match self.parse_item() {
                 Ok(item) => items.push(item),
@@ -1673,12 +1679,6 @@ impl Parser {
         // still over-reads `#` as a compile-time literal, blurring that one
         // diagnostic — the following item still recovers.
         while !self.check(&TokenKind::RBrace) && !self.is_at_end() && !self.at_hard_item_keyword() {
-            // Same rationale as the item loop: lex-error tokens are already
-            // diagnosed, so skip them without re-reporting.
-            if matches!(self.peek_kind(), TokenKind::Error(_)) {
-                self.advance();
-                continue;
-            }
             let before = self.pos;
             match self.parse_stmt_in_block() {
                 Ok(stmt) => stmts.push(stmt),
@@ -5346,11 +5346,13 @@ impl Parser {
 
         let lex_result = crate::lexer::lex_with_line(expr_str, span.line);
         // Lex errors inside the interpolation surface alongside the outer
-        // parser's diagnostics; we still try to parse whatever tokens we got.
+        // parser's diagnostics. Use the lex error's own span — carefully
+        // line-shifted by `lex_with_line` — so the editor highlights the
+        // offending byte, not the whole `{…}`.
         for e in &lex_result.errors {
             self.errors.push(ParseError {
-                message: format!("error parsing template interpolation: {}", e.to_string()),
-                span,
+                message: format!("error parsing template interpolation: {e}"),
+                span: e.span,
             });
         }
 
@@ -5557,7 +5559,7 @@ mod tests {
             "lexer error in test input: {:?}",
             r.errors
         );
-        let mut parser = Parser::from_lex(r);
+        let mut parser = Parser::from_lex_no_trivia(r);
         parser.parse_strict()
     }
 
@@ -5570,7 +5572,7 @@ mod tests {
             "lexer error in test input: {:?}",
             r.errors
         );
-        let mut parser = Parser::from_lex(r);
+        let mut parser = Parser::from_lex_no_trivia(r);
         let module = parser.parse();
         let errors = parser.take_errors();
         (module, errors)
@@ -7282,7 +7284,7 @@ line 2
             "lexer error in test input: {:?}",
             r.errors
         );
-        let mut parser = Parser::from_lex(r);
+        let mut parser = Parser::from_lex_no_trivia(r);
         let module = parser.parse();
         assert!(
             !parser.take_errors().is_empty(),

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -106,49 +106,44 @@ enum ComparisonChainGroup {
 }
 
 impl Parser {
+    /// Parse a hand-built token stream. Used by tests and the interpolation
+    /// re-parser; production sites that have a full [`crate::lexer::LexResult`]
+    /// should call [`Parser::from_lex`] instead so shebang / data section /
+    /// comments flow through.
     pub fn new(tokens: Vec<Token>) -> Self {
-        Self::build(tokens, None, None, Vec::new())
-    }
-
-    /// Creates a new parser with the given tokens, shebang, and data section.
-    pub fn with_metadata(
-        tokens: Vec<Token>,
-        shebang: Option<String>,
-        data_section: Option<String>,
-    ) -> Self {
-        Self::build(tokens, shebang, data_section, Vec::new())
-    }
-
-    /// Creates a new parser with full lexer output, including the comment
-    /// stream so leading comments can be attached to AST nodes as they are
-    /// allocated. Use this on the formatter path; the comment stream is
-    /// otherwise harmless when omitted.
-    pub fn with_trivia(
-        tokens: Vec<Token>,
-        shebang: Option<String>,
-        data_section: Option<String>,
-        comments: Vec<crate::comment::Comment>,
-    ) -> Self {
-        Self::build(tokens, shebang, data_section, comments)
-    }
-
-    fn build(
-        tokens: Vec<Token>,
-        shebang: Option<String>,
-        data_section: Option<String>,
-        comments: Vec<crate::comment::Comment>,
-    ) -> Self {
         Self {
             tokens,
             pos: 0,
             pending_gt: false,
             restrict_struct_literals: false,
-            shebang,
-            data_section,
+            shebang: None,
+            data_section: None,
             include_paths: crate::hashmap::IndexSet::default(),
             parsed_inner_attributes: Vec::new(),
             next_ast_id: 0,
-            comments,
+            comments: Vec::new(),
+            comment_cursor: 0,
+            trivia: crate::comment::TriviaMap::new(),
+            errors: Vec::new(),
+        }
+    }
+
+    /// Parse a complete [`crate::lexer::LexResult`]. The lexer's errors are
+    /// not consumed here — callers route them through
+    /// [`crate::ParseResult::lex_errors`] so the wire format keeps the
+    /// `lexer error:` prefix distinct from `parse error:`.
+    pub fn from_lex(lex: crate::lexer::LexResult) -> Self {
+        Self {
+            tokens: lex.tokens,
+            pos: 0,
+            pending_gt: false,
+            restrict_struct_literals: false,
+            shebang: lex.shebang,
+            data_section: lex.data_section,
+            include_paths: crate::hashmap::IndexSet::default(),
+            parsed_inner_attributes: Vec::new(),
+            next_ast_id: 0,
+            comments: lex.comments,
             comment_cursor: 0,
             trivia: crate::comment::TriviaMap::new(),
             errors: Vec::new(),
@@ -5354,7 +5349,7 @@ impl Parser {
         // parser's diagnostics; we still try to parse whatever tokens we got.
         for e in &lex_result.errors {
             self.errors.push(ParseError {
-                message: format!("error parsing template interpolation: {}", e.message()),
+                message: format!("error parsing template interpolation: {}", e.to_string()),
                 span,
             });
         }
@@ -5562,7 +5557,7 @@ mod tests {
             "lexer error in test input: {:?}",
             r.errors
         );
-        let mut parser = Parser::with_metadata(r.tokens, r.shebang, r.data_section);
+        let mut parser = Parser::from_lex(r);
         parser.parse_strict()
     }
 
@@ -5575,7 +5570,7 @@ mod tests {
             "lexer error in test input: {:?}",
             r.errors
         );
-        let mut parser = Parser::with_metadata(r.tokens, r.shebang, r.data_section);
+        let mut parser = Parser::from_lex(r);
         let module = parser.parse();
         let errors = parser.take_errors();
         (module, errors)
@@ -7287,7 +7282,7 @@ line 2
             "lexer error in test input: {:?}",
             r.errors
         );
-        let mut parser = Parser::with_metadata(r.tokens, r.shebang, r.data_section);
+        let mut parser = Parser::from_lex(r);
         let module = parser.parse();
         assert!(
             !parser.take_errors().is_empty(),

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -320,6 +320,14 @@ impl Parser {
         let mut items = Vec::new();
 
         while !self.is_at_end() {
+            // Skip lexer-emitted error tokens silently — the underlying lex
+            // error was already absorbed via `absorb_lex_errors`, so the
+            // parser would otherwise report a redundant "expected item"
+            // diagnostic for the same span.
+            if matches!(self.peek_kind(), TokenKind::Error(_)) {
+                self.advance();
+                continue;
+            }
             let before = self.pos;
             match self.parse_item() {
                 Ok(item) => items.push(item),
@@ -1670,6 +1678,12 @@ impl Parser {
         // still over-reads `#` as a compile-time literal, blurring that one
         // diagnostic — the following item still recovers.
         while !self.check(&TokenKind::RBrace) && !self.is_at_end() && !self.at_hard_item_keyword() {
+            // Same rationale as the item loop: lex-error tokens are already
+            // diagnosed, so skip them without re-reporting.
+            if matches!(self.peek_kind(), TokenKind::Error(_)) {
+                self.advance();
+                continue;
+            }
             let before = self.pos;
             match self.parse_stmt_in_block() {
                 Ok(stmt) => stmts.push(stmt),
@@ -5335,18 +5349,22 @@ impl Parser {
             });
         }
 
-        let mut lexer = crate::lexer::Lexer::with_line(expr_str, span.line);
-        let tokens = lexer.tokenize().map_err(|e| ParseError {
-            message: format!("error parsing template interpolation: {}", e.message),
-            span,
-        })?;
+        let lex_result = crate::lexer::lex_with_line(expr_str, span.line);
+        // Lex errors inside the interpolation surface alongside the outer
+        // parser's diagnostics; we still try to parse whatever tokens we got.
+        for e in &lex_result.errors {
+            self.errors.push(ParseError {
+                message: format!("error parsing template interpolation: {}", e.message()),
+                span,
+            });
+        }
 
         // Continue the parent's dense `AstId` space so interpolation
         // sub-expressions get unique ids: a fresh `Parser` restarts at 0,
         // and two interpolations (`{a}` and `{b}`) would then collide on
         // `AstId(0)`, clobbering each other's entries in the per-`AstId`
         // annotation maps (expression types, method/static dispatch).
-        let mut parser = Parser::new(tokens);
+        let mut parser = Parser::new(lex_result.tokens);
         parser.next_ast_id = self.next_ast_id;
         let expr = parser.parse_expr()?;
         self.next_ast_id = parser.next_ast_id;
@@ -5532,26 +5550,32 @@ fn parse_attr_number(repr: &str, negate: bool, span: Span) -> ParseResult<crate:
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::lexer::Lexer;
+    use crate::lexer::lex;
 
     /// Parse helper for tests: maps the error-recovering parser back to a
     /// `Result` (first recovered error as `Err`) so existing `.unwrap()` /
     /// `.unwrap_err()` call sites keep working.
     fn parse(source: &str) -> ParseResult<Module> {
-        let mut lexer = Lexer::new(source);
-        let tokens = lexer.tokenize().expect("lexer error");
-        let (data_section, _comments, shebang) = lexer.into_parts();
-        let mut parser = Parser::with_metadata(tokens, shebang, data_section);
+        let r = lex(source);
+        assert!(
+            r.errors.is_empty(),
+            "lexer error in test input: {:?}",
+            r.errors
+        );
+        let mut parser = Parser::with_metadata(r.tokens, r.shebang, r.data_section);
         parser.parse_strict()
     }
 
     /// Parse helper that exposes the full recovery result: the (always
     /// produced) module plus every recovered syntax error.
     fn parse_recovering(source: &str) -> (Module, Vec<ParseError>) {
-        let mut lexer = Lexer::new(source);
-        let tokens = lexer.tokenize().expect("lexer error");
-        let (data_section, _comments, shebang) = lexer.into_parts();
-        let mut parser = Parser::with_metadata(tokens, shebang, data_section);
+        let r = lex(source);
+        assert!(
+            r.errors.is_empty(),
+            "lexer error in test input: {:?}",
+            r.errors
+        );
+        let mut parser = Parser::with_metadata(r.tokens, r.shebang, r.data_section);
         let module = parser.parse();
         let errors = parser.take_errors();
         (module, errors)
@@ -7257,10 +7281,13 @@ line 2
         // `#![TODO]` parses fine but the next inner attribute is malformed. The
         // valid `#![TODO]` must not be discarded by recovery, so has_todo() and
         // the module's inner attributes still see it.
-        let mut lexer = Lexer::new("#![TODO]\n#![wasm_module(\n");
-        let tokens = lexer.tokenize().expect("lexer error");
-        let (data_section, _comments, shebang) = lexer.into_parts();
-        let mut parser = Parser::with_metadata(tokens, shebang, data_section);
+        let r = lex("#![TODO]\n#![wasm_module(\n");
+        assert!(
+            r.errors.is_empty(),
+            "lexer error in test input: {:?}",
+            r.errors
+        );
+        let mut parser = Parser::with_metadata(r.tokens, r.shebang, r.data_section);
         let module = parser.parse();
         assert!(
             !parser.take_errors().is_empty(),

--- a/wado-compiler/src/semantics.rs
+++ b/wado-compiler/src/semantics.rs
@@ -675,20 +675,16 @@ pub async fn semantics<H: CompilerHost>(
     host: &H,
     filename: Option<&str>,
 ) -> Semantics {
-    let parsed = match crate::parse(source) {
-        Ok(p) => p,
-        Err(e) => {
-            // Lexer failure: no usable AST.
-            host.emit_diagnostic(parse_failure_diagnostic(&e, filename));
-            return Semantics::empty();
-        }
-    };
-    // Surface every recovered syntax error, then analyze the partial AST so
-    // queries still resolve in the regions outside the error. If load/bind
+    let parsed = crate::parse(source);
+    // Surface every recovered lex/parse error, then analyze the partial AST
+    // so queries still resolve in the regions outside the error. If load/bind
     // then fails on the partial AST, the result still collapses to
     // `Semantics::empty()` below — recovery helps only when binding succeeds,
     // which holds for the common cases (missing brace, garbage item) where
     // scopes stay separate.
+    for e in &parsed.lex_errors {
+        host.emit_diagnostic(lex_error_diagnostic(e, filename));
+    }
     for e in &parsed.errors {
         host.emit_diagnostic(parse_error_diagnostic(e, filename));
     }
@@ -710,47 +706,6 @@ pub async fn semantics<H: CompilerHost>(
             let _ = logger.error(e);
             Semantics::empty()
         }
-    }
-}
-
-/// Convert a lex/parse failure from [`crate::parse`] into the same
-/// [`crate::Diagnostic`] shape the loader emits for
-/// `LoadError::{LexError, ParseError}`. Keeps every route to a
-/// [`Semantics`] (the [`semantics`] convenience, LSP-side three-stage
-/// composition, batch frontend) producing the same wire diagnostic for
-/// the same input failure.
-#[must_use]
-pub fn parse_failure_diagnostic(
-    err: &crate::CompileError,
-    filename: Option<&str>,
-) -> crate::Diagnostic {
-    use crate::{Code, Diagnostic, DiagnosticSpan, Severity};
-    let (message, line, column) = match err {
-        crate::CompileError::Lexer {
-            message,
-            line,
-            column,
-            ..
-        } => (format!("lexer error: {message}"), *line, *column),
-        crate::CompileError::Parser {
-            message,
-            line,
-            column,
-            ..
-        } => (format!("parse error: {message}"), *line, *column),
-        other => (other.to_string(), 1, 1),
-    };
-    Diagnostic {
-        severity: Severity::Error,
-        code: Code::InvalidSyntax,
-        message,
-        span: filename.map(|f| DiagnosticSpan {
-            file: f.to_string(),
-            line,
-            column,
-            end_line: None,
-            end_column: None,
-        }),
     }
 }
 
@@ -791,7 +746,7 @@ pub fn lex_error_diagnostic(
     Diagnostic {
         severity: Severity::Error,
         code: Code::InvalidSyntax,
-        message: format!("lexer error: {}", err.to_string()),
+        message: format!("lexer error: {err}"),
         span: filename.map(|f| DiagnosticSpan {
             file: f.to_string(),
             line: err.span.line,

--- a/wado-compiler/src/semantics.rs
+++ b/wado-compiler/src/semantics.rs
@@ -791,7 +791,7 @@ pub fn lex_error_diagnostic(
     Diagnostic {
         severity: Severity::Error,
         code: Code::InvalidSyntax,
-        message: format!("lexer error: {}", err.message()),
+        message: format!("lexer error: {}", err.to_string()),
         span: filename.map(|f| DiagnosticSpan {
             file: f.to_string(),
             line: err.span.line,

--- a/wado-compiler/src/semantics.rs
+++ b/wado-compiler/src/semantics.rs
@@ -778,6 +778,30 @@ pub fn parse_error_diagnostic(
     }
 }
 
+/// Convert a single recovered [`crate::lexer::LexError`] into a
+/// `lexer error: …` [`crate::Diagnostic`], attributing the span to
+/// `filename`. The resilient lexer surfaces one of these per recovered
+/// problem; LSP and batch report them alongside parser diagnostics.
+#[must_use]
+pub fn lex_error_diagnostic(
+    err: &crate::lexer::LexError,
+    filename: Option<&str>,
+) -> crate::Diagnostic {
+    use crate::{Code, Diagnostic, DiagnosticSpan, Severity};
+    Diagnostic {
+        severity: Severity::Error,
+        code: Code::InvalidSyntax,
+        message: format!("lexer error: {}", err.message()),
+        span: filename.map(|f| DiagnosticSpan {
+            file: f.to_string(),
+            line: err.span.line,
+            column: err.span.column,
+            end_line: Some(err.span.end_line),
+            end_column: Some(err.span.end_column),
+        }),
+    }
+}
+
 impl Semantics {
     /// Construct an empty [`Semantics`] with no modules at all. Used when
     /// an upstream phase fails outright (parse error on the entry, load

--- a/wado-compiler/src/syntax.rs
+++ b/wado-compiler/src/syntax.rs
@@ -165,7 +165,6 @@ impl SyntaxDefinition {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::lexer::Lexer;
     use crate::token::TokenKind;
 
     #[test]
@@ -208,11 +207,11 @@ mod tests {
             if contextual_keywords.contains(keyword) {
                 continue;
             }
-            let mut lexer = Lexer::new(keyword);
-            let tokens = lexer.tokenize().expect("should lex keyword");
-            assert!(!tokens.is_empty(), "'{keyword}' produced no tokens");
+            let r = crate::lexer::lex(keyword);
+            assert!(r.errors.is_empty(), "lexer error: {:?}", r.errors);
+            assert!(!r.tokens.is_empty(), "'{keyword}' produced no tokens");
             assert!(
-                !matches!(tokens[0].kind, TokenKind::Ident(_)),
+                !matches!(r.tokens[0].kind, TokenKind::Ident(_)),
                 "'{keyword}' in SyntaxDefinition is not recognized as a keyword by lexer"
             );
         }

--- a/wado-compiler/src/token.rs
+++ b/wado-compiler/src/token.rs
@@ -123,12 +123,13 @@ pub enum TokenKind {
     Question,  // ?
 
     // Special
-    /// Lexer-emitted recovery token for an unrecognised character.
-    ///
-    /// Holds the raw source text (typically a single char) so downstream
-    /// consumers (formatter, semantic tokens) can render it. Healthy source
-    /// never produces this variant; it appears only when [`crate::lexer::lex`]
-    /// reports a corresponding [`crate::lexer::LexErrorKind::UnexpectedChar`].
+    /// Lexer-emitted recovery token for an unrecognised character. Healthy
+    /// source never produces this variant; it appears only when
+    /// [`crate::lexer::lex`] also pushes a
+    /// [`crate::lexer::LexErrorKind::UnexpectedChar`].
+    /// [`crate::parser::Parser::from_lex`] filters it out at construction;
+    /// LSP semantic tokens and other consumers that read the raw token
+    /// stream see it directly.
     Error(String),
 
     Eof,
@@ -311,10 +312,10 @@ pub fn canonical_token_bytes(out: &mut Vec<u8>, kind: &TokenKind) {
         StringLit, Struct, TemplateStringLit, Tilde, Trait, True, Type, Unique, Use, Variant,
         While, With, World,
     };
-    // `Error` is excluded: it only appears in resilient lex output for
-    // malformed source. Healthy code (the only thing the canonical hash
-    // sees) never produces it, so omitting it from the encoding keeps the
-    // bytes stable. We assert below.
+    // `Error` is excluded: it only appears in malformed lex output, which
+    // kiln gates out before reaching this function. Omitting it from the
+    // encoding keeps the canonical bytes stable; the arm below panics if
+    // the invariant is ever broken.
 
     fn write_str(out: &mut Vec<u8>, tag: u8, name: &str) {
         out.push(tag);

--- a/wado-compiler/src/token.rs
+++ b/wado-compiler/src/token.rs
@@ -123,6 +123,14 @@ pub enum TokenKind {
     Question,  // ?
 
     // Special
+    /// Lexer-emitted recovery token for an unrecognised character.
+    ///
+    /// Holds the raw source text (typically a single char) so downstream
+    /// consumers (formatter, semantic tokens) can render it. Healthy source
+    /// never produces this variant; it appears only when [`crate::lexer::lex`]
+    /// reports a corresponding [`crate::lexer::LexErrorKind::UnexpectedChar`].
+    Error(String),
+
     Eof,
 }
 
@@ -303,6 +311,10 @@ pub fn canonical_token_bytes(out: &mut Vec<u8>, kind: &TokenKind) {
         StringLit, Struct, TemplateStringLit, Tilde, Trait, True, Type, Unique, Use, Variant,
         While, With, World,
     };
+    // `Error` is excluded: it only appears in resilient lex output for
+    // malformed source. Healthy code (the only thing the canonical hash
+    // sees) never produces it, so omitting it from the encoding keeps the
+    // bytes stable. We assert below.
 
     fn write_str(out: &mut Vec<u8>, tag: u8, name: &str) {
         out.push(tag);
@@ -442,6 +454,17 @@ pub fn canonical_token_bytes(out: &mut Vec<u8>, kind: &TokenKind) {
 
         // Special
         Eof => write_str(out, b'V', "Eof"),
+
+        // Recovery artefacts: not part of the canonical encoding. Source files
+        // tracked by kiln only contain healthy code, so they never carry an
+        // `Error` token, and the sidecar hash stays stable across this variant
+        // being added. Panic in debug builds if this invariant breaks.
+        TokenKind::Error(_) => {
+            debug_assert!(
+                false,
+                "TokenKind::Error must not appear in canonically-hashed token streams"
+            );
+        }
     }
 }
 

--- a/wado-compiler/src/token.rs
+++ b/wado-compiler/src/token.rs
@@ -455,16 +455,15 @@ pub fn canonical_token_bytes(out: &mut Vec<u8>, kind: &TokenKind) {
         // Special
         Eof => write_str(out, b'V', "Eof"),
 
-        // Recovery artefacts: not part of the canonical encoding. Source files
-        // tracked by kiln only contain healthy code, so they never carry an
-        // `Error` token, and the sidecar hash stays stable across this variant
-        // being added. Panic in debug builds if this invariant breaks.
-        TokenKind::Error(_) => {
-            debug_assert!(
-                false,
-                "TokenKind::Error must not appear in canonically-hashed token streams"
-            );
-        }
+        // Recovery artefacts have no canonical encoding. The only consumer
+        // (kiln_provider::hash_source) gates on `LexResult::errors.is_empty()`
+        // before reaching this function, so `Error` tokens are unreachable
+        // here; release builds get a loud panic instead of a silent empty
+        // arm that would collide hashes across distinct malformed sources.
+        TokenKind::Error(_) => unreachable!(
+            "TokenKind::Error must not appear in canonically-hashed token streams; \
+             callers must filter on LexResult::errors.is_empty() first",
+        ),
     }
 }
 

--- a/wado-compiler/tests/e2e.rs
+++ b/wado-compiler/tests/e2e.rs
@@ -700,10 +700,7 @@ fn run_fixture_test_with_opt(fixture_path: &Path, source: &str, opt_level: OptLe
     // For test world: individual tests are already marked #[TODO] by the elaborator,
     // so no special handling is needed here.
     // For CLI/HTTP worlds: runtime failures in #![TODO] modules need catch_unwind.
-    let is_todo_module = match wado_compiler::parse(source) {
-        Ok(r) => r.ast.has_todo(),
-        Err(e) => e.is_todo_module(),
-    };
+    let is_todo_module = wado_compiler::parse(source).ast.has_todo();
 
     if is_todo_module {
         eprintln!("[{test_id}] #![TODO] module — expecting failure");

--- a/wado-compiler/tests/format.rs
+++ b/wado-compiler/tests/format.rs
@@ -94,14 +94,15 @@ fn assert_format_preserves_ast(source: &str) {
         .unwrap_or_else(|e| panic!("test source failed to format: {e:?}\n\nSource:\n{source}"));
 
     let original_ast = wado_compiler::parse(source)
+        .into_fail_fast()
         .unwrap_or_else(|e| panic!("test source failed to parse: {e:?}\n\nSource:\n{source}"))
         .ast;
-    let formatted_ast = match wado_compiler::parse(&formatted) {
-        Ok(r) => r.ast,
-        Err(e) => panic!(
+    let formatted_ast = wado_compiler::parse(&formatted)
+        .into_fail_fast()
+        .unwrap_or_else(|e| panic!(
             "formatted code failed to parse: {e:?}\n\nOriginal:\n{source}\n\nFormatted:\n{formatted}"
-        ),
-    };
+        ))
+        .ast;
 
     let original_debug = normalize_ast_debug(&format!("{original_ast:#?}"));
     let formatted_debug = normalize_ast_debug(&format!("{formatted_ast:#?}"));
@@ -2098,11 +2099,11 @@ fn test_roundtrip_ast_all_fixtures() {
             Err(_) => continue,
         };
 
-        let original_ast = match wado_compiler::parse(&source) {
+        let original_ast = match wado_compiler::parse(&source).into_fail_fast() {
             Ok(r) => r.ast,
             Err(_) => continue,
         };
-        let formatted_ast = match wado_compiler::parse(&formatted) {
+        let formatted_ast = match wado_compiler::parse(&formatted).into_fail_fast() {
             Ok(r) => r.ast,
             Err(e) => {
                 failures.push(format!("{filename}: formatted code failed to parse: {e:?}"));
@@ -2217,11 +2218,11 @@ fn test_roundtrip_ast_all_stdlib() {
                 Err(_) => continue,
             };
 
-            let original_ast = match wado_compiler::parse(&source) {
+            let original_ast = match wado_compiler::parse(&source).into_fail_fast() {
                 Ok(r) => r.ast,
                 Err(_) => continue,
             };
-            let formatted_ast = match wado_compiler::parse(&formatted) {
+            let formatted_ast = match wado_compiler::parse(&formatted).into_fail_fast() {
                 Ok(r) => r.ast,
                 Err(e) => {
                     failures.push(format!("{rel}: formatted code failed to parse: {e:?}"));

--- a/wado-compiler/tests/kiln_loader_redirect.rs
+++ b/wado-compiler/tests/kiln_loader_redirect.rs
@@ -23,6 +23,12 @@ fn build_with_invocations(
 ) -> Semantics {
     block_on(async {
         let parsed = parse(source);
+        assert!(
+            parsed.lex_errors.is_empty() && parsed.errors.is_empty(),
+            "entry source should parse cleanly: lex={:?} parse={:?}",
+            parsed.lex_errors,
+            parsed.errors,
+        );
         let loaded = load(
             parsed,
             Some(filename),

--- a/wado-compiler/tests/kiln_loader_redirect.rs
+++ b/wado-compiler/tests/kiln_loader_redirect.rs
@@ -22,7 +22,7 @@ fn build_with_invocations(
     invocations: InvocationIndex,
 ) -> Semantics {
     block_on(async {
-        let parsed = parse(source).expect("entry source should parse");
+        let parsed = parse(source);
         let loaded = load(
             parsed,
             Some(filename),

--- a/wado-compiler/tests/lexer_recovery.rs
+++ b/wado-compiler/tests/lexer_recovery.rs
@@ -1,0 +1,207 @@
+//! Tests for resilient lexer recovery.
+//!
+//! The new lexer API never fails: it returns a `LexResult` bundling the token
+//! stream, errors, comments, shebang, and data section. Token output is
+//! best-effort even in the presence of malformed input — every byte is
+//! accounted for, and downstream consumers (parser, LSP semantic tokens) can
+//! continue past errors.
+
+use wado_compiler::lexer::{LexErrorKind, lex};
+use wado_compiler::token::TokenKind;
+
+fn token_kinds(source: &str) -> Vec<TokenKind> {
+    lex(source).tokens.into_iter().map(|t| t.kind).collect()
+}
+
+#[test]
+fn lex_never_returns_result() {
+    // Pure API smoke check: lex returns LexResult by value.
+    let r = lex("fn main() {}");
+    assert!(r.errors.is_empty());
+    assert!(matches!(
+        r.tokens.first().map(|t| &t.kind),
+        Some(TokenKind::Fn)
+    ));
+}
+
+#[test]
+fn unexpected_char_emits_error_token_and_continues() {
+    let r = lex("fn @ main()");
+    assert_eq!(r.errors.len(), 1);
+    assert!(matches!(
+        r.errors[0].kind,
+        LexErrorKind::UnexpectedChar('@')
+    ));
+    // The lexer must continue past the bad char and recognise `main()`.
+    let kinds = r.tokens.iter().map(|t| &t.kind).collect::<Vec<_>>();
+    assert!(matches!(kinds[0], TokenKind::Fn));
+    assert!(matches!(kinds[1], TokenKind::Error(s) if s == "@"));
+    assert!(matches!(kinds[2], TokenKind::Ident(s) if s == "main"));
+    assert!(matches!(kinds[3], TokenKind::LParen));
+    assert!(matches!(kinds[4], TokenKind::RParen));
+}
+
+#[test]
+fn multiple_unexpected_chars_each_get_an_error() {
+    let r = lex("@ @ @");
+    assert_eq!(r.errors.len(), 3);
+    for e in &r.errors {
+        assert!(matches!(e.kind, LexErrorKind::UnexpectedChar('@')));
+    }
+}
+
+#[test]
+fn unterminated_string_keeps_preceding_tokens() {
+    // The unterminated string consumes to EOF (multi-line strings are legal),
+    // but the `let x =` tokens before it must survive.
+    let r = lex("let x = \"oops");
+    assert_eq!(r.errors.len(), 1);
+    assert!(matches!(r.errors[0].kind, LexErrorKind::UnterminatedString));
+    let kinds = token_kinds("let x = \"oops");
+    assert!(matches!(kinds[0], TokenKind::Let));
+    assert!(matches!(kinds[1], TokenKind::Ident(ref s) if s == "x"));
+    assert!(matches!(kinds[2], TokenKind::Eq));
+    assert!(matches!(kinds[3], TokenKind::StringLit(ref s) if s == "oops"));
+}
+
+#[test]
+fn unterminated_char_emits_charlit_with_content() {
+    let r = lex("let c = 'a");
+    assert_eq!(r.errors.len(), 1);
+    assert!(matches!(r.errors[0].kind, LexErrorKind::UnterminatedChar));
+    assert!(
+        r.tokens
+            .iter()
+            .any(|t| matches!(&t.kind, TokenKind::CharLit(s) if s == "a"))
+    );
+}
+
+#[test]
+fn empty_char_literal_emits_charlit_and_continues() {
+    // `''` -> error + CharLit("") + subsequent tokens.
+    let r = lex("let c = ''; fn main(){}");
+    assert_eq!(r.errors.len(), 1);
+    assert!(matches!(r.errors[0].kind, LexErrorKind::EmptyCharLiteral));
+    // The lexer must keep parsing after `''` so `fn main(){}` is still tokenised.
+    assert!(r.tokens.iter().any(|t| matches!(t.kind, TokenKind::Fn)));
+    assert!(
+        r.tokens
+            .iter()
+            .any(|t| matches!(&t.kind, TokenKind::Ident(s) if s == "main"))
+    );
+}
+
+#[test]
+fn missing_hex_digits_recovers_to_following_ident() {
+    // `0xZ` was previously an error stopping the lexer. Now: NumberLit("0x") + error,
+    // then continue and pick up `Z` as an identifier.
+    let r = lex("let v = 0xZ;");
+    assert_eq!(r.errors.len(), 1);
+    assert!(matches!(r.errors[0].kind, LexErrorKind::MissingHexDigits));
+    assert!(
+        r.tokens
+            .iter()
+            .any(|t| matches!(&t.kind, TokenKind::Ident(s) if s == "Z"))
+    );
+}
+
+#[test]
+fn missing_binary_digits_recovers() {
+    let r = lex("let v = 0b;");
+    assert_eq!(r.errors.len(), 1);
+    assert!(matches!(
+        r.errors[0].kind,
+        LexErrorKind::MissingBinaryDigits
+    ));
+    assert!(
+        r.tokens
+            .iter()
+            .any(|t| matches!(t.kind, TokenKind::Semicolon))
+    );
+}
+
+#[test]
+fn missing_octal_digits_recovers() {
+    let r = lex("let v = 0o;");
+    assert_eq!(r.errors.len(), 1);
+    assert!(matches!(r.errors[0].kind, LexErrorKind::MissingOctalDigits));
+    assert!(
+        r.tokens
+            .iter()
+            .any(|t| matches!(t.kind, TokenKind::Semicolon))
+    );
+}
+
+#[test]
+fn missing_exponent_digits_recovers() {
+    let r = lex("let v = 1e;");
+    assert_eq!(r.errors.len(), 1);
+    assert!(matches!(
+        r.errors[0].kind,
+        LexErrorKind::MissingExponentDigits
+    ));
+    assert!(
+        r.tokens
+            .iter()
+            .any(|t| matches!(t.kind, TokenKind::Semicolon))
+    );
+}
+
+#[test]
+fn unterminated_block_comment_does_not_lose_preceding_tokens() {
+    // Block comment swallowing the rest of the file is unavoidable, but the
+    // earlier tokens must survive (this was previously dropped on Err).
+    let r = lex("fn main() /* oops");
+    assert_eq!(r.errors.len(), 1);
+    assert!(matches!(
+        r.errors[0].kind,
+        LexErrorKind::UnterminatedBlockComment
+    ));
+    let kinds = r.tokens.iter().map(|t| &t.kind).collect::<Vec<_>>();
+    assert!(matches!(kinds[0], TokenKind::Fn));
+    assert!(matches!(kinds[1], TokenKind::Ident(s) if s == "main"));
+    assert!(matches!(kinds[2], TokenKind::LParen));
+    assert!(matches!(kinds[3], TokenKind::RParen));
+}
+
+#[test]
+fn unterminated_template_string_keeps_preceding_tokens() {
+    let r = lex("let s = `hello {name");
+    assert_eq!(r.errors.len(), 1);
+    assert!(matches!(
+        r.errors[0].kind,
+        LexErrorKind::UnterminatedTemplateString
+    ));
+    assert!(matches!(r.tokens[0].kind, TokenKind::Let));
+}
+
+#[test]
+fn comments_are_in_lex_result() {
+    let r = lex("// hi\nfn main() {}");
+    assert_eq!(r.comments.len(), 1);
+    assert_eq!(r.comments[0].text, " hi");
+}
+
+#[test]
+fn data_section_is_in_lex_result() {
+    let source = "fn main() {}\n__DATA__\nhello";
+    let r = lex(source);
+    assert_eq!(r.data_section.as_deref(), Some("hello"));
+}
+
+#[test]
+fn shebang_is_in_lex_result() {
+    let r = lex("#!/usr/bin/env wado\nfn main() {}");
+    assert_eq!(r.shebang.as_deref(), Some("#!/usr/bin/env wado"));
+}
+
+#[test]
+fn error_spans_are_correct() {
+    let r = lex("fn @ main()");
+    let err = &r.errors[0];
+    // `@` is at byte 3, line 1, column 4 (1-based).
+    assert_eq!(err.span.start, 3);
+    assert_eq!(err.span.end, 4);
+    assert_eq!(err.span.line, 1);
+    assert_eq!(err.span.column, 4);
+}

--- a/wado-compiler/tests/lexer_recovery.rs
+++ b/wado-compiler/tests/lexer_recovery.rs
@@ -77,6 +77,49 @@ fn unterminated_char_emits_charlit_with_content() {
 }
 
 #[test]
+fn multi_char_literal_recovers_as_single_charlit_too_long() {
+    // `'abc'` used to cascade: CharLit("a") + UnterminatedChar + Ident("bc")
+    // + a second UnterminatedChar on the lone closing `'`. Recovery now
+    // consumes up to the closing quote and emits exactly one diagnostic.
+    let r = lex("let c = 'abc';");
+    assert_eq!(r.errors.len(), 1);
+    assert!(matches!(r.errors[0].kind, LexErrorKind::CharLiteralTooLong));
+    let kinds: Vec<&TokenKind> = r.tokens.iter().map(|t| &t.kind).collect();
+    // No stray Ident("bc") — the inner content stays inside the CharLit.
+    assert!(
+        !kinds
+            .iter()
+            .any(|k| matches!(k, TokenKind::Ident(s) if s == "bc")),
+        "found stray Ident(\"bc\") — recovery cascaded: {kinds:?}"
+    );
+    assert!(
+        r.tokens
+            .iter()
+            .any(|t| matches!(&t.kind, TokenKind::CharLit(s) if s == "abc"))
+    );
+    assert!(
+        r.tokens
+            .iter()
+            .any(|t| matches!(t.kind, TokenKind::Semicolon))
+    );
+}
+
+#[test]
+fn unterminated_char_stops_at_newline_not_eof() {
+    // `'ab\n` (no closing quote, then newline): recover at the newline so
+    // the next line still lexes cleanly.
+    let r = lex("let c = 'ab\nlet d = 1;");
+    assert_eq!(r.errors.len(), 1);
+    assert!(matches!(r.errors[0].kind, LexErrorKind::UnterminatedChar));
+    // `let d = 1;` after the broken line must still tokenise.
+    assert!(
+        r.tokens
+            .iter()
+            .any(|t| matches!(&t.kind, TokenKind::Ident(s) if s == "d"))
+    );
+}
+
+#[test]
 fn empty_char_literal_emits_charlit_and_continues() {
     // `''` -> error + CharLit("") + subsequent tokens.
     let r = lex("let c = ''; fn main(){}");

--- a/wado-compiler/tests/literals.rs
+++ b/wado-compiler/tests/literals.rs
@@ -16,7 +16,7 @@ fn parse_expr(source: &str) -> Result<wado_compiler::ast::Module, String> {
 
     let r = lex(&wrapped);
     if let Some(e) = r.errors.first() {
-        return Err(e.message());
+        return Err(e.to_string());
     }
 
     let mut parser = Parser::new(r.tokens);

--- a/wado-compiler/tests/literals.rs
+++ b/wado-compiler/tests/literals.rs
@@ -7,17 +7,19 @@
 //! `Literal::Char` all carry raw source text. Escape interpretation happens in
 //! the elaborator, not here.
 
-use wado_compiler::{Lexer, Parser};
+use wado_compiler::{Parser, lex};
 
 /// Parse a simple expression and return the AST
 fn parse_expr(source: &str) -> Result<wado_compiler::ast::Module, String> {
     // Wrap the expression in a function to make it a valid module
     let wrapped = format!("fn test() {{ let x = {source}; }}");
 
-    let mut lexer = Lexer::new(&wrapped);
-    let tokens = lexer.tokenize().map_err(|e| e.message)?;
+    let r = lex(&wrapped);
+    if let Some(e) = r.errors.first() {
+        return Err(e.message());
+    }
 
-    let mut parser = Parser::new(tokens);
+    let mut parser = Parser::new(r.tokens);
     parser.parse_strict().map_err(|e| e.message)
 }
 

--- a/wado-compiler/tests/string_templates.rs
+++ b/wado-compiler/tests/string_templates.rs
@@ -3,17 +3,19 @@
 //! String templates use backticks and allow interpolation with {expr} syntax.
 //! They also support Python-like format specifiers, e.g., {pi:.2f}
 
-use wado_compiler::{Lexer, Parser};
+use wado_compiler::{Parser, lex};
 
 /// Parse a simple expression and return the AST
 fn parse_expr(source: &str) -> Result<wado_compiler::ast::Module, String> {
     // Wrap the expression in a function to make it a valid module
     let wrapped = format!("fn test() {{ let x = {source}; }}");
 
-    let mut lexer = Lexer::new(&wrapped);
-    let tokens = lexer.tokenize().map_err(|e| e.message)?;
+    let r = lex(&wrapped);
+    if let Some(e) = r.errors.first() {
+        return Err(e.message());
+    }
 
-    let mut parser = Parser::new(tokens);
+    let mut parser = Parser::new(r.tokens);
     parser.parse_strict().map_err(|e| e.message)
 }
 

--- a/wado-compiler/tests/string_templates.rs
+++ b/wado-compiler/tests/string_templates.rs
@@ -12,7 +12,7 @@ fn parse_expr(source: &str) -> Result<wado_compiler::ast::Module, String> {
 
     let r = lex(&wrapped);
     if let Some(e) = r.errors.first() {
-        return Err(e.message());
+        return Err(e.to_string());
     }
 
     let mut parser = Parser::new(r.tokens);

--- a/wado-lsp/AGENTS.md
+++ b/wado-lsp/AGENTS.md
@@ -58,16 +58,18 @@ checks `Semantics::is_complete()` and aborts on partial results;
 LSP-side queries simply degrade to "no answer" for fields the bailed
 phase would have populated.
 
-When a stage fails outright — entry lex/parse error, or loader bail
-on a missing/broken import — `build_semantics` (`src/lib.rs`) emits
-the failure diagnostic via the host and returns
-[`Semantics::empty`]. Every position-bearing query consequently
-returns `None` / `[]` for that snapshot; semantic-token highlighting
-still works because `semantic_tokens::compute` falls back to
-lexer-only classification when `parse` fails. The current behaviour
-is pinned by `tests/parse_error.rs`. A future error-recovering parser
-should let the position queries resolve in regions outside the
-syntax error; until then, the fail-fast degradation is intentional.
+Both lexing and parsing are error-recovering. Recovered lex errors
+surface as `lexer error: …` diagnostics, parser errors as
+`parse error: …`, and the partial `Semantics` still drives position
+queries on the surrounding healthy regions. The loader path is the
+only remaining hard failure: if a missing/broken import or a
+downstream phase bails, `build_semantics` (`src/lib.rs`) emits the
+failure diagnostic via the host and returns [`Semantics::empty`],
+and every position-bearing query returns `None` / `[]` for that
+snapshot. Semantic-token highlighting still works in that case
+because `semantic_tokens::compute` falls back to lexer-only
+classification. The recovery behaviour is pinned by
+`tests/parse_error.rs`.
 
 ### Position encoding
 

--- a/wado-lsp/src/lib.rs
+++ b/wado-lsp/src/lib.rs
@@ -446,10 +446,13 @@ async fn build_semantics<H: CompilerHost>(source: &str, filename: &str, host: &H
             return Semantics::empty();
         }
     };
-    // Report each recovered syntax error, then continue with the partial AST
-    // so position queries resolve in the regions outside the error. A
+    // Report each recovered lex/parse error, then continue with the partial
+    // AST so position queries resolve in the regions outside the error. A
     // load/bind failure on the partial AST still degrades to
     // `Semantics::empty()` below; recovery helps only when binding succeeds.
+    for e in &parsed.lex_errors {
+        host.emit_diagnostic(wado_compiler::lex_error_diagnostic(e, Some(filename)));
+    }
     for e in &parsed.errors {
         host.emit_diagnostic(wado_compiler::parse_error_diagnostic(e, Some(filename)));
     }

--- a/wado-lsp/src/lib.rs
+++ b/wado-lsp/src/lib.rs
@@ -438,14 +438,7 @@ impl<H: CompilerHost> CompilerHost for DiagnosticCollector<'_, H> {
 /// returns [`Semantics::empty`], so callers see a uniformly-shaped
 /// (possibly empty) snapshot regardless of which stage bailed.
 async fn build_semantics<H: CompilerHost>(source: &str, filename: &str, host: &H) -> Semantics {
-    let parsed = match wado_compiler::parse(source) {
-        Ok(p) => p,
-        Err(e) => {
-            // Lexer failure: no usable AST.
-            host.emit_diagnostic(wado_compiler::parse_failure_diagnostic(&e, Some(filename)));
-            return Semantics::empty();
-        }
-    };
+    let parsed = wado_compiler::parse(source);
     // Report each recovered lex/parse error, then continue with the partial
     // AST so position queries resolve in the regions outside the error. A
     // load/bind failure on the partial AST still degrades to

--- a/wado-lsp/src/semantic_tokens.rs
+++ b/wado-lsp/src/semantic_tokens.rs
@@ -67,11 +67,8 @@ pub fn compute(source: &str) -> Vec<SemanticToken> {
     let tokens = lex_result.tokens;
     let comments = lex_result.comments;
 
-    // 2. Parse (best-effort)
-    let ast_types = match wado_compiler::parse(source) {
-        Ok(pr) => collect_type_spans(&pr.ast),
-        Err(_) => TypeSpans::default(),
-    };
+    // 2. Parse (best-effort — resilient, always produces an AST).
+    let ast_types = collect_type_spans(&wado_compiler::parse(source).ast);
 
     // 3. Classify lexer tokens
     let mut result = Vec::new();

--- a/wado-lsp/src/semantic_tokens.rs
+++ b/wado-lsp/src/semantic_tokens.rs
@@ -1,6 +1,6 @@
 use indexmap::IndexMap;
 use wado_compiler::ast::{self, Expr, Item, Stmt, Type};
-use wado_compiler::lexer::Lexer;
+use wado_compiler::lexer::lex;
 use wado_compiler::token::{Token, TokenKind};
 
 use crate::text::{PositionEncoding, codepoints_to_code_units, line_without_terminator};
@@ -61,13 +61,11 @@ pub struct SemanticToken {
 /// count. [`delta_encode`] later converts both into the negotiated LSP
 /// position encoding.
 pub fn compute(source: &str) -> Vec<SemanticToken> {
-    // 1. Lex
-    let mut lexer = Lexer::new(source);
-    let tokens = match lexer.tokenize() {
-        Ok(t) => t,
-        Err(_) => return Vec::new(),
-    };
-    let (_, comments, _) = lexer.into_parts();
+    // 1. Lex (resilient — always succeeds; malformed input simply yields
+    // recovery tokens which classify_token treats as plain).
+    let lex_result = lex(source);
+    let tokens = lex_result.tokens;
+    let comments = lex_result.comments;
 
     // 2. Parse (best-effort)
     let ast_types = match wado_compiler::parse(source) {

--- a/wado-lsp/tests/parse_error.rs
+++ b/wado-lsp/tests/parse_error.rs
@@ -160,7 +160,7 @@ fn lexer_error_recovers_around_stray_character() {
                 &host,
             )
             .await;
-        assert!(hover.is_some(), "hover should resolve before the lex error",);
+        assert!(hover.is_some(), "hover should resolve before the lex error");
     });
 }
 

--- a/wado-lsp/tests/parse_error.rs
+++ b/wado-lsp/tests/parse_error.rs
@@ -11,8 +11,11 @@
 //!   either side of the error.
 //! - `semantic_tokens` keeps producing lexer-level tokens.
 //!
-//! A lexer error (not a parse error) is still fail-fast; that path is
-//! exercised elsewhere.
+//! Lexer errors are also recovered: a stray character or a malformed numeric
+//! prefix surfaces as a `lexer error: …` diagnostic but does not abort
+//! analysis, so position queries still resolve on the surrounding well-formed
+//! regions. The dedicated test `lexer_error_recovers_around_stray_character`
+//! pins this.
 
 use wado_lsp::test_support::MapHost;
 use wado_lsp::{Diagnostic, Engine, Position, Severity};
@@ -122,6 +125,43 @@ fn semantic_tokens_survive_parse_error() {
         0,
         "semantic_tokens must be a multiple of 5 (deltaLine, deltaStart, length, type, mods)",
     );
+}
+
+/// A stray character is now a recovered *lexer* error, not a fatal one. The
+/// LSP must surface a `lexer error: …` diagnostic and still resolve hovers
+/// elsewhere in the file.
+#[test]
+fn lexer_error_recovers_around_stray_character() {
+    futures::executor::block_on(async {
+        let source = "fn f() -> i32 {\n    let x: i32 = 1;\n    return x;\n}\n@\nfn g() -> i32 { return 2; }\n";
+        let mut engine = Engine::new();
+        engine.open_document(&uri(), source.to_string());
+        let host = MapHost::single(PATH, source);
+
+        let diags = engine.diagnostics(&uri(), &host).await;
+        let lex_errs: Vec<&Diagnostic> = diags
+            .iter()
+            .filter(|d| d.severity == Severity::Error && d.message.starts_with("lexer error:"))
+            .collect();
+        assert!(
+            !lex_errs.is_empty(),
+            "expected a lexer-error diagnostic for the stray '@'",
+        );
+
+        // `x` in `let x: i32 = 1;` still hovers — recovery preserves the
+        // surrounding healthy region.
+        let hover = engine
+            .hover(
+                &uri(),
+                Position {
+                    line: 1,
+                    character: 8,
+                },
+                &host,
+            )
+            .await;
+        assert!(hover.is_some(), "hover should resolve before the lex error",);
+    });
 }
 
 /// Re-opening with a fix recovers all semantic features. Sanity check that


### PR DESCRIPTION
## Summary

Reworks the lexer from fail-fast into an error-recovering pipeline. A
stray character, an unterminated string, or a malformed numeric prefix
no longer discards every token before it — the lexer surfaces a
best-effort stream alongside a vector of structured errors, so the
parser keeps recovering on the surrounding regions and the LSP stays
responsive on half-typed input. Before this PR, a single typo killed
`semantic_tokens` and every hover / goto query in the file.

## API

- New free functions `lex(source) -> LexResult` (and `lex_with_line`
  for template-string interpolation re-lexing) replace the
  three-step `Lexer::new(...).tokenize().into_parts()`. `LexResult`
  bundles `tokens`, `errors`, `comments`, `shebang`, `data_section` so
  the lexer is consumed once and every byte of input is accounted for.
- `LexError { kind: LexErrorKind, span }` with an `impl Display`.
  `LexErrorKind` enumerates the recovery situations (`UnexpectedChar`,
  `UnterminatedString`, `MissingHexDigits`, `CharLiteralTooLong`, …).
  `Lexer` itself becomes `pub(crate)`.
- `wado_compiler::parse(source) -> ParseResult` (no `Result`): both
  lexing and parsing are resilient and always produce a `Module`.
  `ParseResult` carries `lex_errors` and `errors` separately so the
  wire prefixes (`lexer error: …` / `parse error: …`) stay distinct.
  `ParseResult::into_fail_fast()` is the single adapter back to
  `CompileError` for batch / format / doc.
- `Parser::{new, from_lex, from_lex_no_trivia}` — `from_lex` keeps the
  comment stream (formatter / doc / dump), `from_lex_no_trivia` drops
  it (loader and other non-formatter paths) so the per-AST-id
  comment-cursor walk and per-`Comment::clone` into `TriviaMap`
  re-vanish on the batch path. Construction-time filtering of
  `TokenKind::Error` means no parser path can mistake one for an
  identifier or emit a duplicate `expected …, found Error(...)`
  diagnostic.
- `lex_error_diagnostic(&LexError, Option<&str>) -> Diagnostic`
  mirrors the existing `parse_error_diagnostic` for the LSP path.
  `CompileError::{from_lex_error, from_parse_error}` and
  `LoadError::{from_lex_error, from_parse_error}` collapse the five
  hand-rolled `{ message, line, column, filename }` projections into
  one site each.

## Recovery, per failure mode

- **Unrecognised char**: emit `TokenKind::Error(<text>)` + an error,
  consume the char, continue.
- **Unterminated string / template**: emit the literal kind with
  everything read so far to EOF (multi-line literals are legal) + an
  error.
- **Unterminated / over-long char**: scan forward up to the next `'`,
  newline, or EOF and emit one `CharLit` + one diagnostic
  (`UnterminatedChar` or `CharLiteralTooLong`). `'abc'` used to
  cascade into `CharLit("a")` + `Ident("bc")` + a second unterminated
  char on the lone closing `'`; it now surfaces as a single
  `CharLit("abc")` + one `CharLiteralTooLong`.
- **Unterminated block comment / empty char (`''`) / missing hex /
  binary / octal / exponent digits**: best-effort kind + error.
- **Template interpolation lex errors** report with the inner
  `LexError`'s own span (carefully line-shifted by `lex_with_line`),
  not the outer interpolation span, so editors highlight the
  offending byte.

## Canonical hashing (kiln)

`TokenKind::Error` does not participate in `canonical_token_bytes` —
the arm is `unreachable!()` because the only consumer
(`kiln_provider::hash_source`) gates on `lex_result.errors.is_empty()`
before reaching it. Healthy code never produces an `Error` token, so
every committed `.kiln.json` / sidecar stays bit-stable across this
variant being added.

## Pipeline / wire format

- LSP `build_semantics` walks `parsed.lex_errors` and `parsed.errors`
  separately, emitting `lexer error: …` and `parse error: …`
  diagnostics. Surrounding healthy regions still resolve hovers /
  jumps. `semantic_tokens::compute` no longer early-returns on lex
  failure — it falls back to lexer-only classification with whatever
  best-effort tokens the lexer surfaced.
- Batch (`compile_with_options`) and the formatter stay fail-fast on
  the first recovered lex error to preserve the historical wire
  shape; the resilient path is the LSP's gain.

## Tests

- `wado-compiler/tests/lexer_recovery.rs` (new, 18 cases) pins one
  recovery shape per error variant — stray chars, unterminated /
  over-long literals, missing prefix digits, multi-error sources,
  span fidelity, recover-at-newline.
- `wado-lsp/tests/parse_error.rs` gains
  `lexer_error_recovers_around_stray_character`, exercising the
  partial-`Semantics` path through `Engine::diagnostics` /
  `Engine::hover`.
- ~30 lexer call sites across `wado-compiler`, `wado-lsp`, and
  `wado-cli` migrated to the new API. Stdlib loaders keep a strict
  `assert!(r.errors.is_empty(), …)` since bundled sources must never
  recover.

Stale `wado-lsp/AGENTS.md` paragraph claiming entry lex/parse failures
return `Semantics::empty()` is replaced with the new behaviour
description.

---
_Generated by [Claude Code](https://claude.ai/code/session_01APmfXdqmTJaJfzhmZbPfQj)_