### PR TITLE
Lower once on gale gen; surface prediction diagnostics on the Kiln path

### DIFF
--- a/package-gale/TODO.md
+++ b/package-gale/TODO.md
@@ -33,12 +33,6 @@ Parts 1–4 have landed; the items below are follow-ups left on the table.
   `ends_with_scan` (today the warn-once invariant is backstopped by the
   `(rule, message)` dedup in `GenContext::warn`, but the suffix heuristic is
   fragile on its own).
-- **Single lowering on `gale gen` (part 3 follow-up).** `cmd_gen` lowers once
-  to read diagnostics for stderr, then `generate` lowers again internally and
-  discards its `LoweredGrammar.diagnostics`. Have `generate` return (or expose)
-  the diagnostics so `gale gen` lowers once. Same site should run
-  `normalize_caches` before the diagnostic lower to match `generate` /
-  `cmd_dump` (benign for parser-built IR today, but inconsistent).
 
 ## LL prediction — remaining gaps
 

--- a/package-gale/src/codegen.wado
+++ b/package-gale/src/codegen.wado
@@ -9,6 +9,7 @@ use { CodeWriter, StructSpec, VariantSpec, EnumSpec } from "./wadopoet.wado";
 use { lower_with_ctx } from "./lower.wado";
 use {
     LoweredGrammar,
+    Diagnostic,
     Rule,
     SimpleRule,
     MultiAltRule,
@@ -28,7 +29,18 @@ pub struct GenerateOptions {
     pub highlight: bool,
 }
 
-pub fn generate(grammar: &mut Grammar, options: &GenerateOptions) -> String {
+/// Result of a codegen pass: the generated `.wado` source plus the
+/// prediction-strategy diagnostics the single lowering raised. Codegen
+/// always lowers exactly once, so the diagnostics ride out on the same
+/// `LoweredGrammar` the emit walk consumes — callers that want to surface
+/// warnings (`gale gen`) read `diagnostics`; callers that only need the
+/// module text (the Kiln generator entry, unit tests) read `source`.
+pub struct GeneratedOutput {
+    pub source: String,
+    pub diagnostics: Array<Diagnostic>,
+}
+
+pub fn generate(grammar: &mut Grammar, options: &GenerateOptions) -> GeneratedOutput {
     // Fill in `snake_name` / `field_name` caches on every name-bearing IR
     // node before any codegen pass touches the grammar. Production IR built
     // through `RuleRefElement::with_options` etc. already has these set —
@@ -66,7 +78,10 @@ pub fn generate(grammar: &mut Grammar, options: &GenerateOptions) -> String {
     // intern its set. Visitor and highlight do not emit `matches { TK_* }`
     // checks so this ordering is safe.
     gen_kind_set_helpers(&mut w, &lowered, &ctx);
-    return w.to_string();
+    return GeneratedOutput {
+        source: w.to_string(),
+        diagnostics: lowered.diagnostics,
+    };
 }
 
 fn gen_header(w: &mut CodeWriter, grammar: &Grammar) {

--- a/package-gale/src/codegen_label_collision_test.wado
+++ b/package-gale/src/codegen_label_collision_test.wado
@@ -31,7 +31,7 @@ WS : (' '|'\\n') -> skip ;
         Ok(g) => g,
         Err(e) => panic(`parse_checked failed: {e.message}`),
     };
-    let out = generate(&mut grammar, &GenerateOptions { highlight: false });
+    let out = generate(&mut grammar, &GenerateOptions { highlight: false }).source;
     // The buggy codegen emitted two `let e = _parse_e(p)?;` lines in the
     // same function body for the alt `a=e ... b=e`. Different functions
     // each having their own copy is fine; the failure mode is the same

--- a/package-gale/src/codegen_lr_label_test.wado
+++ b/package-gale/src/codegen_lr_label_test.wado
@@ -30,7 +30,7 @@ WS : (' '|'\\n') -> skip ;
         Ok(g) => g,
         Err(err) => panic(`parse_checked failed: {err.message}`),
     };
-    let out = generate(&mut grammar, &GenerateOptions { highlight: false });
+    let out = generate(&mut grammar, &GenerateOptions { highlight: false }).source;
 
     // After the fix the LR-aware codegen emits `scan_e_atom` and at
     // least one `scan_e_lr_<N>`. The non-LR path emits a unified

--- a/package-gale/src/codegen_test.wado
+++ b/package-gale/src/codegen_test.wado
@@ -22,6 +22,7 @@ use {
     Visibility,
 } from "./ir.wado";
 use { generate, GenerateOptions } from "./codegen.wado";
+use { DiagnosticKind } from "./gir.wado";
 use { parse } from "./g4/parser.wado";
 
 global DEFAULT_OPTIONS: GenerateOptions = GenerateOptions { highlight: false };
@@ -39,7 +40,7 @@ test "generate header" {
         pending_refs: [],
         source_files: [],
     };
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert output.len() > 0;
     // Grammar was constructed with no source_files, so gen_header falls back
     // to `{name}.g4`.
@@ -62,7 +63,7 @@ test "generate header with multiple source files" {
         pending_refs: [],
         source_files: ["HtmlLexer.g4", "HtmlParser.g4"],
     };
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     let header = `#![generated(by = "gale", sources = ["HtmlLexer.g4", "HtmlParser.g4"])]`;
     for let mut i = 0; i < header.len(); i += 1 {
         assert output.get_byte_unchecked(i) == header.get_byte_unchecked(i);
@@ -86,7 +87,7 @@ test "generate token kind" {
         pending_refs: [],
         source_files: [],
     };
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert str_contains(&output, &"pub enum TokenKind {");
     assert str_contains(&output, &"    NUMBER,");
     assert str_contains(&output, &"    WS,");
@@ -124,7 +125,7 @@ test "generate single-alt struct" {
         pending_refs: [],
         source_files: [],
     };
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert str_contains(&output, &"pub struct JsonNode {");
     assert str_contains(&output, &"    pub span: Span,");
     assert str_contains(&output, &"    pub value: ValueNode,");
@@ -166,7 +167,7 @@ test "generate multi-alt variant with labels" {
         pending_refs: [],
         source_files: [],
     };
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert str_contains(&output, &"pub variant ExprNode {");
     assert str_contains(&output, &"    BinOp(ExprBinOp),");
     assert str_contains(&output, &"    Pass(ExprPass),");
@@ -208,7 +209,7 @@ test "generate multi-alt variant without labels" {
         pending_refs: [],
         source_files: [],
     };
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert str_contains(&output, &"pub variant ItemNode {");
     assert str_contains(&output, &"    Alt0(ItemAlt0),");
     assert str_contains(&output, &"    Alt1(ItemAlt1),");
@@ -253,7 +254,7 @@ test "generate repeat fields" {
         pending_refs: [],
         source_files: [],
     };
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert str_contains(&output, &"    pub item_list: Array<ItemNode>,");
     assert str_contains(&output, &"    pub comma: Option<Token>,");
 }
@@ -288,7 +289,7 @@ test "generate duplicate field names" {
         pending_refs: [],
         source_files: [],
     };
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert str_contains(&output, &"    pub item: ItemNode,");
     assert str_contains(&output, &"    pub item_2: ItemNode,");
 }
@@ -337,7 +338,7 @@ test "generate group variant type for repeated group" {
         pending_refs: [],
         source_files: [],
     };
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert str_contains(&output, &"pub variant StmtOrErrorGroup {");
     assert str_contains(&output, &"    Stmt(StmtNode),");
     assert str_contains(&output, &"    Error(ErrorNode),");
@@ -373,7 +374,7 @@ test "generate wildcard element" {
         pending_refs: [],
         source_files: [],
     };
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert str_contains(&output, &"pub struct AnyNode {");
     assert str_contains(&output, &"    pub wildcard: Token,");
     assert str_contains(&output, &"let wildcard = p.match_any()?;");
@@ -408,7 +409,7 @@ test "generate parser not element" {
         pending_refs: [],
         source_files: [],
     };
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert str_contains(&output, &"pub struct ExceptCommaNode {");
     assert str_contains(&output, &"    pub not_comma: Token,");
     assert str_contains(&output, &"let not_comma = p.match_not([TK_COMMA])?;");
@@ -451,7 +452,7 @@ test "generate list label field" {
         pending_refs: [],
         source_files: [],
     };
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert str_contains(&output, &"    pub items: Array<ItemNode>,");
 }
 
@@ -495,7 +496,7 @@ test "generate standalone group as optional field" {
         pending_refs: [],
         source_files: [],
     };
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert str_contains(&output, &"pub variant FooOrBarGroup {");
     assert str_contains(&output, &"    Foo(FooNode),");
     assert str_contains(&output, &"    Bar(BarNode),");
@@ -512,7 +513,7 @@ test "generate scalar-labeled group `t=(a | b)`" {
     // before dispatching, so the callee sees the inner Group element
     // and the surface field name survives via the rebound op.
     let mut grammar = parse_grammar("grammar T; a : t=('x' | 'y') ;", "(test)");
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     // The generated parser must reference the hoisted anonymous tokens
     // and produce a scalar `t` binding for the labeled group.
     assert str_contains(&output, &"TK_LIT_X");
@@ -529,7 +530,7 @@ test "generate scalar-labeled single-alt group `t=(A B)`" {
         "grammar T; a : t=(A B) ; A : 'a' ; B : 'b' ;",
         "(test)",
     );
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert str_contains(&output, &"p.expect(TK_A)");
     assert str_contains(&output, &"p.expect(TK_B)");
 }
@@ -541,7 +542,7 @@ test "generate scalar-labeled wildcard-in-group `t=(.)*`" {
     // `Element::Repeat`. This shape is the parser-level mirror of
     // wildcard-in-set / wildcard-in-group ANTLR4 patterns.
     let mut grammar = parse_grammar("grammar T; a : t=(.)* ; A : 'a' ;", "(test)");
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert str_contains(&output, &"match_any");
 }
 
@@ -599,7 +600,7 @@ test "generate lexer set_mode" {
         pending_refs: [],
         source_files: [],
     };
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert str_contains(&output, &"best_set_mode");
     assert str_contains(&output, &"best_set_mode = 1");
     assert str_contains(&output, &"current_mode = best_set_mode");
@@ -639,7 +640,7 @@ test "generate lexer more" {
         pending_refs: [],
         source_files: [],
     };
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert str_contains(&output, &"best_more");
     assert str_contains(&output, &"more_start");
     assert str_contains(&output, &"best_more = true");
@@ -699,7 +700,7 @@ test "generate lexer type_override" {
         pending_refs: [],
         source_files: [],
     };
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     // IF rule should produce tokens tagged as TK_ID (not TK_IF).
     assert str_contains(&output, &"best_kind = TK_ID");
     // TK_IF should still exist as a token kind (not renamed), because
@@ -741,7 +742,7 @@ test "generate lexer channel" {
         pending_refs: [],
         source_files: [],
     };
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert str_contains(&output, &"best_channel");
     assert str_contains(&output, &"best_channel = 2");
     // Non-default channels must be routed to trivia, not tokens — ANTLR4
@@ -768,7 +769,7 @@ ID : [a-z]+ ;";
     // Generator-side contract: the emitted dispatch must route `best_channel
     // != 0` matches to trivia via `Token::with_channel`, not to the tokens
     // stream.
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert str_contains(&output, &"else if best_channel != 0");
     assert str_contains(&output, &"trivia.push(Token::with_channel(");
 }
@@ -783,7 +784,7 @@ NUMBER : [0-9]+ ;
 WS : [ \\t\\r\\n]+ -> skip ;
 ";
     let mut grammar = parse_grammar(input, "test.g4");
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert str_contains(&output, &"_parse_expr__inner(p, 2)");
 }
 
@@ -796,7 +797,7 @@ NUMBER : [0-9]+ ;
 WS : [ \\t\\r\\n]+ -> skip ;
 ";
     let mut grammar = parse_grammar(input, "test.g4");
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert str_contains(&output, &"_parse_expr__inner(p, 1)");
     // And the scan-side mirror must be kept in sync.
     assert str_contains(&output, &"scan_expr(tokens, pos, 1)");
@@ -823,7 +824,7 @@ statement : letterA | statement letterA 'b' ;
 letterA : 'a' ;
 ";
     let mut grammar = parse_grammar(input, "test.g4");
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     let scan_body = extract_fn_body(&output, &"fn scan_statement(");
     // The LR loop must save `pos` before the suffix call and restore it on
     // failure. Look for the save+restore pair around `scan_statement_lr_1(`.
@@ -845,7 +846,7 @@ ID : 'a' ;
 WS : [ \\t\\n]+ -> skip ;
 ";
     let mut grammar = parse_grammar(input, "test.g4");
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     let helper = extract_fn_body(&output, &"fn _parse_expr__inner_lr_");
     assert str_contains(&helper, &"b: [left] as Array<ExprNode>,");
 }
@@ -866,7 +867,7 @@ ID : 'a' ;
 WS : [ \\t\\n]+ -> skip ;
 ";
     let mut grammar = parse_grammar(input, "test.g4");
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     let helper = extract_fn_body(&output, &"fn _parse_expr__inner_lr_1");
     // Send is the second LR alt of two left-assoc: own_prec=1, conflict_min=2.
     assert !str_contains(&helper, &"_parse_expr__inner(p)?");
@@ -889,7 +890,7 @@ INT : [0-9]+ ;
 WS : [ \\t\\n]+ -> skip ;
 ";
     let mut grammar = parse_grammar(input, "test.g4");
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     let helper = extract_fn_body(&output, &"fn _parse_expr__inner_lr_");
     assert helper.len() > 0;
     assert !str_contains(&helper, &"_parse_expr__inner(p)?");
@@ -907,7 +908,7 @@ statement : letterA | statement letterA 'b' ;
 letterA : 'a' ;
 ";
     let mut grammar = parse_grammar(input, "test.g4");
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     let parse_body = extract_fn_body(&output, &"fn _parse_statement__inner(");
     assert str_contains(&parse_body, &"scan_statement_lr_1(") || str_contains(&parse_body, &"scan_statement_lr_1 (");
 }
@@ -924,7 +925,7 @@ a : 'x' ;
 b : 'y' ;
 ";
     let mut grammar = parse_grammar(input, "test.g4");
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert str_contains(&output, &"pub fn parse_a(input: &String)");
     assert str_contains(&output, &"pub fn parse_b(input: &String)");
     assert str_contains(&output, &"return _parse_a(&mut parser);");
@@ -943,7 +944,7 @@ NUMBER : [0-9]+ ;
 WS : [ \\t\\n]+ -> skip ;
 ";
     let mut grammar = parse_grammar(input, "test.g4");
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert str_contains(&output, &"pub fn parse_expr(input: &String)");
     assert str_contains(&output, &"return _parse_expr(&mut parser, 0);");
 }
@@ -961,7 +962,7 @@ test "token-only group `(K_A | K_B)` gates p.advance() on a kind-check" {
 a : 'a' ('b' | 'c') 'd' ;
 ";
     let mut grammar = parse_grammar(input, "test.g4");
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     let body = extract_fn_body(&output, &"fn _parse_a__inner(");
     assert str_contains(&body, &"p.match_set([");
     assert !str_contains(&body, &"let lit_b_or_lit_c = p.advance();");
@@ -1011,7 +1012,7 @@ options { caseInsensitive = true; }
 IF : 'if' ;
 WS : [ \\t]+ -> skip ;";
     let mut grammar = parse_grammar(input, "test.g4");
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     // A case-insensitive 'i' must use the branchless CI comparison helper.
     assert str_contains(&output, &"!chars[pos].eq_ignore_ascii_case(&'i')");
     assert str_contains(&output, &"!chars[pos].eq_ignore_ascii_case(&'f')");
@@ -1022,7 +1023,7 @@ test "caseInsensitive grammar option makes char-range match CI" {
 options { caseInsensitive = true; }
 ID : [a-z]+ ;";
     let mut grammar = parse_grammar(input, "test.g4");
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     // A case-insensitive [a-z] must also accept [A-Z].
     assert str_contains(&output, &"'A' <= chars[pos] <= 'Z'");
 }
@@ -1034,7 +1035,7 @@ IF : 'if' ;
 STRICT options { caseInsensitive = false; } : 'x' ;
 WS : [ \\t]+ -> skip ;";
     let mut grammar = parse_grammar(input, "test.g4");
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     // IF still CI: the literal 'i' must use the branchless CI helper.
     assert str_contains(&output, &"!chars[pos].eq_ignore_ascii_case(&'i')");
     // STRICT: rule-level caseInsensitive=false means 'x' must NOT be folded,
@@ -1048,7 +1049,7 @@ test "lexer rule caseInsensitive=true enables CI when grammar-level absent" {
 KW options { caseInsensitive = true; } : 'go' ;
 ID : [a-z]+ ;";
     let mut grammar = parse_grammar(input, "test.g4");
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert str_contains(&output, &"!chars[pos].eq_ignore_ascii_case(&'g')");
     // ID is not CI; its range must stay [a-z] without a mirrored [A-Z].
     assert !str_contains(&output, &"'A' <= chars[pos] <= 'Z'");
@@ -1067,7 +1068,7 @@ rule : ID ;
 ID : [a-z]+ ;
 WS : [ \\t]+ -> skip ;";
     let mut grammar = parse_grammar(input, "test.g4");
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert str_contains(&output, &"    VIRTUAL_TOK,  // virtual");
     assert str_contains(&output, &"global TK_VIRTUAL_TOK: i32 = ") && str_contains(&output, &";  // virtual");
     assert str_contains(&output, &"TK_VIRTUAL_TOK => \"VIRTUAL_TOK\",  // virtual");
@@ -1080,7 +1081,7 @@ options { caseInsensitive = true; }
 DIGITS : [0-9]+ ;
 SEMI : ';' ;";
     let mut grammar = parse_grammar(input, "test.g4");
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     // Digit range must not be duplicated.
     assert str_contains(&output, &"'0' <= chars[pos] <= '9'");
     // Non-letter literal must not be duplicated — plain mismatch form.
@@ -1106,7 +1107,7 @@ test "metadata comment lists grammar-level options" {
         pending_refs: [],
         source_files: [],
     };
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert str_contains(&output, &"// Grammar metadata from source .g4 prequels:");
     assert str_contains(&output, &"//   option language = Python");
     assert str_contains(&output, &"//   option superClass = my.pkg.BaseParser");
@@ -1131,7 +1132,7 @@ test "metadata comment formats string and int option values" {
         pending_refs: [],
         source_files: [],
     };
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert str_contains(&output, &"//   option tokenVocab = \"foo.g4\"");
     assert str_contains(&output, &"//   option k = 3");
     assert str_contains(&output, &"//   option init = { ... }");
@@ -1154,7 +1155,7 @@ test "metadata comment lists named actions" {
         pending_refs: [],
         source_files: [],
     };
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert str_contains(&output, &"// Grammar metadata from source .g4 prequels:");
     assert str_contains(&output, &"//   @header");
     assert str_contains(&output, &"//   @parser::members");
@@ -1174,7 +1175,7 @@ test "metadata block omitted when no options and no named actions" {
         pending_refs: [],
         source_files: [],
     };
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert !str_contains(&output, &"// Grammar metadata from source .g4 prequels:");
 }
 
@@ -1216,7 +1217,7 @@ test "visibility comment emitted on non-default parser rule" {
         pending_refs: [],
         source_files: [],
     };
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert str_contains(&output, &"// rule visibility: public (ignored by codegen, matches ANTLR4)");
     // Default visibility must not add any comment.
     assert !str_contains(&output, &"// rule visibility: default");
@@ -1237,7 +1238,7 @@ test "visibility comment emitted on non-default lexer rule" {
         pending_refs: [],
         source_files: [],
     };
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert str_contains(&output, &"// rule visibility: protected (ignored by codegen, matches ANTLR4)");
 }
 
@@ -1255,7 +1256,7 @@ B : 'B' ;
 WS : [ \\t\\n\\r]+ -> skip ;
 ";
     let mut grammar = parse_grammar(input, "test.g4");
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert str_contains(&output, &"fn try_a(");
     assert str_contains(&output, &"fn try_b(");
     assert str_contains(&output, &"first_char == 'A'");
@@ -1271,7 +1272,7 @@ FLOAT : [0-9]+ '.' [0-9]+ ;
 WS : (' '|'\\n') -> skip ;
 ";
     let mut grammar = parse_grammar(input, "test.g4");
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     let body = extract_fn_body(&output, &"fn _parse_b__inner(");
     assert str_contains(&body, &"let mut val: Array<Token>");
     assert str_contains(&body, &"p.match_set([TK_INT, TK_FLOAT])");
@@ -1285,7 +1286,7 @@ statement : 'x' | ifStmt ;
 ifStmt : 'if' 'y' statement ('else' statement)?? ;
 ";
     let mut grammar = parse_grammar(input, "test.g4");
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert str_contains(&output, &"lit_else_statement: Option<");
     assert !str_contains(&output, &"lit_else_statement: Array<");
     let body = extract_fn_body(&output, &"fn _parse_if_stmt__inner(");
@@ -1304,7 +1305,7 @@ ID : [a-zA-Z]+ ;
 WS : [ \\t\\n\\r]+ -> skip ;
 ";
     let mut grammar = parse_grammar(input, "test.g4");
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert !str_contains(&output, &"fn try_a(");
     assert str_contains(&output, &"classify_keyword");
 }
@@ -1324,8 +1325,49 @@ B : 'a' ;
 C : 'c' ;
 ";
     let mut grammar = parse_grammar(input, "test.g4");
-    let output = generate(&mut grammar, &DEFAULT_OPTIONS);
+    let output = generate(&mut grammar, &DEFAULT_OPTIONS).source;
     assert str_contains(&output, &"fn try_b(");
+}
+
+test "generate returns source and lowering diagnostics from one lowering" {
+    // `r : A B | A C ;` — both alts start with `A`, so lowering resolves
+    // the overlap with a scan tournament and raises one OverlapTournament
+    // diagnostic. `generate` hands the diagnostics back on its
+    // `GeneratedOutput`, so `gale gen` surfaces them on stderr without
+    // lowering the grammar a second time.
+    let input = "grammar Test;
+r : A B | A C ;
+A : 'a' ;
+B : 'b' ;
+C : 'c' ;
+";
+    let mut grammar = parse_grammar(input, "test.g4");
+    let generated = generate(&mut grammar, &DEFAULT_OPTIONS);
+    assert generated.source.len() > 0;
+    assert generated.diagnostics.len() == 1,
+        `expected 1 diagnostic, got {generated.diagnostics.len()}`;
+    let d = &generated.diagnostics[0];
+    assert str_contains(&d.rule, &"r"), `expected rule label to mention "r", got "{d.rule}"`;
+    if let OverlapTournament = &d.kind {
+    } else {
+        panic("expected DiagnosticKind::OverlapTournament");
+    }
+}
+
+test "generate raises no diagnostics for disjoint alts" {
+    // `r : A | B ;` has disjoint first sets, so lowering dispatches
+    // directly with nothing to warn about — `GeneratedOutput.diagnostics`
+    // is empty.
+    let input = "grammar Test;
+r : A | B ;
+A : 'a' ;
+B : 'b' ;
+";
+    let mut grammar = parse_grammar(input, "test.g4");
+    let generated = generate(&mut grammar, &DEFAULT_OPTIONS);
+    assert generated.source.len() > 0;
+    assert generated.diagnostics.is_empty(),
+        `expected no diagnostics, got {generated.diagnostics.len()}`;
 }
 
 fn str_contains(haystack: &String, needle: &String) -> bool {

--- a/package-gale/src/generator.wado
+++ b/package-gale/src/generator.wado
@@ -84,7 +84,9 @@ export fn generate(req: Request<Options>) -> Result<Response, Error> {
     }
 
     let gen_opts = GenerateOptions { highlight: req.options.highlight };
-    let wado_source = codegen_generate(&mut grammar, &gen_opts);
+    // The Kiln surface only emits module text; prediction-strategy
+    // diagnostics are surfaced by the `gale gen` CLI, not here.
+    let wado_source = codegen_generate(&mut grammar, &gen_opts).source;
 
     // Kiln entry module name mirrors Gale's CLI convention: snake-case
     // the grammar name. Reuses `gen_util::to_snake_case` so the filename

--- a/package-gale/src/generator.wado
+++ b/package-gale/src/generator.wado
@@ -17,7 +17,7 @@
 //! `let req = bind_request::<Options>(req)?;` prepended. The v1
 //! explicit form still compiles for packages that prefer it.
 
-use { Request, Response, Error, OutputFile } from "core:kiln";
+use { Request, Response, Error, OutputFile, KilnHost, Diagnostic as KilnDiagnostic, DiagnosticLevel } from "core:kiln";
 use { parse } from "./g4/parser.wado";
 use { Grammar, merge_grammars, check_references, synthesize_implicit_tokens } from "./ir.wado";
 use { generate as codegen_generate, GenerateOptions } from "./codegen.wado";
@@ -43,7 +43,7 @@ impl Deserialize for Options;
 /// `bind_request` shape during
 /// `kiln::import_check::inject_kiln_request_adapter` (runs before
 /// analyze).
-export fn generate(req: Request<Options>) -> Result<Response, Error> {
+export fn generate(req: Request<Options>) -> Result<Response, Error> with KilnHost {
     // Parse the primary grammar plus any supplementary grammars listed in
     // `inputs` (e.g. a sibling lexer grammar for a split parser grammar).
     // `merge_grammars` handles the single-grammar case by returning the
@@ -84,9 +84,20 @@ export fn generate(req: Request<Options>) -> Result<Response, Error> {
     }
 
     let gen_opts = GenerateOptions { highlight: req.options.highlight };
-    // The Kiln surface only emits module text; prediction-strategy
-    // diagnostics are surfaced by the `gale gen` CLI, not here.
-    let wado_source = codegen_generate(&mut grammar, &gen_opts).source;
+    let generated = codegen_generate(&mut grammar, &gen_opts);
+    // Surface Gale's prediction-strategy diagnostics through the Kiln host so
+    // they appear as normal compile warnings. The Kiln surface is the
+    // production entry (the `gale gen` CLI prints the same warnings on
+    // stderr), so a grammar built either way gets identical visibility. Gale
+    // diagnostics carry no source span yet, so the rule label leads the text.
+    for let d of &generated.diagnostics {
+        KilnHost::emit_diagnostic(KilnDiagnostic {
+            level: DiagnosticLevel::Warning,
+            span: null,
+            message: `gale: {d.rule}: {d.message}`,
+        });
+    }
+    let wado_source = generated.source;
 
     // Kiln entry module name mirrors Gale's CLI convention: snake-case
     // the grammar name. Reuses `gen_util::to_snake_case` so the filename

--- a/package-gale/src/main.wado
+++ b/package-gale/src/main.wado
@@ -90,19 +90,17 @@ fn cmd_gen(paths: Array<String>, options: &GenerateOptions) with Stdout, Stderr,
         return;
     }
 
-    // Surface prediction-strategy diagnostics on stderr before
-    // generation. `generate` lowers internally and already produces these
-    // on its `LoweredGrammar`, but does not hand them back, so we lower
-    // once more here to read them — a redundant pass that should be
-    // removed by having `generate` return its diagnostics (TODO.md).
-    // Warnings are advisory; generation still proceeds and must succeed.
-    let lit_tokens = collect_literal_tokens(&merged.parser_rules);
-    let diag_lowered = lower(&merged, &lit_tokens);
-    for let d of &diag_lowered.diagnostics {
+    // Generate once and surface the prediction-strategy diagnostics the
+    // single lowering raised. `generate` runs `normalize_caches` and lowers
+    // internally (matching `cmd_dump`), so there is no separate diagnostic
+    // pass to keep in sync. Warnings are advisory; generation still
+    // proceeds and must succeed.
+    let generated = generate(&mut merged, options);
+    for let d of &generated.diagnostics {
         eprintln(`gale: warning: {d.rule}: {d.message}`);
     }
 
-    print(generate(&mut merged, options));
+    print(generated.source);
 }
 
 fn cmd_dump(paths: Array<String>) with Stdout, Stderr, Preopens {

--- a/package-gale/tests/driver_overlap_tournament_test.wado
+++ b/package-gale/tests/driver_overlap_tournament_test.wado
@@ -1,0 +1,18 @@
+// Regression: a grammar whose lowering raises an OverlapTournament
+// diagnostic must (a) still generate a working parser and (b) surface the
+// warning through the Kiln host at build time. The warning text appears on
+// the compiler's diagnostic stream during this test's Kiln invocation; the
+// runtime assertions below confirm the generated parser itself is correct.
+use overlap from "./grammars/ll_overlap_tournament.g4"
+    with {
+        generator: {
+            module: "../src/generator.wado",
+            options: { highlight: false },
+            output_dir: "tests/generated/overlap_tournament",
+        },
+    };
+
+test "tournament grammar still parses both alts" {
+    assert overlap::parse(&"a b") matches { Ok(_) };
+    assert overlap::parse(&"a c") matches { Ok(_) };
+}

--- a/package-gale/tests/generated/alt_shared_ident_prefix/alt_shared_ident_prefix.g4.kiln.json
+++ b/package-gale/tests/generated/alt_shared_ident_prefix/alt_shared_ident_prefix.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2ee6d3eee11bdf5b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/alt_shared_ident_prefix.g4",
     "hash": "61bb2be46f96c2c573f0cf8deb04193ba17af86139cf1e7d2ec8d3caedfa0518"

--- a/package-gale/tests/generated/antlr4/ANTLRv4Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4/ANTLRv4Lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6fd58782d32cfb10",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/ANTLRv4Lexer.g4",
     "hash": "30bd52b58a5916a63041f501c2d45358431c5c379f1ed3e8a3fbbb311f3572bd"

--- a/package-gale/tests/generated/antlr4_compat_a/FullContextParsing/FullContextIF_THEN_ELSEParse_1/FullContextIF_THEN_ELSEParse_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/FullContextParsing/FullContextIF_THEN_ELSEParse_1/FullContextIF_THEN_ELSEParse_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-638680e10de193b9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/FullContextParsing/FullContextIF_THEN_ELSEParse_1.g4",
     "hash": "741538d9d6c17ba04aef378568b4ab2abdfbffd161000d9ab169b2a4d9abf5d0"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_1/AmbigLR_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_1/AmbigLR_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-aa54d1f54c3c3397",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/AmbigLR_1.g4",
     "hash": "24d8561b0961d6320b98bd4cfaff5fdf42796f8247fb92c253a205a5937f6edd"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_2/AmbigLR_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_2/AmbigLR_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-00a06ace4397e1c2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/AmbigLR_2.g4",
     "hash": "24d8561b0961d6320b98bd4cfaff5fdf42796f8247fb92c253a205a5937f6edd"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_3/AmbigLR_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_3/AmbigLR_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-46a15312ac52c3a2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/AmbigLR_3.g4",
     "hash": "24d8561b0961d6320b98bd4cfaff5fdf42796f8247fb92c253a205a5937f6edd"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_4/AmbigLR_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_4/AmbigLR_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-beadf766755ec773",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/AmbigLR_4.g4",
     "hash": "24d8561b0961d6320b98bd4cfaff5fdf42796f8247fb92c253a205a5937f6edd"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_5/AmbigLR_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_5/AmbigLR_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-aac47e3f7ad2f611",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/AmbigLR_5.g4",
     "hash": "24d8561b0961d6320b98bd4cfaff5fdf42796f8247fb92c253a205a5937f6edd"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a6ec2b8f2ddde283",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_1.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-61c5e70fcdb6da1f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_10.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-699ecb3a8f815e27",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_2.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-262e54587e9044c3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_3.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a998eaa06c653a5b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_4.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fc22b0fc36d36630",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_5.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2852af861801de26",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_6.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-320d631a0baf5c0b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_7.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3bd4c5ea00e5572f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_8.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-49d484703a919155",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_9.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-713ef5230fbaf9f1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_1.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-558b311b80c4da10",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_2.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c369756dc031bf12",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_3.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-abed1c70b5e6c53f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_1.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a1b502206053bf7a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_2.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-68045ae831d55159",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_3.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-678c469712c8fc23",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_4.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-16bc5e2c231c2ba8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_5.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c116bb1cfe62a2a8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_6.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0484794f535b91f2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_7.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fe2840241e9172a0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_1.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-235cd53ca8f4663a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_10.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ed84013859c673b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_11.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-739357c31b4c8ca4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_12.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-70a21a8410fad983",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_2.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_3/JavaExpressions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_3/JavaExpressions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-84ac2f3f46fb93bc",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_3.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_4/JavaExpressions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_4/JavaExpressions_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-21d6144f1ef80bed",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_4.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-99bcc333174e8ead",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_5.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2f290cf17eba13e0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_6.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bd943cd5ec077b75",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_7.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6ad535192ef3e12f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_8.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-43dcc5eba0df7ec4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_9.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-112c4a21992a04ed",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_1.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-459d0b754845c21f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_2.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1181507cda20d45b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_3.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4b506a26b7b7c7b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_1.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-34e6293e9d4c3e83",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_2.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b2467e37954af95c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_3.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-be8254158e713214",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_1.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4fc8261d73da648f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_2.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-93334f393b16d8e0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_3.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_1/MultipleAlternativesWithCommonLabel_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_1/MultipleAlternativesWithCommonLabel_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f8f837edca2c89e7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_1.g4",
     "hash": "ae1955a63072b61bfb19d308ec36275bae7fd4ca41cb570ddcd3113f86f61d81"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_2/MultipleAlternativesWithCommonLabel_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_2/MultipleAlternativesWithCommonLabel_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e9a04fe0052b621e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_2.g4",
     "hash": "ae1955a63072b61bfb19d308ec36275bae7fd4ca41cb570ddcd3113f86f61d81"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_3/MultipleAlternativesWithCommonLabel_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_3/MultipleAlternativesWithCommonLabel_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1105f32afc8cf90d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_3.g4",
     "hash": "ae1955a63072b61bfb19d308ec36275bae7fd4ca41cb570ddcd3113f86f61d81"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_4/MultipleAlternativesWithCommonLabel_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_4/MultipleAlternativesWithCommonLabel_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-689fb2e6742c4014",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_4.g4",
     "hash": "ae1955a63072b61bfb19d308ec36275bae7fd4ca41cb570ddcd3113f86f61d81"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_5/MultipleAlternativesWithCommonLabel_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_5/MultipleAlternativesWithCommonLabel_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bba1df3c39861ac6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_5.g4",
     "hash": "ae1955a63072b61bfb19d308ec36275bae7fd4ca41cb570ddcd3113f86f61d81"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e522638eb5f62a2f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrecedenceFilterConsidersContext.g4",
     "hash": "c92df3158f9ed1c1b43de581aedaf3b0918fa525ff0258f855022b78585b860b"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-709c12dbc0d22c0c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrefixAndOtherAlt_1.g4",
     "hash": "f946ec43c09928b2aae968a817d4ff315478257d5700925eab82fd22d94714d8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1f6f1364b2571756",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrefixAndOtherAlt_2.g4",
     "hash": "f946ec43c09928b2aae968a817d4ff315478257d5700925eab82fd22d94714d8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixOpWithActionAndLabel_1/PrefixOpWithActionAndLabel_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixOpWithActionAndLabel_1/PrefixOpWithActionAndLabel_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1bceb663d8f72bbc",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrefixOpWithActionAndLabel_1.g4",
     "hash": "277dfd7e556da18b06db5bf0fccd85fe10f7a2e1f0229f7a11d5580da4f5fc38"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixOpWithActionAndLabel_2/PrefixOpWithActionAndLabel_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixOpWithActionAndLabel_2/PrefixOpWithActionAndLabel_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f66f69768ea9b073",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrefixOpWithActionAndLabel_2.g4",
     "hash": "277dfd7e556da18b06db5bf0fccd85fe10f7a2e1f0229f7a11d5580da4f5fc38"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixOpWithActionAndLabel_3/PrefixOpWithActionAndLabel_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixOpWithActionAndLabel_3/PrefixOpWithActionAndLabel_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-39c67a17295485a8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrefixOpWithActionAndLabel_3.g4",
     "hash": "277dfd7e556da18b06db5bf0fccd85fe10f7a2e1f0229f7a11d5580da4f5fc38"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_1/ReturnValueAndActionsAndLabels_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_1/ReturnValueAndActionsAndLabels_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5692d6e3f456dfbc",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsAndLabels_1.g4",
     "hash": "8598d942da23d2752eeb86358ab94f137ea6ecbd4536dad7a93253b6dbba2583"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_2/ReturnValueAndActionsAndLabels_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_2/ReturnValueAndActionsAndLabels_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5c5ed2412472f210",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsAndLabels_2.g4",
     "hash": "8598d942da23d2752eeb86358ab94f137ea6ecbd4536dad7a93253b6dbba2583"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_3/ReturnValueAndActionsAndLabels_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_3/ReturnValueAndActionsAndLabels_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-37625c9ce8fecf22",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsAndLabels_3.g4",
     "hash": "8598d942da23d2752eeb86358ab94f137ea6ecbd4536dad7a93253b6dbba2583"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_4/ReturnValueAndActionsAndLabels_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_4/ReturnValueAndActionsAndLabels_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-25e049ca5b917254",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsAndLabels_4.g4",
     "hash": "8598d942da23d2752eeb86358ab94f137ea6ecbd4536dad7a93253b6dbba2583"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_1/ReturnValueAndActionsList1_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_1/ReturnValueAndActionsList1_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-98215ef7f217d444",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList1_1.g4",
     "hash": "97ed3cba25571f64d3b3f1ada1225af38693f6353aa699ec825c47886f968b1e"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_2/ReturnValueAndActionsList1_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_2/ReturnValueAndActionsList1_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4b874ab98e1307f7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList1_2.g4",
     "hash": "97ed3cba25571f64d3b3f1ada1225af38693f6353aa699ec825c47886f968b1e"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_3/ReturnValueAndActionsList1_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_3/ReturnValueAndActionsList1_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d3f80bba204a6230",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList1_3.g4",
     "hash": "97ed3cba25571f64d3b3f1ada1225af38693f6353aa699ec825c47886f968b1e"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_4/ReturnValueAndActionsList1_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_4/ReturnValueAndActionsList1_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b49376635cb5520f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList1_4.g4",
     "hash": "97ed3cba25571f64d3b3f1ada1225af38693f6353aa699ec825c47886f968b1e"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_1/ReturnValueAndActionsList2_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_1/ReturnValueAndActionsList2_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fe2931b7e3ce7624",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList2_1.g4",
     "hash": "d020b96fea143032cbc0f3f58b543f99e6ee62a9921e2c0c402a721dfeb8e67c"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_2/ReturnValueAndActionsList2_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_2/ReturnValueAndActionsList2_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-38b61cfa75fd52d2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList2_2.g4",
     "hash": "d020b96fea143032cbc0f3f58b543f99e6ee62a9921e2c0c402a721dfeb8e67c"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_3/ReturnValueAndActionsList2_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_3/ReturnValueAndActionsList2_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-292efe417a055f21",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList2_3.g4",
     "hash": "d020b96fea143032cbc0f3f58b543f99e6ee62a9921e2c0c402a721dfeb8e67c"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_4/ReturnValueAndActionsList2_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_4/ReturnValueAndActionsList2_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a83798d7b64b39bf",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList2_4.g4",
     "hash": "d020b96fea143032cbc0f3f58b543f99e6ee62a9921e2c0c402a721dfeb8e67c"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_1/ReturnValueAndActions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_1/ReturnValueAndActions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-21861166aaabb459",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActions_1.g4",
     "hash": "b75cc6b1b5387a38b7faf0c7f28b2278e632d380687b5cfbd93d691d753d4dfc"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_2/ReturnValueAndActions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_2/ReturnValueAndActions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-baee6ffe2906a543",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActions_2.g4",
     "hash": "b75cc6b1b5387a38b7faf0c7f28b2278e632d380687b5cfbd93d691d753d4dfc"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_3/ReturnValueAndActions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_3/ReturnValueAndActions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7ac903d674117074",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActions_3.g4",
     "hash": "b75cc6b1b5387a38b7faf0c7f28b2278e632d380687b5cfbd93d691d753d4dfc"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_4/ReturnValueAndActions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_4/ReturnValueAndActions_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e520c27c5b2a98e7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActions_4.g4",
     "hash": "b75cc6b1b5387a38b7faf0c7f28b2278e632d380687b5cfbd93d691d753d4dfc"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/SemPred/SemPred.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/SemPred/SemPred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-960ef5ffa9d45556",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/SemPred.g4",
     "hash": "a19c17fc308f32463fe399a657b189a837ad4fa52afc1206ab0d1d8a38dcbe04"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5d3495c986bff9bd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_1.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-33ccce79b79bf5e2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_2.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6dcbc071fc2f601e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_3.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-741313c066ff2cd5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_1.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-381677e2c28357d8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_2.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4d665f3c7d50cbb6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_3.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-18d85335cd7b6ba7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_4.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6c0e1c831530f504",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_5.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d5dda292b3d95344",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_6.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bc586f7b630f85cb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_7.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b8fe4abc43e4380d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_8.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ddd4f8db5f21632f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_9.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1a2ad3adca9a2a07",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_1.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-eed4df03ca7a51f5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_2.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bfcc2ec63de46569",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_3.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-20cd1bcceb40fb33",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_4.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-cfe1fc1849a20141",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_5.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-88482992acd5509f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_6.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-78bbab6b273081fa",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_7.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-03918ec747b14ad6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_8.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a66253165de20181",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_9.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/WhitespaceInfluence_1/WhitespaceInfluence_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/WhitespaceInfluence_1/WhitespaceInfluence_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-89a85f684acf5d9a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/WhitespaceInfluence_1.g4",
     "hash": "eb2ee832bbd5bc64766c64a697b83e430bc397e5e3c51480f276099243202a4c"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/WhitespaceInfluence_2/WhitespaceInfluence_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/WhitespaceInfluence_2/WhitespaceInfluence_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-57e6b2b178d12e3c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/WhitespaceInfluence_2.g4",
     "hash": "eb2ee832bbd5bc64766c64a697b83e430bc397e5e3c51480f276099243202a4c"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/DFAToATNThatFailsBackToDFA/DFAToATNThatFailsBackToDFA.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/DFAToATNThatFailsBackToDFA/DFAToATNThatFailsBackToDFA.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-43662820cd720381",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerErrors/DFAToATNThatFailsBackToDFA.g4",
     "hash": "48db67da6df9caa67f3e56b39408023058c363703e5eac58a74bea22a92f0066"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/DFAToATNThatMatchesThenFailsInATN/DFAToATNThatMatchesThenFailsInATN.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/DFAToATNThatMatchesThenFailsInATN/DFAToATNThatMatchesThenFailsInATN.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-92639b4998fdb6d8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerErrors/DFAToATNThatMatchesThenFailsInATN.g4",
     "hash": "ce03131129eb8147280be2cb5319ce363f7a4184ab6b871b761128c49ce4edb3"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/EnforcedGreedyNestedBraces_1/EnforcedGreedyNestedBraces_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/EnforcedGreedyNestedBraces_1/EnforcedGreedyNestedBraces_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ab2dc616bbf25ced",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerErrors/EnforcedGreedyNestedBraces_1.g4",
     "hash": "492b2ecee9f08f105799b38ff8e81a375902fbb29ec5d849b5f6459f2abc26a5"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/EnforcedGreedyNestedBraces_2/EnforcedGreedyNestedBraces_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/EnforcedGreedyNestedBraces_2/EnforcedGreedyNestedBraces_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-11f55d79f5b51619",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerErrors/EnforcedGreedyNestedBraces_2.g4",
     "hash": "492b2ecee9f08f105799b38ff8e81a375902fbb29ec5d849b5f6459f2abc26a5"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/ErrorInMiddle/ErrorInMiddle.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/ErrorInMiddle/ErrorInMiddle.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-32e6c8d04a1f19dc",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerErrors/ErrorInMiddle.g4",
     "hash": "ca5afb8c050f2d8b96fd19595dc603645d812846f62c9d767d56f7d0a0c5a0d9"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharAtStart/InvalidCharAtStart.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharAtStart/InvalidCharAtStart.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4ef9785e331127f4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerErrors/InvalidCharAtStart.g4",
     "hash": "97fcf7891b064a11fbcda1b83696ecfa795d3917c98f4efc47dfef9d8781364d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharAtStartAfterDFACache/InvalidCharAtStartAfterDFACache.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharAtStartAfterDFACache/InvalidCharAtStartAfterDFACache.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-85823d9f7794aa53",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerErrors/InvalidCharAtStartAfterDFACache.g4",
     "hash": "97fcf7891b064a11fbcda1b83696ecfa795d3917c98f4efc47dfef9d8781364d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharInToken/InvalidCharInToken.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharInToken/InvalidCharInToken.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a6221528b7ed7b0f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerErrors/InvalidCharInToken.g4",
     "hash": "97fcf7891b064a11fbcda1b83696ecfa795d3917c98f4efc47dfef9d8781364d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharInTokenAfterDFACache/InvalidCharInTokenAfterDFACache.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharInTokenAfterDFACache/InvalidCharInTokenAfterDFACache.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-583a97ab9cabd77e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerErrors/InvalidCharInTokenAfterDFACache.g4",
     "hash": "97fcf7891b064a11fbcda1b83696ecfa795d3917c98f4efc47dfef9d8781364d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/LexerExecDFA/LexerExecDFA.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/LexerExecDFA/LexerExecDFA.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0993dfa42831103f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerErrors/LexerExecDFA.g4",
     "hash": "9082786e9c7fc41aaf4fdfc2878c546039534e8b4ce83af668f95a9189b005d8"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/StringsEmbeddedInActions_1/StringsEmbeddedInActions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/StringsEmbeddedInActions_1/StringsEmbeddedInActions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-799e43fbadd97c49",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerErrors/StringsEmbeddedInActions_1.g4",
     "hash": "5e54d404efadb816a1078633ba2ec12083f375115c60fb0a60fab0de281a428e"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/StringsEmbeddedInActions_2/StringsEmbeddedInActions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/StringsEmbeddedInActions_2/StringsEmbeddedInActions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-16583a74c70842a2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerErrors/StringsEmbeddedInActions_2.g4",
     "hash": "5e54d404efadb816a1078633ba2ec12083f375115c60fb0a60fab0de281a428e"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/ActionPlacement/ActionPlacement.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/ActionPlacement/ActionPlacement.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0b7d7ee907eff28d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/ActionPlacement.g4",
     "hash": "d2e2766e7a6e95053b231cd43aca1fe4f764aee1d333e2302d278b5b067e209c"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSet/CharSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSet/CharSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ec6a82f66661d3b2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/CharSet.g4",
     "hash": "8e650ba32b5a406d9b26183b2d8bedcce9c1db181bdb411ad7c5839dcf4b228d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetInSet/CharSetInSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetInSet/CharSetInSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-059a913c8f048685",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/CharSetInSet.g4",
     "hash": "b5e383c044a1563de26a51b2d6b7cb2248fd55be0e3964e1d14b3610562eec1b"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetNot/CharSetNot.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetNot/CharSetNot.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6b134e988acd6363",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/CharSetNot.g4",
     "hash": "69cca11dfc28d919af7dc2ee9fe3723a7cd21d664d0be3beac4731d55c756c1c"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetPlus/CharSetPlus.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetPlus/CharSetPlus.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bf99cbf4ca947742",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/CharSetPlus.g4",
     "hash": "0cbc99fa0bac4ead651732b006ec8eb8eeca91cf996b2f879d7b0169d1ea3d1d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetRange/CharSetRange.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetRange/CharSetRange.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c934afe8d6fb12c3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/CharSetRange.g4",
     "hash": "3e05d18b49d5c8c36a07be0bfad40393aad4dbfd51a4236754351f81326709b1"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithEscapedChar/CharSetWithEscapedChar.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithEscapedChar/CharSetWithEscapedChar.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-beee1b790da6eca8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/CharSetWithEscapedChar.g4",
     "hash": "5223c3ae6c31d174c32451245dd1b500378e5db8269d2436d6c3e13348c843a1"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithMissingEscapeChar/CharSetWithMissingEscapeChar.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithMissingEscapeChar/CharSetWithMissingEscapeChar.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6d0d4b989a50e1d8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/CharSetWithMissingEscapeChar.g4",
     "hash": "50af99ded636823b3572ef557e472106e875b6a577bfce40a5a9f136e02a5425"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithQuote1/CharSetWithQuote1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithQuote1/CharSetWithQuote1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-86d2205ba2955dc2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/CharSetWithQuote1.g4",
     "hash": "be53ac24d9dde8c37359d79d1cc412859db4f7c36ea7d8994a7e41abb529735e"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithQuote2/CharSetWithQuote2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithQuote2/CharSetWithQuote2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8069a3abadd3121d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/CharSetWithQuote2.g4",
     "hash": "9abf142b50b105db8ba755c0a77ed4d38d3f00173bf0b86e12df3eb7f3d9f869"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/EOFSuffixInFirstRule_2/EOFSuffixInFirstRule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/EOFSuffixInFirstRule_2/EOFSuffixInFirstRule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-aea1b38951921107",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/EOFSuffixInFirstRule_2.g4",
     "hash": "441bbb7e472213eb37da15d9b0992d1c4d399644b0fa057762e0b579ae06e531"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/EscapedCharacters/EscapedCharacters.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/EscapedCharacters/EscapedCharacters.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e8300fe6f4844494",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/EscapedCharacters.g4",
     "hash": "88a4f34355fb87e7adbc718fcfe030c51f5c362d158b4cce6a5796189ba1cd4a"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyClosure/GreedyClosure.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyClosure/GreedyClosure.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b0942d820fcbb7cd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/GreedyClosure.g4",
     "hash": "d1458a9fc1db2a1bc64866ee5b621bdea6b8aca8fd321a6053f7b64c496bf279"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyConfigs/GreedyConfigs.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyConfigs/GreedyConfigs.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3de5a17518246534",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/GreedyConfigs.g4",
     "hash": "bdd0480bbe82e2296561739001674c10fb887a4867707fe2de4f1c1eb323655b"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyOptional/GreedyOptional.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyOptional/GreedyOptional.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6a5d57f15ad9cc05",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/GreedyOptional.g4",
     "hash": "0e2acf0a59884a4de77f9b74b30c2dc30770c78b1a11db4db50b1cea97df2d4d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyPositiveClosure/GreedyPositiveClosure.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyPositiveClosure/GreedyPositiveClosure.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-19156932f057309b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/GreedyPositiveClosure.g4",
     "hash": "5d96b0c62fad69596130c0cfe142462b2dffa59bcc399e1decfd28cd0ad2ac03"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/HexVsID/HexVsID.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/HexVsID/HexVsID.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8abb80787ab55f9c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/HexVsID.g4",
     "hash": "a1aa12f4fe19f66adc2b83628e3806eb535b11a974c9e7173202674b57eb3bf2"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/KeywordID/KeywordID.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/KeywordID/KeywordID.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9ea33c5c30fad565",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/KeywordID.g4",
     "hash": "5eec334a6818219de3e310c919f6fa92ee282ea3d98561d1e53fa586df4b7645"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyClosure/NonGreedyClosure.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyClosure/NonGreedyClosure.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c329de00201a662b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/NonGreedyClosure.g4",
     "hash": "919895cc80becbaa85e86b313156de11fb8cc30e641612bb47a295326f546a2c"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyConfigs/NonGreedyConfigs.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyConfigs/NonGreedyConfigs.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6e481196977fb897",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/NonGreedyConfigs.g4",
     "hash": "ccf5c3efabd0e9fb90790d1eecb50a96b56642cb5f696121dbebe686a03d9c66"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyOptional/NonGreedyOptional.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyOptional/NonGreedyOptional.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-98a2517cd6de3281",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/NonGreedyOptional.g4",
     "hash": "611a3d559cf19bd50743e764270d813639b924662b03e7075f24f3ac3520ac9d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyPositiveClosure/NonGreedyPositiveClosure.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyPositiveClosure/NonGreedyPositiveClosure.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7f8b9d47090908f8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/NonGreedyPositiveClosure.g4",
     "hash": "a19bcb18c02be6721bf1028a7c1335d28291e3e247dbd8e5fa2fcbc88d716fe4"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyTermination1/NonGreedyTermination1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyTermination1/NonGreedyTermination1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-544276065b3f5292",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/NonGreedyTermination1.g4",
     "hash": "5841fcdcd5adf818f59bf6e0f6a29db4d1027ce77dcc476160b96079fcf35a8b"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyTermination2/NonGreedyTermination2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyTermination2/NonGreedyTermination2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-69c6ed615346bda3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/NonGreedyTermination2.g4",
     "hash": "9ea5e3f0fd959bb4a51b464e3c49d7f20e95f5189bab762287847163d70a5960"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/Parentheses/Parentheses.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/Parentheses/Parentheses.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c6d5ce9be675555a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/Parentheses.g4",
     "hash": "10a47eed1b802ff2274c0d7ffffc1a145b6142f25340091ecdb1176446429acc"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/QuoteTranslation/QuoteTranslation.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/QuoteTranslation/QuoteTranslation.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c3104f60588afc47",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/QuoteTranslation.g4",
     "hash": "fd454e5ff551c86e4eab1e50e2375a62b8246aae8b700f386202c3fbc795225f"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/RecursiveLexerRuleRefWithWildcardPlus_1/RecursiveLexerRuleRefWithWildcardPlus_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/RecursiveLexerRuleRefWithWildcardPlus_1/RecursiveLexerRuleRefWithWildcardPlus_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a70c0ee99123e3c1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/RecursiveLexerRuleRefWithWildcardPlus_1.g4",
     "hash": "ccf3affeed08d41932ee1b94716d414b1bae3d229b6c7f3f4d17e62300e91492"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/RecursiveLexerRuleRefWithWildcardStar_1/RecursiveLexerRuleRefWithWildcardStar_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/RecursiveLexerRuleRefWithWildcardStar_1/RecursiveLexerRuleRefWithWildcardStar_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ff63ca508475ca7d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/RecursiveLexerRuleRefWithWildcardStar_1.g4",
     "hash": "7b6ed71096a57f601b91ad9c0bee2e6b2fc376dcf23c80eb7430b84c165be764"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/RefToRuleDoesNotSetTokenNorEmitAnother/RefToRuleDoesNotSetTokenNorEmitAnother.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/RefToRuleDoesNotSetTokenNorEmitAnother/RefToRuleDoesNotSetTokenNorEmitAnother.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-dfeb7d6ff29cae4e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/RefToRuleDoesNotSetTokenNorEmitAnother.g4",
     "hash": "95a088465b495a7bfbf61a77ce9bb6ae79caa9288236175927e10273cca715f1"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/ReservedWordsEscaping/ReservedWordsEscaping.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/ReservedWordsEscaping/ReservedWordsEscaping.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-943ecf575772c038",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/ReservedWordsEscaping.g4",
     "hash": "66600b7a97e9750d7527d65b8f6799e6e8f39806bf1a1bc70f349d2d79549d04"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/ReservedWordsEscaping_NULL/ReservedWordsEscaping_NULL.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/ReservedWordsEscaping_NULL/ReservedWordsEscaping_NULL.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-cca11faf9eb972a7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/ReservedWordsEscaping_NULL.g4",
     "hash": "c0512ddd17eb85b03ec5ee0bdfbd91e04bf5186ea196a43c6699b55bf350e582"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/Slashes/Slashes.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/Slashes/Slashes.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5b895275cf797a70",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/Slashes.g4",
     "hash": "8542b8d313ce35cd690e1408d548786844016931b7659852bbcb1af80919f7df"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/StackoverflowDueToNotEscapedHyphen/StackoverflowDueToNotEscapedHyphen.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/StackoverflowDueToNotEscapedHyphen/StackoverflowDueToNotEscapedHyphen.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2644dac05d6694ee",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/StackoverflowDueToNotEscapedHyphen.g4",
     "hash": "8ac36d903f20ad5d1c01d8de6e7555e7095b62f80282b91c7309cb119f6e0e81"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/TokenType0xFFFF/TokenType0xFFFF.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/TokenType0xFFFF/TokenType0xFFFF.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-85e7fc009af36623",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/TokenType0xFFFF.g4",
     "hash": "510dfbf59b57e04442706e8d5ae998b7daa9bfb6e4ab2347959fcaf010e4793c"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/UnicodeCharSet/UnicodeCharSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/UnicodeCharSet/UnicodeCharSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-43a5a4f219cff449",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/UnicodeCharSet.g4",
     "hash": "be6380e8ca1f1838a7908f37fc269bbfe32d7522dff990274bfc144c90d5a73f"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/ZeroLengthToken/ZeroLengthToken.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/ZeroLengthToken/ZeroLengthToken.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8ed7f21c46440147",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LexerExec/ZeroLengthToken.g4",
     "hash": "602fefbd71118c707ee514a7eb2d6eeac92032b2009e51b705b154429bffd5ea"

--- a/package-gale/tests/generated/antlr4_compat_a/ParseTrees/RuleRef/RuleRef.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParseTrees/RuleRef/RuleRef.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-169bf906f921e598",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParseTrees/RuleRef.g4",
     "hash": "94e77d3cf0e835f48dfd591d6b9b625e723dc68af632bce754d64e7a83682e5f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParseTrees/Token2/Token2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParseTrees/Token2/Token2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0ba95439abba4779",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParseTrees/Token2.g4",
     "hash": "7f89f3118adb112f187ec9a91475c3230eb8d3e0f11d5f98649b5ca5cd018210"

--- a/package-gale/tests/generated/antlr4_compat_a/ParseTrees/TwoAltLoop/TwoAltLoop.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParseTrees/TwoAltLoop/TwoAltLoop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-dfb4bb64c6c70d96",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParseTrees/TwoAltLoop.g4",
     "hash": "01ee51d71cecc10fa33d0b88dd68d026e6e3e811ceaa04d124aaf32b943836ef"

--- a/package-gale/tests/generated/antlr4_compat_a/ParseTrees/TwoAlts/TwoAlts.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParseTrees/TwoAlts/TwoAlts.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7e35452b6694c6ca",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParseTrees/TwoAlts.g4",
     "hash": "18ff657616b51f930ed3ce29a3df32d447b93f1ff9f857f30f3eb53458857f94"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ConjuringUpToken/ConjuringUpToken.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ConjuringUpToken/ConjuringUpToken.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-88b2932f5ec4fe02",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserErrors/ConjuringUpToken.g4",
     "hash": "cec24d194020155bc5c53585d2a955c7d39e697e652fa11acaf3efc1a7589fb7"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ConjuringUpTokenFromSet/ConjuringUpTokenFromSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ConjuringUpTokenFromSet/ConjuringUpTokenFromSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-949514c025c718e0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserErrors/ConjuringUpTokenFromSet.g4",
     "hash": "b56e1ba56f51bf544a254459dcc27c19e3f719f8eafae34e005aef07581e6517"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ContextListGetters/ContextListGetters.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ContextListGetters/ContextListGetters.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c046d2e955ea50d7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserErrors/ContextListGetters.g4",
     "hash": "b7f98ec81bd992592439948185bb23c69116c968bf6f2529cf779cfa9801366f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_1/DuplicatedLeftRecursiveCall_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_1/DuplicatedLeftRecursiveCall_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-14e4c615c6247171",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserErrors/DuplicatedLeftRecursiveCall_1.g4",
     "hash": "cb574c6c608fb07e3c875b5c7561874060c04e7a280293a55ab819142ffe274f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_2/DuplicatedLeftRecursiveCall_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_2/DuplicatedLeftRecursiveCall_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6fa8c086a7f8b385",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserErrors/DuplicatedLeftRecursiveCall_2.g4",
     "hash": "cb574c6c608fb07e3c875b5c7561874060c04e7a280293a55ab819142ffe274f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_3/DuplicatedLeftRecursiveCall_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_3/DuplicatedLeftRecursiveCall_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-38daa485fd706c29",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserErrors/DuplicatedLeftRecursiveCall_3.g4",
     "hash": "cb574c6c608fb07e3c875b5c7561874060c04e7a280293a55ab819142ffe274f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_4/DuplicatedLeftRecursiveCall_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_4/DuplicatedLeftRecursiveCall_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3f74525ca7ce7306",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserErrors/DuplicatedLeftRecursiveCall_4.g4",
     "hash": "cb574c6c608fb07e3c875b5c7561874060c04e7a280293a55ab819142ffe274f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ExtraneousInput/ExtraneousInput.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ExtraneousInput/ExtraneousInput.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-69d327b1ce53e23e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserErrors/ExtraneousInput.g4",
     "hash": "d65f706ca2451405802574364ae8d3d7abf995b07027e8a4625c575ee48c919b"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/InvalidATNStateRemoval/InvalidATNStateRemoval.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/InvalidATNStateRemoval/InvalidATNStateRemoval.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-35f2301c1e275a74",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserErrors/InvalidATNStateRemoval.g4",
     "hash": "264f98bcea9cc9d12c0c89782381318f9404f87e10f26da3a6762a42f6738109"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LL1ErrorInfo/LL1ErrorInfo.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LL1ErrorInfo/LL1ErrorInfo.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3630e43f048325ae",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserErrors/LL1ErrorInfo.g4",
     "hash": "894561cdd0b332fdb9c86599422d88ee6f45086a452209a385b14df01e56f8aa"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LL2/LL2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LL2/LL2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-27275e28a7283862",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserErrors/LL2.g4",
     "hash": "2aaa2b6a34f4a4348b34477ca85e32d712d0090ea04767439f00a52c9e369525"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LL3/LL3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LL3/LL3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2c02059c81383bdf",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserErrors/LL3.g4",
     "hash": "c71f82724eba5c68a8618a7e086bdd6d4945e4a769695822a02a3e560fc12d76"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LLStar/LLStar.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LLStar/LLStar.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c58b4a7f2470bfbd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserErrors/LLStar.g4",
     "hash": "3e937ce2ce494c4be9f9c68d8901657bf961c2323261dd30954d25990d001418"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionBeforeLoop/MultiTokenDeletionBeforeLoop.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionBeforeLoop/MultiTokenDeletionBeforeLoop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-11c428dc92bce342",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserErrors/MultiTokenDeletionBeforeLoop.g4",
     "hash": "e85e3274b80d9927fac0d6f6fd84f36c85e3495b5c8288e0dcb1117c16f07173"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionBeforeLoop2/MultiTokenDeletionBeforeLoop2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionBeforeLoop2/MultiTokenDeletionBeforeLoop2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5c85c00cf85bcd7f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserErrors/MultiTokenDeletionBeforeLoop2.g4",
     "hash": "51530a0ee95353c6b0fb35a295e36225ea546f7677798f9ce2d4671ba35b7edd"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionDuringLoop/MultiTokenDeletionDuringLoop.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionDuringLoop/MultiTokenDeletionDuringLoop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f956579d72cda75b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserErrors/MultiTokenDeletionDuringLoop.g4",
     "hash": "bb77678589d1936b056f87c3eafaa90d32f55c9a10beee93b8160102affad30f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionDuringLoop2/MultiTokenDeletionDuringLoop2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionDuringLoop2/MultiTokenDeletionDuringLoop2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4b2726c798a3f404",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserErrors/MultiTokenDeletionDuringLoop2.g4",
     "hash": "e425f4fea0c6671792c777df6308de1546711741603dfcde04e0cf3ebebf6b9f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/NoViableAltAvoidance/NoViableAltAvoidance.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/NoViableAltAvoidance/NoViableAltAvoidance.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d86bb14016285c15",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserErrors/NoViableAltAvoidance.g4",
     "hash": "b28914eab8290e79724e3e1b2ac223e8b6c5021ac6ca3c564ee873762146bbfc"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleSetInsertion/SingleSetInsertion.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleSetInsertion/SingleSetInsertion.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a740dc5de6aa9be1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserErrors/SingleSetInsertion.g4",
     "hash": "5c5213e807e10eac992c2dd076d8f12a8df33bb71c1803ee039588b15da2782b"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletion/SingleTokenDeletion.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletion/SingleTokenDeletion.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5567b7a22ba37d48",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserErrors/SingleTokenDeletion.g4",
     "hash": "25554c7741a77a1d8537817aac67e64f061017ef4c7c06a01596c0279a6b03ec"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforeAlt/SingleTokenDeletionBeforeAlt.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforeAlt/SingleTokenDeletionBeforeAlt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8bc2797041d59085",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserErrors/SingleTokenDeletionBeforeAlt.g4",
     "hash": "8620c2090497e410ec32e4c6556c760c41ffe1a00ca410ee8a598dfdd77baf3c"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforeLoop/SingleTokenDeletionBeforeLoop.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforeLoop/SingleTokenDeletionBeforeLoop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-955b5c33d9e7273a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserErrors/SingleTokenDeletionBeforeLoop.g4",
     "hash": "981912e9f61c0e8e34da6607456532112011597125c30dcbddf0125401041f85"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforeLoop2/SingleTokenDeletionBeforeLoop2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforeLoop2/SingleTokenDeletionBeforeLoop2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-db65a1054c5e73e1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserErrors/SingleTokenDeletionBeforeLoop2.g4",
     "hash": "959f4e3f298f227e7e5c734f8325acfb023db1858bc5f3c11f1236c771316b55"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforePredict/SingleTokenDeletionBeforePredict.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforePredict/SingleTokenDeletionBeforePredict.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6a740074fa5af7c4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserErrors/SingleTokenDeletionBeforePredict.g4",
     "hash": "3e937ce2ce494c4be9f9c68d8901657bf961c2323261dd30954d25990d001418"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionDuringLoop/SingleTokenDeletionDuringLoop.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionDuringLoop/SingleTokenDeletionDuringLoop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-add885d747200bef",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserErrors/SingleTokenDeletionDuringLoop.g4",
     "hash": "bb77678589d1936b056f87c3eafaa90d32f55c9a10beee93b8160102affad30f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionDuringLoop2/SingleTokenDeletionDuringLoop2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionDuringLoop2/SingleTokenDeletionDuringLoop2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-792ed25474d04331",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserErrors/SingleTokenDeletionDuringLoop2.g4",
     "hash": "e425f4fea0c6671792c777df6308de1546711741603dfcde04e0cf3ebebf6b9f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionExpectingSet/SingleTokenDeletionExpectingSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionExpectingSet/SingleTokenDeletionExpectingSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ed06340b010d215f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserErrors/SingleTokenDeletionExpectingSet.g4",
     "hash": "82fab2ac95de6f83693cfada43a42fb29c81c33276e86a92c9ffe512e0619240"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenInsertion/SingleTokenInsertion.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenInsertion/SingleTokenInsertion.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b22c89bcb3a2b88e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserErrors/SingleTokenInsertion.g4",
     "hash": "4153af41f9ffb8e3498f2f8624598a75ecb726bce94b85532bc26a2f9a553a93"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/TokenMismatch/TokenMismatch.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/TokenMismatch/TokenMismatch.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e68ef4bce9bbab9b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserErrors/TokenMismatch.g4",
     "hash": "25554c7741a77a1d8537817aac67e64f061017ef4c7c06a01596c0279a6b03ec"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/TokenMismatch2/TokenMismatch2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/TokenMismatch2/TokenMismatch2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6e1085f00c2900ad",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserErrors/TokenMismatch2.g4",
     "hash": "4bd0badd70e068efac023f2f42dff67c8439fb46b31ad4ecffa908f2eb619d18"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/APlus/APlus.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/APlus/APlus.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-728d3d84fcf455c3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/APlus.g4",
     "hash": "2b0dbbd74f199abf2352f0d10d69380a3efa3415df6e4766c0ec28607af19cda"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/AStar_2/AStar_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/AStar_2/AStar_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1a756c9763de62cf",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/AStar_2.g4",
     "hash": "a92a7a73eaf0898b23dda4615fc26ca13df1545ef078fde29cdf8c3bc9cbb95e"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorAPlus/AorAPlus.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorAPlus/AorAPlus.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c42842cac56908aa",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/AorAPlus.g4",
     "hash": "d4aee965be5cd3da519492b2a33a77762e9b3679da9f616bc2e85a73f2202fae"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorAStar_2/AorAStar_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorAStar_2/AorAStar_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5549786fa4e45e89",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/AorAStar_2.g4",
     "hash": "6d4d8fd0f1b4d3dc3e2e8faf8ea35103229eb6c35779eaccc5d82b1628327b23"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorB/AorB.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorB/AorB.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-af2d4db1d1c41fa2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/AorB.g4",
     "hash": "a5be6ae4578376bc6ce8bc8244b8547a686c023b8288b7ee1b788e3109641aef"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorBPlus/AorBPlus.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorBPlus/AorBPlus.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e9cba1c238b58c8f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/AorBPlus.g4",
     "hash": "513f4bbe3648eb8ee7cda9846f4decf54510992284d1f855c91d3ff63f4eb561"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorBStar_2/AorBStar_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorBStar_2/AorBStar_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-62a21287c929c510",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/AorBStar_2.g4",
     "hash": "30bd8a0630f5fee2c9cdd84358bb4330bdbbef41ce747fb918a5317b26d72094"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Basic/Basic.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Basic/Basic.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6478199efe55bc2a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/Basic.g4",
     "hash": "12d9ef272c7c1189094b1667f57d2434ee01e7390bde72fef40bbd2c39c655ad"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/BuildParseTree_FALSE/BuildParseTree_FALSE.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/BuildParseTree_FALSE/BuildParseTree_FALSE.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-481eced579ea16c7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/BuildParseTree_FALSE.g4",
     "hash": "2a131cc48cdbfa4950f7c16ef0fcb51f4679926cabf71d403883a9fc01e9cb99"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1d1b100d63f04166",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/BuildParseTree_TRUE.g4",
     "hash": "2a131cc48cdbfa4950f7c16ef0fcb51f4679926cabf71d403883a9fc01e9cb99"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseGreedyBinding1/IfIfElseGreedyBinding1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseGreedyBinding1/IfIfElseGreedyBinding1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-178da7119841f92f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/IfIfElseGreedyBinding1.g4",
     "hash": "87cddc954cc58d91bcee872b5e1136ec8db7cdba27d288e3158f1263465e1c68"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseGreedyBinding2/IfIfElseGreedyBinding2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseGreedyBinding2/IfIfElseGreedyBinding2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f862b65924b584c3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/IfIfElseGreedyBinding2.g4",
     "hash": "9961fd76deec1ff3f156b53cae19057402f659774e286b5109f317f9099548bf"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseNonGreedyBinding1/IfIfElseNonGreedyBinding1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseNonGreedyBinding1/IfIfElseNonGreedyBinding1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-81adad1ce0ed6fa6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/IfIfElseNonGreedyBinding1.g4",
     "hash": "17ad7d25ee1aed14f17ea5029f7488a334ac41dae14112578dd467489ca814cd"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseNonGreedyBinding2/IfIfElseNonGreedyBinding2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseNonGreedyBinding2/IfIfElseNonGreedyBinding2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e177ceb86d9657b8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/IfIfElseNonGreedyBinding2.g4",
     "hash": "82b13e026c76cbd8d6e148ff6b07a4afcaff767d281341b009acb47f2177fa99"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_1/Keyword_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_1/Keyword_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ab26a078dce4ba4d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/Keyword_1.g4",
     "hash": "ce8b6e86f90fd838f389c969f26848a74f12cedfc2269000d54013aefc9d7cfd"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_2/Keyword_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_2/Keyword_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-71926d55e62dc139",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/Keyword_2.g4",
     "hash": "4901211c2a6d24bc31faad4232c52b1076c788c30ca1626ee8189f377298edb3"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_3/Keyword_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_3/Keyword_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2dfb8df028c35315",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/Keyword_3.g4",
     "hash": "be54343e5d0af2db673e19012a397a002684ea46cbfae40b2d7283c34d120aaf"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_4/Keyword_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_4/Keyword_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6f611c6ff41ad4b7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/Keyword_4.g4",
     "hash": "f093c2f32b839973701e676ff0a7ac42b07bde81fe26d0dd62242d5bddea35df"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_5/Keyword_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_5/Keyword_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-77b6fe2367098780",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/Keyword_5.g4",
     "hash": "288f969b08c50c65a8fe90dca09e2900316e61a1e643ed8dffe19f0baf33caeb"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_6/Keyword_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_6/Keyword_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-208d3031e87fb60b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/Keyword_6.g4",
     "hash": "f1f23150782692a30fca3499f09edc2d8b32615fe4158fdd496ca236f257abfd"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/LL1OptionalBlock_2/LL1OptionalBlock_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/LL1OptionalBlock_2/LL1OptionalBlock_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9d45b4605cb12aa1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/LL1OptionalBlock_2.g4",
     "hash": "a2b9873d31df6aa521f495b2f4f63cbcb01917154e56af08ec8162e66ec4b375"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/LabelAliasingAcrossLabeledAlternatives/LabelAliasingAcrossLabeledAlternatives.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/LabelAliasingAcrossLabeledAlternatives/LabelAliasingAcrossLabeledAlternatives.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7407b4e055dc9668",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/LabelAliasingAcrossLabeledAlternatives.g4",
     "hash": "10da0f9ef1418b4e7996ee9ca537b6eb00e24cd75a5e9cadcf6a0f2cd05403d8"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Labels/Labels.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Labels/Labels.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c7a0d435b3d768e0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/Labels.g4",
     "hash": "6263c0c263ff2e359d5ffe29f5156e36760ebc32acbd8fcae5cb2b94eea08fae"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/ListLabelForClosureContext/ListLabelForClosureContext.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/ListLabelForClosureContext/ListLabelForClosureContext.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fd388b2fbd095aaf",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/ListLabelForClosureContext.g4",
     "hash": "b74922c349f6fd54727a73a9292ac1aa7379006a6b5858b2120f09137b8f5220"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/ListLabelsOnRuleRefStartOfAlt/ListLabelsOnRuleRefStartOfAlt.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/ListLabelsOnRuleRefStartOfAlt/ListLabelsOnRuleRefStartOfAlt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b6e9d57c79d09026",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/ListLabelsOnRuleRefStartOfAlt.g4",
     "hash": "936dbddefbedcc17fb63d1cebd59dba273f24001d8510aa9e4584026b3a77a47"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/ListLabelsOnSet/ListLabelsOnSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/ListLabelsOnSet/ListLabelsOnSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f1cd7211aa8232fa",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/ListLabelsOnSet.g4",
     "hash": "3e061c74b0839caf5d204be5aa58fad88f4a12eacb1a4b5987312548a5e87351"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/MultipleEOFHandling/MultipleEOFHandling.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/MultipleEOFHandling/MultipleEOFHandling.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bfbb91211458856c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/MultipleEOFHandling.g4",
     "hash": "f1cb5bab46a024203403073ff94ae02fed6987c2e63b627edf697a7d299b08c6"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/OpenDeviceStatement_Case1/OpenDeviceStatement_Case1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/OpenDeviceStatement_Case1/OpenDeviceStatement_Case1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b78910bf9bf158f2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/OpenDeviceStatement_Case1.g4",
     "hash": "e7e0d629d700077ba7d1c73b090f445f1d1e6a71e05a0ec865a1119f159c0689"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/OpenDeviceStatement_Case2/OpenDeviceStatement_Case2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/OpenDeviceStatement_Case2/OpenDeviceStatement_Case2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e5674944ed003268",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/OpenDeviceStatement_Case2.g4",
     "hash": "3e809216e16c70dfb0f29110bb04e4f17b9cc8df65e343e657587db8125919d1"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/OpenDeviceStatement_Case3/OpenDeviceStatement_Case3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/OpenDeviceStatement_Case3/OpenDeviceStatement_Case3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3e764b7acdb12698",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/OpenDeviceStatement_Case3.g4",
     "hash": "3e809216e16c70dfb0f29110bb04e4f17b9cc8df65e343e657587db8125919d1"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_1/Optional_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_1/Optional_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c274b4f5c3986095",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/Optional_1.g4",
     "hash": "81da3d25df801643a2b8b428b72db781e2a8d51f46e90fe17e5c4d569460040c"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_2/Optional_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_2/Optional_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-aedb0aa92cf17a71",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/Optional_2.g4",
     "hash": "81da3d25df801643a2b8b428b72db781e2a8d51f46e90fe17e5c4d569460040c"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_3/Optional_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_3/Optional_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9167a5251f4b8f7b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/Optional_3.g4",
     "hash": "81da3d25df801643a2b8b428b72db781e2a8d51f46e90fe17e5c4d569460040c"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_4/Optional_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_4/Optional_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fb9e364a1f321866",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/Optional_4.g4",
     "hash": "81da3d25df801643a2b8b428b72db781e2a8d51f46e90fe17e5c4d569460040c"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/OrderingPredicates/OrderingPredicates.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/OrderingPredicates/OrderingPredicates.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-eb23dd6200692539",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/OrderingPredicates.g4",
     "hash": "9e1c1b5e4eb5492597f2e750d5935cb9a2fad092868471a4a1244f39f05c60e5"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredicatedIfIfElse/PredicatedIfIfElse.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredicatedIfIfElse/PredicatedIfIfElse.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2adf50b71d6b26eb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/PredicatedIfIfElse.g4",
     "hash": "440287edf9ce1d9d35ced00c525bdf5620ab0d710872d6c3df66275a20b6a6b7"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-94c0b5df15a69680",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/PredictionIssue334.g4",
     "hash": "05f509013c98f1d1ef907d23c43aa328f3c9ee0ad9166b21ac03dbc715ee8542"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3ebf8faf7a4261df",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/PredictionMode_LL.g4",
     "hash": "8542495134a20f622112aa07fc5cd71fcc1b8e3669f41ff329126b355c4df7f4"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/ReferenceToATN_2/ReferenceToATN_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/ReferenceToATN_2/ReferenceToATN_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7cb38e03f3cad365",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/ReferenceToATN_2.g4",
     "hash": "51acdad9c9d5ac16101b107cd251308154503481b21347eba16ed71c07207cf8"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/ReservedWordsEscaping/ReservedWordsEscaping.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/ReservedWordsEscaping/ReservedWordsEscaping.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-99d95126dccfc721",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/ReservedWordsEscaping.g4",
     "hash": "1e3d6a30a764c799a1fb20bef01bebe365e7bea96c458c080dfbb708bfd800e8"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/TokenOffset/TokenOffset.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/TokenOffset/TokenOffset.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c220c68df172fdc8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/TokenOffset.g4",
     "hash": "e74488674b6ea2a5b0c7c5c0da5c63c5f40e5cbd3659293737c5f866eec3dadb"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Wildcard/Wildcard.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Wildcard/Wildcard.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-38fea6538d89f39e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/Wildcard.g4",
     "hash": "443ea5e8b3a600f483f353e7b727214ae7b46b07d48a05209575e59a4e5f87ff"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape/uStartingCharDoesNotCauseIllegalUnicodeEscape.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape/uStartingCharDoesNotCauseIllegalUnicodeEscape.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2339d2f209eeb675",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape.g4",
     "hash": "2ddf63624620f170bb9fc4afce010caed86e03e13c5841514ae5f185dda39973"

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_1/DropLoopEntryBranchInLRRule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_1/DropLoopEntryBranchInLRRule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-52627404e5640445",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Performance/DropLoopEntryBranchInLRRule_1.g4",
     "hash": "b939eb6c32ee7ec29a924f62f15dbcc4185a8e719a264dc0f73c4b0abccc59bd"

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_2/DropLoopEntryBranchInLRRule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_2/DropLoopEntryBranchInLRRule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-59b8af4a0fa6b3ee",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Performance/DropLoopEntryBranchInLRRule_2.g4",
     "hash": "b939eb6c32ee7ec29a924f62f15dbcc4185a8e719a264dc0f73c4b0abccc59bd"

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_3/DropLoopEntryBranchInLRRule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_3/DropLoopEntryBranchInLRRule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f5521d38c0216647",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Performance/DropLoopEntryBranchInLRRule_3.g4",
     "hash": "b939eb6c32ee7ec29a924f62f15dbcc4185a8e719a264dc0f73c4b0abccc59bd"

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_4/DropLoopEntryBranchInLRRule_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_4/DropLoopEntryBranchInLRRule_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c5ad84645f427a7d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Performance/DropLoopEntryBranchInLRRule_4.g4",
     "hash": "b939eb6c32ee7ec29a924f62f15dbcc4185a8e719a264dc0f73c4b0abccc59bd"

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_5/DropLoopEntryBranchInLRRule_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_5/DropLoopEntryBranchInLRRule_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e4e42c238a991ee1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Performance/DropLoopEntryBranchInLRRule_5.g4",
     "hash": "b939eb6c32ee7ec29a924f62f15dbcc4185a8e719a264dc0f73c4b0abccc59bd"

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/ExpressionGrammar_1/ExpressionGrammar_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/ExpressionGrammar_1/ExpressionGrammar_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-56eb79099f605626",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Performance/ExpressionGrammar_1.g4",
     "hash": "fdad284b75dbe1e75f3820211869d5d5e166b393077d55d5450945c644e77f47"

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/ExpressionGrammar_2/ExpressionGrammar_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/ExpressionGrammar_2/ExpressionGrammar_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0c991191e7c26565",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Performance/ExpressionGrammar_2.g4",
     "hash": "fdad284b75dbe1e75f3820211869d5d5e166b393077d55d5450945c644e77f47"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/DisableRule/DisableRule.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/DisableRule/DisableRule.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-86a2ab3396aab386",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalLexer/DisableRule.g4",
     "hash": "5b1574a02354c266f21fd591064fe38a2e504dc819f17e3926537f3a06d4fc7f"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/EnumNotID/EnumNotID.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/EnumNotID/EnumNotID.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-913cec3fde51b4e9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalLexer/EnumNotID.g4",
     "hash": "85fe205c1e5199d59ecdfde76be2b554d5417cf4f3044467d2c3c2bc6be62a38"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/IDnotEnum/IDnotEnum.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/IDnotEnum/IDnotEnum.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-62b49dae9cdfa1e9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalLexer/IDnotEnum.g4",
     "hash": "6931892d68c03b3e5aa6440e19df4ec4d482979716d8265bb90d754b4ef6ef7a"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/IDvsEnum/IDvsEnum.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/IDvsEnum/IDvsEnum.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-99254c1dc443e2ed",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalLexer/IDvsEnum.g4",
     "hash": "56ae33e82f989514e362fec8cc72a6550b7a4460f7cf651186c0fc5577e2596d"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/Indent/Indent.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/Indent/Indent.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-cd7a12324cae4154",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalLexer/Indent.g4",
     "hash": "ae673bead61ac8db918560678d525133be3f118e57d3af6dc6170f0a5f59854a"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/LexerInputPositionSensitivePredicates/LexerInputPositionSensitivePredicates.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/LexerInputPositionSensitivePredicates/LexerInputPositionSensitivePredicates.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-55720fd860adaf84",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalLexer/LexerInputPositionSensitivePredicates.g4",
     "hash": "3b657b482bf4474734371c82bad60577eab45adcb768b00be1f1332976f573a7"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/PredicatedKeywords/PredicatedKeywords.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/PredicatedKeywords/PredicatedKeywords.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-469bc7973b79e9b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalLexer/PredicatedKeywords.g4",
     "hash": "2d282eb6b99756b6a78e5b9350752b0e8a9c44853cd80fc99024cca551f2c8a2"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/RuleSempredFunction/RuleSempredFunction.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/RuleSempredFunction/RuleSempredFunction.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-06588ae5e8ac8f6e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalLexer/RuleSempredFunction.g4",
     "hash": "afb90011be3fc07f2b609aab80113b4cdc176601aa78430bdc8af851cd096c57"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ActionHidesPreds/ActionHidesPreds.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ActionHidesPreds/ActionHidesPreds.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5ebe2ee47798d213",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/ActionHidesPreds.g4",
     "hash": "7176de59d1c79178e55d5e86f1c9d45d2a84c42d0306624c059f6291b7bef8aa"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ActionsHidePredsInGlobalFOLLOW/ActionsHidePredsInGlobalFOLLOW.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ActionsHidePredsInGlobalFOLLOW/ActionsHidePredsInGlobalFOLLOW.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a94c1b64bd13fbed",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/ActionsHidePredsInGlobalFOLLOW.g4",
     "hash": "ccdf783cb1b30be5a7b33fa50258508b6fa6564ffc640f83cdd701860cefceab"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/AtomWithClosureInTranslatedLRRule/AtomWithClosureInTranslatedLRRule.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/AtomWithClosureInTranslatedLRRule/AtomWithClosureInTranslatedLRRule.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5a178af823f9ac9a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/AtomWithClosureInTranslatedLRRule.g4",
     "hash": "92e1a1f0924ff1342f55dce399ac903cbd1ee449cb61b490823161e0100e84ea"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/DepedentPredsInGlobalFOLLOW/DepedentPredsInGlobalFOLLOW.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/DepedentPredsInGlobalFOLLOW/DepedentPredsInGlobalFOLLOW.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-692f131977ac56a3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/DepedentPredsInGlobalFOLLOW.g4",
     "hash": "23c2d14982503d975310e5e3c23f6d5acf82bdea14758b8edf43a21de15fc46b"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored/DependentPredNotInOuterCtxShouldBeIgnored.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored/DependentPredNotInOuterCtxShouldBeIgnored.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3fe42b4ce1e78640",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored.g4",
     "hash": "9d9906068c7233613cbd6b5d1291c8c6fcb0cd0cdc09eb46491a16d77043a351"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/DisabledAlternative/DisabledAlternative.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/DisabledAlternative/DisabledAlternative.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a255bb34009ec064",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/DisabledAlternative.g4",
     "hash": "dd7e12c1c8029e091a0a98c9844b768fe2beb66e2dd4499affa4dd42426bbebb"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/IndependentPredNotPassedOuterCtxToAvoidCastException/IndependentPredNotPassedOuterCtxToAvoidCastException.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/IndependentPredNotPassedOuterCtxToAvoidCastException/IndependentPredNotPassedOuterCtxToAvoidCastException.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8d1b342c55cae162",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/IndependentPredNotPassedOuterCtxToAvoidCastException.g4",
     "hash": "7750e6dc3c86efd7c47184ad7f428310bd808cbee7cc760d88cbf6c76aed00ea"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/Order/Order.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/Order/Order.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b0cb8abb4f972c24",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/Order.g4",
     "hash": "fe5bc85134bb1581bdcae00261221a4d8d5cf7fc66861514c518c932db73927c"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7f162199fbfa5a4d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/PredFromAltTestedInLoopBack_2.g4",
     "hash": "b6144b334167648d1e1560be8a7590525c8b34cbba2e27d040c41026fa7c9323"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredTestedEvenWhenUnAmbig_1/PredTestedEvenWhenUnAmbig_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredTestedEvenWhenUnAmbig_1/PredTestedEvenWhenUnAmbig_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3b39341559a48cc1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/PredTestedEvenWhenUnAmbig_1.g4",
     "hash": "e612218883337369509a10795a6c896ed4fd346099904bcdea49689b70eacb58"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredicateDependentOnArg/PredicateDependentOnArg.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredicateDependentOnArg/PredicateDependentOnArg.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f608cd4c953fcc54",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/PredicateDependentOnArg.g4",
     "hash": "63ad05004eaa3eae497c7ac7b869f512be40e3b08c490a4edefce0a7bfd03be4"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredicateDependentOnArg2/PredicateDependentOnArg2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredicateDependentOnArg2/PredicateDependentOnArg2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d0d8e7243a5ed8fa",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/PredicateDependentOnArg2.g4",
     "hash": "54d5032bc72d9ef84bb3c836a5c580fad72122817b40fc5380affd8a13521f6c"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredsInGlobalFOLLOW/PredsInGlobalFOLLOW.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredsInGlobalFOLLOW/PredsInGlobalFOLLOW.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d3df6d6bd95a1bd9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/PredsInGlobalFOLLOW.g4",
     "hash": "5bc8badde05794d30336979aa4a8e376565246e39e74e5e79ffcc7d3640896ab"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/RewindBeforePredEval/RewindBeforePredEval.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/RewindBeforePredEval/RewindBeforePredEval.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-83aa6f01e7804f87",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/RewindBeforePredEval.g4",
     "hash": "1e8283c5161522a98e12bd6b9c0b904b195ed3b305a7cd1104d32111a16230ac"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/Simple/Simple.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/Simple/Simple.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-677df452d792bc67",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/Simple.g4",
     "hash": "35ff1d3690b2d9d2c179b9064ac1f19102b739667e99e936dc923f266be1a29b"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ToLeft/ToLeft.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ToLeft/ToLeft.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-be444147c4503b8c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/ToLeft.g4",
     "hash": "4663e60c7732087dc2db2c9b615d6a9d091258c9088e5494ada4888d59fe97ed"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ToLeftWithVaryingPredicate/ToLeftWithVaryingPredicate.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ToLeftWithVaryingPredicate/ToLeftWithVaryingPredicate.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-210346e30f72367f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/ToLeftWithVaryingPredicate.g4",
     "hash": "660b45f425c3ed090eab8100788e1b44cea8e8acf7a3a7df551673b469969613"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/UnpredicatedPathsInAlt/UnpredicatedPathsInAlt.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/UnpredicatedPathsInAlt/UnpredicatedPathsInAlt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-35f1c77265d94b3d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/UnpredicatedPathsInAlt.g4",
     "hash": "b92936412d8caa3aa5e0a9f0859db4db2dbd59b422445fc0ac7646ad9de7e7b5"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/CharSetLiteral/CharSetLiteral.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/CharSetLiteral/CharSetLiteral.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-071abee69c5f8b99",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/CharSetLiteral.g4",
     "hash": "06e8171bff5cb8897907a7253d3622ee2b3fe0046ae8d0b91af1e53eea95199a"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/LexerOptionalSet/LexerOptionalSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/LexerOptionalSet/LexerOptionalSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f34fde4990cf3527",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/LexerOptionalSet.g4",
     "hash": "805d183407ee6d3e197aa59c47746f31a3a876616ba81d2796b4eade4fd0cb1a"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/LexerPlusSet/LexerPlusSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/LexerPlusSet/LexerPlusSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0a05f3c65ac671fe",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/LexerPlusSet.g4",
     "hash": "82d73edf927d0b41773a2aed77c24eb6c1e15ae757745711744a98d92a30ba9f"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/LexerStarSet/LexerStarSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/LexerStarSet/LexerStarSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-067c6d0cdaeafd72",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/LexerStarSet.g4",
     "hash": "5fc2408d6d827c200d5f3dda95c90ca51c0304141e1966710e5ba3ee4e8c9c62"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/NotChar/NotChar.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/NotChar/NotChar.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-df532a39582b5252",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/NotChar.g4",
     "hash": "ea4e829495a2862424c660528e60b42538171fd98c4add9d59de52bfebb03636"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/NotCharSet/NotCharSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/NotCharSet/NotCharSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f06d5349b86b506d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/NotCharSet.g4",
     "hash": "e746afb6f30a6057ad02472688eed14093eb3c3667bdf9e3c181886b47e78837"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/NotCharSetWithRuleRef3/NotCharSetWithRuleRef3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/NotCharSetWithRuleRef3/NotCharSetWithRuleRef3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d4da046f1e65bec9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/NotCharSetWithRuleRef3.g4",
     "hash": "13b313e51177c018f7ae34ebaa84db67e86a0d4b36209ad3fd1711f2ad2fb7c7"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/OptionalLexerSingleElement/OptionalLexerSingleElement.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/OptionalLexerSingleElement/OptionalLexerSingleElement.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ca7134f26228c2de",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/OptionalLexerSingleElement.g4",
     "hash": "3921de873d86bac58271a10481e3c0e015c69cd9d31da1c2278263a953b16c45"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/OptionalSet/OptionalSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/OptionalSet/OptionalSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3d68ae8128fb39ab",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/OptionalSet.g4",
     "hash": "c13dc8792637b8734bddc522d5c7eb48f4d40806f34c7540b36f59d70a45db0b"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/OptionalSingleElement/OptionalSingleElement.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/OptionalSingleElement/OptionalSingleElement.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-efeddf2f7e9b125b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/OptionalSingleElement.g4",
     "hash": "6ed40cb1f8e0cf841fa0926ccc6a4d62bc3164537ac07270baaf99e7bff650ed"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/ParserNotSet/ParserNotSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/ParserNotSet/ParserNotSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3b9f8eb9e42815a6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/ParserNotSet.g4",
     "hash": "5cd8c64df8a97020ac5413953d3f986284c2d0d02ecffa78f56e74501fd843a4"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/ParserNotToken/ParserNotToken.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/ParserNotToken/ParserNotToken.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-aad9720a02ffb8dc",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/ParserNotToken.g4",
     "hash": "f3628c394dba3dcf943da3c57ae49f9638ad607d2889b3c93a404ffdee955bdd"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/ParserNotTokenWithLabel/ParserNotTokenWithLabel.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/ParserNotTokenWithLabel/ParserNotTokenWithLabel.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-769f62ca417d9ed5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/ParserNotTokenWithLabel.g4",
     "hash": "0a93f8b72d55e95661fd29f1dc20be1ba499092a4627974f10deafbabfc1902d"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/ParserSet/ParserSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/ParserSet/ParserSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-20c70a227c9554ea",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/ParserSet.g4",
     "hash": "9f4a6537aa3fabe41aabda8b6dceb0b110ae6dc2c1ca606d1bb6a4c17bc0523f"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/PlusLexerSingleElement/PlusLexerSingleElement.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/PlusLexerSingleElement/PlusLexerSingleElement.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9e32c82dca8baf2a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/PlusLexerSingleElement.g4",
     "hash": "308fe96545620a9956a16a0b905efbd6838f91f1380d112f59c8f5e7ec847df6"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/PlusSet/PlusSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/PlusSet/PlusSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-27c278babd34c7f1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/PlusSet.g4",
     "hash": "e22104935432d1ef1346e156287f6ffc20f7a823a3a6fc35eead1aa59f7e5bff"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/RuleAsSet/RuleAsSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/RuleAsSet/RuleAsSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8d93a0978fbdee9f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/RuleAsSet.g4",
     "hash": "b292a08285fc28948b206aa219a2c5707f54b8d7d059e4b9435a685e35604a0f"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/SeqDoesNotBecomeSet/SeqDoesNotBecomeSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/SeqDoesNotBecomeSet/SeqDoesNotBecomeSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-56cef52f926ea67e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/SeqDoesNotBecomeSet.g4",
     "hash": "1e9c5a53f120329c72dade19fb74f37b769fa3e8620ce55c964187b4b31afa04"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/StarLexerSingleElement_1/StarLexerSingleElement_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/StarLexerSingleElement_1/StarLexerSingleElement_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-dae05255d7087267",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/StarLexerSingleElement_1.g4",
     "hash": "9ef8e31aeee6cc982752fab2eb2bc1f24a2c1c941b2188809dfd5924be72e052"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/StarLexerSingleElement_2/StarLexerSingleElement_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/StarLexerSingleElement_2/StarLexerSingleElement_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e43de691a19bfcc5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/StarLexerSingleElement_2.g4",
     "hash": "9ef8e31aeee6cc982752fab2eb2bc1f24a2c1c941b2188809dfd5924be72e052"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/StarSet/StarSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/StarSet/StarSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-df2617285346a8e4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/StarSet.g4",
     "hash": "b6e8bd3225682605f4be8329a1ae6a16abcad1fcd59e904ef3b62582e975e58c"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedBMPRangeSet/UnicodeEscapedBMPRangeSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedBMPRangeSet/UnicodeEscapedBMPRangeSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0005566e799dba7a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/UnicodeEscapedBMPRangeSet.g4",
     "hash": "91d810085adf2f3357827ce10f4bbad8b3e368cee7f7cb7a3f7a1de5dcd9fb25"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedBMPSet/UnicodeEscapedBMPSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedBMPSet/UnicodeEscapedBMPSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0060929253ada741",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/UnicodeEscapedBMPSet.g4",
     "hash": "1ebdc64bc0460ae535aeffbdc92a3f5761026b451f53b16a67a1e4ca5c5adfd0"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedSMPRangeSet/UnicodeEscapedSMPRangeSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedSMPRangeSet/UnicodeEscapedSMPRangeSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e54a3fb3292bae9f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/UnicodeEscapedSMPRangeSet.g4",
     "hash": "315c93a355628ed83d531af6a8acae7963652887c8317e90194f639f487a1454"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedSMPSet/UnicodeEscapedSMPSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedSMPSet/UnicodeEscapedSMPSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6165c080cf12dd08",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/UnicodeEscapedSMPSet.g4",
     "hash": "537c313c2d870d0c4e8fd6353c23f77e4510a436510e08e010dadf6674649f67"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeNegatedBMPSetIncludesSMPCodePoints/UnicodeNegatedBMPSetIncludesSMPCodePoints.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeNegatedBMPSetIncludesSMPCodePoints/UnicodeNegatedBMPSetIncludesSMPCodePoints.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-353a1e6aa47b228f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/UnicodeNegatedBMPSetIncludesSMPCodePoints.g4",
     "hash": "466941b1536dede6ac3205c0840ef6d5769d6ebbb02068e3078667aa3b723bf0"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints/UnicodeNegatedSMPSetIncludesBMPCodePoints.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints/UnicodeNegatedSMPSetIncludesBMPCodePoints.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bd7acbaa64d536c9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints.g4",
     "hash": "69ab5aeb81e985edb26b848195ad01840cbc068de1413e0dc41dc606755f5d85"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeUnescapedBMPRangeSet/UnicodeUnescapedBMPRangeSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeUnescapedBMPRangeSet/UnicodeUnescapedBMPRangeSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-080df775962946d3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/UnicodeUnescapedBMPRangeSet.g4",
     "hash": "f35a7b066983f55034da8d5bb525e9f4265b04e208656d8bf80e2647ec315064"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeUnescapedBMPSet/UnicodeUnescapedBMPSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeUnescapedBMPSet/UnicodeUnescapedBMPSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-da721cd708e5efb0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/UnicodeUnescapedBMPSet.g4",
     "hash": "116c1a706a18422d1b24ff9c3f8cc3e9c183c8047ace31fbbb1b2e4e3b9d2b89"

--- a/package-gale/tests/generated/antlr4_compat_b/FullContextParsing/ExprAmbiguity_1/ExprAmbiguity_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/FullContextParsing/ExprAmbiguity_1/ExprAmbiguity_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9e6a660e962943cf",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/FullContextParsing/ExprAmbiguity_1.g4",
     "hash": "14b8e903ab55457ab6f1ff7095b057b77680cdb6892d993f7509940795fdfec1"

--- a/package-gale/tests/generated/antlr4_compat_b/FullContextParsing/ExprAmbiguity_2/ExprAmbiguity_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/FullContextParsing/ExprAmbiguity_2/ExprAmbiguity_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a241ad7263b0316c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/FullContextParsing/ExprAmbiguity_2.g4",
     "hash": "14b8e903ab55457ab6f1ff7095b057b77680cdb6892d993f7509940795fdfec1"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a6ec2b8f2ddde283",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_1.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-61c5e70fcdb6da1f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_10.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-699ecb3a8f815e27",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_2.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-262e54587e9044c3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_3.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a998eaa06c653a5b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_4.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fc22b0fc36d36630",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_5.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2852af861801de26",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_6.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-320d631a0baf5c0b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_7.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3bd4c5ea00e5572f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_8.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-49d484703a919155",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Declarations_9.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-713ef5230fbaf9f1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_1.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-558b311b80c4da10",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_2.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c369756dc031bf12",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/DirectCallToLeftRecursiveRule_3.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-abed1c70b5e6c53f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_1.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a1b502206053bf7a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_2.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-68045ae831d55159",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_3.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-678c469712c8fc23",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_4.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-16bc5e2c231c2ba8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_5.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c116bb1cfe62a2a8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_6.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0484794f535b91f2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Expressions_7.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fe2840241e9172a0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_1.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-235cd53ca8f4663a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_10.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ed84013859c673b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_11.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-739357c31b4c8ca4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_12.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-70a21a8410fad983",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_2.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-99bcc333174e8ead",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_5.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2f290cf17eba13e0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_6.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bd943cd5ec077b75",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_7.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6ad535192ef3e12f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_8.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-43dcc5eba0df7ec4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_9.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-112c4a21992a04ed",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_1.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-459d0b754845c21f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_2.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1181507cda20d45b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/LabelsOnOpSubrule_3.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4b506a26b7b7c7b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_1.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-34e6293e9d4c3e83",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_2.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b2467e37954af95c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActionsPredicatesOptions_3.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-be8254158e713214",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_1.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4fc8261d73da648f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_2.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-93334f393b16d8e0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleActions_3.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e522638eb5f62a2f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrecedenceFilterConsidersContext.g4",
     "hash": "c92df3158f9ed1c1b43de581aedaf3b0918fa525ff0258f855022b78585b860b"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-709c12dbc0d22c0c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrefixAndOtherAlt_1.g4",
     "hash": "f946ec43c09928b2aae968a817d4ff315478257d5700925eab82fd22d94714d8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1f6f1364b2571756",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/PrefixAndOtherAlt_2.g4",
     "hash": "f946ec43c09928b2aae968a817d4ff315478257d5700925eab82fd22d94714d8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList1_1/ReturnValueAndActionsList1_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList1_1/ReturnValueAndActionsList1_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-98215ef7f217d444",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList1_1.g4",
     "hash": "97ed3cba25571f64d3b3f1ada1225af38693f6353aa699ec825c47886f968b1e"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList1_3/ReturnValueAndActionsList1_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList1_3/ReturnValueAndActionsList1_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d3f80bba204a6230",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList1_3.g4",
     "hash": "97ed3cba25571f64d3b3f1ada1225af38693f6353aa699ec825c47886f968b1e"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList2_1/ReturnValueAndActionsList2_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList2_1/ReturnValueAndActionsList2_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fe2931b7e3ce7624",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList2_1.g4",
     "hash": "d020b96fea143032cbc0f3f58b543f99e6ee62a9921e2c0c402a721dfeb8e67c"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList2_3/ReturnValueAndActionsList2_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList2_3/ReturnValueAndActionsList2_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-292efe417a055f21",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList2_3.g4",
     "hash": "d020b96fea143032cbc0f3f58b543f99e6ee62a9921e2c0c402a721dfeb8e67c"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/SemPred/SemPred.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/SemPred/SemPred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-960ef5ffa9d45556",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/SemPred.g4",
     "hash": "a19c17fc308f32463fe399a657b189a837ad4fa52afc1206ab0d1d8a38dcbe04"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/SemPredFailOption/SemPredFailOption.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/SemPredFailOption/SemPredFailOption.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a26551c8d0a65a59",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/SemPredFailOption.g4",
     "hash": "baacd97f45a8e197f2d9363c57506eebffd7f8862b34984e659ed317ac48a7d5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5d3495c986bff9bd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_1.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-33ccce79b79bf5e2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_2.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6dcbc071fc2f601e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/Simple_3.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-741313c066ff2cd5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_1.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-381677e2c28357d8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_2.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4d665f3c7d50cbb6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_3.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-18d85335cd7b6ba7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_4.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6c0e1c831530f504",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_5.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d5dda292b3d95344",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_6.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bc586f7b630f85cb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_7.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b8fe4abc43e4380d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_8.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ddd4f8db5f21632f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExprExplicitAssociativity_9.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1a2ad3adca9a2a07",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_1.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-eed4df03ca7a51f5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_2.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bfcc2ec63de46569",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_3.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-20cd1bcceb40fb33",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_4.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-cfe1fc1849a20141",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_5.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-88482992acd5509f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_6.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-78bbab6b273081fa",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_7.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-03918ec747b14ad6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_8.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a66253165de20181",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/TernaryExpr_9.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/ExtraToken/ExtraToken.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/ExtraToken/ExtraToken.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f98287cee6b90751",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParseTrees/ExtraToken.g4",
     "hash": "156ed9b936c29311886ba71c031dac87cd4b6840001fee2eb9fe68aaa966ecb6"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/NoViableAlt/NoViableAlt.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/NoViableAlt/NoViableAlt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-dac7a0991b16026a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParseTrees/NoViableAlt.g4",
     "hash": "9231f03d8ef47e85e3d2852cfafaddcc6f66c6b8c974af0a13924510275448b7"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/RuleRef/RuleRef.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/RuleRef/RuleRef.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-169bf906f921e598",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParseTrees/RuleRef.g4",
     "hash": "94e77d3cf0e835f48dfd591d6b9b625e723dc68af632bce754d64e7a83682e5f"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/Sync/Sync.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/Sync/Sync.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-47349b342118b43c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParseTrees/Sync.g4",
     "hash": "7f0cc226fbcaf40b919d6fabc5b7e88c8fe92ed6637415b5c5a4be42addac7e8"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/Token2/Token2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/Token2/Token2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0ba95439abba4779",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParseTrees/Token2.g4",
     "hash": "7f89f3118adb112f187ec9a91475c3230eb8d3e0f11d5f98649b5ca5cd018210"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/TwoAltLoop/TwoAltLoop.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/TwoAltLoop/TwoAltLoop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-dfb4bb64c6c70d96",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParseTrees/TwoAltLoop.g4",
     "hash": "01ee51d71cecc10fa33d0b88dd68d026e6e3e811ceaa04d124aaf32b943836ef"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/TwoAlts/TwoAlts.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/TwoAlts/TwoAlts.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7e35452b6694c6ca",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParseTrees/TwoAlts.g4",
     "hash": "18ff657616b51f930ed3ce29a3df32d447b93f1ff9f857f30f3eb53458857f94"

--- a/package-gale/tests/generated/antlr4_compat_b/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1d1b100d63f04166",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/BuildParseTree_TRUE.g4",
     "hash": "2a131cc48cdbfa4950f7c16ef0fcb51f4679926cabf71d403883a9fc01e9cb99"

--- a/package-gale/tests/generated/antlr4_compat_b/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-94c0b5df15a69680",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/PredictionIssue334.g4",
     "hash": "05f509013c98f1d1ef907d23c43aa328f3c9ee0ad9166b21ac03dbc715ee8542"

--- a/package-gale/tests/generated/antlr4_compat_b/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3ebf8faf7a4261df",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/PredictionMode_LL.g4",
     "hash": "8542495134a20f622112aa07fc5cd71fcc1b8e3669f41ff329126b355c4df7f4"

--- a/package-gale/tests/generated/antlr4_compat_b/SemPredEvalParser/PredFromAltTestedInLoopBack_1/PredFromAltTestedInLoopBack_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/SemPredEvalParser/PredFromAltTestedInLoopBack_1/PredFromAltTestedInLoopBack_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3c84aa606fbeb863",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/PredFromAltTestedInLoopBack_1.g4",
     "hash": "b6144b334167648d1e1560be8a7590525c8b34cbba2e27d040c41026fa7c9323"

--- a/package-gale/tests/generated/antlr4_compat_b/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7f162199fbfa5a4d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/PredFromAltTestedInLoopBack_2.g4",
     "hash": "b6144b334167648d1e1560be8a7590525c8b34cbba2e27d040c41026fa7c9323"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/FullContextParsing/FullContextIF_THEN_ELSEParse_1/FullContextIF_THEN_ELSEParse_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/FullContextParsing/FullContextIF_THEN_ELSEParse_1/FullContextIF_THEN_ELSEParse_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-638680e10de193b9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/FullContextParsing/FullContextIF_THEN_ELSEParse_1.g4",
     "hash": "741538d9d6c17ba04aef378568b4ab2abdfbffd161000d9ab169b2a4d9abf5d0"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/JavaExpressions_3/JavaExpressions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/JavaExpressions_3/JavaExpressions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-84ac2f3f46fb93bc",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_3.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/JavaExpressions_4/JavaExpressions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/JavaExpressions_4/JavaExpressions_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-21d6144f1ef80bed",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/JavaExpressions_4.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_1/MultipleAlternativesWithCommonLabel_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_1/MultipleAlternativesWithCommonLabel_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f8f837edca2c89e7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_1.g4",
     "hash": "ae1955a63072b61bfb19d308ec36275bae7fd4ca41cb570ddcd3113f86f61d81"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_2/MultipleAlternativesWithCommonLabel_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_2/MultipleAlternativesWithCommonLabel_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e9a04fe0052b621e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_2.g4",
     "hash": "ae1955a63072b61bfb19d308ec36275bae7fd4ca41cb570ddcd3113f86f61d81"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_3/MultipleAlternativesWithCommonLabel_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_3/MultipleAlternativesWithCommonLabel_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1105f32afc8cf90d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_3.g4",
     "hash": "ae1955a63072b61bfb19d308ec36275bae7fd4ca41cb570ddcd3113f86f61d81"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_4/MultipleAlternativesWithCommonLabel_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_4/MultipleAlternativesWithCommonLabel_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-689fb2e6742c4014",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_4.g4",
     "hash": "ae1955a63072b61bfb19d308ec36275bae7fd4ca41cb570ddcd3113f86f61d81"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_5/MultipleAlternativesWithCommonLabel_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_5/MultipleAlternativesWithCommonLabel_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bba1df3c39861ac6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_5.g4",
     "hash": "ae1955a63072b61bfb19d308ec36275bae7fd4ca41cb570ddcd3113f86f61d81"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_1/ReturnValueAndActionsAndLabels_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_1/ReturnValueAndActionsAndLabels_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5692d6e3f456dfbc",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsAndLabels_1.g4",
     "hash": "8598d942da23d2752eeb86358ab94f137ea6ecbd4536dad7a93253b6dbba2583"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_2/ReturnValueAndActionsAndLabels_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_2/ReturnValueAndActionsAndLabels_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5c5ed2412472f210",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsAndLabels_2.g4",
     "hash": "8598d942da23d2752eeb86358ab94f137ea6ecbd4536dad7a93253b6dbba2583"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_3/ReturnValueAndActionsAndLabels_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_3/ReturnValueAndActionsAndLabels_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-37625c9ce8fecf22",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsAndLabels_3.g4",
     "hash": "8598d942da23d2752eeb86358ab94f137ea6ecbd4536dad7a93253b6dbba2583"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_4/ReturnValueAndActionsAndLabels_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_4/ReturnValueAndActionsAndLabels_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-25e049ca5b917254",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsAndLabels_4.g4",
     "hash": "8598d942da23d2752eeb86358ab94f137ea6ecbd4536dad7a93253b6dbba2583"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList1_2/ReturnValueAndActionsList1_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList1_2/ReturnValueAndActionsList1_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4b874ab98e1307f7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList1_2.g4",
     "hash": "97ed3cba25571f64d3b3f1ada1225af38693f6353aa699ec825c47886f968b1e"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList1_4/ReturnValueAndActionsList1_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList1_4/ReturnValueAndActionsList1_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b49376635cb5520f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList1_4.g4",
     "hash": "97ed3cba25571f64d3b3f1ada1225af38693f6353aa699ec825c47886f968b1e"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList2_2/ReturnValueAndActionsList2_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList2_2/ReturnValueAndActionsList2_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-38b61cfa75fd52d2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList2_2.g4",
     "hash": "d020b96fea143032cbc0f3f58b543f99e6ee62a9921e2c0c402a721dfeb8e67c"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList2_4/ReturnValueAndActionsList2_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList2_4/ReturnValueAndActionsList2_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a83798d7b64b39bf",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/LeftRecursion/ReturnValueAndActionsList2_4.g4",
     "hash": "d020b96fea143032cbc0f3f58b543f99e6ee62a9921e2c0c402a721dfeb8e67c"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserErrors/ContextListGetters/ContextListGetters.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserErrors/ContextListGetters/ContextListGetters.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c046d2e955ea50d7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserErrors/ContextListGetters.g4",
     "hash": "b7f98ec81bd992592439948185bb23c69116c968bf6f2529cf779cfa9801366f"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserErrors/LL1ErrorInfo/LL1ErrorInfo.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserErrors/LL1ErrorInfo/LL1ErrorInfo.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3630e43f048325ae",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserErrors/LL1ErrorInfo.g4",
     "hash": "894561cdd0b332fdb9c86599422d88ee6f45086a452209a385b14df01e56f8aa"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/APlus/APlus.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/APlus/APlus.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-728d3d84fcf455c3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/APlus.g4",
     "hash": "2b0dbbd74f199abf2352f0d10d69380a3efa3415df6e4766c0ec28607af19cda"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AStar_2/AStar_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AStar_2/AStar_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1a756c9763de62cf",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/AStar_2.g4",
     "hash": "a92a7a73eaf0898b23dda4615fc26ca13df1545ef078fde29cdf8c3bc9cbb95e"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorAPlus/AorAPlus.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorAPlus/AorAPlus.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c42842cac56908aa",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/AorAPlus.g4",
     "hash": "d4aee965be5cd3da519492b2a33a77762e9b3679da9f616bc2e85a73f2202fae"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorAStar_2/AorAStar_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorAStar_2/AorAStar_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5549786fa4e45e89",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/AorAStar_2.g4",
     "hash": "6d4d8fd0f1b4d3dc3e2e8faf8ea35103229eb6c35779eaccc5d82b1628327b23"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorB/AorB.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorB/AorB.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-af2d4db1d1c41fa2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/AorB.g4",
     "hash": "a5be6ae4578376bc6ce8bc8244b8547a686c023b8288b7ee1b788e3109641aef"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorBPlus/AorBPlus.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorBPlus/AorBPlus.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e9cba1c238b58c8f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/AorBPlus.g4",
     "hash": "513f4bbe3648eb8ee7cda9846f4decf54510992284d1f855c91d3ff63f4eb561"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorBStar_2/AorBStar_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorBStar_2/AorBStar_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-62a21287c929c510",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/AorBStar_2.g4",
     "hash": "30bd8a0630f5fee2c9cdd84358bb4330bdbbef41ce747fb918a5317b26d72094"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Basic/Basic.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Basic/Basic.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6478199efe55bc2a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/Basic.g4",
     "hash": "12d9ef272c7c1189094b1667f57d2434ee01e7390bde72fef40bbd2c39c655ad"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/BuildParseTree_FALSE/BuildParseTree_FALSE.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/BuildParseTree_FALSE/BuildParseTree_FALSE.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-481eced579ea16c7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/BuildParseTree_FALSE.g4",
     "hash": "2a131cc48cdbfa4950f7c16ef0fcb51f4679926cabf71d403883a9fc01e9cb99"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseGreedyBinding1/IfIfElseGreedyBinding1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseGreedyBinding1/IfIfElseGreedyBinding1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-178da7119841f92f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/IfIfElseGreedyBinding1.g4",
     "hash": "87cddc954cc58d91bcee872b5e1136ec8db7cdba27d288e3158f1263465e1c68"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseGreedyBinding2/IfIfElseGreedyBinding2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseGreedyBinding2/IfIfElseGreedyBinding2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f862b65924b584c3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/IfIfElseGreedyBinding2.g4",
     "hash": "9961fd76deec1ff3f156b53cae19057402f659774e286b5109f317f9099548bf"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseNonGreedyBinding1/IfIfElseNonGreedyBinding1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseNonGreedyBinding1/IfIfElseNonGreedyBinding1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-81adad1ce0ed6fa6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/IfIfElseNonGreedyBinding1.g4",
     "hash": "17ad7d25ee1aed14f17ea5029f7488a334ac41dae14112578dd467489ca814cd"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseNonGreedyBinding2/IfIfElseNonGreedyBinding2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseNonGreedyBinding2/IfIfElseNonGreedyBinding2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e177ceb86d9657b8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/IfIfElseNonGreedyBinding2.g4",
     "hash": "82b13e026c76cbd8d6e148ff6b07a4afcaff767d281341b009acb47f2177fa99"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_1/Keyword_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_1/Keyword_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ab26a078dce4ba4d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/Keyword_1.g4",
     "hash": "ce8b6e86f90fd838f389c969f26848a74f12cedfc2269000d54013aefc9d7cfd"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_2/Keyword_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_2/Keyword_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-71926d55e62dc139",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/Keyword_2.g4",
     "hash": "4901211c2a6d24bc31faad4232c52b1076c788c30ca1626ee8189f377298edb3"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_3/Keyword_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_3/Keyword_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2dfb8df028c35315",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/Keyword_3.g4",
     "hash": "be54343e5d0af2db673e19012a397a002684ea46cbfae40b2d7283c34d120aaf"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_4/Keyword_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_4/Keyword_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6f611c6ff41ad4b7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/Keyword_4.g4",
     "hash": "f093c2f32b839973701e676ff0a7ac42b07bde81fe26d0dd62242d5bddea35df"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_5/Keyword_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_5/Keyword_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-77b6fe2367098780",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/Keyword_5.g4",
     "hash": "288f969b08c50c65a8fe90dca09e2900316e61a1e643ed8dffe19f0baf33caeb"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_6/Keyword_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_6/Keyword_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-208d3031e87fb60b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/Keyword_6.g4",
     "hash": "f1f23150782692a30fca3499f09edc2d8b32615fe4158fdd496ca236f257abfd"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/LL1OptionalBlock_2/LL1OptionalBlock_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/LL1OptionalBlock_2/LL1OptionalBlock_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9d45b4605cb12aa1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/LL1OptionalBlock_2.g4",
     "hash": "a2b9873d31df6aa521f495b2f4f63cbcb01917154e56af08ec8162e66ec4b375"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/LabelAliasingAcrossLabeledAlternatives/LabelAliasingAcrossLabeledAlternatives.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/LabelAliasingAcrossLabeledAlternatives/LabelAliasingAcrossLabeledAlternatives.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7407b4e055dc9668",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/LabelAliasingAcrossLabeledAlternatives.g4",
     "hash": "10da0f9ef1418b4e7996ee9ca537b6eb00e24cd75a5e9cadcf6a0f2cd05403d8"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/ReferenceToATN_2/ReferenceToATN_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/ReferenceToATN_2/ReferenceToATN_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7cb38e03f3cad365",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/ReferenceToATN_2.g4",
     "hash": "51acdad9c9d5ac16101b107cd251308154503481b21347eba16ed71c07207cf8"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/TokenOffset/TokenOffset.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/TokenOffset/TokenOffset.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c220c68df172fdc8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/TokenOffset.g4",
     "hash": "e74488674b6ea2a5b0c7c5c0da5c63c5f40e5cbd3659293737c5f866eec3dadb"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Wildcard/Wildcard.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Wildcard/Wildcard.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-38fea6538d89f39e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/Wildcard.g4",
     "hash": "443ea5e8b3a600f483f353e7b727214ae7b46b07d48a05209575e59a4e5f87ff"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape/uStartingCharDoesNotCauseIllegalUnicodeEscape.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape/uStartingCharDoesNotCauseIllegalUnicodeEscape.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2339d2f209eeb675",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape.g4",
     "hash": "2ddf63624620f170bb9fc4afce010caed86e03e13c5841514ae5f185dda39973"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/ActionHidesPreds/ActionHidesPreds.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/ActionHidesPreds/ActionHidesPreds.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5ebe2ee47798d213",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/ActionHidesPreds.g4",
     "hash": "7176de59d1c79178e55d5e86f1c9d45d2a84c42d0306624c059f6291b7bef8aa"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/ActionsHidePredsInGlobalFOLLOW/ActionsHidePredsInGlobalFOLLOW.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/ActionsHidePredsInGlobalFOLLOW/ActionsHidePredsInGlobalFOLLOW.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a94c1b64bd13fbed",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/ActionsHidePredsInGlobalFOLLOW.g4",
     "hash": "ccdf783cb1b30be5a7b33fa50258508b6fa6564ffc640f83cdd701860cefceab"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/DepedentPredsInGlobalFOLLOW/DepedentPredsInGlobalFOLLOW.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/DepedentPredsInGlobalFOLLOW/DepedentPredsInGlobalFOLLOW.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-692f131977ac56a3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/DepedentPredsInGlobalFOLLOW.g4",
     "hash": "23c2d14982503d975310e5e3c23f6d5acf82bdea14758b8edf43a21de15fc46b"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/IndependentPredNotPassedOuterCtxToAvoidCastException/IndependentPredNotPassedOuterCtxToAvoidCastException.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/IndependentPredNotPassedOuterCtxToAvoidCastException/IndependentPredNotPassedOuterCtxToAvoidCastException.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8d1b342c55cae162",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/IndependentPredNotPassedOuterCtxToAvoidCastException.g4",
     "hash": "7750e6dc3c86efd7c47184ad7f428310bd808cbee7cc760d88cbf6c76aed00ea"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/Order/Order.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/Order/Order.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b0cb8abb4f972c24",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/Order.g4",
     "hash": "fe5bc85134bb1581bdcae00261221a4d8d5cf7fc66861514c518c932db73927c"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/PredTestedEvenWhenUnAmbig_1/PredTestedEvenWhenUnAmbig_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/PredTestedEvenWhenUnAmbig_1/PredTestedEvenWhenUnAmbig_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3b39341559a48cc1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/PredTestedEvenWhenUnAmbig_1.g4",
     "hash": "e612218883337369509a10795a6c896ed4fd346099904bcdea49689b70eacb58"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/PredicateDependentOnArg/PredicateDependentOnArg.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/PredicateDependentOnArg/PredicateDependentOnArg.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f608cd4c953fcc54",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/PredicateDependentOnArg.g4",
     "hash": "63ad05004eaa3eae497c7ac7b869f512be40e3b08c490a4edefce0a7bfd03be4"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/PredsInGlobalFOLLOW/PredsInGlobalFOLLOW.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/PredsInGlobalFOLLOW/PredsInGlobalFOLLOW.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d3df6d6bd95a1bd9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/PredsInGlobalFOLLOW.g4",
     "hash": "5bc8badde05794d30336979aa4a8e376565246e39e74e5e79ffcc7d3640896ab"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/RewindBeforePredEval/RewindBeforePredEval.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/RewindBeforePredEval/RewindBeforePredEval.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-83aa6f01e7804f87",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/RewindBeforePredEval.g4",
     "hash": "1e8283c5161522a98e12bd6b9c0b904b195ed3b305a7cd1104d32111a16230ac"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/Simple/Simple.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/Simple/Simple.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-677df452d792bc67",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/Simple.g4",
     "hash": "35ff1d3690b2d9d2c179b9064ac1f19102b739667e99e936dc923f266be1a29b"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/ToLeft/ToLeft.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/ToLeft/ToLeft.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-be444147c4503b8c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/ToLeft.g4",
     "hash": "4663e60c7732087dc2db2c9b615d6a9d091258c9088e5494ada4888d59fe97ed"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/ToLeftWithVaryingPredicate/ToLeftWithVaryingPredicate.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/ToLeftWithVaryingPredicate/ToLeftWithVaryingPredicate.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-210346e30f72367f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/ToLeftWithVaryingPredicate.g4",
     "hash": "660b45f425c3ed090eab8100788e1b44cea8e8acf7a3a7df551673b469969613"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/UnpredicatedPathsInAlt/UnpredicatedPathsInAlt.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/UnpredicatedPathsInAlt/UnpredicatedPathsInAlt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-35f1c77265d94b3d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/SemPredEvalParser/UnpredicatedPathsInAlt.g4",
     "hash": "b92936412d8caa3aa5e0a9f0859db4db2dbd59b422445fc0ac7646ad9de7e7b5"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/CharSetLiteral/CharSetLiteral.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/CharSetLiteral/CharSetLiteral.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-071abee69c5f8b99",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/CharSetLiteral.g4",
     "hash": "06e8171bff5cb8897907a7253d3622ee2b3fe0046ae8d0b91af1e53eea95199a"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/LexerOptionalSet/LexerOptionalSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/LexerOptionalSet/LexerOptionalSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f34fde4990cf3527",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/LexerOptionalSet.g4",
     "hash": "805d183407ee6d3e197aa59c47746f31a3a876616ba81d2796b4eade4fd0cb1a"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/LexerPlusSet/LexerPlusSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/LexerPlusSet/LexerPlusSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0a05f3c65ac671fe",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/LexerPlusSet.g4",
     "hash": "82d73edf927d0b41773a2aed77c24eb6c1e15ae757745711744a98d92a30ba9f"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/LexerStarSet/LexerStarSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/LexerStarSet/LexerStarSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-067c6d0cdaeafd72",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/LexerStarSet.g4",
     "hash": "5fc2408d6d827c200d5f3dda95c90ca51c0304141e1966710e5ba3ee4e8c9c62"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/NotChar/NotChar.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/NotChar/NotChar.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-df532a39582b5252",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/NotChar.g4",
     "hash": "ea4e829495a2862424c660528e60b42538171fd98c4add9d59de52bfebb03636"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/NotCharSet/NotCharSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/NotCharSet/NotCharSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f06d5349b86b506d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/NotCharSet.g4",
     "hash": "e746afb6f30a6057ad02472688eed14093eb3c3667bdf9e3c181886b47e78837"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/NotCharSetWithRuleRef3/NotCharSetWithRuleRef3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/NotCharSetWithRuleRef3/NotCharSetWithRuleRef3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d4da046f1e65bec9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/NotCharSetWithRuleRef3.g4",
     "hash": "13b313e51177c018f7ae34ebaa84db67e86a0d4b36209ad3fd1711f2ad2fb7c7"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/OptionalLexerSingleElement/OptionalLexerSingleElement.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/OptionalLexerSingleElement/OptionalLexerSingleElement.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ca7134f26228c2de",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/OptionalLexerSingleElement.g4",
     "hash": "3921de873d86bac58271a10481e3c0e015c69cd9d31da1c2278263a953b16c45"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/OptionalSet/OptionalSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/OptionalSet/OptionalSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3d68ae8128fb39ab",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/OptionalSet.g4",
     "hash": "c13dc8792637b8734bddc522d5c7eb48f4d40806f34c7540b36f59d70a45db0b"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/OptionalSingleElement/OptionalSingleElement.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/OptionalSingleElement/OptionalSingleElement.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-efeddf2f7e9b125b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/OptionalSingleElement.g4",
     "hash": "6ed40cb1f8e0cf841fa0926ccc6a4d62bc3164537ac07270baaf99e7bff650ed"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/ParserNotSet/ParserNotSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/ParserNotSet/ParserNotSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3b9f8eb9e42815a6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/ParserNotSet.g4",
     "hash": "5cd8c64df8a97020ac5413953d3f986284c2d0d02ecffa78f56e74501fd843a4"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/ParserNotToken/ParserNotToken.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/ParserNotToken/ParserNotToken.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-aad9720a02ffb8dc",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/ParserNotToken.g4",
     "hash": "f3628c394dba3dcf943da3c57ae49f9638ad607d2889b3c93a404ffdee955bdd"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/ParserNotTokenWithLabel/ParserNotTokenWithLabel.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/ParserNotTokenWithLabel/ParserNotTokenWithLabel.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-769f62ca417d9ed5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/ParserNotTokenWithLabel.g4",
     "hash": "0a93f8b72d55e95661fd29f1dc20be1ba499092a4627974f10deafbabfc1902d"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/ParserSet/ParserSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/ParserSet/ParserSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-20c70a227c9554ea",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/ParserSet.g4",
     "hash": "9f4a6537aa3fabe41aabda8b6dceb0b110ae6dc2c1ca606d1bb6a4c17bc0523f"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/PlusLexerSingleElement/PlusLexerSingleElement.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/PlusLexerSingleElement/PlusLexerSingleElement.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9e32c82dca8baf2a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/PlusLexerSingleElement.g4",
     "hash": "308fe96545620a9956a16a0b905efbd6838f91f1380d112f59c8f5e7ec847df6"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/PlusSet/PlusSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/PlusSet/PlusSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-27c278babd34c7f1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/PlusSet.g4",
     "hash": "e22104935432d1ef1346e156287f6ffc20f7a823a3a6fc35eead1aa59f7e5bff"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/RuleAsSet/RuleAsSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/RuleAsSet/RuleAsSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8d93a0978fbdee9f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/RuleAsSet.g4",
     "hash": "b292a08285fc28948b206aa219a2c5707f54b8d7d059e4b9435a685e35604a0f"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/SeqDoesNotBecomeSet/SeqDoesNotBecomeSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/SeqDoesNotBecomeSet/SeqDoesNotBecomeSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-56cef52f926ea67e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/SeqDoesNotBecomeSet.g4",
     "hash": "1e9c5a53f120329c72dade19fb74f37b769fa3e8620ce55c964187b4b31afa04"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/StarLexerSingleElement_1/StarLexerSingleElement_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/StarLexerSingleElement_1/StarLexerSingleElement_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-dae05255d7087267",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/StarLexerSingleElement_1.g4",
     "hash": "9ef8e31aeee6cc982752fab2eb2bc1f24a2c1c941b2188809dfd5924be72e052"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/StarLexerSingleElement_2/StarLexerSingleElement_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/StarLexerSingleElement_2/StarLexerSingleElement_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e43de691a19bfcc5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/StarLexerSingleElement_2.g4",
     "hash": "9ef8e31aeee6cc982752fab2eb2bc1f24a2c1c941b2188809dfd5924be72e052"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/StarSet/StarSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/StarSet/StarSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-df2617285346a8e4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/StarSet.g4",
     "hash": "b6e8bd3225682605f4be8329a1ae6a16abcad1fcd59e904ef3b62582e975e58c"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints/UnicodeNegatedSMPSetIncludesBMPCodePoints.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints/UnicodeNegatedSMPSetIncludesBMPCodePoints.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bd7acbaa64d536c9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "../../grammars/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints.g4",
     "hash": "69ab5aeb81e985edb26b848195ad01840cbc068de1413e0dc41dc606755f5d85"

--- a/package-gale/tests/generated/at_end_alt_gaps/at_end_alt_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/at_end_alt_gaps/at_end_alt_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-105bcd36568c5dd8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/at_end_alt_gaps.g4",
     "hash": "9cd47ca80f5762b4107f87ae05f1bce472bbfb8aca3c06ef0bdbf501ac519f82"

--- a/package-gale/tests/generated/calculator/calculator.g4.kiln.json
+++ b/package-gale/tests/generated/calculator/calculator.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7fbe69e34c931e16",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/calculator.g4",
     "hash": "67431dad6dcc459fea7d4c448fb04944de2c4cf61ecd75d546aeccd93b4564d7"

--- a/package-gale/tests/generated/ci_rule_override/ci_rule_override.g4.kiln.json
+++ b/package-gale/tests/generated/ci_rule_override/ci_rule_override.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-66c270910e5642be",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/ci_rule_override.g4",
     "hash": "6efdfe55ecb215bf526900a32a11c664a57c9e14d61c6a67758f870adc73d09b"

--- a/package-gale/tests/generated/ci_sql/ci_sql.g4.kiln.json
+++ b/package-gale/tests/generated/ci_sql/ci_sql.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b9bfa38391d7f122",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/ci_sql.g4",
     "hash": "41b72934417dd2f6fa0359722ce53ca05cd10cccde08fd9f3d0d58018f2137fe"

--- a/package-gale/tests/generated/css3/css3Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/css3/css3Lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fa4a5fa8cced30ae",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/css3Lexer.g4",
     "hash": "4733198f782344f0d3dbd2456ee9f6db955f53c688d14334fb403985551c963c"

--- a/package-gale/tests/generated/diagnostics/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/diagnostics/JSON.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-deb9206518cd2a6f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/JSON.g4",
     "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"

--- a/package-gale/tests/generated/html/HTMLLexer.g4.kiln.json
+++ b/package-gale/tests/generated/html/HTMLLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c6b3fd168a1b47a8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/HTMLLexer.g4",
     "hash": "1d3b243228b182ddeca45bf2c7f9ec6512c176bcec126444bce7cbe7a8e93052"

--- a/package-gale/tests/generated/json/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/json/JSON.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-deb9206518cd2a6f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/JSON.g4",
     "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"

--- a/package-gale/tests/generated/json_highlight/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/json_highlight/JSON.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-deb9206518cd2a6f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/JSON.g4",
     "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"

--- a/package-gale/tests/generated/label_gaps/label_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/label_gaps/label_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6e9e12ac993603d7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/label_gaps.g4",
     "hash": "8e2049cd7baf82750b8e242018ffdc1f8e684226f8e27fe8068ad7838d6da425"

--- a/package-gale/tests/generated/label_list_collision/label_list_collision.g4.kiln.json
+++ b/package-gale/tests/generated/label_list_collision/label_list_collision.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-46e32ac3c676e666",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/label_list_collision.g4",
     "hash": "245eac983b4d16903ac917751c3f59e886be8be3e55623cdb25e40c782b58d44"

--- a/package-gale/tests/generated/lexer_command_gaps/lexer_command_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/lexer_command_gaps/lexer_command_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c1bc56a77b40e824",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/lexer_command_gaps.g4",
     "hash": "253a32f9908895a3ffaa23ac8e32eaa12f43998f25d7d2b73637ddf11a3cb3c9"

--- a/package-gale/tests/generated/lexer_greedy_suffix/lexer_greedy_suffix.g4.kiln.json
+++ b/package-gale/tests/generated/lexer_greedy_suffix/lexer_greedy_suffix.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6d59efe1924c9daa",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/lexer_greedy_suffix.g4",
     "hash": "2286e1ce4403101b6a2c197a88b3ba06ef185d7c31e99ad55033185275953d1a"

--- a/package-gale/tests/generated/ll_basic/ll_basic.g4.kiln.json
+++ b/package-gale/tests/generated/ll_basic/ll_basic.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1206cd75cc164570",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/ll_basic.g4",
     "hash": "13868e6cd6d82823b75c7c4c47196769892a7455d2a5708059eda73d059fa079"

--- a/package-gale/tests/generated/ll_ctx_follow/ll_ctx_follow.g4.kiln.json
+++ b/package-gale/tests/generated/ll_ctx_follow/ll_ctx_follow.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b6ecd573d27c61b4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/ll_ctx_follow.g4",
     "hash": "dfd02fd3f5e412a278dd35d357b67bd1b5c3ee832a93ead373965a1ea4caa7ed"

--- a/package-gale/tests/generated/ll_lr_atom/ll_lr_atom.g4.kiln.json
+++ b/package-gale/tests/generated/ll_lr_atom/ll_lr_atom.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-57755379135c6d22",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/ll_lr_atom.g4",
     "hash": "a03827fb8ff2576a6b7eb0997c60f88f94b45f673cc5ef743531000f7441227a"

--- a/package-gale/tests/generated/ll_multi_alt/ll_multi_alt.g4.kiln.json
+++ b/package-gale/tests/generated/ll_multi_alt/ll_multi_alt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4ba2b45344ba5494",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/ll_multi_alt.g4",
     "hash": "16387da958668ca8bfdc3a1502dec2180c703bb9affd3b19c2e669b8be9197a6"

--- a/package-gale/tests/generated/ll_multi_alt_overlap/ll_multi_alt_overlap.g4.kiln.json
+++ b/package-gale/tests/generated/ll_multi_alt_overlap/ll_multi_alt_overlap.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e527efdc825ca74e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/ll_multi_alt_overlap.g4",
     "hash": "570115cb7ce13e54d54def090f3ec3c79f9d8fcde7a904ce0043cace1a35336a"

--- a/package-gale/tests/generated/ll_multi_token_tail/ll_multi_token_tail.g4.kiln.json
+++ b/package-gale/tests/generated/ll_multi_token_tail/ll_multi_token_tail.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-467a302512739408",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/ll_multi_token_tail.g4",
     "hash": "5b3c6e9762dfdcb510a7454132f535cb903673dc4c85d38e903d48cdcea40a5b"

--- a/package-gale/tests/generated/ll_nullable_suffix/ll_nullable_suffix.g4.kiln.json
+++ b/package-gale/tests/generated/ll_nullable_suffix/ll_nullable_suffix.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f9a69797fc3574b8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/ll_nullable_suffix.g4",
     "hash": "d66de357f8340f6036dea6270e51c73a58b209b0a07685a7df03b2d18d218fe4"

--- a/package-gale/tests/generated/ll_optional_non_greedy/ll_optional_non_greedy.g4.kiln.json
+++ b/package-gale/tests/generated/ll_optional_non_greedy/ll_optional_non_greedy.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f6ce50e9c72d6bb2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/ll_optional_non_greedy.g4",
     "hash": "5c694d978288bb194b7285fb45a327ad16638c376930352bbe88ff0c94d0ace2"

--- a/package-gale/tests/generated/ll_wildcard_alt/ll_wildcard_alt.g4.kiln.json
+++ b/package-gale/tests/generated/ll_wildcard_alt/ll_wildcard_alt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b7f46d8d9ce550a7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/ll_wildcard_alt.g4",
     "hash": "5679207b4c2a4bdb85056206fff12aef1cb8c4998f099751195b3e09aea7047d"

--- a/package-gale/tests/generated/mode_gaps/mode_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/mode_gaps/mode_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-934b67223a7d4708",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/mode_gaps.g4",
     "hash": "2129310ea345f84328b61531ce102c6306fda62ef4fa71d7c64d1dc4bb9f1d14"

--- a/package-gale/tests/generated/multiple_eof/multiple_eof.g4.kiln.json
+++ b/package-gale/tests/generated/multiple_eof/multiple_eof.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-eca210b3fbc81812",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/multiple_eof.g4",
     "hash": "2b097a4cde773ec14e56e4222cd34af3735931774e74c4c77ca7b37f41afaa43"

--- a/package-gale/tests/generated/non_greedy_gaps/non_greedy_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/non_greedy_gaps/non_greedy_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a7aa34c1db2fca6a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/non_greedy_gaps.g4",
     "hash": "b7ebb6e1d962ee295bf43cc5a13f167cbd270ef3d9e15a052d2eb060eefb012c"

--- a/package-gale/tests/generated/opt_sep_list/opt_sep_list.g4.kiln.json
+++ b/package-gale/tests/generated/opt_sep_list/opt_sep_list.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-cd40f6c8cb4fefca",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/opt_sep_list.g4",
     "hash": "c6a879a1e89a7a0cf4fddca366393412ec939a5579f079fab250cee7d8be33fd"

--- a/package-gale/tests/generated/overlap_tournament/ll_overlap_tournament.g4.kiln.json
+++ b/package-gale/tests/generated/overlap_tournament/ll_overlap_tournament.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-0c62cb678fa1202a",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
+  "primary": {
+    "path": "grammars/ll_overlap_tournament.g4",
+    "hash": "c6fd0821861f96cf907e2a88c796e161295e33bdc2a280ae9567fe31cbc15833"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "664ab6cf3faaeab6e21bef83b6aabf97790e28cadcb4d21099d7bae5dee7cf3f",
+  "outputs": [
+    {
+      "path": "tests/generated/overlap_tournament/overlap_tournament.wado",
+      "hash": "f16d863e0e34e2aa44b3eddef786e2945946fc5c9e238eef46997ed69cc823bd",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/overlap_tournament/overlap_tournament.wado
+++ b/package-gale/tests/generated/overlap_tournament/overlap_tournament.wado
@@ -1,0 +1,1089 @@
+#![generated(by = "local:src/generator.wado", sources = ["grammars/ll_overlap_tournament.g4"])]
+#![generated(by = "gale", sources = ["OverlapTournament.g4"])]
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &Array<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &Array<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &Array<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: Array<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: Array<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// ParseError represents a parse failure with location and expected tokens.
+///
+/// `message` is the local "expected X, got Y" description, kept free of
+/// position and rule context so it stays composable. `line`/`col` are a
+/// 1-based line and 0-based column (ANTLR4 `Token` convention) resolved
+/// from `span.start` against the source at error-construction time;
+/// `Parser::error` fills them in. `rule_stack` records the chain of parser
+/// rules that were active when the error was raised, innermost first — each
+/// rule entry wrapper pushes its own name as the `Err` propagates outward,
+/// so the last element is the start rule and the first is the rule the
+/// failing token sat in. The `Display` impl renders all of this into a
+/// human-readable diagnostic.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: Array<String>,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub rule_stack: Array<String> = [],
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: Array<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+
+    /// Construct a ParseError whose position is already resolved. Used by
+    /// `Parser::error`, which has the source on hand to compute line/col.
+    pub fn at(message: String, span: Span, expected: Array<String>, line: i32, col: i32) -> ParseError {
+        return ParseError { message, span, expected, line, col, rule_stack: [] };
+    }
+
+    /// Render the rule chain as `outer > ... > inner` (start rule first).
+    /// `rule_stack` is stored innermost-first, so iterate it in reverse.
+    /// Consecutive duplicates are collapsed: a left-recursive rule re-enters
+    /// itself once per precedence level, which would otherwise print
+    /// `expr > expr > expr` for a deep expression.
+    pub fn rule_path(&self) -> String {
+        let mut out = String::with_capacity(self.rule_stack.len() * 8);
+        let n = self.rule_stack.len();
+        let mut written = 0;
+        for let mut i = 0; i < n; i += 1 {
+            let name = &self.rule_stack[n - 1 - i];
+            if written > 0 && *name == self.rule_stack[n - i] {
+                continue;
+            }
+            if written > 0 {
+                out.push_str(&" > ");
+            }
+            out.push_str(name);
+            written += 1;
+        }
+        return out;
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`parse error at {self.line}:{self.col}: {self.message}`);
+        if !self.rule_stack.is_empty() {
+            f.write_str(&`\n  in rule: {self.rule_path()}`);
+        }
+    }
+}
+
+/// CstChild is either a terminal token or a non-terminal sub-tree.
+pub variant CstChild {
+    Token(Token),
+    Node(CstNode),
+}
+
+/// CstNode is a generic (untyped) concrete syntax tree node.
+pub struct CstNode {
+    pub name: String,
+    pub span: Span,
+    pub children: Array<CstChild>,
+}
+
+impl CstNode {
+    /// Produce an ANTLR4-style S-expression representation of this tree.
+    /// Rule nodes become `(name child1 child2 ...)`, tokens become their text.
+    /// Tokens with empty text (e.g. EOF) are omitted.
+    pub fn to_string_tree(&self) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(out: &mut String, node: &CstNode) {
+    out.push_str(&`({node.name}`);
+    for let child of &node.children {
+        if let Token(t) = *child {
+            if !t.text.is_empty() {
+                out.push_str(&` {t.text}`);
+            }
+        } else if let Node(n) = *child {
+            out.push_str(&" ");
+            cst_to_string_tree_impl(out, &n);
+        }
+    }
+    out.push_str(&")");
+}
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Find the first direct child Node of `parent` whose rule name equals
+/// `name`. Returns `None` when no such child exists.
+///
+/// Used by Stage B sub-tree drivers: many ANTLR4 descriptors print a
+/// labelled sub-tree (`@after { <ToStringTree("$r.ctx"):writeln()> }`)
+/// rather than the start rule's full tree. Gale's `parse()` always
+/// returns the full tree, so the test must navigate down to the
+/// referenced child before comparing.
+pub fn find_first_child_node(parent: &CstNode, name: &String) -> Option<CstNode> {
+    for let child of &parent.children {
+        if let Node(n) = *child {
+            if n.name == *name {
+                return Option::<CstNode>::Some(n);
+            }
+        }
+    }
+    return null;
+}
+
+/// Produce an ANTLR4-style `Token.toString()` dump of the token stream:
+///
+///   [@<idx>,<start>:<end>='<text>',<<type>>,<line>:<col>]\n  (per token)
+///
+/// Used by Stage L (token-stream equivalence) tests against the upstream
+/// `LexerExec` / etc. `[output]` blocks.
+///
+/// - `tokens` is the public-channel stream returned by the generated
+///   `tokenize(input)`. Skip-channel tokens never reach this array, so no
+///   filtering is needed here.
+/// - `input` is the original source; passed in so line/col can be
+///   computed from byte offsets (Gale's `Token` does not carry these).
+/// - `eof_kind` is the value of the generated `TK_EOF` constant; EOF
+///   tokens print as `<EOF>` text with type id `-1`.
+///
+/// Type IDs are remapped from Gale's 0-based numbering to ANTLR4's
+/// 1-based: `kind + 1` for explicit lexer rules, `-1` for EOF. Lexer-only
+/// grammars never introduce implicit literals, so the contiguous
+/// `0..num_lexer_rules` range maps directly onto ANTLR4's
+/// `1..num_lexer_rules+1`.
+///
+/// Text escaping follows `CommonToken.toString` (`vendor/antlr4/runtime/
+/// Java/src/org/antlr/v4/runtime/CommonToken.java`): only `\n`, `\r`,
+/// `\t` are escaped; backslashes and quotes pass through unchanged.
+pub fn to_lexer_string(tokens: &Array<Token>, input: &String, eof_kind: i32) -> String {
+    let chars: Array<char> = input.chars().collect();
+    let mut out = String::with_capacity(tokens.len() * 32);
+    let mut index = 0;
+    for let mut i = 0; i < tokens.len(); i += 1 {
+        let tok = &tokens[i];
+        // Non-default-channel tokens (e.g. `-> channel(HIDDEN)`) are invisible
+        // to the parser, so the generated tokenizer parks them in the next
+        // token's `leading_trivia` alongside skip tokens. ANTLR4 still emits
+        // them into the token dump in source order with a `channel=N`
+        // attribute and a sequential index, so interleave them ahead of their
+        // host token. Skip tokens carry channel 0 and are discarded entirely —
+        // they neither print nor advance the index (matching ANTLR4's
+        // `Lexer.skip()`).
+        for let tr of &tok.leading_trivia {
+            if tr.channel != 0 {
+                emit_lexer_token(&mut out, tr, &chars, index, eof_kind);
+                index += 1;
+            }
+        }
+        emit_lexer_token(&mut out, tok, &chars, index, eof_kind);
+        index += 1;
+    }
+    return out;
+}
+
+/// Renders a single token in ANTLR4's `CommonToken.toString` format, used by
+/// `to_lexer_string` for both main-stream tokens and interleaved
+/// non-default-channel trivia. `channel=N` is printed only for non-default
+/// channels, matching ANTLR4.
+fn emit_lexer_token(out: &mut String, tok: &Token, chars: &Array<char>, index: i32, eof_kind: i32) {
+    let is_eof = tok.kind == eof_kind;
+    let mut text_buf = String::with_capacity(16);
+    if is_eof {
+        text_buf.push_str(&"<EOF>");
+    } else {
+        for let mut j = tok.text.start; j < tok.text.end; j += 1 {
+            let c = tok.text.chars[j];
+            match c {
+                '\n' => text_buf.push_str(&"\\n"),
+                '\r' => text_buf.push_str(&"\\r"),
+                '\t' => text_buf.push_str(&"\\t"),
+                _ => text_buf.push(c),
+            }
+        }
+    }
+    let type_id = if is_eof { -1 } else { tok.kind + 1 };
+    let line_col = line_col_at(chars, tok.span.start);
+    let line = line_col.0;
+    let col = line_col.1;
+    let end_inclusive = tok.span.end - 1;
+    let channel_attr = if tok.channel != 0 { `channel={tok.channel},` } else { String::from("") };
+    out.push_str(&`[@{index},{tok.span.start}:{end_inclusive}='{text_buf}',<{type_id}>,{channel_attr}{line}:{col}]\n`);
+}
+
+/// Compute (line, column) at a 0-based char index in `chars`, with
+/// 1-based line and 0-based column to match ANTLR4's `Token` getters.
+fn line_col_at(chars: &Array<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+
+/// Highlight override: when inside a specific rule, override the capture for a token kind.
+pub struct HighlightOverride {
+    pub rule_name: String,
+    pub token_kind: i32,
+    pub capture: String,
+}
+
+/// Highlight mapping: defaults by token kind + context-aware overrides.
+///
+/// `rule_names` is the canonical name table used to resolve override
+/// `rule_name`s into integer ids that match what the generated walker
+/// passes to `Visitor::enter_rule`. The generator emits the names in
+/// parser-rule declaration order; index = rule id.
+pub struct HighlightMapping {
+    pub defaults: Array<String>,
+    pub rule_names: Array<String>,
+    pub overrides: Array<HighlightOverride>,
+}
+
+/// A single highlight capture: a named range in the source text.
+pub struct HighlightCapture {
+    pub capture: String,
+    pub start: i32,
+    pub end: i32,
+}
+
+/// Internal override form with the rule resolved to an integer id so the
+/// per-token classify loop avoids a String compare on every iteration.
+struct ResolvedOverride {
+    rule_id: i32,
+    token_kind: i32,
+    capture: String,
+}
+
+/// HighlightVisitor collects highlight captures during a CST walk.
+pub struct HighlightVisitor {
+    defaults: Array<String>,
+    overrides: Array<ResolvedOverride>,
+    rule_stack: Array<i32>,
+    pub captures: Array<HighlightCapture>,
+}
+
+impl HighlightVisitor {
+    pub fn new(mapping: HighlightMapping) -> HighlightVisitor {
+        let mut overrides: Array<ResolvedOverride> = Array::with_capacity(mapping.overrides.len());
+        for let ov of &mapping.overrides {
+            let mut id: i32 = -1;
+            for let mut i = 0; i < mapping.rule_names.len(); i += 1 {
+                if mapping.rule_names[i] == ov.rule_name {
+                    id = i;
+                    break;
+                }
+            }
+            // Skip overrides whose rule_name doesn't match any known rule —
+            // they can never fire (no rule_id on the stack is ever < 0) and
+            // would otherwise waste a comparison on every classify() call.
+            if id < 0 {
+                continue;
+            }
+            overrides.push(ResolvedOverride {
+                rule_id: id,
+                token_kind: ov.token_kind,
+                capture: ov.capture,
+            });
+        }
+        return HighlightVisitor {
+            defaults: mapping.defaults,
+            overrides,
+            rule_stack: [],
+            captures: [],
+        };
+    }
+
+    fn classify(&self, kind: i32) -> String {
+        for let ov of &self.overrides {
+            if ov.token_kind == kind {
+                for let rule_id of &self.rule_stack {
+                    if *rule_id == ov.rule_id {
+                        return ov.capture;
+                    }
+                }
+            }
+        }
+        if kind >= 0 && kind < self.defaults.len() {
+            return self.defaults[kind];
+        }
+        return "";
+    }
+}
+
+impl Visitor for HighlightVisitor {
+    fn enter_rule(&mut self, rule_id: i32, name: &String, span: &Span) {
+        self.rule_stack.push(rule_id);
+    }
+
+    fn exit_rule(&mut self, rule_id: i32, name: &String, span: &Span) {
+        self.rule_stack.pop();
+    }
+
+    fn visit_token(&mut self, token: &Token) {
+        for let trivia of &token.leading_trivia {
+            let cap = self.classify(trivia.kind);
+            if !cap.is_empty() {
+                self.captures.push(HighlightCapture { capture: cap, start: trivia.span.start, end: trivia.span.end });
+            }
+        }
+        if token.text.is_empty() {
+            return;
+        }
+        let cap = self.classify(token.kind);
+        if !cap.is_empty() {
+            self.captures.push(HighlightCapture { capture: cap, start: token.span.start, end: token.span.end });
+        }
+    }
+}
+
+fn escape_html(out: &mut String, text: &String) {
+    for let c of text.chars() {
+        if c == '&' {
+            out.push_str(&"&amp;");
+        } else if c == '<' {
+            out.push_str(&"&lt;");
+        } else if c == '>' {
+            out.push_str(&"&gt;");
+        } else if c == '"' {
+            out.push_str(&"&quot;");
+        } else {
+            out.push(c);
+        }
+    }
+}
+
+fn escape_html_char(out: &mut String, c: char) {
+    if c == '&' {
+        out.push_str(&"&amp;");
+    } else if c == '<' {
+        out.push_str(&"&lt;");
+    } else if c == '>' {
+        out.push_str(&"&gt;");
+    } else if c == '"' {
+        out.push_str(&"&quot;");
+    } else {
+        out.push(c);
+    }
+}
+
+fn push_class(out: &mut String, capture: &String) {
+    for let c of capture.chars() {
+        if c == '.' {
+            out.push(' ');
+        } else {
+            out.push(c);
+        }
+    }
+}
+
+/// Produce a highlighted HTML fragment from source text and captures.
+/// Captures must be sorted by start position (as produced by HighlightVisitor).
+pub fn highlight_html(source: &String, captures: &Array<HighlightCapture>) -> String {
+    let mut out = String::with_capacity(source.len() * 5);
+    let mut pos = 0;
+    let mut iter = source.chars();
+    for let cap of captures {
+        while pos < cap.start {
+            if let Some(c) = iter.next() {
+                escape_html_char(&mut out, c);
+            }
+            pos += 1;
+        }
+        out.push_str(&"<span class=\"");
+        push_class(&mut out, &cap.capture);
+        out.push_str(&"\">");
+        let end = cap.end;
+        while pos < end {
+            if let Some(c) = iter.next() {
+                escape_html_char(&mut out, c);
+            }
+            pos += 1;
+        }
+        out.push_str(&"</span>");
+    }
+    while let Some(c) = iter.next() {
+        escape_html_char(&mut out, c);
+    }
+    return out;
+}
+
+fn substr(chars: &Array<char>, start: i32, end: i32) -> String {
+    let mut out = String::with_capacity(end - start);
+    let mut i = start;
+    while i < end && i < chars.len() {
+        out.push(chars[i]);
+        i += 1;
+    }
+    return out;
+}
+
+/// Visitor trait for walking typed CST nodes.
+/// Default methods are no-ops; override to add behavior.
+///
+/// `rule_id` is the parser-rule's index in the grammar's parser_rules array
+/// (0..n in declaration order). It's passed alongside `name` so visitors
+/// that want cheap dispatch (HighlightVisitor's rule stack) can avoid
+/// String compares while visitors that care about the name (TreeRecorder)
+/// can still use it.
+pub trait Visitor {
+    fn enter_rule(&mut self, rule_id: i32, name: &String, span: &Span) {
+    }
+    fn exit_rule(&mut self, rule_id: i32, name: &String, span: &Span) {
+    }
+    fn visit_token(&mut self, token: &Token) {
+    }
+}
+
+/// TreeRecorder is a Visitor that records events for building a CstNode tree.
+pub struct TreeRecorder {
+    events: Array<TreeEvent>,
+}
+
+variant TreeEvent {
+    Enter(TreeEnterInfo),
+    Exit,
+    VisitToken(Token),
+}
+
+struct TreeEnterInfo {
+    name: String,
+    span: Span,
+}
+
+impl TreeRecorder {
+    pub fn new() -> TreeRecorder {
+        return TreeRecorder { events: [] };
+    }
+
+    pub fn build(&self) -> CstNode {
+        let mut pos = 0;
+        return tree_build_node(&self.events, &mut pos);
+    }
+}
+
+impl Visitor for TreeRecorder {
+    fn enter_rule(&mut self, rule_id: i32, name: &String, span: &Span) {
+        self.events.push(TreeEvent::Enter(TreeEnterInfo { name: *name, span: *span }));
+    }
+
+    fn exit_rule(&mut self, rule_id: i32, name: &String, span: &Span) {
+        self.events.push(TreeEvent::Exit);
+    }
+
+    fn visit_token(&mut self, token: &Token) {
+        self.events.push(TreeEvent::VisitToken(*token));
+    }
+}
+
+fn tree_build_node(events: &Array<TreeEvent>, pos: &mut i32) -> CstNode {
+    if let Enter(info) = events[*pos] {
+        *pos += 1;
+        let mut children: Array<CstChild> = [];
+        loop {
+            if *pos >= events.len() {
+                break;
+            }
+            let ev = events[*pos];
+            if let Exit = ev {
+                *pos += 1;
+                break;
+            }
+            if let Enter(_) = ev {
+                children.push(CstChild::Node(tree_build_node(events, pos)));
+            } else if let VisitToken(t) = ev {
+                children.push(CstChild::Token(t));
+                *pos += 1;
+            }
+        }
+        return CstNode { name: info.name, span: info.span, children };
+    }
+    panic("TreeRecorder: expected Enter event");
+    return CstNode { name: "", span: Span::new(0, 0), children: [] };
+}
+
+pub enum TokenKind {
+    A,
+    B,
+    C,
+    WS,
+    Eof,
+    Error,
+}
+
+pub variant RNode {
+    Alt0(RAlt0),
+    Alt1(RAlt1),
+}
+
+pub struct RAlt0 {
+    pub span: Span,
+    pub a: Token,
+    pub b: Token,
+}
+
+pub struct RAlt1 {
+    pub span: Span,
+    pub a: Token,
+    pub c: Token,
+}
+
+global TK_A: i32 = 0;
+global TK_B: i32 = 1;
+global TK_C: i32 = 2;
+global TK_WS: i32 = 3;
+global TK_EOF: i32 = 4;
+global TK_ERROR: i32 = 5;
+
+struct Lexer {
+    chars: Array<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.chars().collect(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_a(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != 'a' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_b(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != 'b' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_c(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != 'c' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_ws(chars: &Array<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !(false || chars[pos] == ' ' || chars[pos] == '\t' || chars[pos] == '\r' || chars[pos] == '\n') { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            if pos >= chars.len() { break rep_0; }
+            if !(false || chars[pos] == ' ' || chars[pos] == '\t' || chars[pos] == '\r' || chars[pos] == '\n') { break rep_0; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+pub fn tokenize(input: &String) -> Array<Token> {
+    let mut lexer = Lexer::new(input);
+    let mut tokens: Array<Token> = Array::with_capacity(lexer.chars.len() / 4 + 1);
+    let mut trivia: Array<Token> = [];
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == '\t' || first_char == '\n' || first_char == '\r' || first_char == ' ' {
+            end = try_ws(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if first_char == 'a' {
+            end = try_a(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_A; }
+        } else if first_char == 'b' {
+            end = try_b(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_B; }
+        } else if first_char == 'c' {
+            end = try_c(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_C; }
+        }
+        if best_end <= start {
+            let tok = Token::with_trivia(TK_ERROR, lexer.slice(start, start + 1), Span::new(start, start + 1), trivia);
+            tokens.push(tok);
+            trivia = [];
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                trivia.push(Token::new(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end)));
+            } else {
+                let tok = Token::with_trivia(best_kind, lexer.slice(tok_start, best_end), Span::new(tok_start, best_end), trivia);
+                tokens.push(tok);
+                trivia = [];
+            }
+            lexer.pos = best_end;
+        }
+    }
+    tokens.push(Token::with_trivia(TK_EOF, LexerSlice::empty(&lexer.chars), Span::new(lexer.pos, lexer.pos), trivia));
+    return tokens;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_A => "A",
+        TK_B => "B",
+        TK_C => "C",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        _ => "Unknown",
+    };
+}
+
+struct Parser {
+    tokens: Array<Token>,
+    pos: i32,
+    chars: Array<char>,
+}
+
+impl Parser {
+    fn new(tokens: Array<Token>, chars: Array<char>) -> Parser {
+        return Parser { tokens, pos: 0, chars };
+    }
+
+    fn error(&self, message: String, span: Span, expected: Array<String>) -> ParseError {
+        let lc = line_col_at(&self.chars, span.start);
+        return ParseError::at(message, span, expected, lc.0, lc.1);
+    }
+
+    fn peek(&self) -> &Token {
+        return &self.tokens[self.pos];
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.tokens[self.pos].kind;
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.tokens.len() { return TK_EOF; }
+        return self.tokens[idx].kind;
+    }
+
+    fn advance(&mut self) -> Token {
+        let tok = self.tokens[self.pos];
+        self.pos += 1;
+        return tok;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens[self.pos - 1].span.end;
+    }
+
+    fn expect(&mut self, kind: i32) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind == kind {
+            if kind == TK_EOF {
+                return Result::<Token, ParseError>::Ok(self.tokens[self.pos]);
+            }
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        let name = token_kind_name(kind);
+        return Result::<Token, ParseError>::Err(self.error(
+            `expected {name}, got "{tok.text}"`,
+            tok.span,
+            [name],
+        ));
+    }
+
+    fn fail(&self, name: String) -> Result<Token, ParseError> {
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(self.error(
+            `expected {name}, got "{tok.text}"`,
+            tok.span,
+            [name],
+        ));
+    }
+
+    fn match_any(&mut self) -> Result<Token, ParseError> {
+        if self.tokens[self.pos].kind != TK_EOF {
+            return Result::<Token, ParseError>::Ok(self.advance());
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(self.error(
+            `expected any token, got "{tok.text}"`,
+            tok.span,
+            ["any token"],
+        ));
+    }
+
+    fn match_not(&mut self, excluded: Array<i32>) -> Result<Token, ParseError> {
+        let k = self.tokens[self.pos].kind;
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                return Result::<Token, ParseError>::Ok(self.advance());
+            }
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(self.error(
+            `unexpected token "{tok.text}"`,
+            tok.span,
+            ["set complement"],
+        ));
+    }
+
+    fn match_set(&mut self, included: Array<i32>) -> Result<Token, ParseError> {
+        let k = self.tokens[self.pos].kind;
+        for let x of included {
+            if x == k {
+                if k == TK_EOF {
+                    return Result::<Token, ParseError>::Ok(self.tokens[self.pos]);
+                }
+                return Result::<Token, ParseError>::Ok(self.advance());
+            }
+        }
+        let tok = &self.tokens[self.pos];
+        return Result::<Token, ParseError>::Err(self.error(
+            `unexpected token "{tok.text}"`,
+            tok.span,
+            ["token set"],
+        ));
+    }
+}
+
+fn scan_r(tokens: &Array<Token>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let start = pos;
+    let mut pos = pos;
+    let alt_kind = if pos < tokens.len() { tokens[pos].kind } else { TK_EOF };
+    scan_alts: {
+        if alt_kind == TK_A {
+            let mut best: i32 = -1;
+            pos = start;
+            try_0: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_A { break try_0; }
+                pos += 1;
+                if pos >= tokens.len() || tokens[pos].kind != TK_B { break try_0; }
+                pos += 1;
+                if pos > best { best = pos; }
+            }
+            pos = start;
+            try_1: {
+                if pos >= tokens.len() || tokens[pos].kind != TK_A { break try_1; }
+                pos += 1;
+                if pos >= tokens.len() || tokens[pos].kind != TK_C { break try_1; }
+                pos += 1;
+                if pos > best { best = pos; }
+            }
+            if best >= 0 { pos = best; break scan_alts; }
+            return -1;
+        } else {
+            return -1;
+        }
+    }
+    return pos;
+}
+
+fn _parse_r__inner_bt_0(p: &mut Parser) -> Result<RNode, ParseError> {
+    let start = p.peek().span.start;
+    let a = p.expect(TK_A)?;
+    let b = p.expect(TK_B)?;
+    return Result::<RNode, ParseError>::Ok(RNode::Alt0(RAlt0 {
+        span: Span::new(start, i32::max(start, p.last_end())),
+        a,
+        b,
+    }));
+}
+
+fn _parse_r__inner_scan_0(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_A { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_B { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn _parse_r__inner_bt_1(p: &mut Parser) -> Result<RNode, ParseError> {
+    let start = p.peek().span.start;
+    let a = p.expect(TK_A)?;
+    let c = p.expect(TK_C)?;
+    return Result::<RNode, ParseError>::Ok(RNode::Alt1(RAlt1 {
+        span: Span::new(start, i32::max(start, p.last_end())),
+        a,
+        c,
+    }));
+}
+
+fn _parse_r__inner_scan_1(tokens: &Array<Token>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos].kind != TK_A { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos].kind != TK_C { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn _parse_r__inner(p: &mut Parser) -> Result<RNode, ParseError> {
+    let start = p.peek().span.start;
+    let kind = p.peek_kind();
+    if kind == TK_A {
+        let a = p.expect(TK_A)?;
+        if p.peek_kind() == TK_B {
+            let b = p.expect(TK_B)?;
+            return Result::<RNode, ParseError>::Ok(RNode::Alt0(RAlt0 {
+                span: Span::new(start, i32::max(start, p.last_end())),
+                a,
+                b,
+            }));
+        } else if p.peek_kind() == TK_C {
+            let c = p.expect(TK_C)?;
+            return Result::<RNode, ParseError>::Ok(RNode::Alt1(RAlt1 {
+                span: Span::new(start, i32::max(start, p.last_end())),
+                a,
+                c,
+            }));
+        }
+    }
+    return Result::<RNode, ParseError>::Err(p.error(
+        "expected r",
+        p.peek().span,
+        ["TK_A"],
+    ));
+}
+
+fn _parse_r(p: &mut Parser) -> Result<RNode, ParseError> {
+    let r = _parse_r__inner(p);
+    if let Err(mut e) = r {
+        e.rule_stack.push("r");
+        return Result::<RNode, ParseError>::Err(e);
+    }
+    return r;
+}
+
+pub fn parse_r(input: &String) -> Result<RNode, ParseError> {
+    let tokens = tokenize(input);
+    let chars: Array<char> = input.chars().collect();
+    let mut parser = Parser::new(tokens, chars);
+    return _parse_r(&mut parser);
+}
+
+pub fn parse(input: &String) -> Result<RNode, ParseError> {
+    return parse_r(input);
+}
+
+pub fn walk_r<V: Visitor>(v: &mut V, node: &RNode) {
+    match node {
+        Alt0(n) => {
+            v.enter_rule(0, &"r", &n.span);
+            v.visit_token(&n.a);
+            v.visit_token(&n.b);
+            v.exit_rule(0, &"r", &n.span);
+        }
+        Alt1(n) => {
+            v.enter_rule(0, &"r", &n.span);
+            v.visit_token(&n.a);
+            v.visit_token(&n.c);
+            v.exit_rule(0, &"r", &n.span);
+        }
+    }
+}
+
+pub fn to_tree(node: &RNode) -> CstNode {
+    let mut recorder = TreeRecorder::new();
+    walk_r(&mut recorder, node);
+    return recorder.build();
+}
+

--- a/package-gale/tests/generated/parser_gaps/parser_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/parser_gaps/parser_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8eb28e22b79ba2bd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/parser_gaps.g4",
     "hash": "8262a9d7c10805db35e063564eaea6deb43e8de540af19d0969551d042b6d03a"

--- a/package-gale/tests/generated/parser_set_group_dispatch/parser_set_group_dispatch.g4.kiln.json
+++ b/package-gale/tests/generated/parser_set_group_dispatch/parser_set_group_dispatch.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ed667626677cf0f6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/parser_set_group_dispatch.g4",
     "hash": "c36bfab5dcc4c7f598aa83ca22dca3fd716225387804db2223b3c47986b73355"

--- a/package-gale/tests/generated/recursive_lexer/recursive_lexer.g4.kiln.json
+++ b/package-gale/tests/generated/recursive_lexer/recursive_lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b23078c163edb700",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/recursive_lexer.g4",
     "hash": "3bba2a980c91c247bfa081040a71e8349ebd29cec177d15cf69feb75f40e705f"

--- a/package-gale/tests/generated/right_assoc_gaps/right_assoc_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/right_assoc_gaps/right_assoc_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7382226003c5d9e1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/right_assoc_gaps.g4",
     "hash": "7632fce865fe8aa2c3c460beea14a27a0a020b9ccb2312fb59a2c980f12f639a"

--- a/package-gale/tests/generated/rust/RustLexer.g4.kiln.json
+++ b/package-gale/tests/generated/rust/RustLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-28566ce8c3b8a5b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/RustLexer.g4",
     "hash": "a9069b6b1a5650b0f5f115897eaa0edaddc42007b262c5096b59eb1de15323d3"

--- a/package-gale/tests/generated/sexpression/sexpression.g4.kiln.json
+++ b/package-gale/tests/generated/sexpression/sexpression.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1847ef51d5668bfd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/sexpression.g4",
     "hash": "74549e6167e186b754886880a5d473ad3361bee8440368f99e1b233e2c1c7bdb"

--- a/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite/SQLite.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-880d9db12a6d7521",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/SQLite.g4",
     "hash": "72e3fa9877777afa5a4f9e8196d4cb194bb599e719d43b7b29d09eeed3e4c5e0"

--- a/package-gale/tests/generated/sqlite_highlight/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/sqlite_highlight/SQLite.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-880d9db12a6d7521",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/SQLite.g4",
     "hash": "72e3fa9877777afa5a4f9e8196d4cb194bb599e719d43b7b29d09eeed3e4c5e0"

--- a/package-gale/tests/generated/typescript/TypeScriptLexer.g4.kiln.json
+++ b/package-gale/tests/generated/typescript/TypeScriptLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b6f068637d3275ff",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/TypeScriptLexer.g4",
     "hash": "f7089740f7e82bbb90a6c4b13c75959b6ceaf3003be0dd0657c52b9eb6a594b7"

--- a/package-gale/tests/generated/unicode_props/unicode_props.g4.kiln.json
+++ b/package-gale/tests/generated/unicode_props/unicode_props.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f37fa830f2a0df13",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1135bc72509cac113d84a2b3361650f188878d2c57e3e980e585df0f11a0aa4d",
+  "generator_source_hash": "d3ac259400b079be60c35cb5e8e5838a0826b390243f398645fbc03245c3bb33",
   "primary": {
     "path": "grammars/unicode_props.g4",
     "hash": "7559b99d20b67597cdc99b2e9e0eaeea1ad4b0931d40859c1dbb600e20d1c5c0"

--- a/package-gale/tests/grammars/ll_overlap_tournament.g4
+++ b/package-gale/tests/grammars/ll_overlap_tournament.g4
@@ -1,0 +1,15 @@
+// Source: hand-written regression grammar for Gale prediction diagnostics.
+// License: same as the Gale package.
+//
+// Both alts of `r` start with `A`, so lowering resolves the overlap with a
+// scan-side longest-match tournament and raises one OverlapTournament
+// diagnostic. Used to exercise the Kiln generator surfacing that warning
+// through `KilnHost::emit_diagnostic` at build time.
+grammar OverlapTournament;
+
+r : A B | A C ;
+
+A : 'a' ;
+B : 'b' ;
+C : 'c' ;
+WS : [ \t\r\n]+ -> skip ;

--- a/wado-cli/src/compiler_host.rs
+++ b/wado-cli/src/compiler_host.rs
@@ -206,13 +206,22 @@ impl CompilerHost for FilesystemCompilerHost {
                 .clone()
         };
         let component = self.get_or_compile_kiln_component(&engine, component_wasm)?;
-        kiln_runtime::run_generator(
+        let (response, diagnostics) = kiln_runtime::run_generator(
             &engine,
             self.inner.clone(),
             &component,
             request,
             KilnRunPolicy::default(),
         )
-        .await
+        .await?;
+        // Relay generator-emitted diagnostics through `self` so they are
+        // both collected and printed. `run_generator` only has the
+        // collect-only inner host on hand, so it hands the diagnostics back
+        // for the printing wrapper here to surface them — this is what makes
+        // e.g. Gale's prediction warnings visible at build time.
+        for diag in diagnostics {
+            kiln_runtime::relay_diagnostic(self, diag);
+        }
+        Ok(response)
     }
 }

--- a/wado-cli/src/compiler_host.rs
+++ b/wado-cli/src/compiler_host.rs
@@ -206,22 +206,23 @@ impl CompilerHost for FilesystemCompilerHost {
                 .clone()
         };
         let component = self.get_or_compile_kiln_component(&engine, component_wasm)?;
-        let (response, diagnostics) = kiln_runtime::run_generator(
+        let (outcome, diagnostics) = kiln_runtime::run_generator(
             &engine,
             self.inner.clone(),
             &component,
             request,
             KilnRunPolicy::default(),
         )
-        .await?;
-        // Relay generator-emitted diagnostics through `self` so they are
-        // both collected and printed. `run_generator` only has the
-        // collect-only inner host on hand, so it hands the diagnostics back
-        // for the printing wrapper here to surface them — this is what makes
-        // e.g. Gale's prediction warnings visible at build time.
+        .await;
+        // Relay generator-emitted diagnostics through `self` so they are both
+        // collected and printed. `run_generator` only has the collect-only
+        // inner host on hand, so it hands the diagnostics back for the
+        // printing wrapper here to surface them — this is what makes e.g.
+        // Gale's prediction warnings visible at build time. Relay before
+        // propagating `outcome` so diagnostics survive a generator failure.
         for diag in diagnostics {
             kiln_runtime::relay_diagnostic(self, diag);
         }
-        Ok(response)
+        outcome
     }
 }

--- a/wado-cli/src/kiln_runtime.rs
+++ b/wado-cli/src/kiln_runtime.rs
@@ -143,13 +143,14 @@ pub async fn run_generator<H: CompilerHost + 'static>(
     let reads = Arc::new(Mutex::new(Vec::<GeneratorReadRecord>::new()));
     let diagnostics = Arc::new(Mutex::new(Vec::<GeneratorDiagnostic>::new()));
 
-    // Run the generator in an inner future that yields the typed outcome.
-    // Diagnostics are drained and returned alongside the outcome on BOTH the
-    // success and the generator-error path, so the caller can surface them
-    // regardless — `emit_diagnostic`'s contract is "printed even if the
-    // generator eventually fails". The only host reachable from here is the
-    // collect-only inner host, so the actual relay (print + collect) is the
-    // caller's job (see `FilesystemCompilerHost::run_generator`).
+    // Run the generator in an inner future that yields the typed outcome, then
+    // drain the diagnostics and return them alongside it — on both the success
+    // and the failure path. `emit_diagnostic` guarantees they are printed even
+    // when the generator returns successfully; relaying on the error path too
+    // keeps a failing generator from swallowing the diagnostics that explain
+    // the failure. The only host reachable here is the collect-only inner
+    // host, so the relay (print + collect) is the caller's job (see
+    // `FilesystemCompilerHost::run_generator`).
     let reads_inner = reads.clone();
     let diagnostics_inner = diagnostics.clone();
     let outcome: Result<GeneratorResponse, GeneratorRunnerError> = async move {

--- a/wado-cli/src/kiln_runtime.rs
+++ b/wado-cli/src/kiln_runtime.rs
@@ -136,7 +136,7 @@ pub async fn run_generator<H: CompilerHost + 'static>(
     component: &Component,
     request: GeneratorRequest,
     policy: KilnRunPolicy,
-) -> Result<GeneratorResponse, GeneratorRunnerError> {
+) -> Result<(GeneratorResponse, Vec<GeneratorDiagnostic>), GeneratorRunnerError> {
     let reads = Arc::new(Mutex::new(Vec::<GeneratorReadRecord>::new()));
     let diagnostics = Arc::new(Mutex::new(Vec::<GeneratorDiagnostic>::new()));
 
@@ -185,20 +185,26 @@ pub async fn run_generator<H: CompilerHost + 'static>(
         .map_err(|e| GeneratorRunnerError::Host(format!("generate call: {e}")))?
         .map_err(|e| GeneratorRunnerError::Host(format!("generate call: {e}")))?;
 
-    for diag in diagnostics.lock().unwrap().drain(..) {
-        relay_diagnostic(host.as_ref(), diag);
-    }
+    // Hand the generator-emitted diagnostics back to the caller rather than
+    // relaying them here: the only host reachable from this function is the
+    // collect-only inner host, so relaying here would never print them. The
+    // CLI host relays them through its printing wrapper instead (see
+    // `FilesystemCompilerHost::run_generator`).
+    let emitted: Vec<GeneratorDiagnostic> = diagnostics.lock().unwrap().drain(..).collect();
 
     match result {
-        Ok(response) => Ok(GeneratorResponse {
-            files: response.files.into_iter().map(lift_output_file).collect(),
-            reads: std::mem::take(&mut *reads.lock().unwrap()),
-        }),
+        Ok(response) => Ok((
+            GeneratorResponse {
+                files: response.files.into_iter().map(lift_output_file).collect(),
+                reads: std::mem::take(&mut *reads.lock().unwrap()),
+            },
+            emitted,
+        )),
         Err(e) => Err(GeneratorRunnerError::Generator(lift_error(e))),
     }
 }
 
-fn relay_diagnostic<H: CompilerHost + ?Sized>(host: &H, diag: GeneratorDiagnostic) {
+pub(crate) fn relay_diagnostic<H: CompilerHost + ?Sized>(host: &H, diag: GeneratorDiagnostic) {
     use wado_compiler::{Code, Diagnostic, DiagnosticSpan, Severity};
     let severity = match diag.level {
         GeneratorDiagnosticLevel::Error => Severity::Error,

--- a/wado-cli/src/kiln_runtime.rs
+++ b/wado-cli/src/kiln_runtime.rs
@@ -136,72 +136,80 @@ pub async fn run_generator<H: CompilerHost + 'static>(
     component: &Component,
     request: GeneratorRequest,
     policy: KilnRunPolicy,
-) -> Result<(GeneratorResponse, Vec<GeneratorDiagnostic>), GeneratorRunnerError> {
+) -> (
+    Result<GeneratorResponse, GeneratorRunnerError>,
+    Vec<GeneratorDiagnostic>,
+) {
     let reads = Arc::new(Mutex::new(Vec::<GeneratorReadRecord>::new()));
     let diagnostics = Arc::new(Mutex::new(Vec::<GeneratorDiagnostic>::new()));
 
-    let state = KilnHostState {
-        host: host.clone(),
-        reads: reads.clone(),
-        diagnostics: diagnostics.clone(),
-    };
+    // Run the generator in an inner future that yields the typed outcome.
+    // Diagnostics are drained and returned alongside the outcome on BOTH the
+    // success and the generator-error path, so the caller can surface them
+    // regardless — `emit_diagnostic`'s contract is "printed even if the
+    // generator eventually fails". The only host reachable from here is the
+    // collect-only inner host, so the actual relay (print + collect) is the
+    // caller's job (see `FilesystemCompilerHost::run_generator`).
+    let reads_inner = reads.clone();
+    let diagnostics_inner = diagnostics.clone();
+    let outcome: Result<GeneratorResponse, GeneratorRunnerError> = async move {
+        let state = KilnHostState {
+            host: host.clone(),
+            reads: reads_inner.clone(),
+            diagnostics: diagnostics_inner,
+        };
 
-    // The kiln determinism guarantee (WEP 2026-04-12 §"Design
-    // principles" #1) says the linker exposes only `core:kiln/kiln-
-    // host`. The compiler handles the panic-path stderr elision
-    // at codegen time so the generator component never imports WASI
-    // in the first place.
-    let mut linker: Linker<KilnHostState<H>> = Linker::new(engine);
-    kiln_host::add_to_linker::<_, HasSelf<_>>(&mut linker, |s| s)
-        .map_err(|e| GeneratorRunnerError::Host(format!("linker setup: {e}")))?;
+        // The kiln determinism guarantee (WEP 2026-04-12 §"Design
+        // principles" #1) says the linker exposes only `core:kiln/kiln-
+        // host`. The compiler handles the panic-path stderr elision
+        // at codegen time so the generator component never imports WASI
+        // in the first place.
+        let mut linker: Linker<KilnHostState<H>> = Linker::new(engine);
+        kiln_host::add_to_linker::<_, HasSelf<_>>(&mut linker, |s| s)
+            .map_err(|e| GeneratorRunnerError::Host(format!("linker setup: {e}")))?;
 
-    let mut store = Store::new(engine, state);
-    let fuel = if policy.fuel == 0 {
-        u64::MAX
-    } else {
-        policy.fuel
-    };
-    store
-        .set_fuel(fuel)
-        .map_err(|e| GeneratorRunnerError::Host(format!("set fuel: {e}")))?;
+        let mut store = Store::new(engine, state);
+        let fuel = if policy.fuel == 0 {
+            u64::MAX
+        } else {
+            policy.fuel
+        };
+        store
+            .set_fuel(fuel)
+            .map_err(|e| GeneratorRunnerError::Host(format!("set fuel: {e}")))?;
 
-    let generator = Generator::instantiate_async(&mut store, component, &linker)
-        .await
-        .map_err(|e| GeneratorRunnerError::Host(format!("instantiate: {e}")))?;
+        let generator = Generator::instantiate_async(&mut store, component, &linker)
+            .await
+            .map_err(|e| GeneratorRunnerError::Host(format!("instantiate: {e}")))?;
 
-    let wit_request = kiln_types::RawRequest {
-        primary: lower_input_file(&request.primary),
-        inputs: request.inputs.iter().map(lower_input_file).collect(),
-        options: request.options,
-    };
+        let wit_request = kiln_types::RawRequest {
+            primary: lower_input_file(&request.primary),
+            inputs: request.inputs.iter().map(lower_input_file).collect(),
+            options: request.options,
+        };
 
-    // Async exports in wasmtime bindgen take an `Accessor` rather than
-    // `&mut Store`, so we drive the call through `run_concurrent`. The
-    // outer Result combines wasmtime's runtime errors and the
-    // generator's own typed `error` variant.
-    let result = store
-        .run_concurrent(async |accessor| generator.call_generate(accessor, wit_request).await)
-        .await
-        .map_err(|e| GeneratorRunnerError::Host(format!("generate call: {e}")))?
-        .map_err(|e| GeneratorRunnerError::Host(format!("generate call: {e}")))?;
+        // Async exports in wasmtime bindgen take an `Accessor` rather than
+        // `&mut Store`, so we drive the call through `run_concurrent`. The
+        // outer Result combines wasmtime's runtime errors and the
+        // generator's own typed `error` variant.
+        let result = store
+            .run_concurrent(async |accessor| generator.call_generate(accessor, wit_request).await)
+            .await
+            .map_err(|e| GeneratorRunnerError::Host(format!("generate call: {e}")))?
+            .map_err(|e| GeneratorRunnerError::Host(format!("generate call: {e}")))?;
 
-    // Hand the generator-emitted diagnostics back to the caller rather than
-    // relaying them here: the only host reachable from this function is the
-    // collect-only inner host, so relaying here would never print them. The
-    // CLI host relays them through its printing wrapper instead (see
-    // `FilesystemCompilerHost::run_generator`).
-    let emitted: Vec<GeneratorDiagnostic> = diagnostics.lock().unwrap().drain(..).collect();
-
-    match result {
-        Ok(response) => Ok((
-            GeneratorResponse {
+        match result {
+            Ok(response) => Ok(GeneratorResponse {
                 files: response.files.into_iter().map(lift_output_file).collect(),
-                reads: std::mem::take(&mut *reads.lock().unwrap()),
-            },
-            emitted,
-        )),
-        Err(e) => Err(GeneratorRunnerError::Generator(lift_error(e))),
+                reads: std::mem::take(&mut *reads_inner.lock().unwrap()),
+            }),
+            Err(e) => Err(GeneratorRunnerError::Generator(lift_error(e))),
+        }
     }
+    .await;
+
+    let emitted: Vec<GeneratorDiagnostic> = diagnostics.lock().unwrap().drain(..).collect();
+    (outcome, emitted)
 }
 
 pub(crate) fn relay_diagnostic<H: CompilerHost + ?Sized>(host: &H, diag: GeneratorDiagnostic) {

--- a/wado-compiler/src/codegen/component.rs
+++ b/wado-compiler/src/codegen/component.rs
@@ -2127,11 +2127,10 @@ fn generate_cm_imports(
                         let resolved_ty = project.cm_interface_registry.resolve_type(ty);
                         let val_type = if let Type::Named(named) = &resolved_ty
                             && named.source_interface.as_deref().is_some_and(|s| {
-                                crate::component_model::source_uses_cm_abi(s)
-                                    && project
-                                        .cm_interface_registry
-                                        .get_struct_fields_by_source(s, &named.name)
-                                        .is_some()
+                                project
+                                    .cm_interface_registry
+                                    .get_struct_fields_by_source(s, &named.name)
+                                    .is_some()
                             }) {
                             shared_type_gen.set_next_idx(local_type_idx);
                             let resource_exports: IndexMap<&str, u32> = own_resource_type_indices
@@ -2172,11 +2171,10 @@ fn generate_cm_imports(
                     let resolved_ty = project.cm_interface_registry.resolve_type(ty);
                     if let Type::Named(named) = &resolved_ty
                         && named.source_interface.as_deref().is_some_and(|s| {
-                            crate::component_model::source_uses_cm_abi(s)
-                                && project
-                                    .cm_interface_registry
-                                    .get_struct_fields_by_source(s, &named.name)
-                                    .is_some()
+                            project
+                                .cm_interface_registry
+                                .get_struct_fields_by_source(s, &named.name)
+                                .is_some()
                         })
                     {
                         shared_type_gen.set_next_idx(local_type_idx);

--- a/wado-compiler/src/codegen/component.rs
+++ b/wado-compiler/src/codegen/component.rs
@@ -2127,7 +2127,7 @@ fn generate_cm_imports(
                         let resolved_ty = project.cm_interface_registry.resolve_type(ty);
                         let val_type = if let Type::Named(named) = &resolved_ty
                             && named.source_interface.as_deref().is_some_and(|s| {
-                                s.starts_with("wasi:")
+                                crate::component_model::source_uses_cm_abi(s)
                                     && project
                                         .cm_interface_registry
                                         .get_struct_fields_by_source(s, &named.name)
@@ -2172,7 +2172,7 @@ fn generate_cm_imports(
                     let resolved_ty = project.cm_interface_registry.resolve_type(ty);
                     if let Type::Named(named) = &resolved_ty
                         && named.source_interface.as_deref().is_some_and(|s| {
-                            s.starts_with("wasi:")
+                            crate::component_model::source_uses_cm_abi(s)
                                 && project
                                     .cm_interface_registry
                                     .get_struct_fields_by_source(s, &named.name)

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -2421,7 +2421,7 @@ impl CmInstanceTypeGen {
                     let source_owned: String = named
                         .source_interface
                         .as_deref()
-                        .filter(|s| s.starts_with("wasi:"))
+                        .filter(|s| source_uses_cm_abi(s))
                         .map(str::to_string)
                         .or(interface_hint_match)
                         .or_else(|| {
@@ -2435,7 +2435,7 @@ impl CmInstanceTypeGen {
                         })
                         .unwrap_or_else(|| {
                             panic!(
-                                "unresolved wasi named type reference `{name}` while emitting CM instance"
+                                "unresolved CM named type reference `{name}` while emitting CM instance"
                             )
                         });
                     let source = source_owned.as_str();
@@ -2746,6 +2746,21 @@ fn join_val_types(a: Option<ValType>, b: Option<ValType>) -> ValType {
     }
 }
 
+/// True when a type's `source_interface` denotes a Component Model interface
+/// whose values follow the canonical ABI — records flatten to their fields,
+/// strings to (ptr, len), options/variants to a discriminant plus payload —
+/// rather than being passed as opaque Wado GC structs.
+///
+/// This covers the WASI interfaces and the `core:kiln` host interfaces the
+/// Kiln generator world imports (`KilnHost`, plus the `core:kiln/types`
+/// request/response records). The check is on the *explicit* source so it is
+/// safe to widen: every stdlib `core:kiln` type carries its `#[cm(...)]`
+/// source after the registry's two-pass bootstrap, and plain Wado structs
+/// have no `source_interface` at all.
+pub fn source_uses_cm_abi(source: &str) -> bool {
+    source.starts_with("wasi:") || source.starts_with("core:kiln/")
+}
+
 /// Flatten a pre-resolved AST type into CM core-level `ValType`s.
 ///
 /// Compound types like String and `Array<T>` are lowered to (ptr: i32, len: i32)
@@ -2773,7 +2788,7 @@ pub fn flatten_cm_param_type(ty: &Type, out: &mut Vec<ValType>, registry: &CmInt
             name if named
                 .source_interface
                 .as_deref()
-                .filter(|s| s.starts_with("wasi:"))
+                .filter(|s| source_uses_cm_abi(s))
                 .or_else(|| registry.find_wasi_struct_source(name))
                 .and_then(|s| registry.get_struct_fields_by_source(s, name))
                 .is_some() =>
@@ -2781,7 +2796,7 @@ pub fn flatten_cm_param_type(ty: &Type, out: &mut Vec<ValType>, registry: &CmInt
                 let source = named
                     .source_interface
                     .as_deref()
-                    .filter(|s| s.starts_with("wasi:"))
+                    .filter(|s| source_uses_cm_abi(s))
                     .or_else(|| registry.find_wasi_struct_source(name))
                     .expect("already matched above");
                 let fields = registry
@@ -2795,7 +2810,7 @@ pub fn flatten_cm_param_type(ty: &Type, out: &mut Vec<ValType>, registry: &CmInt
             name if named
                 .source_interface
                 .as_deref()
-                .filter(|s| s.starts_with("wasi:"))
+                .filter(|s| source_uses_cm_abi(s))
                 .or_else(|| registry.find_wasi_variant_source(name))
                 .and_then(|s| registry.get_variant_cases_by_source(s, name))
                 .is_some() =>
@@ -2804,7 +2819,7 @@ pub fn flatten_cm_param_type(ty: &Type, out: &mut Vec<ValType>, registry: &CmInt
                 let source = named
                     .source_interface
                     .as_deref()
-                    .filter(|s| s.starts_with("wasi:"))
+                    .filter(|s| source_uses_cm_abi(s))
                     .or_else(|| registry.find_wasi_variant_source(name))
                     .expect("already matched above");
                 if let Some(cases) = registry.get_variant_cases_by_source(source, name) {

--- a/wado-compiler/src/synthesis/cm_binding/import_adapter.rs
+++ b/wado-compiler/src/synthesis/cm_binding/import_adapter.rs
@@ -918,14 +918,9 @@ pub(super) fn synthesize_adapter(
                 let wado_fields = cm_interface_registry
                     .get_struct_fields_with_wado_names_by_source(source, &n.name)
                     .expect("struct fields_with_wado_names present when fields are");
-                // Flatten each field per the canonical ABI through the shared
-                // helper: a scalar field passes through, but a String / Option
-                // / nested-record / enum field expands to its own flat slots,
-                // so a record with compound fields — e.g. the kiln-host
-                // `Diagnostic { level, span: Option<SourceSpan>, message:
-                // String }` — matches the import's flattened signature. Same
-                // rule as the nested-field path in
-                // `synthesize_flatten_value_to_flat_args`.
+                // Flatten each field through the shared helper so a String /
+                // Option / nested-record / enum field expands to its own flat
+                // slots, matching the import's flattened signature.
                 flatten_cm_record_fields(
                     wado_fields,
                     param_local,

--- a/wado-compiler/src/synthesis/cm_binding/import_adapter.rs
+++ b/wado-compiler/src/synthesis/cm_binding/import_adapter.rs
@@ -147,7 +147,7 @@ fn synthesize_lift_flat_result(
             // a resolved source_interface; otherwise fall back to a bare Err.
             let lifted_variant = if let Type::Named(n) = err_ty
                 && let Some(source) = n.source_interface.as_deref()
-                && source.starts_with("wasi:")
+                && crate::component_model::source_uses_cm_abi(source)
             {
                 try_lift_wasi_variant_or_enum(
                     n,
@@ -504,7 +504,7 @@ pub(super) fn synthesize_adapter(
             // Struct (record) param: single GC reference, binding extracts fields
             Type::Named(n)
                 if n.source_interface.as_deref().is_some_and(|s| {
-                    s.starts_with("wasi:")
+                    crate::component_model::source_uses_cm_abi(s)
                         && cm_interface_registry
                             .get_struct_fields_by_source(s, &n.name)
                             .is_some()
@@ -534,7 +534,7 @@ pub(super) fn synthesize_adapter(
             // Variant param: single GC reference, binding lowers to flat args
             Type::Named(n)
                 if n.source_interface.as_deref().is_some_and(|s| {
-                    s.starts_with("wasi:")
+                    crate::component_model::source_uses_cm_abi(s)
                         && cm_interface_registry
                             .get_variant_cases_by_source(s, &n.name)
                             .is_some()
@@ -907,7 +907,7 @@ pub(super) fn synthesize_adapter(
             // Struct (record) param: extract fields as flat args
             Type::Named(n)
                 if n.source_interface.as_deref().is_some_and(|s| {
-                    s.starts_with("wasi:")
+                    crate::component_model::source_uses_cm_abi(s)
                         && cm_interface_registry
                             .get_struct_fields_by_source(s, &n.name)
                             .is_some()
@@ -921,6 +921,13 @@ pub(super) fn synthesize_adapter(
                 let wado_fields = cm_interface_registry
                     .get_struct_fields_with_wado_names_by_source(source, &n.name)
                     .expect("struct fields_with_wado_names present when fields are");
+                // Each field is itself flattened per the canonical ABI: a
+                // scalar field passes through, but a String / Option / nested
+                // record field expands to its own flat slots. Recursing here
+                // (rather than pushing the raw field value) is what lets a
+                // record with compound fields — e.g. the kiln-host
+                // `Diagnostic { level, span: Option<SourceSpan>, message:
+                // String }` — match the import's flattened signature.
                 for (field_idx, (wado_name, _, field_ty)) in wado_fields.iter().enumerate() {
                     let field_type_id = {
                         let mut tt = type_table.borrow_mut();
@@ -931,7 +938,7 @@ pub(super) fn synthesize_adapter(
                             &func_info.package,
                         )
                     };
-                    flat_args.push(TirExpr {
+                    let field_expr = TirExpr {
                         kind: TirExprKind::FieldAccess {
                             expr: Box::new(local_ref(param_local, param_name, struct_type_id)),
                             field_index: field_idx as u32,
@@ -939,14 +946,26 @@ pub(super) fn synthesize_adapter(
                         },
                         type_id: field_type_id,
                         span: synth_span(),
-                    });
+                    };
+                    synthesize_flatten_value_to_flat_args(
+                        field_ty,
+                        field_expr,
+                        &format!("__{param_name}_f{field_idx}"),
+                        &mut next_local,
+                        &mut body_stmts,
+                        &mut locals,
+                        &mut flat_args,
+                        cm_interface_registry,
+                        &func_info.package,
+                        type_table,
+                    );
                 }
             }
             // Variant param: for async, pass GC ref (lowered in Step 3 indirect params);
             // for sync, flatten directly to flat i32 args.
             Type::Named(n)
                 if n.source_interface.as_deref().is_some_and(|s| {
-                    s.starts_with("wasi:")
+                    crate::component_model::source_uses_cm_abi(s)
                         && cm_interface_registry
                             .get_variant_cases_by_source(s, &n.name)
                             .is_some()
@@ -1079,7 +1098,7 @@ pub(super) fn synthesize_adapter(
             matches!(ty, Type::Named(n) if n
                 .source_interface
                 .as_deref()
-                .is_some_and(|s| s.starts_with("wasi:")
+                .is_some_and(|s| crate::component_model::source_uses_cm_abi(s)
                     && cm_interface_registry
                         .get_variant_cases_by_source(s, &n.name)
                         .is_some()))
@@ -1133,7 +1152,7 @@ pub(super) fn synthesize_adapter(
                 // WASI variants: lower directly to the buffer using registry-aware layout
                 if let Type::Named(n) = ty
                     && let Some(source) = n.source_interface.as_deref()
-                    && source.starts_with("wasi:")
+                    && crate::component_model::source_uses_cm_abi(source)
                     && cm_interface_registry
                         .get_variant_cases_by_source(source, &n.name)
                         .is_some()

--- a/wado-compiler/src/synthesis/cm_binding/import_adapter.rs
+++ b/wado-compiler/src/synthesis/cm_binding/import_adapter.rs
@@ -34,9 +34,9 @@ use crate::synthesis::common::{
 
 use super::lift::{materialize_if_needed, synthesize_lift, try_lift_wasi_variant_or_enum};
 use super::lower::{
-    synthesize_flatten_option_to_flat_args, synthesize_flatten_value_to_flat_args,
-    synthesize_lower, synthesize_lower_option_to_memory, synthesize_lower_tuple,
-    synthesize_lower_wasi_variant_to_memory,
+    flatten_cm_record_fields, synthesize_flatten_option_to_flat_args,
+    synthesize_flatten_value_to_flat_args, synthesize_lower, synthesize_lower_option_to_memory,
+    synthesize_lower_tuple, synthesize_lower_wasi_variant_to_memory,
 };
 use super::types::{
     LiftContext, binary_add, cm_param_align, cm_param_size, cm_param_store_plan,
@@ -504,10 +504,9 @@ pub(super) fn synthesize_adapter(
             // Struct (record) param: single GC reference, binding extracts fields
             Type::Named(n)
                 if n.source_interface.as_deref().is_some_and(|s| {
-                    crate::component_model::source_uses_cm_abi(s)
-                        && cm_interface_registry
-                            .get_struct_fields_by_source(s, &n.name)
-                            .is_some()
+                    cm_interface_registry
+                        .get_struct_fields_by_source(s, &n.name)
+                        .is_some()
                 }) =>
             {
                 let struct_type_id = {
@@ -534,10 +533,9 @@ pub(super) fn synthesize_adapter(
             // Variant param: single GC reference, binding lowers to flat args
             Type::Named(n)
                 if n.source_interface.as_deref().is_some_and(|s| {
-                    crate::component_model::source_uses_cm_abi(s)
-                        && cm_interface_registry
-                            .get_variant_cases_by_source(s, &n.name)
-                            .is_some()
+                    cm_interface_registry
+                        .get_variant_cases_by_source(s, &n.name)
+                        .is_some()
                 }) =>
             {
                 let variant_type_id = {
@@ -907,10 +905,9 @@ pub(super) fn synthesize_adapter(
             // Struct (record) param: extract fields as flat args
             Type::Named(n)
                 if n.source_interface.as_deref().is_some_and(|s| {
-                    crate::component_model::source_uses_cm_abi(s)
-                        && cm_interface_registry
-                            .get_struct_fields_by_source(s, &n.name)
-                            .is_some()
+                    cm_interface_registry
+                        .get_struct_fields_by_source(s, &n.name)
+                        .is_some()
                 }) =>
             {
                 let struct_type_id = params[start_idx].type_id;
@@ -921,54 +918,36 @@ pub(super) fn synthesize_adapter(
                 let wado_fields = cm_interface_registry
                     .get_struct_fields_with_wado_names_by_source(source, &n.name)
                     .expect("struct fields_with_wado_names present when fields are");
-                // Each field is itself flattened per the canonical ABI: a
-                // scalar field passes through, but a String / Option / nested
-                // record field expands to its own flat slots. Recursing here
-                // (rather than pushing the raw field value) is what lets a
-                // record with compound fields — e.g. the kiln-host
+                // Flatten each field per the canonical ABI through the shared
+                // helper: a scalar field passes through, but a String / Option
+                // / nested-record / enum field expands to its own flat slots,
+                // so a record with compound fields — e.g. the kiln-host
                 // `Diagnostic { level, span: Option<SourceSpan>, message:
-                // String }` — match the import's flattened signature.
-                for (field_idx, (wado_name, _, field_ty)) in wado_fields.iter().enumerate() {
-                    let field_type_id = {
-                        let mut tt = type_table.borrow_mut();
-                        cm_type_to_type_id(
-                            field_ty,
-                            &mut tt,
-                            cm_interface_registry,
-                            &func_info.package,
-                        )
-                    };
-                    let field_expr = TirExpr {
-                        kind: TirExprKind::FieldAccess {
-                            expr: Box::new(local_ref(param_local, param_name, struct_type_id)),
-                            field_index: field_idx as u32,
-                            field_name: wado_name.clone(),
-                        },
-                        type_id: field_type_id,
-                        span: synth_span(),
-                    };
-                    synthesize_flatten_value_to_flat_args(
-                        field_ty,
-                        field_expr,
-                        &format!("__{param_name}_f{field_idx}"),
-                        &mut next_local,
-                        &mut body_stmts,
-                        &mut locals,
-                        &mut flat_args,
-                        cm_interface_registry,
-                        &func_info.package,
-                        type_table,
-                    );
-                }
+                // String }` — matches the import's flattened signature. Same
+                // rule as the nested-field path in
+                // `synthesize_flatten_value_to_flat_args`.
+                flatten_cm_record_fields(
+                    wado_fields,
+                    param_local,
+                    param_name,
+                    struct_type_id,
+                    &format!("__{param_name}"),
+                    &mut next_local,
+                    &mut body_stmts,
+                    &mut locals,
+                    &mut flat_args,
+                    cm_interface_registry,
+                    &func_info.package,
+                    type_table,
+                );
             }
             // Variant param: for async, pass GC ref (lowered in Step 3 indirect params);
             // for sync, flatten directly to flat i32 args.
             Type::Named(n)
                 if n.source_interface.as_deref().is_some_and(|s| {
-                    crate::component_model::source_uses_cm_abi(s)
-                        && cm_interface_registry
-                            .get_variant_cases_by_source(s, &n.name)
-                            .is_some()
+                    cm_interface_registry
+                        .get_variant_cases_by_source(s, &n.name)
+                        .is_some()
                 }) =>
             {
                 if func_info.is_async {
@@ -1098,10 +1077,9 @@ pub(super) fn synthesize_adapter(
             matches!(ty, Type::Named(n) if n
                 .source_interface
                 .as_deref()
-                .is_some_and(|s| crate::component_model::source_uses_cm_abi(s)
-                    && cm_interface_registry
-                        .get_variant_cases_by_source(s, &n.name)
-                        .is_some()))
+                .is_some_and(|s| cm_interface_registry
+                    .get_variant_cases_by_source(s, &n.name)
+                    .is_some()))
                 || matches!(ty, Type::Generic(g) if g.name == "Option" && g.args.len() == 1)
         });
 
@@ -1152,7 +1130,6 @@ pub(super) fn synthesize_adapter(
                 // WASI variants: lower directly to the buffer using registry-aware layout
                 if let Type::Named(n) = ty
                     && let Some(source) = n.source_interface.as_deref()
-                    && crate::component_model::source_uses_cm_abi(source)
                     && cm_interface_registry
                         .get_variant_cases_by_source(source, &n.name)
                         .is_some()

--- a/wado-compiler/src/synthesis/cm_binding/lower.rs
+++ b/wado-compiler/src/synthesis/cm_binding/lower.rs
@@ -883,7 +883,12 @@ pub(super) fn flatten_cm_record_fields(
         let resolved_field = cm_interface_registry.resolve_type(field_ty);
         let field_type_id = {
             let mut tt = type_table.borrow_mut();
-            cm_type_to_type_id(&resolved_field, &mut tt, cm_interface_registry, wasi_package)
+            cm_type_to_type_id(
+                &resolved_field,
+                &mut tt,
+                cm_interface_registry,
+                wasi_package,
+            )
         };
         let field_expr = field_access(
             local_ref(val_local, val_name, value_type_id),

--- a/wado-compiler/src/synthesis/cm_binding/lower.rs
+++ b/wado-compiler/src/synthesis/cm_binding/lower.rs
@@ -823,15 +823,11 @@ pub(super) fn synthesize_flatten_value_to_flat_args(
                 type_table,
             );
         }
-        // CM record → concatenation of its fields' flat args, in declared
-        // order; otherwise a simple primitive / handle / plain Wado GC struct
-        // passes through directly. The record check keys on the explicit
-        // source interface (set for both `wasi:*` and `core:kiln/*` types by
-        // the registry bootstrap, including nested field types) and resolves
-        // its fields with one registry lookup; a plain Wado struct carries no
-        // `source_interface` and falls through. Reached for a nested record
-        // field — e.g. `SourceSpan` inside `Option<SourceSpan>` — so
-        // arbitrarily nested CM records lower through one recursion.
+        // CM record → its fields' flat args via `flatten_cm_record_fields`,
+        // in declared order; anything else — primitive, handle, or a plain
+        // Wado GC struct (no `source_interface`) — passes through. A single
+        // registry lookup gates it, and recursion handles nested records
+        // (e.g. `SourceSpan` inside `Option<SourceSpan>`).
         _ => {
             if let Type::Named(n) = &resolved
                 && let Some(fields) = n.source_interface.as_deref().and_then(|s| {

--- a/wado-compiler/src/synthesis/cm_binding/lower.rs
+++ b/wado-compiler/src/synthesis/cm_binding/lower.rs
@@ -28,7 +28,8 @@ use crate::synthesis::common::{
 };
 
 use super::types::{
-    binary_add, cm_type_to_type_id, flatten_param_type, kebab_to_pascal, variant_tag, variant_test,
+    binary_add, cm_type_to_type_id, field_access, flatten_param_type, kebab_to_pascal, variant_tag,
+    variant_test,
 };
 
 /// Zero constant matching a CM flat slot type (i32/i64/f32/f64).
@@ -612,13 +613,14 @@ pub(super) fn synthesize_flatten_value_to_flat_args(
                 TypeTable::I32,
             ));
         }
-        // Enum → variant_tag (single i32)
+        // Enum → variant_tag (single i32). The registry lookup is the gate:
+        // every source it holds is a CM interface, so a prefix check would be
+        // redundant (same for the record/variant gates below).
         Type::Named(n)
             if n.source_interface.as_deref().is_some_and(|s| {
-                crate::component_model::source_uses_cm_abi(s)
-                    && cm_interface_registry
-                        .get_enum_variants_by_source(s, &n.name)
-                        .is_some()
+                cm_interface_registry
+                    .get_enum_variants_by_source(s, &n.name)
+                    .is_some()
             }) =>
         {
             flat_args.push(variant_tag(value));
@@ -626,10 +628,9 @@ pub(super) fn synthesize_flatten_value_to_flat_args(
         // Variant → disc + join of all case payload flats
         Type::Named(n)
             if n.source_interface.as_deref().is_some_and(|s| {
-                crate::component_model::source_uses_cm_abi(s)
-                    && cm_interface_registry
-                        .get_variant_cases_by_source(s, &n.name)
-                        .is_some()
+                cm_interface_registry
+                    .get_variant_cases_by_source(s, &n.name)
+                    .is_some()
             }) =>
         {
             let source = n
@@ -823,59 +824,30 @@ pub(super) fn synthesize_flatten_value_to_flat_args(
             );
         }
         // CM record → concatenation of its fields' flat args, in declared
-        // order. Keyed on the explicit source interface so it fires for both
-        // `wasi:*` and `core:kiln/*` records and never for a plain Wado GC
-        // struct (which carries no `source_interface`). Reached for a nested
-        // record field — e.g. `SourceSpan` inside `Option<SourceSpan>` — so
+        // order; otherwise a simple primitive / handle / plain Wado GC struct
+        // passes through directly. The record check keys on the explicit
+        // source interface (set for both `wasi:*` and `core:kiln/*` types by
+        // the registry bootstrap, including nested field types) and resolves
+        // its fields with one registry lookup; a plain Wado struct carries no
+        // `source_interface` and falls through. Reached for a nested record
+        // field — e.g. `SourceSpan` inside `Option<SourceSpan>` — so
         // arbitrarily nested CM records lower through one recursion.
-        Type::Named(n)
-            if n.source_interface
-                .as_deref()
-                .and_then(|s| {
+        _ => {
+            if let Type::Named(n) = &resolved
+                && let Some(fields) = n.source_interface.as_deref().and_then(|s| {
                     cm_interface_registry.get_struct_fields_with_wado_names_by_source(s, &n.name)
                 })
-                .is_some() =>
-        {
-            let source = n
-                .source_interface
-                .as_deref()
-                .expect("CM struct source_interface present");
-            let resolved_fields: Vec<(String, Type)> = cm_interface_registry
-                .get_struct_fields_with_wado_names_by_source(source, &n.name)
-                .expect("CM struct fields present")
-                .iter()
-                .map(|(wn, _, ft)| (wn.clone(), cm_interface_registry.resolve_type(ft)))
-                .collect();
-            let value_type_id = value.type_id;
-            let val_local = alloc_local(next_local, locals, value_type_id);
-            stmts.push(let_stmt(
-                &format!("{prefix}_rec"),
-                val_local,
-                value_type_id,
-                value,
-            ));
-            for (field_idx, (wado_name, field_ty)) in resolved_fields.iter().enumerate() {
-                let field_type_id = {
-                    let mut tt = type_table.borrow_mut();
-                    cm_type_to_type_id(field_ty, &mut tt, cm_interface_registry, wasi_package)
-                };
-                let field_expr = TirExpr {
-                    kind: TirExprKind::FieldAccess {
-                        expr: Box::new(local_ref(
-                            val_local,
-                            &format!("{prefix}_rec"),
-                            value_type_id,
-                        )),
-                        field_index: field_idx as u32,
-                        field_name: wado_name.clone(),
-                    },
-                    type_id: field_type_id,
-                    span: synth_span(),
-                };
-                synthesize_flatten_value_to_flat_args(
-                    field_ty,
-                    field_expr,
-                    &format!("{prefix}_f{field_idx}"),
+            {
+                let value_type_id = value.type_id;
+                let val_local = alloc_local(next_local, locals, value_type_id);
+                let val_name = format!("{prefix}_rec");
+                stmts.push(let_stmt(&val_name, val_local, value_type_id, value));
+                flatten_cm_record_fields(
+                    fields,
+                    val_local,
+                    &val_name,
+                    value_type_id,
+                    prefix,
                     next_local,
                     stmts,
                     locals,
@@ -884,12 +856,57 @@ pub(super) fn synthesize_flatten_value_to_flat_args(
                     wasi_package,
                     type_table,
                 );
+            } else {
+                flat_args.push(value);
             }
         }
-        // Simple primitives / handles → pass through directly
-        _ => {
-            flat_args.push(value);
-        }
+    }
+}
+
+/// Flatten a CM record value (already bound to `val_local` of `value_type_id`)
+/// into its fields' flat CM-ABI args, in declared order. Each field recurses
+/// through [`synthesize_flatten_value_to_flat_args`], so String / Option /
+/// enum / nested-record fields expand to their own flat slots. Shared by the
+/// nested-field path here and the top-level struct-param path in
+/// `import_adapter`, so both flatten a record by exactly the same rule.
+pub(super) fn flatten_cm_record_fields(
+    fields: &[(String, String, Type)],
+    val_local: u32,
+    val_name: &str,
+    value_type_id: TypeId,
+    prefix: &str,
+    next_local: &mut u32,
+    stmts: &mut Vec<TirStmt>,
+    locals: &mut Vec<TirLocal>,
+    flat_args: &mut Vec<TirExpr>,
+    cm_interface_registry: &CmInterfaceRegistry,
+    wasi_package: &str,
+    type_table: &RefCell<TypeTable>,
+) {
+    for (field_idx, (wado_name, _, field_ty)) in fields.iter().enumerate() {
+        let resolved_field = cm_interface_registry.resolve_type(field_ty);
+        let field_type_id = {
+            let mut tt = type_table.borrow_mut();
+            cm_type_to_type_id(&resolved_field, &mut tt, cm_interface_registry, wasi_package)
+        };
+        let field_expr = field_access(
+            local_ref(val_local, val_name, value_type_id),
+            wado_name,
+            field_idx as u32,
+            field_type_id,
+        );
+        synthesize_flatten_value_to_flat_args(
+            &resolved_field,
+            field_expr,
+            &format!("{prefix}_f{field_idx}"),
+            next_local,
+            stmts,
+            locals,
+            flat_args,
+            cm_interface_registry,
+            wasi_package,
+            type_table,
+        );
     }
 }
 

--- a/wado-compiler/src/synthesis/cm_binding/lower.rs
+++ b/wado-compiler/src/synthesis/cm_binding/lower.rs
@@ -615,7 +615,7 @@ pub(super) fn synthesize_flatten_value_to_flat_args(
         // Enum → variant_tag (single i32)
         Type::Named(n)
             if n.source_interface.as_deref().is_some_and(|s| {
-                s.starts_with("wasi:")
+                crate::component_model::source_uses_cm_abi(s)
                     && cm_interface_registry
                         .get_enum_variants_by_source(s, &n.name)
                         .is_some()
@@ -626,7 +626,7 @@ pub(super) fn synthesize_flatten_value_to_flat_args(
         // Variant → disc + join of all case payload flats
         Type::Named(n)
             if n.source_interface.as_deref().is_some_and(|s| {
-                s.starts_with("wasi:")
+                crate::component_model::source_uses_cm_abi(s)
                     && cm_interface_registry
                         .get_variant_cases_by_source(s, &n.name)
                         .is_some()
@@ -635,7 +635,7 @@ pub(super) fn synthesize_flatten_value_to_flat_args(
             let source = n
                 .source_interface
                 .as_deref()
-                .expect("wasi variant source_interface present");
+                .expect("CM variant source_interface present");
             let vt = value.type_id;
             let val_local = alloc_local(next_local, locals, vt);
             stmts.push(let_stmt(&format!("{prefix}_val"), val_local, vt, value));
@@ -802,6 +802,88 @@ pub(super) fn synthesize_flatten_value_to_flat_args(
                 for (i, (pl, pt)) in payload_locals.iter().enumerate() {
                     flat_args.push(local_ref(*pl, &format!("{prefix}_p{i}"), *pt));
                 }
+            }
+        }
+        // Option<T> → discriminant i32 + flatten(T). Delegates to the
+        // dedicated option flattener, which conditionally lowers the Some
+        // payload via a Match. Reached for an `Option` field of a CM record
+        // (e.g. `span: Option<SourceSpan>` on the kiln-host Diagnostic).
+        Type::Generic(g) if g.name == "Option" && g.args.len() == 1 => {
+            synthesize_flatten_option_to_flat_args(
+                &g.args[0],
+                value,
+                prefix,
+                next_local,
+                stmts,
+                locals,
+                flat_args,
+                cm_interface_registry,
+                wasi_package,
+                type_table,
+            );
+        }
+        // CM record → concatenation of its fields' flat args, in declared
+        // order. Keyed on the explicit source interface so it fires for both
+        // `wasi:*` and `core:kiln/*` records and never for a plain Wado GC
+        // struct (which carries no `source_interface`). Reached for a nested
+        // record field — e.g. `SourceSpan` inside `Option<SourceSpan>` — so
+        // arbitrarily nested CM records lower through one recursion.
+        Type::Named(n)
+            if n.source_interface
+                .as_deref()
+                .and_then(|s| {
+                    cm_interface_registry.get_struct_fields_with_wado_names_by_source(s, &n.name)
+                })
+                .is_some() =>
+        {
+            let source = n
+                .source_interface
+                .as_deref()
+                .expect("CM struct source_interface present");
+            let resolved_fields: Vec<(String, Type)> = cm_interface_registry
+                .get_struct_fields_with_wado_names_by_source(source, &n.name)
+                .expect("CM struct fields present")
+                .iter()
+                .map(|(wn, _, ft)| (wn.clone(), cm_interface_registry.resolve_type(ft)))
+                .collect();
+            let value_type_id = value.type_id;
+            let val_local = alloc_local(next_local, locals, value_type_id);
+            stmts.push(let_stmt(
+                &format!("{prefix}_rec"),
+                val_local,
+                value_type_id,
+                value,
+            ));
+            for (field_idx, (wado_name, field_ty)) in resolved_fields.iter().enumerate() {
+                let field_type_id = {
+                    let mut tt = type_table.borrow_mut();
+                    cm_type_to_type_id(field_ty, &mut tt, cm_interface_registry, wasi_package)
+                };
+                let field_expr = TirExpr {
+                    kind: TirExprKind::FieldAccess {
+                        expr: Box::new(local_ref(
+                            val_local,
+                            &format!("{prefix}_rec"),
+                            value_type_id,
+                        )),
+                        field_index: field_idx as u32,
+                        field_name: wado_name.clone(),
+                    },
+                    type_id: field_type_id,
+                    span: synth_span(),
+                };
+                synthesize_flatten_value_to_flat_args(
+                    field_ty,
+                    field_expr,
+                    &format!("{prefix}_f{field_idx}"),
+                    next_local,
+                    stmts,
+                    locals,
+                    flat_args,
+                    cm_interface_registry,
+                    wasi_package,
+                    type_table,
+                );
             }
         }
         // Simple primitives / handles → pass through directly

--- a/wado-compiler/src/synthesis/cm_binding/types.rs
+++ b/wado-compiler/src/synthesis/cm_binding/types.rs
@@ -368,13 +368,12 @@ pub(super) fn is_gc_passthrough_param(
     match ty {
         Type::Named(n) if n.name == names.string => true,
         Type::Named(n) => n.source_interface.as_deref().is_some_and(|s| {
-            crate::component_model::source_uses_cm_abi(s)
-                && (cm_interface_registry
-                    .get_variant_cases_by_source(s, &n.name)
+            cm_interface_registry
+                .get_variant_cases_by_source(s, &n.name)
+                .is_some()
+                || cm_interface_registry
+                    .get_struct_fields_by_source(s, &n.name)
                     .is_some()
-                    || cm_interface_registry
-                        .get_struct_fields_by_source(s, &n.name)
-                        .is_some())
         }),
         Type::Generic(g) if g.name == names.array && g.args.len() == 1 => true,
         Type::Generic(g) if g.name == names.option && g.args.len() == 1 => true,

--- a/wado-compiler/src/synthesis/cm_binding/types.rs
+++ b/wado-compiler/src/synthesis/cm_binding/types.rs
@@ -368,10 +368,13 @@ pub(super) fn is_gc_passthrough_param(
     match ty {
         Type::Named(n) if n.name == names.string => true,
         Type::Named(n) => n.source_interface.as_deref().is_some_and(|s| {
-            s.starts_with("wasi:")
-                && cm_interface_registry
+            crate::component_model::source_uses_cm_abi(s)
+                && (cm_interface_registry
                     .get_variant_cases_by_source(s, &n.name)
                     .is_some()
+                    || cm_interface_registry
+                        .get_struct_fields_by_source(s, &n.name)
+                        .is_some())
         }),
         Type::Generic(g) if g.name == names.array && g.args.len() == 1 => true,
         Type::Generic(g) if g.name == names.option && g.args.len() == 1 => true,
@@ -415,12 +418,12 @@ pub fn flatten_param_type(
                 "f32" => vec![TypeTable::F32],
                 "f64" => vec![TypeTable::F64],
                 name => {
-                    // Without a resolved WASI source the reference is not a WASI
-                    // variant/struct — flatten to a single i32 handle.
+                    // Without a resolved CM-interface source the reference is
+                    // not a CM variant/struct — flatten to a single i32 handle.
                     let Some(source) = named
                         .source_interface
                         .as_deref()
-                        .filter(|s| s.starts_with("wasi:"))
+                        .filter(|s| crate::component_model::source_uses_cm_abi(s))
                     else {
                         return vec![TypeTable::I32];
                     };

--- a/wado-compiler/src/wir_build/translate.rs
+++ b/wado-compiler/src/wir_build/translate.rs
@@ -2086,7 +2086,13 @@ impl FunctionTranslator<'_, '_> {
                         result_ty: WirType::I32,
                     }
                 } else {
-                    WirInstr::I32Const(0)
+                    // A plain `enum` lowers to a bare i32 discriminant (see
+                    // `EnumConstruct` below), so the value already *is* the
+                    // tag — pass it through. The previous `I32Const(0)` stub
+                    // silently mis-tagged every plain enum (the case never
+                    // arose until enums began flowing through CM-import
+                    // binding synthesis via `variant_tag`).
+                    val
                 }
             }
             NirExprKind::VariantTest {


### PR DESCRIPTION
## Summary

Started as the "single lowering on `gale gen`" cleanup, then grew to deliver
the diagnostics that cleanup exposes on the **Kiln** path too — which
uncovered (and fixes) a Component Model codegen gap.

### 1. Single lowering on `gale gen` (original scope)

`generate` now returns `GeneratedOutput { source, diagnostics }` from its one
lowering instead of `gale gen` lowering a second time just to read warnings.
Callers that only need the module text read `.source` (the Kiln entry, unit
tests). No source-only wrapper kept.

### 2. Surface Gale prediction diagnostics on the Kiln path

`gale gen` already printed prediction-strategy warnings on stderr, but the
Kiln generator surface — the production entry every in-tree consumer uses —
discarded them. The Kiln entry now forwards each diagnostic through
`KilnHost::emit_diagnostic(level: Warning)`.

### 3. Component Model: compound record params for interface imports (compiler fix)

`KilnHost::emit_diagnostic(diagnostic: Diagnostic)` is the first in-tree call
to a CM import whose param is a record with String / Option / nested-record /
enum fields. It hit an unimplemented path and produced an invalid core module
(`type mismatch: expected i32, found (ref …)`). Fixes:

- Generalize the `starts_with("wasi:")` CM-ABI gates to a `source_uses_cm_abi`
  helper (`wasi:` or `core:kiln/`) — additive; WASI behavior unchanged.
- Recursively flatten record params (`synthesize_flatten_value_to_flat_args`
  gains record + Option arms; the struct-param binding body flattens each
  field through it).
- Fix `VariantTag` codegen for plain enums (a Wado `enum` is a bare i32
  discriminant; the non-`Ref` arm returned `i32.const 0`, silently
  mis-tagging every enum — never exercised until enums flowed through
  CM-import binding synthesis).

### 4. Print Kiln generator diagnostics (CLI routing fix)

Relayed generator diagnostics were sent through the collect-only inner host,
so they were recorded but never printed. `run_generator` now hands them back
to its caller, which relays them through the printing wrapper. (Diagnostics
aren't cached in `.kiln.json` yet, so they surface on a cache miss; replay on
hit is a follow-up.)

## Testing

- `wado-compiler` e2e (WASI corpus): 2704 passed, 0 failed.
- `package-gale` at -O2: 1651 passed, 0 failed; generator component recompiles
  cleanly (no ICE).
- End-to-end (`--no-cache`): `warning: gale: rule 'r': alts 0, 1 share
  lookahead {TK_A}; resolved by longest-match scan tournament …` prints at
  build time with correct severity, and the generated parser parses both alts.

Regression fixtures: `package-gale/tests/grammars/ll_overlap_tournament.g4`
+ `tests/driver_overlap_tournament_test.wado`.

https://claude.ai/code/session_01HbFnGN8kP18FgTkFnEo7CV