### PR TITLE
Richer type/trait diagnostics: symmetric operator errors and trait-bound reason chains

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -115,3 +115,4 @@ It may include TODOs on WIP.
 - [Elaborator Re-architecture — TypeSystem / Annotate / Reify](./wep-2026-05-26-elaborator-rearchitecture.md)
 - [Constant Object Globalization](./wep-2026-05-31-const-object-globalization.md)
 - [`NirExprKind::ArrayLiteral` — a NIR-Materialized Array Node](./wep-2026-05-31-nir-array-literal.md)
+- [Diagnostic Reason Chains for Type and Trait Errors](./wep-2026-06-02-diagnostic-reason-chains.md)

--- a/docs/wep-2026-06-02-diagnostic-reason-chains.md
+++ b/docs/wep-2026-06-02-diagnostic-reason-chains.md
@@ -53,9 +53,8 @@ changes that move trait/operator diagnostics from `proximate` toward `all`.
 Add `TypeError::OperatorNotApplicable { op, operands, note }` and route every
 operator type error through it. The requires-trait check inspects both
 operands, so a pair that cannot combine under the operator produces one
-symmetric message naming both types regardless of operand order, e.g.
-`` operator `-` cannot be applied to types `i32` and `Array<i32>` ``. The
-misleading "invalid pattern:" prefix is gone.
+symmetric message naming both types regardless of operand order, and the
+misleading "invalid pattern:" prefix is gone (see Examples).
 
 ### Trait-bound reason chains
 
@@ -64,13 +63,8 @@ auto-derive structure (struct fields, generic-struct fields with type-argument
 substitution, and variant payloads), finds the first member that breaks the
 trait, and recurses into it. The result is a step-by-step chain, depth-bounded
 and cycle-guarded, carried on `TraitBoundNotSatisfied` and rendered by default
-as indented `note:` lines beneath the headline at every bound-check site:
-
-```
-error: type 'Outer' does not implement trait 'Ord' required by bound on 'T'
-  note: `Outer` does not implement `Ord` because field `inner` of type `Inner` does not implement `Ord`
-  note: `Inner` does not implement `Ord` because field `f` of type `fn() -> i32` does not implement `Ord`
-```
+as indented `note:` lines beneath the headline at every bound-check site (see
+Examples).
 
 ### Rendering mechanism
 
@@ -80,6 +74,107 @@ in ~85 places and carries a single optional span; adding structured
 secondary-span notes would touch all of them, so it is deferred until the value
 is proven. Substring-matched `compile_error` fixtures keep working because the
 headline is unchanged and notes are appended.
+
+## Examples
+
+All examples are the actual compiler output on the MVP. The location prefix
+(`file:line:col:`) and the leading timestamp are elided for brevity.
+
+### Operator error — symmetry
+
+The same defect under both operand orders previously read as two unrelated
+errors. Source:
+
+```wado
+fn f(a: i32, lst: Array<i32>) -> i32 { return a - lst; }   // and the mirror: lst - a
+```
+
+Before:
+
+```
+// a - lst
+error: type mismatch: expected 'i32', found 'Array<i32>'
+// lst - a
+error: invalid pattern: operator `-` cannot be applied to type `Array<i32>`: type does not implement `Sub`
+```
+
+After:
+
+```
+// a - lst
+error: operator `-` cannot be applied to types `i32` and `Array<i32>`
+// lst - a
+error: operator `-` cannot be applied to types `Array<i32>` and `i32`
+```
+
+### Operator error — same type, missing trait impl
+
+Source:
+
+```wado
+struct V2 { x: i32 }
+let _ = a - b;   // a, b: V2, no `impl Sub for V2`
+```
+
+Before:
+
+```
+error: invalid pattern: operator `-` cannot be applied to type `V2`: type does not implement `Sub`
+```
+
+After:
+
+```
+error: operator `-` cannot be applied to type `V2`: type does not implement `Sub`
+```
+
+### Trait bound — single field
+
+Source:
+
+```wado
+struct Handler { cb: fn(i32) -> i32 }
+fn smallest<T: Ord>(a: T, b: T) -> T { if a < b { return a; } return b; }
+let _ = smallest(Handler { cb: |x: i32| x }, Handler { cb: |x: i32| x });
+```
+
+Before:
+
+```
+error: type 'Handler' does not implement trait 'Ord' required by bound on 'T'
+```
+
+After:
+
+```
+error: type 'Handler' does not implement trait 'Ord' required by bound on 'T'
+  note: `Handler` does not implement `Ord` because field `cb` of type `fn(i32) -> i32` does not implement `Ord`
+```
+
+### Trait bound — recursive chain
+
+Source:
+
+```wado
+struct Inner { f: fn() -> i32 }
+struct Outer { inner: Inner }
+fn smallest<T: Ord>(a: T, b: T) -> T { if a < b { return a; } return b; }
+let _ = smallest(Outer { inner: Inner { f: || 1 } }, Outer { inner: Inner { f: || 2 } });
+```
+
+Before:
+
+```
+error: type 'Outer' does not implement trait 'Ord' required by bound on 'T'
+```
+
+After:
+
+```
+error: type 'Outer' does not implement trait 'Ord' required by bound on 'T'
+  note: `Outer` does not implement `Ord` because field `inner` of type `Inner` does not implement `Ord`
+  note: `Inner` does not implement `Ord` because field `f` of type `fn() -> i32` does not implement `Ord`
+```
 
 ## Consequences
 

--- a/docs/wep-2026-06-02-diagnostic-reason-chains.md
+++ b/docs/wep-2026-06-02-diagnostic-reason-chains.md
@@ -1,0 +1,114 @@
+# WEP: Diagnostic Reason Chains for Type and Trait Errors
+
+## Context
+
+Wado source — including this compiler — is increasingly written and repaired
+by AI coding agents. The error messages the compiler emits are therefore read
+by agents as much as by humans, and the two audiences have different needs.
+
+Krishnamurthi and Flatt, "Type-Error Ablation and AI Coding Agents"
+(arXiv:2606.01522, 2026), ran a controlled experiment on an ML-style language
+and found:
+
+- More detailed type-error messages measurably improve an agent's ability to
+  fix the error. Their four reporting modes ordered strictly by fix rate:
+  `untyped` (test failures only) < `min` (conflicting types only) <
+  `proximate` (one blame location) < `all` (the full unification stack, which
+  is more likely to contain the true cause).
+- Type-system feedback beats test-only feedback: a type error is a causal
+  signal ("these types conflict, here is why") while a test failure is only a
+  symptomatic one.
+- The benefit lands on the agent's first hypothesis, not on iterative retries —
+  so the cause should be present in the initial message.
+
+An inventory of Wado's diagnostics placed them at the paper's `proximate`
+level: a single span plus both the expected and found type names, but no chain
+of expressions or causes. Two concrete gaps stood out, both confirmed by
+writing and compiling Wado programs:
+
+- Binary-operator type errors were routed through `TypeError::InvalidPattern`,
+  which mislabeled them as "invalid pattern:", and were asymmetric — `a - lst`
+  reported a `TypeMismatch` while `lst - a` reported an operator error, so the
+  same defect read differently depending on operand order (the paper's
+  "symmetric chaff" effect).
+- Trait-bound failures (`T: Ord` unsatisfied) named only the type and trait,
+  never the field whose type breaks the auto-derive. The blame sits at the
+  call site, far from the cause.
+
+Unlike the paper's `proximate`-vs-`all` framing, Wado anchors types at function
+signatures (parameters require annotations), so ordinary type mismatches are
+already local. The places where Wado's cause is genuinely far from the blame
+are trait resolution and generic inference — the same territory as
+interactive Rust trait-error debuggers.
+
+## Decision
+
+Make diagnostics richer by default. We explicitly reject a separate
+"AI mode": a single detailed default serves both audiences and avoids a
+configuration surface that agents would have to discover. The MVP ships two
+changes that move trait/operator diagnostics from `proximate` toward `all`.
+
+### Operator errors
+
+Add `TypeError::OperatorNotApplicable { op, operands, note }` and route every
+operator type error through it. The requires-trait check inspects both
+operands, so a pair that cannot combine under the operator produces one
+symmetric message naming both types regardless of operand order, e.g.
+`` operator `-` cannot be applied to types `i32` and `Array<i32>` ``. The
+misleading "invalid pattern:" prefix is gone.
+
+### Trait-bound reason chains
+
+Add `trait_unimpl_reason_chain(type_id, trait_name)`, which walks the `Eq`/`Ord`
+auto-derive structure (struct fields, generic-struct fields with type-argument
+substitution, and variant payloads), finds the first member that breaks the
+trait, and recurses into it. The result is a step-by-step chain, depth-bounded
+and cycle-guarded, carried on `TraitBoundNotSatisfied` and rendered by default
+as indented `note:` lines beneath the headline at every bound-check site:
+
+```
+error: type 'Outer' does not implement trait 'Ord' required by bound on 'T'
+  note: `Outer` does not implement `Ord` because field `inner` of type `Inner` does not implement `Ord`
+  note: `Inner` does not implement `Ord` because field `f` of type `fn() -> i32` does not implement `Ord`
+```
+
+### Rendering mechanism
+
+The MVP folds the chain into the existing `Diagnostic.message` string (the
+same pattern as `OperatorNotApplicable`'s `note`). `Diagnostic` is constructed
+in ~85 places and carries a single optional span; adding structured
+secondary-span notes would touch all of them, so it is deferred until the value
+is proven. Substring-matched `compile_error` fixtures keep working because the
+headline is unchanged and notes are appended.
+
+## Consequences
+
+Shipped and validated:
+
+- [x] `OperatorNotApplicable`: symmetric, correctly-labeled operator errors.
+- [x] Trait-bound reason chains for `Eq`/`Ord` auto-derive (struct, generic
+      struct, variant), recursive and on by default at all five bound-check
+      sites.
+- [x] Unit tests plus E2E fixtures (`operator_not_applicable_*`,
+      `trait_bound_reason_*`); no regressions in the `wado-compiler` suite.
+
+Trade-offs and known limits:
+
+- Notes are strings without their own spans; they explain the cause but do not
+  point the editor at the offending field's definition.
+- Only the `Eq`/`Ord` auto-derive rules are unfolded. A missing user-written
+  `impl Trait for T` is not explained beyond "does not implement".
+- Generic inference provenance is not tracked: when `T` is inferred to a
+  concrete type from an argument, the diagnostic cannot yet say where that
+  binding came from (`infer.rs` records `bindings` without source origin).
+- `Diagnostic` remains single-span; this WEP does not change that model.
+
+Next steps, in priority order toward the paper's `all` level:
+
+- [ ] Give `Diagnostic` structured notes with their own spans (builder or
+      `Default` to avoid editing all construction sites), so a note can point
+      at the field definition.
+- [ ] Track inference provenance through unification so a `TypeMismatch` from
+      generic inference can show where a type variable was bound.
+- [ ] Explain a missing user-written `impl` (candidate impls, near-misses).
+- [ ] Extend reason chains beyond `Eq`/`Ord` to other structural bounds.

--- a/wado-compiler/src/elaborator/call.rs
+++ b/wado-compiler/src/elaborator/call.rs
@@ -500,10 +500,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                     );
                                 } else {
                                     let type_name = self.type_id_to_string(type_arg);
+                                    let reason =
+                                        self.trait_unimpl_reason_chain(type_arg, &bound.name);
                                     let _ = self.logger.error(TypeError::TraitBoundNotSatisfied {
                                         type_name,
                                         trait_name: bound.name.clone(),
                                         param_name: param.name.clone(),
+                                        reason,
                                         span: call.span,
                                     });
                                 }

--- a/wado-compiler/src/elaborator/expr.rs
+++ b/wado-compiler/src/elaborator/expr.rs
@@ -3543,10 +3543,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         for bound in bounds {
                             if !self.type_implements_trait(type_arg, bound) {
                                 let type_name = self.type_id_to_string(type_arg);
+                                let reason = self.trait_unimpl_reason_chain(type_arg, bound);
                                 let _ = self.logger.error(TypeError::TraitBoundNotSatisfied {
                                     type_name,
                                     trait_name: bound.clone(),
                                     param_name: param_name.clone(),
+                                    reason,
                                     span: struct_lit.span,
                                 });
                             }
@@ -4485,10 +4487,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             && !self.type_implements_trait(element_type, &ord_trait_name)
         {
             let type_name = self.type_id_to_string(element_type);
+            let reason = self.trait_unimpl_reason_chain(element_type, &ord_trait_name);
             let _ = self.logger.error(TypeError::TraitBoundNotSatisfied {
                 type_name,
                 trait_name: ord_trait_name,
                 param_name: "T".to_string(),
+                reason,
                 span: range.span,
             });
             return TirExpr::new(TirExprKind::Unit, TypeTable::ERROR, range.span);

--- a/wado-compiler/src/elaborator/operators.rs
+++ b/wado-compiler/src/elaborator/operators.rs
@@ -137,6 +137,34 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
     }
 
+    /// True when an operand type has no native Wasm binary-op instruction
+    /// and must therefore dispatch through a trait implementation. Used to
+    /// detect operator misuse symmetrically: either operand being such a
+    /// type means the operator cannot fall through to a primitive
+    /// instruction.
+    fn binop_operand_requires_trait(&self, type_id: TypeId) -> bool {
+        let tt = self.tysys.type_table.borrow();
+        match tt.get(type_id) {
+            ResolvedType::Struct { .. } | ResolvedType::GenericInstance { .. } => true,
+            ResolvedType::Newtype { base_type, .. } => {
+                let ultimate = tt.get_ultimate_base_type(*base_type);
+                matches!(
+                    tt.get(ultimate),
+                    ResolvedType::Struct { .. } | ResolvedType::GenericInstance { .. }
+                )
+            }
+            // Types with no native Wasm binary-op support and no prelude
+            // trait impl. Without rejection, codegen emits `ref.eq` /
+            // `i32.eq` against a GC reference and fails validation.
+            ResolvedType::Function { .. }
+            | ResolvedType::Resource { .. }
+            | ResolvedType::GenericResource { .. }
+            | ResolvedType::Reactive(_)
+            | ResolvedType::AssocTypeProjection { .. } => true,
+            _ => false,
+        }
+    }
+
     /// Build a binary-op `TirExpr` given pre-resolved operands.
     ///
     /// Shared between [`Self::resolve_binary`] (the user-AST entry point)
@@ -219,8 +247,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     BinaryOp::Or => "||",
                     _ => unreachable!(),
                 };
-                let _ = self.logger.error(TypeError::InvalidPattern {
-                    message: format!("operator `{op_str}` cannot be applied to type `{type_name}`"),
+                let _ = self.logger.error(TypeError::OperatorNotApplicable {
+                    op: op_str.to_string(),
+                    operands: vec![type_name],
+                    note: None,
                     span,
                 });
                 return TirExpr::new(TirExprKind::Unit, TypeTable::ERROR, span);
@@ -285,10 +315,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     ) else {
                         let type_name = self.tysys.type_table.borrow().type_name(left.type_id);
                         let op_str = if op == BinaryOp::Eq { "==" } else { "!=" };
-                        let _ = self.logger.error(TypeError::InvalidPattern {
-                            message: format!(
-                                "operator `{op_str}` cannot be applied to type `{type_name}` (does not implement Eq trait)"
-                            ),
+                        let _ = self.logger.error(TypeError::OperatorNotApplicable {
+                            op: op_str.to_string(),
+                            operands: vec![type_name],
+                            note: Some("type does not implement `Eq`".to_string()),
                             span,
                         });
                         return TirExpr::new(TirExprKind::Unit, TypeTable::ERROR, span);
@@ -339,10 +369,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             BinaryOp::GtEq => ">=",
                             _ => unreachable!(),
                         };
-                        let _ = self.logger.error(TypeError::InvalidPattern {
-                            message: format!(
-                                "operator `{op_str}` cannot be applied to type `{type_name}` (does not implement Ord trait)"
-                            ),
+                        let _ = self.logger.error(TypeError::OperatorNotApplicable {
+                            op: op_str.to_string(),
+                            operands: vec![type_name],
+                            note: Some("type does not implement `Ord`".to_string()),
                             span,
                         });
                         return TirExpr::new(TirExprKind::Unit, TypeTable::ERROR, span);
@@ -644,9 +674,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     BinaryOp::Mod => "%",
                     _ => unreachable!(),
                 };
-                let _ = self.logger.error(TypeError::InvalidPattern {
-                    message: format!(
-                        "arithmetic operator `{op_char}` is not allowed on flags types; use bitwise operators (`|`, `&`, `^`) instead"
+                let type_name = self.tysys.type_table.borrow().type_name(left.type_id);
+                let _ = self.logger.error(TypeError::OperatorNotApplicable {
+                    op: op_char.to_string(),
+                    operands: vec![type_name],
+                    note: Some(
+                        "flags types support only bitwise operators (`|`, `&`, `^`)".to_string(),
                     ),
                     span,
                 });
@@ -668,52 +701,36 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     ResolvedType::Primitive(PrimitiveType::F32) => "f32",
                     _ => "f64",
                 };
-                let _ = self.logger.error(TypeError::InvalidPattern {
-                    message: format!(
-                        "operator `%` is not supported on `{type_name}`; use `{type_name}::fmod(a, b)` instead"
-                    ),
+                let _ = self.logger.error(TypeError::OperatorNotApplicable {
+                    op: "%".to_string(),
+                    operands: vec![type_name.to_string()],
+                    note: Some(format!("use `{type_name}::fmod(a, b)` instead")),
                     span,
                 });
                 return TirExpr::new(TirExprKind::Unit, TypeTable::ERROR, span);
             }
         }
 
-        // If the left operand is a non-primitive type that cannot fall through
-        // to a native Wasm binary instruction, it must dispatch through a
-        // trait implementation.  Reaching here with such a type means no
-        // matching trait impl was found — emit a diagnostic before we can
-        // accidentally build a TIR `Binary` node that would crash codegen
-        // with "type mismatch: expected ... found (ref $type)" on Wasm
-        // validation (see regression fixture `typecheck_binop_fn_eq.wado`).
+        // If either operand is a non-primitive type that cannot fall through
+        // to a native Wasm binary instruction, the operator must dispatch
+        // through a trait implementation. Reaching here means no matching
+        // impl was found — emit a diagnostic before we accidentally build a
+        // TIR `Binary` node that would crash codegen with "type mismatch:
+        // expected ... found (ref $type)" on Wasm validation (see regression
+        // fixture `typecheck_binop_fn_eq.wado`). Checking both operands keeps
+        // the message symmetric: `a - lst` and `lst - a` report the same
+        // error regardless of which side is the non-primitive one.
         {
-            let requires_trait = match &left_type {
-                ResolvedType::Struct { .. } | ResolvedType::GenericInstance { .. } => true,
-                ResolvedType::Newtype { base_type, .. } => {
-                    let tt = self.tysys.type_table.borrow();
-                    let ultimate = tt.get_ultimate_base_type(*base_type);
-                    matches!(
-                        tt.get(ultimate),
-                        ResolvedType::Struct { .. } | ResolvedType::GenericInstance { .. }
-                    )
-                }
-                // Types with no native Wasm binary-op support and no trait
-                // implementation in the prelude.  Without this rejection,
-                // codegen emits `ref.eq` / `i32.eq` against a GC reference
-                // and fails validation.
-                ResolvedType::Function { .. }
-                | ResolvedType::Resource { .. }
-                | ResolvedType::GenericResource { .. }
-                | ResolvedType::Reactive(_)
-                | ResolvedType::AssocTypeProjection { .. } => true,
-                _ => false,
-            };
-            if requires_trait
+            let left_requires = self.binop_operand_requires_trait(left.type_id);
+            let right_requires = self.binop_operand_requires_trait(right.type_id);
+            if (left_requires || right_requires)
                 && !matches!(op, BinaryOp::And | BinaryOp::Or)
                 && left.type_id != TypeTable::ERROR
                 && right.type_id != TypeTable::ERROR
             {
                 let type_table = self.tysys.type_table.borrow();
-                let type_name = type_table.type_name(left.type_id);
+                let left_name = type_table.type_name(left.type_id);
+                let right_name = type_table.type_name(right.type_id);
                 let op_char = match op {
                     BinaryOp::Add => "+",
                     BinaryOp::Sub => "-",
@@ -740,28 +757,44 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         items.trait_name(CompilerItem::Ord).to_string(),
                     )
                 };
-                let trait_name: String = match op {
-                    BinaryOp::Add => "Add".to_string(),
-                    BinaryOp::Sub => "Sub".to_string(),
-                    BinaryOp::Mul => "Mul".to_string(),
-                    BinaryOp::Div => "Div".to_string(),
-                    BinaryOp::Mod => "Rem".to_string(),
-                    BinaryOp::BitAnd => "BitAnd".to_string(),
-                    BinaryOp::BitOr => "BitOr".to_string(),
-                    BinaryOp::BitXor => "BitXor".to_string(),
-                    BinaryOp::Shl => "Shl".to_string(),
-                    BinaryOp::Shr => "Shr".to_string(),
-                    BinaryOp::Eq | BinaryOp::NotEq => eq_trait_name,
-                    BinaryOp::Lt | BinaryOp::LtEq | BinaryOp::Gt | BinaryOp::GtEq => ord_trait_name,
-                    _ => "?".to_string(),
-                };
                 drop(type_table);
-                let _ = self.logger.error(TypeError::InvalidPattern {
-                    message: format!(
-                        "operator `{op_char}` cannot be applied to type `{type_name}`: type does not implement `{trait_name}`"
-                    ),
-                    span,
-                });
+                if left_name == right_name {
+                    // Both operands share a type that lacks the operator's
+                    // trait impl (e.g. `Point - Point` with no `Sub`).
+                    let trait_name: String = match op {
+                        BinaryOp::Add => "Add".to_string(),
+                        BinaryOp::Sub => "Sub".to_string(),
+                        BinaryOp::Mul => "Mul".to_string(),
+                        BinaryOp::Div => "Div".to_string(),
+                        BinaryOp::Mod => "Rem".to_string(),
+                        BinaryOp::BitAnd => "BitAnd".to_string(),
+                        BinaryOp::BitOr => "BitOr".to_string(),
+                        BinaryOp::BitXor => "BitXor".to_string(),
+                        BinaryOp::Shl => "Shl".to_string(),
+                        BinaryOp::Shr => "Shr".to_string(),
+                        BinaryOp::Eq | BinaryOp::NotEq => eq_trait_name,
+                        BinaryOp::Lt | BinaryOp::LtEq | BinaryOp::Gt | BinaryOp::GtEq => {
+                            ord_trait_name
+                        }
+                        _ => "?".to_string(),
+                    };
+                    let _ = self.logger.error(TypeError::OperatorNotApplicable {
+                        op: op_char.to_string(),
+                        operands: vec![left_name],
+                        note: Some(format!("type does not implement `{trait_name}`")),
+                        span,
+                    });
+                } else {
+                    // Mixed operand types that cannot combine under this
+                    // operator (e.g. `i32 - Array<i32>`). Reported the same
+                    // way regardless of which operand is non-primitive.
+                    let _ = self.logger.error(TypeError::OperatorNotApplicable {
+                        op: op_char.to_string(),
+                        operands: vec![left_name, right_name],
+                        note: None,
+                        span,
+                    });
+                }
                 return TirExpr::new(TirExprKind::Unit, TypeTable::ERROR, span);
             }
         }

--- a/wado-compiler/src/elaborator/operators.rs
+++ b/wado-compiler/src/elaborator/operators.rs
@@ -750,13 +750,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     BinaryOp::GtEq => ">=",
                     _ => "?",
                 };
-                let (eq_trait_name, ord_trait_name) = {
-                    let items = type_table.compiler_items();
-                    (
-                        items.trait_name(CompilerItem::Eq).to_string(),
-                        items.trait_name(CompilerItem::Ord).to_string(),
-                    )
-                };
                 drop(type_table);
                 if left_name == right_name {
                     // Both operands share a type that lacks the operator's
@@ -772,10 +765,20 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         BinaryOp::BitXor => "BitXor".to_string(),
                         BinaryOp::Shl => "Shl".to_string(),
                         BinaryOp::Shr => "Shr".to_string(),
-                        BinaryOp::Eq | BinaryOp::NotEq => eq_trait_name,
-                        BinaryOp::Lt | BinaryOp::LtEq | BinaryOp::Gt | BinaryOp::GtEq => {
-                            ord_trait_name
-                        }
+                        BinaryOp::Eq | BinaryOp::NotEq => self
+                            .tysys
+                            .type_table
+                            .borrow()
+                            .compiler_items()
+                            .trait_name(CompilerItem::Eq)
+                            .to_string(),
+                        BinaryOp::Lt | BinaryOp::LtEq | BinaryOp::Gt | BinaryOp::GtEq => self
+                            .tysys
+                            .type_table
+                            .borrow()
+                            .compiler_items()
+                            .trait_name(CompilerItem::Ord)
+                            .to_string(),
                         _ => "?".to_string(),
                     };
                     let _ = self.logger.error(TypeError::OperatorNotApplicable {

--- a/wado-compiler/src/elaborator/trait_query.rs
+++ b/wado-compiler/src/elaborator/trait_query.rs
@@ -107,6 +107,109 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         result
     }
 
+    /// Explain *why* `type_id` does not implement `trait_name` by walking the
+    /// auto-derive structure. Each returned entry is one step of a reason
+    /// chain, deepest cause last; an empty result means no structural
+    /// explanation is available (the type is itself a leaf — e.g. a function
+    /// type — whose non-conformance the headline message already states).
+    ///
+    /// Only the `Eq` / `Ord` auto-derive paths are explained, since those are
+    /// the structural-conformance rules a diagnostic can usefully unfold.
+    pub(super) fn trait_unimpl_reason_chain(
+        &self,
+        type_id: TypeId,
+        trait_name: &str,
+    ) -> Vec<String> {
+        let mut chain = Vec::new();
+        self.collect_trait_unimpl_reason(type_id, trait_name, &mut chain);
+        chain
+    }
+
+    fn collect_trait_unimpl_reason(
+        &self,
+        type_id: TypeId,
+        trait_name: &str,
+        chain: &mut Vec<String>,
+    ) {
+        // Bound the depth so a pathologically nested (or cyclic) type cannot
+        // produce an unbounded chain.
+        if chain.len() >= 8 {
+            return;
+        }
+
+        let (eq_name, ord_name) = {
+            let tt = self.tysys.type_table.borrow();
+            let items = tt.compiler_items();
+            (
+                items.trait_name(CompilerItem::Eq).to_string(),
+                items.trait_name(CompilerItem::Ord).to_string(),
+            )
+        };
+        let is_eq = trait_name == eq_name;
+        let is_eq_or_ord = is_eq || trait_name == ord_name;
+
+        let resolved = self.tysys.type_table.borrow().get(type_id).clone();
+
+        // Collect the members to walk as owned (label, member type) pairs,
+        // releasing the field/case borrow before the conformance recursion.
+        let members: Vec<(String, TypeId)> = match &resolved {
+            ResolvedType::Struct { name, .. } if is_eq_or_ord => {
+                let Some(info) = self.lookup_struct_fields(name) else {
+                    return;
+                };
+                info.fields
+                    .iter()
+                    .map(|(fname, tid, _)| (format!("field `{fname}`"), *tid))
+                    .collect()
+            }
+            ResolvedType::GenericInstance {
+                name, type_args, ..
+            } if is_eq_or_ord => {
+                let Some(info) = self.lookup_struct_fields(name) else {
+                    return;
+                };
+                let param_map: IndexMap<TypeId, TypeId> = info
+                    .type_param_type_ids
+                    .iter()
+                    .zip(type_args.iter())
+                    .map(|(param, arg)| (*param, *arg))
+                    .collect();
+                info.fields
+                    .iter()
+                    .map(|(fname, tid, _)| {
+                        let concrete = param_map.get(tid).copied().unwrap_or(*tid);
+                        (format!("field `{fname}`"), concrete)
+                    })
+                    .collect()
+            }
+            ResolvedType::Variant { name, .. } if is_eq => {
+                let Some(info) = self.lookup_variant_case(name) else {
+                    return;
+                };
+                info.cases
+                    .iter()
+                    .filter(|c| c.payload != TypeTable::UNIT)
+                    .map(|c| (format!("variant `{}`", c.name), c.payload))
+                    .collect()
+            }
+            _ => return,
+        };
+
+        // Report the first member that breaks the trait, then recurse to
+        // explain that member in turn.
+        for (label, member_tid) in members {
+            if !self.type_implements_trait(member_tid, trait_name) {
+                let owner = self.type_id_to_string(type_id);
+                let member_ty = self.type_id_to_string(member_tid);
+                chain.push(format!(
+                    "`{owner}` does not implement `{trait_name}` because {label} of type `{member_ty}` does not implement `{trait_name}`"
+                ));
+                self.collect_trait_unimpl_reason(member_tid, trait_name, chain);
+                return;
+            }
+        }
+    }
+
     fn type_implements_trait_inner(&self, resolved: &ResolvedType, trait_name: &str) -> bool {
         // Type parameters satisfy bounds declared on them (e.g., T: Describable
         // means T implements Describable within the scope of that declaration)
@@ -780,10 +883,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         );
                     } else {
                         let type_name = self.type_id_to_string(type_arg);
+                        let reason = self.trait_unimpl_reason_chain(type_arg, &bound.name);
                         let _ = self.logger.error(TypeError::TraitBoundNotSatisfied {
                             type_name,
                             trait_name: bound.name.clone(),
                             param_name: param.name.clone(),
+                            reason,
                             span,
                         });
                     }

--- a/wado-compiler/src/elaborator/type_resolution.rs
+++ b/wado-compiler/src/elaborator/type_resolution.rs
@@ -383,11 +383,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                     if !self.type_implements_trait(type_arg, bound) {
                                         // Get the type name for the error message
                                         let type_name = self.type_id_to_string(type_arg);
+                                        let reason =
+                                            self.trait_unimpl_reason_chain(type_arg, bound);
                                         let _ =
                                             self.logger.error(TypeError::TraitBoundNotSatisfied {
                                                 type_name,
                                                 trait_name: bound.clone(),
                                                 param_name: param_name.clone(),
+                                                reason,
                                                 span,
                                             });
                                     }

--- a/wado-compiler/src/elaborator/types.rs
+++ b/wado-compiler/src/elaborator/types.rs
@@ -189,6 +189,12 @@ pub enum TypeError {
         type_name: String,
         trait_name: String,
         param_name: String,
+        /// Reason chain explaining *why* `type_name` does not implement
+        /// `trait_name`, walking the auto-derive structure step by step
+        /// (e.g. "`Handler` does not implement `Ord` because field `cb` …").
+        /// Empty when no structural explanation is available. Rendered as
+        /// indented `note:` lines beneath the headline message.
+        reason: Vec<String>,
         span: Span,
     },
 
@@ -404,6 +410,17 @@ pub enum TypeError {
 /// message names one operand type when `operands` has a single entry and
 /// both when it has two, keeping the wording symmetric regardless of which
 /// operand triggered the error.
+/// Append a trait-bound reason chain as indented `note:` lines beneath a
+/// headline message. Shared by the `Display` impl and the `Diagnostic`
+/// conversion so the chain renders identically on every surface.
+pub(super) fn append_reason_chain(mut message: String, reason: &[String]) -> String {
+    for step in reason {
+        message.push_str("\n  note: ");
+        message.push_str(step);
+    }
+    message
+}
+
 pub(super) fn format_operator_not_applicable(
     op: &str,
     operands: &[String],
@@ -504,13 +521,14 @@ impl std::fmt::Display for TypeError {
                 type_name,
                 trait_name,
                 param_name,
+                reason,
                 span,
             } => {
-                write!(
-                    f,
+                let headline = format!(
                     "{}:{}: type '{}' does not implement trait '{}' required by bound on '{}'",
                     span.line, span.column, type_name, trait_name, param_name
-                )
+                );
+                write!(f, "{}", append_reason_chain(headline, reason))
             }
             TypeError::InvalidPattern { message, span } => {
                 write!(
@@ -863,11 +881,15 @@ impl From<TypeError> for crate::compiler_host::Diagnostic {
                 type_name,
                 trait_name,
                 param_name,
+                reason,
                 span,
             } => (
                 Code::TypeMismatch,
-                format!(
-                    "type '{type_name}' does not implement trait '{trait_name}' required by bound on '{param_name}'"
+                append_reason_chain(
+                    format!(
+                        "type '{type_name}' does not implement trait '{trait_name}' required by bound on '{param_name}'"
+                    ),
+                    reason,
                 ),
                 *span,
             ),

--- a/wado-compiler/src/elaborator/types.rs
+++ b/wado-compiler/src/elaborator/types.rs
@@ -195,6 +195,22 @@ pub enum TypeError {
     /// Invalid pattern in context
     InvalidPattern { message: String, span: Span },
 
+    /// A unary or binary operator cannot be applied to its operand type(s).
+    ///
+    /// Replaces the former practice of routing operator errors through
+    /// `InvalidPattern`, which mislabeled them with an "invalid pattern:"
+    /// prefix. `operands` holds one type name when both operands share a
+    /// type (or for unary operators) and two names when a binary operator
+    /// is applied to two differing types; `note` carries an optional
+    /// explanation appended after a colon (e.g. "type does not implement
+    /// `Sub`").
+    OperatorNotApplicable {
+        op: String,
+        operands: Vec<String>,
+        note: Option<String>,
+        span: Span,
+    },
+
     /// Invalid type cast
     InvalidCast {
         from: String,
@@ -381,6 +397,29 @@ pub enum TypeError {
     },
 }
 
+/// Render the human-readable body of an [`TypeError::OperatorNotApplicable`].
+///
+/// Shared by the `Display` impl and the `From<TypeError> for Diagnostic`
+/// conversion so both surfaces phrase operator errors identically. The
+/// message names one operand type when `operands` has a single entry and
+/// both when it has two, keeping the wording symmetric regardless of which
+/// operand triggered the error.
+pub(super) fn format_operator_not_applicable(
+    op: &str,
+    operands: &[String],
+    note: Option<&str>,
+) -> String {
+    let base = match operands {
+        [t] => format!("operator `{op}` cannot be applied to type `{t}`"),
+        [l, r] => format!("operator `{op}` cannot be applied to types `{l}` and `{r}`"),
+        _ => format!("operator `{op}` cannot be applied"),
+    };
+    match note {
+        Some(note) => format!("{base}: {note}"),
+        None => base,
+    }
+}
+
 impl std::fmt::Display for TypeError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -478,6 +517,20 @@ impl std::fmt::Display for TypeError {
                     f,
                     "{}:{}: invalid pattern: {}",
                     span.line, span.column, message
+                )
+            }
+            TypeError::OperatorNotApplicable {
+                op,
+                operands,
+                note,
+                span,
+            } => {
+                write!(
+                    f,
+                    "{}:{}: {}",
+                    span.line,
+                    span.column,
+                    format_operator_not_applicable(op, operands, note.as_deref())
                 )
             }
             TypeError::InvalidCast {
@@ -821,6 +874,16 @@ impl From<TypeError> for crate::compiler_host::Diagnostic {
             TypeError::InvalidPattern { message, span } => (
                 Code::InvalidSyntax,
                 format!("invalid pattern: {message}"),
+                *span,
+            ),
+            TypeError::OperatorNotApplicable {
+                op,
+                operands,
+                note,
+                span,
+            } => (
+                Code::TypeMismatch,
+                format_operator_not_applicable(op, operands, note.as_deref()),
                 *span,
             ),
             TypeError::InvalidCast {

--- a/wado-compiler/tests/fixtures/flags_arith_add.wado
+++ b/wado-compiler/tests/fixtures/flags_arith_add.wado
@@ -11,4 +11,4 @@ export fn run() {
 }
 
 __DATA__
-{"compile_error": "arithmetic operator `+` is not allowed on flags types"}
+{"compile_error": "operator `+` cannot be applied to type"}

--- a/wado-compiler/tests/fixtures/flags_arith_div.wado
+++ b/wado-compiler/tests/fixtures/flags_arith_div.wado
@@ -10,4 +10,4 @@ export fn run() {
 }
 
 __DATA__
-{"compile_error": "arithmetic operator `/` is not allowed on flags types"}
+{"compile_error": "operator `/` cannot be applied to type"}

--- a/wado-compiler/tests/fixtures/flags_arith_mod.wado
+++ b/wado-compiler/tests/fixtures/flags_arith_mod.wado
@@ -10,4 +10,4 @@ export fn run() {
 }
 
 __DATA__
-{"compile_error": "arithmetic operator `%` is not allowed on flags types"}
+{"compile_error": "operator `%` cannot be applied to type"}

--- a/wado-compiler/tests/fixtures/flags_arith_mul.wado
+++ b/wado-compiler/tests/fixtures/flags_arith_mul.wado
@@ -10,4 +10,4 @@ export fn run() {
 }
 
 __DATA__
-{"compile_error": "arithmetic operator `*` is not allowed on flags types"}
+{"compile_error": "operator `*` cannot be applied to type"}

--- a/wado-compiler/tests/fixtures/flags_arith_sub.wado
+++ b/wado-compiler/tests/fixtures/flags_arith_sub.wado
@@ -11,4 +11,4 @@ export fn run() {
 }
 
 __DATA__
-{"compile_error": "arithmetic operator `-` is not allowed on flags types"}
+{"compile_error": "operator `-` cannot be applied to type"}

--- a/wado-compiler/tests/fixtures/float_mod_error.wado
+++ b/wado-compiler/tests/fixtures/float_mod_error.wado
@@ -5,4 +5,4 @@ export fn run() {
 }
 
 __DATA__
-{"compile_error": "operator `%` is not supported on `f64`"}
+{"compile_error": "operator `%` cannot be applied to type `f64`"}

--- a/wado-compiler/tests/fixtures/operator_not_applicable_mixed.wado
+++ b/wado-compiler/tests/fixtures/operator_not_applicable_mixed.wado
@@ -1,0 +1,14 @@
+// A binary operator applied to two incompatible types reports a symmetric
+// "cannot be applied to types L and R" message naming both operands, rather
+// than a one-sided "type mismatch". Reproduces the operand-order asymmetry
+// fixed alongside the operator-error rework.
+fn f(a: i32, lst: Array<i32>) -> i32 {
+    return a - lst;
+}
+
+export fn run() {
+    let _ = f(1, [2, 3]);
+}
+
+__DATA__
+{"compile_error": "operator `-` cannot be applied to types `i32` and `Array<i32>`"}

--- a/wado-compiler/tests/fixtures/operator_not_applicable_string.wado
+++ b/wado-compiler/tests/fixtures/operator_not_applicable_string.wado
@@ -1,0 +1,8 @@
+// The non-primitive operand on the left side produces the same symmetric
+// operator error (not an "invalid pattern:" message).
+export fn run() {
+    let _ = "x" * 3;
+}
+
+__DATA__
+{"compile_error": "operator `*` cannot be applied to types `String` and `i32`"}

--- a/wado-compiler/tests/fixtures/trait_bound_reason_field.wado
+++ b/wado-compiler/tests/fixtures/trait_bound_reason_field.wado
@@ -1,0 +1,17 @@
+// A `T: Ord` bound is unsatisfied because the argument struct has a field
+// whose type (a function) does not implement Ord. The diagnostic must
+// explain the cause, naming the offending field, not just state that the
+// type fails the bound.
+struct Handler { cb: fn(i32) -> i32 }
+
+fn smallest<T: Ord>(a: T, b: T) -> T {
+    if a < b { return a; }
+    return b;
+}
+
+export fn run() {
+    let _ = smallest(Handler { cb: |x: i32| x }, Handler { cb: |x: i32| x });
+}
+
+__DATA__
+{"compile_error": "does not implement `Ord` because field `cb`"}

--- a/wado-compiler/tests/fixtures/trait_bound_reason_nested.wado
+++ b/wado-compiler/tests/fixtures/trait_bound_reason_nested.wado
@@ -1,0 +1,20 @@
+// The reason chain unfolds recursively through nested structs: Outer fails
+// because field `inner: Inner` fails, which fails because field `f` is a
+// function type. The deepest cause is reported as a further `note:` line.
+struct Inner { f: fn() -> i32 }
+struct Outer { inner: Inner }
+
+fn smallest<T: Ord>(a: T, b: T) -> T {
+    if a < b { return a; }
+    return b;
+}
+
+export fn run() {
+    let _ = smallest(
+        Outer { inner: Inner { f: || 1 } },
+        Outer { inner: Inner { f: || 2 } },
+    );
+}
+
+__DATA__
+{"compile_error": "because field `inner`"}

--- a/wado-compiler/tests/trait_query.rs
+++ b/wado-compiler/tests/trait_query.rs
@@ -222,6 +222,59 @@ export fn run() {
     );
 }
 
+#[test]
+fn operator_error_is_not_labeled_invalid_pattern() {
+    // Operator type errors must read as operator errors, not as
+    // "invalid pattern:" — the latter is reserved for actual pattern
+    // contexts (match arms, `if let`, destructuring). Routing operator
+    // errors through `InvalidPattern` mislabeled them.
+    let msg = compile_err_contains(
+        r#"
+export fn run() {
+    let _ = "x" - 3;
+}
+"#,
+        "cannot be applied",
+    );
+    assert!(
+        !msg.contains("invalid pattern"),
+        "operator error must not be labeled `invalid pattern`, got: {msg}"
+    );
+}
+
+#[test]
+fn operator_mismatch_is_symmetric_in_operand_order() {
+    // A binary operator applied to two incompatible types must produce
+    // the same kind of message regardless of which operand is the
+    // non-primitive one. Previously `a - lst` (primitive lhs) reported a
+    // `TypeMismatch` while `lst - a` (non-primitive lhs) reported an
+    // operator error, so the same defect read completely differently
+    // depending on operand order.
+    let left_primitive = compile_err_contains(
+        r"
+fn f(a: i32, lst: Array<i32>) -> i32 { return a - lst; }
+export fn run() { let _ = f(1, [2, 3]); }
+",
+        "cannot be applied",
+    );
+    let left_non_primitive = compile_err_contains(
+        r"
+fn f(a: i32, lst: Array<i32>) -> i32 { return lst - a; }
+export fn run() { let _ = f(1, [2, 3]); }
+",
+        "cannot be applied",
+    );
+    // Both name the two operand types.
+    assert!(
+        left_primitive.contains("i32") && left_primitive.contains("Array<i32>"),
+        "expected both operand types, got: {left_primitive}"
+    );
+    assert!(
+        left_non_primitive.contains("i32") && left_non_primitive.contains("Array<i32>"),
+        "expected both operand types, got: {left_non_primitive}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Unary trait operators (Neg, BitNot) go through the same subsystem
 // ---------------------------------------------------------------------------

--- a/wado-compiler/tests/trait_query.rs
+++ b/wado-compiler/tests/trait_query.rs
@@ -275,6 +275,55 @@ export fn run() { let _ = f(1, [2, 3]); }
     );
 }
 
+#[test]
+fn trait_bound_error_explains_offending_field() {
+    // When a `T: Ord` bound is unsatisfied, the diagnostic must explain WHY:
+    // name the struct field whose type breaks the auto-derive, not just state
+    // that the type "does not implement Ord".
+    let msg = compile_err_contains(
+        r"
+struct Handler { cb: fn(i32) -> i32 }
+fn smallest<T: Ord>(a: T, b: T) -> T {
+    if a < b { return a; }
+    return b;
+}
+export fn run() {
+    let _ = smallest(Handler { cb: |x: i32| x }, Handler { cb: |x: i32| x });
+}
+",
+        "does not implement trait 'Ord'",
+    );
+    assert!(
+        msg.contains("note:") && msg.contains("field `cb`"),
+        "expected a reason chain naming field `cb`, got: {msg}"
+    );
+}
+
+#[test]
+fn trait_bound_error_reason_chain_is_recursive() {
+    // The reason chain unfolds through nested structs: Outer fails because
+    // field `inner: Inner` fails, which in turn fails because field `f` is a
+    // function type.
+    let msg = compile_err_contains(
+        r"
+struct Inner { f: fn() -> i32 }
+struct Outer { inner: Inner }
+fn smallest<T: Ord>(a: T, b: T) -> T {
+    if a < b { return a; }
+    return b;
+}
+export fn run() {
+    let _ = smallest(Outer { inner: Inner { f: || 1 } }, Outer { inner: Inner { f: || 2 } });
+}
+",
+        "does not implement trait 'Ord'",
+    );
+    assert!(
+        msg.contains("field `inner`") && msg.contains("field `f`"),
+        "expected a recursive reason chain (Outer -> inner -> f), got: {msg}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Unary trait operators (Neg, BitNot) go through the same subsystem
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Motivation

Wado source — including this compiler — is increasingly written and repaired by AI coding agents, so the compiler's error messages are read by agents as much as by humans. Krishnamurthi & Flatt, *Type-Error Ablation and AI Coding Agents* (arXiv:2606.01522), show that more detailed type-error messages measurably improve an agent's fix rate, and that the benefit lands on the agent's *first* hypothesis — so the cause should be present in the initial message.

An inventory placed Wado's diagnostics at the paper's `proximate` level (a single span plus both types, but no chain of causes). This PR moves trait/operator diagnostics toward the paper's `all` level, **by default** — no separate "AI mode". See `docs/wep-2026-06-02-diagnostic-reason-chains.md`.

## Changes

### 1. Symmetric, correctly-labeled operator errors

Operator type errors were routed through `TypeError::InvalidPattern`, which mislabeled them `invalid pattern:`, and were asymmetric — `a - lst` reported a `TypeMismatch` while `lst - a` reported an operator error. Added `TypeError::OperatorNotApplicable`; the requires-trait check now inspects both operands so the message is symmetric:

```
operator `-` cannot be applied to types `i32` and `Array<i32>`   // a - lst
operator `-` cannot be applied to types `Array<i32>` and `i32`   // lst - a
```

### 2. Trait-bound reason chains

A `T: Ord` / `T: Eq` failure named only the type and trait, never the field that breaks the auto-derive. Added `trait_unimpl_reason_chain`, which walks the `Eq`/`Ord` auto-derive structure (struct fields, generic-struct fields with type-arg substitution, variant payloads), finds the first member that breaks the trait, and recurses — rendered by default as indented `note:` lines:

```
error: type 'Outer' does not implement trait 'Ord' required by bound on 'T'
  note: `Outer` does not implement `Ord` because field `inner` of type `Inner` does not implement `Ord`
  note: `Inner` does not implement `Ord` because field `f` of type `fn() -> i32` does not implement `Ord`
```

The chain is folded into the existing `Diagnostic.message` string (same pattern as `OperatorNotApplicable`'s `note`), avoiding edits to the ~85 `Diagnostic` construction sites. Structured note spans are deferred to a follow-up (tracked in the WEP).

## Testing

- Unit tests (`trait_query.rs`): operator prefix removal, operand-order symmetry, single + recursive reason chains.
- E2E fixtures: `operator_not_applicable_{mixed,string}`, `trait_bound_reason_{field,nested}` (O0/O2). The operator fixtures also backfill coverage for the operator rework.
- Full `wado-compiler` suite green; no regressions. Operator overloading (`impl Sub`) and `Eq`/`Ord` auto-derive verified to still compile.

## Known limits / follow-ups (see WEP)

- Notes are strings without their own spans (no jump-to-field yet).
- Only `Eq`/`Ord` auto-derive is unfolded; missing user `impl`s and generic-inference provenance are not yet explained.

https://claude.ai/code/session_01NQ4k2LDiqQ3Fn6y9cBDVmp

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQ4k2LDiqQ3Fn6y9cBDVmp)_