### PR TITLE
elaborator: Stage 7-B — make the call / operator surface record-only

### DIFF
--- a/wado-compiler/src/elaborator.rs
+++ b/wado-compiler/src/elaborator.rs
@@ -203,22 +203,24 @@ pub struct Elaborator<'a, H: CompilerHost> {
     /// instances can `borrow_mut()` it from `&self` contexts (e.g.
     /// `record_use_specifier_references`).
     pub(super) interner: Rc<RefCell<ModuleSourceInterner>>,
-    /// Side-channel populated by [`Self::resolve_method_call_with`]
-    /// immediately before it builds the final `TirExprKind::MethodCall`,
-    /// carrying the `(self_kind, is_ref_impl)` the dispatch resolved.
-    /// Synthetic callers (e.g. for-of's `.into_iter()` / `.next()`) read
-    /// it back to record the dispatch info their own way — they pass
-    /// `call_id == None` so the in-function `record_method_dispatch`
-    /// call is skipped, and reify needs the recorded receiver-adjustment
-    /// inputs all the same (Gap 6 of WEP 2026-05-26 §`Design notes
-    /// (Stage 5)`).
+    /// Side-channel populated by [`Self::resolve_method_call_with`] for the
+    /// successful-dispatch case, carrying the `(self_kind, is_ref_impl,
+    /// FunctionRef)` the dispatch resolved. Synthetic callers (e.g. for-of's
+    /// `.into_iter()` / `.next()`) read it back to record the dispatch info
+    /// their own way — they pass `call_id == None` so the in-function
+    /// `record_method_dispatch` call is skipped, and reify needs the
+    /// recorded receiver-adjustment inputs + the resolved `FunctionRef` all
+    /// the same (Gap 6 of WEP 2026-05-26 §`Design notes (Stage 5)`).
+    /// Since Stage 7-B `resolve_method_call_with` returns only a typed
+    /// placeholder, so the `FunctionRef` travels through this channel rather
+    /// than being recovered from the returned `MethodCall` TIR.
     ///
     /// Cleared at the top of `resolve_method_call_with` so a synthetic
     /// caller never accidentally reads a stale value from a previous
     /// dispatch. `None` means either no dispatch ran (the short-circuit
     /// paths returned early) or the method-not-found recovery branch
     /// took over.
-    pub(super) pending_method_dispatch: Option<(ast::SelfKind, bool)>,
+    pub(super) pending_method_dispatch: Option<(ast::SelfKind, bool, tir::FunctionRef)>,
     /// Side-channel populated by [`Self::resolve_binary`] and the
     /// `Expr::Index` arm of [`Self::resolve_expr`] before they call
     /// the trait-operator dispatcher, carrying the source-level

--- a/wado-compiler/src/elaborator.rs
+++ b/wado-compiler/src/elaborator.rs
@@ -212,7 +212,7 @@ pub struct Elaborator<'a, H: CompilerHost> {
     /// recorded receiver-adjustment inputs + the resolved `FunctionRef` all
     /// the same (Gap 6 of WEP 2026-05-26 §`Design notes (Stage 5)`).
     /// Since Stage 7-B `resolve_method_call_with` returns only a typed
-    /// placeholder, so the `FunctionRef` travels through this channel rather
+    /// placeholder, the `FunctionRef` travels through this channel rather
     /// than being recovered from the returned `MethodCall` TIR.
     ///
     /// Cleared at the top of `resolve_method_call_with` so a synthetic

--- a/wado-compiler/src/elaborator/call.rs
+++ b/wado-compiler/src/elaborator/call.rs
@@ -1217,16 +1217,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             }
         }
 
-        let callee_expr = self.deref_to_value(callee_expr, call.span);
-
-        TirExpr::new(
-            TirExprKind::IndirectCall {
-                callee: Box::new(callee_expr),
-                args,
-            },
-            return_type,
-            call.span,
-        )
+        // Stage 7-B: reify (`reify_call`'s indirect-call branch) rebuilds
+        // the `IndirectCall` from the AST — resolving the callee, applying
+        // `deref_to_value`, and reifying the args — so the combined walk
+        // projects only the result type. `callee_expr` and `args` were
+        // resolved / typechecked above for their fact-recording side effects.
+        let _ = (callee_expr, args);
+        placeholder(return_type, call.span)
     }
 
     /// Look up the return type of a function
@@ -2785,24 +2782,16 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             self.sem.types.static_method_dispatch.insert(
                 key,
                 super::sem::types::StaticMethodDispatch {
-                    function_ref: func_ref.clone(),
+                    function_ref: func_ref,
                     param_is_mut: vec![false; args.len()],
                     type_args: vec![],
                 },
             );
 
-            return TirExpr::new(
-                TirExprKind::Call {
-                    func: func_ref,
-                    type_args: vec![],
-                    args: args
-                        .iter()
-                        .map(|e| CallArg::new(e.clone(), false))
-                        .collect(),
-                },
-                final_return_type,
-                call.span,
-            );
+            // Stage 7-B: reify rebuilds the `T::method(...)` `Call` from the
+            // recorded `static_method_dispatch`; project only the result type.
+            let _ = args;
+            return placeholder(final_return_type, call.span);
         }
 
         let _ = self.logger.error(TypeError::UnknownFunction {

--- a/wado-compiler/src/elaborator/call.rs
+++ b/wado-compiler/src/elaborator/call.rs
@@ -1222,7 +1222,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Stage 7-B: reify (`reify_call`'s indirect-call branch) rebuilds
         // the `IndirectCall` from the AST — resolving the callee, applying
-        // `deref_to_value`, and reifying the args — so the combined walk
+        // `deref_to_value_static`, and reifying the args — so the combined walk
         // projects only the result type. `callee_expr` and `args` were
         // resolved / typechecked above for their fact-recording side effects.
         let _ = (callee_expr, args);

--- a/wado-compiler/src/elaborator/call.rs
+++ b/wado-compiler/src/elaborator/call.rs
@@ -604,41 +604,24 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     }
                 }
 
-                let tir_call = self.resolve_static_method_call_from_qualified(
+                // Stage 5/7-B (WEP 2026-05-26): `resolve_static_method_call_from_qualified`
+                // records the resolved `FunctionRef` under `call.id` itself
+                // (`static_method_dispatch`) so reify can reproduce the same
+                // `Call` shape without re-running impl lookup, mangled-name
+                // construction, or monomorph-info shaping — facts reify
+                // cannot reconstruct from the AST alone. It returns only a
+                // typed placeholder.
+                return self.resolve_static_method_call_from_qualified(
                     prefix,
                     suffix,
                     &mangled_name,
                     &args,
                     &impl_type_args_inferred,
                     &method_type_args,
+                    call.id,
                     call.span,
                     ctx,
                 );
-                // Stage 5 (WEP 2026-05-26): record the resolved
-                // `FunctionRef` so reify can reproduce the same TIR
-                // shape without re-running impl lookup, mangled-name
-                // construction, or monomorph-info shaping. Reify cannot
-                // reconstruct these from the AST alone — they depend on
-                // trait-impl resolution that lives only in the elaborator.
-                if let crate::tir::TirExprKind::Call {
-                    func,
-                    args: tir_args,
-                    type_args: tir_type_args,
-                } = &tir_call.kind
-                {
-                    let func_ref = func.clone();
-                    let param_is_mut: Vec<bool> = tir_args.iter().map(|a| a.is_mut).collect();
-                    let key = self.ann_key(call.id);
-                    self.sem.types.static_method_dispatch.insert(
-                        key,
-                        super::sem::types::StaticMethodDispatch {
-                            function_ref: func_ref,
-                            param_is_mut,
-                            type_args: tir_type_args.clone(),
-                        },
-                    );
-                }
-                return tir_call;
             }
             // Check if this is a flags type method call: Perms::none(), Perms::all()
             else if let Some(flags_info) = self.lookup_flags_case(prefix).cloned()

--- a/wado-compiler/src/elaborator/call.rs
+++ b/wado-compiler/src/elaborator/call.rs
@@ -15,6 +15,18 @@ use super::callee::{CalleeRef, StaticMethodRef};
 use super::infer::InferCtx;
 use super::types::{FunctionContext, TypeError};
 
+/// Body-walk placeholder for a resolved call. Stage 7-B: the combined walk
+/// records the dispatch decision (`static_method_dispatch` /
+/// `generic_instantiations` / `call_param_types` / the variant + `From`
+/// facts) and resolves the arguments for their side-effect fact recording,
+/// but no longer assembles the call's TIR — reify is the sole producer and
+/// rebuilds it from the recorded facts. The returned `TirExpr` only needs
+/// the right `type_id` + `span` for the caller's outer typecheck /
+/// `expression_types` recording.
+fn placeholder(type_id: TypeId, span: crate::token::Span) -> TirExpr {
+    TirExpr::new(TirExprKind::Unit, type_id, span)
+}
+
 /// View of a `ResolvedType::Function` after peeling references and
 /// fn-type newtypes. Returned by [`Elaborator::as_fn_signature`].
 struct FnSignature {
@@ -540,14 +552,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             call.id,
                             super::sem::types::DesugarKind::NewtypeFromUnwrap,
                         );
-                        return TirExpr::new(
-                            TirExprKind::Cast {
-                                expr: Box::new(args[0].clone()),
-                                target_type: base_id,
-                            },
-                            base_id,
-                            call.span,
-                        );
+                        // Stage 7-B: reify rebuilds the newtype `Cast` from the
+                        // recorded `DesugarKind`; project only the result type.
+                        return placeholder(base_id, call.span);
                     }
 
                     // Base→Newtype: UserId::from(u64_val) where type UserId = u64
@@ -564,14 +571,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 call.id,
                                 super::sem::types::DesugarKind::NewtypeFromWrap,
                             );
-                            return TirExpr::new(
-                                TirExprKind::Cast {
-                                    expr: Box::new(args[0].clone()),
-                                    target_type: newtype_type_id,
-                                },
-                                newtype_type_id,
-                                call.span,
-                            );
+                            // Stage 7-B: reify rebuilds the newtype `Cast` from
+                            // the recorded `DesugarKind`; project only the type.
+                            return placeholder(newtype_type_id, call.span);
                         }
                     }
                 }
@@ -630,20 +632,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 if let Some(prefix_seg) = ident.segments.first() {
                     self.record_item_reference_by_name(prefix_seg.id, prefix);
                 }
-                let member_count = flags_info.members.len();
-                let value: u64 = match suffix {
-                    "none" => 0,
-                    "all" => u64::from((1u32 << member_count) - 1),
-                    _ => unreachable!(),
-                };
-                return TirExpr::new(
-                    TirExprKind::IntLiteral {
-                        value,
-                        repr: value.to_string(),
-                    },
-                    flags_info.type_id,
-                    call.span,
-                );
+                // Stage 7-B: reify rebuilds the flags `none()` / `all()`
+                // constant from the AST + flags info; the combined walk
+                // projects only the result type.
+                return placeholder(flags_info.type_id, call.span);
             }
             // Check if this is a variant case construction (Color::Red)
             else if let Some(variant_info) = self.lookup_variant_case(prefix) {
@@ -711,16 +703,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     };
                     self.record_generic_instantiation(call.id, type_args, variant_type);
 
-                    return TirExpr::new(
-                        TirExprKind::VariantConstruct {
-                            variant_type,
-                            case_index: case_index as u32,
-                            case_name: case_data.name.clone(),
-                            payload,
-                        },
-                        variant_type,
-                        call.span,
-                    );
+                    // Stage 7-B: reify rebuilds the `VariantConstruct` from
+                    // the AST + variant info + recorded `generic_instantiations`;
+                    // the combined walk projects only the result type. The
+                    // payload was resolved above (and fed variant type-arg
+                    // inference) for its fact-recording side effects.
+                    let _ = (case_index, payload);
+                    return placeholder(variant_type, call.span);
                 }
                 // If no matching case, check for From<T> synthesis requests
                 else if suffix == "from" && args.len() == 1 {
@@ -859,16 +848,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             };
                             self.record_generic_instantiation(call.id, type_args, variant_type);
 
-                            return TirExpr::new(
-                                TirExprKind::VariantConstruct {
-                                    variant_type,
-                                    case_index: case_index as u32,
-                                    case_name: case_data.name.clone(),
-                                    payload,
-                                },
-                                variant_type,
-                                call.span,
-                            );
+                            // Stage 7-B: reify rebuilds the `VariantConstruct`;
+                            // the combined walk projects only the result type.
+                            let _ = (case_index, payload);
+                            return placeholder(variant_type, call.span);
                         }
                     }
 
@@ -950,21 +933,18 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     self.sem.types.static_method_dispatch.insert(
                         key,
                         super::sem::types::StaticMethodDispatch {
-                            function_ref: func_ref.clone(),
+                            function_ref: func_ref,
                             param_is_mut,
                             type_args: vec![],
                         },
                     );
 
-                    return TirExpr::new(
-                        TirExprKind::Call {
-                            func: func_ref,
-                            type_args: vec![],
-                            args: call_args,
-                        },
-                        return_type,
-                        call.span,
-                    );
+                    // Stage 7-B: reify rebuilds the `Call` from the recorded
+                    // `static_method_dispatch`; the combined walk projects
+                    // only the result type. `call_args` (resolved above) is
+                    // discarded.
+                    let _ = call_args;
+                    return placeholder(return_type, call.span);
                 }
                 (
                     Some(CalleeRef::new(ns_source, suffix)),
@@ -1155,11 +1135,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
 
         let param_is_mut = self.lookup_function_param_is_mut(&call.callee);
-        let call_args: Vec<CallArg> = args
-            .into_iter()
-            .zip(param_is_mut.iter().copied().chain(std::iter::repeat(false)))
-            .map(|(expr, is_mut)| CallArg::new(expr, is_mut))
-            .collect();
         let func_ref = FunctionRef {
             module_source: callee.module,
             name: callee.name,
@@ -1178,20 +1153,18 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         self.sem.types.static_method_dispatch.insert(
             key,
             super::sem::types::StaticMethodDispatch {
-                function_ref: func_ref.clone(),
+                function_ref: func_ref,
                 param_is_mut,
                 type_args: type_args.clone(),
             },
         );
-        TirExpr::new(
-            TirExprKind::Call {
-                func: func_ref,
-                type_args,
-                args: call_args,
-            },
-            return_type,
-            call.span,
-        )
+        // Stage 7-B: reify rebuilds the `Call` TIR from the recorded
+        // `static_method_dispatch` + `generic_instantiations` +
+        // `call_param_types` and the resolved args; the combined walk
+        // projects only the result type. `args` was resolved above for its
+        // fact-recording side effects and is now discarded.
+        let _ = (args, type_args);
+        placeholder(return_type, call.span)
     }
 
     /// Lower `call` into a `TirExprKind::IndirectCall` using `callee_expr`

--- a/wado-compiler/src/elaborator/item.rs
+++ b/wado-compiler/src/elaborator/item.rs
@@ -1275,7 +1275,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             timeout_ms,
         };
 
-        Some((placeholder_function(function_name, test_decl.span), tir_test))
+        Some((
+            placeholder_function(function_name, test_decl.span),
+            tir_test,
+        ))
     }
 
     /// Resolve a method (function with &self parameter)

--- a/wado-compiler/src/elaborator/item.rs
+++ b/wado-compiler/src/elaborator/item.rs
@@ -10,10 +10,10 @@ use crate::compiler_item::{
 use crate::hashmap::IndexSet;
 use crate::logger::Logger;
 use crate::module_source::ModuleSource;
-use crate::name::{LocalMethodName, MethodName};
+use crate::name::MethodName;
 use crate::tir::{
     FunctionKind, TirEffect, TirEffectOp, TirFunction, TirGlobal, TirParam, TirResource, TirStruct,
-    TirTest, TirVariantCase, TirVariantDecl, TypeId, TypeTable,
+    TirTest, TirVariantDecl, TypeId, TypeTable,
 };
 use crate::token::Span;
 
@@ -38,6 +38,49 @@ pub(super) fn extract_compiler_item<H: CompilerHost>(
         });
     }
     items.into_iter().next()
+}
+
+/// Body-walk placeholder for a function / method / test. Stage 7-B: the
+/// combined walk records the signature facts (`fn_param_types`,
+/// `fn_return_types`, `decl_type_params`, `function_effects`,
+/// `method_names`, …) and resolves the body for its side-effect fact
+/// recording, but no longer assembles the function's TIR — reify is the
+/// sole producer. The returned `TirFunction` flows only into the
+/// discarded `tir_module` of `resolve_module`, so a minimal shell with
+/// the right name + span is all callers need.
+fn placeholder_function(name: String, span: Span) -> TirFunction {
+    TirFunction {
+        module_source: ModuleSource::default(),
+        name,
+        is_pub: false,
+        is_export: false,
+        is_async: false,
+        type_params: vec![],
+        impl_type_params: vec![],
+        monomorph_info: None,
+        method_info: None,
+        params: vec![],
+        return_type: TypeTable::UNIT,
+        task_return_type: None,
+        effects: vec![],
+        stores: vec![],
+        body: None,
+        span,
+        local_count: 0,
+        locals: vec![],
+        address_taken_locals: IndexSet::default(),
+        stores_aliased_locals: IndexSet::default(),
+        is_cm_binding: false,
+        is_dispatch_wrapper: false,
+        is_cm_export: false,
+        is_ambient: false,
+        inline_hint: crate::tir::InlineHint::Auto,
+        compiler_item: None,
+        export_name: None,
+        allocator_tag: None,
+        kind: FunctionKind::Regular,
+        return_abi: crate::tir::ReturnAbi::default(),
+    }
 }
 
 /// Push a [`RegisterError`] into the diagnostic stream. Duplicate
@@ -455,45 +498,23 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         scope.trait_ctx.type_params.clear();
         scope.register_generic_params(&struct_decl.type_params, 0);
 
-        // Resolve field defaults in the struct's module scope. A field default
-        // is standalone (no self, no other fields in scope) and must be pure;
-        // the purity check runs in `effect_check`.
+        // Resolve field types (recorded below as `struct_field_types`) and
+        // walk each field default for its side-effect fact recording (the
+        // default's per-`AstId` expression types, which `reify_struct`'s
+        // `reify_expr` reads back). A field default is standalone (no self,
+        // no other fields in scope) and must be pure; the purity check runs
+        // in `effect_check`. The resolved default TIR itself is discarded —
+        // reify re-emits it from the AST + recorded types.
         let mut field_ctx =
             FunctionContext::new(TypeTable::UNIT, format!("struct:{}", struct_decl.name));
-        let mut fields = Vec::new();
-        for (index, field) in struct_decl.fields.iter().enumerate() {
+        let mut struct_field_types: Vec<TypeId> = Vec::with_capacity(struct_decl.fields.len());
+        for field in &struct_decl.fields {
             let type_id = scope.resolve_type(&field.ty);
-            let serde_rename = field.attrs.iter().find_map(|a| {
-                if a.name == "serde" {
-                    a.kv_value("rename").map(str::to_string)
-                } else {
-                    None
-                }
-            });
-            let default_expr = field.default.as_ref().map(|default_ast| {
+            if let Some(default_ast) = &field.default {
                 let resolved = scope.resolve_expr(default_ast, &mut field_ctx, Some(type_id));
                 scope.typecheck(resolved.type_id, type_id, default_ast.span());
-                Box::new(resolved)
-            });
-            // A field with a declared default is implicitly non-required at
-            // deserialization time: the synthesized Deserialize uses the
-            // default expression when the field is absent (WEP 2026-04-11).
-            let serde_default = default_expr.is_some()
-                || field
-                    .attrs
-                    .iter()
-                    .any(|a| a.name == "serde" && a.has_arg("default"));
-            fields.push(crate::tir::TirField {
-                name: field.name.clone(),
-                is_pub: field.is_pub,
-                type_id,
-                index: index as u32,
-                span: field.span,
-                is_hidden: field.attrs.iter().any(|a| a.name == "hidden"),
-                serde_rename,
-                serde_default,
-                default_expr,
-            });
+            }
+            struct_field_types.push(type_id);
         }
 
         // Convert AST type params to TIR type params (while type params still in scope)
@@ -518,35 +539,30 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         self.sem
             .types
             .decl_type_params
-            .insert(self.ann_key(struct_decl.id), type_params.clone());
+            .insert(self.ann_key(struct_decl.id), type_params);
 
         // Record per-field resolved types for reify to read instead of
         // re-resolving them off the static decl pass + UNKNOWN-fallback.
         // The static pass cannot follow `pub use` re-export chains; the
         // resolution we just did, with `loaded_modules` in scope, can.
-        let struct_field_types: Vec<TypeId> = fields.iter().map(|f| f.type_id).collect();
         self.sem
             .types
             .struct_field_types
             .insert(self.ann_key(struct_decl.id), struct_field_types);
 
-        let serde_rename_all = struct_decl.attrs.iter().find_map(|a| {
-            if a.name == "serde" {
-                a.kv_value("rename_all").map(str::to_string)
-            } else {
-                None
-            }
-        });
-
+        // Stage 7-B: reify (`reify_struct`) emits the `TirStruct` from the
+        // recorded `struct_field_types` / `decl_type_params` + the AST.
+        // The combined walk's struct TIR is discarded, so a minimal shell
+        // is enough here.
         TirStruct {
             name: struct_decl.name.clone(),
             module_source: self.current_module_source.clone(),
             is_pub: struct_decl.is_pub,
-            type_params,
-            monomorph_info: None, // Not from monomorphization
-            fields,
+            type_params: vec![],
+            monomorph_info: None,
+            fields: vec![],
             span: struct_decl.span,
-            serde_rename_all,
+            serde_rename_all: None,
         }
     }
 
@@ -735,29 +751,33 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // The function name is used for #function compile-time literal (empty for global init)
         let mut ctx = FunctionContext::new(ty, format!("global:{}", global_decl.name));
 
-        // Resolve the initializer expression with expected type for type inference
+        // Resolve the initializer expression with expected type for type
+        // inference. The resolved TIR is discarded — its per-`AstId`
+        // expression types are recorded for reify (`reify_global`), which
+        // re-emits the initializer from the AST.
         let initializer = self.resolve_expr(&global_decl.initializer, &mut ctx, Some(ty));
 
         // Type check: initializer type must match declared type.
         self.typecheck(initializer.type_id, ty, global_decl.initializer.span());
 
+        // Stage 7-B: reify emits the `TirGlobal`; the combined walk's copy
+        // is discarded, so a minimal shell with the resolved type is enough.
         Some(TirGlobal {
             name: global_decl.name.clone(),
             ty,
-            initializer,
+            initializer: crate::tir::TirExpr::new(
+                crate::tir::TirExprKind::Unit,
+                ty,
+                global_decl.initializer.span(),
+            ),
             mutable: global_decl.mutable,
             wado_mutable: global_decl.mutable,
             is_pub: global_decl.is_pub,
             module_source: self.current_module_source.clone(),
             span: global_decl.span,
-            // Both flags are set by the lower phase: `is_nullable` for
-            // any global whose Wasm slot needs to accept `ref.null`, and
-            // `lazy_init` for globals whose initializer runs in
-            // `__initialize_module` (i.e. codegen narrows reads after
-            // init). Constant `null` initializers set only `is_nullable`.
             is_nullable: false,
             lazy_init: false,
-            locals: ctx.locals.clone(),
+            locals: vec![],
         })
     }
 
@@ -773,23 +793,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let mut scope = self.enter_inherited_type_param_scope();
         scope.trait_ctx.type_params.clear();
         scope.register_generic_params(&variant_decl.type_params, 0);
-
-        // Resolve each case - each variant case has exactly one payload type
-        let mut cases = Vec::new();
-        for (index, case) in variant_decl.cases.iter().enumerate() {
-            // Unit variants have `()` (unit type) payload
-            let payload = if let Some(payload_ty) = &case.payload {
-                scope.resolve_type(payload_ty)
-            } else {
-                TypeTable::UNIT
-            };
-            cases.push(TirVariantCase {
-                name: case.name.clone(),
-                index: index as u32,
-                payload,
-                span: case.span,
-            });
-        }
 
         // Convert AST type params to TIR type params (while type params still in scope)
         let type_params: Vec<crate::tir::TirTypeParam> = variant_decl
@@ -813,7 +816,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         self.sem
             .types
             .decl_type_params
-            .insert(self.ann_key(variant_decl.id), type_params.clone());
+            .insert(self.ann_key(variant_decl.id), type_params);
 
         register_variant_compiler_item(
             &self.tysys.type_table,
@@ -824,52 +827,17 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             self.logger,
         );
 
+        // Stage 7-B: reify (`reify_variant_decl`) emits the `TirVariantDecl`
+        // from `tysys.all_variant_cases` (payloads) + the recorded
+        // `decl_type_params` + the AST. The combined walk's variant TIR is
+        // discarded, so a minimal shell is enough here.
         TirVariantDecl {
             name: variant_decl.name.clone(),
             module_source: self.current_module_source.clone(),
             is_pub: variant_decl.is_pub,
-            type_params,
-            cases,
+            type_params: vec![],
+            cases: vec![],
             span: variant_decl.span,
-        }
-    }
-
-    /// Extract custom wasm export name from `#[export_name("...")]` attribute.
-    pub(super) fn extract_export_name(attrs: &[crate::ast::Attribute]) -> Option<String> {
-        attrs
-            .iter()
-            .find(|a| a.name == "export_name")
-            .and_then(|a| a.args.first())
-            .map(|a| a.as_str().to_string())
-    }
-
-    /// Extract allocator tag from `#[allocator("...")]` attribute.
-    fn extract_allocator_tag(attrs: &[crate::ast::Attribute]) -> Option<String> {
-        attrs
-            .iter()
-            .find(|a| a.name == "allocator")
-            .and_then(|a| a.args.first())
-            .map(|a| a.as_str().to_string())
-    }
-
-    /// Extract `#[ambient]` marker from function attributes.
-    /// Ambient functions bypass effect-check propagation to callers: they may
-    /// declare effects for implementation purposes, but callers don't need to
-    /// list those effects. Intended for low-level helpers like `log_stdout`
-    /// that use an implicit ambient capability.
-    pub(super) fn extract_is_ambient(attrs: &[crate::ast::Attribute]) -> bool {
-        attrs.iter().any(|a| a.name == "ambient")
-    }
-
-    pub(super) fn extract_inline_hint(attrs: &[crate::ast::Attribute]) -> crate::tir::InlineHint {
-        let Some(attr) = attrs.iter().find(|a| a.name == "inline") else {
-            return crate::tir::InlineHint::Auto;
-        };
-        match attr.args.first().map(super::super::ast::AttrArg::as_str) {
-            Some("always") => crate::tir::InlineHint::Always,
-            Some("never") => crate::tir::InlineHint::Never,
-            None => crate::tir::InlineHint::Hint,
-            _ => crate::tir::InlineHint::Auto,
         }
     }
 
@@ -1106,7 +1074,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     span: param.span,
                 });
             }
-            let default_expr = param.default.as_ref().map(|default_ast| {
+            // Walk the default for its side-effect fact recording (its
+            // per-`AstId` expression types, which reify reads back); the
+            // resolved TIR is discarded — reify re-emits it from the AST.
+            if let Some(default_ast) = &param.default {
                 if func.is_export {
                     let _ = scope.logger.error(TypeError::DefaultInExportFn {
                         function: func.name.clone(),
@@ -1116,8 +1087,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 }
                 let resolved = scope.resolve_expr(default_ast, &mut ctx, Some(type_id));
                 scope.typecheck(resolved.type_id, type_id, default_ast.span());
-                Box::new(resolved)
-            });
+            }
             let index = ctx.add_local(param.name.clone(), type_id, param.is_mut, Some(param.id));
             scope.record_local_symbol(
                 param.id,
@@ -1126,12 +1096,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 param.is_mut,
                 type_id,
             );
+            // `params` survives only to feed the recorded `fn_param_types`
+            // and `validate_stores`; the TIR `default_expr` is not built.
             params.push(TirParam {
                 name: param.name.clone(),
                 type_id,
                 local_index: index,
                 is_mut: param.is_mut,
-                default_expr,
+                default_expr: None,
                 span: param.span,
             });
         }
@@ -1148,11 +1120,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Validate stores declarations
         scope.validate_stores(&func.stores, &params, func.span);
 
-        // Resolve body
-        let body = func
-            .body
-            .as_ref()
-            .map(|b| scope.resolve_block(b, &mut ctx, None));
+        // Walk the body for its side-effect fact recording; the resolved
+        // `TirBlock` is discarded (reify re-emits it from the AST + facts).
+        if let Some(b) = func.body.as_ref() {
+            scope.resolve_block(b, &mut ctx, None);
+        }
 
         scope.validate_missing_return_ast(return_type, func.body.as_ref(), func.span);
 
@@ -1196,11 +1168,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // `current_effect_param_decls`, so the annotate phase records
         // the already-resolved list here keyed by the function's `AstId`.
         let func_key = scope.ann_key(func.id);
-        scope
-            .sem
-            .types
-            .function_effects
-            .insert(func_key, effects.clone());
+        scope.sem.types.function_effects.insert(func_key, effects);
 
         // Stage 5: an async function's wasm return type is erased to
         // `()`; record the declared (pre-erasure) return type so reify
@@ -1232,49 +1200,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             .types
             .fn_return_types
             .insert(sig_key.clone(), return_type);
-        self.sem
-            .types
-            .decl_type_params
-            .insert(sig_key, type_params.clone());
+        self.sem.types.decl_type_params.insert(sig_key, type_params);
 
-        Some(TirFunction {
-            module_source: ModuleSource::default(),
-            name: func.name.clone(),
-            is_pub: func.is_pub,
-            is_export: func.is_export,
-            is_async: func.is_async,
-            type_params,
-            impl_type_params: vec![], // Not a method, no impl type params
-            monomorph_info: None,     // Not from monomorphization
-            method_info: None,        // Not a method
-            params,
-            return_type,
-            task_return_type: if func.is_async {
-                Some(declared_return_type)
-            } else {
-                None
-            },
-            effects,
-            stores: func.stores.clone(),
-            body,
-            span: func.span,
-            local_count: ctx.next_local,
-            locals: ctx.locals.clone(),
-            address_taken_locals: ctx.address_taken_locals,
-            stores_aliased_locals: IndexSet::default(),
-            // Scratch local fields - computed by lower phase
-            is_cm_binding: false,
-            is_dispatch_wrapper: false,
-            is_cm_export: false,
-            is_ambient: Self::extract_is_ambient(&func.attrs),
-            inline_hint: Self::extract_inline_hint(&func.attrs),
-            compiler_item: extract_compiler_item(&func.attrs, func.span, self.logger),
-            export_name: Self::extract_export_name(&func.attrs),
-            allocator_tag: Self::extract_allocator_tag(&func.attrs),
-            kind: FunctionKind::Regular,
-
-            return_abi: crate::tir::ReturnAbi::default(),
-        })
+        // Stage 7-B: reify (`reify_function`) emits the `TirFunction` from
+        // the recorded signature facts + the AST. The combined walk's copy
+        // is discarded, so a minimal shell with the right name + span is
+        // all `resolve_module` needs.
+        Some(placeholder_function(func.name.clone(), func.span))
     }
 
     /// Resolve a test declaration to a `TirFunction` and `TirTest`
@@ -1324,46 +1256,18 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let return_type = TypeTable::UNIT;
         let mut ctx = FunctionContext::new(return_type, function_name.clone());
 
-        // Resolve the test body
-        let body = self.resolve_block(&test_decl.body, &mut ctx, None);
+        // Walk the test body for its side-effect fact recording (its
+        // per-`AstId` expression types, recorded under the `function_name`
+        // context so `#function` literals match what reify emits); the
+        // resolved `TirBlock` is discarded.
+        self.resolve_block(&test_decl.body, &mut ctx, None);
 
-        let tir_func = TirFunction {
-            module_source: ModuleSource::default(),
-            name: function_name.clone(),
-            is_pub: false,    // Tests are not public
-            is_export: false, // Tests are not world exports
-            is_async: false,  // Tests are never async
-            type_params: vec![],
-            impl_type_params: vec![],
-            monomorph_info: None,
-            method_info: None,
-            params: vec![], // Tests have no parameters
-            return_type,
-            task_return_type: None,
-            effects: vec![], // Tests can have any effects (they're allowed to do I/O)
-            stores: vec![],
-            body: Some(body),
-            span: test_decl.span,
-            local_count: ctx.next_local,
-            locals: ctx.locals.clone(),
-            address_taken_locals: ctx.address_taken_locals,
-            stores_aliased_locals: IndexSet::default(),
-            is_cm_binding: false,
-            is_dispatch_wrapper: false,
-            is_cm_export: false,
-            is_ambient: false,
-            inline_hint: crate::tir::InlineHint::Auto,
-            compiler_item: None,
-            export_name: None,
-            allocator_tag: None,
-            kind: FunctionKind::Regular,
-
-            return_abi: crate::tir::ReturnAbi::default(),
-        };
-
+        // Stage 7-B: reify (`reify_test_decl`) emits both the `TirFunction`
+        // and the `TirTest` from the AST + recorded facts. The combined
+        // walk's copies are discarded, so minimal shells are enough.
         let tir_test = TirTest {
             name: test_decl.name.clone(),
-            function_name,
+            function_name: function_name.clone(),
             line: test_decl.span.line,
             span: test_decl.span,
             expect_trap,
@@ -1371,7 +1275,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             timeout_ms,
         };
 
-        Some((tir_func, tir_test))
+        Some((placeholder_function(function_name, test_decl.span), tir_test))
     }
 
     /// Resolve a method (function with &self parameter)
@@ -1401,9 +1305,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // so dispatch synthesis can tell two same-named effects /
         // resources apart.
         let base_trait_name: Option<String> = trait_type.map(|t| scope.get_type_name(t));
-        let base_trait_module: Option<ModuleSource> = base_trait_name
-            .as_deref()
-            .map(|n| scope.canonical_decl_key(n).0);
 
         // First, collect type params from impl block's generic type (e.g., impl Box<T>)
         // Also build impl_type_params for the TirFunction
@@ -1660,21 +1561,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let old_self_type = scope.trait_ctx.self_type;
         scope.trait_ctx.self_type = Some(scope.resolve_type(impl_type));
 
-        // Concrete `TypeId`s of the trait/resource type arguments at this
-        // impl site (e.g. `[u8]` for `impl Stream<u8> for MockCM`). Resolved
-        // here — after impl-block + method-level type params are in scope —
-        // so that generic impls (`impl<T> Stream<T>`) round-trip the right
-        // `TypeParam` TypeId. Used by the dispatch synthesis to key
-        // per-monomorphisation infrastructure off `(base_trait, trait_type_args)`.
-        let trait_type_args: Vec<TypeId> = match trait_type {
-            Some(ast::Type::Generic(generic)) => generic
-                .args
-                .iter()
-                .map(|arg| scope.resolve_type(arg))
-                .collect(),
-            _ => Vec::new(),
-        };
-
         // Resolve return type
         let return_type = func
             .return_type
@@ -1770,11 +1656,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     span: default_ast.span(),
                 });
             }
-            let default_expr = param.default.as_ref().map(|default_ast| {
+            // Walk the default for its side-effect fact recording; the
+            // resolved TIR is discarded (reify re-emits it from the AST).
+            if let Some(default_ast) = &param.default {
                 let resolved = scope.resolve_expr(default_ast, &mut ctx, Some(type_id));
                 scope.typecheck(resolved.type_id, type_id, default_ast.span());
-                Box::new(resolved)
-            });
+            }
             let index = ctx.add_local(param.name.clone(), type_id, param.is_mut, Some(param.id));
             scope.record_local_symbol(
                 param.id,
@@ -1783,12 +1670,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 param.is_mut,
                 type_id,
             );
+            // `params` survives only to feed the recorded `fn_param_types`
+            // and `validate_stores`; the TIR `default_expr` is not built.
             params.push(TirParam {
                 name: param.name.clone(),
                 type_id,
                 local_index: index,
                 is_mut: param.is_mut,
-                default_expr,
+                default_expr: None,
                 span: param.span,
             });
         }
@@ -1796,11 +1685,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Validate stores declarations
         scope.validate_stores(&func.stores, &params, func.span);
 
-        // Resolve body
-        let body = func
-            .body
-            .as_ref()
-            .map(|b| scope.resolve_block(b, &mut ctx, None));
+        // Walk the body for its side-effect fact recording; the resolved
+        // `TirBlock` is discarded (reify re-emits it from the AST + facts).
+        if let Some(b) = func.body.as_ref() {
+            scope.resolve_block(b, &mut ctx, None);
+        }
 
         scope.validate_missing_return_ast(return_type, func.body.as_ref(), func.span);
 
@@ -1853,11 +1742,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // `current_effect_param_decls`, so the annotate phase records
         // the already-resolved list here keyed by the method's `AstId`.
         let method_key = scope.ann_key(func.id);
-        scope
-            .sem
-            .types
-            .function_effects
-            .insert(method_key, effects.clone());
+        scope.sem.types.function_effects.insert(method_key, effects);
 
         // Restore effect params and Self type. `trait_ctx` is auto-restored on
         // `drop(scope)`, which replaces everything set up above.
@@ -1881,7 +1766,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         self.sem
             .types
             .decl_type_params
-            .insert(self.ann_key(func.id), type_params.clone());
+            .insert(self.ann_key(func.id), type_params);
 
         // Store type parameters for generic methods (for call site substitution)
         if !func.type_params.is_empty() {
@@ -1895,50 +1780,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 .insert(mangled_name, method_resolved_param_types);
         }
 
-        Some(TirFunction {
-            module_source: ModuleSource::default(),
-            name: func.name.clone(), // Will be mangled by caller
-            is_pub: func.is_pub,
-            is_export: false, // Methods are not world exports
-            is_async: false,  // Methods are never async
-            type_params,
-            impl_type_params, // Type params from impl block (e.g., T from impl Counter<T>)
-            monomorph_info: None, // Not from monomorphization
-            method_info: Some(LocalMethodName {
-                struct_name: struct_name.to_string(),
-                base_struct_name: struct_name.to_string(),
-                trait_name: trait_name.map(String::from),
-                base_trait_name,
-                base_trait_module,
-                trait_type_args,
-                method_name: func.name.clone(),
-                method_type_args: vec![],
-                is_type_param_receiver: false,
-                is_ref_impl: false,
-                cm_name: None,
-            }),
-            params,
-            return_type,
-            task_return_type: None,
-            effects,
-            stores: func.stores.clone(),
-            body,
-            span: func.span,
-            local_count: ctx.next_local,
-            locals: ctx.locals.clone(),
-            address_taken_locals: ctx.address_taken_locals,
-            stores_aliased_locals: IndexSet::default(),
-            is_cm_binding: false,
-            is_dispatch_wrapper: false,
-            is_cm_export: false,
-            is_ambient: Self::extract_is_ambient(&func.attrs),
-            inline_hint: Self::extract_inline_hint(&func.attrs),
-            compiler_item: extract_compiler_item(&func.attrs, func.span, self.logger),
-            export_name: None,
-            allocator_tag: None,
-            kind: FunctionKind::Regular,
-
-            return_abi: crate::tir::ReturnAbi::default(),
-        })
+        // Stage 7-B: reify (`reify_method`) emits the method's `TirFunction`
+        // from the recorded facts (`method_impl_type_params`,
+        // `method_names`, `fn_param_types`, `fn_return_types`,
+        // `decl_type_params`, `function_effects`, the impl facts, …) + the
+        // AST. The combined walk's copy is discarded, so a minimal shell
+        // is all `resolve_module` needs.
+        Some(placeholder_function(func.name.clone(), func.span))
     }
 }

--- a/wado-compiler/src/elaborator/method_call.rs
+++ b/wado-compiler/src/elaborator/method_call.rs
@@ -5,8 +5,8 @@ use crate::compiler_host::CompilerHost;
 use crate::module_source::ModuleSource;
 use crate::name::{LocalMethodName, MethodName};
 use crate::tir::{
-    CallArg, FunctionRef, MonomorphInfo, ResolvedType, SubstitutionContext, TirExpr, TirExprKind,
-    TypeId, TypeTable,
+    FunctionRef, MonomorphInfo, ResolvedType, SubstitutionContext, TirExpr, TirExprKind, TypeId,
+    TypeTable,
 };
 use crate::token::Span;
 
@@ -41,6 +41,11 @@ pub(super) struct MethodCallInput<'a> {
     pub args: &'a [ast::Expr],
     pub expected_type: Option<TypeId>,
     pub span: Span,
+}
+
+/// Body-walk placeholder for a resolved (method / static) call. Stage 7-B.
+fn placeholder(type_id: TypeId, span: Span) -> TirExpr {
+    TirExpr::new(TirExprKind::Unit, type_id, span)
 }
 
 impl<H: CompilerHost> Elaborator<'_, H> {
@@ -805,25 +810,22 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // Side-channel for synthetic callers (Gap 6 of Stage 5):
             // for-of's `.into_iter()` / `.next()` dispatches pass
             // `call_id == None` so `record_method_dispatch` skips them,
-            // but the synthetic caller still needs the
-            // receiver-adjustment inputs for its own recording. We
-            // populate the channel regardless of `call_id`; the
-            // `method_found` gate keeps the error-recovery placeholder
-            // from leaking out.
-            self.pending_method_dispatch = Some((self_kind, is_ref_impl));
+            // but the synthetic caller still needs the receiver-adjustment
+            // inputs *and* the resolved `FunctionRef` for its own
+            // recording. We populate the channel regardless of `call_id`;
+            // the `method_found` gate keeps the error-recovery placeholder
+            // from leaking out. Stage 7-B: the `FunctionRef` rides the
+            // channel because the returned TIR is now a typed placeholder.
+            self.pending_method_dispatch = Some((self_kind, is_ref_impl, func));
         }
 
-        Self::build_tir_method_call(
-            receiver,
-            func,
-            method_type_args, // Use inferred type args
-            args.into_iter()
-                .zip(param_is_mut.into_iter().chain(std::iter::repeat(false)))
-                .map(|(expr, is_mut)| CallArg::new(expr, is_mut))
-                .collect(),
-            return_type,
-            span,
-        )
+        // Stage 7-B: reify rebuilds the `MethodCall` TIR from the recorded
+        // `method_dispatch` (or, for synthetic call_id==None callers, from
+        // `pending_method_dispatch`) and the resolved receiver / args; the
+        // combined walk projects only the result type. `receiver` and
+        // `args` were resolved above for their fact-recording side effects.
+        let _ = (receiver, args);
+        placeholder(return_type, span)
     }
 
     /// Resolve a static method call: `Array::<i32>::with_capacity(100)` or `Point::origin()`
@@ -1023,14 +1025,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 static_call.span,
                             );
                         }
-                        return TirExpr::new(
-                            TirExprKind::IntLiteral {
-                                value: 0,
-                                repr: "0".to_string(),
-                            },
-                            flags_info.type_id,
-                            static_call.span,
-                        );
+                        return placeholder(flags_info.type_id, static_call.span);
                     }
                     "all" => {
                         if !args.is_empty() {
@@ -1045,22 +1040,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 static_call.span,
                             );
                         }
-                        let member_count = flags_info.members.len();
-                        let all_bits = if member_count == 0 {
-                            0u32
-                        } else if member_count >= 32 {
-                            u32::MAX
-                        } else {
-                            (1u32 << member_count) - 1
-                        };
-                        return TirExpr::new(
-                            TirExprKind::IntLiteral {
-                                value: u64::from(all_bits),
-                                repr: all_bits.to_string(),
-                            },
-                            flags_info.type_id,
-                            static_call.span,
-                        );
+                        return placeholder(flags_info.type_id, static_call.span);
                     }
                     _ => {}
                 }
@@ -1098,20 +1078,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         return TirExpr::new(TirExprKind::Unit, TypeTable::ERROR, static_call.span);
                     }
 
-                    // Payload is the single argument, or None for unit variants
-                    let payload = args.into_iter().next().map(Box::new);
-
-                    // Create VariantConstruct expression
-                    return TirExpr::new(
-                        TirExprKind::VariantConstruct {
-                            variant_type: target_type_id,
-                            case_index: case_index as u32,
-                            case_name: case_data.name.clone(),
-                            payload,
-                        },
-                        target_type_id,
-                        static_call.span,
-                    );
+                    // Stage 7-B: reify rebuilds the `VariantConstruct` from
+                    // the AST + variant info; the combined walk projects only
+                    // the result type.
+                    let _ = case_index;
+                    return placeholder(target_type_id, static_call.span);
                 }
                 // If no matching case, fall through to general method lookup
                 // (e.g., trait methods like `AppError::from(e)`)
@@ -1165,21 +1136,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         self.typecheck(args[0].type_id, expected_type, span);
                     }
 
-                    // Payload was already resolved with the correct expected type
-                    // (substituted in the param_types computation above).
-                    let payload = args.into_iter().next().map(Box::new);
-
-                    // Create VariantConstruct expression
-                    return TirExpr::new(
-                        TirExprKind::VariantConstruct {
-                            variant_type: target_type_id,
-                            case_index: case_index as u32,
-                            case_name: case_data.name.clone(),
-                            payload,
-                        },
-                        target_type_id,
-                        static_call.span,
-                    );
+                    // Stage 7-B: reify rebuilds the `VariantConstruct` from
+                    // the AST + variant info; the combined walk projects only
+                    // the result type. The payload was already resolved (and
+                    // typechecked) above for its fact-recording side effects.
+                    let _ = case_index;
+                    return placeholder(target_type_id, static_call.span);
                 }
                 // If no matching case, fall through to general method lookup
                 // (e.g., trait methods like `Result::<T, E>::from(e)`)
@@ -1217,15 +1179,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 .get_newtype_base(target_type_id);
             let base_of_arg = self.tysys.type_table.borrow().get_newtype_base(arg_type);
             if base_of_target == Some(arg_type) || base_of_arg == Some(target_type_id) {
-                let arg = args.into_iter().next().unwrap();
-                return TirExpr::new(
-                    TirExprKind::Cast {
-                        expr: Box::new(arg),
-                        target_type: target_type_id,
-                    },
-                    target_type_id,
-                    static_call.span,
-                );
+                // Stage 7-B: reify rebuilds the newtype `Cast`; the combined
+                // walk projects only the result type.
+                return placeholder(target_type_id, static_call.span);
             }
         }
 
@@ -1519,19 +1475,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             },
         );
 
-        TirExpr::new(
-            TirExprKind::Call {
-                func: func_ref,
-                type_args: method_type_args,
-                args: args
-                    .into_iter()
-                    .zip(param_is_mut.into_iter().chain(std::iter::repeat(false)))
-                    .map(|(expr, is_mut)| CallArg::new(expr, is_mut))
-                    .collect(),
-            },
-            return_type,
-            static_call.span,
-        )
+        // Stage 7-B: reify rebuilds the static-method `Call` TIR from the
+        // recorded `static_method_dispatch` + resolved args; the combined
+        // walk projects only the result type. `args` was resolved above for
+        // its fact-recording side effects and is now discarded.
+        let _ = args;
+        placeholder(return_type, static_call.span)
     }
 
     /// Look up `#[cm("...")]` for a static (no-self) method on a resource type in a module.
@@ -2642,6 +2591,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         args: &[TirExpr],
         impl_type_args: &[TypeId],
         method_type_args: &[TypeId],
+        call_id: AstId,
         span: Span,
         _ctx: &mut FunctionContext,
     ) -> TirExpr {
@@ -2755,31 +2705,37 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             ..
         } = method_ref;
 
-        TirExpr::new(
-            TirExprKind::Call {
-                func: FunctionRef {
-                    module_source: struct_module,
-                    name: final_mangled_name,
-                    monomorph_info,
-                    method_info: Some({
-                        let mut m = LocalMethodName::new(
-                            actual_struct_name,
-                            trait_name_opt,
-                            method_name.to_string(),
-                        );
-                        m.cm_name = cm_name;
-                        m
-                    }),
-                },
+        let func_ref = FunctionRef {
+            module_source: struct_module,
+            name: final_mangled_name,
+            monomorph_info,
+            method_info: Some({
+                let mut m =
+                    LocalMethodName::new(actual_struct_name, trait_name_opt, method_name.to_string());
+                m.cm_name = cm_name;
+                m
+            }),
+        };
+
+        // Stage 7-B: record the static-method dispatch decision (formerly
+        // recovered by the caller from the built `Call` TIR) so reify can
+        // reproduce the same `Call` shape without re-running impl lookup,
+        // mangled-name construction, or monomorph-info shaping. The per-arg
+        // `is_mut` flags match what the old `CallArg`s carried.
+        let param_is_mut: Vec<bool> = args
+            .iter()
+            .zip(param_is_mut.iter().copied().chain(std::iter::repeat(false)))
+            .map(|(_, is_mut)| is_mut)
+            .collect();
+        self.sem.types.static_method_dispatch.insert(
+            self.ann_key(call_id),
+            super::sem::types::StaticMethodDispatch {
+                function_ref: func_ref,
+                param_is_mut,
                 type_args: vec![],
-                args: args
-                    .iter()
-                    .zip(param_is_mut.iter().copied().chain(std::iter::repeat(false)))
-                    .map(|(expr, is_mut)| CallArg::new(expr.clone(), is_mut))
-                    .collect(),
             },
-            return_type,
-            span,
-        )
+        );
+
+        placeholder(return_type, span)
     }
 }

--- a/wado-compiler/src/elaborator/method_call.rs
+++ b/wado-compiler/src/elaborator/method_call.rs
@@ -801,11 +801,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 &func,
                 self_kind,
                 is_ref_impl,
-                param_is_mut.clone(),
+                param_is_mut,
                 param_names,
                 param_defaults,
                 return_type,
-                method_type_args.clone(),
+                method_type_args,
             );
             // Side-channel for synthetic callers (Gap 6 of Stage 5):
             // for-of's `.into_iter()` / `.next()` dispatches pass
@@ -1469,9 +1469,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         self.sem.types.static_method_dispatch.insert(
             key,
             super::sem::types::StaticMethodDispatch {
-                function_ref: func_ref.clone(),
-                param_is_mut: param_is_mut.clone(),
-                type_args: method_type_args.clone(),
+                function_ref: func_ref,
+                param_is_mut,
+                type_args: method_type_args,
             },
         );
 
@@ -2710,8 +2710,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             name: final_mangled_name,
             monomorph_info,
             method_info: Some({
-                let mut m =
-                    LocalMethodName::new(actual_struct_name, trait_name_opt, method_name.to_string());
+                let mut m = LocalMethodName::new(
+                    actual_struct_name,
+                    trait_name_opt,
+                    method_name.to_string(),
+                );
                 m.cm_name = cm_name;
                 m
             }),

--- a/wado-compiler/src/elaborator/method_lookup.rs
+++ b/wado-compiler/src/elaborator/method_lookup.rs
@@ -18,6 +18,14 @@ use super::types::{
     IndexValueTraitInfo, KeyValueLiteralTraitInfo, MethodInfo, SequenceLiteralTraitInfo, TypeError,
 };
 
+/// Body-walk placeholder for the IndexMut method-call rewrite. Stage 7-B:
+/// the combined walk records the inner `operator_dispatch`, the outer
+/// `method_dispatch`, and the `IndexMutMethodCall` desugar; reify rebuilds
+/// the full `*recv.index_mut(idx).method(args)` expansion from those facts.
+fn placeholder(type_id: TypeId, span: Span) -> TirExpr {
+    TirExpr::new(TirExprKind::Unit, type_id, span)
+}
+
 /// Lightweight reference to an impl block, avoiding deep clones.
 /// Stores just enough info to re-access the impl block's fields on demand.
 enum ImplBlockRef {
@@ -3456,14 +3464,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             },
         );
 
-        let index_mut_call = Self::build_tir_method_call(
-            receiver_for_index_mut,
-            index_mut_func,
-            vec![],
-            vec![CallArg::new(index_resolved, false)],
-            mut_ref_output_type,
-            index_expr.span,
-        );
+        // Stage 7-B: reify (`reify_index_mut_method_call`) rebuilds the
+        // inner `*expr.index_mut(idx)` from the recorded `operator_dispatch`
+        // above; the combined walk only needed the dispatch fact. The
+        // receiver + index were resolved above for their side effects.
+        let _ = (receiver_for_index_mut, index_mut_func, index_resolved);
 
         // Step 2: Resolve method args with expected parameter types for literal coercion
         let args: Vec<TirExpr> = method_call
@@ -3482,11 +3487,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             .iter()
             .map(|ty| self.resolve_type(ty))
             .collect();
-
-        // Step 4: Create the method call on the result of index_mut
-        // The receiver for the method is index_mut_call (which has type &mut Output)
-        let receiver_for_method =
-            self.adjust_receiver_for_self_kind(index_mut_call, self_kind, false, method_call.span);
 
         let mangled_method_name = MethodName::format_local(
             &output_struct_name,
@@ -3537,21 +3537,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             super::sem::types::DesugarKind::IndexMutMethodCall,
         );
 
-        Some(Self::build_tir_method_call(
-            receiver_for_method,
-            func,
-            type_args,
-            args.into_iter()
-                .zip(
-                    method_param_is_mut
-                        .into_iter()
-                        .chain(std::iter::repeat(false)),
-                )
-                .map(|(expr, is_mut)| CallArg::new(expr, is_mut))
-                .collect(),
-            return_type,
-            method_call.span,
-        ))
+        // Stage 7-B: reify (`reify_index_mut_method_call`) rebuilds the
+        // outer `MethodCall` (and the `__index_mut_val` synthesis) from the
+        // recorded `method_dispatch` + `IndexMutMethodCall` desugar; the
+        // combined walk projects only the result type. `args` was resolved
+        // above for its fact-recording side effects.
+        let _ = (args, func);
+        Some(placeholder(return_type, method_call.span))
     }
 
     /// Sole elaborator-side constructor of [`TirExprKind::MethodCall`].

--- a/wado-compiler/src/elaborator/method_lookup.rs
+++ b/wado-compiler/src/elaborator/method_lookup.rs
@@ -18,7 +18,7 @@ use super::types::{
     IndexValueTraitInfo, KeyValueLiteralTraitInfo, MethodInfo, SequenceLiteralTraitInfo, TypeError,
 };
 
-/// Body-walk placeholder for the IndexMut method-call rewrite. Stage 7-B:
+/// Body-walk placeholder for the `IndexMut` method-call rewrite. Stage 7-B:
 /// the combined walk records the inner `operator_dispatch`, the outer
 /// `method_dispatch`, and the `IndexMutMethodCall` desugar; reify rebuilds
 /// the full `*recv.index_mut(idx).method(args)` expansion from those facts.
@@ -3526,11 +3526,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             &func,
             self_kind,
             method_is_ref_impl,
-            method_param_is_mut.clone(),
+            method_param_is_mut,
             method_param_names,
             method_param_defaults,
             return_type,
-            type_args.clone(),
+            type_args,
         );
         self.record_desugar(
             method_call.id,

--- a/wado-compiler/src/elaborator/method_lookup.rs
+++ b/wado-compiler/src/elaborator/method_lookup.rs
@@ -1707,12 +1707,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
     }
 
-    /// Dereference a receiver until it's a value (non-reference) type
-    pub(super) fn deref_to_value(&self, receiver: TirExpr, span: Span) -> TirExpr {
-        Self::deref_to_value_static(receiver, span, &self.tysys.type_table)
-    }
-
-    /// `&TypeTable`-only version of [`Self::deref_to_value`], paired
+    /// `&TypeTable`-only version of the receiver-deref loop, paired
     /// with [`Self::adjust_receiver_for_self_kind_static`] for Stage 5
     /// reify reuse.
     pub(super) fn deref_to_value_static(

--- a/wado-compiler/src/elaborator/operators.rs
+++ b/wado-compiler/src/elaborator/operators.rs
@@ -1212,7 +1212,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         self.record_index_assign_dispatch(
                             index_expr.id,
                             super::sem::types::OperatorDispatch {
-                                function_ref: func.clone(),
+                                function_ref: func,
                                 self_kind: trait_info.self_kind,
                                 arg_ref_wraps: vec![false, false],
                                 return_type: TypeTable::UNIT,

--- a/wado-compiler/src/elaborator/operators.rs
+++ b/wado-compiler/src/elaborator/operators.rs
@@ -193,20 +193,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         });
                     }
                 }
-                let op = if op == BinaryOp::Eq {
-                    TirBinaryOp::RefEq
-                } else {
-                    TirBinaryOp::RefNotEq
-                };
-                return TirExpr::new(
-                    TirExprKind::Binary {
-                        op,
-                        left: Box::new(left),
-                        right: Box::new(right),
-                    },
-                    TypeTable::BOOL,
-                    span,
-                );
+                // Stage 7-B: reify rebuilds the reference `==` / `!=`
+                // (`RefEq` / `RefNotEq`) from the AST; project only the type.
+                return placeholder(TypeTable::BOOL, span);
             } else if both_refs {
                 // All operators other than == and != are invalid on reference types
                 let type_name = self.tysys.type_table.borrow().type_name(left.type_id);
@@ -816,15 +805,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             _ => left.type_id, // Arithmetic ops preserve the type
         };
 
-        TirExpr::new(
-            TirExprKind::Binary {
-                left: Box::new(left),
-                op: tir_op,
-                right: Box::new(right),
-            },
-            type_id,
-            span,
-        )
+        // Stage 7-B: reify rebuilds the native `Binary` from the AST +
+        // recorded operand `expression_types`; the combined walk projects
+        // only the result type. `left` / `right` were resolved by the
+        // caller and typechecked above for their side effects.
+        let _ = (tir_op, left, right);
+        placeholder(type_id, span)
     }
 
     /// Resolve a unary expression

--- a/wado-compiler/src/elaborator/operators.rs
+++ b/wado-compiler/src/elaborator/operators.rs
@@ -14,6 +14,16 @@ use super::Elaborator;
 use super::types::{FunctionContext, ResolvedTraitMethod, TypeError};
 use super::util;
 
+/// Body-walk placeholder for an operator expression. Stage 7-B: the
+/// combined walk records the dispatch decision (`operator_dispatch`) and
+/// typechecks the operands, but no longer assembles the overloaded
+/// operator's `MethodCall` TIR — reify rebuilds it from the recorded
+/// fact + the AST. The returned `TirExpr` only needs the right `type_id`
+/// + `span` for the caller's outer typecheck / `expression_types` recording.
+fn placeholder(type_id: TypeId, span: Span) -> TirExpr {
+    TirExpr::new(TirExprKind::Unit, type_id, span)
+}
+
 /// The right-hand side of an assignment passed to
 /// [`Elaborator::assign_to_target`]. Either an AST expression (the
 /// regular [`Elaborator::resolve_assign`] path) or an already-resolved
@@ -1560,34 +1570,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             wrap_flags.push(wrap);
         }
 
-        let receiver =
-            self.adjust_receiver_for_self_kind(receiver, resolved.self_kind, false, span);
-
-        let call_args: Vec<CallArg> = args
-            .into_iter()
-            .zip(wrap_flags.iter().copied())
-            .map(|(arg, wrap)| {
-                let arg_expr = if wrap {
-                    let arg_ref_type = self
-                        .tysys
-                        .type_table
-                        .borrow_mut()
-                        .intern(ResolvedType::Ref(arg.type_id));
-                    TirExpr::new(
-                        TirExprKind::Unary {
-                            op: TirUnaryOp::Ref,
-                            expr: Box::new(arg),
-                        },
-                        arg_ref_type,
-                        span,
-                    )
-                } else {
-                    arg
-                };
-                CallArg::new(arg_expr, false)
-            })
-            .collect();
-
         let mangled_method_name = MethodName::format_local(
             &resolved.impl_name,
             Some(&resolved.trait_name),
@@ -1620,7 +1602,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             self.record_operator_dispatch(
                 ast_id,
                 super::sem::types::OperatorDispatch {
-                    function_ref: function_ref.clone(),
+                    function_ref,
                     self_kind: resolved.self_kind,
                     arg_ref_wraps: wrap_flags,
                     return_type: resolved.return_type,
@@ -1629,14 +1611,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             );
         }
 
-        Self::build_tir_method_call(
-            receiver,
-            function_ref,
-            vec![],
-            call_args,
-            resolved.return_type,
-            span,
-        )
+        // Stage 7-B: reify rebuilds the overloaded operator's `MethodCall`
+        // from the recorded `operator_dispatch` (receiver adjustment via
+        // `self_kind`, arg `&`-wrapping via `arg_ref_wraps`) + the AST; the
+        // combined walk projects only the result type. `receiver` and
+        // `args` were resolved / typechecked above for their side effects.
+        let _ = (receiver, args);
+        placeholder(resolved.return_type, span)
     }
 
     /// Wrap an `Ord::cmp` method call into a `bool` by comparing the returned

--- a/wado-compiler/src/elaborator/operators.rs
+++ b/wado-compiler/src/elaborator/operators.rs
@@ -5,8 +5,8 @@ use crate::compiler_host::CompilerHost;
 use crate::compiler_item::CompilerItem;
 use crate::name::{LocalMethodName, MethodName};
 use crate::tir::{
-    CallArg, FunctionRef, PrimitiveType, ResolvedType, TirBinaryOp, TirExpr, TirExprKind,
-    TirUnaryOp, TypeId, TypeTable,
+    FunctionRef, PrimitiveType, ResolvedType, TirBinaryOp, TirExpr, TirExprKind, TirUnaryOp,
+    TypeId, TypeTable,
 };
 use crate::token::Span;
 
@@ -1034,6 +1034,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             _ => expr.type_id,
         };
 
+        // NOTE (Stage 7-B): `resolve_unary` still builds its `Unary` TIR.
+        // The `*ptr` / `&x` / `&mut x` shapes are structurally inspected by
+        // `assign_to_target`'s l-value validation and by receiver
+        // adjustment, so the resolved `kind` must stay real until those
+        // consumers read the validity from the AST instead. Converting this
+        // to a placeholder broke `*x = v` ("expression is not assignable").
         TirExpr::new(
             TirExprKind::Unary {
                 op,
@@ -1176,17 +1182,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             },
                         );
 
-                        return Self::build_tir_method_call(
-                            receiver,
-                            func,
-                            vec![],
-                            vec![
-                                CallArg::new(index_resolved, false),
-                                CallArg::new(value_tir, false),
-                            ],
-                            TypeTable::UNIT,
-                            span,
-                        );
+                        // Stage 7-B: reify rebuilds `arr.index_assign(idx,
+                        // value)` from the recorded `index_assign_dispatch` +
+                        // AST; project only the (unit) result type. `receiver`
+                        // / `index_resolved` / `value_tir` were resolved above
+                        // for their fact-recording side effects.
+                        let _ = (receiver, index_resolved, value_tir);
+                        return placeholder(TypeTable::UNIT, span);
                     }
                 }
             }
@@ -1237,16 +1239,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     });
                     return TirExpr::new(TirExprKind::Unit, TypeTable::ERROR, span);
                 }
-                // Generate GlobalVarSet instead of Assign
-                return TirExpr::new(
-                    TirExprKind::GlobalVarSet {
-                        module_source: module_source.clone(),
-                        name: name.clone(),
-                        value: Box::new(value_tir),
-                    },
-                    TypeTable::UNIT,
-                    span,
-                );
+                // Stage 7-B: reify rebuilds the `GlobalVarSet` from the AST;
+                // project only the (unit) result type.
+                let _ = value_tir;
+                return placeholder(TypeTable::UNIT, span);
             }
         }
 
@@ -1284,14 +1280,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             return TirExpr::new(TirExprKind::Unit, TypeTable::ERROR, span);
         }
 
-        TirExpr::new(
-            TirExprKind::Assign {
-                target: Box::new(target),
-                value: Box::new(value_tir),
-            },
-            TypeTable::UNIT,
-            span,
-        )
+        // Stage 7-B: reify rebuilds the `Assign` from the AST + recorded
+        // target / value types; project only the (unit) result type. The
+        // target + value were resolved above for their side effects, and the
+        // l-value validation / global-mutability checks already ran.
+        let _ = (target, value_tir);
+        placeholder(TypeTable::UNIT, span)
     }
 
     /// Resolve `target op= value` as the equivalent `target = target op value`,
@@ -1359,7 +1353,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         chain: &ast::ComparisonChainExpr,
         ctx: &mut FunctionContext,
     ) -> TirExpr {
-        use crate::tir::{TirBlock, TirStmt, TirStmtKind};
+        use crate::tir::TirStmt;
 
         if chain.comparisons.is_empty() {
             // Degenerate parse — no chain expansion fires, so this is not
@@ -1439,14 +1433,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         ctx.exit_scope();
 
-        // Wrap the bindings + final && chain in a TIR Block whose value is
-        // the boolean result.
-        stmts.push(TirStmt::new(TirStmtKind::Expr(acc_tir), chain.span));
-        TirExpr::new(
-            TirExprKind::Block(TirBlock::new(stmts, chain.span)),
-            TypeTable::BOOL,
-            chain.span,
-        )
+        // Stage 7-B: reify rebuilds the `(a<b) && (b<c) …` Block (with the
+        // `__mK` middle bindings) from the recorded `ComparisonChain`
+        // desugar + the AST; the combined walk projects only the boolean
+        // result type. The operand resolutions, middle-binding local
+        // allocations, and per-comparison dispatch above ran for their
+        // fact-recording side effects.
+        let _ = (stmts, acc_tir);
+        placeholder(TypeTable::BOOL, chain.span)
     }
 
     /// Helper: bind a comparison-chain middle term to a `__mK` local and

--- a/wado-compiler/src/elaborator/operators.rs
+++ b/wado-compiler/src/elaborator/operators.rs
@@ -14,12 +14,14 @@ use super::Elaborator;
 use super::types::{FunctionContext, ResolvedTraitMethod, TypeError};
 use super::util;
 
-/// Body-walk placeholder for an operator expression. Stage 7-B: the
-/// combined walk records the dispatch decision (`operator_dispatch`) and
-/// typechecks the operands, but no longer assembles the overloaded
-/// operator's `MethodCall` TIR — reify rebuilds it from the recorded
-/// fact + the AST. The returned `TirExpr` only needs the right `type_id`
-/// + `span` for the caller's outer typecheck / `expression_types` recording.
+/// Body-walk placeholder for an operator / assignment expression. Stage
+/// 7-B: the combined walk typechecks the operands and records any dispatch
+/// decision (`operator_dispatch` for an overloaded op, `index_assign_dispatch`
+/// for `arr[i] = v`), but no longer assembles the resulting TIR (the native
+/// `Binary`, the overloaded `MethodCall`, the `Assign` / `GlobalVarSet`, or
+/// the comparison-chain `Block`) — reify rebuilds it from the recorded facts
+/// + the AST. The returned `TirExpr` only needs the right `type_id` + `span`
+/// for the caller's outer typecheck / `expression_types` recording.
 fn placeholder(type_id: TypeId, span: Span) -> TirExpr {
     TirExpr::new(TirExprKind::Unit, type_id, span)
 }

--- a/wado-compiler/src/elaborator/stmt.rs
+++ b/wado-compiler/src/elaborator/stmt.rs
@@ -2640,17 +2640,15 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             },
             ctx,
         );
-        // Capture the `(self_kind, is_ref_impl)` the dispatch chose
-        // (Gap 6 of WEP 2026-05-26): the synthetic call passed
+        // Capture the `(self_kind, is_ref_impl, FunctionRef)` the dispatch
+        // chose (Gap 6 of WEP 2026-05-26): the synthetic call passed
         // `call_id == None` so `record_method_dispatch` skipped it, but
-        // reify needs the receiver-adjustment inputs to reproduce the
-        // same call shape. Also capture the resolved `FunctionRef`
-        // before `into_iter_call` is consumed by the iterator `let`.
+        // reify needs the receiver-adjustment inputs + the resolved
+        // `FunctionRef` to reproduce the same call shape. Since Stage 7-B
+        // `resolve_method_call_with` returns a typed placeholder, the
+        // `FunctionRef` rides `pending_method_dispatch` rather than being
+        // recovered from `into_iter_call.kind`.
         let into_iter_dispatch = self.pending_method_dispatch.take();
-        let into_iter_func = match &into_iter_call.kind {
-            TirExprKind::MethodCall { func, .. } => Some(func.clone()),
-            _ => None,
-        };
         let iter_type = into_iter_call.type_id;
 
         // Iterator-trait conformance check, mirroring the pre-refactor
@@ -2714,10 +2712,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             ctx,
         );
         let next_dispatch = self.pending_method_dispatch.take();
-        let next_func = match &next_call.kind {
-            TirExprKind::MethodCall { func, .. } => Some(func.clone()),
-            _ => None,
-        };
         let option_type = next_call.type_id;
 
         // Build the `Option::Some(<user binding>)` arm pattern directly as
@@ -2764,21 +2758,19 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // record when both dispatches succeeded (the trait-check error
         // path above bailed without resolving them).
         if let (
-            Some(into_iter_func),
-            Some(into_iter_dispatch),
-            Some(next_func),
-            Some(next_dispatch),
-        ) = (into_iter_func, into_iter_dispatch, next_func, next_dispatch)
+            Some((into_iter_self_kind, into_iter_is_ref_impl, into_iter_func)),
+            Some((next_self_kind, next_is_ref_impl, next_func)),
+        ) = (into_iter_dispatch, next_dispatch)
         {
             self.record_for_of_iterator(
                 for_of.id,
                 super::sem::types::ForOfIteratorInfo {
                     into_iter: into_iter_func,
-                    into_iter_self_kind: into_iter_dispatch.0,
-                    into_iter_is_ref_impl: into_iter_dispatch.1,
+                    into_iter_self_kind,
+                    into_iter_is_ref_impl,
                     next: next_func,
-                    next_self_kind: next_dispatch.0,
-                    next_is_ref_impl: next_dispatch.1,
+                    next_self_kind,
+                    next_is_ref_impl,
                     item_type,
                     iter_type,
                 },


### PR DESCRIPTION
## Stage 7-B (WEP 2026-05-26, elaborator re-architecture)

Continues Stage 7-B: the combined walk's TIR has been dead since Stage 7-A (reify is the sole producer), so this PR converts the call / method-call / operator / item surface of the combined walk from "build TIR + record facts" to **record-only**. Each `resolve_*` keeps its fact recording, type computation, and `resolve_expr`/`resolve_block` side effects, but returns a typed **placeholder** instead of assembling TIR. Reify rebuilds every node from the recorded facts + the AST.

Net **−310 lines** across `elaborator/{item,call,method_call,operators,method_lookup,stmt}.rs` + `elaborator.rs`.

### Converted to record-only
- **item.rs** — `resolve_struct` / `resolve_variant_decl` / `resolve_global` / `resolve_function` / `resolve_method` / `resolve_test_decl` (signature facts + body walk kept; `TirFunction` / `TirStruct` / … shells dropped).
- **method_call.rs** — instance, static, and qualified-static calls; tuple `.len()` / `.zip()` deliberately kept (they short-circuit before dispatch and the type-pack `TupleZip` participates in monomorphisation).
- **call.rs** — free / builtin / namespaced / static-method `Call`, variant constructors, flags constants, newtype `From` casts, indirect (closure) calls, `T::method` calls.
- **operators.rs** — overloaded-operator `MethodCall`, native `Binary` (incl. `RefEq` / `RefNotEq`), `Assign` / `GlobalVarSet` / `IndexAssign`, comparison-chain `Block`.
- **method_lookup.rs** — the `m["k"].push(1)` IndexMut rewrite.

### Two coupling fixes worth flagging
- **for-of synthetic calls** recovered the resolved `FunctionRef` from the returned `MethodCall.kind`; since the call now returns a placeholder, the `FunctionRef` rides the `pending_method_dispatch` side channel instead.
- **qualified-static caller** likewise read the returned `Call.kind`; `resolve_static_method_call_from_qualified` now records `static_method_dispatch` under the call id itself.

### Deliberately deferred
- **`resolve_unary`** still builds real `Unary` TIR: `*ptr` / `&x` / `&mut x` results are structurally inspected by `assign_to_target`'s l-value validation and by receiver adjustment, so the resolved `kind` must stay real until those consumers read validity from the AST. Placeholdering it broke `*x = v` across gale — see the in-code `NOTE`. This (plus expr.rs / stmt.rs structural exprs and the final "annotate stops returning TIR" step) is the remaining Stage 7-B work.

### Validation
`mise run test` green at every commit (E2E 2730, WIR golden, LSP, gale CLI). Synced with `origin/main` (clean merge).

https://claude.ai/code/session_01PSD6vREjgRQhmRVhyJb3oZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSD6vREjgRQhmRVhyJb3oZ)_