### PR TITLE
Optimizer remarks: surface residual value-semantic copies for coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,11 +224,9 @@ The result: a language where common agentic coding pitfalls are eliminated by de
 
 ## Development
 
-Wado is developed entirely through agentic coding — AI agents write all the code while the human handles language design and project management.
-
 ### Development Process
 
-This approach requires active management:
+Developing entirely through agentic coding requires active management:
 
 - **Refactoring guidance**: Left unchecked, agents generate case-specific code that only works for immediate tests. Regular intervention steers toward generalizable solutions.
 - **Code minimization**: Agents tend to over-generate logic. Compilers need minimal, general-purpose code — the opposite of what agents naturally produce.

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -117,3 +117,4 @@ It may include TODOs on WIP.
 - [`NirExprKind::ArrayLiteral` — a NIR-Materialized List Node](./wep-2026-05-31-nir-array-literal.md)
 - [Diagnostic Reason Chains for Type and Trait Errors](./wep-2026-06-02-diagnostic-reason-chains.md)
 - [Redesign `builtin::array` into a First-Class `List<T>`](./wep-2026-06-02-builtin-array-redesign.md)
+- [Optimizer Remarks for Missed Optimizations](./wep-2026-06-03-optimizer-remarks.md)

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -117,4 +117,4 @@ It may include TODOs on WIP.
 - [`NirExprKind::ArrayLiteral` — a NIR-Materialized List Node](./wep-2026-05-31-nir-array-literal.md)
 - [Diagnostic Reason Chains for Type and Trait Errors](./wep-2026-06-02-diagnostic-reason-chains.md)
 - [Redesign `builtin::array` into a First-Class `List<T>`](./wep-2026-06-02-builtin-array-redesign.md)
-- [Optimizer Remarks for Missed Optimizations](./wep-2026-06-03-optimizer-remarks.md)
+- [Optimizer Remarks for Residual Value-Copy Costs](./wep-2026-06-03-optimizer-remarks.md)

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -117,4 +117,4 @@ It may include TODOs on WIP.
 - [`NirExprKind::ArrayLiteral` — a NIR-Materialized List Node](./wep-2026-05-31-nir-array-literal.md)
 - [Diagnostic Reason Chains for Type and Trait Errors](./wep-2026-06-02-diagnostic-reason-chains.md)
 - [Redesign `builtin::array` into a First-Class `List<T>`](./wep-2026-06-02-builtin-array-redesign.md)
-- [Optimizer Remarks for Residual Value-Copy Costs](./wep-2026-06-03-optimizer-remarks.md)
+- [Optimizer Remarks for Missed Optimizations](./wep-2026-06-03-optimizer-remarks.md)

--- a/docs/wep-2026-06-03-optimizer-remarks.md
+++ b/docs/wep-2026-06-03-optimizer-remarks.md
@@ -96,8 +96,8 @@ optimization appears in the final NIR as one of: a remaining `$value_copy$T(...)
 call, or an `array_clone` / `array_clone_shallow` / `copy_value` call. The remark
 collects all of these in entry-module functions. (`array_copy` is excluded — it
 is bulk buffer movement inside stdlib helpers like `String::push`, not a
-value-semantic copy.) Actual shipped output, where `b` is a `List<i32>` copied
-then mutated:
+value-semantic copy.) Example output (`--log-level info`), where `b` is a
+`List<i32>` copied then mutated:
 
 ```
 src.wado:5:5: info: remark: a copy of `List<i32>` survives optimization
@@ -109,13 +109,18 @@ carries no per-instruction span (only function-level `WirMeta` does), so a
 WIR-sourced remark could not point at the source. The optimized NIR is the last
 IR with per-expression spans, and `wir_build` lowers these copies one-to-one, so
 NIR is both span-accurate and faithful. Even so the synthesized copy nodes
-(`array_clone`, demoted spine copies) carry no user span themselves, so the
-remark is anchored to the enclosing statement — the `let mut b = a;` that performs
-the copy. The reference escape hatch (`&T` / `&mut T`) is the only construct that
-shares rather than copies (spec.md); naming it as a suggestion is deferred to the
+(`array_clone`, demoted spine copies) carry placeholder spans, as do the inner
+statements of the blocks that SROA reconstruction wraps them in, so the remark
+anchors to the enclosing _real_ statement — the `let mut b = a;` that performs the
+copy — rather than descending into those synthesized inner statements. The
+reference escape hatch (`&T` / `&mut T`) is the only construct that shares rather
+than copies (spec.md); naming it as a suggestion is deferred to the
 read-only-vs-required classification below.
 
 ### Surviving aggregate allocations (failed SROA)
+
+_Not yet implemented — design for the next remark kind; see the Consequences
+checklist._
 
 Scalar Replacement of Aggregates (`sroa`, `container_sroa`, `field_scalarize`,
 `sroa_param`) dissolves a struct or tuple into individual scalar locals, removing

--- a/docs/wep-2026-06-03-optimizer-remarks.md
+++ b/docs/wep-2026-06-03-optimizer-remarks.md
@@ -1,0 +1,143 @@
+# WEP: Optimizer Remarks for Missed Optimizations
+
+## Context
+
+Wado source — including this compiler — is increasingly written and repaired by
+AI coding agents. [WEP: Diagnostic Reason Chains](./wep-2026-06-02-diagnostic-reason-chains.md)
+acted on this for _correctness_ feedback: it adopted the finding (Krishnamurthi
+and Flatt, "Type-Error Ablation and AI Coding Agents", arXiv:2606.01522) that
+detailed, causal, source-located error messages measurably raise an agent's
+first-try fix rate, and made type/trait diagnostics richer by default.
+
+A second paper extends the same lesson to a different compiler subsystem.
+"AI Coding Agents Need Better Compiler Remarks" (arXiv:2604.13927, 2026) studies
+_optimization remarks_ — the compiler's feedback about why a desired
+optimization did **not** fire — rather than hard errors. Driving an agent to
+restructure C loops for auto-vectorization on the TSVC suite, it found:
+
+- Remarks are the bottleneck, not the model. Adding the compiler's stock
+  vectorization remarks raised the success rate ~3.3x for the same small model;
+  hand-written remarks that name the exact data-flow obstacle and prescribe a
+  fix added a further 40–59 points.
+- The split is precise-vs-vague, and vague is _worse than nothing_. A remark
+  like "unsafe dependent memory operations in loop" triggered
+  semantic-breaking hallucinations — the agent mangled program logic trying to
+  satisfy a constraint it could not see. A precise remark —
+  "assumed write-after-read dependence between `a[i+1]` and `a[i]`; suggestion:
+  use a temporary" — carries the dependence kind, both source locations, and an
+  actionable transformation, and the agent fixes the source.
+- The three ingredients of a useful remark: the **why** (the analysis fact that
+  blocked the pass), **where** (file:line:col for each participant), and a
+  **prescriptive suggestion** (the source change that would unblock it).
+
+This is the same meta-principle as the Diagnostic Reason Chains WEP — precise,
+causal, prescriptive feedback by default; vague feedback is actively harmful —
+applied to a subsystem that WEP does not touch. Type/trait diagnostics report
+_errors_: the program is rejected. Optimizer remarks report _missed wins_: the
+program compiles and runs correctly but slower or larger than the source
+structure could allow. Different audience need (performance, not correctness),
+different subsystem (the NIR/WIR optimizer, not the type checker), so a separate
+WEP rather than an extension of the existing one.
+
+### Where Wado stands today
+
+The optimizer (see [optimizer.md](./optimizer.md)) runs a 23-pass NIR
+fixed-point loop plus WIR-level passes, every one of which can silently decline
+to fire on a given construct: a function over the inline threshold, a value copy
+not elided because an alias guard tripped, LICM refusing to hoist a possibly
+mutated field, SROA giving up on an escaping aggregate. None of this is
+observable. The compiler emits no remark for any missed optimization; the only
+trace of the concept in the codebase is one incidental `// missed optimisation`
+comment in `licm.rs`. An agent (or human) tuning a hot Wado function has no
+signal for _why_ a pass did not engage or _what to change_, which is exactly the
+gap the paper measures.
+
+Wado's optimizer philosophy ("prefer a native Wasm instruction over a complex
+transformation; let the runtime JIT do low-level work like vectorization")
+means the paper's literal task — coaxing the compiler to auto-vectorize — does
+not transfer: Wado deliberately leaves SIMD to the JIT. What transfers is the
+_remark mechanism_ applied to the passes Wado does own, the ones whose firing is
+a direct function of source structure and value-semantics shape: inlining, value-
+copy elision/demotion, SROA / container SROA, LICM, dead-argument/return
+elimination. These are precisely the passes where a small source rewrite flips
+the outcome, so a prescriptive remark has a concrete fix to name.
+
+## Decision
+
+Introduce **optimizer remarks**: an opt-in channel in which a pass that declines
+a profitable transformation emits a structured, source-located, prescriptive
+note. Adopt the paper's three principles as hard requirements — every remark
+carries the blocking analysis fact (why), a span for each participant (where),
+and a concrete source-level suggestion (how) — and the corollary: a pass that
+cannot meet all three stays silent rather than emit a vague remark, because the
+paper shows vague remarks are net-negative.
+
+### Opt-in, unlike error diagnostics
+
+The Diagnostic Reason Chains WEP made errors rich _by default_ and rejected an
+"AI mode". Remarks take the opposite default: **off unless requested**. The
+reasoning is not inconsistent — it follows the same goal of maximizing signal.
+An error names one rejected program; a missed-optimization remark could fire on
+many call sites of every compile, and on-by-default noise would bury the rare
+actionable remark. LLVM gates the analogue behind `-Rpass`; Wado gates it behind
+an explicit surface (proposed: a `--remarks[=pass,...]` flag on
+`wado compile`, and exposure through `wado dump`). Within that surface, the
+default-rich, never-vague principle holds in full.
+
+### MVP scope (proposed)
+
+Prove the mechanism on one pass before generalizing. Function inlining is the
+best first target: its decision is a single legible predicate (callee cost vs.
+the level's inline threshold), the fix is unambiguous, and the threshold is
+already opt-level-driven. A declined inline would emit, for example (proposed
+output, not yet implemented):
+
+```
+remark: `parse_header` was not inlined into `decode` [hot.wado:42:5]
+  note: callee cost 21 exceeds the -O2 inline threshold (13)
+  suggestion: split `parse_header`, raise the level to -O3, or mark it for inlining
+```
+
+The remark names the callee and call site (where), the cost-vs-threshold fact
+that blocked it (why), and the levers that would change the outcome (how) —
+never a bare "could not inline".
+
+### Reusing existing infrastructure
+
+Remarks are diagnostics with spans, so they should reuse the rendering path the
+Diagnostic Reason Chains WEP already exercises (headline + indented `note:` /
+`suggestion:` lines) rather than invent a parallel one. That WEP's open
+follow-up — give `Diagnostic` structured, independently-spanned notes — is a
+shared dependency: a remark that points at both the call site and the callee
+definition needs multi-span notes, the same capability type/trait reason chains
+want for pointing at an offending field. Building it once serves both.
+
+## Consequences
+
+This WEP is design-stage; nothing below is implemented yet.
+
+- [ ] Decide the remark surface: `--remarks[=pass,...]` flag on `wado compile`,
+      `wado dump` exposure, and/or `--log-level` integration.
+- [ ] Define a `Remark` representation (pass name, participant spans, the
+      blocking fact, the suggestion) and where passes emit it without threading
+      it through every transformation.
+- [ ] MVP: inlining-declined remarks with the three required ingredients,
+      plus E2E fixtures asserting remark text at a fixed `-Ox`.
+- [ ] Extend to the source-structure-sensitive passes (value-copy elision,
+      SROA / container SROA, LICM) once the inlining MVP validates the shape.
+
+Trade-offs and boundaries:
+
+- The paper's specific task (compiler auto-vectorization) is intentionally out
+  of scope: Wado leaves SIMD to the runtime JIT. Only the remark _mechanism_
+  transfers, applied to Wado's own passes.
+- Off-by-default is a deliberate divergence from the errors-by-default stance of
+  the Diagnostic Reason Chains WEP, justified by remark volume; the never-vague
+  principle is shared, not divergent.
+- Multi-span structured notes on `Diagnostic` are a shared prerequisite with the
+  Diagnostic Reason Chains WEP's next steps; this WEP does not duplicate that
+  work, it depends on it.
+- Risk: a remark that misstates why a pass declined is worse than none (the
+  paper's central finding). Each remark must be derived from the pass's actual
+  decision predicate, not a heuristic guess, and is gated on a test asserting it
+  fires exactly when the pass declines for that reason.

--- a/docs/wep-2026-06-03-optimizer-remarks.md
+++ b/docs/wep-2026-06-03-optimizer-remarks.md
@@ -150,12 +150,12 @@ the first two kinds.
   `$value_copy$T` calls; aggregate allocations the SROA passes left in place),
   not from any pass's internals.
 - Surfaced as an info-level `remark:` diagnostic through the existing logger, not
-  a dedicated flag. It rides `--log-level`: shown at the default `Info` level,
-  silenced by `--log-level warn`. This needs no new configuration surface for an
-  agent to discover, and the low-noise-by-construction property (the optimizer
-  has already removed the easy copies) keeps the default-on volume small. The
-  never-vague principle still holds: a remark that cannot supply why + where is
-  not emitted.
+  a dedicated flag. It rides `--log-level`, which is the opt-in mechanism: the
+  CLI is quiet by default (default `warn`), so remarks appear under
+  `wado compile --log-level info`. This resolves the original opt-in goal without
+  a new configuration surface — the remark keeps its semantically-correct `Info`
+  severity, and the standard verbosity knob gates it. The never-vague principle
+  still holds: a remark that cannot supply why + where is not emitted.
 - Never vague: a remark that cannot supply why + where stays silent, since the
   paper shows vague remarks are net-negative.
 

--- a/docs/wep-2026-06-03-optimizer-remarks.md
+++ b/docs/wep-2026-06-03-optimizer-remarks.md
@@ -1,4 +1,4 @@
-# WEP: Optimizer Remarks for Residual Value-Copy Costs
+# WEP: Optimizer Remarks for Missed Optimizations
 
 ## Context
 
@@ -21,8 +21,8 @@ auto-vectorization on the TSVC suite, it found:
   further 40–59 points.
 - The split is precise-vs-vague, and vague is _worse than nothing_. A remark
   like "unsafe dependent memory operations in loop" triggered semantic-breaking
-  hallucinations; a precise remark naming the dependence kind and both source
-  locations let the agent fix the source.
+  hallucinations; a precise remark naming the obstacle and both source locations
+  let the agent fix the source.
 - The three ingredients of a useful remark: the _why_ (the fact that blocked the
   optimization), _where_ (file:line:col for each participant), and a
   _prescriptive suggestion_ (the source change that would help).
@@ -67,41 +67,31 @@ cost, the fact disappears from the final IR and the remark self-retires. That is
 the correct behavior, and it directly answers "don't write code to fit the
 current optimizer."
 
-## The flagship case: residual value-copy costs
+## The flagship costs: residual aggregates
 
 Value semantics is Wado's defining feature: assignment, parameter passing, and
-return all deep-copy the value; references (`&T`, `&mut T`) are the only escape
-hatch (spec.md). A large part of the optimizer exists precisely to remove these
-hidden copies, and most of them are in fact removed. Concretely, a deep copy is
-a call to a synthesized `$value_copy$T` helper (`FunctionKind::ValueCopy`), and
-the `value_copy_elide` pass strips the wrapper wherever the copy is provably
-unnecessary.
+return all deep-copy the value, and aggregates (structs, tuples, `List<T>`) are
+GC-managed heap objects (spec.md). Two of the optimizer's heaviest jobs exist to
+remove the hidden cost of that model — redundant deep copies, and the
+allocations themselves — and most of the time they succeed. The cost that
+remains is invisible at the source: `f(x)` looks free, and a struct literal looks
+like a register's worth of work, whether or not either survives as a runtime
+copy or heap allocation.
 
-The problem is observability. While coding, you cannot see which copies the
-optimizer eliminated and which survived. `f(x)` looks free; whether it
-deep-copies a whole aggregate at runtime is invisible at the source. This is the
-gap an agent (or human) tuning a hot Wado function falls into — not "I wrote a
-copy" (the optimizer usually erases that) but "I have no way to know which copies
-actually remain."
+Both costs share the structure the principle wants: the optimizer represents each
+as a concrete construct in the IR and tries to remove it, so a _survivor_ is an
+observable fact in the final NIR, rare because the easy cases are already gone,
+and self-retiring as the optimizer matures. They become the first two remark
+kinds.
 
-A residual-copy remark closes exactly that gap. After optimization, a deep copy
-that survived is literally a remaining `$value_copy$T(...)` call in the final
-NIR. The remark walks the final NIR, collects those survivors for aggregate types
-above a size threshold, and maps each back to its source span. The design is
-self-justifying:
+### Surviving value copies
 
-- Low-noise by construction — the optimizer has already erased the easy copies,
-  so a survivor is rare and meaningful.
-- Self-decoupling — fewer survivors as the optimizer matures; the remark count
-  tracks genuine residual cost rather than today's heuristics.
-- Wado-specific — it teaches the cost model agents most often mispredict when
-  they carry priors from borrow-checked or reference-default languages.
-
-Its primary value is observability: the residual-copy set is information
-otherwise unobtainable during coding. Where the copied value is only read, the
-remark can also prescribe the reference escape hatch.
-
-Example (proposed output, not yet implemented):
+A deep copy is a call to a synthesized `$value_copy$T` helper
+(`FunctionKind::ValueCopy`), and the `value_copy_elide` pass strips the wrapper
+wherever the copy is provably unnecessary. A copy that survives optimization is
+therefore a remaining `$value_copy$T(...)` call in the final NIR. The remark
+collects those survivors for aggregate types above a size threshold and maps each
+back to its source span (proposed output, not yet implemented):
 
 ```
 remark: a deep copy of `Matrix` survives optimization here [stats.wado:12:18]
@@ -109,16 +99,44 @@ remark: a deep copy of `Matrix` survives optimization here [stats.wado:12:18]
   suggestion: take `m: &Matrix` if the callee only reads it
 ```
 
-This carries the why (a deep copy of `Matrix` remains), the where (the call
-site), and a how that applies when the value is read-only — never a bare "copy
-not elided".
+The _why_ is the surviving copy, the _where_ is the call site, and the _how_
+applies when the value is read-only: the reference escape hatch (`&T` / `&mut T`)
+is the only construct that shares rather than copies (spec.md).
+
+### Surviving aggregate allocations (failed SROA)
+
+Scalar Replacement of Aggregates (`sroa`, `container_sroa`, `field_scalarize`,
+`sroa_param`) dissolves a struct or tuple into individual scalar locals, removing
+the GC heap allocation entirely — by the pass's own note, "the single most
+impactful optimization for WasmGC-targeting compilers." It is gated by escape
+analysis: an aggregate used only for field access is scalarized; one with _soft_
+escapes (call argument, return, nested literal) is scalarized with reconstruction
+at the escape site; one with a _hard_ escape (address taken, closure capture,
+bare local assignment, reference stored) is left as a heap allocation.
+
+The observable survivor is an aggregate allocation that remains in the final IR.
+The remark reports it with the hard-escape reason the pass already classified —
+so the _why_ is the analysis fact, not a guess:
+
+```
+remark: `Point` stays heap-allocated here; SROA could not scalarize it [path.wado:30:13]
+  note: the value escapes by being captured in a closure at path.wado:33:20
+  suggestion: pass the fields the closure needs instead of capturing `Point`
+```
+
+Because SROA already distinguishes hard from soft escapes, the remark can name
+the precise escape that blocked it, and can stay silent on soft escapes that were
+scalarized anyway.
 
 ## Decision
 
-Introduce optimizer remarks, with residual value-copy remarks as the first kind.
+Introduce optimizer remarks, with residual value-copy and failed-SROA remarks as
+the first two kinds.
 
-- Bind to the semantic cost model; derive firing from facts observable in the
-  final NIR — residual `$value_copy$T` calls — not from any pass's internals.
+- Bind to the semantic cost model — Wado's aggregate copies and allocations —
+  and derive firing from facts observable in the final NIR (residual
+  `$value_copy$T` calls; aggregate allocations the SROA passes left in place),
+  not from any pass's internals.
 - Opt-in, not on by default. Errors name one rejected program and are rich by
   default (the Diagnostic Reason Chains stance); a cost remark is advisory and
   could be plentiful, so it is gated behind an explicit surface (proposed:
@@ -129,21 +147,23 @@ Introduce optimizer remarks, with residual value-copy remarks as the first kind.
 
 ### MVP scope (proposed)
 
-- Walk the final NIR; collect residual `$value_copy$T(...)` calls for aggregate
-  types above a size threshold; emit one remark per survivor with its source
-  span. Surfacing the survivor set with spans is already the valuable
-  information; this is the MVP.
-- E2E fixtures pin the behavior at a fixed `-Ox`: one fixture where a copy
-  survives asserts the remark fires, one where the optimizer elides it asserts
-  it does not.
+- Start with surviving value copies: walk the final NIR, collect residual
+  `$value_copy$T(...)` calls for aggregate types above a size threshold, emit one
+  remark per survivor with its source span. Surfacing the survivor set with spans
+  is already the valuable information.
+- Then add failed-SROA remarks, reusing the SROA passes' existing hard-escape
+  classification for the _why_ and the escape site for a second span.
+- E2E fixtures pin each at a fixed `-Ox`: a fixture where the cost survives
+  asserts the remark fires; a fixture where the optimizer removes it asserts it
+  does not.
 
 ### Reusing existing infrastructure
 
 Remarks are diagnostics with spans, so they reuse the rendering path the
 Diagnostic Reason Chains WEP already exercises (headline + indented `note:` /
 `suggestion:` lines). That WEP's open follow-up — structured, independently-
-spanned notes on `Diagnostic` — is a shared dependency: a remark that points at
-both the call site and the parameter definition needs multi-span notes, the same
+spanned notes on `Diagnostic` — is a shared dependency: a failed-SROA remark
+naming both the allocation and its escape site needs two spans, the same
 capability the type/trait reason chains want. Building it once serves both.
 
 ## Consequences
@@ -152,24 +172,25 @@ This WEP is design-stage; nothing below is implemented yet.
 
 - [ ] Decide the remark surface: `--remarks` on `wado compile`, `wado dump`
       exposure, and/or `--log-level` integration.
-- [ ] Define how the final-NIR walk collects residual `$value_copy$T` calls with
-      source provenance and a size threshold.
+- [ ] Define how the final-NIR walk collects residual `$value_copy$T` calls and
+      surviving aggregate allocations with source provenance and a size threshold.
 - [ ] MVP: residual value-copy remarks with why + where, plus the survives /
       elided fixture pair at a fixed `-Ox`.
-- [ ] Classify each survivor (read-only → suggest `&`; mutated / stored /
-      returned → explain why the copy is required) so the suggestion is offered
-      only when a reference would actually do.
+- [ ] Failed-SROA remarks: surface the surviving allocation and reuse the SROA
+      passes' hard-escape classification for the cause and escape-site span.
+- [ ] Classify each survivor's actionability (read-only copy → suggest `&`;
+      removable escape → suggest restructuring; otherwise explain why the cost is
+      required) so a suggestion is offered only when a fix would actually help.
 
 Trade-offs and boundaries:
 
 - Pure observability is valuable even without a suggestion: knowing which copies
-  remain is information the source cannot otherwise reveal.
+  and allocations remain is information the source cannot otherwise reveal.
 - Self-retiring as the optimizer matures is a feature, not a regression: the
-  remark reports residual cost, so its disappearance means the cost is gone.
-- Not every survivor is reference-fixable; some copies are semantically required
-  (an independent mutable value, a stored or returned aggregate). The MVP
-  surfaces the fact; the read-only-vs-required classification is the follow-up
-  above, and until it lands the suggestion is withheld rather than guessed.
+  remarks report residual cost, so their disappearance means the cost is gone.
+- Not every survivor is fixable; some copies are semantically required, and some
+  escapes are inherent. The MVP surfaces the fact; the actionability
+  classification above withholds the suggestion rather than guessing.
 - The paper's specific task (auto-vectorization) is intentionally out of scope:
   Wado leaves SIMD to the JIT. Only the remark mechanism transfers.
 - Rejected alternatives, recorded for design history: inlining remarks (fail

--- a/docs/wep-2026-06-03-optimizer-remarks.md
+++ b/docs/wep-2026-06-03-optimizer-remarks.md
@@ -1,4 +1,4 @@
-# WEP: Optimizer Remarks for Missed Optimizations
+# WEP: Optimizer Remarks for Residual Value-Copy Costs
 
 ## Context
 
@@ -11,133 +11,168 @@ first-try fix rate, and made type/trait diagnostics richer by default.
 
 A second paper extends the same lesson to a different compiler subsystem.
 "AI Coding Agents Need Better Compiler Remarks" (arXiv:2604.13927, 2026) studies
-_optimization remarks_ — the compiler's feedback about why a desired
-optimization did **not** fire — rather than hard errors. Driving an agent to
-restructure C loops for auto-vectorization on the TSVC suite, it found:
+_optimization remarks_ — the compiler's feedback about a desired optimization —
+rather than hard errors. Driving an agent to restructure C loops for
+auto-vectorization on the TSVC suite, it found:
 
 - Remarks are the bottleneck, not the model. Adding the compiler's stock
   vectorization remarks raised the success rate ~3.3x for the same small model;
-  hand-written remarks that name the exact data-flow obstacle and prescribe a
-  fix added a further 40–59 points.
+  hand-written remarks that name the exact obstacle and prescribe a fix added a
+  further 40–59 points.
 - The split is precise-vs-vague, and vague is _worse than nothing_. A remark
-  like "unsafe dependent memory operations in loop" triggered
-  semantic-breaking hallucinations — the agent mangled program logic trying to
-  satisfy a constraint it could not see. A precise remark —
-  "assumed write-after-read dependence between `a[i+1]` and `a[i]`; suggestion:
-  use a temporary" — carries the dependence kind, both source locations, and an
-  actionable transformation, and the agent fixes the source.
-- The three ingredients of a useful remark: the **why** (the analysis fact that
-  blocked the pass), **where** (file:line:col for each participant), and a
-  **prescriptive suggestion** (the source change that would unblock it).
+  like "unsafe dependent memory operations in loop" triggered semantic-breaking
+  hallucinations; a precise remark naming the dependence kind and both source
+  locations let the agent fix the source.
+- The three ingredients of a useful remark: the _why_ (the fact that blocked the
+  optimization), _where_ (file:line:col for each participant), and a
+  _prescriptive suggestion_ (the source change that would help).
 
 This is the same meta-principle as the Diagnostic Reason Chains WEP — precise,
 causal, prescriptive feedback by default; vague feedback is actively harmful —
 applied to a subsystem that WEP does not touch. Type/trait diagnostics report
-_errors_: the program is rejected. Optimizer remarks report _missed wins_: the
-program compiles and runs correctly but slower or larger than the source
-structure could allow. Different audience need (performance, not correctness),
-different subsystem (the NIR/WIR optimizer, not the type checker), so a separate
-WEP rather than an extension of the existing one.
+_errors_: the program is rejected. Optimizer remarks report _costs_: the program
+is correct but pays a runtime price the source structure could avoid. Different
+audience need (performance, not correctness), different subsystem (the optimizer,
+not the type checker), so a separate WEP.
 
-### Where Wado stands today
+## What transfers, and the design principle it forces
 
-The optimizer (see [optimizer.md](./optimizer.md)) runs a 23-pass NIR
-fixed-point loop plus WIR-level passes, every one of which can silently decline
-to fire on a given construct: a function over the inline threshold, a value copy
-not elided because an alias guard tripped, LICM refusing to hoist a possibly
-mutated field, SROA giving up on an escaping aggregate. None of this is
-observable. The compiler emits no remark for any missed optimization; the only
-trace of the concept in the codebase is one incidental `// missed optimisation`
-comment in `licm.rs`. An agent (or human) tuning a hot Wado function has no
-signal for _why_ a pass did not engage or _what to change_, which is exactly the
-gap the paper measures.
+The paper's literal task does not transfer. It coaxes a compiler into
+auto-vectorizing; Wado's optimizer philosophy is to leave low-level work like
+SIMD to the runtime JIT (see [optimizer.md](./optimizer.md)). What transfers is
+the _remark mechanism_, and choosing where to point it surfaces a sharp design
+constraint, because Wado's optimizer is still developing and remarks must not be
+written to fit its current internals.
 
-Wado's optimizer philosophy ("prefer a native Wasm instruction over a complex
-transformation; let the runtime JIT do low-level work like vectorization")
-means the paper's literal task — coaxing the compiler to auto-vectorize — does
-not transfer: Wado deliberately leaves SIMD to the JIT. What transfers is the
-_remark mechanism_ applied to the passes Wado does own, the ones whose firing is
-a direct function of source structure and value-semantics shape: inlining, value-
-copy elision/demotion, SROA / container SROA, LICM, dead-argument/return
-elimination. These are precisely the passes where a small source rewrite flips
-the outcome, so a prescriptive remark has a concrete fix to name.
+Inlining was the obvious first candidate and is rejected. It fails three tests a
+remark must pass:
+
+- _Durable_ — it must not bind to optimizer heuristics that are in flux.
+  Inlining is governed by a cost-vs-threshold heuristic that will keep changing.
+- _Actionable_ — there must be a clear source change. "Too big to inline" leaves
+  the author with no reliable move.
+- _Reliable_ — applying the change must reliably help. An inline hint exists
+  already and does not reliably make code faster.
+
+Inlining misses all three. The principle that survives the bar:
+
+> A remark should bind to the language's semantic cost model, not to an optimizer
+> heuristic, and it should fire from a fact observable in the final IR, not from a
+> pass's internal decision.
+
+Binding to the final IR is what decouples the remark from the immature
+optimizer. The remark machinery reads the optimizer's _output_ — a stable
+interface — never its pass internals. As the optimizer improves and removes a
+cost, the fact disappears from the final IR and the remark self-retires. That is
+the correct behavior, and it directly answers "don't write code to fit the
+current optimizer."
+
+## The flagship case: residual value-copy costs
+
+Value semantics is Wado's defining feature: assignment, parameter passing, and
+return all deep-copy the value; references (`&T`, `&mut T`) are the only escape
+hatch (spec.md). A large part of the optimizer exists precisely to remove these
+hidden copies, and most of them are in fact removed. Concretely, a deep copy is
+a call to a synthesized `$value_copy$T` helper (`FunctionKind::ValueCopy`), and
+the `value_copy_elide` pass strips the wrapper wherever the copy is provably
+unnecessary.
+
+The problem is observability. While coding, you cannot see which copies the
+optimizer eliminated and which survived. `f(x)` looks free; whether it
+deep-copies a whole aggregate at runtime is invisible at the source. This is the
+gap an agent (or human) tuning a hot Wado function falls into — not "I wrote a
+copy" (the optimizer usually erases that) but "I have no way to know which copies
+actually remain."
+
+A residual-copy remark closes exactly that gap. After optimization, a deep copy
+that survived is literally a remaining `$value_copy$T(...)` call in the final
+NIR. The remark walks the final NIR, collects those survivors for aggregate types
+above a size threshold, and maps each back to its source span. The design is
+self-justifying:
+
+- Low-noise by construction — the optimizer has already erased the easy copies,
+  so a survivor is rare and meaningful.
+- Self-decoupling — fewer survivors as the optimizer matures; the remark count
+  tracks genuine residual cost rather than today's heuristics.
+- Wado-specific — it teaches the cost model agents most often mispredict when
+  they carry priors from borrow-checked or reference-default languages.
+
+Its primary value is observability: the residual-copy set is information
+otherwise unobtainable during coding. Where the copied value is only read, the
+remark can also prescribe the reference escape hatch.
+
+Example (proposed output, not yet implemented):
+
+```
+remark: a deep copy of `Matrix` survives optimization here [stats.wado:12:18]
+  note: `frobenius` receives `Matrix` by value; the copy could not be elided
+  suggestion: take `m: &Matrix` if the callee only reads it
+```
+
+This carries the why (a deep copy of `Matrix` remains), the where (the call
+site), and a how that applies when the value is read-only — never a bare "copy
+not elided".
 
 ## Decision
 
-Introduce **optimizer remarks**: an opt-in channel in which a pass that declines
-a profitable transformation emits a structured, source-located, prescriptive
-note. Adopt the paper's three principles as hard requirements — every remark
-carries the blocking analysis fact (why), a span for each participant (where),
-and a concrete source-level suggestion (how) — and the corollary: a pass that
-cannot meet all three stays silent rather than emit a vague remark, because the
-paper shows vague remarks are net-negative.
+Introduce optimizer remarks, with residual value-copy remarks as the first kind.
 
-### Opt-in, unlike error diagnostics
-
-The Diagnostic Reason Chains WEP made errors rich _by default_ and rejected an
-"AI mode". Remarks take the opposite default: **off unless requested**. The
-reasoning is not inconsistent — it follows the same goal of maximizing signal.
-An error names one rejected program; a missed-optimization remark could fire on
-many call sites of every compile, and on-by-default noise would bury the rare
-actionable remark. LLVM gates the analogue behind `-Rpass`; Wado gates it behind
-an explicit surface (proposed: a `--remarks[=pass,...]` flag on
-`wado compile`, and exposure through `wado dump`). Within that surface, the
-default-rich, never-vague principle holds in full.
+- Bind to the semantic cost model; derive firing from facts observable in the
+  final NIR — residual `$value_copy$T` calls — not from any pass's internals.
+- Opt-in, not on by default. Errors name one rejected program and are rich by
+  default (the Diagnostic Reason Chains stance); a cost remark is advisory and
+  could be plentiful, so it is gated behind an explicit surface (proposed:
+  `--remarks` on `wado compile`, plus `wado dump` exposure). Within that surface
+  the default-rich, never-vague principle holds in full.
+- Never vague: a remark that cannot supply why + where stays silent, since the
+  paper shows vague remarks are net-negative.
 
 ### MVP scope (proposed)
 
-Prove the mechanism on one pass before generalizing. Function inlining is the
-best first target: its decision is a single legible predicate (callee cost vs.
-the level's inline threshold), the fix is unambiguous, and the threshold is
-already opt-level-driven. A declined inline would emit, for example (proposed
-output, not yet implemented):
-
-```
-remark: `parse_header` was not inlined into `decode` [hot.wado:42:5]
-  note: callee cost 21 exceeds the -O2 inline threshold (13)
-  suggestion: split `parse_header`, raise the level to -O3, or mark it for inlining
-```
-
-The remark names the callee and call site (where), the cost-vs-threshold fact
-that blocked it (why), and the levers that would change the outcome (how) —
-never a bare "could not inline".
+- Walk the final NIR; collect residual `$value_copy$T(...)` calls for aggregate
+  types above a size threshold; emit one remark per survivor with its source
+  span. Surfacing the survivor set with spans is already the valuable
+  information; this is the MVP.
+- E2E fixtures pin the behavior at a fixed `-Ox`: one fixture where a copy
+  survives asserts the remark fires, one where the optimizer elides it asserts
+  it does not.
 
 ### Reusing existing infrastructure
 
-Remarks are diagnostics with spans, so they should reuse the rendering path the
+Remarks are diagnostics with spans, so they reuse the rendering path the
 Diagnostic Reason Chains WEP already exercises (headline + indented `note:` /
-`suggestion:` lines) rather than invent a parallel one. That WEP's open
-follow-up — give `Diagnostic` structured, independently-spanned notes — is a
-shared dependency: a remark that points at both the call site and the callee
-definition needs multi-span notes, the same capability type/trait reason chains
-want for pointing at an offending field. Building it once serves both.
+`suggestion:` lines). That WEP's open follow-up — structured, independently-
+spanned notes on `Diagnostic` — is a shared dependency: a remark that points at
+both the call site and the parameter definition needs multi-span notes, the same
+capability the type/trait reason chains want. Building it once serves both.
 
 ## Consequences
 
 This WEP is design-stage; nothing below is implemented yet.
 
-- [ ] Decide the remark surface: `--remarks[=pass,...]` flag on `wado compile`,
-      `wado dump` exposure, and/or `--log-level` integration.
-- [ ] Define a `Remark` representation (pass name, participant spans, the
-      blocking fact, the suggestion) and where passes emit it without threading
-      it through every transformation.
-- [ ] MVP: inlining-declined remarks with the three required ingredients,
-      plus E2E fixtures asserting remark text at a fixed `-Ox`.
-- [ ] Extend to the source-structure-sensitive passes (value-copy elision,
-      SROA / container SROA, LICM) once the inlining MVP validates the shape.
+- [ ] Decide the remark surface: `--remarks` on `wado compile`, `wado dump`
+      exposure, and/or `--log-level` integration.
+- [ ] Define how the final-NIR walk collects residual `$value_copy$T` calls with
+      source provenance and a size threshold.
+- [ ] MVP: residual value-copy remarks with why + where, plus the survives /
+      elided fixture pair at a fixed `-Ox`.
+- [ ] Classify each survivor (read-only → suggest `&`; mutated / stored /
+      returned → explain why the copy is required) so the suggestion is offered
+      only when a reference would actually do.
 
 Trade-offs and boundaries:
 
-- The paper's specific task (compiler auto-vectorization) is intentionally out
-  of scope: Wado leaves SIMD to the runtime JIT. Only the remark _mechanism_
-  transfers, applied to Wado's own passes.
-- Off-by-default is a deliberate divergence from the errors-by-default stance of
-  the Diagnostic Reason Chains WEP, justified by remark volume; the never-vague
-  principle is shared, not divergent.
-- Multi-span structured notes on `Diagnostic` are a shared prerequisite with the
-  Diagnostic Reason Chains WEP's next steps; this WEP does not duplicate that
-  work, it depends on it.
-- Risk: a remark that misstates why a pass declined is worse than none (the
-  paper's central finding). Each remark must be derived from the pass's actual
-  decision predicate, not a heuristic guess, and is gated on a test asserting it
-  fires exactly when the pass declines for that reason.
+- Pure observability is valuable even without a suggestion: knowing which copies
+  remain is information the source cannot otherwise reveal.
+- Self-retiring as the optimizer matures is a feature, not a regression: the
+  remark reports residual cost, so its disappearance means the cost is gone.
+- Not every survivor is reference-fixable; some copies are semantically required
+  (an independent mutable value, a stored or returned aggregate). The MVP
+  surfaces the fact; the read-only-vs-required classification is the follow-up
+  above, and until it lands the suggestion is withheld rather than guessed.
+- The paper's specific task (auto-vectorization) is intentionally out of scope:
+  Wado leaves SIMD to the JIT. Only the remark mechanism transfers.
+- Rejected alternatives, recorded for design history: inlining remarks (fail
+  durable / actionable / reliable, above); loop-allocation hoisting remarks
+  (bind to the LICM pass rather than a language-level semantic cost, so they
+  violate the principle).

--- a/docs/wep-2026-06-03-optimizer-remarks.md
+++ b/docs/wep-2026-06-03-optimizer-remarks.md
@@ -88,20 +88,32 @@ kinds.
 
 A deep copy is a call to a synthesized `$value_copy$T` helper
 (`FunctionKind::ValueCopy`), and the `value_copy_elide` pass strips the wrapper
-wherever the copy is provably unnecessary. A copy that survives optimization is
-therefore a remaining `$value_copy$T(...)` call in the final NIR. The remark
-collects those survivors for aggregate types above a size threshold and maps each
-back to its source span (proposed output, not yet implemented):
+wherever the copy is provably unnecessary. But a copy is not always removed _or_
+left intact: `value_copy_demote` rewrites a deep copy whose elements are never
+mutated into a shallow spine copy, lowered as a `builtin::array_clone` /
+`array_clone_shallow` call on the backing array. So a value copy that survives
+optimization appears in the final NIR as one of: a remaining `$value_copy$T(...)`
+call, or an `array_clone` / `array_clone_shallow` / `copy_value` call. The remark
+collects all of these in entry-module functions. (`array_copy` is excluded — it
+is bulk buffer movement inside stdlib helpers like `String::push`, not a
+value-semantic copy.) Actual shipped output, where `b` is a `List<i32>` copied
+then mutated:
 
 ```
-remark: a deep copy of `Matrix` survives optimization here [stats.wado:12:18]
-  note: `frobenius` receives `Matrix` by value; the copy could not be elided
-  suggestion: take `m: &Matrix` if the callee only reads it
+src.wado:5:5: info: remark: a copy of `List<i32>` survives optimization
 ```
 
-The _why_ is the surviving copy, the _where_ is the call site, and the _how_
-applies when the value is read-only: the reference escape hatch (`&T` / `&mut T`)
-is the only construct that shares rather than copies (spec.md).
+Why the final NIR and not the final WIR: the WIR is the last IR before codegen
+and would be the most authoritative "this copy executes" signal, but `WirInstr`
+carries no per-instruction span (only function-level `WirMeta` does), so a
+WIR-sourced remark could not point at the source. The optimized NIR is the last
+IR with per-expression spans, and `wir_build` lowers these copies one-to-one, so
+NIR is both span-accurate and faithful. Even so the synthesized copy nodes
+(`array_clone`, demoted spine copies) carry no user span themselves, so the
+remark is anchored to the enclosing statement — the `let mut b = a;` that performs
+the copy. The reference escape hatch (`&T` / `&mut T`) is the only construct that
+shares rather than copies (spec.md); naming it as a suggestion is deferred to the
+read-only-vs-required classification below.
 
 ### Surviving aggregate allocations (failed SROA)
 
@@ -137,25 +149,30 @@ the first two kinds.
   and derive firing from facts observable in the final NIR (residual
   `$value_copy$T` calls; aggregate allocations the SROA passes left in place),
   not from any pass's internals.
-- Opt-in, not on by default. Errors name one rejected program and are rich by
-  default (the Diagnostic Reason Chains stance); a cost remark is advisory and
-  could be plentiful, so it is gated behind an explicit surface (proposed:
-  `--remarks` on `wado compile`, plus `wado dump` exposure). Within that surface
-  the default-rich, never-vague principle holds in full.
+- Surfaced as an info-level `remark:` diagnostic through the existing logger, not
+  a dedicated flag. It rides `--log-level`: shown at the default `Info` level,
+  silenced by `--log-level warn`. This needs no new configuration surface for an
+  agent to discover, and the low-noise-by-construction property (the optimizer
+  has already removed the easy copies) keeps the default-on volume small. The
+  never-vague principle still holds: a remark that cannot supply why + where is
+  not emitted.
 - Never vague: a remark that cannot supply why + where stays silent, since the
   paper shows vague remarks are net-negative.
 
-### MVP scope (proposed)
+### MVP scope
 
-- Start with surviving value copies: walk the final NIR, collect residual
-  `$value_copy$T(...)` calls for aggregate types above a size threshold, emit one
-  remark per survivor with its source span. Surfacing the survivor set with spans
-  is already the valuable information.
-- Then add failed-SROA remarks, reusing the SROA passes' existing hard-escape
-  classification for the _why_ and the escape site for a second span.
-- E2E fixtures pin each at a fixed `-Ox`: a fixture where the cost survives
-  asserts the remark fires; a fixture where the optimizer removes it asserts it
-  does not.
+Shipped: surviving value copies. `remarks::collect_value_copy_remarks` walks the
+optimized NIR's entry-module functions, collects residual `$value_copy$T` calls
+and `array_clone` / `array_clone_shallow` / `copy_value` calls, and emits one
+info-level remark per survivor anchored to the enclosing statement.
+`logger.remark` carries the span and the entry filename; tests
+(`wado-compiler/tests/remarks.rs`) pin the behavior at `-O2` — a `List<i32>`
+copied then mutated fires one remark on the copy line; a `Point` that SROA
+scalarizes fires none. No size threshold yet: a synthesized copy helper only
+exists for non-trivial aggregates, so survivors are already non-trivial.
+
+Next: failed-SROA remarks, reusing the SROA passes' existing hard-escape
+classification for the _why_ and the escape site for a second span.
 
 ### Reusing existing infrastructure
 
@@ -168,19 +185,24 @@ capability the type/trait reason chains want. Building it once serves both.
 
 ## Consequences
 
-This WEP is design-stage; nothing below is implemented yet.
+Shipped:
 
-- [ ] Decide the remark surface: `--remarks` on `wado compile`, `wado dump`
-      exposure, and/or `--log-level` integration.
-- [ ] Define how the final-NIR walk collects residual `$value_copy$T` calls and
-      surviving aggregate allocations with source provenance and a size threshold.
-- [ ] MVP: residual value-copy remarks with why + where, plus the survives /
-      elided fixture pair at a fixed `-Ox`.
+- [x] Remark surface: info-level `remark:` diagnostic via `logger.remark`, gated
+      by `--log-level` (no dedicated flag). `Code::Remark`.
+- [x] Final-NIR walk (`remarks::collect_value_copy_remarks`) over entry-module
+      functions, detecting `$value_copy$T` and `array_clone` / `array_clone_shallow`
+      / `copy_value` survivors, anchored to the enclosing statement span.
+- [x] Surviving value-copy remarks with why + where, plus the survives / elided
+      test pair at `-O2` (`wado-compiler/tests/remarks.rs`).
+
+Next:
+
 - [ ] Failed-SROA remarks: surface the surviving allocation and reuse the SROA
       passes' hard-escape classification for the cause and escape-site span.
 - [ ] Classify each survivor's actionability (read-only copy → suggest `&`;
       removable escape → suggest restructuring; otherwise explain why the cost is
       required) so a suggestion is offered only when a fix would actually help.
+- [ ] Broaden beyond the entry module to all user (non-stdlib) modules.
 
 Trade-offs and boundaries:
 

--- a/wado-cli/src/args.rs
+++ b/wado-cli/src/args.rs
@@ -135,11 +135,17 @@ pub const OPT_ITERATIONS_SPEC: OptSpec = OptSpec {
     desc: "Override number of fixed-point optimization iterations",
 };
 
+/// Default log level for CLI subcommands. The CLI is quiet by default:
+/// warnings and errors show, but info-level output — including optimizer
+/// `remark:`s (WEP `wep-2026-06-03-optimizer-remarks.md`) — needs an explicit
+/// `--log-level info`.
+pub const DEFAULT_LOG_LEVEL: LogLevel = LogLevel::Warn;
+
 pub const LOG_LEVEL_SPEC: OptSpec = OptSpec {
     long: Some("log-level"),
     short: None,
     value: Some("<level>"),
-    desc: "Log level: debug, info, warn, error, off (default: info)",
+    desc: "Log level: debug, info, warn, error, off (default: warn)",
 };
 
 pub const WORLD_SPEC: OptSpec = OptSpec {

--- a/wado-cli/src/check.rs
+++ b/wado-cli/src/check.rs
@@ -82,7 +82,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<CheckOptions, CliExit> {
     let usage = format_usage();
     let mut input: Option<String> = None;
     let mut warn_only = false;
-    let mut log_level = LogLevel::default();
+    let mut log_level = args::DEFAULT_LOG_LEVEL;
     while let Some(arg) = args::next_arg(&mut parser)? {
         if let Some(opt) = args::match_opt(&arg, Opt::ALL, |o| o.spec()) {
             match opt {

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -219,7 +219,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<CompileOptions, CliExit>
     let mut input: Option<String> = None;
     let mut opt_level = OptLevel::default();
     let mut wat_to_stdout = false;
-    let mut log_level = LogLevel::default();
+    let mut log_level = args::DEFAULT_LOG_LEVEL;
     let mut target_world: Option<String> = None;
     let mut skip_validation = false;
     let mut inline_threshold: Option<usize> = None;

--- a/wado-cli/src/compiler_host.rs
+++ b/wado-cli/src/compiler_host.rs
@@ -39,7 +39,7 @@ impl FilesystemCompilerHost {
         Self {
             inner: Arc::new(wado_lsp::FilesystemCompilerHost::new(base_path)),
             print_diagnostics: true,
-            log_level: LogLevel::Warn,
+            log_level: crate::args::DEFAULT_LOG_LEVEL,
             start_time: Instant::now(),
             kiln_engine: OnceLock::new(),
             kiln_components: Mutex::new(Vec::new()),

--- a/wado-cli/src/compiler_host.rs
+++ b/wado-cli/src/compiler_host.rs
@@ -39,7 +39,7 @@ impl FilesystemCompilerHost {
         Self {
             inner: Arc::new(wado_lsp::FilesystemCompilerHost::new(base_path)),
             print_diagnostics: true,
-            log_level: LogLevel::Info,
+            log_level: LogLevel::Warn,
             start_time: Instant::now(),
             kiln_engine: OnceLock::new(),
             kiln_components: Mutex::new(Vec::new()),

--- a/wado-cli/src/run.rs
+++ b/wado-cli/src/run.rs
@@ -177,7 +177,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<RunOptions, CliExit> {
     let usage = format_usage();
     let mut input: Option<String> = None;
     let mut opt_level = OptLevel::default();
-    let mut log_level = LogLevel::default();
+    let mut log_level = args::DEFAULT_LOG_LEVEL;
     let mut profile = ProfileMode::None;
     let mut preopened_dirs: Vec<(String, String)> = Vec::new();
     let mut program_args: Vec<String> = Vec::new();

--- a/wado-cli/src/serve.rs
+++ b/wado-cli/src/serve.rs
@@ -229,7 +229,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<ServeOptions, CliExit> {
     let usage = format_usage();
     let mut input: Option<String> = None;
     let mut opt_level = OptLevel::default();
-    let mut log_level = LogLevel::default();
+    let mut log_level = args::DEFAULT_LOG_LEVEL;
     let mut addr = "0.0.0.0:8080".to_string();
     let mut inline_threshold: Option<usize> = None;
     let mut opt_iterations: Option<u32> = None;

--- a/wado-cli/src/test.rs
+++ b/wado-cli/src/test.rs
@@ -349,7 +349,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<TestOptions, CliExit> {
     let mut cli_excludes: Vec<String> = Vec::new();
     let mut jobs: Option<usize> = None;
     let mut opt_level = OptLevel::default();
-    let mut log_level = LogLevel::default();
+    let mut log_level = args::DEFAULT_LOG_LEVEL;
     let mut inline_threshold: Option<usize> = None;
     let mut opt_iterations: Option<u32> = None;
     let mut allocator: Option<String> = None;

--- a/wado-compiler/src/compiler_host.rs
+++ b/wado-compiler/src/compiler_host.rs
@@ -132,6 +132,8 @@ pub enum Code {
     // General logging
     /// Generic log message (info, debug, etc.)
     Log,
+    /// Optimizer remark (residual cost that survived optimization).
+    Remark,
 
     // Kiln errors
     /// A generator's `Options` struct uses a shape not supported by Kiln.
@@ -189,6 +191,7 @@ impl std::fmt::Display for Code {
             Code::SpanStart => "SPAN_START",
             Code::SpanEnd => "SPAN_END",
             Code::Log => "LOG",
+            Code::Remark => "REMARK",
             Code::GeneratorOptionsUnsupported => "GENERATOR_OPTIONS_UNSUPPORTED",
             Code::GeneratorOptionsInvalid => "GENERATOR_OPTIONS_INVALID",
             Code::KilnStaleCache => "KILN_STALE_CACHE",

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -31,6 +31,7 @@ pub mod nir_visitor;
 pub mod optimize;
 pub mod package;
 pub mod parser;
+pub mod remarks;
 pub mod semantics;
 pub mod stdlib;
 pub(crate) mod stdlib_snapshot;
@@ -62,6 +63,7 @@ pub use compiler_host::{
     Severity, SourceError,
 };
 pub use logger::{Bail, Logger};
+pub use remarks::{Remark, collect_value_copy_remarks};
 pub use semantics::{
     Cursor, Definition, Semantics, lex_error_diagnostic, parse_error_diagnostic, semantics,
     semantics_of,
@@ -300,6 +302,9 @@ fn compile_after_load<H: CompilerHost>(
     Bail,
 > {
     let module_name = filename.unwrap_or_else(|| "module".to_string());
+    // Kept for attributing optimizer remarks to the entry file; `module_name`
+    // itself is moved into the `Package` before remarks are emitted.
+    let entry_filename = module_name.clone();
     let implicit_modules = load_result.implicit_modules.clone();
     let entry_ast = load_result.entry_ast.clone();
     let mut load_result = load_result;
@@ -633,6 +638,16 @@ fn compile_after_load<H: CompilerHost>(
             logger,
         )
     };
+
+    // Emit optimizer remarks for residual value-semantic copies that survived
+    // the NIR pipeline. NIR is the last IR with per-expression spans; see
+    // `remarks` and WEP `wep-2026-06-03-optimizer-remarks.md`.
+    for remark in remarks::collect_value_copy_remarks(&nir) {
+        logger.remark(
+            remark.message,
+            compiler_host::DiagnosticSpan::from_span(&remark.span, Some(&entry_filename)),
+        );
+    }
 
     // === Phase 12: Build WIR (NirPackage → WirPackage) ===
     let mut wir_package = {

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -641,12 +641,16 @@ fn compile_after_load<H: CompilerHost>(
 
     // Emit optimizer remarks for residual value-semantic copies that survived
     // the NIR pipeline. NIR is the last IR with per-expression spans; see
-    // `remarks` and WEP `wep-2026-06-03-optimizer-remarks.md`.
-    for remark in remarks::collect_value_copy_remarks(&nir) {
-        logger.remark(
-            remark.message,
-            compiler_host::DiagnosticSpan::from_span(&remark.span, Some(&entry_filename)),
-        );
+    // `remarks` and WEP `wep-2026-06-03-optimizer-remarks.md`. Gated on the log
+    // level so the NIR walk is skipped entirely when remarks would be filtered
+    // out (the default CLI level is `warn`).
+    if logger.would_log(compiler_host::Severity::Info) {
+        for remark in remarks::collect_value_copy_remarks(&nir) {
+            logger.remark(
+                remark.message,
+                compiler_host::DiagnosticSpan::from_span(&remark.span, Some(&entry_filename)),
+            );
+        }
     }
 
     // === Phase 12: Build WIR (NirPackage → WirPackage) ===

--- a/wado-compiler/src/logger.rs
+++ b/wado-compiler/src/logger.rs
@@ -190,6 +190,12 @@ impl<'a, H: CompilerHost> Logger<'a, H> {
 
     // === Informational logging (fire-and-forget, filtered by level) ===
 
+    /// Whether a diagnostic of `severity` would be emitted at the current level.
+    /// Lets callers skip building a diagnostic that would be filtered out.
+    pub fn would_log(&self, severity: Severity) -> bool {
+        self.should_log(severity)
+    }
+
     /// Check if the given severity should be logged at the current level
     fn should_log(&self, severity: Severity) -> bool {
         match self.level {
@@ -239,10 +245,11 @@ impl<'a, H: CompilerHost> Logger<'a, H> {
     /// Emit an optimizer remark at info level, carrying a source span.
     ///
     /// Remarks report residual costs that survived optimization (see WEP
-    /// `wep-2026-06-03-optimizer-remarks.md`). They are gated like `info` —
-    /// shown at the default `Info` level, silenced by `--log-level warn` — but
-    /// carry a span so the source location is rendered. The `remark:` prefix is
-    /// added here so call sites pass only the bare message.
+    /// `wep-2026-06-03-optimizer-remarks.md`). They are gated at `Info`
+    /// severity; since the CLI is quiet by default (`warn`), seeing them takes
+    /// `--log-level info`. The span lets the source location be rendered, and
+    /// the `remark:` prefix is added here so call sites pass only the bare
+    /// message.
     pub fn remark(&self, message: impl Into<String>, span: DiagnosticSpan) {
         if self.should_log(Severity::Info) {
             let diag = self.apply_file_context(Diagnostic {

--- a/wado-compiler/src/logger.rs
+++ b/wado-compiler/src/logger.rs
@@ -25,7 +25,9 @@
 
 use std::cell::{Cell, RefCell};
 
-use crate::compiler_host::{Code, CompilerHost, Diagnostic, LogLevel, Severity, SpanEmitter};
+use crate::compiler_host::{
+    Code, CompilerHost, Diagnostic, DiagnosticSpan, LogLevel, Severity, SpanEmitter,
+};
 
 /// Maximum number of errors before compilation is aborted
 pub const MAX_ERRORS: usize = 100;
@@ -231,6 +233,25 @@ impl<'a, H: CompilerHost> Logger<'a, H> {
                 message: message.into(),
                 span: None,
             });
+        }
+    }
+
+    /// Emit an optimizer remark at info level, carrying a source span.
+    ///
+    /// Remarks report residual costs that survived optimization (see WEP
+    /// `wep-2026-06-03-optimizer-remarks.md`). They are gated like `info` —
+    /// shown at the default `Info` level, silenced by `--log-level warn` — but
+    /// carry a span so the source location is rendered. The `remark:` prefix is
+    /// added here so call sites pass only the bare message.
+    pub fn remark(&self, message: impl Into<String>, span: DiagnosticSpan) {
+        if self.should_log(Severity::Info) {
+            let diag = self.apply_file_context(Diagnostic {
+                severity: Severity::Info,
+                code: Code::Remark,
+                message: format!("remark: {}", message.into()),
+                span: Some(span),
+            });
+            self.host.emit_diagnostic(diag);
         }
     }
 

--- a/wado-compiler/src/nir_package.rs
+++ b/wado-compiler/src/nir_package.rs
@@ -126,6 +126,21 @@ impl NirPackage {
         self.target_world == world_registry::TEST_WORLD
     }
 
+    /// Build the lookup of synthesized value-copy helpers, keyed by
+    /// `(module_source, name)` → the type each helper deep-copies. Shared by the
+    /// `value_copy_elide` optimizer pass and the `remarks` collector so the two
+    /// stay in lock-step with the helper-identification convention.
+    pub fn value_copy_helper_types(&self) -> IndexMap<(ModuleSource, String), TypeId> {
+        self.functions
+            .iter()
+            .filter_map(|f| {
+                let f = f.borrow();
+                f.value_copy_type()
+                    .map(|t| ((f.module_source.clone(), f.name.clone()), t))
+            })
+            .collect()
+    }
+
     /// Check whether the active world declares an
     /// `import {interface_name} { ... }` block.
     ///

--- a/wado-compiler/src/optimize/value_copy_elide.rs
+++ b/wado-compiler/src/optimize/value_copy_elide.rs
@@ -24,15 +24,7 @@ use crate::nir_visitor::{NirOptVisitor, NirRefVisitor, opt_walk_expr, opt_walk_s
 use crate::tir::{ResolvedType, TypeId, TypeTable};
 
 pub fn elide_synthesized_value_copies(project: &mut NirPackage) {
-    let value_copy_set: IndexMap<(ModuleSource, String), TypeId> = project
-        .functions
-        .iter()
-        .filter_map(|f| {
-            let f = f.borrow();
-            f.value_copy_type()
-                .map(|t| ((f.module_source.clone(), f.name.clone()), t))
-        })
-        .collect();
+    let value_copy_set = project.value_copy_helper_types();
     if value_copy_set.is_empty() {
         return;
     }

--- a/wado-compiler/src/remarks.rs
+++ b/wado-compiler/src/remarks.rs
@@ -1,0 +1,145 @@
+//! Optimizer remarks: surface residual value-semantic copies that survive
+//! optimization. See WEP `wep-2026-06-03-optimizer-remarks.md`.
+//!
+//! Wado deep-copies aggregates on assignment, parameter passing, and return.
+//! A large part of the optimizer exists to remove those hidden copies, and most
+//! of them are removed; the ones that remain are invisible while coding. After
+//! the NIR optimization pipeline, a surviving copy appears as one of:
+//!
+//! - a call to a synthesized `$value_copy$T` deep-copy helper, or
+//! - a `builtin::array_clone` / `array_clone_shallow` / `copy_value` call — the
+//!   lowered (and possibly `value_copy_demote`-shallowed) spine copy of a
+//!   `List<T>` or `String`.
+//!
+//! NIR is the last IR that still carries per-expression source spans — WIR
+//! instructions do not — and `wir_build` lowers these copies one-to-one, so
+//! walking the optimized NIR yields the residual-copy set with exact source
+//! locations. Detection is restricted to the entry module so the pervasive
+//! buffer copies inside stdlib helpers (`String::push` growth, …) are not
+//! reported; those are `array_copy`, which is deliberately excluded anyway.
+
+use crate::hashmap::IndexMap;
+use crate::module_source::ModuleSource;
+use crate::nir::{NirExpr, NirExprKind, NirStmt, NirUnaryOp};
+use crate::nir_package::NirPackage;
+use crate::nir_visitor::NirRefVisitor;
+use crate::tir::{TypeId, TypeTable};
+use crate::token::Span;
+
+/// A single optimizer remark: a residual cost with its source span.
+pub struct Remark {
+    /// The remark text, without the `remark:` prefix the logger adds.
+    pub message: String,
+    /// Where the copy survives, in the original source.
+    pub span: Span,
+}
+
+/// Collect remarks for value-semantic copies that survive optimization,
+/// restricted to functions defined in the entry module.
+pub fn collect_value_copy_remarks(package: &NirPackage) -> Vec<Remark> {
+    let value_copy_set: IndexMap<(ModuleSource, String), TypeId> = package
+        .functions
+        .iter()
+        .filter_map(|f| {
+            let f = f.borrow();
+            f.value_copy_type()
+                .map(|t| ((f.module_source.clone(), f.name.clone()), t))
+        })
+        .collect();
+
+    let type_table_ref = package.type_table.borrow();
+    let type_table: &TypeTable = &type_table_ref;
+    let mut remarks = Vec::new();
+    for func_rc in &package.functions {
+        let func = func_rc.borrow();
+        if func.module_source != package.entry_module_source || func.is_value_copy() {
+            continue;
+        }
+        let Some(body) = func.body.as_ref() else {
+            continue;
+        };
+        let mut collector = Collector {
+            value_copy_set: &value_copy_set,
+            type_table,
+            remarks: &mut remarks,
+            current_span: body.span,
+        };
+        collector.visit_block(body);
+    }
+    remarks
+}
+
+struct Collector<'a> {
+    value_copy_set: &'a IndexMap<(ModuleSource, String), TypeId>,
+    type_table: &'a TypeTable,
+    remarks: &'a mut Vec<Remark>,
+    /// Span of the enclosing statement. The synthesized copy nodes
+    /// (`array_clone`, demoted spine copies) carry no user span, so the remark
+    /// points at the statement that performs the copy (`let mut b = a;`).
+    current_span: Span,
+}
+
+impl Collector<'_> {
+    /// If `expr` is a surviving value-copy operation, return the type whose
+    /// value is copied.
+    fn copied_type(&self, expr: &NirExpr) -> Option<TypeId> {
+        let NirExprKind::Call { func, args, .. } = &expr.kind else {
+            return None;
+        };
+        // Deep `$value_copy$T` helper call.
+        if args.len() == 1
+            && let Some(&type_id) = self
+                .value_copy_set
+                .get(&(func.module_source.clone(), func.name.clone()))
+        {
+            return Some(type_id);
+        }
+        // Lowered / demoted spine copy of a `List<T>` or `String`. `array_copy`
+        // is excluded on purpose: it is bulk buffer movement inside stdlib
+        // helpers, not a value-semantic copy.
+        if matches!(
+            func.monomorphized_builtin_name().as_deref(),
+            Some("builtin::array_clone" | "builtin::array_clone_shallow" | "builtin::copy_value")
+        ) {
+            return args.first().map(|a| clone_source_type(&a.expr));
+        }
+        None
+    }
+}
+
+impl NirRefVisitor for Collector<'_> {
+    fn visit_stmt(&mut self, stmt: &NirStmt) {
+        let prev = self.current_span;
+        self.current_span = stmt.span;
+        self.walk_stmt(stmt);
+        self.current_span = prev;
+    }
+
+    fn visit_expr(&mut self, expr: &NirExpr) {
+        if let Some(type_id) = self.copied_type(expr) {
+            let type_name = self.type_table.type_name(type_id);
+            self.remarks.push(Remark {
+                message: format!("a copy of `{type_name}` survives optimization"),
+                span: self.current_span,
+            });
+        }
+        self.walk_expr(expr);
+    }
+}
+
+/// For an `array_clone(&agg.repr)` call, recover the aggregate type (`List<T>`
+/// or `String`) that owns the cloned `repr`, peeling the `&`/`&mut` reference
+/// and the `.repr` field access. Falls back to the argument's own type.
+fn clone_source_type(arg: &NirExpr) -> TypeId {
+    let inner = match &arg.kind {
+        NirExprKind::Unary {
+            op: NirUnaryOp::Ref | NirUnaryOp::MutRef,
+            expr,
+        } => expr,
+        _ => arg,
+    };
+    match &inner.kind {
+        NirExprKind::FieldAccess { expr, .. } => expr.type_id,
+        _ => inner.type_id,
+    }
+}

--- a/wado-compiler/src/remarks.rs
+++ b/wado-compiler/src/remarks.rs
@@ -6,17 +6,22 @@
 //! of them are removed; the ones that remain are invisible while coding. After
 //! the NIR optimization pipeline, a surviving copy appears as one of:
 //!
-//! - a call to a synthesized `$value_copy$T` deep-copy helper, or
-//! - a `builtin::array_clone` / `array_clone_shallow` / `copy_value` call — the
-//!   lowered (and possibly `value_copy_demote`-shallowed) spine copy of a
-//!   `List<T>` or `String`.
+//! - a call to a synthesized `$value_copy$T` deep-copy helper,
+//! - a `builtin::array_clone` / `array_clone_shallow` call — the lowered (and
+//!   possibly `value_copy_demote`-shallowed) spine copy of a `List<T>` or
+//!   `String`, or
+//! - a `builtin::copy_value` call — a direct deep copy of a value.
 //!
 //! NIR is the last IR that still carries per-expression source spans — WIR
 //! instructions do not — and `wir_build` lowers these copies one-to-one, so
 //! walking the optimized NIR yields the residual-copy set with exact source
-//! locations. Detection is restricted to the entry module so the pervasive
-//! buffer copies inside stdlib helpers (`String::push` growth, …) are not
-//! reported; those are `array_copy`, which is deliberately excluded anyway.
+//! locations.
+//!
+//! Detection is restricted to the entry module's functions. This excludes the
+//! pervasive buffer copies inside stdlib helpers (`String::push` growth, …) and,
+//! as a current limitation, also copies in other user modules of a multi-file
+//! program (see the WEP's "broaden beyond the entry module" item). `array_copy`
+//! is excluded regardless: it is bulk buffer movement, not a value-semantic copy.
 
 use crate::hashmap::IndexMap;
 use crate::module_source::ModuleSource;
@@ -37,21 +42,17 @@ pub struct Remark {
 /// Collect remarks for value-semantic copies that survive optimization,
 /// restricted to functions defined in the entry module.
 pub fn collect_value_copy_remarks(package: &NirPackage) -> Vec<Remark> {
-    let value_copy_set: IndexMap<(ModuleSource, String), TypeId> = package
-        .functions
-        .iter()
-        .filter_map(|f| {
-            let f = f.borrow();
-            f.value_copy_type()
-                .map(|t| ((f.module_source.clone(), f.name.clone()), t))
-        })
-        .collect();
+    let value_copy_set = package.value_copy_helper_types();
 
     let type_table_ref = package.type_table.borrow();
     let type_table: &TypeTable = &type_table_ref;
     let mut remarks = Vec::new();
     for func_rc in &package.functions {
         let func = func_rc.borrow();
+        // A value-copy helper is synthesized in the module that defines the
+        // copied type, so a helper for an entry-module type also lives in the
+        // entry module. Skipping helper *bodies* keeps the copies inside a
+        // helper from being reported against the helper itself.
         if func.module_source != package.entry_module_source || func.is_value_copy() {
             continue;
         }
@@ -63,6 +64,7 @@ pub fn collect_value_copy_remarks(package: &NirPackage) -> Vec<Remark> {
             type_table,
             remarks: &mut remarks,
             current_span: body.span,
+            in_value_block: false,
         };
         collector.visit_block(body);
     }
@@ -73,10 +75,13 @@ struct Collector<'a> {
     value_copy_set: &'a IndexMap<(ModuleSource, String), TypeId>,
     type_table: &'a TypeTable,
     remarks: &'a mut Vec<Remark>,
-    /// Span of the enclosing statement. The synthesized copy nodes
-    /// (`array_clone`, demoted spine copies) carry no user span, so the remark
-    /// points at the statement that performs the copy (`let mut b = a;`).
+    /// Span of the enclosing real statement. Synthesized copy nodes
+    /// (`array_clone`, demoted spine copies) carry placeholder spans, so the
+    /// remark points at the statement that performs the copy (`let mut b = a;`).
     current_span: Span,
+    /// True while walking a block used as an expression value, whose inner
+    /// statements are synthesized and must not override `current_span`.
+    in_value_block: bool,
 }
 
 impl Collector<'_> {
@@ -94,21 +99,30 @@ impl Collector<'_> {
         {
             return Some(type_id);
         }
-        // Lowered / demoted spine copy of a `List<T>` or `String`. `array_copy`
-        // is excluded on purpose: it is bulk buffer movement inside stdlib
-        // helpers, not a value-semantic copy.
-        if matches!(
-            func.monomorphized_builtin_name().as_deref(),
-            Some("builtin::array_clone" | "builtin::array_clone_shallow" | "builtin::copy_value")
-        ) {
-            return args.first().map(|a| clone_source_type(&a.expr));
+        // Lowered / demoted copies. `array_copy` is excluded on purpose: it is
+        // bulk buffer movement inside stdlib helpers, not a value-semantic copy.
+        match func.monomorphized_builtin_name().as_deref() {
+            // `array_clone(&agg.repr)` copies a `List<T>` / `String` backing
+            // array; recover the owning aggregate type from the argument.
+            Some("builtin::array_clone" | "builtin::array_clone_shallow") => {
+                args.first().map(|a| clone_source_type(&a.expr))
+            }
+            // `copy_value(v)` deep-copies a value directly, so the call's result
+            // type is the copied type.
+            Some("builtin::copy_value") => Some(expr.type_id),
+            _ => None,
         }
-        None
     }
 }
 
 impl NirRefVisitor for Collector<'_> {
     fn visit_stmt(&mut self, stmt: &NirStmt) {
+        if self.in_value_block {
+            // Inside a block-as-value: keep the enclosing real statement's span
+            // rather than the synthesized inner statement's placeholder span.
+            self.walk_stmt(stmt);
+            return;
+        }
         let prev = self.current_span;
         self.current_span = stmt.span;
         self.walk_stmt(stmt);
@@ -123,8 +137,30 @@ impl NirRefVisitor for Collector<'_> {
                 span: self.current_span,
             });
         }
-        self.walk_expr(expr);
+        if is_value_block(expr) {
+            let prev = self.in_value_block;
+            self.in_value_block = true;
+            self.walk_expr(expr);
+            self.in_value_block = prev;
+        } else {
+            self.walk_expr(expr);
+        }
     }
+}
+
+/// Block-shaped expressions used as a value. Their inner statement lists come
+/// from lowering / SROA reconstruction and carry placeholder spans, so the
+/// remark anchors to the enclosing real statement instead of descending into
+/// them.
+fn is_value_block(expr: &NirExpr) -> bool {
+    matches!(
+        expr.kind,
+        NirExprKind::Block(_)
+            | NirExprKind::If { .. }
+            | NirExprKind::Match { .. }
+            | NirExprKind::Switch { .. }
+            | NirExprKind::LabeledBlock { .. }
+    )
 }
 
 /// For an `array_clone(&agg.repr)` call, recover the aggregate type (`List<T>`

--- a/wado-compiler/tests/remarks.rs
+++ b/wado-compiler/tests/remarks.rs
@@ -1,0 +1,96 @@
+//! Optimizer remark tests (WEP `wep-2026-06-03-optimizer-remarks.md`).
+//!
+//! A value-semantic copy that survives the optimizer is reported as an
+//! info-level `remark:` diagnostic with a source span; a copy the optimizer
+//! removes (scalarizes / elides) is not.
+
+mod common;
+
+use common::{InMemoryHost, runtime};
+use wado_compiler::{CompilerOptions, OptLevel};
+
+/// Compile `source` at `-O2` and return the `remark:` diagnostics as
+/// `"line:col message"` strings.
+fn remarks_for(source: &str) -> Vec<String> {
+    let host = InMemoryHost::new();
+    let options = CompilerOptions {
+        opt_level: OptLevel::O2,
+        ..CompilerOptions::default()
+    };
+    let _ = runtime().block_on(wado_compiler::compile_with_options(
+        source,
+        &host,
+        Some("test.wado"),
+        options,
+    ));
+    host.diagnostics()
+        .into_iter()
+        .filter(|d| d.message.starts_with("remark:"))
+        .map(|d| {
+            let loc = d
+                .span
+                .as_ref()
+                .map(|s| format!("{}:{}", s.line, s.column))
+                .unwrap_or_default();
+            format!("{loc} {}", d.message)
+        })
+        .collect()
+}
+
+#[test]
+fn surviving_list_copy_is_remarked() {
+    // `b` is a deep value-copy of `a` that is then mutated, so the copy of the
+    // backing array cannot be elided and survives to the final IR.
+    let remarks = remarks_for(
+        r#"
+use { println } from "core:cli";
+
+export fn run() with Stdout {
+    let a: List<i32> = [1, 2, 3];
+    let mut b = a;
+    b.push(4);
+    println(`{a.len()} {b.len()}`);
+}
+"#,
+    );
+
+    assert_eq!(
+        remarks.len(),
+        1,
+        "expected exactly one remark, got {remarks:?}"
+    );
+    assert!(
+        remarks[0].contains("a copy of") && remarks[0].contains("List<i32>"),
+        "unexpected remark text: {remarks:?}"
+    );
+    // The remark points at the copying statement `let mut b = a;` (line 6).
+    assert!(
+        remarks[0].starts_with("6:"),
+        "remark should point at the copy statement on line 6: {remarks:?}"
+    );
+}
+
+#[test]
+fn scalarized_struct_copy_is_not_remarked() {
+    // SROA scalarizes `Point` into i32 locals, so the copy disappears entirely;
+    // no heap copy executes, so there is nothing to remark on.
+    let remarks = remarks_for(
+        r#"
+use { println } from "core:cli";
+
+struct Point { x: i32, y: i32 }
+
+export fn run() with Stdout {
+    let a = Point { x: 1, y: 2 };
+    let mut b = a;
+    b.x = 9;
+    println(`{a.x} {b.x}`);
+}
+"#,
+    );
+
+    assert!(
+        remarks.is_empty(),
+        "expected no remark (copy scalarized away), got {remarks:?}"
+    );
+}

--- a/wado-compiler/tests/remarks.rs
+++ b/wado-compiler/tests/remarks.rs
@@ -94,3 +94,39 @@ export fn run() with Stdout {
         "expected no remark (copy scalarized away), got {remarks:?}"
     );
 }
+
+#[test]
+fn struct_field_copy_remark_points_at_copy_statement() {
+    // `Bag` is SROA-decomposed and its `items` copy is reconstructed inside a
+    // synthesized block whose inner statements carry placeholder spans. The
+    // remark must anchor to the enclosing real statement `let mut b = a;`
+    // (line 8), not to the placeholder span of the inner synthesized statement.
+    let remarks = remarks_for(
+        r#"
+use { println } from "core:cli";
+
+struct Bag { items: List<i32> }
+
+export fn run() with Stdout {
+    let a = Bag { items: [1, 2, 3] };
+    let mut b = a;
+    b.items.push(4);
+    println(`{a.items.len()} {b.items.len()}`);
+}
+"#,
+    );
+
+    assert_eq!(
+        remarks.len(),
+        1,
+        "expected exactly one remark, got {remarks:?}"
+    );
+    assert!(
+        remarks[0].contains("a copy of") && remarks[0].contains("List<i32>"),
+        "unexpected remark text: {remarks:?}"
+    );
+    assert!(
+        remarks[0].starts_with("8:"),
+        "remark should point at the copy statement on line 8, not a placeholder span: {remarks:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds **optimizer remarks** — agent-facing compiler feedback that surfaces residual costs the optimizer could not remove — starting with **residual value-semantic copies**. Grounded in recent research on AI coding agents (arXiv:2604.13927, "AI Coding Agents Need Better Compiler Remarks"; complements the existing diagnostic-reason-chains work from arXiv:2606.01522). Full design in [`docs/wep-2026-06-03-optimizer-remarks.md`](docs/wep-2026-06-03-optimizer-remarks.md).

Wado deep-copies aggregates by value semantics, and a large part of the optimizer exists to remove these hidden copies — most are removed, but which ones *survive* is invisible while coding. This surfaces the survivors.

## What it does

After the NIR pipeline, a surviving copy appears as a `$value_copy$T` helper call or a demoted `array_clone` / `array_clone_shallow` / `copy_value` call. `remarks::collect_value_copy_remarks` walks the optimized NIR's entry-module functions and emits each as an info-level `remark:` with a source location:

```
$ wado compile --log-level info file.wado
file.wado:5:5: info: remark: a copy of `List<i32>` survives optimization
```

## Design decisions

- **Source = optimized NIR, not final WIR.** WIR is the most authoritative "this copy executes" signal, but `WirInstr` carries no per-instruction span, so a WIR-sourced remark could not point at the source. NIR is the last IR with per-expression spans and `wir_build` lowers these copies one-to-one.
- **`array_copy` excluded** — it is bulk buffer movement inside stdlib helpers, not a value-semantic copy.
- **Opt-in via `--log-level info`.** This PR also makes the CLI quiet by default (default log level `warn`), since remarks are the only info-level output in a normal compile. The remark keeps its semantically-correct `Info` severity; the standard verbosity knob gates it — no dedicated flag.
- **Anchored to the enclosing real statement**, skipping the placeholder spans of SROA-synthesized inner blocks.

## Testing

`wado-compiler/tests/remarks.rs` pins behavior at `-O2`: a `List<i32>` copied then mutated fires one remark on the copy line; a `Point` that SROA scalarizes fires none; a struct-with-`List`-field copy anchors to the copy statement (not a placeholder span). Full `wado-compiler` (3825) and `wado-cli` suites pass.

## Also

- Removes a duplicated "developed entirely through agentic coding" sentence in the README.

🤖 https://claude.ai/code/session_01Bvq8mSfULXK67zDW8GvfQd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bvq8mSfULXK67zDW8GvfQd)_