### PR TITLE
docs: clarify the development test cycle and tidy AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,14 +94,26 @@ See also:
 - `docs/compiler.md` for the compiler internals.
 - `docs/optimizer.md` for the optimization passes.
 
+### Bundled Library
+
+The compiler bundles Wasm modules for language features:
+
+- `wado-bundled-libm/` — deterministic math functions using the `libm` crate.
+
+## The CLI
+
 The CLI is implemented in `wado-cli/` as a subcommand-style CLI. The sections below describe each subcommand.
+
+In the examples below, `wado` is shorthand for `cargo run --bin wado --`.
+
+A Wado program targets a Wasm _world_: the CLI command (`wasi:cli/command`, the default), the HTTP service (`wasi:http/service`, run via `wado serve`), or the test world (`wasi:test`, used by E2E tests). Several defaults — including the allocator — depend on the target world.
 
 ### Compile Command
 
 ```sh
-cargo run --bin wado -- compile -o file.wasm file.wado    # generate Wasm
-cargo run --bin wado -- compile -o file.wat file.wado     # generate WAT
-cargo run --bin wado -- compile --wat-to-stdout file.wado # output WAT to stdout
+wado compile -o file.wasm file.wado    # generate Wasm
+wado compile -o file.wat file.wado     # generate WAT
+wado compile --wat-to-stdout file.wado # output WAT to stdout
 ```
 
 To inspect invalid Wasm when debugging codegen bugs, use `--no-validate`:
@@ -132,7 +144,7 @@ wado compile --allocator debug file.wado     # debug allocator
 ### Run Command
 
 ```sh
-cargo run --bin wado -- run file.wado  # run a CLI program with wasmtime
+wado run file.wado  # run a CLI program with wasmtime
 ```
 
 ### Serve Command
@@ -177,12 +189,6 @@ The compiler emits timestamped diagnostics to stderr. Use `--log-level` to contr
 ```sh
 wado compile --log-level debug file.wado
 ```
-
-### Bundled Library
-
-The compiler bundles Wasm modules for language features:
-
-- `wado-bundled-libm/` — deterministic math functions using the `libm` crate.
 
 ## The Standard Library
 

--- a/wado-compiler/AGENTS.md
+++ b/wado-compiler/AGENTS.md
@@ -8,6 +8,20 @@ This is the wado-compiler crate.
 - Use utilities in `name.rs` to handle name mangling and monomorphization. Other components must not know the details of name formats.
 - If applicable, use visitor utilities instead of walking IR nodes by hand.
 
+## Development Cycle
+
+Escalate the test scope as the work matures, so the fast feedback stays fast:
+
+- **`cargo check`** — lightest. Just confirms the crate still compiles. Run it
+  constantly while iterating.
+- **`mise run test`** — the compiler dev-cycle test. Run it during development
+  to verify the Rust crates (including the E2E fixtures) still pass.
+- **`mise run test-wado`** — broader: exercises the Wado standard library and
+  other `.wado` modules. Run it when wrapping up a dev cycle.
+- **`mise run on-task-done`** (via the `on-task-done` skill) — the full finish
+  pass (format, clippy-fix, golden fixtures, stdlib docs, the test suites). It
+  takes a long time, so run it only when explicitly instructed to finish a task.
+
 ## Standard Libraries
 
 Standard libraries (stdlib) are implemented in `lib`, with `lib/wasi/` for WASI interface and `lib/core/` for the core library.

--- a/wado-compiler/AGENTS.md
+++ b/wado-compiler/AGENTS.md
@@ -12,15 +12,15 @@ This is the wado-compiler crate.
 
 Escalate the test scope as the work matures, so the fast feedback stays fast:
 
-- **`cargo check`** — lightest. Just confirms the crate still compiles. Run it
+- `cargo check` — lightest. Just confirms the crate still compiles. Run it
   constantly while iterating.
-- **`mise run test`** — the compiler dev-cycle test. Run it during development
-  to verify the Rust crates (including the E2E fixtures) still pass.
-- **`mise run test-wado`** — broader: exercises the Wado standard library and
-  other `.wado` modules. Run it when wrapping up a dev cycle.
-- **`mise run on-task-done`** (via the `on-task-done` skill) — the full finish
-  pass (format, clippy-fix, golden fixtures, stdlib docs, the test suites). It
-  takes a long time, so run it only when explicitly instructed to finish a task.
+- `mise run test` — the compiler dev-cycle test. Run it during development to
+  verify the Rust crates (including the E2E fixtures) still pass.
+- `mise run test-wado` — broader: exercises the Wado standard library and other
+  `.wado` modules. Run it when wrapping up a dev cycle.
+- `mise run on-task-done` (via the `on-task-done` skill) — the full finish pass
+  (format, clippy-fix, golden fixtures, stdlib docs, the test suites). It takes a
+  long time, so run it only when explicitly instructed to finish a task.
 
 ## Standard Libraries
 


### PR DESCRIPTION
## Summary

Small documentation cleanups to make the AGENTS.md guidance easier to act on.

### `wado-compiler/AGENTS.md` — Development Cycle
Added a **Development Cycle** section that maps each test scope to its phase, so fast feedback stays fast:

- `cargo check` — lightest; just confirms the crate compiles. Run constantly while iterating.
- `mise run test` — the compiler dev-cycle test (Rust crates incl. E2E fixtures).
- `mise run test-wado` — broader; exercises the Wado stdlib and other `.wado` modules. Run when wrapping up a dev cycle.
- `mise run on-task-done` — the full finish pass; slow, so only when explicitly instructed.

### Root `AGENTS.md` — review fixes
1. **Unified CLI invocation.** Noted that `wado` in examples is shorthand for `cargo run --bin wado --`, and converted the remaining `cargo run --bin wado --` examples to bare `wado` so the whole file is consistent.
2. **Introduced the Wasm *world* concept up front** (CLI command / HTTP service / test), so the allocator defaults that reference "HTTP world" and "test world" have context where they appear.
3. **Split the CLI out of "The Compiler".** CLI subcommands now live under a new "## The CLI" section; the compiler-internal "Bundled Library" topic stays under "## The Compiler".

## Notes
Docs-only change; no code or behavior is affected. Markdown formatted via `mise run format`.

https://claude.ai/code/session_017zsVMa4YagY7Ah5fGir1FD

---
_Generated by [Claude Code](https://claude.ai/code/session_017zsVMa4YagY7Ah5fGir1FD)_