### PR TITLE
revert(ci): drop the tagpr CHANGELOG-format workaround

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -31,39 +31,6 @@ jobs:
       - name: Check out the vendored wasmtime fork (path dependency)
         run: git submodule update --init --depth 1 vendor/wasmtime
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: ci
-          save-if: false
-
       - uses: Songmu/tagpr@v1
-        id: tagpr
         env:
           GITHUB_TOKEN: "${{ steps.app-token.outputs.token }}"
-
-      # tagpr's changelog isn't dprint-clean, so Tidy would push a chore commit
-      # (retriggering CI) on every release PR. Format it here instead.
-      - name: Format the release changelog
-        if: steps.tagpr.outputs.pull_request != ''
-        env:
-          GH_TOKEN: "${{ steps.app-token.outputs.token }}"
-          APP_SLUG: "${{ steps.app-token.outputs.app-slug }}"
-          TAGPR_PR: "${{ steps.tagpr.outputs.pull_request }}"
-        run: |
-          set -e
-          branch=$(jq -r .head.ref <<<"$TAGPR_PR")
-          git fetch origin "$branch"
-          git checkout "$branch"
-          git submodule update --init --depth 1 vendor/wasmtime
-          cargo run -p wado-dev-tools --quiet -- format-md CHANGELOG.md
-          if git diff --quiet -- CHANGELOG.md; then
-            echo "CHANGELOG.md already formatted; nothing to do."
-            exit 0
-          fi
-          user_id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)
-          git config user.name "${APP_SLUG}[bot]"
-          git config user.email "${user_id}+${APP_SLUG}[bot]@users.noreply.github.com"
-          git add CHANGELOG.md
-          # Use the "chore: tidy" subject so Tidy's precheck short-circuits.
-          git commit -m "chore: tidy"
-          git push origin "HEAD:$branch"

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -26,6 +26,11 @@ jobs:
           fetch-depth: 0
           token: "${{ steps.app-token.outputs.token }}"
 
+      # postVersionCommand (cargo update, see .tagpr) needs the vendored
+      # wasmtime path dependency, or Cargo.lock is left stale on the release PR.
+      - name: Check out the vendored wasmtime fork (path dependency)
+        run: git submodule update --init --depth 1 vendor/wasmtime
+
       - uses: Songmu/tagpr@v1
         env:
           GITHUB_TOKEN: "${{ steps.app-token.outputs.token }}"

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -26,11 +26,6 @@ jobs:
           fetch-depth: 0
           token: "${{ steps.app-token.outputs.token }}"
 
-      # postVersionCommand (cargo update, see .tagpr) needs the vendored
-      # wasmtime path dependency, or Cargo.lock is left stale on the release PR.
-      - name: Check out the vendored wasmtime fork (path dependency)
-        run: git submodule update --init --depth 1 vendor/wasmtime
-
       - uses: Songmu/tagpr@v1
         env:
           GITHUB_TOKEN: "${{ steps.app-token.outputs.token }}"


### PR DESCRIPTION
## Summary

tagpr now emits dprint/markdown-lint-clean `CHANGELOG.md` (a blank line after the release heading), so the ad-hoc "Format the release changelog" step in `tagpr.yml` is no longer needed. Without it, Tidy has nothing to fix on the release PR, so no follow-up `chore: tidy` push retriggers CI.

This removes that workaround:

- The **"Format the release changelog"** step (checked out the release branch, ran `format-md CHANGELOG.md`, and pushed a commit).
- The `id: tagpr` it relied on for its `if` condition.
- The read-only `Swatinem/rust-cache` step that existed solely to build `wado-dev-tools` for that step.

## What stays (and why)

- **`vendor/wasmtime` submodule checkout** + `.tagpr`'s `postVersionCommand = cargo update --workspace`: these are **not** part of the markdown workaround. They sync `Cargo.lock` after tagpr bumps the workspace version, so the release PR's `--locked` CI jobs pass on the first round. Confirmed load-bearing (tracked `Cargo.lock`, `wado-*` pinned to the workspace version, ~8 `--locked` CI jobs). `.tagpr` is unchanged.
- The unrelated `permissions: contents: read` security fix.

## Note on history

The branch contains two canceling commits (`8cf97e6d` removed the submodule step, `dad06fb4` reverted that) from an exploration of whether the submodule was also droppable — it isn't. They net to no change but leave the history slightly noisy.

https://claude.ai/code/session_01K42UY3eMe1h1DevZpxbG6x

---
_Generated by [Claude Code](https://claude.ai/code/session_01K42UY3eMe1h1DevZpxbG6x)_