### PR TITLE
fix(jco): run example/hello.wado on upstream jco b1f93c27

### DIFF
--- a/.claude/skills/jco/SKILL.md
+++ b/.claude/skills/jco/SKILL.md
@@ -7,12 +7,22 @@ description: Debug and patch jco (JS Component Tooling) for Wado wasm transpilat
 
 jco (`vendor/jco`) is bytecodealliance's tool for transpiling Wasm Components to JavaScript. Wado uses a patched fork because upstream jco has incomplete support for P3 async stream delivery and JSPI integration.
 
+The pinned submodule points at a clean upstream commit; the Wado patches live
+in `vendor/jco.patch` and are applied to the working tree before building.
+
+> **Node 24+ required.** The runtime uses JSPI (`WebAssembly.Suspending`). Node
+> 22 ships an older JSPI where `WebAssembly.Suspending` is not a constructor and
+> fails. The repo pins Node 24 via `mise.toml`; make sure `node` resolves to it
+> (paths outside the repo, e.g. `/tmp`, may pick up a system Node 22).
+
 ## Setup
 
 ```sh
 git submodule update --init vendor/jco
 cd vendor/jco
-PUPPETEER_SKIP_DOWNLOAD=1 npm install --ignore-scripts
+git apply ../../vendor/jco.patch                     # apply the Wado patches
+# Upstream jco is a pnpm workspace; install the CLI package + its deps:
+NPM_TOKEN="" PUPPETEER_SKIP_DOWNLOAD=1 pnpm --filter "@bytecodealliance/jco" install
 ```
 
 ## Build Cycle
@@ -33,8 +43,11 @@ rm -f packages/jco/obj/js-component-bindgen-component.*
 cd /home/user/wado
 cargo run --bin wado -- compile -o /tmp/hello.wasm example/hello.wado
 rm -rf /tmp/hello-jco
+# --no-wasi-shim disables jco's automatic WASI->preview3-shim rewrite, so the
+# --map entries to the Wado shims in example/jco-shim/ take effect.
 node vendor/jco/packages/jco/src/jco.js transpile /tmp/hello.wasm \
   -o /tmp/hello-jco \
+  --no-wasi-shim \
   --map "wasi:cli/*=$(pwd)/example/jco-shim/cli.js#*"
 echo '{"type": "module"}' > /tmp/hello-jco/package.json
 node --experimental-wasm-jspi -e "
@@ -115,23 +128,26 @@ JCO_DEBUG=1 node --experimental-wasm-jspi run.mjs
 
 ## Saving Patches
 
-After making changes in `vendor/jco`, save the patch relative to upstream:
+The submodule stays pinned at a clean upstream commit (currently `b1f93c27`);
+the patches are never committed into the submodule, only saved to
+`vendor/jco.patch`. After editing the jco Rust source, regenerate the patch
+from the submodule's `HEAD` (the pinned upstream commit):
 
 ```sh
 cd vendor/jco
-# Find upstream base (the commit before our patches)
-git log --oneline | head -5
-# Save patch from upstream base
-git diff <upstream-commit> -- . > /home/user/wado/vendor/jco.patch
+git diff HEAD -- crates/js-component-bindgen/src/ > /home/user/wado/vendor/jco.patch
 ```
 
-Then commit both the submodule ref update and the patch file:
+Then commit the patch file (and, when bumping upstream, the submodule ref):
 
 ```sh
 cd /home/user/wado
-git add vendor/jco vendor/jco.patch
+git add vendor/jco.patch     # + `git add vendor/jco` only when bumping the pin
 git commit -m "Update jco patches: <description>"
 ```
+
+To bump the pinned upstream commit, `git checkout <commit>` inside `vendor/jco`,
+`git add vendor/jco` in the parent, then re-apply/regenerate the patch.
 
 ## Key Source Locations in jco
 
@@ -156,11 +172,19 @@ git commit -m "Update jco patches: <description>"
 - `random.js` — `wasi:random` via Node.js crypto
 - `clocks.js` — `wasi:clocks` via `process.hrtime` / `Date.now`
 
-The `--map` flag maps WASI interfaces to shim files during transpilation.
+The `--map` flag maps WASI interfaces to shim files during transpilation (with
+`--no-wasi-shim` so the maps win over jco's built-in shims).
+
+`cli.js`'s `writeViaStream` returns a `Promise` because `write-via-stream` is an
+async WASI function: jco lowers its result as a future and expects the host to
+return a Promise/Thenable (a sync return triggers `unrecognized future object`).
 
 ## Current Patches (on top of upstream main)
 
+Saved in `vendor/jco.patch`, applied to the working tree before building. The
+pinned upstream commit already provides a table-based `FutureDropReadable/Writable`
+implementation, so only these three patches remain:
+
 1. **Stream write hook** (`async_stream.rs`): `globalThis._jcoStreamWriteHook` delivers stream data directly from linear memory, bypassing the rendezvous mechanism.
-2. **Missing intrinsic dependencies** (`mod.rs`): `StreamNewFromLift` → `SymbolResourceRep`; `FutureDropReadable/Writable` → `GlobalFutureMap`, `FutureEndClass`, etc.
-3. **futureDropReadable/Writable** (`async_future.rs`, `transpile_bindgen.rs`): Pass `componentIdx` as bound parameter; accept single `futureEndIdx` from wasm; tolerate handle 0 (stream hook bypass).
-4. **Async export void return** (`function_bindgen.rs`): Fall back to `task.completionPromise()` when JSPI returns `undefined`.
+2. **Missing intrinsic dependencies** (`mod.rs`): `StreamNewFromLift` → `SymbolResourceRep`; `FutureDropReadable/Writable` → `GlobalFutureMap`, `FutureEndClass`, `FutureReadableEndClass`, `FutureWritableEndClass`, `GetOrCreateAsyncState` (otherwise the stdout write path references undefined future-end classes, e.g. `FutureReadableEnd is not defined`).
+3. **Async export void return** (`function_bindgen.rs`): when a JSPI-wrapped async export returns `undefined` (result delivered via `task.return`), fall back to `task.completionPromise()` instead of lifting `undefined` (which throws `invalid variant discriminant for expected`).

--- a/example/jco-shim/cli.js
+++ b/example/jco-shim/cli.js
@@ -20,10 +20,14 @@ export const types = {
   OutputStream: class OutputStream {},
 };
 
+// `write-via-stream` is an async WASI function, so jco lowers its result as a
+// future and expects the host to return a Promise/Thenable. The actual bytes
+// are delivered out-of-band through `_jcoStreamWriteHook`, so the returned
+// promise only needs to resolve to the operation result.
 export const stdout = {
   writeViaStream(_stream) {
     _defaultTarget = process.stdout;
-    return { tag: "ok" };
+    return Promise.resolve({ tag: "ok" });
   },
 };
 stdout.writeViaStream._isHostProvided = true;
@@ -31,7 +35,7 @@ stdout.writeViaStream._isHostProvided = true;
 export const stderr = {
   writeViaStream(_stream) {
     _defaultTarget = process.stderr;
-    return { tag: "ok" };
+    return Promise.resolve({ tag: "ok" });
   },
 };
 stderr.writeViaStream._isHostProvided = true;

--- a/mise.toml
+++ b/mise.toml
@@ -522,15 +522,24 @@ run = """
 #!/usr/bin/env bash
 set -xe -o pipefail
 cd vendor/jco
-PUPPETEER_SKIP_DOWNLOAD=1 npm install --ignore-scripts 2>&1 | tail -3
+# Apply the Wado patches on top of the pinned upstream checkout (idempotent:
+# skip if they are already applied to the working tree).
+if git apply --reverse --check ../../vendor/jco.patch 2>/dev/null; then
+  echo "jco.patch already applied"
+else
+  git apply ../../vendor/jco.patch
+  echo "applied jco.patch"
+fi
+# Upstream jco uses a pnpm workspace; install only the CLI package and its deps.
+NPM_TOKEN="" PUPPETEER_SKIP_DOWNLOAD=1 pnpm --filter "@bytecodealliance/jco" install 2>&1 | tail -3
 cargo build -p xtask --target x86_64-unknown-linux-gnu
+rm -f packages/jco/obj/js-component-bindgen-component.*
 ./target/x86_64-unknown-linux-gnu/debug/xtask build debug
 echo "jco built successfully at vendor/jco"
 """
 
 [tasks.jco-transpile]
 description = "Transpile a Wado .wasm component to JS via patched jco"
-usage = "jco-transpile <wasm-file> [output-dir]"
 run = """
 #!/usr/bin/env bash
 set -e -o pipefail
@@ -545,7 +554,10 @@ if [ ! -f "vendor/jco/packages/jco/obj/js-component-bindgen-component.js" ]; the
 fi
 
 rm -rf "$OUTPUT_DIR"
+# --no-wasi-shim disables jco's automatic rewrite of WASI imports to the bundled
+# preview2/preview3 shims, so our --map entries to the Wado shims take effect.
 node "$JCO" transpile "$WASM_FILE" -o "$OUTPUT_DIR" \
+  --no-wasi-shim \
   --map "wasi:cli/*=${SHIM_DIR}/cli.js#*" \
   --map "wasi:random/*=${SHIM_DIR}/random.js#*" \
   --map "wasi:clocks/*=${SHIM_DIR}/clocks.js#*"

--- a/vendor/jco.patch
+++ b/vendor/jco.patch
@@ -1,39 +1,46 @@
 diff --git a/crates/js-component-bindgen/src/function_bindgen.rs b/crates/js-component-bindgen/src/function_bindgen.rs
-index 8bb0dfbc..e5a9fcb8 100644
+index 7a947cff..1cb4b9d8 100644
 --- a/crates/js-component-bindgen/src/function_bindgen.rs
 +++ b/crates/js-component-bindgen/src/function_bindgen.rs
-@@ -1518,11 +1518,24 @@ impl Bindgen for FunctionBindgen<'_> {
-                               taskID: task.id(),
-                               componentIdx: task.componentIdx(),
-                               fn: () => {callee}({args}),
--                          }});
--                          "#,
-+                          }});"#,
-                     callee = self.callee,
-                     args = operands.join(", "),
+@@ -1677,6 +1677,33 @@ impl Bindgen for FunctionBindgen<'_> {
+                     "#,
                  );
-+                // For async exports using task.return, the JSPI Promising wrapper
-+                // returns undefined (void core wasm function). The task's completion
-+                // promise (resolved by task.return) provides the already-lifted result.
-+                if self.is_async && sig_results_length > 0 {
+ 
++                // Wado patch: an async export delivers its result via `task.return`,
++                // so the JSPI-wrapped core export returns `undefined` (a void core
++                // function) once the task has completed synchronously. In that case
++                // the already-lifted result is available on the task's completion
++                // promise; return it directly instead of running the result lift on
++                // `ret` (which would see `undefined` and throw). When `ret` is a real
++                // value the function suspended/blocked and the driver loop below
++                // drives it to completion as usual.
++                if (self.requires_async_porcelain || self.is_async) && sig_results_length > 0 {
 +                    uwriteln!(
 +                        self.src,
 +                        r#"
 +                          if (ret === undefined) {{
-+                              const taskResult = await task.completionPromise();
-+                              if (taskResult !== undefined) {{ return taskResult; }}
++                              let taskResult = await task.completionPromise();
++                              if (taskResult !== undefined) {{
++                                  if (task.getErrHandling() === 'throw-result-err') {{
++                                      if (typeof taskResult !== 'object') {{ return taskResult; }}
++                                      if (taskResult.tag === 'err') {{ throw taskResult.val; }}
++                                      if (taskResult.tag === 'ok') {{ taskResult = taskResult.val; }}
++                                  }}
++                                  return taskResult;
++                              }}
 +                          }}
-+                          "#,
++                        "#,
 +                    );
 +                }
- 
++
                  if self.tracing_enabled {
                      let prefix = self.tracing_prefix;
+                     let to_result_string =
 diff --git a/crates/js-component-bindgen/src/intrinsics/mod.rs b/crates/js-component-bindgen/src/intrinsics/mod.rs
-index db2e9e07..4b45bfe6 100644
+index 52433ec1..41017a92 100644
 --- a/crates/js-component-bindgen/src/intrinsics/mod.rs
 +++ b/crates/js-component-bindgen/src/intrinsics/mod.rs
-@@ -1492,6 +1492,7 @@ pub fn render_intrinsics(args: RenderIntrinsicsArgs) -> Source {
+@@ -1540,6 +1540,7 @@ pub fn render_intrinsics(args: RenderIntrinsicsArgs) -> Source {
              &Intrinsic::AsyncStream(AsyncStreamIntrinsic::GlobalStreamTableMap),
              &Intrinsic::AsyncStream(AsyncStreamIntrinsic::HostStreamClass),
              &Intrinsic::AsyncStream(AsyncStreamIntrinsic::ExternalStreamClass),
@@ -41,10 +48,14 @@ index db2e9e07..4b45bfe6 100644
          ]);
      }
  
-@@ -1509,6 +1510,22 @@ pub fn render_intrinsics(args: RenderIntrinsicsArgs) -> Source {
+@@ -1593,6 +1594,26 @@ pub fn render_intrinsics(args: RenderIntrinsicsArgs) -> Source {
          ]);
      }
  
++    // Wado patch: dropping a future end requires the future-end classes, the
++    // global future map and async state lookup to be emitted as well. Upstream
++    // does not pull these in transitively, so a component that only drops future
++    // ends (e.g. the stdout write path) would reference undefined classes.
 +    if args
 +        .intrinsics
 +        .contains(&Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureDropReadable))
@@ -64,63 +75,11 @@ index db2e9e07..4b45bfe6 100644
      if args.intrinsics.contains(&Intrinsic::GlobalBufferManager) {
          args.intrinsics.extend([&Intrinsic::BufferManagerClass]);
      }
-diff --git a/crates/js-component-bindgen/src/intrinsics/p3/async_future.rs b/crates/js-component-bindgen/src/intrinsics/p3/async_future.rs
-index 1ec1529b..d1b20b25 100644
---- a/crates/js-component-bindgen/src/intrinsics/p3/async_future.rs
-+++ b/crates/js-component-bindgen/src/intrinsics/p3/async_future.rs
-@@ -496,38 +496,31 @@ impl AsyncFutureIntrinsic {
-             Self::FutureDropReadable | Self::FutureDropWritable => {
-                 let debug_log_fn = Intrinsic::DebugLog.name();
-                 let future_drop_fn = self.name();
--                let is_writable = matches!(self, Self::FutureDropWritable);
-                 let global_future_map = Self::GlobalFutureMap.name();
--                let future_end_class = if is_writable {
--                    Self::FutureWritableEndClass.name()
--                } else {
--                    Self::FutureReadableEndClass.name()
--                };
-                 let get_or_create_async_state_fn =
-                     Intrinsic::Component(ComponentIntrinsic::GetOrCreateAsyncState).name();
-                 output.push_str(&format!("
-                     function {future_drop_fn}(
--                        futureIdx,
-+                        componentIdx,
-                         futureEndIdx,
-                     ) {{
-                         {debug_log_fn}('[{future_drop_fn}()] args', {{
--                            futureIdx,
-+                            componentIdx,
-                             futureEndIdx,
-                         }});
- 
-                         const state = {get_or_create_async_state_fn}(componentIdx);
-                         if (!state.mayLeave) {{ throw new Error('component instance is not marked as may leave'); }}
- 
--                        const future = {global_future_map}.remove(futureIdx);
--
--                        const futureEnd = {global_future_map}.remove(futureEndIdx);
--                        if (!(futureEnd instanceof {future_end_class})) {{ throw new Error('invalid future end, expected [{future_end_class}]'); }}
-+                        // futureEndIdx may be 0 when the stream write hook bypassed
-+                        // the future mechanism, in which case we skip the drop.
-+                        if (futureEndIdx === 0) {{ return; }}
- 
--                        if (futureEnd.elementTypeRep() !== future.elementTypeRep()) {{
--                          throw new Error('future type [' + future.elementTypeRep() + '], does not match future end type [' + futureEnd.elementTypeRep() + ']');
-+                        const futureEnd = {global_future_map}.get(futureEndIdx);
-+                        if (futureEnd) {{
-+                            {global_future_map}.remove(futureEndIdx);
-+                            futureEnd.drop();
-                         }}
--
--                        futureEnd.drop();
-                     }}
-                 "));
-             }
 diff --git a/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs b/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
-index daa83c43..7ced1cb9 100644
+index a551aeaa..063ee245 100644
 --- a/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
 +++ b/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
-@@ -1617,9 +1617,23 @@ impl AsyncStreamIntrinsic {
+@@ -1842,9 +1842,23 @@ impl AsyncStreamIntrinsic {
                              throw new Error(`stream end table idx [${{streamEnd.streamTableIdx()}}] != operation table idx [${{streamTableIdx}}]`);
                          }}
  
@@ -145,39 +104,3 @@ index daa83c43..7ced1cb9 100644
                              ptr,
                              count,
                              eventCode: {event_code},
-diff --git a/crates/js-component-bindgen/src/transpile_bindgen.rs b/crates/js-component-bindgen/src/transpile_bindgen.rs
-index 7fe0cf5d..ccf7fd44 100644
---- a/crates/js-component-bindgen/src/transpile_bindgen.rs
-+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
-@@ -1730,25 +1730,25 @@ impl<'a> Instantiator<'a, '_> {
-                 );
-             }
- 
--            Trampoline::FutureDropReadable { ty, .. } => {
-+            Trampoline::FutureDropReadable { ty: _, instance, .. } => {
-                 let future_drop_readable_fn = self.bindgen.intrinsic(Intrinsic::AsyncFuture(
-                     AsyncFutureIntrinsic::FutureDropReadable,
-                 ));
-+                let instance_idx = instance.as_u32();
-                 uwriteln!(
-                     self.src.js,
--                    "const trampoline{i} = {future_drop_readable_fn}.bind(null, {future_idx});\n",
--                    future_idx = ty.as_u32(),
-+                    "const trampoline{i} = {future_drop_readable_fn}.bind(null, {instance_idx});\n",
-                 );
-             }
- 
--            Trampoline::FutureDropWritable { ty, .. } => {
-+            Trampoline::FutureDropWritable { ty: _, instance, .. } => {
-                 let future_drop_writable_fn = self.bindgen.intrinsic(Intrinsic::AsyncFuture(
-                     AsyncFutureIntrinsic::FutureDropWritable,
-                 ));
-+                let instance_idx = instance.as_u32();
-                 uwriteln!(
-                     self.src.js,
--                    "const trampoline{i} = {future_drop_writable_fn}.bind(null, {future_idx});\n",
--                    future_idx = ty.as_u32(),
-+                    "const trampoline{i} = {future_drop_writable_fn}.bind(null, {instance_idx});\n",
-                 );
-             }
- 


### PR DESCRIPTION
## Summary

Bumps the `vendor/jco` submodule to upstream latest (`b1f93c27`) and re-bases the Wado patches on top so the jco-transpiled `example/hello.wado` transpiles and runs again.

The released jco (npm `@bytecodealliance/jco@1.20.0`) transpiles hello.wado but fails at runtime with `FutureReadableEnd is not defined`, so the patched fork is still required. Upstream has since moved to a pnpm workspace, rewritten the P3 future-drop machinery (now table-based), and lowers async WASI imports through a stricter future path — all of which broke the previous patch set.

## Changes

- **`vendor/jco` → `b1f93c27`** (was `dba5be8`), committed as a clean upstream pin.
- **`vendor/jco.patch`** rebuilt against the new tree. Two of the four old patches (futureDrop in `async_future.rs` / `transpile_bindgen.rs`) are now obsolete — upstream provides a table-based `FutureDropReadable/Writable`. The three remaining patches:
  1. **Stream write hook** (`async_stream.rs`) — `globalThis._jcoStreamWriteHook` delivers stream bytes straight from linear memory, bypassing the rendezvous.
  2. **Missing intrinsic deps** (`mod.rs`) — pull in the future-end classes + async-state lookup for the future-drop path (fixes `FutureReadableEnd is not defined`).
  3. **Async export void return** (`function_bindgen.rs`) — when a JSPI-wrapped async export returns `undefined` (result delivered via `task.return`), fall back to `task.completionPromise()` instead of lifting `undefined` (fixes `invalid variant discriminant for expected`). Adapted to the new `CallWasm` codegen.
- **`example/jco-shim/cli.js`** — `writeViaStream` now returns a `Promise`, since `write-via-stream` is async and jco lowers its result as a future (a sync return triggers `unrecognized future object`).
- **`mise.toml`**:
  - `build-jco` applies `jco.patch` idempotently and installs via `pnpm --filter "@bytecodealliance/jco"` (upstream is now a pnpm workspace; `npm install` no longer pulls the CLI deps).
  - `jco-transpile` passes `--no-wasi-shim` so the Wado shim `--map` entries win over jco's built-in shims; also drops an invalid `usage` spec that made the task fail with `Failed to parse KDL document`.
- **`.claude/skills/jco/SKILL.md`** — documents Node 24 (JSPI `WebAssembly.Suspending`), pnpm, `--no-wasi-shim`, and the trimmed patch set.

## Verification

```
mise run build-jco
wado compile -o /tmp/hello.wasm example/hello.wado
jco transpile --no-wasi-shim --map "wasi:cli/*=example/jco-shim/cli.js#*" ...
node --experimental-wasm-jspi run.mjs   # → "Hello, world!", exit 0
```

> **Note:** Node 24 is required. Outside the repo (e.g. `/tmp`) mise's Node pin drops and a system Node 22 — whose JSPI lacks the `WebAssembly.Suspending` constructor — may be picked up.

https://claude.ai/code/session_01Tx8Smf2D7q2xUnWvtBY28n

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tx8Smf2D7q2xUnWvtBY28n)_