### PR TITLE
Improve benchmark dashboard HTML and workflow

### DIFF
--- a/.github/pages/runtime-index.html
+++ b/.github/pages/runtime-index.html
@@ -75,8 +75,16 @@
         flex-wrap: wrap;
         width: 100%;
       }
-      .benchmark-chart {
+      .benchmark-scroller {
+        width: 100%;
         max-width: 1000px;
+        overflow-x: auto;
+      }
+      .benchmark-canvas-box {
+        height: 400px;
+      }
+      .benchmark-chart {
+        display: block;
       }
     </style>
     <title>Runtime Benchmarks (Combined)</title>
@@ -167,10 +175,26 @@
           return groups;
         }
 
+        // Show only the most recent commits; older data stays in data.js but
+        // is not plotted. The chart is horizontally scrollable when crowded.
+        const MAX_POINTS = 100;
+        const PX_PER_POINT = 14;
+        const MIN_CHART_WIDTH = 1000;
+
         function renderCombinedGraph(parent, baseName, optLevelMap) {
+          // Scroll container: keeps the chart within the page width but lets
+          // the user scroll horizontally when there are many commits.
+          const scroller = document.createElement('div');
+          scroller.className = 'benchmark-scroller';
+          parent.appendChild(scroller);
+
+          const canvasBox = document.createElement('div');
+          canvasBox.className = 'benchmark-canvas-box';
+          scroller.appendChild(canvasBox);
+
           const canvas = document.createElement('canvas');
           canvas.className = 'benchmark-chart';
-          parent.appendChild(canvas);
+          canvasBox.appendChild(canvas);
 
           // Find all unique commit IDs across all optimization levels, preserving order
           const commitIds = [];
@@ -186,6 +210,15 @@
               }
             }
           }
+
+          // Keep only the most recent MAX_POINTS commits.
+          if (commitIds.length > MAX_POINTS) {
+            commitIds.splice(0, commitIds.length - MAX_POINTS);
+          }
+
+          // Widen the canvas box so each point gets enough room; this is what
+          // makes the scroller scroll.
+          canvasBox.style.width = Math.max(MIN_CHART_WIDTH, commitIds.length * PX_PER_POINT) + 'px';
 
           // Sort optimization levels
           const sortedOpts = [...optLevelMap.keys()].sort();
@@ -226,6 +259,8 @@
               datasets,
             },
             options: {
+              responsive: true,
+              maintainAspectRatio: false,
               title: {
                 display: true,
                 text: baseName,

--- a/.github/pages/runtime-index.html
+++ b/.github/pages/runtime-index.html
@@ -218,7 +218,11 @@
           new Chart(canvas, {
             type: 'line',
             data: {
-              labels: commitIds.map(id => id.slice(0, 7)),
+              labels: commitIds.map(id => {
+                const meta = commitMeta.get(id);
+                const ymd = new Date(meta.commit.timestamp).toISOString().slice(0, 10);
+                return ymd + ' ' + id.slice(0, 7);
+              }),
               datasets,
             },
             options: {

--- a/.github/pages/runtime-index.html
+++ b/.github/pages/runtime-index.html
@@ -92,6 +92,10 @@
         <strong>Repository:</strong>
         <a id="repository-link" rel="noopener"></a>
       </div>
+      <div class="header-item">
+        <strong>Note:</strong>
+        <span>The graphs show throughput, so higher is better.</span>
+      </div>
     </header>
     <main id="main"></main>
     <footer>

--- a/.github/pages/runtime-index.html
+++ b/.github/pages/runtime-index.html
@@ -12,7 +12,7 @@
       }
       body {
         color: #4a4a4a;
-        margin: 8px;
+        margin: 16px;
         font-size: 1em;
         font-weight: 400;
       }
@@ -77,14 +77,26 @@
       }
       .benchmark-scroller {
         width: 100%;
-        max-width: 1000px;
         overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
       }
       .benchmark-canvas-box {
+        min-width: 100%;
         height: 400px;
       }
       .benchmark-chart {
         display: block;
+      }
+      @media (max-width: 600px) {
+        body {
+          margin: 8px;
+        }
+        .benchmark-canvas-box {
+          height: 300px;
+        }
+        .benchmark-title {
+          font-size: 1.5rem;
+        }
       }
     </style>
     <title>Runtime Benchmarks (Combined)</title>
@@ -175,11 +187,10 @@
           return groups;
         }
 
-        // Show only the most recent commits; older data stays in data.js but
-        // is not plotted. The chart is horizontally scrollable when crowded.
-        const MAX_POINTS = 100;
-        const PX_PER_POINT = 14;
-        const MIN_CHART_WIDTH = 1000;
+        // Every commit gets a fixed horizontal slot, so the chart grows as wide
+        // as it needs and the container scrolls horizontally. How many points
+        // are visible at once therefore depends on the viewport width.
+        const PX_PER_POINT = 16;
 
         function renderCombinedGraph(parent, baseName, optLevelMap) {
           // Scroll container: keeps the chart within the page width but lets
@@ -211,14 +222,11 @@
             }
           }
 
-          // Keep only the most recent MAX_POINTS commits.
-          if (commitIds.length > MAX_POINTS) {
-            commitIds.splice(0, commitIds.length - MAX_POINTS);
-          }
-
-          // Widen the canvas box so each point gets enough room; this is what
-          // makes the scroller scroll.
-          canvasBox.style.width = Math.max(MIN_CHART_WIDTH, commitIds.length * PX_PER_POINT) + 'px';
+          // Give every commit PX_PER_POINT of width. CSS min-width keeps the box
+          // filling the viewport when there are only a few points, so the chart
+          // never looks cramped on the left; once it grows past the viewport the
+          // container scrolls instead.
+          canvasBox.style.width = (commitIds.length * PX_PER_POINT) + 'px';
 
           // Sort optimization levels
           const sortedOpts = [...optLevelMap.keys()].sort();
@@ -301,6 +309,9 @@
               },
             },
           });
+
+          // Start scrolled to the most recent commits (the right edge).
+          scroller.scrollLeft = scroller.scrollWidth;
         }
 
         function render(groups) {

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -57,6 +57,7 @@ jobs:
           auto-push: true
           comment-on-alert: false
           fail-on-alert: false
+          summary-always: true
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: benchmarks/runtime-throughput
           skip-fetch-gh-pages: true
@@ -71,6 +72,7 @@ jobs:
           auto-push: true
           comment-on-alert: false
           fail-on-alert: false
+          summary-always: true
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: benchmarks/wasm-size
           skip-fetch-gh-pages: true
@@ -108,6 +110,7 @@ jobs:
           alert-threshold: '150%'
           fail-threshold: '200%'
           alert-comment-cc-users: ''
+          summary-always: true
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: benchmarks/runtime-throughput
           skip-fetch-gh-pages: true
@@ -126,6 +129,7 @@ jobs:
           alert-threshold: '110%'
           fail-threshold: '130%'
           alert-comment-cc-users: ''
+          summary-always: true
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: benchmarks/wasm-size
           skip-fetch-gh-pages: true

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,8 +3,12 @@ name: Benchmark
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary

Polishes the combined runtime-benchmark dashboard (`.github/pages/runtime-index.html`) and the benchmark workflow (`.github/workflows/benchmark.yml`).

### Dashboard (`runtime-index.html`)
- Add a header note explaining the graphs show **throughput, so higher is better**.
- X-axis labels now show **date + commit hash** (e.g. `2026-06-05 1540d37`) instead of just the hash.
- Graphs are now **responsive with horizontal scroll**: each commit gets a fixed 16px slot, the canvas fills the viewport when there are few points and scrolls horizontally when crowded, and the view starts scrolled to the most recent commit. The number of points visible at once follows the viewport width.
- Mobile support: full-width scroller, touch scrolling, smaller graph height and title on narrow screens.

### Workflow (`benchmark.yml`)
- **Skip on markdown-only changes** via `paths-ignore: ['**/*.md']` on both `push` and `pull_request`.
- **Always write results to the job summary** (`summary-always: true`) so the Checks tab always reflects the latest run. This mitigates stale alert comments: when a real regression is fixed and re-pushed, the comment may linger (upstream [#334](https://github.com/benchmark-action/github-action-benchmark/issues/334)), but the job summary always shows the current state.

## Notes
- The benchmark workflow is not a required status check, so `paths-ignore` is safe here.

https://claude.ai/code/session_01CfQkSteQobqyXYMaiAUPKV

---
_Generated by [Claude Code](https://claude.ai/code/session_01CfQkSteQobqyXYMaiAUPKV)_