### PR TITLE
fix(benchmark): fixed header/legend/axis on combined benchmark pages

### DIFF
--- a/.github/pages/runtime-index.html
+++ b/.github/pages/runtime-index.html
@@ -75,6 +75,18 @@
         flex-wrap: wrap;
         width: 100%;
       }
+      .benchmark-graph {
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+      }
+      .benchmark-graph-title {
+        font-size: 18px;
+        font-weight: 600;
+        text-align: center;
+        margin: 8px 0;
+        word-break: break-word;
+      }
       .benchmark-scroller {
         width: 100%;
         overflow-x: auto;
@@ -193,11 +205,23 @@
         const PX_PER_POINT = 16;
 
         function renderCombinedGraph(parent, baseName, optLevelMap) {
+          // Column wrapper so the fixed title sits above the scrollable chart.
+          const graph = document.createElement('div');
+          graph.className = 'benchmark-graph';
+          parent.appendChild(graph);
+
+          // Title lives outside the scroller, so it stays fixed while only the
+          // chart area scrolls horizontally.
+          const title = document.createElement('div');
+          title.className = 'benchmark-graph-title';
+          title.textContent = baseName;
+          graph.appendChild(title);
+
           // Scroll container: keeps the chart within the page width but lets
           // the user scroll horizontally when there are many commits.
           const scroller = document.createElement('div');
           scroller.className = 'benchmark-scroller';
-          parent.appendChild(scroller);
+          graph.appendChild(scroller);
 
           const canvasBox = document.createElement('div');
           canvasBox.className = 'benchmark-canvas-box';
@@ -270,9 +294,7 @@
               responsive: true,
               maintainAspectRatio: false,
               title: {
-                display: true,
-                text: baseName,
-                fontSize: 18,
+                display: false,
               },
               scales: {
                 xAxes: [{

--- a/.github/pages/runtime-index.html
+++ b/.github/pages/runtime-index.html
@@ -105,10 +105,20 @@
         height: 2px;
         margin-right: 6px;
       }
+      .benchmark-chart-wrap {
+        position: relative;
+        width: 100%;
+      }
       .benchmark-scroller {
         width: 100%;
         overflow-x: auto;
         -webkit-overflow-scrolling: touch;
+      }
+      .benchmark-axis-overlay {
+        position: absolute;
+        top: 0;
+        left: 0;
+        pointer-events: none;
       }
       .benchmark-canvas-box {
         min-width: 100%;
@@ -242,11 +252,17 @@
           legend.className = 'benchmark-graph-legend';
           graph.appendChild(legend);
 
+          // Wrapper that the fixed y-axis overlay is positioned against. It must
+          // sit outside the scroller so the overlay does not scroll with it.
+          const chartWrap = document.createElement('div');
+          chartWrap.className = 'benchmark-chart-wrap';
+          graph.appendChild(chartWrap);
+
           // Scroll container: keeps the chart within the page width but lets
           // the user scroll horizontally when there are many commits.
           const scroller = document.createElement('div');
           scroller.className = 'benchmark-scroller';
-          graph.appendChild(scroller);
+          chartWrap.appendChild(scroller);
 
           const canvasBox = document.createElement('div');
           canvasBox.className = 'benchmark-canvas-box';
@@ -255,6 +271,13 @@
           const canvas = document.createElement('canvas');
           canvas.className = 'benchmark-chart';
           canvasBox.appendChild(canvas);
+
+          // Fixed y-axis: an overlay canvas pinned to the left of the wrapper.
+          // After the chart renders we copy its y-axis strip here, so the axis
+          // (labels, ticks, title) stays visible while the chart scrolls.
+          const axisOverlay = document.createElement('canvas');
+          axisOverlay.className = 'benchmark-axis-overlay';
+          chartWrap.appendChild(axisOverlay);
 
           // Find all unique commit IDs across all optimization levels, preserving order
           const commitIds = [];
@@ -318,7 +341,7 @@
             return '';
           })();
 
-          new Chart(canvas, {
+          const chart = new Chart(canvas, {
             type: 'line',
             data: {
               labels: commitIds.map(id => {
@@ -331,6 +354,9 @@
             options: {
               responsive: true,
               maintainAspectRatio: false,
+              animation: {
+                onComplete: () => syncAxis(),
+              },
               title: {
                 display: false,
               },
@@ -372,6 +398,35 @@
               },
             },
           });
+
+          // Copy the chart's y-axis strip into the fixed overlay so the axis
+          // stays put while the chart scrolls. Runs after every (re)render via
+          // animation.onComplete, and on viewport resize (the canvas height
+          // changes at the mobile breakpoint).
+          function syncAxis() {
+            const area = chart.chartArea;
+            if (!area) return;
+            const dpr = window.devicePixelRatio || 1;
+            const axisW = Math.ceil(area.left);   // y-axis strip width, CSS px
+            const cssH = canvasBox.clientHeight;  // chart height, CSS px
+            if (axisW <= 0 || cssH <= 0) return;
+            axisOverlay.style.width = axisW + 'px';
+            axisOverlay.style.height = cssH + 'px';
+            axisOverlay.width = Math.round(axisW * dpr);
+            axisOverlay.height = Math.round(cssH * dpr);
+            const ctx = axisOverlay.getContext('2d');
+            // Opaque background so scrolled chart content cannot show through.
+            ctx.fillStyle = '#fff';
+            ctx.fillRect(0, 0, axisOverlay.width, axisOverlay.height);
+            // Source and destination share device-pixel dimensions, so copy 1:1.
+            ctx.drawImage(
+              canvas,
+              0, 0, axisOverlay.width, axisOverlay.height,
+              0, 0, axisOverlay.width, axisOverlay.height,
+            );
+          }
+
+          window.addEventListener('resize', () => setTimeout(syncAxis, 250));
 
           // Start scrolled to the most recent commits (the right edge).
           scroller.scrollLeft = scroller.scrollWidth;

--- a/.github/pages/runtime-index.html
+++ b/.github/pages/runtime-index.html
@@ -87,6 +87,24 @@
         margin: 8px 0;
         word-break: break-word;
       }
+      .benchmark-graph-legend {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 4px 16px;
+        margin-bottom: 8px;
+      }
+      .benchmark-legend-item {
+        display: flex;
+        align-items: center;
+        font-size: 0.75rem;
+      }
+      .benchmark-legend-swatch {
+        width: 24px;
+        height: 2px;
+        margin-right: 6px;
+      }
       .benchmark-scroller {
         width: 100%;
         overflow-x: auto;
@@ -217,6 +235,13 @@
           title.textContent = baseName;
           graph.appendChild(title);
 
+          // Legend lives outside the scroller too, so it stays fixed while the
+          // chart scrolls. Populated below once the optimization levels and
+          // their colors are known.
+          const legend = document.createElement('div');
+          legend.className = 'benchmark-graph-legend';
+          graph.appendChild(legend);
+
           // Scroll container: keeps the chart within the page width but lets
           // the user scroll horizontally when there are many commits.
           const scroller = document.createElement('div');
@@ -254,6 +279,19 @@
 
           // Sort optimization levels
           const sortedOpts = [...optLevelMap.keys()].sort();
+
+          // Build the HTML legend now that the optimization levels are known.
+          for (const opt of sortedOpts) {
+            const color = OPT_COLORS[opt] || FALLBACK_COLOR;
+            const item = document.createElement('div');
+            item.className = 'benchmark-legend-item';
+            const swatch = document.createElement('span');
+            swatch.className = 'benchmark-legend-swatch';
+            swatch.style.backgroundColor = color;
+            item.appendChild(swatch);
+            item.appendChild(document.createTextNode(opt));
+            legend.appendChild(item);
+          }
 
           // Build datasets: one line per optimization level
           const datasets = sortedOpts.map(opt => {
@@ -294,6 +332,9 @@
               responsive: true,
               maintainAspectRatio: false,
               title: {
+                display: false,
+              },
+              legend: {
                 display: false,
               },
               scales: {

--- a/.github/pages/runtime-index.html
+++ b/.github/pages/runtime-index.html
@@ -99,6 +99,13 @@
         display: flex;
         align-items: center;
         font-size: 0.75rem;
+        cursor: pointer;
+        user-select: none;
+        -webkit-user-select: none;
+      }
+      .benchmark-legend-item.is-hidden {
+        opacity: 0.4;
+        text-decoration: line-through;
       }
       .benchmark-legend-swatch {
         width: 24px;
@@ -304,7 +311,10 @@
           const sortedOpts = [...optLevelMap.keys()].sort();
 
           // Build the HTML legend now that the optimization levels are known.
-          for (const opt of sortedOpts) {
+          // Legend order matches the dataset order below, so the item index is
+          // the dataset index. Clicking an item toggles that dataset's
+          // visibility, mirroring Chart.js's built-in legend behaviour.
+          sortedOpts.forEach((opt, index) => {
             const color = OPT_COLORS[opt] || FALLBACK_COLOR;
             const item = document.createElement('div');
             item.className = 'benchmark-legend-item';
@@ -313,8 +323,14 @@
             swatch.style.backgroundColor = color;
             item.appendChild(swatch);
             item.appendChild(document.createTextNode(opt));
+            item.addEventListener('click', () => {
+              const meta = chart.getDatasetMeta(index);
+              meta.hidden = meta.hidden === null ? !chart.data.datasets[index].hidden : null;
+              item.classList.toggle('is-hidden', meta.hidden === true);
+              chart.update();
+            });
             legend.appendChild(item);
-          }
+          });
 
           // Build datasets: one line per optimization level
           const datasets = sortedOpts.map(opt => {

--- a/.github/pages/wasm-size-index.html
+++ b/.github/pages/wasm-size-index.html
@@ -1,0 +1,470 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes" />
+    <style>
+      html {
+        font-family: BlinkMacSystemFont,-apple-system,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Fira Sans","Droid Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
+        -webkit-font-smoothing: antialiased;
+        background-color: #fff;
+        font-size: 16px;
+      }
+      body {
+        color: #4a4a4a;
+        margin: 16px;
+        font-size: 1em;
+        font-weight: 400;
+      }
+      header {
+        margin-bottom: 8px;
+        display: flex;
+        flex-direction: column;
+      }
+      main {
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+      }
+      a {
+        color: #3273dc;
+        cursor: pointer;
+        text-decoration: none;
+      }
+      a:hover {
+        color: #000;
+      }
+      button {
+        color: #fff;
+        background-color: #3298dc;
+        border-color: transparent;
+        cursor: pointer;
+        text-align: center;
+      }
+      button:hover {
+        background-color: #2793da;
+      }
+      .spacer {
+        flex: auto;
+      }
+      .small {
+        font-size: 0.75rem;
+      }
+      footer {
+        margin-top: 16px;
+        display: flex;
+        align-items: center;
+      }
+      .benchmark-set {
+        margin: 8px 0;
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+      }
+      .benchmark-title {
+        font-size: 2rem;
+        font-weight: 600;
+        word-break: break-word;
+        text-align: center;
+      }
+      .benchmark-graphs {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-around;
+        align-items: center;
+        flex-wrap: wrap;
+        width: 100%;
+      }
+      .benchmark-graph {
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+      }
+      .benchmark-graph-title {
+        font-size: 18px;
+        font-weight: 600;
+        text-align: center;
+        margin: 8px 0;
+        word-break: break-word;
+      }
+      .benchmark-graph-legend {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 4px 16px;
+        margin-bottom: 8px;
+      }
+      .benchmark-legend-item {
+        display: flex;
+        align-items: center;
+        font-size: 0.75rem;
+        cursor: pointer;
+        user-select: none;
+        -webkit-user-select: none;
+      }
+      .benchmark-legend-item.is-hidden {
+        opacity: 0.4;
+        text-decoration: line-through;
+      }
+      .benchmark-legend-swatch {
+        width: 24px;
+        height: 2px;
+        margin-right: 6px;
+      }
+      .benchmark-chart-wrap {
+        position: relative;
+        width: 100%;
+      }
+      .benchmark-scroller {
+        width: 100%;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+      }
+      .benchmark-axis-overlay {
+        position: absolute;
+        top: 0;
+        left: 0;
+        pointer-events: none;
+      }
+      .benchmark-canvas-box {
+        min-width: 100%;
+        height: 400px;
+      }
+      .benchmark-chart {
+        display: block;
+      }
+      @media (max-width: 600px) {
+        body {
+          margin: 8px;
+        }
+        .benchmark-canvas-box {
+          height: 300px;
+        }
+        .benchmark-title {
+          font-size: 1.5rem;
+        }
+      }
+    </style>
+    <title>Wasm Size Benchmarks (Combined)</title>
+  </head>
+
+  <body>
+    <header id="header">
+      <div class="header-item">
+        <strong>Last Update:</strong>
+        <span id="last-update"></span>
+      </div>
+      <div class="header-item">
+        <strong>Repository:</strong>
+        <a id="repository-link" rel="noopener"></a>
+      </div>
+      <div class="header-item">
+        <strong>Note:</strong>
+        <span>The graphs show wasm binary size, so smaller is better.</span>
+      </div>
+    </header>
+    <main id="main"></main>
+    <footer>
+      <button id="dl-button">Download data as JSON</button>
+      <div class="spacer"></div>
+      <div class="small">Powered by <a rel="noopener" href="https://github.com/marketplace/actions/continuous-benchmark">github-action-benchmark</a></div>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.2/dist/Chart.min.js"></script>
+    <script src="data.js"></script>
+    <script>
+      'use strict';
+      (function() {
+        const OPT_COLORS = {
+          '-O1': '#3273dc',
+          '-O2': '#23d160',
+          '-O3': '#ff3860',
+        };
+        const FALLBACK_COLOR = '#ffdd57';
+
+        const OPT_PATTERN = / \((-O\d)\)$/;
+
+        function init() {
+          const data = window.BENCHMARK_DATA;
+
+          document.getElementById('last-update').textContent = new Date(data.lastUpdate).toString();
+          const repoLink = document.getElementById('repository-link');
+          repoLink.href = data.repoUrl;
+          repoLink.textContent = data.repoUrl;
+
+          document.getElementById('dl-button').onclick = () => {
+            const dataUrl = 'data:,' + JSON.stringify(data, null, 2);
+            const a = document.createElement('a');
+            a.href = dataUrl;
+            a.download = 'benchmark_data.json';
+            a.click();
+          };
+
+          // Collect all bench results per benchmark name
+          const benchesByName = new Map();
+          for (const entries of Object.values(data.entries)) {
+            for (const entry of entries) {
+              const {commit, date, tool, benches} = entry;
+              for (const bench of benches) {
+                const result = { commit, date, tool, bench };
+                if (!benchesByName.has(bench.name)) {
+                  benchesByName.set(bench.name, []);
+                }
+                benchesByName.get(bench.name).push(result);
+              }
+            }
+          }
+
+          // Group by base name (strip optimization level suffix)
+          const groups = new Map();
+          for (const [name, results] of benchesByName) {
+            const match = name.match(OPT_PATTERN);
+            if (match) {
+              const baseName = name.replace(OPT_PATTERN, '');
+              const optLevel = match[1];
+              if (!groups.has(baseName)) {
+                groups.set(baseName, new Map());
+              }
+              groups.get(baseName).set(optLevel, results);
+            }
+            // Skip entries without optimization level suffix (legacy data)
+          }
+
+          return groups;
+        }
+
+        // Every commit gets a fixed horizontal slot, so the chart grows as wide
+        // as it needs and the container scrolls horizontally. How many points
+        // are visible at once therefore depends on the viewport width.
+        const PX_PER_POINT = 16;
+
+        function renderCombinedGraph(parent, baseName, optLevelMap) {
+          // Column wrapper so the fixed title sits above the scrollable chart.
+          const graph = document.createElement('div');
+          graph.className = 'benchmark-graph';
+          parent.appendChild(graph);
+
+          // Title lives outside the scroller, so it stays fixed while only the
+          // chart area scrolls horizontally.
+          const title = document.createElement('div');
+          title.className = 'benchmark-graph-title';
+          title.textContent = baseName;
+          graph.appendChild(title);
+
+          // Legend lives outside the scroller too, so it stays fixed while the
+          // chart scrolls. Populated below once the optimization levels and
+          // their colors are known.
+          const legend = document.createElement('div');
+          legend.className = 'benchmark-graph-legend';
+          graph.appendChild(legend);
+
+          // Wrapper that the fixed y-axis overlay is positioned against. It must
+          // sit outside the scroller so the overlay does not scroll with it.
+          const chartWrap = document.createElement('div');
+          chartWrap.className = 'benchmark-chart-wrap';
+          graph.appendChild(chartWrap);
+
+          // Scroll container: keeps the chart within the page width but lets
+          // the user scroll horizontally when there are many commits.
+          const scroller = document.createElement('div');
+          scroller.className = 'benchmark-scroller';
+          chartWrap.appendChild(scroller);
+
+          const canvasBox = document.createElement('div');
+          canvasBox.className = 'benchmark-canvas-box';
+          scroller.appendChild(canvasBox);
+
+          const canvas = document.createElement('canvas');
+          canvas.className = 'benchmark-chart';
+          canvasBox.appendChild(canvas);
+
+          // Fixed y-axis: an overlay canvas pinned to the left of the wrapper.
+          // After the chart renders we copy its y-axis strip here, so the axis
+          // (labels, ticks, title) stays visible while the chart scrolls.
+          const axisOverlay = document.createElement('canvas');
+          axisOverlay.className = 'benchmark-axis-overlay';
+          chartWrap.appendChild(axisOverlay);
+
+          // Find all unique commit IDs across all optimization levels, preserving order
+          const commitIds = [];
+          const commitSet = new Set();
+          const commitMeta = new Map();
+          for (const results of optLevelMap.values()) {
+            for (const r of results) {
+              const id = r.commit.id;
+              if (!commitSet.has(id)) {
+                commitSet.add(id);
+                commitIds.push(id);
+                commitMeta.set(id, r);
+              }
+            }
+          }
+
+          // Give every commit PX_PER_POINT of width. CSS min-width keeps the box
+          // filling the viewport when there are only a few points, so the chart
+          // never looks cramped on the left; once it grows past the viewport the
+          // container scrolls instead.
+          canvasBox.style.width = (commitIds.length * PX_PER_POINT) + 'px';
+
+          // Sort optimization levels
+          const sortedOpts = [...optLevelMap.keys()].sort();
+
+          // Build the HTML legend now that the optimization levels are known.
+          // Legend order matches the dataset order below, so the item index is
+          // the dataset index. Clicking an item toggles that dataset's
+          // visibility, mirroring Chart.js's built-in legend behaviour.
+          sortedOpts.forEach((opt, index) => {
+            const color = OPT_COLORS[opt] || FALLBACK_COLOR;
+            const item = document.createElement('div');
+            item.className = 'benchmark-legend-item';
+            const swatch = document.createElement('span');
+            swatch.className = 'benchmark-legend-swatch';
+            swatch.style.backgroundColor = color;
+            item.appendChild(swatch);
+            item.appendChild(document.createTextNode(opt));
+            item.addEventListener('click', () => {
+              const meta = chart.getDatasetMeta(index);
+              meta.hidden = meta.hidden === null ? !chart.data.datasets[index].hidden : null;
+              item.classList.toggle('is-hidden', meta.hidden === true);
+              chart.update();
+            });
+            legend.appendChild(item);
+          });
+
+          // Build datasets: one line per optimization level
+          const datasets = sortedOpts.map(opt => {
+            const results = optLevelMap.get(opt);
+            const valueByCommit = new Map();
+            for (const r of results) {
+              valueByCommit.set(r.commit.id, r.bench.value);
+            }
+            const color = OPT_COLORS[opt] || FALLBACK_COLOR;
+            return {
+              label: opt,
+              data: commitIds.map(id => valueByCommit.has(id) ? valueByCommit.get(id) : null),
+              borderColor: color,
+              backgroundColor: color + '40',
+              fill: false,
+              spanGaps: true,
+            };
+          });
+
+          const unit = (() => {
+            for (const results of optLevelMap.values()) {
+              if (results.length > 0) return results[0].bench.unit;
+            }
+            return '';
+          })();
+
+          const chart = new Chart(canvas, {
+            type: 'line',
+            data: {
+              labels: commitIds.map(id => {
+                const meta = commitMeta.get(id);
+                const ymd = new Date(meta.commit.timestamp).toISOString().slice(0, 10);
+                return ymd + ' ' + id.slice(0, 7);
+              }),
+              datasets,
+            },
+            options: {
+              responsive: true,
+              maintainAspectRatio: false,
+              animation: {
+                onComplete: () => syncAxis(),
+              },
+              title: {
+                display: false,
+              },
+              legend: {
+                display: false,
+              },
+              scales: {
+                xAxes: [{
+                  scaleLabel: { display: true, labelString: 'commit' },
+                }],
+                yAxes: [{
+                  scaleLabel: { display: true, labelString: unit },
+                  ticks: { beginAtZero: true },
+                }],
+              },
+              tooltips: {
+                mode: 'index',
+                intersect: false,
+                callbacks: {
+                  afterTitle: items => {
+                    const {index} = items[0];
+                    const id = commitIds[index];
+                    const meta = commitMeta.get(id);
+                    if (!meta) return '';
+                    return '\n' + meta.commit.message + '\n\n' + meta.commit.timestamp + ' by @' + meta.commit.committer.username + '\n';
+                  },
+                  label: item => {
+                    if (item.value === null || item.value === undefined) return null;
+                    return item.dataset.label + ': ' + item.value + ' ' + unit;
+                  },
+                },
+              },
+              onClick: (_mouseEvent, activeElems) => {
+                if (activeElems.length === 0) return;
+                const index = activeElems[0]._index;
+                const id = commitIds[index];
+                const meta = commitMeta.get(id);
+                if (meta) window.open(meta.commit.url, '_blank');
+              },
+            },
+          });
+
+          // Copy the chart's y-axis strip into the fixed overlay so the axis
+          // stays put while the chart scrolls. Runs after every (re)render via
+          // animation.onComplete, and on viewport resize (the canvas height
+          // changes at the mobile breakpoint).
+          function syncAxis() {
+            const area = chart.chartArea;
+            if (!area) return;
+            const dpr = window.devicePixelRatio || 1;
+            const axisW = Math.ceil(area.left);   // y-axis strip width, CSS px
+            const cssH = canvasBox.clientHeight;  // chart height, CSS px
+            if (axisW <= 0 || cssH <= 0) return;
+            axisOverlay.style.width = axisW + 'px';
+            axisOverlay.style.height = cssH + 'px';
+            axisOverlay.width = Math.round(axisW * dpr);
+            axisOverlay.height = Math.round(cssH * dpr);
+            const ctx = axisOverlay.getContext('2d');
+            // Opaque background so scrolled chart content cannot show through.
+            ctx.fillStyle = '#fff';
+            ctx.fillRect(0, 0, axisOverlay.width, axisOverlay.height);
+            // Source and destination share device-pixel dimensions, so copy 1:1.
+            ctx.drawImage(
+              canvas,
+              0, 0, axisOverlay.width, axisOverlay.height,
+              0, 0, axisOverlay.width, axisOverlay.height,
+            );
+          }
+
+          window.addEventListener('resize', () => setTimeout(syncAxis, 250));
+
+          // Start scrolled to the most recent commits (the right edge).
+          scroller.scrollLeft = scroller.scrollWidth;
+        }
+
+        function render(groups) {
+          const main = document.getElementById('main');
+          for (const [baseName, optLevelMap] of groups) {
+            const setElem = document.createElement('div');
+            setElem.className = 'benchmark-set';
+            main.appendChild(setElem);
+
+            const graphsElem = document.createElement('div');
+            graphsElem.className = 'benchmark-graphs';
+            setElem.appendChild(graphsElem);
+
+            renderCombinedGraph(graphsElem, baseName, optLevelMap);
+          }
+        }
+
+        render(init());
+      })();
+    </script>
+  </body>
+</html>

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -82,11 +82,13 @@ jobs:
         run: |
           git worktree add /tmp/gh-pages gh-pages
           mkdir -p /tmp/gh-pages/benchmarks/runtime-throughput
+          mkdir -p /tmp/gh-pages/benchmarks/wasm-size
           cp .github/pages/runtime-index.html /tmp/gh-pages/benchmarks/runtime-throughput/index.html
+          cp .github/pages/wasm-size-index.html /tmp/gh-pages/benchmarks/wasm-size/index.html
           cd /tmp/gh-pages
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add benchmarks/runtime-throughput/index.html
+          git add benchmarks/runtime-throughput/index.html benchmarks/wasm-size/index.html
           git diff --cached --quiet || {
             git commit -m "Deploy combined benchmark graphs"
             git push origin gh-pages


### PR DESCRIPTION
## Summary

The combined runtime-throughput benchmark page made the **whole** chart scroll horizontally, so the title, legend, and y-axis scrolled out of view along with the plot. This makes only the plot area scroll while the surrounding chrome stays fixed, and applies the same treatment to the wasm-size page.

## Changes

- **Fixed graph title**: moved out of the Chart.js canvas into an HTML element above the scroll container (in-canvas title disabled).
- **Fixed legend**: rendered as an HTML legend above the scroller (in-canvas legend disabled). Restored Chart.js's **click-to-toggle** behaviour — clicking an item hides/shows its dataset and dims/strikes the item.
- **Fixed y-axis**: pinned an overlay canvas to the left of the chart and copy the rendered y-axis strip into it after each render (and on resize), masking scrolled content behind an opaque background. Labels/ticks/unit stay aligned because the strip is copied straight from the chart.
- **Wasm-size combined page**: added `.github/pages/wasm-size-index.html` mirroring the runtime page, with the note reading *"The graphs show wasm binary size, so smaller is better."* The workflow now deploys it to `benchmarks/wasm-size/index.html`.

## Notes

- These are browser-rendered behaviours; inline scripts were syntax-validated, but the final visual/scroll behaviour should be confirmed in a real browser once deployed to GitHub Pages.

https://claude.ai/code/session_01HMqgnUx2BoHqWXhy5EhB4o

---
_Generated by [Claude Code](https://claude.ai/code/session_01HMqgnUx2BoHqWXhy5EhB4o)_