### PR TITLE
fix(benchmark): render wasm-size graphs and serialize gh-pages writes

### DIFF
--- a/.github/pages/wasm-size-index.html
+++ b/.github/pages/wasm-size-index.html
@@ -177,6 +177,7 @@
       'use strict';
       (function() {
         const OPT_COLORS = {
+          '-Os': '#3273dc',
           '-O1': '#3273dc',
           '-O2': '#23d160',
           '-O3': '#ff3860',
@@ -216,19 +217,19 @@
             }
           }
 
-          // Group by base name (strip optimization level suffix)
+          // Group by base name. wasm-size programs are compiled once at -Os and
+          // carry no optimization-level suffix, so each forms a single series.
+          // A name that does carry a ` (-Ox)` suffix groups under its base name
+          // as one line per level, mirroring the runtime page.
           const groups = new Map();
           for (const [name, results] of benchesByName) {
             const match = name.match(OPT_PATTERN);
-            if (match) {
-              const baseName = name.replace(OPT_PATTERN, '');
-              const optLevel = match[1];
-              if (!groups.has(baseName)) {
-                groups.set(baseName, new Map());
-              }
-              groups.get(baseName).set(optLevel, results);
+            const baseName = match ? name.replace(OPT_PATTERN, '') : name;
+            const series = match ? match[1] : '-Os';
+            if (!groups.has(baseName)) {
+              groups.set(baseName, new Map());
             }
-            // Skip entries without optimization level suffix (legacy data)
+            groups.get(baseName).set(series, results);
           }
 
           return groups;

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,6 +10,16 @@ on:
     paths-ignore:
       - '**/*.md'
 
+# Only push events write to gh-pages, and two runs writing concurrently race on
+# the branch tip (the store steps and the deploy push). Serialize all push runs
+# under one group so they land one at a time; cancel-in-progress: false lets the
+# in-progress run finish and push its data instead of being killed mid-write.
+# Pull-request runs only read gh-pages, so give each its own group (keyed by
+# run id) to keep them fully independent.
+concurrency:
+  group: benchmark-gh-pages-${{ github.event_name == 'push' && 'main' || github.run_id }}
+  cancel-in-progress: false
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0


### PR DESCRIPTION
## Summary

The wasm-size benchmark page rendered blank, and the workflow that publishes it can race on the `gh-pages` branch when several pushes land close together. This fixes both.

## Blank wasm-size page

`.github/pages/wasm-size-index.html` was mirrored from the runtime-throughput page, which plots one line per optimization level and discards any benchmark whose name lacks a ` (-Ox)` suffix as "legacy data". wasm-size programs are compiled once at `-Os` and emit plain names (`hello_world`, `pi_approx`, `zlib`, `sqlite_highlight`), so **every** entry was dropped and no graph was drawn — the page was empty.

The grouping now treats a plain name as its own base name with a single `-Os` series, while still grouping any future ` (-Ox)`-suffixed names by level. The data on `gh-pages` was never corrupted; only the renderer threw it away. Verified against the real 736-entry data set: previously 0 graphs, now 4 (one line each, correct point counts).

## gh-pages write race

Only push-triggered runs write `gh-pages`, and two running concurrently race on the branch tip — both the `auto-push` store steps and the manual "Deploy combined benchmark pages" push (which has no retry) can hit non-fast-forward rejections when another run pushes in between.

A `concurrency` group serializes push runs through `gh-pages` one at a time; `cancel-in-progress: false` keeps the in-progress run alive to finish its write instead of being killed mid-push. Pull-request runs only read `gh-pages`, so they are keyed by run id to stay independent and uncancelled.

Trade-off: during a burst of rapid merges to `main`, GitHub may supersede a pending run, so an intermediate commit's data point can occasionally be skipped. Sizes are absolute, so the trend is preserved.

https://claude.ai/code/session_01VFsAta7E4D1DLwmBeGpytj

---
_Generated by [Claude Code](https://claude.ai/code/session_01VFsAta7E4D1DLwmBeGpytj)_