### PR TITLE
perf(zlib): speed up inflate by removing redundant sliding window

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -67,19 +67,19 @@ zlib compression of twitter.json (631514 bytes).
 
 | Implementation         |  Throughput |   ms/iter | vs best |
 | ---------------------- | ----------: | --------: | ------: |
-| Rust (zlib-rs)         | 157.67 MB/s |  4.005 ms |   1.00x |
-| JavaScript (node:zlib) | 133.42 MB/s |  4.733 ms |   1.18x |
-| **Wado** (core:zlib)   |  23.21 MB/s | 27.203 ms |   6.79x |
+| Rust (zlib-rs)         | 158.49 MB/s |  3.985 ms |   1.00x |
+| JavaScript (node:zlib) | 132.86 MB/s |  4.753 ms |   1.19x |
+| **Wado** (core:zlib)   |  23.57 MB/s | 26.788 ms |   6.72x |
 
 ## Compression: decompress
 
 zlib decompression of twitter.json (631514 bytes).
 
-| Implementation         |  Throughput |   ms/iter | vs best |
-| ---------------------- | ----------: | --------: | ------: |
-| Rust (zlib-rs)         |   1.38 GB/s |  0.457 ms |   1.00x |
-| JavaScript (node:zlib) | 746.19 MB/s |  0.846 ms |   1.85x |
-| **Wado** (core:zlib)   |  55.79 MB/s | 11.319 ms |  24.74x |
+| Implementation         |  Throughput |  ms/iter | vs best |
+| ---------------------- | ----------: | -------: | ------: |
+| Rust (zlib-rs)         |   1.40 GB/s | 0.450 ms |   1.00x |
+| JavaScript (node:zlib) | 787.15 MB/s | 0.802 ms |   1.78x |
+| **Wado** (core:zlib)   | 119.52 MB/s | 5.283 ms |  11.74x |
 
 ## JSON: twitter
 

--- a/wado-compiler/lib/core/prelude/list.wado
+++ b/wado-compiler/lib/core/prelude/list.wado
@@ -224,12 +224,18 @@ impl List<T> {
             self.repr = new_repr;
         }
         let base = self.used;
-        // Forward element-by-element copy intentionally propagates just-written
-        // values for DEFLATE-style run-length back-references (src < dst, overlap).
-        // `builtin::array_copy` uses copy-as-if-buffered semantics, so it cannot
-        // replace this loop.
-        for let mut i = 0; i < count; i += 1 {
-            builtin::array_set(&mut self.repr, base + i, builtin::array_get(&self.repr, src_start + i));
+        if src_start + count <= base {
+            // Non-overlapping source and destination: a single bulk copy is
+            // safe and much faster than element-by-element.
+            builtin::array_copy(&mut self.repr, base, &self.repr, src_start, count);
+        } else {
+            // Overlapping (DEFLATE-style run-length back-reference, src < dst):
+            // forward element-by-element copy intentionally propagates
+            // just-written values. `builtin::array_copy` uses copy-as-if-buffered
+            // semantics, so it cannot replace this loop.
+            for let mut i = 0; i < count; i += 1 {
+                builtin::array_set(&mut self.repr, base + i, builtin::array_get(&self.repr, src_start + i));
+            }
         }
         self.used = new_used;
     }

--- a/wado-compiler/lib/core/zlib.wado
+++ b/wado-compiler/lib/core/zlib.wado
@@ -395,9 +395,7 @@ global MAXBITS: i32 = 15;
 global LENGTH_BASE: List<i32> = [
     3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 15, 17, 19, 23, 27, 31, 35, 43, 51, 59, 67, 83, 99, 115, 131, 163, 195, 227, 258,
 ];
-global LENGTH_EXTRA: List<i32> = [
-    0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 0,
-];
+global LENGTH_EXTRA: List<i32> = [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 0];
 global DIST_BASE: List<i32> = [
     1, 2, 3, 4, 5, 7, 9, 13, 17, 25, 33, 49, 65, 97, 129, 193, 257, 385, 513, 769, 1025, 1537, 2049, 3073, 4097, 6145,
     8193, 12289, 16385, 24577,
@@ -409,7 +407,16 @@ global DIST_EXTRA: List<i32> = [
 // Build a set of tables to decode the provided canonical Huffman code.
 // Returns [result, root_bits, table_offset_after]
 // result: 0=success, -1=invalid code, 1=not enough space
-fn inflate_table(codetype: i32, lens: &List<u16>, lens_offset: i32, codes_count: i32, table: &mut List<Code>, table_start: i32, bits_in: i32, work: &mut List<u16>) -> [i32, i32, i32] {
+fn inflate_table(
+    codetype: i32,
+    lens: &List<u16>,
+    lens_offset: i32,
+    codes_count: i32,
+    table: &mut List<Code>,
+    table_start: i32,
+    bits_in: i32,
+    work: &mut List<u16>,
+) -> [i32, i32, i32] {
     // Length codes 257..285 base
     let lbase: List<u16> = [
         3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 15, 17, 19, 23, 27, 31, 35, 43, 51, 59, 67, 83, 99, 115, 131, 163, 195, 227,
@@ -673,13 +680,6 @@ struct InflateState {
     last_block: bool,
     wrap: i32,  // 0=raw, 1=zlib
 
-    // window
-    wbits: i32,
-    wsize: i32,
-    whave: i32,
-    wnext: i32,
-    window: List<u8>,
-
     // bit buffer
     hold: u32,
     bits: i32,
@@ -716,16 +716,10 @@ struct InflateState {
 
 impl InflateState {
     fn new(raw: bool) -> InflateState {
-        let wbits = 15;
         return InflateState {
             mode: if raw { InflateMode::TypeDo } else { InflateMode::Head },
             last_block: false,
             wrap: if raw { 0 } else { 1 },
-            wbits,
-            wsize: 0,
-            whave: 0,
-            wnext: 0,
-            window: List::filled(1 << wbits, 0),
             hold: 0,
             bits: 0,
             length: 0,
@@ -786,52 +780,6 @@ impl InflateState {
         let result2 = inflate_table(DISTS_TYPE, &self.lens, 0, 32, &mut self.codes, dist_start, 5, &mut self.work);
         self.distcode_off = dist_start;
         self.distbits = result2.1;
-    }
-
-    // Update sliding window
-    fn update_window(&mut self, output: &List<u8>, out_end: i32, copy_len: i32) {
-        if self.wsize == 0 {
-            self.wsize = 1 << self.wbits;
-            self.wnext = 0;
-            self.whave = 0;
-        }
-
-        let mut remaining = copy_len;
-        if remaining >= self.wsize {
-            // copy last wsize bytes
-            let src_start = out_end - self.wsize;
-            for let mut i = 0; i < self.wsize; i += 1 {
-                self.window[i] = output[src_start + i];
-            }
-            self.wnext = 0;
-            self.whave = self.wsize;
-        } else {
-            let dist = self.wsize - self.wnext;
-            let mut copy_now = remaining;
-            if copy_now > dist {
-                copy_now = dist;
-            }
-            let src_start = out_end - remaining;
-            for let mut i = 0; i < copy_now; i += 1 {
-                self.window[self.wnext + i] = output[src_start + i];
-            }
-            remaining -= copy_now;
-            if remaining > 0 {
-                for let mut i = 0; i < remaining; i += 1 {
-                    self.window[i] = output[src_start + copy_now + i];
-                }
-                self.wnext = remaining;
-                self.whave = self.wsize;
-            } else {
-                self.wnext += copy_now;
-                if self.wnext == self.wsize {
-                    self.wnext = 0;
-                }
-                if self.whave < self.wsize {
-                    self.whave += copy_now;
-                }
-            }
-        }
     }
 }
 
@@ -1371,56 +1319,24 @@ fn inflate_raw_ex(input: &List<u8>, input_offset: i32, input_length: i32) -> [Li
             },
             Match => {
                 // Copy a <length, distance> back-reference (RFC 1951 section
-                // 3.2.5). The source may overlap the current position, so bytes
-                // are copied one at a time when they come from recent output.
+                // 3.2.5). The entire decoded stream is retained in `output`, so
+                // every back-reference is satisfied directly from it; no separate
+                // sliding window is needed. `copy_within_append` handles the
+                // run-length case where source and destination overlap. A
+                // distance that points before the start of the output is invalid
+                // (RFC 1951 section 3.2.3: "a distance cannot refer past the
+                // beginning of the output stream").
                 let out_pos = output.len();
-                let mut copy = state.length;
                 if state.offset > out_pos {
-                    // The distance reaches into the sliding window. A distance
-                    // that points before the start of the output is invalid
-                    // (RFC 1951 section 3.2.3: "a distance cannot refer past the
-                    // beginning of the output stream").
-                    let mut win_copy = state.offset - out_pos;
-                    if win_copy > state.whave {
-                        state.mode = InflateMode::Bad;
-                    } else {
-                        let mut from_win = 0;
-                        if state.wnext >= win_copy {
-                            from_win = state.wnext - win_copy;
-                        } else {
-                            from_win = state.wsize - (win_copy - state.wnext);
-                        }
-                        if win_copy > copy {
-                            win_copy = copy;
-                        }
-                        for let mut i = 0; i < win_copy; i += 1 {
-                            output.push(state.window[(from_win + i) % state.wsize]);
-                        }
-                        copy -= win_copy;
-                        // rest from output
-                        if copy > 0 {
-                            let src_start = output.len() - state.offset;
-                            output.copy_within_append(src_start, copy);
-                        }
-                    }
+                    state.mode = InflateMode::Bad;
                 } else {
-                    // copy from output
                     let src_start = out_pos - state.offset;
-                    output.copy_within_append(src_start, copy);
-                }
-                if state.mode != InflateMode::Bad {
-                    // update window
-                    state.update_window(&output, output.len(), state.length);
+                    output.copy_within_append(src_start, state.length);
                     state.mode = InflateMode::Len;
                 }
             },
             Lit => {
                 output.push(state.length as u8);
-                // update window periodically
-                if output.len() % 32768 == 0 {
-                    let wlen = if output.len() > 32768 { 32768 } else { output.len() };
-                    state.update_window(&output, output.len(), wlen);
-                }
                 state.mode = InflateMode::Len;
             },
             Check => {
@@ -1456,12 +1372,6 @@ fn inflate_raw_ex(input: &List<u8>, input_offset: i32, input_length: i32) -> [Li
                 leave = true;
             },
         }
-    }
-
-    // final window update
-    if output.len() > 0 {
-        let wlen = if output.len() > 32768 { 32768 } else { output.len() };
-        state.update_window(&output, output.len(), wlen);
     }
 
     // Return bytes consumed from input. The decode succeeded only if it ran to
@@ -2190,7 +2100,15 @@ fn gen_huffman_codes(lengths: &List<u8>, max_sym: i32, max_bits: i32) -> List<En
 }
 
 // Write a dynamic Huffman block
-fn write_dynamic_block(bw: &mut BitWriter, symbols: &List<i32>, distances: &List<i32>, sym_count: i32, is_last: bool, length_codes_table: &List<u8>, dist_codes_table: &List<u8>) {
+fn write_dynamic_block(
+    bw: &mut BitWriter,
+    symbols: &List<i32>,
+    distances: &List<i32>,
+    sym_count: i32,
+    is_last: bool,
+    length_codes_table: &List<u8>,
+    dist_codes_table: &List<u8>,
+) {
     // 0..255=literal, 256=EOB, 257+=length
     // distance for each length symbol (0 for literals)
 
@@ -2399,7 +2317,17 @@ fn write_dynamic_block(bw: &mut BitWriter, symbols: &List<i32>, distances: &List
 }
 
 // Write a fixed Huffman block from symbol buffer
-fn write_fixed_block(bw: &mut BitWriter, symbols: &List<i32>, distances: &List<i32>, sym_count: i32, is_last: bool, ltree: &List<EncCode>, dtree: &List<EncCode>, length_codes_table: &List<u8>, dist_codes_table: &List<u8>) {
+fn write_fixed_block(
+    bw: &mut BitWriter,
+    symbols: &List<i32>,
+    distances: &List<i32>,
+    sym_count: i32,
+    is_last: bool,
+    ltree: &List<EncCode>,
+    dtree: &List<EncCode>,
+    length_codes_table: &List<u8>,
+    dist_codes_table: &List<u8>,
+) {
     if is_last {
         bw.write_bits(1, 1);  // BFINAL
     } else {
@@ -3080,7 +3008,11 @@ fn zlib_wrap(input: &List<u8>, deflated: &List<u8>, level: i32) -> List<u8> {
 ///
 /// `level` defaults to `Z_DEFAULT_COMPRESSION` and `strategy` defaults to
 /// `Z_DEFAULT_STRATEGY`.
-pub fn zlib_compress(input: &List<u8>, level: i32 = Z_DEFAULT_COMPRESSION, strategy: i32 = Z_DEFAULT_STRATEGY) -> List<u8> {
+pub fn zlib_compress(
+    input: &List<u8>,
+    level: i32 = Z_DEFAULT_COMPRESSION,
+    strategy: i32 = Z_DEFAULT_STRATEGY,
+) -> List<u8> {
     let deflated = deflate_with_level(input, level, strategy);
     return zlib_wrap(input, &deflated, level);
 }
@@ -3229,7 +3161,11 @@ pub fn inflate_gzip(input: &List<u8>) -> Result<List<u8>, ZlibError> {
 /// `level` defaults to `Z_DEFAULT_COMPRESSION` and `strategy` defaults to
 /// `Z_DEFAULT_STRATEGY`. Use `gzip_compress_with_header` to set MTIME, file
 /// name, comment, and other gzip header fields.
-pub fn gzip_compress(input: &List<u8>, level: i32 = Z_DEFAULT_COMPRESSION, strategy: i32 = Z_DEFAULT_STRATEGY) -> List<u8> {
+pub fn gzip_compress(
+    input: &List<u8>,
+    level: i32 = Z_DEFAULT_COMPRESSION,
+    strategy: i32 = Z_DEFAULT_STRATEGY,
+) -> List<u8> {
     let deflated = deflate_with_level(input, level, strategy);
     let mut output: List<u8> = List::with_capacity(deflated.len() + 18);
 

--- a/wado-compiler/tests/generated/fixtures/monomorphize_for_of_closure_local.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/monomorphize_for_of_closure_local.wir.wado
@@ -26,12 +26,12 @@ struct tuple//[i32, i32, i32] {  // TypeId(3)
     mut 2: i32,
 }
 
-struct tuple//[i32, String] {  // TypeId(4)
+struct tuple//[i32, core:prelude/string.wado/String] {  // TypeId(4)
     mut 0: i32,
     mut 1: ref "core:prelude/string.wado//String",
 }
 
-struct tuple//[i32, String, bool] {  // TypeId(5)
+struct tuple//[i32, core:prelude/string.wado/String, bool] {  // TypeId(5)
     mut 0: i32,
     mut 1: ref "core:prelude/string.wado//String",
     mut 2: bool,
@@ -63,11 +63,11 @@ type "functype//wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.w
 
 type "functype//wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/__cm_export____test_1_closure_capturing_the_per_iteration_binding_inside_variadic_for_of" = fn();  // TypeId(18)
 
-type "functype//wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_capturing<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool>>" = fn(ref "tuple//[i32, String, bool]") -> i32;  // TypeId(19)
+type "functype//wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_capturing<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool>>" = fn(ref "tuple//[i32, core:prelude/string.wado/String, bool]") -> i32;  // TypeId(19)
 
 type "functype//wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_capturing<core:prelude/types.wado/Tuple<i32,i32,i32>>" = fn(ref "tuple//[i32, i32, i32]") -> i32;  // TypeId(20)
 
-type "functype//wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_with_closure<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String>>" = fn(ref "tuple//[i32, String]") -> i32;  // TypeId(21)
+type "functype//wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_with_closure<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String>>" = fn(ref "tuple//[i32, core:prelude/string.wado/String]") -> i32;  // TypeId(21)
 
 type "functype//wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_with_closure<core:prelude/types.wado/Tuple<i32,i32,i32>>" = fn(ref "tuple//[i32, i32, i32]") -> i32;  // TypeId(22)
 
@@ -126,7 +126,7 @@ fn "wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/__test_0
     let homo: ref "tuple//[i32, i32, i32]";
     let __v0_1: i32;
     let __cond_2: bool;
-    let het: ref "tuple//[i32, String]";
+    let het: ref "tuple//[i32, core:prelude/string.wado/String]";
     let __v0_4: i32;
     let __cond_5: bool;
     let __local_6: ref "core:prelude/string.wado//String";
@@ -138,17 +138,15 @@ fn "wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/__test_0
     let f_24: ref "core:prelude/format.wado//Formatter";
     let f_29: ref "core:prelude/format.wado//Formatter";
     homo = struct.new "tuple//[i32, i32, i32]" { 0: 10, 1: 20, 2: 30 };
-    __v0_1 = "wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_with_closure<core:prelude/types.wado/Tuple<i32,i32,i32>>"(homo);
-    __cond_2 = __v0_1 == 63;
+    __cond_2 = local.tee __v0_1("wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_with_closure<core:prelude/types.wado/Tuple<i32,i32,i32>>"(homo)) == 63;
     if __cond_2 == 0 {
         "core:internal/panic"(__local_6 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(155), used: 0 }; "core:prelude/string.wado/String::push_str"(__local_6, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Assertion failed in "), used: 20 }); "core:prelude/string.wado/String::push_str"(__local_6, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("__test_0_closure_with_internal_let_inside_variadic_for_of"), used: 57 }); "core:prelude/string.wado/String::push"(__local_6, 32); "core:prelude/string.wado/String::push"(__local_6, 97); "core:prelude/string.wado/String::push"(__local_6, 116); "core:prelude/string.wado/String::push"(__local_6, 32); "core:prelude/string.wado/String::push_str"(__local_6, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado"), used: 67 }); "core:prelude/string.wado/String::push"(__local_6, 58); __local_7 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_6 }; f_13 = __local_7; "core:prelude/primitive.wado/i32::fmt_decimal"(45, f_13); "core:prelude/string.wado/String::push_str"(__local_6, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("
 condition: sum_with_closure(homo) == 63
 "), used: 41 }); "core:prelude/string.wado/String::push_str"(__local_6, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("sum_with_closure(homo): "), used: 24 }); __local_7 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_6 }; f_18 = __local_7; "core:prelude/primitive.wado/i32::fmt_decimal"(__v0_1, f_18); "core:prelude/string.wado/String::push"(__local_6, 10); __local_6);
         unreachable;
     }
-    het = struct.new "tuple//[i32, String]" { 0: 5, 1: struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(120), used: 1 } };
-    __v0_4 = "wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_with_closure<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String>>"(het);
-    __cond_5 = __v0_4 == 107;
+    het = struct.new "tuple//[i32, core:prelude/string.wado/String]" { 0: 5, 1: struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(120), used: 1 } };
+    __cond_5 = local.tee __v0_4("wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_with_closure<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String>>"(het)) == 107;
     if __cond_5 == 0 {
         "core:internal/panic"(__local_8 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(154), used: 0 }; "core:prelude/string.wado/String::push_str"(__local_8, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Assertion failed in "), used: 20 }); "core:prelude/string.wado/String::push_str"(__local_8, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("__test_0_closure_with_internal_let_inside_variadic_for_of"), used: 57 }); "core:prelude/string.wado/String::push"(__local_8, 32); "core:prelude/string.wado/String::push"(__local_8, 97); "core:prelude/string.wado/String::push"(__local_8, 116); "core:prelude/string.wado/String::push"(__local_8, 32); "core:prelude/string.wado/String::push_str"(__local_8, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado"), used: 67 }); "core:prelude/string.wado/String::push"(__local_8, 58); __local_9 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_8 }; f_24 = __local_9; "core:prelude/primitive.wado/i32::fmt_decimal"(47, f_24); "core:prelude/string.wado/String::push_str"(__local_8, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("
 condition: sum_with_closure(het) == 107
@@ -170,16 +168,14 @@ fn "wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/__test_1
     let f_16: ref "core:prelude/format.wado//Formatter";
     let f_22: ref "core:prelude/format.wado//Formatter";
     let f_27: ref "core:prelude/format.wado//Formatter";
-    __v0_0 = "wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_capturing<core:prelude/types.wado/Tuple<i32,i32,i32>>"(struct.new "tuple//[i32, i32, i32]" { 0: 10, 1: 20, 2: 30 });
-    __cond_1 = __v0_0 == 60;
+    __cond_1 = local.tee __v0_0("wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_capturing<core:prelude/types.wado/Tuple<i32,i32,i32>>"(struct.new "tuple//[i32, i32, i32]" { 0: 10, 1: 20, 2: 30 })) == 60;
     if __cond_1 == 0 {
         "core:internal/panic"(__local_4 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(165), used: 0 }; "core:prelude/string.wado/String::push_str"(__local_4, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Assertion failed in "), used: 20 }); "core:prelude/string.wado/String::push_str"(__local_4, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("__test_1_closure_capturing_the_per_iteration_binding_inside_variadic_for_of"), used: 75 }); "core:prelude/string.wado/String::push"(__local_4, 32); "core:prelude/string.wado/String::push"(__local_4, 97); "core:prelude/string.wado/String::push"(__local_4, 116); "core:prelude/string.wado/String::push"(__local_4, 32); "core:prelude/string.wado/String::push_str"(__local_4, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado"), used: 67 }); "core:prelude/string.wado/String::push"(__local_4, 58); __local_5 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_4 }; f_11 = __local_5; "core:prelude/primitive.wado/i32::fmt_decimal"(51, f_11); "core:prelude/string.wado/String::push_str"(__local_4, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("
 condition: sum_capturing([10, 20, 30]) == 60
 "), used: 46 }); "core:prelude/string.wado/String::push_str"(__local_4, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("sum_capturing([10, 20, 30]): "), used: 29 }); __local_5 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_4 }; f_16 = __local_5; "core:prelude/primitive.wado/i32::fmt_decimal"(__v0_0, f_16); "core:prelude/string.wado/String::push"(__local_4, 10); __local_4);
         unreachable;
     }
-    __v0_2 = "wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_capturing<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool>>"(struct.new "tuple//[i32, String, bool]" { 0: 5, 1: struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(120), used: 1 }, 2: 1 });
-    __cond_3 = __v0_2 == 106;
+    __cond_3 = local.tee __v0_2("wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_capturing<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool>>"(struct.new "tuple//[i32, core:prelude/string.wado/String, bool]" { 0: 5, 1: struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(120), used: 1 }, 2: 1 })) == 106;
     if __cond_3 == 0 {
         "core:internal/panic"(__local_6 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(170), used: 0 }; "core:prelude/string.wado/String::push_str"(__local_6, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Assertion failed in "), used: 20 }); "core:prelude/string.wado/String::push_str"(__local_6, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("__test_1_closure_capturing_the_per_iteration_binding_inside_variadic_for_of"), used: 75 }); "core:prelude/string.wado/String::push"(__local_6, 32); "core:prelude/string.wado/String::push"(__local_6, 97); "core:prelude/string.wado/String::push"(__local_6, 116); "core:prelude/string.wado/String::push"(__local_6, 32); "core:prelude/string.wado/String::push_str"(__local_6, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado"), used: 67 }); "core:prelude/string.wado/String::push"(__local_6, 58); __local_7 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_6 }; f_22 = __local_7; "core:prelude/primitive.wado/i32::fmt_decimal"(52, f_22); "core:prelude/string.wado/String::push_str"(__local_6, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("
 condition: sum_capturing([5, \"x\", true]) == 106
@@ -201,12 +197,8 @@ fn "wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/__cm_exp
 fn "wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_capturing<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool>>"(items) {
     let acc: i32;
     let v_5: i32;
-    acc = 0;
     v_5 = items.0;
-    acc = 0 + v_5;
-    acc = acc + 100;
-    acc = acc + 1;
-    return acc;
+    return local.tee acc(local.tee acc(local.tee acc(0 + v_5) + 100) + 1);
 }
 
 fn "wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_capturing<core:prelude/types.wado/Tuple<i32,i32,i32>>"(items) {
@@ -220,19 +212,15 @@ fn "wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_capt
     v_6 = items.1;
     acc = acc + v_6;
     v_8 = items.2;
-    acc = acc + v_8;
-    return acc;
+    return local.tee acc(acc + v_8);
 }
 
 fn "wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_with_closure<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String>>"(items) {
     let acc: i32;
     let v_5: i32;
     let __local_2_11: i32;
-    acc = 0;
     v_5 = items.0;
-    acc = 0 + __local_2_11 = v_5 + 1; __local_2_11;
-    acc = acc + 101;
-    return acc;
+    return local.tee acc(local.tee acc(0 + __local_2_11 = v_5 + 1; __local_2_11) + 101);
 }
 
 fn "wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_with_closure<core:prelude/types.wado/Tuple<i32,i32,i32>>"(items) {
@@ -249,8 +237,7 @@ fn "wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_with
     v_6 = items.1;
     acc = acc + __local_2_17 = v_6 + 1; __local_2_17;
     v_8 = items.2;
-    acc = acc + __local_2_21 = v_8 + 1; __local_2_21;
-    return acc;
+    return local.tee acc(acc + __local_2_21 = v_8 + 1; __local_2_21);
 }
 
 fn "core:internal/gc_array_to_memory"(arr, ptr, len) {
@@ -328,8 +315,7 @@ fn "core:internal/cm_stream_write_raw_u8"(handle, data, len) {
     let ptr: i32;
     let raw_len: i32;
     let result: i32;
-    packed = "core:internal/cm_lower_list_u8"(data, len);
-    ptr = builtin::i32_wrap_i64(packed);
+    ptr = builtin::i32_wrap_i64(local.tee packed("core:internal/cm_lower_list_u8"(data, len)));
     raw_len = builtin::i32_wrap_i64(packed >> 32_i64);
     result = "wasi/stream-write"(handle, ptr, raw_len);
     if result == -1 {
@@ -388,8 +374,7 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
     let offset: i32;
     let self_6: ref "core:prelude/string.wado//String";
     is_negative = self < 0;
-    abs_val = select i64(is_negative, 0_i64 - builtin::i64_extend_i32_s(self), builtin::i64_extend_i32_s(self));
-    digit_count = "core:prelude/primitive.wado/count_digits_i64"(abs_val);
+    digit_count = "core:prelude/primitive.wado/count_digits_i64"(local.tee abs_val(select i64(is_negative, 0_i64 - builtin::i64_extend_i32_s(self), builtin::i64_extend_i32_s(self))));
     offset = "core:prelude/format.wado/Formatter::prepare_int_write"(f, is_negative, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
     "core:prelude/primitive.wado/write_decimal_digits"(self_6 = f.buf; self_6.repr, offset, abs_val, digit_count);
 }
@@ -404,10 +389,7 @@ fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
     if min_capacity <= capacity {
         return;
     }
-    a_7 = capacity * 2;
-    a_5 = select i32(a_7 > min_capacity, a_7, min_capacity);
-    new_capacity = select i32(a_5 > 8, a_5, 8);
-    new_repr = builtin::array_new<u8>(new_capacity);
+    new_repr = builtin::array_new<u8>(local.tee new_capacity(a_7 = capacity * 2; a_5 = select i32(a_7 > min_capacity, a_7, min_capacity); select i32(a_5 > 8, a_5, 8)));
     builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }

--- a/wado-compiler/tests/generated/fixtures/monomorphize_for_of_local_in_match_arm.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/monomorphize_for_of_local_in_match_arm.wir.wado
@@ -20,7 +20,7 @@ struct core:prelude/format.wado//Formatter {  // TypeId(2)
     mut buf: ref "core:prelude/string.wado//String",
 }
 
-struct tuple//[i32, String, bool, i32] {  // TypeId(3)
+struct tuple//[i32, core:prelude/string.wado/String, bool, i32] {  // TypeId(3)
     mut 0: i32,
     mut 1: ref "core:prelude/string.wado//String",
     mut 2: bool,
@@ -49,9 +49,9 @@ type "functype//wado-compiler/tests/fixtures/monomorphize_for_of_local_in_match_
 
 type "functype//wado-compiler/tests/fixtures/monomorphize_for_of_local_in_match_arm.wado/__cm_export____test_0_per_iteration_local_typed_concretely_inside_match_arm_and_while_body" = fn();  // TypeId(14)
 
-type "functype//wado-compiler/tests/fixtures/monomorphize_for_of_local_in_match_arm.wado/sum_in_while<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>" = fn(ref "tuple//[i32, String, bool, i32]") -> i32;  // TypeId(15)
+type "functype//wado-compiler/tests/fixtures/monomorphize_for_of_local_in_match_arm.wado/sum_in_while<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>" = fn(ref "tuple//[i32, core:prelude/string.wado/String, bool, i32]") -> i32;  // TypeId(15)
 
-type "functype//wado-compiler/tests/fixtures/monomorphize_for_of_local_in_match_arm.wado/sum_in_match<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>" = fn(ref "tuple//[i32, String, bool, i32]") -> i32;  // TypeId(16)
+type "functype//wado-compiler/tests/fixtures/monomorphize_for_of_local_in_match_arm.wado/sum_in_match<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>" = fn(ref "tuple//[i32, core:prelude/string.wado/String, bool, i32]") -> i32;  // TypeId(16)
 
 type "functype//core:internal/gc_array_to_memory" = fn(ref Array<u8>, i32, i32);  // TypeId(17)
 
@@ -105,7 +105,7 @@ import fn wasi/stream-new from "wasi/stream-new";
 import fn wasi/future-drop-readable:transmission-cli from "wasi/future-drop-readable:transmission-cli";
 
 fn "wado-compiler/tests/fixtures/monomorphize_for_of_local_in_match_arm.wado/__test_0_per_iteration_local_typed_concretely_inside_match_arm_and_while_body"() {
-    let t: ref "tuple//[i32, String, bool, i32]";
+    let t: ref "tuple//[i32, core:prelude/string.wado/String, bool, i32]";
     let __v0_1: i32;
     let __cond_2: bool;
     let __v0_3: i32;
@@ -118,17 +118,15 @@ fn "wado-compiler/tests/fixtures/monomorphize_for_of_local_in_match_arm.wado/__t
     let f_17: ref "core:prelude/format.wado//Formatter";
     let f_23: ref "core:prelude/format.wado//Formatter";
     let f_28: ref "core:prelude/format.wado//Formatter";
-    t = struct.new "tuple//[i32, String, bool, i32]" { 0: 10, 1: struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(120), used: 1 }, 2: 1, 3: 20 };
-    __v0_1 = "wado-compiler/tests/fixtures/monomorphize_for_of_local_in_match_arm.wado/sum_in_match<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>"(t);
-    __cond_2 = __v0_1 == 131;
+    t = struct.new "tuple//[i32, core:prelude/string.wado/String, bool, i32]" { 0: 10, 1: struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(120), used: 1 }, 2: 1, 3: 20 };
+    __cond_2 = local.tee __v0_1("wado-compiler/tests/fixtures/monomorphize_for_of_local_in_match_arm.wado/sum_in_match<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>"(t)) == 131;
     if __cond_2 == 0 {
         "core:internal/panic"(__local_5 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(142), used: 0 }; "core:prelude/string.wado/String::push_str"(__local_5, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Assertion failed in "), used: 20 }); "core:prelude/string.wado/String::push_str"(__local_5, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("__test_0_per_iteration_local_typed_concretely_inside_match_arm_and_while_body"), used: 77 }); "core:prelude/string.wado/String::push"(__local_5, 32); "core:prelude/string.wado/String::push"(__local_5, 97); "core:prelude/string.wado/String::push"(__local_5, 116); "core:prelude/string.wado/String::push"(__local_5, 32); "core:prelude/string.wado/String::push_str"(__local_5, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("wado-compiler/tests/fixtures/monomorphize_for_of_local_in_match_arm.wado"), used: 72 }); "core:prelude/string.wado/String::push"(__local_5, 58); __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_5 }; f_12 = __local_6; "core:prelude/primitive.wado/i32::fmt_decimal"(44, f_12); "core:prelude/string.wado/String::push_str"(__local_5, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("
 condition: sum_in_match(t) == 131
 "), used: 35 }); "core:prelude/string.wado/String::push_str"(__local_5, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("sum_in_match(t): "), used: 17 }); __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_5 }; f_17 = __local_6; "core:prelude/primitive.wado/i32::fmt_decimal"(__v0_1, f_17); "core:prelude/string.wado/String::push"(__local_5, 10); __local_5);
         unreachable;
     }
-    __v0_3 = "wado-compiler/tests/fixtures/monomorphize_for_of_local_in_match_arm.wado/sum_in_while<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>"(t);
-    __cond_4 = __v0_3 == 131;
+    __cond_4 = local.tee __v0_3("wado-compiler/tests/fixtures/monomorphize_for_of_local_in_match_arm.wado/sum_in_while<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>"(t)) == 131;
     if __cond_4 == 0 {
         "core:internal/panic"(__local_7 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(142), used: 0 }; "core:prelude/string.wado/String::push_str"(__local_7, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Assertion failed in "), used: 20 }); "core:prelude/string.wado/String::push_str"(__local_7, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("__test_0_per_iteration_local_typed_concretely_inside_match_arm_and_while_body"), used: 77 }); "core:prelude/string.wado/String::push"(__local_7, 32); "core:prelude/string.wado/String::push"(__local_7, 97); "core:prelude/string.wado/String::push"(__local_7, 116); "core:prelude/string.wado/String::push"(__local_7, 32); "core:prelude/string.wado/String::push_str"(__local_7, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("wado-compiler/tests/fixtures/monomorphize_for_of_local_in_match_arm.wado"), used: 72 }); "core:prelude/string.wado/String::push"(__local_7, 58); __local_8 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_7 }; f_23 = __local_8; "core:prelude/primitive.wado/i32::fmt_decimal"(45, f_23); "core:prelude/string.wado/String::push_str"(__local_7, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("
 condition: sum_in_while(t) == 131
@@ -206,12 +204,9 @@ fn "wado-compiler/tests/fixtures/monomorphize_for_of_local_in_match_arm.wado/sum
     let v_13: i32;
     acc = 0;
     v_6 = items.0;
-    acc = 0 + v_6;
-    acc = acc + 100;
-    acc = acc + 1;
+    acc = local.tee acc(local.tee acc(0 + v_6) + 100) + 1;
     v_13 = items.3;
-    acc = acc + v_13;
-    return acc;
+    return local.tee acc(acc + v_13);
 }
 
 fn "core:internal/gc_array_to_memory"(arr, ptr, len) {
@@ -289,8 +284,7 @@ fn "core:internal/cm_stream_write_raw_u8"(handle, data, len) {
     let ptr: i32;
     let raw_len: i32;
     let result: i32;
-    packed = "core:internal/cm_lower_list_u8"(data, len);
-    ptr = builtin::i32_wrap_i64(packed);
+    ptr = builtin::i32_wrap_i64(local.tee packed("core:internal/cm_lower_list_u8"(data, len)));
     raw_len = builtin::i32_wrap_i64(packed >> 32_i64);
     result = "wasi/stream-write"(handle, ptr, raw_len);
     if result == -1 {
@@ -349,8 +343,7 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
     let offset: i32;
     let self_6: ref "core:prelude/string.wado//String";
     is_negative = self < 0;
-    abs_val = select i64(is_negative, 0_i64 - builtin::i64_extend_i32_s(self), builtin::i64_extend_i32_s(self));
-    digit_count = "core:prelude/primitive.wado/count_digits_i64"(abs_val);
+    digit_count = "core:prelude/primitive.wado/count_digits_i64"(local.tee abs_val(select i64(is_negative, 0_i64 - builtin::i64_extend_i32_s(self), builtin::i64_extend_i32_s(self))));
     offset = "core:prelude/format.wado/Formatter::prepare_int_write"(f, is_negative, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
     "core:prelude/primitive.wado/write_decimal_digits"(self_6 = f.buf; self_6.repr, offset, abs_val, digit_count);
 }
@@ -365,10 +358,7 @@ fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
     if min_capacity <= capacity {
         return;
     }
-    a_7 = capacity * 2;
-    a_5 = select i32(a_7 > min_capacity, a_7, min_capacity);
-    new_capacity = select i32(a_5 > 8, a_5, 8);
-    new_repr = builtin::array_new<u8>(new_capacity);
+    new_repr = builtin::array_new<u8>(local.tee new_capacity(a_7 = capacity * 2; a_5 = select i32(a_7 > min_capacity, a_7, min_capacity); select i32(a_5 > 8, a_5, 8)));
     builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }

--- a/wado-compiler/tests/generated/fixtures/monomorphize_generic_method_in_for_of.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/monomorphize_generic_method_in_for_of.wir.wado
@@ -20,7 +20,7 @@ struct core:prelude/format.wado//Formatter {  // TypeId(2)
     mut buf: ref "core:prelude/string.wado//String",
 }
 
-struct tuple//[i32, String, bool, i32] {  // TypeId(3)
+struct tuple//[i32, core:prelude/string.wado/String, bool, i32] {  // TypeId(3)
     mut 0: i32,
     mut 1: ref "core:prelude/string.wado//String",
     mut 2: bool,
@@ -49,15 +49,15 @@ type "functype//wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_
 
 type "functype//wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/__cm_export____test_0_generic_method_in_variadic_for_of_monomorphizes_in_every_position" = fn();  // TypeId(14)
 
-type "functype//wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_in_binary<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>" = fn(ref "tuple//[i32, String, bool, i32]") -> i32;  // TypeId(15)
+type "functype//wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_in_binary<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>" = fn(ref "tuple//[i32, core:prelude/string.wado/String, bool, i32]") -> i32;  // TypeId(15)
 
-type "functype//wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_in_match<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>" = fn(ref "tuple//[i32, String, bool, i32]") -> i32;  // TypeId(16)
+type "functype//wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_in_match<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>" = fn(ref "tuple//[i32, core:prelude/string.wado/String, bool, i32]") -> i32;  // TypeId(16)
 
-type "functype//wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_in_while<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>" = fn(ref "tuple//[i32, String, bool, i32]") -> i32;  // TypeId(17)
+type "functype//wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_in_while<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>" = fn(ref "tuple//[i32, core:prelude/string.wado/String, bool, i32]") -> i32;  // TypeId(17)
 
-type "functype//wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_in_if<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>" = fn(ref "tuple//[i32, String, bool, i32]") -> i32;  // TypeId(18)
+type "functype//wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_in_if<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>" = fn(ref "tuple//[i32, core:prelude/string.wado/String, bool, i32]") -> i32;  // TypeId(18)
 
-type "functype//wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_direct<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>" = fn(ref "tuple//[i32, String, bool, i32]") -> i32;  // TypeId(19)
+type "functype//wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_direct<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>" = fn(ref "tuple//[i32, core:prelude/string.wado/String, bool, i32]") -> i32;  // TypeId(19)
 
 type "functype//core:internal/gc_array_to_memory" = fn(ref Array<u8>, i32, i32);  // TypeId(20)
 
@@ -111,7 +111,7 @@ import fn wasi/stream-new from "wasi/stream-new";
 import fn wasi/future-drop-readable:transmission-cli from "wasi/future-drop-readable:transmission-cli";
 
 fn "wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/__test_0_generic_method_in_variadic_for_of_monomorphizes_in_every_position"() {
-    let t: ref "tuple//[i32, String, bool, i32]";
+    let t: ref "tuple//[i32, core:prelude/string.wado/String, bool, i32]";
     let __v0_1: i32;
     let __cond_2: bool;
     let __v0_3: i32;
@@ -142,41 +142,36 @@ fn "wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/__te
     let f_62: ref "core:prelude/format.wado//Formatter";
     let f_68: ref "core:prelude/format.wado//Formatter";
     let f_73: ref "core:prelude/format.wado//Formatter";
-    t = struct.new "tuple//[i32, String, bool, i32]" { 0: 10, 1: struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(120), used: 1 }, 2: 1, 3: 20 };
-    __v0_1 = "wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_direct<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>"(t);
-    __cond_2 = __v0_1 == 131;
+    t = struct.new "tuple//[i32, core:prelude/string.wado/String, bool, i32]" { 0: 10, 1: struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(120), used: 1 }, 2: 1, 3: 20 };
+    __cond_2 = local.tee __v0_1("wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_direct<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>"(t)) == 131;
     if __cond_2 == 0 {
         "core:internal/panic"(__local_11 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(138), used: 0 }; "core:prelude/string.wado/String::push_str"(__local_11, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Assertion failed in "), used: 20 }); "core:prelude/string.wado/String::push_str"(__local_11, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("__test_0_generic_method_in_variadic_for_of_monomorphizes_in_every_position"), used: 74 }); "core:prelude/string.wado/String::push"(__local_11, 32); "core:prelude/string.wado/String::push"(__local_11, 97); "core:prelude/string.wado/String::push"(__local_11, 116); "core:prelude/string.wado/String::push"(__local_11, 32); "core:prelude/string.wado/String::push_str"(__local_11, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado"), used: 71 }); "core:prelude/string.wado/String::push"(__local_11, 58); __local_12 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_11 }; f_24 = __local_12; "core:prelude/primitive.wado/i32::fmt_decimal"(64, f_24); "core:prelude/string.wado/String::push_str"(__local_11, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("
 condition: sum_direct(t) == 131
 "), used: 33 }); "core:prelude/string.wado/String::push_str"(__local_11, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("sum_direct(t): "), used: 15 }); __local_12 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_11 }; f_29 = __local_12; "core:prelude/primitive.wado/i32::fmt_decimal"(__v0_1, f_29); "core:prelude/string.wado/String::push"(__local_11, 10); __local_11);
         unreachable;
     }
-    __v0_3 = "wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_in_if<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>"(t);
-    __cond_4 = __v0_3 == 131;
+    __cond_4 = local.tee __v0_3("wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_in_if<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>"(t)) == 131;
     if __cond_4 == 0 {
         "core:internal/panic"(__local_13 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(136), used: 0 }; "core:prelude/string.wado/String::push_str"(__local_13, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Assertion failed in "), used: 20 }); "core:prelude/string.wado/String::push_str"(__local_13, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("__test_0_generic_method_in_variadic_for_of_monomorphizes_in_every_position"), used: 74 }); "core:prelude/string.wado/String::push"(__local_13, 32); "core:prelude/string.wado/String::push"(__local_13, 97); "core:prelude/string.wado/String::push"(__local_13, 116); "core:prelude/string.wado/String::push"(__local_13, 32); "core:prelude/string.wado/String::push_str"(__local_13, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado"), used: 71 }); "core:prelude/string.wado/String::push"(__local_13, 58); __local_14 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_13 }; f_35 = __local_14; "core:prelude/primitive.wado/i32::fmt_decimal"(65, f_35); "core:prelude/string.wado/String::push_str"(__local_13, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("
 condition: sum_in_if(t) == 131
 "), used: 32 }); "core:prelude/string.wado/String::push_str"(__local_13, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("sum_in_if(t): "), used: 14 }); __local_14 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_13 }; f_40 = __local_14; "core:prelude/primitive.wado/i32::fmt_decimal"(__v0_3, f_40); "core:prelude/string.wado/String::push"(__local_13, 10); __local_13);
         unreachable;
     }
-    __v0_5 = "wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_in_while<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>"(t);
-    __cond_6 = __v0_5 == 131;
+    __cond_6 = local.tee __v0_5("wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_in_while<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>"(t)) == 131;
     if __cond_6 == 0 {
         "core:internal/panic"(__local_15 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(142), used: 0 }; "core:prelude/string.wado/String::push_str"(__local_15, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Assertion failed in "), used: 20 }); "core:prelude/string.wado/String::push_str"(__local_15, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("__test_0_generic_method_in_variadic_for_of_monomorphizes_in_every_position"), used: 74 }); "core:prelude/string.wado/String::push"(__local_15, 32); "core:prelude/string.wado/String::push"(__local_15, 97); "core:prelude/string.wado/String::push"(__local_15, 116); "core:prelude/string.wado/String::push"(__local_15, 32); "core:prelude/string.wado/String::push_str"(__local_15, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado"), used: 71 }); "core:prelude/string.wado/String::push"(__local_15, 58); __local_16 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_15 }; f_46 = __local_16; "core:prelude/primitive.wado/i32::fmt_decimal"(66, f_46); "core:prelude/string.wado/String::push_str"(__local_15, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("
 condition: sum_in_while(t) == 131
 "), used: 35 }); "core:prelude/string.wado/String::push_str"(__local_15, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("sum_in_while(t): "), used: 17 }); __local_16 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_15 }; f_51 = __local_16; "core:prelude/primitive.wado/i32::fmt_decimal"(__v0_5, f_51); "core:prelude/string.wado/String::push"(__local_15, 10); __local_15);
         unreachable;
     }
-    __v0_7 = "wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_in_match<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>"(t);
-    __cond_8 = __v0_7 == 131;
+    __cond_8 = local.tee __v0_7("wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_in_match<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>"(t)) == 131;
     if __cond_8 == 0 {
         "core:internal/panic"(__local_17 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(142), used: 0 }; "core:prelude/string.wado/String::push_str"(__local_17, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Assertion failed in "), used: 20 }); "core:prelude/string.wado/String::push_str"(__local_17, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("__test_0_generic_method_in_variadic_for_of_monomorphizes_in_every_position"), used: 74 }); "core:prelude/string.wado/String::push"(__local_17, 32); "core:prelude/string.wado/String::push"(__local_17, 97); "core:prelude/string.wado/String::push"(__local_17, 116); "core:prelude/string.wado/String::push"(__local_17, 32); "core:prelude/string.wado/String::push_str"(__local_17, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado"), used: 71 }); "core:prelude/string.wado/String::push"(__local_17, 58); __local_18 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_17 }; f_57 = __local_18; "core:prelude/primitive.wado/i32::fmt_decimal"(67, f_57); "core:prelude/string.wado/String::push_str"(__local_17, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("
 condition: sum_in_match(t) == 131
 "), used: 35 }); "core:prelude/string.wado/String::push_str"(__local_17, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("sum_in_match(t): "), used: 17 }); __local_18 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_17 }; f_62 = __local_18; "core:prelude/primitive.wado/i32::fmt_decimal"(__v0_7, f_62); "core:prelude/string.wado/String::push"(__local_17, 10); __local_17);
         unreachable;
     }
-    __v0_9 = "wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_in_binary<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>"(t);
-    __cond_10 = __v0_9 == 131;
+    __cond_10 = local.tee __v0_9("wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_in_binary<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>"(t)) == 131;
     if __cond_10 == 0 {
         "core:internal/panic"(__local_19 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(144), used: 0 }; "core:prelude/string.wado/String::push_str"(__local_19, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Assertion failed in "), used: 20 }); "core:prelude/string.wado/String::push_str"(__local_19, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("__test_0_generic_method_in_variadic_for_of_monomorphizes_in_every_position"), used: 74 }); "core:prelude/string.wado/String::push"(__local_19, 32); "core:prelude/string.wado/String::push"(__local_19, 97); "core:prelude/string.wado/String::push"(__local_19, 116); "core:prelude/string.wado/String::push"(__local_19, 32); "core:prelude/string.wado/String::push_str"(__local_19, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado"), used: 71 }); "core:prelude/string.wado/String::push"(__local_19, 58); __local_20 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_19 }; f_68 = __local_20; "core:prelude/primitive.wado/i32::fmt_decimal"(68, f_68); "core:prelude/string.wado/String::push_str"(__local_19, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("
 condition: sum_in_binary(t) == 131
@@ -210,11 +205,11 @@ fn "wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_
     let __sroa_acc_total: i32;
     __sroa_acc_total = 0;
     v_5 = items.0;
-    __sroa_acc_total = 0 + v_5;
-    __sroa_acc_total = __sroa_acc_total + 100;
-    __sroa_acc_total = __sroa_acc_total + 1;
+    drop(local.tee __sroa_acc_total(0 + v_5));
+    drop(local.tee __sroa_acc_total(__sroa_acc_total + 100));
+    drop(local.tee __sroa_acc_total(__sroa_acc_total + 1));
     v_10 = items.3;
-    __sroa_acc_total = __sroa_acc_total + v_10;
+    drop(local.tee __sroa_acc_total(__sroa_acc_total + v_10));
     return __sroa_acc_total;
 }
 
@@ -234,7 +229,7 @@ fn "wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_
             if once_3 == 0 {
                 break b5;
             }
-            __sroa_acc_total = __sroa_acc_total + v_5;
+            drop(local.tee __sroa_acc_total(__sroa_acc_total + v_5));
             once_3 = 0;
             continue l6;
         };
@@ -245,7 +240,7 @@ fn "wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_
             if once_7 == 0 {
                 break b8;
             }
-            __sroa_acc_total = __sroa_acc_total + 100;
+            drop(local.tee __sroa_acc_total(__sroa_acc_total + 100));
             once_7 = 0;
             continue l9;
         };
@@ -256,7 +251,7 @@ fn "wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_
             if once_9 == 0 {
                 break b11;
             }
-            __sroa_acc_total = __sroa_acc_total + 1;
+            drop(local.tee __sroa_acc_total(__sroa_acc_total + 1));
             once_9 = 0;
             continue l12;
         };
@@ -268,7 +263,7 @@ fn "wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_
             if once_11 == 0 {
                 break b14;
             }
-            __sroa_acc_total = __sroa_acc_total + v_10;
+            drop(local.tee __sroa_acc_total(__sroa_acc_total + v_10));
             once_11 = 0;
             continue l15;
         };
@@ -282,11 +277,11 @@ fn "wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_
     let __sroa_acc_total: i32;
     __sroa_acc_total = 0;
     v_4 = items.0;
-    __sroa_acc_total = 0 + v_4;
-    __sroa_acc_total = __sroa_acc_total + 100;
-    __sroa_acc_total = __sroa_acc_total + 1;
+    drop(local.tee __sroa_acc_total(0 + v_4));
+    drop(local.tee __sroa_acc_total(__sroa_acc_total + 100));
+    drop(local.tee __sroa_acc_total(__sroa_acc_total + 1));
     v_7 = items.3;
-    __sroa_acc_total = __sroa_acc_total + v_7;
+    drop(local.tee __sroa_acc_total(__sroa_acc_total + v_7));
     return __sroa_acc_total;
 }
 
@@ -296,11 +291,11 @@ fn "wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_
     let __sroa_acc_total: i32;
     __sroa_acc_total = 0;
     v_4 = items.0;
-    __sroa_acc_total = 0 + v_4;
-    __sroa_acc_total = __sroa_acc_total + 100;
-    __sroa_acc_total = __sroa_acc_total + 1;
+    drop(local.tee __sroa_acc_total(0 + v_4));
+    drop(local.tee __sroa_acc_total(__sroa_acc_total + 100));
+    drop(local.tee __sroa_acc_total(__sroa_acc_total + 1));
     v_7 = items.3;
-    __sroa_acc_total = __sroa_acc_total + v_7;
+    drop(local.tee __sroa_acc_total(__sroa_acc_total + v_7));
     return __sroa_acc_total;
 }
 
@@ -379,8 +374,7 @@ fn "core:internal/cm_stream_write_raw_u8"(handle, data, len) {
     let ptr: i32;
     let raw_len: i32;
     let result: i32;
-    packed = "core:internal/cm_lower_list_u8"(data, len);
-    ptr = builtin::i32_wrap_i64(packed);
+    ptr = builtin::i32_wrap_i64(local.tee packed("core:internal/cm_lower_list_u8"(data, len)));
     raw_len = builtin::i32_wrap_i64(packed >> 32_i64);
     result = "wasi/stream-write"(handle, ptr, raw_len);
     if result == -1 {
@@ -439,8 +433,7 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
     let offset: i32;
     let self_6: ref "core:prelude/string.wado//String";
     is_negative = self < 0;
-    abs_val = select i64(is_negative, 0_i64 - builtin::i64_extend_i32_s(self), builtin::i64_extend_i32_s(self));
-    digit_count = "core:prelude/primitive.wado/count_digits_i64"(abs_val);
+    digit_count = "core:prelude/primitive.wado/count_digits_i64"(local.tee abs_val(select i64(is_negative, 0_i64 - builtin::i64_extend_i32_s(self), builtin::i64_extend_i32_s(self))));
     offset = "core:prelude/format.wado/Formatter::prepare_int_write"(f, is_negative, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
     "core:prelude/primitive.wado/write_decimal_digits"(self_6 = f.buf; self_6.repr, offset, abs_val, digit_count);
 }
@@ -455,10 +448,7 @@ fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
     if min_capacity <= capacity {
         return;
     }
-    a_7 = capacity * 2;
-    a_5 = select i32(a_7 > min_capacity, a_7, min_capacity);
-    new_capacity = select i32(a_5 > 8, a_5, 8);
-    new_repr = builtin::array_new<u8>(new_capacity);
+    new_repr = builtin::array_new<u8>(local.tee new_capacity(a_7 = capacity * 2; a_5 = select i32(a_7 > min_capacity, a_7, min_capacity); select i32(a_5 > 8, a_5, 8)));
     builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }

--- a/wado-compiler/tests/generated/fixtures/monomorphize_generic_reactive_local.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/monomorphize_generic_reactive_local.wir.wado
@@ -203,8 +203,7 @@ fn "core:internal/cm_stream_write_raw_u8"(handle, data, len) {
     let ptr: i32;
     let raw_len: i32;
     let result: i32;
-    packed = "core:internal/cm_lower_list_u8"(data, len);
-    ptr = builtin::i32_wrap_i64(packed);
+    ptr = builtin::i32_wrap_i64(local.tee packed("core:internal/cm_lower_list_u8"(data, len)));
     raw_len = builtin::i32_wrap_i64(packed >> 32_i64);
     result = "wasi/stream-write"(handle, ptr, raw_len);
     if result == -1 {
@@ -263,8 +262,7 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
     let offset: i32;
     let self_6: ref "core:prelude/string.wado//String";
     is_negative = self < 0;
-    abs_val = select i64(is_negative, 0_i64 - builtin::i64_extend_i32_s(self), builtin::i64_extend_i32_s(self));
-    digit_count = "core:prelude/primitive.wado/count_digits_i64"(abs_val);
+    digit_count = "core:prelude/primitive.wado/count_digits_i64"(local.tee abs_val(select i64(is_negative, 0_i64 - builtin::i64_extend_i32_s(self), builtin::i64_extend_i32_s(self))));
     offset = "core:prelude/format.wado/Formatter::prepare_int_write"(f, is_negative, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
     "core:prelude/primitive.wado/write_decimal_digits"(self_6 = f.buf; self_6.repr, offset, abs_val, digit_count);
 }
@@ -279,10 +277,7 @@ fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
     if min_capacity <= capacity {
         return;
     }
-    a_7 = capacity * 2;
-    a_5 = select i32(a_7 > min_capacity, a_7, min_capacity);
-    new_capacity = select i32(a_5 > 8, a_5, 8);
-    new_repr = builtin::array_new<u8>(new_capacity);
+    new_repr = builtin::array_new<u8>(local.tee new_capacity(a_7 = capacity * 2; a_5 = select i32(a_7 > min_capacity, a_7, min_capacity); select i32(a_5 > 8, a_5, 8)));
     builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }


### PR DESCRIPTION
## Summary

Speeds up `core:zlib` decompression by ~2.2x by eliminating a redundant sliding window in the inflate path, plus a bulk-copy fast path in `List::copy_within_append`.

`inflate_raw_ex` retains the entire decoded stream in `output`, so the separate 32 KiB sliding window was pure overhead: every back-reference is already satisfiable directly from `output`, while the window-update copy on each match (plus the periodic copy on literals) duplicated all matched output bytes. Guest profiling of decompressing twitter.json showed `update_window` alone at **31.7%** of runtime.

## Changes

- **Remove the sliding-window machinery** from `InflateState` / `inflate_raw_ex`: the `window`/`wsize`/`whave`/`wnext` fields, `update_window`, the `Match` window branch, the per-literal modulo check, and the final window flush. The `Match` case now reduces to: an out-of-range distance is invalid (`Bad`), otherwise `copy_within_append` from `output`. This is correct because the full output is always retained (a valid DEFLATE distance never refers past the start of the output, RFC 1951 §3.2.3).
- **Add a non-overlapping fast path to `List::copy_within_append`**: when source and destination ranges don't overlap, a single `builtin::array_copy` replaces the element-by-element loop. The overlapping DEFLATE run-length case still uses the forward-propagating loop.
- **Update `benchmark/README.md`** with the new best-of-three zlib numbers.

Net diff for the library change is +21 / −111 lines — the code is both faster and simpler.

## Results

Decompression of twitter.json (631514 bytes), best-of-three:

| Implementation         | Throughput (before → after) |
| ---------------------- | --------------------------- |
| **Wado** (core:zlib)   | 55.79 → **119.52 MB/s** (2.14x; vs zlib-rs 24.74x → 11.74x) |
| Rust (zlib-rs)         | 1.40 GB/s (reference) |
| JavaScript (node:zlib) | 787.15 MB/s |

Compression is unchanged (only the inflate path was touched).

## Testing

- `zlib_test.wado`: 76 pass
- `list_test.wado`: 66 pass
- `zlib_interop` cross-validation against zlib-rs / flate2 (incl. fuzz round-trips): 49 pass

https://claude.ai/code/session_0116V5nr7eGtriZxUt9otTS6

---
_Generated by [Claude Code](https://claude.ai/code/session_0116V5nr7eGtriZxUt9otTS6)_