### PR TITLE
LSP: classify semantic tokens by resolved symbol kind; unify keyword/operator registry

### DIFF
--- a/wado-compiler/src/codegen.rs
+++ b/wado-compiler/src/codegen.rs
@@ -58,12 +58,12 @@ fn validate_core_module(wasm: &[u8], entry_module: &ModuleSource) {
 /// Find the function whose body byte range contains `offset`, with its name
 /// from the custom `name` section. Debug aid for validation ICEs.
 fn locate_offset_function(wasm: &[u8], offset: usize) -> Option<(u32, Option<String>)> {
-    use std::collections::HashMap;
+    use crate::hashmap::IndexMap;
     use wasmparser::{Name, Parser, Payload};
     let mut import_funcs = 0u32;
     let mut defined = 0u32;
     let mut bodies: Vec<(u32, std::ops::Range<usize>)> = Vec::new();
-    let mut names: HashMap<u32, String> = HashMap::new();
+    let mut names: IndexMap<u32, String> = IndexMap::default();
     for payload in Parser::new(0).parse_all(wasm) {
         match payload.ok()? {
             Payload::ImportSection(reader) => {

--- a/wado-compiler/src/lexer.rs
+++ b/wado-compiler/src/lexer.rs
@@ -714,53 +714,10 @@ impl<'a> Lexer<'a> {
 
         let text = &self.input[start..self.pos];
 
-        match text {
-            "use" => TokenKind::Use,
-            "from" => TokenKind::From,
-            "as" => TokenKind::As,
-            "fn" => TokenKind::Fn,
-            "with" => TokenKind::With,
-            "let" => TokenKind::Let,
-            "mut" => TokenKind::Mut,
-            "return" => TokenKind::Return,
-            "if" => TokenKind::If,
-            "else" => TokenKind::Else,
-            "match" => TokenKind::Match,
-            "for" => TokenKind::For,
-            "while" => TokenKind::While,
-            "loop" => TokenKind::Loop,
-            "break" => TokenKind::Break,
-            "continue" => TokenKind::Continue,
-            "in" => TokenKind::In,
-            "of" => TokenKind::Of,
-            "pub" => TokenKind::Pub,
-            "effect" => TokenKind::Effect,
-            "interface" => TokenKind::Interface,
-            "reactive" => TokenKind::Reactive,
-            "unique" => TokenKind::Unique,
-            "struct" => TokenKind::Struct,
-            "enum" => TokenKind::Enum,
-            "variant" => TokenKind::Variant,
-            "flags" => TokenKind::Flags,
-            "type" => TokenKind::Type,
-            "impl" => TokenKind::Impl,
-            "trait" => TokenKind::Trait,
-            "resource" => TokenKind::Resource,
-            "world" => TokenKind::World,
-            "async" => TokenKind::Async,
-            "import" => TokenKind::Import,
-            "export" => TokenKind::Export,
-            "assert" => TokenKind::Assert,
-            "global" => TokenKind::Global,
-            "const" => TokenKind::Const,
-            "matches" => TokenKind::Matches,
-            "stores" => TokenKind::Stores,
-            // Note: "test", "do", "resume" are contextual keywords handled by the parser, not here
-            "true" => TokenKind::True,
-            "false" => TokenKind::False,
-            "null" => TokenKind::Null,
-            _ => TokenKind::Ident(text.to_string()),
-        }
+        // The keyword set is generated from `crate::syntax::KEYWORDS`.
+        // Contextual keywords ("test", "do", "resume") are intentionally absent
+        // — the parser recognises them positionally, so they lex as identifiers.
+        TokenKind::from_keyword(text).unwrap_or_else(|| TokenKind::Ident(text.to_string()))
     }
 
     fn lex_number(&mut self) -> TokenKind {

--- a/wado-compiler/src/semantics.rs
+++ b/wado-compiler/src/semantics.rs
@@ -261,6 +261,16 @@ impl Semantics {
         self.references.get(key).cloned()
     }
 
+    /// Iterate every declared symbol with its canonical key, across all
+    /// modules. Includes both item-level symbols and the synthetic local
+    /// table (`let` / parameter bindings), mirroring [`Self::symbol_at`].
+    /// Callers that want a single module filter on `key.module`. Used by
+    /// semantic-token highlighting to classify declaration sites in one pass
+    /// instead of a positional lookup per token.
+    pub fn iter_symbols(&self) -> impl Iterator<Item = (&SymbolKey, &Symbol)> {
+        self.symbols.iter().chain(self.locals.iter())
+    }
+
     /// Iterate every recorded use-site `(use_key, def_key)` edge.
     ///
     /// Each `use_key` is typically an [`IdentExpr`] id; `def_key` is the

--- a/wado-compiler/src/symbol.rs
+++ b/wado-compiler/src/symbol.rs
@@ -258,6 +258,13 @@ impl SymbolTable {
         Self::default()
     }
 
+    /// Iterate every symbol with its canonical key, across all modules.
+    /// Order follows insertion (`define` order). Callers that want a single
+    /// module filter on `key.module`.
+    pub fn iter(&self) -> impl Iterator<Item = (&SymbolKey, &Symbol)> {
+        self.symbols.iter()
+    }
+
     /// Check whether a symbol with `name` is already defined directly in
     /// `module_source`.  Unlike [`Self::lookup_in_module`], this does **not**
     /// follow re-export chains — it only inspects symbols registered via

--- a/wado-compiler/src/syntax.rs
+++ b/wado-compiler/src/syntax.rs
@@ -74,8 +74,15 @@ macro_rules! keyword_registry {
 
 /// Generate the operator registry and the `TokenKind` → text/category
 /// mappings from one table.
+///
+/// The trailing `: bool` flag records whether the operator should render as an
+/// `operator` semantic token in the LSP. It is `false` for tokens that double
+/// as punctuation (`&` / `|` for references and unions/closures; `::` / `?` /
+/// `..` / `...` for paths, try, and ranges), which look wrong tinted as
+/// operators. Keeping the flag in the registry means it cannot drift from the
+/// category list.
 macro_rules! operator_registry {
-    ( $( $text:literal => $variant:ident : $cat:ident ),+ $(,)? ) => {
+    ( $( $text:literal => $variant:ident : $cat:ident : $highlight:literal ),+ $(,)? ) => {
         /// Every operator/punctuation token paired with its category. The
         /// lexer's maximal-munch scanner produces these tokens; a test pins
         /// that each spelling lexes back to the listed variant.
@@ -99,6 +106,17 @@ macro_rules! operator_registry {
                 match self {
                     $( TokenKind::$variant => Some(OperatorCategory::$cat), )+
                     _ => None,
+                }
+            }
+
+            /// Whether this token should be highlighted as an `operator`
+            /// semantic token. See the macro docs for why this is narrower
+            /// than "has an operator category".
+            #[must_use]
+            pub fn is_highlight_operator(&self) -> bool {
+                match self {
+                    $( TokenKind::$variant => $highlight, )+
+                    _ => false,
                 }
             }
         }
@@ -159,50 +177,52 @@ keyword_registry! {
 
 operator_registry! {
     // Comparison.
-    "==" => EqEq : Comparison,
-    "!=" => NotEq : Comparison,
-    "<=" => LtEq : Comparison,
-    ">=" => GtEq : Comparison,
-    "<" => Lt : Comparison,
-    ">" => Gt : Comparison,
+    "==" => EqEq : Comparison : true,
+    "!=" => NotEq : Comparison : true,
+    "<=" => LtEq : Comparison : true,
+    ">=" => GtEq : Comparison : true,
+    "<" => Lt : Comparison : true,
+    ">" => Gt : Comparison : true,
     // Logical.
-    "&&" => And : Logical,
-    "||" => Or : Logical,
-    "!" => Not : Logical,
+    "&&" => And : Logical : true,
+    "||" => Or : Logical : true,
+    "!" => Not : Logical : true,
     // Arithmetic.
-    "+" => Plus : Arithmetic,
-    "-" => Minus : Arithmetic,
-    "*" => Star : Arithmetic,
-    "/" => Slash : Arithmetic,
-    "%" => Percent : Arithmetic,
-    // Bitwise.
-    "&" => Ampersand : Bitwise,
-    "|" => Pipe : Bitwise,
-    "^" => Caret : Bitwise,
-    "~" => Tilde : Bitwise,
-    "<<" => LtLt : Bitwise,
-    ">>" => GtGt : Bitwise,
+    "+" => Plus : Arithmetic : true,
+    "-" => Minus : Arithmetic : true,
+    "*" => Star : Arithmetic : true,
+    "/" => Slash : Arithmetic : true,
+    "%" => Percent : Arithmetic : true,
+    // Bitwise. `&` and `|` double as reference and union/closure punctuation,
+    // so they are not highlighted as operators.
+    "&" => Ampersand : Bitwise : false,
+    "|" => Pipe : Bitwise : false,
+    "^" => Caret : Bitwise : true,
+    "~" => Tilde : Bitwise : true,
+    "<<" => LtLt : Bitwise : true,
+    ">>" => GtGt : Bitwise : true,
     // Assignment.
-    "+=" => PlusEq : Assignment,
-    "-=" => MinusEq : Assignment,
-    "*=" => StarEq : Assignment,
-    "/=" => SlashEq : Assignment,
-    "%=" => PercentEq : Assignment,
-    "&=" => AmpEq : Assignment,
-    "|=" => PipeEq : Assignment,
-    "^=" => CaretEq : Assignment,
-    "<<=" => ShlEq : Assignment,
-    ">>=" => ShrEq : Assignment,
-    "=" => Eq : Assignment,
-    // Other.
-    "->" => Arrow : Other,
-    "=>" => FatArrow : Other,
-    "::" => ColonColon : Other,
-    "?" => Question : Other,
-    "..<" => DotDotLt : Other,
-    "..=" => DotDotEq : Other,
-    ".." => DotDot : Other,
-    "..." => DotDotDot : Other,
+    "+=" => PlusEq : Assignment : true,
+    "-=" => MinusEq : Assignment : true,
+    "*=" => StarEq : Assignment : true,
+    "/=" => SlashEq : Assignment : true,
+    "%=" => PercentEq : Assignment : true,
+    "&=" => AmpEq : Assignment : true,
+    "|=" => PipeEq : Assignment : true,
+    "^=" => CaretEq : Assignment : true,
+    "<<=" => ShlEq : Assignment : true,
+    ">>=" => ShrEq : Assignment : true,
+    "=" => Eq : Assignment : true,
+    // Other. Arrows and bounded ranges highlight; paths/try/unbounded ranges
+    // (`::`, `?`, `..`, `...`) are punctuation and do not.
+    "->" => Arrow : Other : true,
+    "=>" => FatArrow : Other : true,
+    "::" => ColonColon : Other : false,
+    "?" => Question : Other : false,
+    "..<" => DotDotLt : Other : true,
+    "..=" => DotDotEq : Other : true,
+    ".." => DotDot : Other : false,
+    "..." => DotDotDot : Other : false,
 }
 
 /// Contextual keywords: lexed as identifiers (the parser recognises them in
@@ -448,6 +468,40 @@ mod tests {
                 kind.operator_category(),
                 Some(*cat),
                 "'{text}' operator_category mismatch"
+            );
+        }
+    }
+
+    /// Pin the exact set of operators that highlight as `operator` semantic
+    /// tokens. Punctuation-like tokens (`&` / `|` references & unions; `::` /
+    /// `?` / `..` / `...` paths/try/ranges) must stay excluded.
+    #[test]
+    fn highlight_operator_set_is_pinned() {
+        let highlighted: Vec<&str> = OPERATORS
+            .iter()
+            .filter(|(text, _)| {
+                crate::lexer::lex(text).tokens[0]
+                    .kind
+                    .is_highlight_operator()
+            })
+            .map(|(text, _)| *text)
+            .collect();
+        let mut expected = vec![
+            "==", "!=", "<=", ">=", "<", ">", // comparison
+            "&&", "||", "!", // logical
+            "+", "-", "*", "/", "%", // arithmetic
+            "^", "~", "<<", ">>", // bitwise (excludes `&` and `|`)
+            "+=", "-=", "*=", "/=", "%=", "&=", "|=", "^=", "<<=", ">>=", "=", // assignment
+            "->", "=>", "..<", "..=", // other (excludes `::`, `?`, `..`, `...`)
+        ];
+        let mut got = highlighted.clone();
+        got.sort_unstable();
+        expected.sort_unstable();
+        assert_eq!(got, expected, "highlight operator set drifted");
+        for excluded in ["&", "|", "::", "?", "..", "..."] {
+            assert!(
+                !highlighted.contains(&excluded),
+                "'{excluded}' must not be a highlight operator"
             );
         }
     }

--- a/wado-compiler/src/syntax.rs
+++ b/wado-compiler/src/syntax.rs
@@ -1,7 +1,239 @@
 //! Canonical syntax definition for the Wado language
 //!
-//! This module provides language-agnostic syntax information that can be
-//! transformed into editor-specific formats by wado-cli.
+//! This module is the **single source of truth** for which words are
+//! keywords, which symbols are operators, and how each is categorized. The
+//! lexer (`TokenKind::from_keyword`), the token→text mapping
+//! (`TokenKind::as_keyword_str` / `operator_str`), the LSP highlighter
+//! (`TokenKind::operator_category`), and the editor-grammar generator
+//! (`SyntaxDefinition::wado`, consumed by wado-cli) all derive from the
+//! [`KEYWORDS`] / [`OPERATORS`] tables below, so they cannot drift apart.
+
+use crate::token::TokenKind;
+
+/// Editorial role of a keyword, chosen so the `TextMate` generator can map
+/// each onto a widely-themed scope. See [`KeywordCategories`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeywordCategory {
+    Control,
+    StorageType,
+    StorageModifier,
+    Other,
+    /// `true` / `false` / `null` / `self` — rendered as constants, not keywords.
+    Constant,
+    /// Keyword-shaped binary operator (`matches`): lexes as a keyword token
+    /// but highlights as an operator.
+    Operator,
+}
+
+/// Category of an operator/punctuation token. See [`OperatorCategories`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OperatorCategory {
+    Comparison,
+    Logical,
+    Arithmetic,
+    Bitwise,
+    Assignment,
+    Other,
+}
+
+/// Generate the keyword registry and the `TokenKind` ↔ text mappings from one
+/// table, so the lexer, the reverse mapping, and the grammar stay in sync.
+macro_rules! keyword_registry {
+    ( $( $text:literal => $variant:ident : $cat:ident ),+ $(,)? ) => {
+        /// Every real keyword token paired with its editorial category. The
+        /// authoritative list — adding a keyword here wires the lexer, the
+        /// reverse text mapping, and the grammar in one edit.
+        pub const KEYWORDS: &[(&str, KeywordCategory)] = &[
+            $( ($text, KeywordCategory::$cat) ),+
+        ];
+
+        impl TokenKind {
+            /// Map source text to its keyword token, if it is one. Used by the
+            /// lexer's identifier/keyword disambiguation.
+            #[must_use]
+            pub(crate) fn from_keyword(text: &str) -> Option<TokenKind> {
+                match text {
+                    $( $text => Some(TokenKind::$variant), )+
+                    _ => None,
+                }
+            }
+
+            /// The keyword's source spelling, if this token is a keyword
+            /// (including `true` / `false` / `null` and the `matches` operator
+            /// keyword). Used to allow keywords as field names and to highlight.
+            #[must_use]
+            pub fn as_keyword_str(&self) -> Option<&'static str> {
+                match self {
+                    $( TokenKind::$variant => Some($text), )+
+                    _ => None,
+                }
+            }
+        }
+    };
+}
+
+/// Generate the operator registry and the `TokenKind` → text/category
+/// mappings from one table.
+macro_rules! operator_registry {
+    ( $( $text:literal => $variant:ident : $cat:ident ),+ $(,)? ) => {
+        /// Every operator/punctuation token paired with its category. The
+        /// lexer's maximal-munch scanner produces these tokens; a test pins
+        /// that each spelling lexes back to the listed variant.
+        pub const OPERATORS: &[(&str, OperatorCategory)] = &[
+            $( ($text, OperatorCategory::$cat) ),+
+        ];
+
+        impl TokenKind {
+            /// The operator's source spelling, if this token is an operator.
+            #[must_use]
+            pub fn operator_str(&self) -> Option<&'static str> {
+                match self {
+                    $( TokenKind::$variant => Some($text), )+
+                    _ => None,
+                }
+            }
+
+            /// The operator's category, if this token is an operator.
+            #[must_use]
+            pub fn operator_category(&self) -> Option<OperatorCategory> {
+                match self {
+                    $( TokenKind::$variant => Some(OperatorCategory::$cat), )+
+                    _ => None,
+                }
+            }
+        }
+    };
+}
+
+keyword_registry! {
+    // Control flow.
+    "if" => If : Control,
+    "else" => Else : Control,
+    "while" => While : Control,
+    "for" => For : Control,
+    "loop" => Loop : Control,
+    "break" => Break : Control,
+    "continue" => Continue : Control,
+    "return" => Return : Control,
+    "match" => Match : Control,
+    // Storage types: items and bindings.
+    "fn" => Fn : StorageType,
+    "let" => Let : StorageType,
+    "global" => Global : StorageType,
+    "const" => Const : StorageType,
+    "struct" => Struct : StorageType,
+    "enum" => Enum : StorageType,
+    "variant" => Variant : StorageType,
+    "flags" => Flags : StorageType,
+    "impl" => Impl : StorageType,
+    "trait" => Trait : StorageType,
+    "type" => Type : StorageType,
+    "resource" => Resource : StorageType,
+    "world" => World : StorageType,
+    "effect" => Effect : StorageType,
+    "interface" => Interface : StorageType,
+    // Storage modifiers: visibility and qualifiers.
+    "pub" => Pub : StorageModifier,
+    "export" => Export : StorageModifier,
+    "mut" => Mut : StorageModifier,
+    "async" => Async : StorageModifier,
+    "unique" => Unique : StorageModifier,
+    "stores" => Stores : StorageModifier,
+    "reactive" => Reactive : StorageModifier,
+    // Other keywords.
+    "use" => Use : Other,
+    "from" => From : Other,
+    "import" => Import : Other,
+    "as" => As : Other,
+    "with" => With : Other,
+    "in" => In : Other,
+    "of" => Of : Other,
+    "assert" => Assert : Other,
+    // Constants.
+    "true" => True : Constant,
+    "false" => False : Constant,
+    "null" => Null : Constant,
+    // Operator keyword.
+    "matches" => Matches : Operator,
+}
+
+operator_registry! {
+    // Comparison.
+    "==" => EqEq : Comparison,
+    "!=" => NotEq : Comparison,
+    "<=" => LtEq : Comparison,
+    ">=" => GtEq : Comparison,
+    "<" => Lt : Comparison,
+    ">" => Gt : Comparison,
+    // Logical.
+    "&&" => And : Logical,
+    "||" => Or : Logical,
+    "!" => Not : Logical,
+    // Arithmetic.
+    "+" => Plus : Arithmetic,
+    "-" => Minus : Arithmetic,
+    "*" => Star : Arithmetic,
+    "/" => Slash : Arithmetic,
+    "%" => Percent : Arithmetic,
+    // Bitwise.
+    "&" => Ampersand : Bitwise,
+    "|" => Pipe : Bitwise,
+    "^" => Caret : Bitwise,
+    "~" => Tilde : Bitwise,
+    "<<" => LtLt : Bitwise,
+    ">>" => GtGt : Bitwise,
+    // Assignment.
+    "+=" => PlusEq : Assignment,
+    "-=" => MinusEq : Assignment,
+    "*=" => StarEq : Assignment,
+    "/=" => SlashEq : Assignment,
+    "%=" => PercentEq : Assignment,
+    "&=" => AmpEq : Assignment,
+    "|=" => PipeEq : Assignment,
+    "^=" => CaretEq : Assignment,
+    "<<=" => ShlEq : Assignment,
+    ">>=" => ShrEq : Assignment,
+    "=" => Eq : Assignment,
+    // Other.
+    "->" => Arrow : Other,
+    "=>" => FatArrow : Other,
+    "::" => ColonColon : Other,
+    "?" => Question : Other,
+    "..<" => DotDotLt : Other,
+    "..=" => DotDotEq : Other,
+    ".." => DotDot : Other,
+    "..." => DotDotDot : Other,
+}
+
+/// Contextual keywords: lexed as identifiers (the parser recognises them in
+/// position) but highlighted as keywords. They have no `TokenKind`, so they
+/// live outside [`KEYWORDS`] and feed only the grammar.
+pub const CONTEXTUAL_KEYWORDS: &[(&str, KeywordCategory)] = &[
+    ("task", KeywordCategory::Control),
+    ("do", KeywordCategory::Control),
+    ("resume", KeywordCategory::Control),
+    ("test", KeywordCategory::Other),
+    ("self", KeywordCategory::Constant),
+];
+
+/// Spellings of every keyword (real + contextual) in the given category.
+fn keywords_in(category: KeywordCategory) -> Vec<&'static str> {
+    KEYWORDS
+        .iter()
+        .chain(CONTEXTUAL_KEYWORDS.iter())
+        .filter(|(_, c)| *c == category)
+        .map(|(text, _)| *text)
+        .collect()
+}
+
+/// Spellings of every operator in the given category.
+fn operators_in(category: OperatorCategory) -> Vec<&'static str> {
+    OPERATORS
+        .iter()
+        .filter(|(_, c)| *c == category)
+        .map(|(text, _)| *text)
+        .collect()
+}
 
 /// Complete syntax definition for the Wado language
 #[derive(Debug)]
@@ -71,43 +303,23 @@ impl SyntaxDefinition {
             scope_name: "source.wado",
             file_extensions: vec![".wado"],
             keywords: KeywordCategories {
-                control: vec![
-                    "if", "else", "while", "for", "loop", "break", "continue", "return", "match",
-                    "task", "do", "resume",
-                ],
-                storage_type: vec![
-                    "fn",
-                    "let",
-                    "global",
-                    "const",
-                    "struct",
-                    "enum",
-                    "variant",
-                    "flags",
-                    "impl",
-                    "trait",
-                    "type",
-                    "resource",
-                    "world",
-                    "effect",
-                    "interface",
-                ],
-                storage_modifier: vec![
-                    "pub", "export", "mut", "async", "unique", "stores", "reactive",
-                ],
-                other: vec![
-                    "use", "from", "import", "test", "as", "with", "in", "of", "assert",
-                ],
+                control: keywords_in(KeywordCategory::Control),
+                storage_type: keywords_in(KeywordCategory::StorageType),
+                storage_modifier: keywords_in(KeywordCategory::StorageModifier),
+                other: keywords_in(KeywordCategory::Other),
             },
             operators: OperatorCategories {
-                comparison: vec!["==", "!=", "<=", ">=", "<", ">"],
-                logical: vec!["&&", "||", "!"],
-                arithmetic: vec!["+", "-", "*", "/", "%"],
-                bitwise: vec!["&", "|", "^", "~", "<<", ">>"],
-                assignment: vec![
-                    "+=", "-=", "*=", "/=", "%=", "&=", "|=", "^=", "<<=", ">>=", "=",
-                ],
-                other: vec!["->", "=>", "::", "?", "..<", "..=", "..", "...", "matches"],
+                comparison: operators_in(OperatorCategory::Comparison),
+                logical: operators_in(OperatorCategory::Logical),
+                arithmetic: operators_in(OperatorCategory::Arithmetic),
+                bitwise: operators_in(OperatorCategory::Bitwise),
+                assignment: operators_in(OperatorCategory::Assignment),
+                // `matches` is a keyword token but highlights as an operator.
+                other: {
+                    let mut ops = operators_in(OperatorCategory::Other);
+                    ops.extend(keywords_in(KeywordCategory::Operator));
+                    ops
+                },
             },
             builtin_types: vec![
                 "i8",
@@ -143,7 +355,7 @@ impl SyntaxDefinition {
                 "IndexValue",
                 "IndexAssign",
             ],
-            constants: vec!["true", "false", "null", "self"],
+            constants: keywords_in(KeywordCategory::Constant),
             compile_time_literals: vec![
                 "file",
                 "line",
@@ -177,138 +389,67 @@ mod tests {
         assert!(def.keywords.storage_modifier.contains(&"pub"));
     }
 
-    /// Verify all keywords in `SyntaxDefinition` are recognized by the lexer
+    /// Every real keyword round-trips text → token → text and lexes as a
+    /// keyword token (not an identifier). Pins the generated `from_keyword` /
+    /// `as_keyword_str` against the actual lexer.
     #[test]
-    fn test_syntax_keywords_match_lexer() {
-        let def = SyntaxDefinition::wado();
-
-        // Collect all keywords from SyntaxDefinition
-        let all_keywords: Vec<&str> = def
-            .keywords
-            .control
-            .iter()
-            .chain(def.keywords.storage_type.iter())
-            .chain(def.keywords.storage_modifier.iter())
-            .chain(def.keywords.other.iter())
-            .copied()
-            .collect();
-
-        // Contextual keywords: these are in SyntaxDefinition for highlighting
-        // but are parsed as identifiers by the lexer and handled specially by the parser
-        // (e.g. `test` for test blocks, `task` for `task return` statements)
-        let contextual_keywords = ["test", "task", "do", "resume"];
-        // Keyword-shaped operators: lexer keywords exposed via OperatorCategories
-        // rather than KeywordCategories (e.g. `matches`, the binary pattern-test op)
-        let operator_keywords = ["matches"];
-
-        // Verify each keyword is lexed as a keyword token (not an identifier)
-        // Skip contextual keywords which are intentionally lexed as identifiers
-        for keyword in &all_keywords {
-            if contextual_keywords.contains(keyword) {
-                continue;
-            }
-            let r = crate::lexer::lex(keyword);
-            assert!(r.errors.is_empty(), "lexer error: {:?}", r.errors);
-            assert!(!r.tokens.is_empty(), "'{keyword}' produced no tokens");
+    fn keywords_round_trip_through_lexer() {
+        for (text, _cat) in KEYWORDS {
+            let token = TokenKind::from_keyword(text)
+                .unwrap_or_else(|| panic!("'{text}' is missing from from_keyword"));
+            assert_eq!(
+                token.as_keyword_str(),
+                Some(*text),
+                "'{text}' does not round-trip through as_keyword_str"
+            );
+            let r = crate::lexer::lex(text);
+            assert!(
+                r.errors.is_empty(),
+                "lexer error on '{text}': {:?}",
+                r.errors
+            );
             assert!(
                 !matches!(r.tokens[0].kind, TokenKind::Ident(_)),
-                "'{keyword}' in SyntaxDefinition is not recognized as a keyword by lexer"
-            );
-        }
-
-        // Keywords that the lexer recognizes (must be kept in sync with lexer.rs)
-        // This is the authoritative list from lexer.rs lex_ident_or_keyword()
-        let lexer_keywords = [
-            "use",
-            "from",
-            "as",
-            "fn",
-            "with",
-            "let",
-            "mut",
-            "return",
-            "if",
-            "else",
-            "match",
-            "matches",
-            "for",
-            "while",
-            "loop",
-            "break",
-            "continue",
-            "in",
-            "of",
-            "pub",
-            "effect",
-            "interface",
-            "reactive",
-            "unique",
-            "struct",
-            "enum",
-            "variant",
-            "flags",
-            "type",
-            "impl",
-            "trait",
-            "resource",
-            "world",
-            "async",
-            "import",
-            "export",
-            "assert",
-            "global",
-            "const",
-            "stores",
-        ];
-
-        // Verify SyntaxDefinition covers all lexer keywords
-        // (operator keywords like `matches` live in OperatorCategories instead)
-        let def_operators = &def.operators;
-        let all_op_tokens: Vec<&str> = def_operators
-            .comparison
-            .iter()
-            .chain(def_operators.logical.iter())
-            .chain(def_operators.arithmetic.iter())
-            .chain(def_operators.bitwise.iter())
-            .chain(def_operators.assignment.iter())
-            .chain(def_operators.other.iter())
-            .copied()
-            .collect();
-        for keyword in lexer_keywords {
-            let in_keywords = all_keywords.contains(&keyword);
-            let in_operators =
-                operator_keywords.contains(&keyword) && all_op_tokens.contains(&keyword);
-            assert!(
-                in_keywords || in_operators,
-                "lexer keyword '{keyword}' is missing from SyntaxDefinition"
-            );
-        }
-
-        // Verify no extra keywords in SyntaxDefinition (except contextual keywords)
-        for keyword in &all_keywords {
-            assert!(
-                lexer_keywords.contains(keyword) || contextual_keywords.contains(keyword),
-                "SyntaxDefinition keyword '{keyword}' is not in lexer or contextual_keywords"
+                "'{text}' should lex as a keyword token, not an identifier"
             );
         }
     }
 
-    /// Verify all constants in `SyntaxDefinition` are recognized by the lexer
+    /// Contextual keywords are deliberately not lexer keywords: they lex as
+    /// identifiers and the parser recognises them positionally.
     #[test]
-    fn test_syntax_constants_match_lexer() {
-        let def = SyntaxDefinition::wado();
-
-        // Lexer constants (true, false, null are lexed as specific tokens)
-        let lexer_constants = ["true", "false", "null"];
-
-        for constant in lexer_constants {
+    fn contextual_keywords_lex_as_identifiers() {
+        for (text, _cat) in CONTEXTUAL_KEYWORDS {
             assert!(
-                def.constants.contains(&constant),
-                "lexer constant '{constant}' is missing from SyntaxDefinition.constants"
+                TokenKind::from_keyword(text).is_none(),
+                "contextual keyword '{text}' must not be a lexer keyword"
+            );
+            let r = crate::lexer::lex(text);
+            assert!(
+                matches!(r.tokens[0].kind, TokenKind::Ident(_)),
+                "contextual keyword '{text}' should lex as an identifier"
             );
         }
+    }
 
-        // Note: "self" is in constants but handled specially (as identifier in most contexts)
+    /// Every operator round-trips: the lexer emits a token whose
+    /// `operator_str` / `operator_category` agree with the registry.
+    #[test]
+    fn operators_round_trip_through_lexer() {
+        for (text, cat) in OPERATORS {
+            let r = crate::lexer::lex(text);
+            let kind = &r.tokens[0].kind;
+            assert_eq!(
+                kind.operator_str(),
+                Some(*text),
+                "'{text}' does not round-trip through operator_str"
+            );
+            assert_eq!(
+                kind.operator_category(),
+                Some(*cat),
+                "'{text}' operator_category mismatch"
+            );
+        }
     }
 
     /// Verify compile-time literals in `SyntaxDefinition` match the names parsed by `parser.rs`.

--- a/wado-compiler/src/token.rs
+++ b/wado-compiler/src/token.rs
@@ -154,58 +154,10 @@ impl TokenKind {
         }
     }
 
-    /// Returns the keyword as a string if this token is a keyword.
-    /// Used for allowing keywords as field names.
-    #[must_use]
-    pub fn as_keyword_str(&self) -> Option<&'static str> {
-        match self {
-            Self::Use => Some("use"),
-            Self::From => Some("from"),
-            Self::As => Some("as"),
-            Self::Fn => Some("fn"),
-            Self::With => Some("with"),
-            Self::Let => Some("let"),
-            Self::Mut => Some("mut"),
-            Self::Return => Some("return"),
-            Self::If => Some("if"),
-            Self::Else => Some("else"),
-            Self::Match => Some("match"),
-            Self::For => Some("for"),
-            Self::While => Some("while"),
-            Self::Loop => Some("loop"),
-            Self::Break => Some("break"),
-            Self::Continue => Some("continue"),
-            Self::In => Some("in"),
-            Self::Of => Some("of"),
-            Self::Pub => Some("pub"),
-            Self::Effect => Some("effect"),
-            Self::Interface => Some("interface"),
-            Self::Reactive => Some("reactive"),
-            Self::Unique => Some("unique"),
-            Self::Struct => Some("struct"),
-            Self::Enum => Some("enum"),
-            Self::Variant => Some("variant"),
-            Self::Flags => Some("flags"),
-            Self::Type => Some("type"),
-            Self::Impl => Some("impl"),
-            Self::Trait => Some("trait"),
-            Self::Resource => Some("resource"),
-            Self::World => Some("world"),
-            Self::Async => Some("async"),
-            Self::Import => Some("import"),
-            Self::Export => Some("export"),
-            Self::Assert => Some("assert"),
-            Self::Global => Some("global"),
-            Self::Const => Some("const"),
-            Self::Matches => Some("matches"),
-            Self::Stores => Some("stores"),
-            // Note: "test", "do", "resume" are contextual keywords, not listed here
-            Self::True => Some("true"),
-            Self::False => Some("false"),
-            Self::Null => Some("null"),
-            _ => None,
-        }
-    }
+    // `as_keyword_str` (token → keyword text), `from_keyword`, `operator_str`,
+    // and `operator_category` are generated from the canonical registries in
+    // `crate::syntax`, so the keyword/operator sets cannot drift from the
+    // lexer or the editor grammar.
 }
 
 #[derive(Debug, Clone)]

--- a/wado-compiler/tests/generated/fixtures/monomorphize_for_of_closure_local.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/monomorphize_for_of_closure_local.wir.wado
@@ -26,12 +26,12 @@ struct tuple//[i32, i32, i32] {  // TypeId(3)
     mut 2: i32,
 }
 
-struct tuple//[i32, String] {  // TypeId(4)
+struct tuple//[i32, core:prelude/string.wado/String] {  // TypeId(4)
     mut 0: i32,
     mut 1: ref "core:prelude/string.wado//String",
 }
 
-struct tuple//[i32, String, bool] {  // TypeId(5)
+struct tuple//[i32, core:prelude/string.wado/String, bool] {  // TypeId(5)
     mut 0: i32,
     mut 1: ref "core:prelude/string.wado//String",
     mut 2: bool,
@@ -63,11 +63,11 @@ type "functype//wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.w
 
 type "functype//wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/__cm_export____test_1_closure_capturing_the_per_iteration_binding_inside_variadic_for_of" = fn();  // TypeId(18)
 
-type "functype//wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_capturing<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool>>" = fn(ref "tuple//[i32, String, bool]") -> i32;  // TypeId(19)
+type "functype//wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_capturing<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool>>" = fn(ref "tuple//[i32, core:prelude/string.wado/String, bool]") -> i32;  // TypeId(19)
 
 type "functype//wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_capturing<core:prelude/types.wado/Tuple<i32,i32,i32>>" = fn(ref "tuple//[i32, i32, i32]") -> i32;  // TypeId(20)
 
-type "functype//wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_with_closure<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String>>" = fn(ref "tuple//[i32, String]") -> i32;  // TypeId(21)
+type "functype//wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_with_closure<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String>>" = fn(ref "tuple//[i32, core:prelude/string.wado/String]") -> i32;  // TypeId(21)
 
 type "functype//wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_with_closure<core:prelude/types.wado/Tuple<i32,i32,i32>>" = fn(ref "tuple//[i32, i32, i32]") -> i32;  // TypeId(22)
 
@@ -126,7 +126,7 @@ fn "wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/__test_0
     let homo: ref "tuple//[i32, i32, i32]";
     let __v0_1: i32;
     let __cond_2: bool;
-    let het: ref "tuple//[i32, String]";
+    let het: ref "tuple//[i32, core:prelude/string.wado/String]";
     let __v0_4: i32;
     let __cond_5: bool;
     let __local_6: ref "core:prelude/string.wado//String";
@@ -138,17 +138,15 @@ fn "wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/__test_0
     let f_24: ref "core:prelude/format.wado//Formatter";
     let f_29: ref "core:prelude/format.wado//Formatter";
     homo = struct.new "tuple//[i32, i32, i32]" { 0: 10, 1: 20, 2: 30 };
-    __v0_1 = "wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_with_closure<core:prelude/types.wado/Tuple<i32,i32,i32>>"(homo);
-    __cond_2 = __v0_1 == 63;
+    __cond_2 = local.tee __v0_1("wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_with_closure<core:prelude/types.wado/Tuple<i32,i32,i32>>"(homo)) == 63;
     if __cond_2 == 0 {
         "core:internal/panic"(__local_6 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(155), used: 0 }; "core:prelude/string.wado/String::push_str"(__local_6, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Assertion failed in "), used: 20 }); "core:prelude/string.wado/String::push_str"(__local_6, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("__test_0_closure_with_internal_let_inside_variadic_for_of"), used: 57 }); "core:prelude/string.wado/String::push"(__local_6, 32); "core:prelude/string.wado/String::push"(__local_6, 97); "core:prelude/string.wado/String::push"(__local_6, 116); "core:prelude/string.wado/String::push"(__local_6, 32); "core:prelude/string.wado/String::push_str"(__local_6, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado"), used: 67 }); "core:prelude/string.wado/String::push"(__local_6, 58); __local_7 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_6 }; f_13 = __local_7; "core:prelude/primitive.wado/i32::fmt_decimal"(45, f_13); "core:prelude/string.wado/String::push_str"(__local_6, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("
 condition: sum_with_closure(homo) == 63
 "), used: 41 }); "core:prelude/string.wado/String::push_str"(__local_6, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("sum_with_closure(homo): "), used: 24 }); __local_7 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_6 }; f_18 = __local_7; "core:prelude/primitive.wado/i32::fmt_decimal"(__v0_1, f_18); "core:prelude/string.wado/String::push"(__local_6, 10); __local_6);
         unreachable;
     }
-    het = struct.new "tuple//[i32, String]" { 0: 5, 1: struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(120), used: 1 } };
-    __v0_4 = "wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_with_closure<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String>>"(het);
-    __cond_5 = __v0_4 == 107;
+    het = struct.new "tuple//[i32, core:prelude/string.wado/String]" { 0: 5, 1: struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(120), used: 1 } };
+    __cond_5 = local.tee __v0_4("wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_with_closure<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String>>"(het)) == 107;
     if __cond_5 == 0 {
         "core:internal/panic"(__local_8 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(154), used: 0 }; "core:prelude/string.wado/String::push_str"(__local_8, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Assertion failed in "), used: 20 }); "core:prelude/string.wado/String::push_str"(__local_8, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("__test_0_closure_with_internal_let_inside_variadic_for_of"), used: 57 }); "core:prelude/string.wado/String::push"(__local_8, 32); "core:prelude/string.wado/String::push"(__local_8, 97); "core:prelude/string.wado/String::push"(__local_8, 116); "core:prelude/string.wado/String::push"(__local_8, 32); "core:prelude/string.wado/String::push_str"(__local_8, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado"), used: 67 }); "core:prelude/string.wado/String::push"(__local_8, 58); __local_9 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_8 }; f_24 = __local_9; "core:prelude/primitive.wado/i32::fmt_decimal"(47, f_24); "core:prelude/string.wado/String::push_str"(__local_8, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("
 condition: sum_with_closure(het) == 107
@@ -170,16 +168,14 @@ fn "wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/__test_1
     let f_16: ref "core:prelude/format.wado//Formatter";
     let f_22: ref "core:prelude/format.wado//Formatter";
     let f_27: ref "core:prelude/format.wado//Formatter";
-    __v0_0 = "wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_capturing<core:prelude/types.wado/Tuple<i32,i32,i32>>"(struct.new "tuple//[i32, i32, i32]" { 0: 10, 1: 20, 2: 30 });
-    __cond_1 = __v0_0 == 60;
+    __cond_1 = local.tee __v0_0("wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_capturing<core:prelude/types.wado/Tuple<i32,i32,i32>>"(struct.new "tuple//[i32, i32, i32]" { 0: 10, 1: 20, 2: 30 })) == 60;
     if __cond_1 == 0 {
         "core:internal/panic"(__local_4 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(165), used: 0 }; "core:prelude/string.wado/String::push_str"(__local_4, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Assertion failed in "), used: 20 }); "core:prelude/string.wado/String::push_str"(__local_4, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("__test_1_closure_capturing_the_per_iteration_binding_inside_variadic_for_of"), used: 75 }); "core:prelude/string.wado/String::push"(__local_4, 32); "core:prelude/string.wado/String::push"(__local_4, 97); "core:prelude/string.wado/String::push"(__local_4, 116); "core:prelude/string.wado/String::push"(__local_4, 32); "core:prelude/string.wado/String::push_str"(__local_4, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado"), used: 67 }); "core:prelude/string.wado/String::push"(__local_4, 58); __local_5 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_4 }; f_11 = __local_5; "core:prelude/primitive.wado/i32::fmt_decimal"(51, f_11); "core:prelude/string.wado/String::push_str"(__local_4, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("
 condition: sum_capturing([10, 20, 30]) == 60
 "), used: 46 }); "core:prelude/string.wado/String::push_str"(__local_4, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("sum_capturing([10, 20, 30]): "), used: 29 }); __local_5 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_4 }; f_16 = __local_5; "core:prelude/primitive.wado/i32::fmt_decimal"(__v0_0, f_16); "core:prelude/string.wado/String::push"(__local_4, 10); __local_4);
         unreachable;
     }
-    __v0_2 = "wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_capturing<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool>>"(struct.new "tuple//[i32, String, bool]" { 0: 5, 1: struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(120), used: 1 }, 2: 1 });
-    __cond_3 = __v0_2 == 106;
+    __cond_3 = local.tee __v0_2("wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_capturing<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool>>"(struct.new "tuple//[i32, core:prelude/string.wado/String, bool]" { 0: 5, 1: struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(120), used: 1 }, 2: 1 })) == 106;
     if __cond_3 == 0 {
         "core:internal/panic"(__local_6 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(170), used: 0 }; "core:prelude/string.wado/String::push_str"(__local_6, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Assertion failed in "), used: 20 }); "core:prelude/string.wado/String::push_str"(__local_6, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("__test_1_closure_capturing_the_per_iteration_binding_inside_variadic_for_of"), used: 75 }); "core:prelude/string.wado/String::push"(__local_6, 32); "core:prelude/string.wado/String::push"(__local_6, 97); "core:prelude/string.wado/String::push"(__local_6, 116); "core:prelude/string.wado/String::push"(__local_6, 32); "core:prelude/string.wado/String::push_str"(__local_6, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado"), used: 67 }); "core:prelude/string.wado/String::push"(__local_6, 58); __local_7 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_6 }; f_22 = __local_7; "core:prelude/primitive.wado/i32::fmt_decimal"(52, f_22); "core:prelude/string.wado/String::push_str"(__local_6, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("
 condition: sum_capturing([5, \"x\", true]) == 106
@@ -201,12 +197,8 @@ fn "wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/__cm_exp
 fn "wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_capturing<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool>>"(items) {
     let acc: i32;
     let v_5: i32;
-    acc = 0;
     v_5 = items.0;
-    acc = 0 + v_5;
-    acc = acc + 100;
-    acc = acc + 1;
-    return acc;
+    return local.tee acc(local.tee acc(local.tee acc(0 + v_5) + 100) + 1);
 }
 
 fn "wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_capturing<core:prelude/types.wado/Tuple<i32,i32,i32>>"(items) {
@@ -220,19 +212,15 @@ fn "wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_capt
     v_6 = items.1;
     acc = acc + v_6;
     v_8 = items.2;
-    acc = acc + v_8;
-    return acc;
+    return local.tee acc(acc + v_8);
 }
 
 fn "wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_with_closure<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String>>"(items) {
     let acc: i32;
     let v_5: i32;
     let __local_2_11: i32;
-    acc = 0;
     v_5 = items.0;
-    acc = 0 + __local_2_11 = v_5 + 1; __local_2_11;
-    acc = acc + 101;
-    return acc;
+    return local.tee acc(local.tee acc(0 + __local_2_11 = v_5 + 1; __local_2_11) + 101);
 }
 
 fn "wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_with_closure<core:prelude/types.wado/Tuple<i32,i32,i32>>"(items) {
@@ -249,8 +237,7 @@ fn "wado-compiler/tests/fixtures/monomorphize_for_of_closure_local.wado/sum_with
     v_6 = items.1;
     acc = acc + __local_2_17 = v_6 + 1; __local_2_17;
     v_8 = items.2;
-    acc = acc + __local_2_21 = v_8 + 1; __local_2_21;
-    return acc;
+    return local.tee acc(acc + __local_2_21 = v_8 + 1; __local_2_21);
 }
 
 fn "core:internal/gc_array_to_memory"(arr, ptr, len) {
@@ -328,8 +315,7 @@ fn "core:internal/cm_stream_write_raw_u8"(handle, data, len) {
     let ptr: i32;
     let raw_len: i32;
     let result: i32;
-    packed = "core:internal/cm_lower_list_u8"(data, len);
-    ptr = builtin::i32_wrap_i64(packed);
+    ptr = builtin::i32_wrap_i64(local.tee packed("core:internal/cm_lower_list_u8"(data, len)));
     raw_len = builtin::i32_wrap_i64(packed >> 32_i64);
     result = "wasi/stream-write"(handle, ptr, raw_len);
     if result == -1 {
@@ -388,8 +374,7 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
     let offset: i32;
     let self_6: ref "core:prelude/string.wado//String";
     is_negative = self < 0;
-    abs_val = select i64(is_negative, 0_i64 - builtin::i64_extend_i32_s(self), builtin::i64_extend_i32_s(self));
-    digit_count = "core:prelude/primitive.wado/count_digits_i64"(abs_val);
+    digit_count = "core:prelude/primitive.wado/count_digits_i64"(local.tee abs_val(select i64(is_negative, 0_i64 - builtin::i64_extend_i32_s(self), builtin::i64_extend_i32_s(self))));
     offset = "core:prelude/format.wado/Formatter::prepare_int_write"(f, is_negative, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
     "core:prelude/primitive.wado/write_decimal_digits"(self_6 = f.buf; self_6.repr, offset, abs_val, digit_count);
 }
@@ -404,10 +389,7 @@ fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
     if min_capacity <= capacity {
         return;
     }
-    a_7 = capacity * 2;
-    a_5 = select i32(a_7 > min_capacity, a_7, min_capacity);
-    new_capacity = select i32(a_5 > 8, a_5, 8);
-    new_repr = builtin::array_new<u8>(new_capacity);
+    new_repr = builtin::array_new<u8>(local.tee new_capacity(a_7 = capacity * 2; a_5 = select i32(a_7 > min_capacity, a_7, min_capacity); select i32(a_5 > 8, a_5, 8)));
     builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }

--- a/wado-compiler/tests/generated/fixtures/monomorphize_for_of_local_in_match_arm.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/monomorphize_for_of_local_in_match_arm.wir.wado
@@ -20,7 +20,7 @@ struct core:prelude/format.wado//Formatter {  // TypeId(2)
     mut buf: ref "core:prelude/string.wado//String",
 }
 
-struct tuple//[i32, String, bool, i32] {  // TypeId(3)
+struct tuple//[i32, core:prelude/string.wado/String, bool, i32] {  // TypeId(3)
     mut 0: i32,
     mut 1: ref "core:prelude/string.wado//String",
     mut 2: bool,
@@ -49,9 +49,9 @@ type "functype//wado-compiler/tests/fixtures/monomorphize_for_of_local_in_match_
 
 type "functype//wado-compiler/tests/fixtures/monomorphize_for_of_local_in_match_arm.wado/__cm_export____test_0_per_iteration_local_typed_concretely_inside_match_arm_and_while_body" = fn();  // TypeId(14)
 
-type "functype//wado-compiler/tests/fixtures/monomorphize_for_of_local_in_match_arm.wado/sum_in_while<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>" = fn(ref "tuple//[i32, String, bool, i32]") -> i32;  // TypeId(15)
+type "functype//wado-compiler/tests/fixtures/monomorphize_for_of_local_in_match_arm.wado/sum_in_while<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>" = fn(ref "tuple//[i32, core:prelude/string.wado/String, bool, i32]") -> i32;  // TypeId(15)
 
-type "functype//wado-compiler/tests/fixtures/monomorphize_for_of_local_in_match_arm.wado/sum_in_match<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>" = fn(ref "tuple//[i32, String, bool, i32]") -> i32;  // TypeId(16)
+type "functype//wado-compiler/tests/fixtures/monomorphize_for_of_local_in_match_arm.wado/sum_in_match<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>" = fn(ref "tuple//[i32, core:prelude/string.wado/String, bool, i32]") -> i32;  // TypeId(16)
 
 type "functype//core:internal/gc_array_to_memory" = fn(ref Array<u8>, i32, i32);  // TypeId(17)
 
@@ -105,7 +105,7 @@ import fn wasi/stream-new from "wasi/stream-new";
 import fn wasi/future-drop-readable:transmission-cli from "wasi/future-drop-readable:transmission-cli";
 
 fn "wado-compiler/tests/fixtures/monomorphize_for_of_local_in_match_arm.wado/__test_0_per_iteration_local_typed_concretely_inside_match_arm_and_while_body"() {
-    let t: ref "tuple//[i32, String, bool, i32]";
+    let t: ref "tuple//[i32, core:prelude/string.wado/String, bool, i32]";
     let __v0_1: i32;
     let __cond_2: bool;
     let __v0_3: i32;
@@ -118,17 +118,15 @@ fn "wado-compiler/tests/fixtures/monomorphize_for_of_local_in_match_arm.wado/__t
     let f_17: ref "core:prelude/format.wado//Formatter";
     let f_23: ref "core:prelude/format.wado//Formatter";
     let f_28: ref "core:prelude/format.wado//Formatter";
-    t = struct.new "tuple//[i32, String, bool, i32]" { 0: 10, 1: struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(120), used: 1 }, 2: 1, 3: 20 };
-    __v0_1 = "wado-compiler/tests/fixtures/monomorphize_for_of_local_in_match_arm.wado/sum_in_match<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>"(t);
-    __cond_2 = __v0_1 == 131;
+    t = struct.new "tuple//[i32, core:prelude/string.wado/String, bool, i32]" { 0: 10, 1: struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(120), used: 1 }, 2: 1, 3: 20 };
+    __cond_2 = local.tee __v0_1("wado-compiler/tests/fixtures/monomorphize_for_of_local_in_match_arm.wado/sum_in_match<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>"(t)) == 131;
     if __cond_2 == 0 {
         "core:internal/panic"(__local_5 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(142), used: 0 }; "core:prelude/string.wado/String::push_str"(__local_5, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Assertion failed in "), used: 20 }); "core:prelude/string.wado/String::push_str"(__local_5, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("__test_0_per_iteration_local_typed_concretely_inside_match_arm_and_while_body"), used: 77 }); "core:prelude/string.wado/String::push"(__local_5, 32); "core:prelude/string.wado/String::push"(__local_5, 97); "core:prelude/string.wado/String::push"(__local_5, 116); "core:prelude/string.wado/String::push"(__local_5, 32); "core:prelude/string.wado/String::push_str"(__local_5, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("wado-compiler/tests/fixtures/monomorphize_for_of_local_in_match_arm.wado"), used: 72 }); "core:prelude/string.wado/String::push"(__local_5, 58); __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_5 }; f_12 = __local_6; "core:prelude/primitive.wado/i32::fmt_decimal"(44, f_12); "core:prelude/string.wado/String::push_str"(__local_5, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("
 condition: sum_in_match(t) == 131
 "), used: 35 }); "core:prelude/string.wado/String::push_str"(__local_5, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("sum_in_match(t): "), used: 17 }); __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_5 }; f_17 = __local_6; "core:prelude/primitive.wado/i32::fmt_decimal"(__v0_1, f_17); "core:prelude/string.wado/String::push"(__local_5, 10); __local_5);
         unreachable;
     }
-    __v0_3 = "wado-compiler/tests/fixtures/monomorphize_for_of_local_in_match_arm.wado/sum_in_while<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>"(t);
-    __cond_4 = __v0_3 == 131;
+    __cond_4 = local.tee __v0_3("wado-compiler/tests/fixtures/monomorphize_for_of_local_in_match_arm.wado/sum_in_while<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>"(t)) == 131;
     if __cond_4 == 0 {
         "core:internal/panic"(__local_7 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(142), used: 0 }; "core:prelude/string.wado/String::push_str"(__local_7, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Assertion failed in "), used: 20 }); "core:prelude/string.wado/String::push_str"(__local_7, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("__test_0_per_iteration_local_typed_concretely_inside_match_arm_and_while_body"), used: 77 }); "core:prelude/string.wado/String::push"(__local_7, 32); "core:prelude/string.wado/String::push"(__local_7, 97); "core:prelude/string.wado/String::push"(__local_7, 116); "core:prelude/string.wado/String::push"(__local_7, 32); "core:prelude/string.wado/String::push_str"(__local_7, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("wado-compiler/tests/fixtures/monomorphize_for_of_local_in_match_arm.wado"), used: 72 }); "core:prelude/string.wado/String::push"(__local_7, 58); __local_8 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_7 }; f_23 = __local_8; "core:prelude/primitive.wado/i32::fmt_decimal"(45, f_23); "core:prelude/string.wado/String::push_str"(__local_7, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("
 condition: sum_in_while(t) == 131
@@ -206,12 +204,9 @@ fn "wado-compiler/tests/fixtures/monomorphize_for_of_local_in_match_arm.wado/sum
     let v_13: i32;
     acc = 0;
     v_6 = items.0;
-    acc = 0 + v_6;
-    acc = acc + 100;
-    acc = acc + 1;
+    acc = local.tee acc(local.tee acc(0 + v_6) + 100) + 1;
     v_13 = items.3;
-    acc = acc + v_13;
-    return acc;
+    return local.tee acc(acc + v_13);
 }
 
 fn "core:internal/gc_array_to_memory"(arr, ptr, len) {
@@ -289,8 +284,7 @@ fn "core:internal/cm_stream_write_raw_u8"(handle, data, len) {
     let ptr: i32;
     let raw_len: i32;
     let result: i32;
-    packed = "core:internal/cm_lower_list_u8"(data, len);
-    ptr = builtin::i32_wrap_i64(packed);
+    ptr = builtin::i32_wrap_i64(local.tee packed("core:internal/cm_lower_list_u8"(data, len)));
     raw_len = builtin::i32_wrap_i64(packed >> 32_i64);
     result = "wasi/stream-write"(handle, ptr, raw_len);
     if result == -1 {
@@ -349,8 +343,7 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
     let offset: i32;
     let self_6: ref "core:prelude/string.wado//String";
     is_negative = self < 0;
-    abs_val = select i64(is_negative, 0_i64 - builtin::i64_extend_i32_s(self), builtin::i64_extend_i32_s(self));
-    digit_count = "core:prelude/primitive.wado/count_digits_i64"(abs_val);
+    digit_count = "core:prelude/primitive.wado/count_digits_i64"(local.tee abs_val(select i64(is_negative, 0_i64 - builtin::i64_extend_i32_s(self), builtin::i64_extend_i32_s(self))));
     offset = "core:prelude/format.wado/Formatter::prepare_int_write"(f, is_negative, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
     "core:prelude/primitive.wado/write_decimal_digits"(self_6 = f.buf; self_6.repr, offset, abs_val, digit_count);
 }
@@ -365,10 +358,7 @@ fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
     if min_capacity <= capacity {
         return;
     }
-    a_7 = capacity * 2;
-    a_5 = select i32(a_7 > min_capacity, a_7, min_capacity);
-    new_capacity = select i32(a_5 > 8, a_5, 8);
-    new_repr = builtin::array_new<u8>(new_capacity);
+    new_repr = builtin::array_new<u8>(local.tee new_capacity(a_7 = capacity * 2; a_5 = select i32(a_7 > min_capacity, a_7, min_capacity); select i32(a_5 > 8, a_5, 8)));
     builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }

--- a/wado-compiler/tests/generated/fixtures/monomorphize_generic_method_in_for_of.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/monomorphize_generic_method_in_for_of.wir.wado
@@ -20,7 +20,7 @@ struct core:prelude/format.wado//Formatter {  // TypeId(2)
     mut buf: ref "core:prelude/string.wado//String",
 }
 
-struct tuple//[i32, String, bool, i32] {  // TypeId(3)
+struct tuple//[i32, core:prelude/string.wado/String, bool, i32] {  // TypeId(3)
     mut 0: i32,
     mut 1: ref "core:prelude/string.wado//String",
     mut 2: bool,
@@ -49,15 +49,15 @@ type "functype//wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_
 
 type "functype//wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/__cm_export____test_0_generic_method_in_variadic_for_of_monomorphizes_in_every_position" = fn();  // TypeId(14)
 
-type "functype//wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_in_binary<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>" = fn(ref "tuple//[i32, String, bool, i32]") -> i32;  // TypeId(15)
+type "functype//wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_in_binary<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>" = fn(ref "tuple//[i32, core:prelude/string.wado/String, bool, i32]") -> i32;  // TypeId(15)
 
-type "functype//wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_in_match<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>" = fn(ref "tuple//[i32, String, bool, i32]") -> i32;  // TypeId(16)
+type "functype//wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_in_match<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>" = fn(ref "tuple//[i32, core:prelude/string.wado/String, bool, i32]") -> i32;  // TypeId(16)
 
-type "functype//wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_in_while<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>" = fn(ref "tuple//[i32, String, bool, i32]") -> i32;  // TypeId(17)
+type "functype//wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_in_while<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>" = fn(ref "tuple//[i32, core:prelude/string.wado/String, bool, i32]") -> i32;  // TypeId(17)
 
-type "functype//wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_in_if<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>" = fn(ref "tuple//[i32, String, bool, i32]") -> i32;  // TypeId(18)
+type "functype//wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_in_if<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>" = fn(ref "tuple//[i32, core:prelude/string.wado/String, bool, i32]") -> i32;  // TypeId(18)
 
-type "functype//wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_direct<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>" = fn(ref "tuple//[i32, String, bool, i32]") -> i32;  // TypeId(19)
+type "functype//wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_direct<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>" = fn(ref "tuple//[i32, core:prelude/string.wado/String, bool, i32]") -> i32;  // TypeId(19)
 
 type "functype//core:internal/gc_array_to_memory" = fn(ref Array<u8>, i32, i32);  // TypeId(20)
 
@@ -111,7 +111,7 @@ import fn wasi/stream-new from "wasi/stream-new";
 import fn wasi/future-drop-readable:transmission-cli from "wasi/future-drop-readable:transmission-cli";
 
 fn "wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/__test_0_generic_method_in_variadic_for_of_monomorphizes_in_every_position"() {
-    let t: ref "tuple//[i32, String, bool, i32]";
+    let t: ref "tuple//[i32, core:prelude/string.wado/String, bool, i32]";
     let __v0_1: i32;
     let __cond_2: bool;
     let __v0_3: i32;
@@ -142,41 +142,36 @@ fn "wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/__te
     let f_62: ref "core:prelude/format.wado//Formatter";
     let f_68: ref "core:prelude/format.wado//Formatter";
     let f_73: ref "core:prelude/format.wado//Formatter";
-    t = struct.new "tuple//[i32, String, bool, i32]" { 0: 10, 1: struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(120), used: 1 }, 2: 1, 3: 20 };
-    __v0_1 = "wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_direct<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>"(t);
-    __cond_2 = __v0_1 == 131;
+    t = struct.new "tuple//[i32, core:prelude/string.wado/String, bool, i32]" { 0: 10, 1: struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(120), used: 1 }, 2: 1, 3: 20 };
+    __cond_2 = local.tee __v0_1("wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_direct<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>"(t)) == 131;
     if __cond_2 == 0 {
         "core:internal/panic"(__local_11 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(138), used: 0 }; "core:prelude/string.wado/String::push_str"(__local_11, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Assertion failed in "), used: 20 }); "core:prelude/string.wado/String::push_str"(__local_11, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("__test_0_generic_method_in_variadic_for_of_monomorphizes_in_every_position"), used: 74 }); "core:prelude/string.wado/String::push"(__local_11, 32); "core:prelude/string.wado/String::push"(__local_11, 97); "core:prelude/string.wado/String::push"(__local_11, 116); "core:prelude/string.wado/String::push"(__local_11, 32); "core:prelude/string.wado/String::push_str"(__local_11, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado"), used: 71 }); "core:prelude/string.wado/String::push"(__local_11, 58); __local_12 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_11 }; f_24 = __local_12; "core:prelude/primitive.wado/i32::fmt_decimal"(64, f_24); "core:prelude/string.wado/String::push_str"(__local_11, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("
 condition: sum_direct(t) == 131
 "), used: 33 }); "core:prelude/string.wado/String::push_str"(__local_11, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("sum_direct(t): "), used: 15 }); __local_12 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_11 }; f_29 = __local_12; "core:prelude/primitive.wado/i32::fmt_decimal"(__v0_1, f_29); "core:prelude/string.wado/String::push"(__local_11, 10); __local_11);
         unreachable;
     }
-    __v0_3 = "wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_in_if<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>"(t);
-    __cond_4 = __v0_3 == 131;
+    __cond_4 = local.tee __v0_3("wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_in_if<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>"(t)) == 131;
     if __cond_4 == 0 {
         "core:internal/panic"(__local_13 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(136), used: 0 }; "core:prelude/string.wado/String::push_str"(__local_13, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Assertion failed in "), used: 20 }); "core:prelude/string.wado/String::push_str"(__local_13, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("__test_0_generic_method_in_variadic_for_of_monomorphizes_in_every_position"), used: 74 }); "core:prelude/string.wado/String::push"(__local_13, 32); "core:prelude/string.wado/String::push"(__local_13, 97); "core:prelude/string.wado/String::push"(__local_13, 116); "core:prelude/string.wado/String::push"(__local_13, 32); "core:prelude/string.wado/String::push_str"(__local_13, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado"), used: 71 }); "core:prelude/string.wado/String::push"(__local_13, 58); __local_14 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_13 }; f_35 = __local_14; "core:prelude/primitive.wado/i32::fmt_decimal"(65, f_35); "core:prelude/string.wado/String::push_str"(__local_13, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("
 condition: sum_in_if(t) == 131
 "), used: 32 }); "core:prelude/string.wado/String::push_str"(__local_13, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("sum_in_if(t): "), used: 14 }); __local_14 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_13 }; f_40 = __local_14; "core:prelude/primitive.wado/i32::fmt_decimal"(__v0_3, f_40); "core:prelude/string.wado/String::push"(__local_13, 10); __local_13);
         unreachable;
     }
-    __v0_5 = "wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_in_while<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>"(t);
-    __cond_6 = __v0_5 == 131;
+    __cond_6 = local.tee __v0_5("wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_in_while<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>"(t)) == 131;
     if __cond_6 == 0 {
         "core:internal/panic"(__local_15 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(142), used: 0 }; "core:prelude/string.wado/String::push_str"(__local_15, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Assertion failed in "), used: 20 }); "core:prelude/string.wado/String::push_str"(__local_15, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("__test_0_generic_method_in_variadic_for_of_monomorphizes_in_every_position"), used: 74 }); "core:prelude/string.wado/String::push"(__local_15, 32); "core:prelude/string.wado/String::push"(__local_15, 97); "core:prelude/string.wado/String::push"(__local_15, 116); "core:prelude/string.wado/String::push"(__local_15, 32); "core:prelude/string.wado/String::push_str"(__local_15, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado"), used: 71 }); "core:prelude/string.wado/String::push"(__local_15, 58); __local_16 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_15 }; f_46 = __local_16; "core:prelude/primitive.wado/i32::fmt_decimal"(66, f_46); "core:prelude/string.wado/String::push_str"(__local_15, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("
 condition: sum_in_while(t) == 131
 "), used: 35 }); "core:prelude/string.wado/String::push_str"(__local_15, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("sum_in_while(t): "), used: 17 }); __local_16 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_15 }; f_51 = __local_16; "core:prelude/primitive.wado/i32::fmt_decimal"(__v0_5, f_51); "core:prelude/string.wado/String::push"(__local_15, 10); __local_15);
         unreachable;
     }
-    __v0_7 = "wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_in_match<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>"(t);
-    __cond_8 = __v0_7 == 131;
+    __cond_8 = local.tee __v0_7("wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_in_match<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>"(t)) == 131;
     if __cond_8 == 0 {
         "core:internal/panic"(__local_17 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(142), used: 0 }; "core:prelude/string.wado/String::push_str"(__local_17, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Assertion failed in "), used: 20 }); "core:prelude/string.wado/String::push_str"(__local_17, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("__test_0_generic_method_in_variadic_for_of_monomorphizes_in_every_position"), used: 74 }); "core:prelude/string.wado/String::push"(__local_17, 32); "core:prelude/string.wado/String::push"(__local_17, 97); "core:prelude/string.wado/String::push"(__local_17, 116); "core:prelude/string.wado/String::push"(__local_17, 32); "core:prelude/string.wado/String::push_str"(__local_17, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado"), used: 71 }); "core:prelude/string.wado/String::push"(__local_17, 58); __local_18 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_17 }; f_57 = __local_18; "core:prelude/primitive.wado/i32::fmt_decimal"(67, f_57); "core:prelude/string.wado/String::push_str"(__local_17, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("
 condition: sum_in_match(t) == 131
 "), used: 35 }); "core:prelude/string.wado/String::push_str"(__local_17, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("sum_in_match(t): "), used: 17 }); __local_18 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_17 }; f_62 = __local_18; "core:prelude/primitive.wado/i32::fmt_decimal"(__v0_7, f_62); "core:prelude/string.wado/String::push"(__local_17, 10); __local_17);
         unreachable;
     }
-    __v0_9 = "wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_in_binary<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>"(t);
-    __cond_10 = __v0_9 == 131;
+    __cond_10 = local.tee __v0_9("wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_in_binary<core:prelude/types.wado/Tuple<i32,core:prelude/string.wado/String,bool,i32>>"(t)) == 131;
     if __cond_10 == 0 {
         "core:internal/panic"(__local_19 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(144), used: 0 }; "core:prelude/string.wado/String::push_str"(__local_19, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Assertion failed in "), used: 20 }); "core:prelude/string.wado/String::push_str"(__local_19, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("__test_0_generic_method_in_variadic_for_of_monomorphizes_in_every_position"), used: 74 }); "core:prelude/string.wado/String::push"(__local_19, 32); "core:prelude/string.wado/String::push"(__local_19, 97); "core:prelude/string.wado/String::push"(__local_19, 116); "core:prelude/string.wado/String::push"(__local_19, 32); "core:prelude/string.wado/String::push_str"(__local_19, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado"), used: 71 }); "core:prelude/string.wado/String::push"(__local_19, 58); __local_20 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_19 }; f_68 = __local_20; "core:prelude/primitive.wado/i32::fmt_decimal"(68, f_68); "core:prelude/string.wado/String::push_str"(__local_19, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("
 condition: sum_in_binary(t) == 131
@@ -210,11 +205,11 @@ fn "wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_
     let __sroa_acc_total: i32;
     __sroa_acc_total = 0;
     v_5 = items.0;
-    __sroa_acc_total = 0 + v_5;
-    __sroa_acc_total = __sroa_acc_total + 100;
-    __sroa_acc_total = __sroa_acc_total + 1;
+    drop(local.tee __sroa_acc_total(0 + v_5));
+    drop(local.tee __sroa_acc_total(__sroa_acc_total + 100));
+    drop(local.tee __sroa_acc_total(__sroa_acc_total + 1));
     v_10 = items.3;
-    __sroa_acc_total = __sroa_acc_total + v_10;
+    drop(local.tee __sroa_acc_total(__sroa_acc_total + v_10));
     return __sroa_acc_total;
 }
 
@@ -234,7 +229,7 @@ fn "wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_
             if once_3 == 0 {
                 break b5;
             }
-            __sroa_acc_total = __sroa_acc_total + v_5;
+            drop(local.tee __sroa_acc_total(__sroa_acc_total + v_5));
             once_3 = 0;
             continue l6;
         };
@@ -245,7 +240,7 @@ fn "wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_
             if once_7 == 0 {
                 break b8;
             }
-            __sroa_acc_total = __sroa_acc_total + 100;
+            drop(local.tee __sroa_acc_total(__sroa_acc_total + 100));
             once_7 = 0;
             continue l9;
         };
@@ -256,7 +251,7 @@ fn "wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_
             if once_9 == 0 {
                 break b11;
             }
-            __sroa_acc_total = __sroa_acc_total + 1;
+            drop(local.tee __sroa_acc_total(__sroa_acc_total + 1));
             once_9 = 0;
             continue l12;
         };
@@ -268,7 +263,7 @@ fn "wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_
             if once_11 == 0 {
                 break b14;
             }
-            __sroa_acc_total = __sroa_acc_total + v_10;
+            drop(local.tee __sroa_acc_total(__sroa_acc_total + v_10));
             once_11 = 0;
             continue l15;
         };
@@ -282,11 +277,11 @@ fn "wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_
     let __sroa_acc_total: i32;
     __sroa_acc_total = 0;
     v_4 = items.0;
-    __sroa_acc_total = 0 + v_4;
-    __sroa_acc_total = __sroa_acc_total + 100;
-    __sroa_acc_total = __sroa_acc_total + 1;
+    drop(local.tee __sroa_acc_total(0 + v_4));
+    drop(local.tee __sroa_acc_total(__sroa_acc_total + 100));
+    drop(local.tee __sroa_acc_total(__sroa_acc_total + 1));
     v_7 = items.3;
-    __sroa_acc_total = __sroa_acc_total + v_7;
+    drop(local.tee __sroa_acc_total(__sroa_acc_total + v_7));
     return __sroa_acc_total;
 }
 
@@ -296,11 +291,11 @@ fn "wado-compiler/tests/fixtures/monomorphize_generic_method_in_for_of.wado/sum_
     let __sroa_acc_total: i32;
     __sroa_acc_total = 0;
     v_4 = items.0;
-    __sroa_acc_total = 0 + v_4;
-    __sroa_acc_total = __sroa_acc_total + 100;
-    __sroa_acc_total = __sroa_acc_total + 1;
+    drop(local.tee __sroa_acc_total(0 + v_4));
+    drop(local.tee __sroa_acc_total(__sroa_acc_total + 100));
+    drop(local.tee __sroa_acc_total(__sroa_acc_total + 1));
     v_7 = items.3;
-    __sroa_acc_total = __sroa_acc_total + v_7;
+    drop(local.tee __sroa_acc_total(__sroa_acc_total + v_7));
     return __sroa_acc_total;
 }
 
@@ -379,8 +374,7 @@ fn "core:internal/cm_stream_write_raw_u8"(handle, data, len) {
     let ptr: i32;
     let raw_len: i32;
     let result: i32;
-    packed = "core:internal/cm_lower_list_u8"(data, len);
-    ptr = builtin::i32_wrap_i64(packed);
+    ptr = builtin::i32_wrap_i64(local.tee packed("core:internal/cm_lower_list_u8"(data, len)));
     raw_len = builtin::i32_wrap_i64(packed >> 32_i64);
     result = "wasi/stream-write"(handle, ptr, raw_len);
     if result == -1 {
@@ -439,8 +433,7 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
     let offset: i32;
     let self_6: ref "core:prelude/string.wado//String";
     is_negative = self < 0;
-    abs_val = select i64(is_negative, 0_i64 - builtin::i64_extend_i32_s(self), builtin::i64_extend_i32_s(self));
-    digit_count = "core:prelude/primitive.wado/count_digits_i64"(abs_val);
+    digit_count = "core:prelude/primitive.wado/count_digits_i64"(local.tee abs_val(select i64(is_negative, 0_i64 - builtin::i64_extend_i32_s(self), builtin::i64_extend_i32_s(self))));
     offset = "core:prelude/format.wado/Formatter::prepare_int_write"(f, is_negative, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
     "core:prelude/primitive.wado/write_decimal_digits"(self_6 = f.buf; self_6.repr, offset, abs_val, digit_count);
 }
@@ -455,10 +448,7 @@ fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
     if min_capacity <= capacity {
         return;
     }
-    a_7 = capacity * 2;
-    a_5 = select i32(a_7 > min_capacity, a_7, min_capacity);
-    new_capacity = select i32(a_5 > 8, a_5, 8);
-    new_repr = builtin::array_new<u8>(new_capacity);
+    new_repr = builtin::array_new<u8>(local.tee new_capacity(a_7 = capacity * 2; a_5 = select i32(a_7 > min_capacity, a_7, min_capacity); select i32(a_5 > 8, a_5, 8)));
     builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }

--- a/wado-compiler/tests/generated/fixtures/monomorphize_generic_reactive_local.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/monomorphize_generic_reactive_local.wir.wado
@@ -203,8 +203,7 @@ fn "core:internal/cm_stream_write_raw_u8"(handle, data, len) {
     let ptr: i32;
     let raw_len: i32;
     let result: i32;
-    packed = "core:internal/cm_lower_list_u8"(data, len);
-    ptr = builtin::i32_wrap_i64(packed);
+    ptr = builtin::i32_wrap_i64(local.tee packed("core:internal/cm_lower_list_u8"(data, len)));
     raw_len = builtin::i32_wrap_i64(packed >> 32_i64);
     result = "wasi/stream-write"(handle, ptr, raw_len);
     if result == -1 {
@@ -263,8 +262,7 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
     let offset: i32;
     let self_6: ref "core:prelude/string.wado//String";
     is_negative = self < 0;
-    abs_val = select i64(is_negative, 0_i64 - builtin::i64_extend_i32_s(self), builtin::i64_extend_i32_s(self));
-    digit_count = "core:prelude/primitive.wado/count_digits_i64"(abs_val);
+    digit_count = "core:prelude/primitive.wado/count_digits_i64"(local.tee abs_val(select i64(is_negative, 0_i64 - builtin::i64_extend_i32_s(self), builtin::i64_extend_i32_s(self))));
     offset = "core:prelude/format.wado/Formatter::prepare_int_write"(f, is_negative, struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 }, digit_count);
     "core:prelude/primitive.wado/write_decimal_digits"(self_6 = f.buf; self_6.repr, offset, abs_val, digit_count);
 }
@@ -279,10 +277,7 @@ fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
     if min_capacity <= capacity {
         return;
     }
-    a_7 = capacity * 2;
-    a_5 = select i32(a_7 > min_capacity, a_7, min_capacity);
-    new_capacity = select i32(a_5 > 8, a_5, 8);
-    new_repr = builtin::array_new<u8>(new_capacity);
+    new_repr = builtin::array_new<u8>(local.tee new_capacity(a_7 = capacity * 2; a_5 = select i32(a_7 > min_capacity, a_7, min_capacity); select i32(a_5 > 8, a_5, 8)));
     builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }

--- a/wado-lsp/AGENTS.md
+++ b/wado-lsp/AGENTS.md
@@ -16,7 +16,7 @@ Language service engine for the Wado compiler toolchain.
 | `src/uri.rs`                | Typed `Uri` + `UriScheme` for parsing `file:` / `core:` / `wasi:` / `kiln:` URIs once instead of inline string splitting  |
 | `src/text.rs`               | `PositionEncoding` and LSP `Position` ↔ compiler 1-based codepoint `(line, col)` conversion                               |
 | `src/diagnostics.rs`        | Compiler `Diagnostic` to LSP-compatible `Diagnostic` conversion (re-encodes spans in the negotiated position encoding)    |
-| `src/semantic_tokens.rs`    | Semantic token computation (lexer + AST classification). Re-encodes start/length at delta-encode time.                    |
+| `src/semantic_tokens.rs`    | Semantic token computation. Classifies identifiers by resolved `SymbolKind` from the `Semantics` snapshot, falling back to lexer + AST heuristics. Re-encodes start/length at delta-encode time. |
 | `src/definition.rs`         | Go-to-definition via `Cursor::{def_key, def_span}` and a file-path matcher for `use`/`#include` paths                     |
 | `src/hover.rs`              | Hover info; `Cursor::def_symbol` selects the binding, locals render from the AST node, items via `wado_compiler::unparse` |
 | `src/inlay_hints.rs`        | Inlay hints: inferred-type hints on `let` / closure / `for-of` bindings, plus parameter-name hints at call sites          |
@@ -66,9 +66,13 @@ only remaining hard failure: if a missing/broken import or a
 downstream phase bails, `build_semantics` (`src/lib.rs`) emits the
 failure diagnostic via the host and returns [`Semantics::empty`],
 and every position-bearing query returns `None` / `[]` for that
-snapshot. Semantic-token highlighting still works in that case
-because `semantic_tokens::compute` falls back to lexer-only
-classification. The recovery behaviour is pinned by
+snapshot. Semantic-token highlighting still works in that case:
+`Engine::semantic_tokens` passes `None` semantics to
+`semantic_tokens::compute`, which falls back to lexer + AST
+classification. When a snapshot *is* available, identifiers are
+classified by their resolved `SymbolKind` instead, with the same
+heuristic path as the per-token fallback for names the elaborator
+recorded no use→def edge for. The recovery behaviour is pinned by
 `tests/parse_error.rs`.
 
 ### Position encoding

--- a/wado-lsp/AGENTS.md
+++ b/wado-lsp/AGENTS.md
@@ -9,27 +9,27 @@ Language service engine for the Wado compiler toolchain.
 
 ## Architecture
 
-| File                        | Role                                                                                                                      |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `src/lib.rs`                | `Engine` struct: document state + per-document `Semantics` snapshot cache + query dispatch                                |
-| `src/host.rs`               | `FilesystemCompilerHost`: default `CompilerHost` for disk-backed source loading                                           |
-| `src/uri.rs`                | Typed `Uri` + `UriScheme` for parsing `file:` / `core:` / `wasi:` / `kiln:` URIs once instead of inline string splitting  |
-| `src/text.rs`               | `PositionEncoding` and LSP `Position` ↔ compiler 1-based codepoint `(line, col)` conversion                               |
-| `src/diagnostics.rs`        | Compiler `Diagnostic` to LSP-compatible `Diagnostic` conversion (re-encodes spans in the negotiated position encoding)    |
+| File                        | Role                                                                                                                                                                                             |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `src/lib.rs`                | `Engine` struct: document state + per-document `Semantics` snapshot cache + query dispatch                                                                                                       |
+| `src/host.rs`               | `FilesystemCompilerHost`: default `CompilerHost` for disk-backed source loading                                                                                                                  |
+| `src/uri.rs`                | Typed `Uri` + `UriScheme` for parsing `file:` / `core:` / `wasi:` / `kiln:` URIs once instead of inline string splitting                                                                         |
+| `src/text.rs`               | `PositionEncoding` and LSP `Position` ↔ compiler 1-based codepoint `(line, col)` conversion                                                                                                      |
+| `src/diagnostics.rs`        | Compiler `Diagnostic` to LSP-compatible `Diagnostic` conversion (re-encodes spans in the negotiated position encoding)                                                                           |
 | `src/semantic_tokens.rs`    | Semantic token computation. Classifies identifiers by resolved `SymbolKind` from the `Semantics` snapshot, falling back to lexer + AST heuristics. Re-encodes start/length at delta-encode time. |
-| `src/definition.rs`         | Go-to-definition via `Cursor::{def_key, def_span}` and a file-path matcher for `use`/`#include` paths                     |
-| `src/hover.rs`              | Hover info; `Cursor::def_symbol` selects the binding, locals render from the AST node, items via `wado_compiler::unparse` |
-| `src/inlay_hints.rs`        | Inlay hints: inferred-type hints on `let` / closure / `for-of` bindings, plus parameter-name hints at call sites          |
-| `src/references.rs`         | Find-references via `Cursor::references_to_def`                                                                           |
-| `src/document_highlight.rs` | Document highlight; Read/Write classification consults `Semantics::is_write_target`                                       |
-| `src/location.rs`           | URI / span helpers for translating compiler `ModuleSource` to LSP URIs                                                    |
-| `src/query.rs`              | `QueryContext`: per-query bundle (`&Semantics` + source + URI + encoding) consumed by every position-bearing feature      |
-| `src/server.rs`             | `run_stdio()`: blocking stdin/stdout loop feeding the async dispatcher                                                    |
-| `src/server/transport.rs`   | Content-Length framing + typed JSON-RPC send/receive helpers                                                              |
-| `src/server/dispatch.rs`    | LSP method routing, position-encoding negotiation, and server-lifecycle enforcement                                       |
-| `src/server/rpc.rs`         | LSP wire types (params, capabilities, notifications)                                                                      |
-| `src/bin/wado-lsp.rs`       | Binary entrypoint; drives `run_stdio()` via `futures::executor::block_on`                                                 |
-| `src/test_support.rs`       | Shared in-memory `MapHost` for unit + integration tests (`#[doc(hidden)] pub`); replaces per-file `TestHost` duplication  |
+| `src/definition.rs`         | Go-to-definition via `Cursor::{def_key, def_span}` and a file-path matcher for `use`/`#include` paths                                                                                            |
+| `src/hover.rs`              | Hover info; `Cursor::def_symbol` selects the binding, locals render from the AST node, items via `wado_compiler::unparse`                                                                        |
+| `src/inlay_hints.rs`        | Inlay hints: inferred-type hints on `let` / closure / `for-of` bindings, plus parameter-name hints at call sites                                                                                 |
+| `src/references.rs`         | Find-references via `Cursor::references_to_def`                                                                                                                                                  |
+| `src/document_highlight.rs` | Document highlight; Read/Write classification consults `Semantics::is_write_target`                                                                                                              |
+| `src/location.rs`           | URI / span helpers for translating compiler `ModuleSource` to LSP URIs                                                                                                                           |
+| `src/query.rs`              | `QueryContext`: per-query bundle (`&Semantics` + source + URI + encoding) consumed by every position-bearing feature                                                                             |
+| `src/server.rs`             | `run_stdio()`: blocking stdin/stdout loop feeding the async dispatcher                                                                                                                           |
+| `src/server/transport.rs`   | Content-Length framing + typed JSON-RPC send/receive helpers                                                                                                                                     |
+| `src/server/dispatch.rs`    | LSP method routing, position-encoding negotiation, and server-lifecycle enforcement                                                                                                              |
+| `src/server/rpc.rs`         | LSP wire types (params, capabilities, notifications)                                                                                                                                             |
+| `src/bin/wado-lsp.rs`       | Binary entrypoint; drives `run_stdio()` via `futures::executor::block_on`                                                                                                                        |
+| `src/test_support.rs`       | Shared in-memory `MapHost` for unit + integration tests (`#[doc(hidden)] pub`); replaces per-file `TestHost` duplication                                                                         |
 
 ### Engine
 
@@ -69,7 +69,7 @@ and every position-bearing query returns `None` / `[]` for that
 snapshot. Semantic-token highlighting still works in that case:
 `Engine::semantic_tokens` passes `None` semantics to
 `semantic_tokens::compute`, which falls back to lexer + AST
-classification. When a snapshot *is* available, identifiers are
+classification. When a snapshot _is_ available, identifiers are
 classified by their resolved `SymbolKind` instead, with the same
 heuristic path as the per-token fallback for names the elaborator
 recorded no use→def edge for. The recovery behaviour is pinned by

--- a/wado-lsp/src/lib.rs
+++ b/wado-lsp/src/lib.rs
@@ -328,13 +328,19 @@ impl Engine {
     /// Compute semantic tokens for the given document.
     ///
     /// Returns delta-encoded token data for LSP `textDocument/semanticTokens/full`.
-    /// This is a lightweight operation (lex + parse only, no compilation).
-    #[must_use]
-    pub fn semantic_tokens(&self, uri: &str) -> Vec<u32> {
+    /// Reuses the cached [`Semantics`] snapshot so identifiers are classified by
+    /// their resolved symbol kind. When the snapshot cannot be built (loader
+    /// failure), classification falls back to lexer/AST heuristics so
+    /// highlighting still appears — see [`semantic_tokens::compute`].
+    pub async fn semantic_tokens<H: CompilerHost>(&self, uri: &str, host: &H) -> Vec<u32> {
+        // Take the snapshot first (an owned `Rc`) so no borrow of `self` is
+        // held across the `.await`; then borrow the document text.
+        let snapshot = self.snapshot(uri, host).await;
         let Some(doc) = self.documents.get(uri) else {
             return Vec::new();
         };
-        let tokens = semantic_tokens::compute(&doc.text);
+        let sem = snapshot.as_ref().map(|s| &s.sem);
+        let tokens = semantic_tokens::compute(&doc.text, sem);
         semantic_tokens::delta_encode(&tokens, &doc.text, self.position_encoding)
     }
 

--- a/wado-lsp/src/semantic_tokens.rs
+++ b/wado-lsp/src/semantic_tokens.rs
@@ -1,11 +1,17 @@
-use indexmap::IndexMap;
-use wado_compiler::ast::{self, Expr, Item, Stmt, Type};
+use indexmap::{IndexMap, IndexSet};
+use wado_compiler::ast::{self, AstId, Expr, Item, Stmt, Type};
 use wado_compiler::lexer::lex;
+use wado_compiler::semantics::Semantics;
+use wado_compiler::symbol::SymbolKind;
 use wado_compiler::token::{Token, TokenKind};
 
 use crate::text::{PositionEncoding, codepoints_to_code_units, line_without_terminator};
 
 /// LSP semantic token type indices (must match `TOKEN_TYPES` order).
+///
+/// Indices `0..=13` are append-only history: keep them stable so the legend
+/// stays comparable across versions. New kinds (`14..`) map Wado-specific
+/// declarations onto standard LSP scopes that ship in common themes.
 pub mod token_type {
     pub const NAMESPACE: u32 = 0;
     pub const TYPE: u32 = 1;
@@ -21,6 +27,10 @@ pub mod token_type {
     pub const STRING: u32 = 11;
     pub const NUMBER: u32 = 12;
     pub const OPERATOR: u32 = 13;
+    pub const STRUCT: u32 = 14;
+    pub const ENUM: u32 = 15;
+    pub const INTERFACE: u32 = 16;
+    pub const CLASS: u32 = 17;
 }
 
 /// Token type legend for LSP capability declaration.
@@ -39,7 +49,18 @@ pub const TOKEN_TYPES: &[&str] = &[
     "string",
     "number",
     "operator",
+    "struct",
+    "enum",
+    "interface",
+    "class",
 ];
+
+/// LSP semantic token modifier bit positions (must match `TOKEN_MODIFIERS`).
+pub mod token_modifier {
+    pub const DECLARATION: u32 = 1 << 0;
+    pub const DEFINITION: u32 = 1 << 1;
+    pub const READONLY: u32 = 1 << 2;
+}
 
 /// Token modifier legend for LSP capability declaration.
 pub const TOKEN_MODIFIERS: &[&str] = &["declaration", "definition", "readonly"];
@@ -56,24 +77,35 @@ pub struct SemanticToken {
 
 /// Compute semantic tokens for a Wado source string.
 ///
+/// When `sem` is `Some`, identifiers are classified by their resolved symbol
+/// kind (variable / parameter / function / type / …) — accurate even where the
+/// lexer-and-AST heuristics would misclassify (e.g. a bare function reference
+/// with no trailing `(`). Tokens that do not resolve to a symbol, and every
+/// token when `sem` is `None` (loader failed, so no semantics), fall back to
+/// the heuristic classifier so highlighting degrades gracefully rather than
+/// disappearing.
+///
 /// The returned tokens carry `start_char` as a 0-based **codepoint** column
 /// (matching `Span::column - 1` from the lexer) and `length` as a codepoint
 /// count. [`delta_encode`] later converts both into the negotiated LSP
 /// position encoding.
-pub fn compute(source: &str) -> Vec<SemanticToken> {
+pub fn compute(source: &str, sem: Option<&Semantics>) -> Vec<SemanticToken> {
     // 1. Lex (resilient — always succeeds; malformed input simply yields
     // recovery tokens which classify_token treats as plain).
     let lex_result = lex(source);
     let tokens = lex_result.tokens;
     let comments = lex_result.comments;
 
-    // 2. Parse (best-effort — resilient, always produces an AST).
+    // 2. Parse (best-effort — resilient, always produces an AST). The AST
+    // drives the heuristic fallback (type-position spans) and the set of
+    // parameter-binding ids used to split `Variable` symbols into
+    // `parameter` vs `variable`.
     let ast_types = collect_type_spans(&wado_compiler::parse(source).ast);
 
     // 3. Classify lexer tokens
     let mut result = Vec::new();
     for i in 0..tokens.len() {
-        if let Some(st) = classify_token(source, &tokens, i, &ast_types) {
+        if let Some(st) = classify_token(source, &tokens, i, &ast_types, sem) {
             result.push(st);
         }
     }
@@ -177,6 +209,12 @@ pub fn delta_encode(
 struct TypeSpans {
     /// byte start → token type for identifiers that are types/params/etc.
     map: IndexMap<usize, u32>,
+    /// `AstId` of every function / closure parameter binding. A resolved
+    /// `Variable` symbol whose definition id is in this set is a parameter
+    /// (the symbol table records no parameter/local distinction, so it is
+    /// recovered structurally here). Declaration and use sites share the
+    /// binding's definition id, so one set covers both.
+    param_ids: IndexSet<AstId>,
 }
 
 impl TypeSpans {
@@ -187,9 +225,18 @@ impl TypeSpans {
     fn get(&self, start: usize) -> Option<u32> {
         self.map.get(&start).copied()
     }
+
+    fn mark_param(&mut self, id: AstId) {
+        self.param_ids.insert(id);
+    }
+
+    fn is_param(&self, id: AstId) -> bool {
+        self.param_ids.contains(&id)
+    }
 }
 
-/// Walk the AST and collect spans for type names, type parameters, etc.
+/// Walk the AST and collect spans for type names, type parameters, etc.,
+/// plus the id of every parameter binding (see [`TypeSpans::param_ids`]).
 fn collect_type_spans(module: &ast::Module) -> TypeSpans {
     let mut spans = TypeSpans::default();
     for item in &module.items {
@@ -269,6 +316,7 @@ fn visit_item(spans: &mut TypeSpans, item: &Item) {
 fn visit_function(spans: &mut TypeSpans, f: &ast::Function) {
     visit_generic_params(spans, &f.type_params);
     for param in &f.params {
+        spans.mark_param(param.id);
         visit_type(spans, &param.ty);
     }
     if let Some(ret) = &f.return_type {
@@ -483,6 +531,7 @@ fn visit_expr(spans: &mut TypeSpans, expr: &Expr) {
         Expr::Matches(m) => visit_expr(spans, &m.expr),
         Expr::Closure(c) => {
             for param in &c.params {
+                spans.mark_param(param.id);
                 if let Some(ty) = &param.ty {
                     visit_type(spans, ty);
                 }
@@ -535,6 +584,7 @@ fn classify_token(
     tokens: &[Token],
     index: usize,
     ast_types: &TypeSpans,
+    sem: Option<&Semantics>,
 ) -> Option<SemanticToken> {
     let token = &tokens[index];
     if token.kind == TokenKind::Eof {
@@ -562,8 +612,11 @@ fn classify_token(
         // Keywords
         k if k.as_keyword_str().is_some() => (token_type::KEYWORD, 0),
 
-        // Identifiers
-        TokenKind::Ident(_) => classify_ident(tokens, index, ast_types),
+        // Identifiers: prefer the resolved symbol kind when semantics are
+        // available, otherwise fall back to the lexer/AST heuristics.
+        TokenKind::Ident(_) => sem
+            .and_then(|sem| classify_ident_semantic(sem, ast_types, token))
+            .unwrap_or_else(|| classify_ident(tokens, index, ast_types)),
 
         // Literals
         TokenKind::NumberLit(_) => (token_type::NUMBER, 0),
@@ -617,6 +670,60 @@ fn classify_token(
         token_type,
         modifiers,
     })
+}
+
+/// Classify an identifier by its resolved symbol kind.
+///
+/// Resolves the token's position to a [`Cursor`](wado_compiler::Cursor) over
+/// the entry module and follows the use→def edge to the defining symbol.
+/// Returns `None` when the cursor lands on no recognised name (e.g. a field
+/// access, an unresolved method receiver, or any identifier the elaborator
+/// recorded no edge for) so the caller can fall back to the heuristics.
+fn classify_ident_semantic(
+    sem: &Semantics,
+    ast_types: &TypeSpans,
+    token: &Token,
+) -> Option<(u32, u32)> {
+    let entry = &sem.entry_module_source;
+    let cursor = sem.cursor_at(entry, token.span.line, token.span.column)?;
+    let def_key = cursor.def_key()?;
+    let symbol = sem.symbol_at(&def_key)?;
+
+    let mut modifiers = 0;
+    let token_type = match &symbol.kind {
+        SymbolKind::Function(_) => token_type::FUNCTION,
+        SymbolKind::Struct(_) => token_type::STRUCT,
+        SymbolKind::Enum(_) | SymbolKind::Flags(_) | SymbolKind::Variant(_) => token_type::ENUM,
+        SymbolKind::Effect(_) | SymbolKind::Trait(_) => token_type::INTERFACE,
+        SymbolKind::Resource(_) => token_type::CLASS,
+        SymbolKind::Newtype(_) | SymbolKind::BuiltinType | SymbolKind::World(_) => token_type::TYPE,
+        SymbolKind::Variable(v) => {
+            if !v.is_mut {
+                modifiers |= token_modifier::READONLY;
+            }
+            // Parameters live in the entry module (the cursor resolves there),
+            // so a same-module id in the parameter set distinguishes them from
+            // ordinary locals.
+            if def_key.module == *entry && ast_types.is_param(def_key.ast_id) {
+                token_type::PARAMETER
+            } else {
+                token_type::VARIABLE
+            }
+        }
+        SymbolKind::Global(g) => {
+            if !g.is_mut {
+                modifiers |= token_modifier::READONLY;
+            }
+            token_type::VARIABLE
+        }
+    };
+
+    // No use→def edge means the cursor sits on the binding's own declaration.
+    if def_key == *cursor.key() {
+        modifiers |= token_modifier::DECLARATION | token_modifier::DEFINITION;
+    }
+
+    Some((token_type, modifiers))
 }
 
 /// Classify an identifier using AST type spans + lexer context heuristics.
@@ -690,15 +797,22 @@ fn next_is(tokens: &[Token], index: usize, kind: &TokenKind) -> bool {
 mod tests {
     use super::*;
 
+    /// Build a `Semantics` snapshot for `source` so the semantic
+    /// classification path can be exercised in unit tests.
+    fn sem_of(source: &str) -> Semantics {
+        let host = crate::test_support::MapHost::single("/test.wado", source);
+        futures::executor::block_on(wado_compiler::semantics(source, &host, Some("/test.wado")))
+    }
+
     #[test]
     fn test_empty_source() {
-        let tokens = compute("");
+        let tokens = compute("", None);
         assert!(tokens.is_empty());
     }
 
     #[test]
     fn test_keyword_classification() {
-        let tokens = compute("fn foo() {}");
+        let tokens = compute("fn foo() {}", None);
         // `fn` should be keyword
         assert_eq!(tokens[0].token_type, token_type::KEYWORD);
         // `foo` should be function
@@ -707,11 +821,12 @@ mod tests {
 
     #[test]
     fn test_type_annotation() {
-        let tokens = compute("fn foo(x: i32) {}");
+        let tokens = compute("fn foo(x: i32) {}", None);
         // `i32` at char 10 should be TYPE (from AST NamedType span)
         let i32_token = tokens.iter().find(|t| t.start_char == 10).unwrap();
         assert_eq!(i32_token.token_type, token_type::TYPE);
-        // `x` at char 7 should be VARIABLE (parameter, but no separate param detection yet)
+        // `x` at char 7 should be VARIABLE under the heuristic path (no
+        // separate parameter detection without semantics).
         let x_token = tokens.iter().find(|t| t.start_char == 7).unwrap();
         assert!(
             x_token.token_type == token_type::VARIABLE
@@ -721,9 +836,92 @@ mod tests {
 
     #[test]
     fn test_string_literal() {
-        let tokens = compute("let s = \"hello\";");
+        let tokens = compute("let s = \"hello\";", None);
         let string_token = tokens.iter().find(|t| t.token_type == token_type::STRING);
         assert!(string_token.is_some());
+    }
+
+    #[test]
+    fn semantic_parameter_classification() {
+        // With semantics, both the declaration and the use site of a
+        // parameter resolve to PARAMETER — the heuristic path cannot tell a
+        // parameter use from any other variable.
+        let src = "fn foo(x: i32) -> i32 { return x; }";
+        let sem = sem_of(src);
+        let tokens = compute(src, Some(&sem));
+
+        // `x` parameter declaration at char 7.
+        let decl = tokens.iter().find(|t| t.start_char == 7).unwrap();
+        assert_eq!(decl.token_type, token_type::PARAMETER);
+        assert_ne!(decl.modifiers & token_modifier::DECLARATION, 0);
+        assert_ne!(decl.modifiers & token_modifier::READONLY, 0);
+
+        // `x` use site inside `return x` — not a declaration.
+        let use_site = tokens
+            .iter()
+            .find(|t| t.token_type == token_type::PARAMETER && t.start_char != 7)
+            .unwrap();
+        assert_eq!(use_site.modifiers & token_modifier::DECLARATION, 0);
+    }
+
+    #[test]
+    fn semantic_function_reference_without_call() {
+        // A bare function reference (no trailing `(`) is the canonical case
+        // the heuristic gets wrong — it would classify `g` as a variable.
+        let src = "fn g() {}\nfn f() { let h = g; }";
+        let sem = sem_of(src);
+        let tokens = compute(src, Some(&sem));
+
+        // `g` on the second line, used as a value (line 1, after `= `).
+        let g_ref = tokens
+            .iter()
+            .find(|t| t.line == 1 && t.token_type == token_type::FUNCTION && t.start_char > 10)
+            .unwrap();
+        assert_eq!(g_ref.token_type, token_type::FUNCTION);
+    }
+
+    #[test]
+    fn semantic_local_is_readonly_unless_mut() {
+        let src = "fn f() { let a = 1; let mut b = 2; }";
+        let sem = sem_of(src);
+        let tokens = compute(src, Some(&sem));
+
+        // `a` is an immutable local → VARIABLE + readonly + declaration.
+        let a = tokens.iter().find(|t| t.start_char == 13).unwrap();
+        assert_eq!(a.token_type, token_type::VARIABLE);
+        assert_ne!(a.modifiers & token_modifier::READONLY, 0);
+        assert_ne!(a.modifiers & token_modifier::DECLARATION, 0);
+
+        // `b` is `let mut` → not readonly.
+        let b = tokens
+            .iter()
+            .find(|t| t.token_type == token_type::VARIABLE && t.start_char > 25)
+            .unwrap();
+        assert_eq!(b.modifiers & token_modifier::READONLY, 0);
+    }
+
+    #[test]
+    fn semantic_struct_is_struct_kind() {
+        let src = "struct Point { x: i32 }\nfn f() { let p = Point { x: 1 }; }";
+        let sem = sem_of(src);
+        let tokens = compute(src, Some(&sem));
+
+        // `Point` in the struct literal on line 1 resolves to a struct symbol.
+        let point_use = tokens
+            .iter()
+            .find(|t| t.line == 1 && t.token_type == token_type::STRUCT)
+            .unwrap();
+        assert_eq!(point_use.token_type, token_type::STRUCT);
+    }
+
+    #[test]
+    fn falls_back_to_heuristics_without_semantics() {
+        // No semantics: a bare function reference degrades to VARIABLE rather
+        // than disappearing. This pins the graceful-degradation contract.
+        let src = "fn g() {}\nfn f() { let h = g; }";
+        let tokens = compute(src, None);
+        let g_ref = tokens.iter().find(|t| t.line == 1 && t.start_char > 10);
+        assert!(g_ref.is_some(), "identifier must still be classified");
     }
 
     #[test]
@@ -737,7 +935,7 @@ mod tests {
         // line tokens around it (`fn`, `f`, etc.) must still appear,
         // but no COMMENT token may be produced.
         let src = "fn f() {\n    /* multi\n    line */\n    let _ = 1;\n}\n";
-        let tokens = compute(src);
+        let tokens = compute(src, None);
         for tok in &tokens {
             // No token may span lines under any circumstances.
             assert_eq!(

--- a/wado-lsp/src/semantic_tokens.rs
+++ b/wado-lsp/src/semantic_tokens.rs
@@ -1,9 +1,9 @@
 use indexmap::{IndexMap, IndexSet};
 use wado_compiler::ast::{self, AstId, Expr, Item, Stmt, Type};
 use wado_compiler::lexer::lex;
+use wado_compiler::module_source::ModuleSource;
 use wado_compiler::semantics::Semantics;
-use wado_compiler::symbol::SymbolKind;
-use wado_compiler::syntax::OperatorCategory;
+use wado_compiler::symbol::{Symbol, SymbolKey, SymbolKind};
 use wado_compiler::token::{Token, TokenKind};
 
 use crate::text::{PositionEncoding, codepoints_to_code_units, line_without_terminator};
@@ -97,21 +97,32 @@ pub fn compute(source: &str, sem: Option<&Semantics>) -> Vec<SemanticToken> {
     let tokens = lex_result.tokens;
     let comments = lex_result.comments;
 
-    // 2. Parse (best-effort — resilient, always produces an AST). The AST
-    // drives the heuristic fallback (type-position spans) and the set of
-    // parameter-binding ids used to split `Variable` symbols into
-    // `parameter` vs `variable`.
-    let ast_types = collect_type_spans(&wado_compiler::parse(source).ast);
+    // 2. Obtain the AST that drives the heuristic fallback (type-position
+    // spans) and the parameter-id set. Reuse the snapshot's already-parsed
+    // entry module when available; only parse ourselves when there is no
+    // snapshot (loader failure), so the common path does not re-parse.
+    let snapshot_ast = sem.and_then(|s| s.modules.get(&s.entry_module_source));
+    let owned_parse = snapshot_ast.is_none().then(|| wado_compiler::parse(source));
+    let ast = snapshot_ast
+        .or_else(|| owned_parse.as_ref().map(|p| &p.ast))
+        .expect("snapshot AST or freshly parsed AST is present");
+    let ast_types = collect_type_spans(ast);
 
-    // 3. Classify lexer tokens
+    // 3. Precompute the resolved-symbol classification map (byte start →
+    // (token type, modifiers)) in one linear pass over the semantics. This
+    // makes per-token identifier classification an O(1) lookup instead of a
+    // positional AST search (`cursor_at`/`ast_id_at`) per token.
+    let sem_classes = sem.map(|s| build_semantic_classes(s, &ast_types));
+
+    // 4. Classify lexer tokens
     let mut result = Vec::new();
     for i in 0..tokens.len() {
-        if let Some(st) = classify_token(source, &tokens, i, &ast_types, sem) {
+        if let Some(st) = classify_token(source, &tokens, i, &ast_types, sem_classes.as_ref()) {
             result.push(st);
         }
     }
 
-    // 4. Add comments
+    // 5. Add comments
     //
     // LSP semantic tokens MUST NOT span lines. Block comments / doc
     // comments that cross a newline are skipped here — the editor's
@@ -137,7 +148,7 @@ pub fn compute(source: &str, sem: Option<&Semantics>) -> Vec<SemanticToken> {
         });
     }
 
-    // 5. Sort by position
+    // 6. Sort by position
     result.sort_by(|a, b| a.line.cmp(&b.line).then(a.start_char.cmp(&b.start_char)));
     result
 }
@@ -585,7 +596,7 @@ fn classify_token(
     tokens: &[Token],
     index: usize,
     ast_types: &TypeSpans,
-    sem: Option<&Semantics>,
+    sem_classes: Option<&IndexMap<usize, (u32, u32)>>,
 ) -> Option<SemanticToken> {
     let token = &tokens[index];
     if token.kind == TokenKind::Eof {
@@ -613,10 +624,11 @@ fn classify_token(
         // Keywords
         k if k.as_keyword_str().is_some() => (token_type::KEYWORD, 0),
 
-        // Identifiers: prefer the resolved symbol kind when semantics are
-        // available, otherwise fall back to the lexer/AST heuristics.
-        TokenKind::Ident(_) => sem
-            .and_then(|sem| classify_ident_semantic(sem, ast_types, token))
+        // Identifiers: prefer the resolved symbol classification (precomputed
+        // in `sem_classes`, keyed by byte start) when available, otherwise
+        // fall back to the lexer/AST heuristics.
+        TokenKind::Ident(_) => sem_classes
+            .and_then(|classes| classes.get(&token.span.start).copied())
             .unwrap_or_else(|| classify_ident(tokens, index, ast_types)),
 
         // Literals
@@ -625,8 +637,9 @@ fn classify_token(
             (token_type::STRING, 0)
         }
 
-        // Operators (the highlightable subset; see `is_operator`).
-        k if is_operator(k) => (token_type::OPERATOR, 0),
+        // Operators (the highlightable subset; the registry's
+        // `is_highlight_operator` flag excludes punctuation-like tokens).
+        k if k.is_highlight_operator() => (token_type::OPERATOR, 0),
 
         // Punctuation — skip (don't emit semantic tokens for brackets, commas, etc.)
         _ => return None,
@@ -641,48 +654,59 @@ fn classify_token(
     })
 }
 
-/// Whether a token should be highlighted as an operator semantic token.
+/// Build the `byte start → (token type, modifiers)` classification map for
+/// every identifier the semantics can resolve, in one linear pass.
 ///
-/// Derived from the shared [`OperatorCategory`] registry rather than a
-/// hand-maintained list, but narrower than "every operator": `&` / `|`
-/// (also reference and union/closure punctuation) and the path/range/try
-/// punctuation in the `Other` category (`::`, `?`, `..`, `...`) are skipped,
-/// since colouring them as operators tends to look wrong. Arrows and bounded
-/// ranges (`->`, `=>`, `..<`, `..=`) are kept.
-fn is_operator(kind: &TokenKind) -> bool {
-    match kind.operator_category() {
-        Some(
-            OperatorCategory::Comparison
-            | OperatorCategory::Logical
-            | OperatorCategory::Arithmetic
-            | OperatorCategory::Assignment,
-        ) => true,
-        Some(OperatorCategory::Bitwise) => !matches!(kind, TokenKind::Ampersand | TokenKind::Pipe),
-        Some(OperatorCategory::Other) => matches!(
-            kind,
-            TokenKind::Arrow | TokenKind::FatArrow | TokenKind::DotDotLt | TokenKind::DotDotEq
-        ),
-        None => false,
+/// Declarations come from [`Semantics::iter_symbols`] (tagged
+/// `declaration`/`definition`); use sites come from
+/// [`Semantics::iter_references`] (classified by the symbol they point at).
+/// Both key on the byte start of the name span, which equals the lexer
+/// token's `span.start`, so [`classify_token`] resolves identifiers with a
+/// single map lookup. Tokens absent from the map (field access, unresolved
+/// method receivers, …) fall back to the heuristic classifier.
+fn build_semantic_classes(sem: &Semantics, ast_types: &TypeSpans) -> IndexMap<usize, (u32, u32)> {
+    let entry = &sem.entry_module_source;
+    let mut classes: IndexMap<usize, (u32, u32)> = IndexMap::default();
+
+    // Declaration sites: the binding's own name span.
+    for (key, symbol) in sem.iter_symbols() {
+        if key.module != *entry {
+            continue;
+        }
+        let Some(span) = sem.name_span_of(key) else {
+            continue;
+        };
+        let (token_type, mut modifiers) = classify_symbol(symbol, key, ast_types, entry);
+        modifiers |= token_modifier::DECLARATION | token_modifier::DEFINITION;
+        classes.insert(span.start, (token_type, modifiers));
     }
+
+    // Use sites: every recorded use→def edge, classified by the def symbol.
+    for (use_key, def_key) in sem.iter_references() {
+        if use_key.module != *entry {
+            continue;
+        }
+        let (Some(symbol), Some(span)) = (sem.symbol_at(def_key), sem.span_of_key(use_key)) else {
+            continue;
+        };
+        classes.insert(
+            span.start,
+            classify_symbol(symbol, def_key, ast_types, entry),
+        );
+    }
+
+    classes
 }
 
-/// Classify an identifier by its resolved symbol kind.
-///
-/// Resolves the token's position to a [`Cursor`](wado_compiler::Cursor) over
-/// the entry module and follows the use→def edge to the defining symbol.
-/// Returns `None` when the cursor lands on no recognised name (e.g. a field
-/// access, an unresolved method receiver, or any identifier the elaborator
-/// recorded no edge for) so the caller can fall back to the heuristics.
-fn classify_ident_semantic(
-    sem: &Semantics,
+/// Map a resolved symbol to its LSP token type and the modifiers implied by
+/// the symbol itself (e.g. `readonly` for an immutable binding). The
+/// `declaration` modifier is added by the caller for declaration sites.
+fn classify_symbol(
+    symbol: &Symbol,
+    def_key: &SymbolKey,
     ast_types: &TypeSpans,
-    token: &Token,
-) -> Option<(u32, u32)> {
-    let entry = &sem.entry_module_source;
-    let cursor = sem.cursor_at(entry, token.span.line, token.span.column)?;
-    let def_key = cursor.def_key()?;
-    let symbol = sem.symbol_at(&def_key)?;
-
+    entry: &ModuleSource,
+) -> (u32, u32) {
     let mut modifiers = 0;
     let token_type = match &symbol.kind {
         SymbolKind::Function(_) => token_type::FUNCTION,
@@ -695,9 +719,8 @@ fn classify_ident_semantic(
             if !v.is_mut {
                 modifiers |= token_modifier::READONLY;
             }
-            // Parameters live in the entry module (the cursor resolves there),
-            // so a same-module id in the parameter set distinguishes them from
-            // ordinary locals.
+            // The symbol table records no parameter/local distinction, so a
+            // same-module definition id in the parameter set marks parameters.
             if def_key.module == *entry && ast_types.is_param(def_key.ast_id) {
                 token_type::PARAMETER
             } else {
@@ -711,13 +734,7 @@ fn classify_ident_semantic(
             token_type::VARIABLE
         }
     };
-
-    // No use→def edge means the cursor sits on the binding's own declaration.
-    if def_key == *cursor.key() {
-        modifiers |= token_modifier::DECLARATION | token_modifier::DEFINITION;
-    }
-
-    Some((token_type, modifiers))
+    (token_type, modifiers)
 }
 
 /// Classify an identifier using AST type spans + lexer context heuristics.

--- a/wado-lsp/src/semantic_tokens.rs
+++ b/wado-lsp/src/semantic_tokens.rs
@@ -3,6 +3,7 @@ use wado_compiler::ast::{self, AstId, Expr, Item, Stmt, Type};
 use wado_compiler::lexer::lex;
 use wado_compiler::semantics::Semantics;
 use wado_compiler::symbol::SymbolKind;
+use wado_compiler::syntax::OperatorCategory;
 use wado_compiler::token::{Token, TokenKind};
 
 use crate::text::{PositionEncoding, codepoints_to_code_units, line_without_terminator};
@@ -624,40 +625,8 @@ fn classify_token(
             (token_type::STRING, 0)
         }
 
-        // Operators
-        TokenKind::Plus
-        | TokenKind::Minus
-        | TokenKind::Star
-        | TokenKind::Slash
-        | TokenKind::Percent
-        | TokenKind::EqEq
-        | TokenKind::NotEq
-        | TokenKind::Lt
-        | TokenKind::LtEq
-        | TokenKind::Gt
-        | TokenKind::GtEq
-        | TokenKind::And
-        | TokenKind::Or
-        | TokenKind::Not
-        | TokenKind::Caret
-        | TokenKind::Tilde
-        | TokenKind::LtLt
-        | TokenKind::GtGt
-        | TokenKind::Eq
-        | TokenKind::PlusEq
-        | TokenKind::MinusEq
-        | TokenKind::StarEq
-        | TokenKind::SlashEq
-        | TokenKind::PercentEq
-        | TokenKind::AmpEq
-        | TokenKind::PipeEq
-        | TokenKind::CaretEq
-        | TokenKind::ShlEq
-        | TokenKind::ShrEq
-        | TokenKind::Arrow
-        | TokenKind::FatArrow
-        | TokenKind::DotDotLt
-        | TokenKind::DotDotEq => (token_type::OPERATOR, 0),
+        // Operators (the highlightable subset; see `is_operator`).
+        k if is_operator(k) => (token_type::OPERATOR, 0),
 
         // Punctuation — skip (don't emit semantic tokens for brackets, commas, etc.)
         _ => return None,
@@ -670,6 +639,31 @@ fn classify_token(
         token_type,
         modifiers,
     })
+}
+
+/// Whether a token should be highlighted as an operator semantic token.
+///
+/// Derived from the shared [`OperatorCategory`] registry rather than a
+/// hand-maintained list, but narrower than "every operator": `&` / `|`
+/// (also reference and union/closure punctuation) and the path/range/try
+/// punctuation in the `Other` category (`::`, `?`, `..`, `...`) are skipped,
+/// since colouring them as operators tends to look wrong. Arrows and bounded
+/// ranges (`->`, `=>`, `..<`, `..=`) are kept.
+fn is_operator(kind: &TokenKind) -> bool {
+    match kind.operator_category() {
+        Some(
+            OperatorCategory::Comparison
+            | OperatorCategory::Logical
+            | OperatorCategory::Arithmetic
+            | OperatorCategory::Assignment,
+        ) => true,
+        Some(OperatorCategory::Bitwise) => !matches!(kind, TokenKind::Ampersand | TokenKind::Pipe),
+        Some(OperatorCategory::Other) => matches!(
+            kind,
+            TokenKind::Arrow | TokenKind::FatArrow | TokenKind::DotDotLt | TokenKind::DotDotEq
+        ),
+        None => false,
+    }
 }
 
 /// Classify an identifier by its resolved symbol kind.

--- a/wado-lsp/src/server/dispatch.rs
+++ b/wado-lsp/src/server/dispatch.rs
@@ -197,8 +197,9 @@ pub async fn dispatch<W: Write>(
         "textDocument/semanticTokens/full" => {
             let engine = &*engine;
             transport::typed_request(writer, id, params, async |p: SemanticTokensParams| {
+                let host = transport::host_for_uri(&p.text_document.uri);
                 SemanticTokens {
-                    data: engine.semantic_tokens(&p.text_document.uri),
+                    data: engine.semantic_tokens(&p.text_document.uri, &host).await,
                 }
             })
             .await?;

--- a/wado-lsp/tests/parse_error.rs
+++ b/wado-lsp/tests/parse_error.rs
@@ -112,19 +112,20 @@ fn position_queries_resolve_in_healthy_regions() {
 /// Highlighting must keep working even with a syntax error present.
 #[test]
 fn semantic_tokens_survive_parse_error() {
-    let mut engine = Engine::new();
-    engine.open_document(&uri(), BROKEN_SOURCE.to_string());
-    let tokens = engine.semantic_tokens(&uri());
-    assert!(
-        !tokens.is_empty(),
-        "semantic_tokens should still produce lexer-based highlights",
-    );
-    // LSP delta-encoded form: every token is 5 u32s.
-    assert_eq!(
-        tokens.len() % 5,
-        0,
-        "semantic_tokens must be a multiple of 5 (deltaLine, deltaStart, length, type, mods)",
-    );
+    futures::executor::block_on(async {
+        let (engine, host) = engine_with_broken_source();
+        let tokens = engine.semantic_tokens(&uri(), &host).await;
+        assert!(
+            !tokens.is_empty(),
+            "semantic_tokens should still produce lexer-based highlights",
+        );
+        // LSP delta-encoded form: every token is 5 u32s.
+        assert_eq!(
+            tokens.len() % 5,
+            0,
+            "semantic_tokens must be a multiple of 5 (deltaLine, deltaStart, length, type, mods)",
+        );
+    });
 }
 
 /// A stray character is now a recovered *lexer* error, not a fatal one. The

--- a/wado-lsp/tests/semantic_tokens.rs
+++ b/wado-lsp/tests/semantic_tokens.rs
@@ -1,0 +1,127 @@
+//! Integration tests for `Engine::semantic_tokens` — the end-to-end
+//! highlighting path that classifies identifiers by their resolved symbol
+//! kind via the cached `Semantics` snapshot.
+//!
+//! These exercise the wire-facing entry point (delta-encoded `Vec<u32>`),
+//! decoding the 5-tuples back to absolute positions so classification can be
+//! asserted per token. The unit tests in `src/semantic_tokens.rs` cover the
+//! classifier internals; this file pins that the snapshot is actually
+//! threaded through `Engine`.
+
+use wado_lsp::Engine;
+use wado_lsp::semantic_tokens::{token_modifier, token_type};
+use wado_lsp::test_support::MapHost;
+
+/// One decoded semantic token at an absolute position.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Decoded {
+    line: u32,
+    start: u32,
+    length: u32,
+    token_type: u32,
+    modifiers: u32,
+}
+
+/// Decode the LSP delta-encoded `Vec<u32>` back to absolute positions.
+fn decode(data: &[u32]) -> Vec<Decoded> {
+    assert_eq!(data.len() % 5, 0, "data must be a multiple of 5");
+    let mut out = Vec::new();
+    let mut line = 0u32;
+    let mut start = 0u32;
+    for chunk in data.chunks_exact(5) {
+        let (delta_line, delta_start, length, token_type, modifiers) =
+            (chunk[0], chunk[1], chunk[2], chunk[3], chunk[4]);
+        if delta_line == 0 {
+            start += delta_start;
+        } else {
+            line += delta_line;
+            start = delta_start;
+        }
+        out.push(Decoded {
+            line,
+            start,
+            length,
+            token_type,
+            modifiers,
+        });
+    }
+    out
+}
+
+fn tokens_for(source: &str) -> Vec<Decoded> {
+    let path = "/test.wado";
+    let uri = format!("file://{path}");
+    let host = MapHost::single(path, source);
+    let mut engine = Engine::new();
+    engine.open_document(&uri, source.to_string());
+    let data = futures::executor::block_on(engine.semantic_tokens(&uri, &host));
+    decode(&data)
+}
+
+fn at(tokens: &[Decoded], line: u32, start: u32) -> &Decoded {
+    tokens
+        .iter()
+        .find(|t| t.line == line && t.start == start)
+        .unwrap_or_else(|| panic!("no token at {line}:{start} in {tokens:?}"))
+}
+
+#[test]
+fn classifies_by_resolved_symbol_kind() {
+    // `Point` is a struct; `area` is a function; `p` is a local; the field
+    // type `i32` is a type. The heuristic path cannot reach this accuracy.
+    let src = "\
+struct Point { x: i32, y: i32 }
+fn area(p: Point) -> i32 {
+    return p.x;
+}
+";
+    let tokens = tokens_for(src);
+
+    // `Point` declaration (line 0, col 7) → struct + declaration.
+    let point_decl = at(&tokens, 0, 7);
+    assert_eq!(point_decl.token_type, token_type::STRUCT);
+    assert_ne!(point_decl.modifiers & token_modifier::DECLARATION, 0);
+
+    // `Point` in the parameter type position (line 1, after `p: `) → struct.
+    let point_use = tokens
+        .iter()
+        .find(|t| t.line == 1 && t.token_type == token_type::STRUCT)
+        .expect("Point use in parameter type");
+    assert_eq!(point_use.token_type, token_type::STRUCT);
+
+    // `area` declaration → function + declaration.
+    let area = at(&tokens, 1, 3);
+    assert_eq!(area.token_type, token_type::FUNCTION);
+    assert_ne!(area.modifiers & token_modifier::DECLARATION, 0);
+
+    // `p` parameter (line 1, col 8) → parameter.
+    let p_param = at(&tokens, 1, 8);
+    assert_eq!(p_param.token_type, token_type::PARAMETER);
+
+    // `p` use in `return p.x` (line 2) → parameter (resolved, not variable).
+    let p_use = tokens
+        .iter()
+        .find(|t| t.line == 2 && t.token_type == token_type::PARAMETER)
+        .expect("p use site");
+    assert_eq!(p_use.token_type, token_type::PARAMETER);
+}
+
+#[test]
+fn enum_and_readonly_modifiers() {
+    let src = "\
+enum Color { Red, Green }
+fn f() {
+    let c = Color::Red;
+}
+";
+    let tokens = tokens_for(src);
+
+    // `Color` declaration → enum.
+    let color_decl = at(&tokens, 0, 5);
+    assert_eq!(color_decl.token_type, token_type::ENUM);
+
+    // `c` immutable local → variable + readonly.
+    let c = at(&tokens, 2, 8);
+    assert_eq!(c.token_type, token_type::VARIABLE);
+    assert_ne!(c.modifiers & token_modifier::READONLY, 0);
+}

--- a/wado-vscode/syntaxes/wado.tmLanguage.json
+++ b/wado-vscode/syntaxes/wado.tmLanguage.json
@@ -220,7 +220,7 @@
               "name": "keyword.control.other.wado"
             }
           },
-          "match": "\\b(use|from|import|test|as|with|in|of|assert)\\b",
+          "match": "\\b(use|from|import|as|with|in|of|assert|test)\\b",
           "name": "keyword.other.wado"
         },
         {


### PR DESCRIPTION
## Summary

Makes the wado-lsp semantic-token highlighter accurate by classifying identifiers from the compiler's resolved `SymbolKind` instead of lexer/AST heuristics, and unifies the keyword/operator definitions (previously hand-maintained in 4–5 places) into a single registry that the lexer, the token↔text mappings, the LSP highlighter, and the editor-grammar generator all derive from.

## What changed

### 1. Semantic tokens by resolved symbol kind (`wado-lsp`)
- Identifiers are classified by their resolved `SymbolKind` via the cached `Semantics` snapshot: functions, types (`struct`/`enum`/`flags`/`variant`/`trait`/`newtype`/`builtin`/`world`), effects/traits, and resources map onto standard LSP scopes (`struct`, `enum`, `interface`, `class`, added to the legend).
- `Variable` symbols split into `parameter` vs `variable`; token modifiers `declaration`/`definition` (declaration sites) and `readonly` (immutable bindings) are now emitted (previously declared in the legend but always `0`).
- Graceful degradation preserved: tokens with no use→def edge and every token when no snapshot exists (loader failure) fall back to the lexer/AST heuristics.
- `Engine::semantic_tokens` is now async + takes a `CompilerHost`, like the other position-bearing queries.

### 2. Single keyword/operator registry (`wado-compiler`)
- New `KEYWORDS` / `OPERATORS` tables in `syntax.rs` (two `macro_rules!`) are the single source of truth. They generate `TokenKind::from_keyword` (lexer), `as_keyword_str`, `operator_str` / `operator_category` / `is_highlight_operator`, and the categorized lists `SyntaxDefinition::wado` feeds to the grammar generator.
- The LSP's hand-written operator `match` is replaced by the registry's `is_highlight_operator` flag, so the highlight set cannot drift from the operator categories.
- Drift-prone sync tests replaced by round-trip tests that lex each registry entry and check it maps back to the listed token/category. Regenerated grammar diff is one functionally-identical line (`test` reordered in an alternation).

### 3. Performance follow-ups
- Per-identifier classification dropped from O(N·M) to O(N+M): `compute` precomputes a `byte-offset → (token type, modifiers)` map once (declarations from the new `Semantics::iter_symbols`, use sites from `iter_references`) instead of calling `cursor_at`→`ast_id_at` (a linear span scan) per token.
- `compute` reuses the snapshot's already-parsed entry `Module` instead of re-parsing the source.

## Testing
- New unit + integration tests for semantic-token classification (`wado-lsp/tests/semantic_tokens.rs`), registry round-trip tests, and a pinned highlight-operator set.
- `wado-compiler` lib (626), full `wado-lsp` suite, and `wado-cli` LSP/grammar tests pass; clippy clean; formatted.

## Notes
- Also fixes a pre-existing clippy `disallowed_types` failure in `codegen.rs` (std `HashMap` → `IndexMap`).
- Out of scope (follow-up): having the compiler expose "is parameter" on the symbol so the LSP need not recover it via an AST walk.

https://claude.ai/code/session_01J42UKJRMRq2RdaBEZz3EZ8

---
_Generated by [Claude Code](https://claude.ai/code/session_01J42UKJRMRq2RdaBEZz3EZ8)_