### PR TITLE
Remove legacy `builtin::array` type spelling in favor of `Array<T>`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ For the detailed specification, read `docs/spec.md`.
 Unlike Rust:
 
 - No lifetimes. No borrow checker. No ownership. Just GC.
-- Value semantics: every value is deeply copied when assigned or passed to a function, except for references and `builtin::array<T>` (an internal type, not user-facing).
+- Value semantics: every value is deeply copied when assigned or passed to a function, except for references. Even the raw fixed-length GC array `Array<T>` is a value type (deep-copied), so `&` is the only thing with reference semantics.
 - Wado splits Rust's `enum` into `variant` for sum types with payloads and `enum` for plain discriminants (no payload). Bitmask types use `flags`.
 - No macros.
 - No `unsafe`. No raw pointers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ For the detailed specification, read `docs/spec.md`.
 Unlike Rust:
 
 - No lifetimes. No borrow checker. No ownership. Just GC.
-- Value semantics: every value is deeply copied when assigned or passed to a function, except for references. Even the raw fixed-length GC array `Array<T>` is a value type (deep-copied), so `&` is the only thing with reference semantics.
+- Value semantics: every value is deeply copied when assigned or passed to a function, except for references.
 - Wado splits Rust's `enum` into `variant` for sum types with payloads and `enum` for plain discriminants (no payload). Bitmask types use `flags`.
 - No macros.
 - No `unsafe`. No raw pointers.

--- a/benchmark/json_catalog/json_catalog_v2.wado
+++ b/benchmark/json_catalog/json_catalog_v2.wado
@@ -68,7 +68,7 @@ struct CitmCatalog {
 
 struct P {
     input: String,
-    repr: builtin::array<u8>,
+    repr: Array<u8>,
     pos: i32,
     len: i32,
 }

--- a/benchmark/json_catalog/json_catalog_v3.wado
+++ b/benchmark/json_catalog/json_catalog_v3.wado
@@ -273,7 +273,7 @@ fn read_file(path: String) -> String with Preopens {
 struct Cursor {
     tape: List<u64>,
     input: String,
-    repr: builtin::array<u8>,
+    repr: Array<u8>,
     idx: i32,
 }
 

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -2595,7 +2595,7 @@ pub struct FormatSpec {
 pub enum Type {
     Named(NamedType),
     Generic(GenericType),
-    /// Namespaced generic type like `builtin::array<T>`
+    /// Namespaced generic type like `ns::Type<T>` or `T::Assoc`
     NamespacedGeneric(NamespacedGenericType),
     Function(Box<FunctionType>),
     Tuple(Vec<Type>),
@@ -2688,13 +2688,13 @@ pub struct GenericType {
     pub span: Span,
 }
 
-/// Namespaced generic type like `builtin::array<T>`
+/// Namespaced generic type like `ns::Type<T>` or `T::Assoc`
 #[derive(Debug, Clone)]
 pub struct NamespacedGenericType {
     pub id: AstId,
-    /// Namespace (e.g., "builtin")
+    /// Namespace (e.g., "json" for `json::Value`, or a type parameter `T`)
     pub namespace: String,
-    /// Type name (e.g., "array")
+    /// Type name (e.g., "Value")
     pub name: String,
     /// Generic arguments
     pub args: Vec<Type>,

--- a/wado-compiler/src/builtin_registry.rs
+++ b/wado-compiler/src/builtin_registry.rs
@@ -156,7 +156,7 @@ impl BuiltinRegistry {
 
     /// Resolve an AST Type to a `TypeId`
     ///
-    /// Handles primitive types, type parameters, and `builtin::array`<T>.
+    /// Handles primitive types, type parameters, and `Array<T>`.
     fn resolve_type(ty: &Type, type_params: &[String], type_table: &RefCell<TypeTable>) -> TypeId {
         match ty {
             Type::Named(named) => {
@@ -186,17 +186,6 @@ impl BuiltinRegistry {
                     "v128" => TypeTable::V128,
                     "!" => TypeTable::NEVER,
                     _ => TypeTable::UNIT, // Unknown type defaults to UNIT
-                }
-            }
-            Type::NamespacedGeneric(ng) if ng.namespace == "builtin" && ng.name == "array" => {
-                // builtin::array<T> -> BuiltinArray(T)
-                if let Some(first_arg) = ng.args.first() {
-                    let element_type = Self::resolve_type(first_arg, type_params, type_table);
-                    type_table
-                        .borrow_mut()
-                        .intern(ResolvedType::BuiltinArray(element_type))
-                } else {
-                    TypeTable::UNIT
                 }
             }
             // `Array<T>` is the user-facing spelling of the raw GC array

--- a/wado-compiler/src/codegen/emit.rs
+++ b/wado-compiler/src/codegen/emit.rs
@@ -2433,7 +2433,7 @@ impl<'a> WirEmitter<'a> {
                 // Allocate a fresh array the same length as `src` and copy
                 // every element with a JIT-compiled loop. This was the
                 // per-array-field code path inside the former
-                // `emit_value_copy` for raw `builtin::array<T>` fields and is
+                // `emit_value_copy` for raw `Array<T>` fields and is
                 // now reachable only via the synthesized `$value_copy$`
                 // helpers' explicit `builtin::array_clone::<T>(...)` calls.
                 //

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -2053,7 +2053,7 @@ impl CmInterfaceRegistry {
                     stores: func_ty.stores.clone(),
                 }))
             }
-            // NamespacedGeneric types (like builtin::array<T>) are passed through
+            // NamespacedGeneric types (like `ns::Type<T>`) are passed through
             Type::NamespacedGeneric(ng) => {
                 let resolved_args: Vec<Type> =
                     ng.args.iter().map(|arg| self.resolve_type(arg)).collect();

--- a/wado-compiler/src/elaborator/handlers.rs
+++ b/wado-compiler/src/elaborator/handlers.rs
@@ -494,7 +494,7 @@ fn describe_resolved_type_kind(ty: &ResolvedType) -> String {
         ResolvedType::Function { .. } => "function type".to_string(),
         ResolvedType::Ref(_) | ResolvedType::MutRef(_) => "nested reference type".to_string(),
         ResolvedType::Reactive(_) => "reactive type".to_string(),
-        ResolvedType::BuiltinArray(_) => "builtin array".to_string(),
+        ResolvedType::BuiltinArray(_) => "array".to_string(),
         ResolvedType::TypePack { .. } => "type pack".to_string(),
         ResolvedType::Unit => "unit".to_string(),
         ResolvedType::Never => "never".to_string(),

--- a/wado-compiler/src/elaborator/infer.rs
+++ b/wado-compiler/src/elaborator/infer.rs
@@ -157,7 +157,7 @@ pub(super) fn unify(
                 unify(type_table, expected_args[0], first_elem_type, bindings);
             }
         }
-        // Raw builtin array (`builtin::array<T>`).
+        // Raw builtin array (`Array<T>`).
         (ResolvedType::BuiltinArray(expected_elem), ResolvedType::BuiltinArray(actual_elem)) => {
             unify(type_table, *expected_elem, *actual_elem, bindings);
         }

--- a/wado-compiler/src/elaborator/orchestration.rs
+++ b/wado-compiler/src/elaborator/orchestration.rs
@@ -2875,19 +2875,6 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                 type_table.make_mut_ref(inner_type)
             }
             Type::NamespacedGeneric(namespaced) => {
-                // Handle builtin::array<T>
-                if namespaced.namespace == "builtin"
-                    && namespaced.name == "array"
-                    && let Some(elem_ty) = namespaced.args.first()
-                {
-                    let elem = Self::resolve_type_static_with_params(
-                        elem_ty,
-                        type_table,
-                        lookup,
-                        type_params,
-                    );
-                    return type_table.make_builtin_array(elem);
-                }
                 // Handle T::AssocType where T is a type parameter
                 if let Some(index) = type_params.iter().position(|p| p == &namespaced.namespace) {
                     let param_id =

--- a/wado-compiler/src/elaborator/type_resolution.rs
+++ b/wado-compiler/src/elaborator/type_resolution.rs
@@ -121,7 +121,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
     }
 
-    /// Resolve a namespaced generic type like `builtin::array<T>` or `Self::Output`
+    /// Resolve a namespaced generic type like `ns::Type<T>` or `Self::Output`
     pub(super) fn resolve_namespaced_generic_type(
         &mut self,
         namespaced: &crate::ast::NamespacedGenericType,
@@ -206,29 +206,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 );
         }
 
-        if namespaced.namespace.as_str() == "builtin" {
-            if namespaced.name.as_str() == "array" {
-                if namespaced.args.len() != 1 {
-                    let _ = self.logger.error(TypeError::ArgumentCountMismatch {
-                        expected: 1,
-                        found: namespaced.args.len(),
-                        span: namespaced.span,
-                    });
-                    return TypeTable::ERROR;
-                }
-                let element_type = self.resolve_type(&namespaced.args[0]);
-                self.tysys
-                    .type_table
-                    .borrow_mut()
-                    .make_builtin_array(element_type)
-            } else {
-                let _ = self.logger.error(TypeError::UnknownType {
-                    name: format!("builtin::{}", namespaced.name),
-                    span: namespaced.span,
-                });
-                TypeTable::ERROR
-            }
-        } else if self
+        if self
             .sem
             .imports
             .namespace_imports

--- a/wado-compiler/src/lower/plan/value_copy.rs
+++ b/wado-compiler/src/lower/plan/value_copy.rs
@@ -92,7 +92,7 @@ pub fn needs_value_copy(type_id: TypeId, type_table: &TypeTable) -> bool {
         // Its synthesized helper is `array_clone::<T>(&v)` (see
         // `synthesize::build_copy_body`), the same intrinsic that
         // deep-copies the `repr` field of `List<T>` / `String`. This
-        // is the only thing that makes `builtin::array` value-semantic
+        // is the only thing that makes `Array<T>` value-semantic
         // rather than reference-semantic (WEP-2026-06-02 Phase 2).
         ResolvedType::BuiltinArray(_) => true,
         // `&T` / `&mut T` are reference types: assignment copies the
@@ -101,7 +101,7 @@ pub fn needs_value_copy(type_id: TypeId, type_table: &TypeTable) -> bool {
         // value with the original, not duplicate it. Stdlib types
         // that need deep-copy semantics use `List<T>` / `String`
         // (which deep-copy via `array_clone` on their internal
-        // `builtin::array`), not `&mut T`.
+        // `Array<T>`), not `&mut T`.
         ResolvedType::Ref(_) | ResolvedType::MutRef(_) => false,
         // Variants and resources are reference-shaped at WIR level;
         // their copy body is identity (`return v;`).

--- a/wado-compiler/src/lower/plan/value_copy/synthesize.rs
+++ b/wado-compiler/src/lower/plan/value_copy/synthesize.rs
@@ -6,7 +6,7 @@
 //!
 //! For struct types the body is a `StructLiteral` with field-by-field
 //! shallow projections, plus `builtin::array_clone::<T>` for raw
-//! `builtin::array<T>` fields — a one-level shallow copy that does not
+//! `Array<T>` fields — a one-level shallow copy that does not
 //! recurse into nested aggregates. For variant / option / fall-through
 //! types the body is `return v;` (identity).
 //!
@@ -238,7 +238,7 @@ fn build_copy_body(
     extra_locals: &mut Vec<TirLocal>,
     address_taken: &mut IndexSet<u32>,
 ) -> TirBlock {
-    // A bare `builtin::array<T>` deep-copies via `array_clone::<T>(&v)`,
+    // A bare `Array<T>` deep-copies via `array_clone::<T>(&v)`,
     // the same intrinsic `make_field_copy` emits for the `repr` field of
     // `List<T>` / `String`. This is what gives the raw array value
     // semantics (WEP-2026-06-02 Phase 2).
@@ -745,7 +745,7 @@ fn wrap_copy_value(expr: TirExpr, type_id: TypeId, span: Span) -> TirExpr {
 }
 
 /// Build `builtin::array_clone::<elem_type>(&arr)`, the intrinsic that
-/// deep-copies a raw GC array. `array_ty` is the `builtin::array<elem_type>`
+/// deep-copies a raw GC array. `array_ty` is the `Array<elem_type>`
 /// type of `arr`; the call returns a fresh array of the same type. Codegen
 /// gives the clone a per-element `$value_copy$T` pass when `elem_type` is
 /// itself value-semantic (see `wir_build::calls::array_element_copy_func`).

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -1052,7 +1052,7 @@ pub enum TypeNameInfo {
         param_count: usize,
         return_type: String,
     },
-    /// `builtin::array<T>` (raw Wasm GC array, NOT the user-facing `List<T>` struct)
+    /// `Array<T>` (raw Wasm GC array, NOT the user-facing `List<T>` struct)
     BuiltinArray(String),
     /// Reactive<T> with inner type name
     Reactive(String),

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -433,7 +433,7 @@ pub enum ResolvedType {
         /// when I: `IntoIterator`<Item = u8> and `IntoIterator::Iter`: Iterator<Item = `Self::Item`>)
         assoc_type_bindings: Vec<(String, TypeId)>,
     },
-    /// Raw GC array intrinsic (`builtin::array<T>`)
+    /// Raw GC array intrinsic (`Array<T>`)
     /// This is the underlying storage type for String and List<T> structs
     BuiltinArray(TypeId),
     /// Newtype: a distinct type wrapping a base type with the same representation.
@@ -991,7 +991,7 @@ impl TypeTable {
         }
     }
 
-    /// Create a raw GC array type (`builtin::array<T>`)
+    /// Create a raw GC array type (`Array<T>`)
     pub fn make_builtin_array(&mut self, element: TypeId) -> TypeId {
         self.intern(ResolvedType::BuiltinArray(element))
     }

--- a/wado-compiler/src/wir.rs
+++ b/wado-compiler/src/wir.rs
@@ -1490,7 +1490,7 @@ pub enum WirInstr {
         value: Box<WirInstr>,
         len: Box<WirInstr>,
     },
-    /// Deep-copy a `builtin::array<T>`: allocates a new array the same
+    /// Deep-copy an `Array<T>`: allocates a new array the same
     /// length as `src` and copies every element. Emitted by codegen as the
     /// same JIT-compiled loop that previously lived inside `emit_value_copy`
     /// for raw array struct fields.

--- a/wado-compiler/src/wir_build/translate.rs
+++ b/wado-compiler/src/wir_build/translate.rs
@@ -1150,10 +1150,10 @@ impl FunctionTranslator<'_, '_> {
     /// Lower a `ExprKind::ArrayLiteral` to the `Array<T>` struct shape
     /// `struct.new List<T> { repr: array.new_fixed<T>(e0, …, eN-1), used: N }`.
     ///
-    /// `List<T>` is `{ repr: builtin::array<T>, used: i32 }` (see
+    /// `List<T>` is `{ repr: Array<T>, used: i32 }` (see
     /// `lib/core/prelude/list.wado`); this mirrors `translate_string_literal`,
     /// which builds the structurally identical `String { repr, used }`. The
-    /// raw `builtin::array<T>` type is read from the struct's `repr` field, so
+    /// raw `Array<T>` type is read from the struct's `repr` field, so
     /// no element-type bookkeeping is duplicated on the NIR node. The resulting
     /// `ArrayNewFixed` is what `wir_optimize::array::{promote_constant_arrays_to_data,
     /// split_large_array_literals}` already consume.
@@ -1168,7 +1168,7 @@ impl FunctionTranslator<'_, '_> {
                 "[WIR] ArrayLiteral expected Ref WirType for List<T> struct, got {wir_type:?} (type_id={array_type_id:?})"
             );
         };
-        // The `repr` field is a non-nullable ref to the raw `builtin::array<T>`.
+        // The `repr` field is a non-nullable ref to the raw `Array<T>`.
         let WirType::Ref {
             type_id: raw_array_type_id,
             ..

--- a/wado-compiler/tests/generated/fixtures/cross_module_trait_static_self.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/cross_module_trait_static_self.wir.wado
@@ -251,14 +251,14 @@ fn "core:prelude/primitive.wado/write_decimal_digits"(arr, offset, abs_val, digi
 }
 
 fn "./sub/cross_module_trait_static_self_lib.wado/Point^Eq::eq"(self, other) {
-    let __sroa_self_value_6: i32;
-    let __sroa_other_value_7: i32;
-    let __sroa_self_value_8: i32;
-    let __sroa_other_value_9: i32;
-    return (if __sroa_self_value_6 = self.x; __sroa_other_value_7 = other.x; __sroa_self_value_6 == __sroa_other_value_7 -> i32 {
-        __sroa_self_value_8 = self.y;
-        __sroa_other_value_9 = other.y;
-        __sroa_self_value_8 == __sroa_other_value_9;
+    let __sroa_other_value_6: i32;
+    let __sroa_self_value_7: i32;
+    let __sroa_other_value_8: i32;
+    let __sroa_self_value_9: i32;
+    return (if __sroa_self_value_9 = self.x; __sroa_other_value_8 = other.x; __sroa_self_value_9 == __sroa_other_value_8 -> i32 {
+        __sroa_self_value_7 = self.y;
+        __sroa_other_value_6 = other.y;
+        __sroa_self_value_7 == __sroa_other_value_6;
     } else {
         0;
     });
@@ -276,12 +276,12 @@ fn "./sub/cross_module_trait_static_self_lib.wado/Point^Inspect::inspect"(self, 
     "core:prelude/string.wado/String::push_str"(f.buf, s_3);
     s_5 = struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(120, 58, 32), used: 3 };
     "core:prelude/string.wado/String::push_str"(f.buf, s_5);
-    "core:prelude/primitive.wado/i32::fmt_decimal"(local.tee __sroa_self_value_20(self.x), f);
+    "core:prelude/primitive.wado/i32::fmt_decimal"(local.tee __sroa_self_value_21(self.x), f);
     s_11 = struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(44, 32), used: 2 };
     "core:prelude/string.wado/String::push_str"(f.buf, s_11);
     s_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(121, 58, 32), used: 3 };
     "core:prelude/string.wado/String::push_str"(f.buf, s_13);
-    "core:prelude/primitive.wado/i32::fmt_decimal"(local.tee __sroa_self_value_21(self.y), f);
+    "core:prelude/primitive.wado/i32::fmt_decimal"(local.tee __sroa_self_value_20(self.y), f);
     s_19 = struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(32, 125), used: 2 };
     "core:prelude/string.wado/String::push_str"(f.buf, s_19);
 }

--- a/wado-compiler/tests/generated/fixtures/same_name_struct_eq.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/same_name_struct_eq.wir.wado
@@ -281,14 +281,14 @@ fn "core:prelude/primitive.wado/write_decimal_digits"(arr, offset, abs_val, digi
 }
 
 fn "./sub/same_name_struct_eq_a.wado/Stamp^Eq::eq"(self, other) {
-    let __sroa_self_value_6: i64;
-    let __sroa_other_value_7: i64;
-    let __sroa_self_value_8: u32;
-    let __sroa_other_value_9: u32;
-    return (if __sroa_self_value_6 = self.seconds; __sroa_other_value_7 = other.seconds; __sroa_self_value_6 == __sroa_other_value_7 -> i32 {
-        __sroa_self_value_8 = self.nanoseconds;
-        __sroa_other_value_9 = other.nanoseconds;
-        __sroa_self_value_8 == __sroa_other_value_9;
+    let __sroa_other_value_6: u32;
+    let __sroa_self_value_7: u32;
+    let __sroa_other_value_8: i64;
+    let __sroa_self_value_9: i64;
+    return (if __sroa_self_value_9 = self.seconds; __sroa_other_value_8 = other.seconds; __sroa_self_value_9 == __sroa_other_value_8 -> i32 {
+        __sroa_self_value_7 = self.nanoseconds;
+        __sroa_other_value_6 = other.nanoseconds;
+        __sroa_self_value_7 == __sroa_other_value_6;
     } else {
         0;
     });
@@ -300,31 +300,31 @@ fn "./sub/same_name_struct_eq_a.wado/Stamp^Inspect::inspect"(self, f) {
     let s_11: ref "core:prelude/string.wado//String";
     let s_13: ref "core:prelude/string.wado//String";
     let s_19: ref "core:prelude/string.wado//String";
-    let __sroa_self_value_20: i64;
-    let __sroa_self_value_21: u32;
+    let __sroa_self_value_20: u32;
+    let __sroa_self_value_21: i64;
     s_3 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Stamp { "), used: 8 };
     "core:prelude/string.wado/String::push_str"(f.buf, s_3);
     s_5 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("seconds: "), used: 9 };
     "core:prelude/string.wado/String::push_str"(f.buf, s_5);
-    "core:prelude/primitive.wado/i64::fmt_decimal"(local.tee __sroa_self_value_20(self.seconds), f);
+    "core:prelude/primitive.wado/i64::fmt_decimal"(local.tee __sroa_self_value_21(self.seconds), f);
     s_11 = struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(44, 32), used: 2 };
     "core:prelude/string.wado/String::push_str"(f.buf, s_11);
     s_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("nanoseconds: "), used: 13 };
     "core:prelude/string.wado/String::push_str"(f.buf, s_13);
-    "core:prelude/primitive.wado/u32::fmt_decimal"(local.tee __sroa_self_value_21(self.nanoseconds), f);
+    "core:prelude/primitive.wado/u32::fmt_decimal"(local.tee __sroa_self_value_20(self.nanoseconds), f);
     s_19 = struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(32, 125), used: 2 };
     "core:prelude/string.wado/String::push_str"(f.buf, s_19);
 }
 
 fn "./sub/same_name_struct_eq_b.wado/Stamp^Eq::eq"(self, other) {
-    let __sroa_self_value_6: i64;
-    let __sroa_other_value_7: i64;
-    let __sroa_self_value_8: u32;
-    let __sroa_other_value_9: u32;
-    return (if __sroa_self_value_6 = self.seconds; __sroa_other_value_7 = other.seconds; __sroa_self_value_6 == __sroa_other_value_7 -> i32 {
-        __sroa_self_value_8 = self.nanoseconds;
-        __sroa_other_value_9 = other.nanoseconds;
-        __sroa_self_value_8 == __sroa_other_value_9;
+    let __sroa_other_value_6: u32;
+    let __sroa_self_value_7: u32;
+    let __sroa_other_value_8: i64;
+    let __sroa_self_value_9: i64;
+    return (if __sroa_self_value_9 = self.seconds; __sroa_other_value_8 = other.seconds; __sroa_self_value_9 == __sroa_other_value_8 -> i32 {
+        __sroa_self_value_7 = self.nanoseconds;
+        __sroa_other_value_6 = other.nanoseconds;
+        __sroa_self_value_7 == __sroa_other_value_6;
     } else {
         0;
     });
@@ -336,18 +336,18 @@ fn "./sub/same_name_struct_eq_b.wado/Stamp^Inspect::inspect"(self, f) {
     let s_11: ref "core:prelude/string.wado//String";
     let s_13: ref "core:prelude/string.wado//String";
     let s_19: ref "core:prelude/string.wado//String";
-    let __sroa_self_value_20: i64;
-    let __sroa_self_value_21: u32;
+    let __sroa_self_value_20: u32;
+    let __sroa_self_value_21: i64;
     s_3 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Stamp { "), used: 8 };
     "core:prelude/string.wado/String::push_str"(f.buf, s_3);
     s_5 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("seconds: "), used: 9 };
     "core:prelude/string.wado/String::push_str"(f.buf, s_5);
-    "core:prelude/primitive.wado/i64::fmt_decimal"(local.tee __sroa_self_value_20(self.seconds), f);
+    "core:prelude/primitive.wado/i64::fmt_decimal"(local.tee __sroa_self_value_21(self.seconds), f);
     s_11 = struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(44, 32), used: 2 };
     "core:prelude/string.wado/String::push_str"(f.buf, s_11);
     s_13 = struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("nanoseconds: "), used: 13 };
     "core:prelude/string.wado/String::push_str"(f.buf, s_13);
-    "core:prelude/primitive.wado/u32::fmt_decimal"(local.tee __sroa_self_value_21(self.nanoseconds), f);
+    "core:prelude/primitive.wado/u32::fmt_decimal"(local.tee __sroa_self_value_20(self.nanoseconds), f);
     s_19 = struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(32, 125), used: 2 };
     "core:prelude/string.wado/String::push_str"(f.buf, s_19);
 }


### PR DESCRIPTION
## Summary

The raw fixed-length GC array is now a first-class value type named `Array<T>` (`#[compiler_item("array")]`, see WEP-2026-06-02). That makes the old `builtin::array<T>` **type spelling** redundant legacy, so this PR removes it from `.wado` / `.rs` and leaves `Array<T>` as the only way to name the type.

Scope note: the `builtin::array_*` *intrinsic functions* (`array_new`, `array_get`, `array_set`, `array_copy`, `array_clone`, `array_fill`, …) are intentionally **kept** — they remain the lowering layer that emits the `array.*` instructions and back `Array<T>`'s methods, exactly as the WEP specifies. Only the legacy *type* spelling is gone.

## Changes

`.wado`
- `benchmark/json_catalog/json_catalog_v2.wado`, `json_catalog_v3.wado`: `repr: builtin::array<u8>` → `repr: Array<u8>`.

`.rs` — drop the type-spelling resolver special-cases so `builtin::array<T>` is no longer an accepted `NamespacedGeneric` type (writing it now yields an unknown-type error); `Array<T>` (the `Generic` spelling) is the only spelling:
- `elaborator/type_resolution.rs`, `elaborator/orchestration.rs`, `builtin_registry.rs`.

`.rs` — update doc-comments/labels that referred to the legacy *type* `builtin::array<T>` → `Array<T>` (`name.rs`, `wir_build/translate.rs`, `codegen/emit.rs`, `lower/plan/value_copy{,/synthesize}.rs`, `tir.rs`, `component_model.rs`, `wir.rs`, `ast.rs`, `infer.rs`, `handlers.rs`).

`docs` — `AGENTS.md` (`CLAUDE.md` symlink): the value-semantics note no longer carries `builtin::array<T>` as a user-facing-exception; references are the only thing with reference semantics.

The internal `ResolvedType::BuiltinArray` representation, and `NamespacedGeneric` itself (still used pervasively for `Self::Output` / `T::Item` projections and `ns::Type` aliases), are unchanged.

## Testing

- `cargo check` (wado-compiler, wado-cli) — clean.
- `mise run test` — all green, 0 failed.
- `mise run format` — clean.

https://claude.ai/code/session_018T3dDwLkdaMt9ZVe3vd7ij

---
_Generated by [Claude Code](https://claude.ai/code/session_018T3dDwLkdaMt9ZVe3vd7ij)_