### PR TITLE
perf(optimize): ValueGraph foundation + Stage 3/5 rule migrations

### DIFF
--- a/docs/wep-2026-06-05-worklist-rewrite-engine.md
+++ b/docs/wep-2026-06-05-worklist-rewrite-engine.md
@@ -141,17 +141,32 @@ pass is removed — the old and new paths co-exist during migration.
 - [x] Per-function dirty-set gate over the existing loop (Phase 6).
 - [x] Reduce per-session allocation (`EngineBuffers` pooling; `Engine::new`
       allocations cut, byte-identical).
-- [ ] Migrate the position-flexible structural rules into the shared session:
-      `ref_elim`, `elide_box_local`, `labeled_block_fusion`, `container_sroa`,
-      `sroa`, `value_copy_elide` / `value_copy_demote`, `tmpl_hoist`.
-- [ ] Add the engine-maintained value-numbering / reaching-def side-table;
-      migrate `copy_prop`, `store_load_forward`, `condition_implication`, and
-      the flow-sensitive half of `const_folding` into rules over it.
+- [x] Migrate the position-flexible structural rules to the engine:
+      `ref_elim`, `elide_box_local`, `value_copy_elide`,
+      `labeled_block_fusion` (all four fold into the shared post-inline
+      peephole session); `sroa`, `container_sroa` (per-function standalone
+      engine sessions whose `apply_block` fires once at the body root). The
+      driver of every migrated pass routes its mutations through the engine
+      edit API so the parent map and use index stay coherent — preparation
+      for the interprocedural worklist below.
+- [x] Migrate the flow-sensitive intra-procedural passes onto per-function
+      standalone engine sessions: `store_load_forward`, `copy_prop`, `cse`,
+      `licm`, `condition_implication`, `tmpl_hoist`. Each one fires once at
+      the body root and runs its whole-function analysis + rewrite in one
+      shot, with mutations through the engine edit API. The value-numbering
+      / reaching-def side-table is still pending — these rules carry their
+      own dataflow walkers in the meantime.
+- [ ] Add the engine-maintained value-numbering / reaching-def side-table so
+      `copy_prop` / `store_load_forward` / `condition_implication` / the
+      flow-sensitive half of `const_folding` (which still has its own driver
+      and calls into the `niri` CTFE interpreter for in-place mutations)
+      consult it instead of reconstructing their own per-function dataflow.
 - [ ] CSE / GVN over the same numbering (or Layer 2, only if measured
       necessary).
 - [ ] Replace the global fixed-point loop with the interprocedural call-graph
-      worklist driving `inline` / `dae` / `drve` / `sroa_param` plus targeted
-      re-combine; remove `OptConfig::iterations`.
+      worklist driving `inline` / `dae` / `drve` / `sroa_param` /
+      `value_copy_demote` (the surviving interprocedural passes) plus
+      targeted re-combine; remove `OptConfig::iterations`.
 - [ ] Keep terminal / once-only stages explicit pre- or post-combine, not loop
       members: `match_to_switch`, `select_lowering`, `multi_value_return`,
       `field_scalarize`, `const_object_globalization`, and `dce`.

--- a/docs/wep-2026-06-05-worklist-rewrite-engine.md
+++ b/docs/wep-2026-06-05-worklist-rewrite-engine.md
@@ -6,10 +6,14 @@ single worklist engine, with optimizations expressed as declarative rewrite
 rules under equality-saturation semantics, and a call-graph-driven
 interprocedural driver replacing the global fixed-point loop.
 
-The engine substrate, the arena NIR, and the routing of every
-intra-procedural pass through the engine edit API have landed. The
-pure-value layer, the saturation driver, and the interprocedural worklist
-are the open continuation specified here.
+The engine substrate, the arena NIR, the routing of every intra-procedural
+pass through the engine edit API, and the standalone ValueGraph
+foundation (kinds, hash-cons pool, per-function builder) have landed. The
+required-path rule migrations and interprocedural worklist remain. The
+full Layer-2 promotion (Skel pure-`ExprKind` retirement and saturation-
+driven engine) stays in this WEP as the terminal ideal but is gated
+behind measurement — see "Why Layer 2 promotion is deferred" and the
+"Optional acceleration" entries in the migration plan.
 
 ## Context
 
@@ -131,20 +135,29 @@ all reduce to one principle: same `ValueId` means same value. Two
 expressions sharing a `ValueId` need not both be computed; an operand
 reading the same `ValueId` as a known literal is itself that literal.
 
-### Saturation and extraction
+### Saturation and extraction (optional acceleration)
 
-The engine runs all rules together until either no new ValueIds are
-produced and no Skel rewrites fire, or a budget hits (node count budget,
-per-ValueId rewrite count, outer iteration limit — all three). After
-saturation, an extraction pass walks the SkelTree picking a cost-minimal
-Skel form for each `Operand::Value(...)`. A multi-use `ValueId` is
-materialised once with a hoisted `let __t = ...` only when the cost model
-favours sharing over duplication — that is the "real CSE" decision.
+The terminal architecture runs all rules together until either no new
+ValueIds are produced and no Skel rewrites fire, or a budget hits (node
+count budget, per-ValueId rewrite count, outer iteration limit — all
+three). After saturation, an extraction pass walks the SkelTree picking
+a cost-minimal Skel form for each `Operand::Value(...)`. A multi-use
+`ValueId` is materialised once with a hoisted `let __t = ...` only when
+the cost model favours sharing over duplication — that is the "real CSE"
+decision.
 
-The global fixed-point loop, `OptConfig::iterations`, per-rule
-`applied: Cell<bool>` guards, the `peephole.rs` rule-list module, and the
-per-pass dirty-set in `gate.rs` are all retired in favour of the
-saturation driver.
+Equality saturation is **optional acceleration**, not a required
+checkpoint. The required path runs the rules **destructively** as today
+— a rule that fires replaces the source node, the engine re-enqueues
+neighbours, and the global fixed-point loop converges (the existing
+`peephole.rs` / `gate.rs` model). The ValueGraph still buys
+hash-cons-based equality and reaching-def-by-construction in destructive
+mode; what only saturation unlocks is phase-ordering dissolution and
+algebraic exploration (e.g. re-association, distributive law,
+strength-reduction-per-use, cost-based share-vs-duplicate).
+
+Stage 8 below promotes the engine to saturation + extraction. It is
+deferred until measured wins justify the cost — see the rationale below.
 
 ## Why two-tier (not classical SSA)
 
@@ -163,12 +176,46 @@ saturation driver.
 Full SSA / sea-of-nodes stays rejected. So does building the ValueGraph
 without a SkelTree (it would lose the effect ordering Wasm codegen needs).
 
+## Why Layer 2 promotion (Stages 7 – 8) is deferred
+
+The ValueGraph as an _engine side-table_ (Stages 1 – 6) delivers
+hash-cons equality, reaching-def-by-construction, and analysis sharing.
+Promoting it into the SkelTree (Stage 7: `Operand::Value` replaces pure
+`ExprKind` variants) and switching the engine from destructive rewrites
+to equality saturation (Stage 8) unlocks only **algebraic exploration**
+on top of the side-table baseline: re-association, distributive law,
+strength-reduction-per-use, cost-based share-vs-duplicate. The required
+optimisations Wado actually carries (allocation elimination, structural
+cleanup, dense-`Match` lowering, bounds-check elimination, inlining)
+are all single-direction structural rewrites — saturation buys nothing
+for them.
+
+Wado's output target is **Wasm**, which a host runtime JITs again. Most
+of the algebraic improvements saturation excels at (re-association,
+strength reduction, De Morgan) are redone by the host JIT. Cranelift's
+aegraph reports 5 – 10 % improvement on native-AOT code; the
+corresponding number for JIT-target Wasm is much smaller because the
+host JIT re-does the algebraic part.
+
+So Stages 7 – 8 stay in the WEP as the terminal ideal — they describe
+the architecture this design points at — but they are not part of the
+required path. They activate when measurement justifies their cost
+(e.g., a future native-AOT backend lands, or Wasm output measurably
+benefits from algebraic exploration the JIT cannot do).
+
 ## Migration plan
 
-Each migrated rule must be byte-output-identical to the pass it replaces,
+The plan has two parts: the **required path** (Stages 1 – 6, 9) that
+delivers TODO② via engine-maintained side-tables and the
+interprocedural worklist, and an **optional acceleration** (Stages 7 – 8)
+that promotes the ValueGraph from a side-table into IR-level operands
+and replaces destructive rules with equality saturation.
+
+Each migrated rule must be byte-output-identical to the pass it replaces
 on the full fixture + E2E suite and on `package-gale`, before the
-predecessor is deleted. Stage 7 alters the NIR shape (pure
-`ExprKind` variants vanish) but the WIR output stays byte-identical.
+predecessor is deleted. If the optional acceleration ever activates,
+Stage 7 alters the NIR shape (pure `ExprKind` variants vanish) but the
+WIR output stays byte-identical.
 
 ### Completed substrate
 
@@ -184,41 +231,43 @@ predecessor is deleted. Stage 7 alters the NIR shape (pure
       `const_folding` (peephole session). Mutations all go through
       `Engine::*`; parent map and use index invariants are upheld.
 
-### Stage 1 — ValueGraph foundation
+### Required path
 
-- [ ] `ValueId`, `ValueKind`, `ValuePool` with hash-cons; the full
+#### Stage 1 — ValueGraph foundation
+
+- [x] `ValueId`, `ValueKind`, `ValuePool` with hash-cons; the full
       `ValueKind` set above (heap-version-bearing kinds may be stubbed
       until Stage 5). Standalone module, exhaustive unit tests, no engine
       integration. SkelTree unchanged.
 
-### Stage 2 — Per-function builder
+#### Stage 2 — Per-function builder
 
-- [ ] Walk the SkelTree assigning `ValueId` to every pure `ExprId`.
+- [x] Walk the SkelTree assigning `ValueId` to every pure `ExprId`.
       Maintain `current_value: HashMap<local_idx, ValueId>`; build
       `Select` at If / Match / Switch endpoints; emit `Opaque` for loop
       locals; seed parameters with `Opaque`.
-- [ ] Side table `value_of: IndexMap<ExprId, ValueId>` populated per
+- [x] Side table `value_of: IndexMap<ExprId, ValueId>` populated per
       function. Engine exposes `engine.value(expr) -> Option<ValueId>`;
       ValueGraph is built at session start. No incremental maintenance
       under edits at this stage — a rule that edits invalidates the
       table; rules either re-trigger the build or refrain from further
       queries.
 
-### Stage 3 — CSE migration
+#### Stage 3 — CSE migration
 
 - [ ] `CseRule` uses `engine.value(e1) == engine.value(e2)` for
       equality. The structural `CseKey` and its supporting walks are
       deleted after byte-identical confirmation. First end-to-end proof
       that Stage 1 + 2 are correctly wired.
 
-### Stage 4 — copy_prop migration
+#### Stage 4 — copy_prop migration
 
 - [ ] `let x = y` where `engine.value(y_def) == engine.value(let_value)`
       is a copy. Source-stability follows from ValueIds being equal
       across the target's scope. The independent block-writes precompute
       folds into ValueGraph maintenance.
 
-### Stage 5 — store_load_forward + heap-version activation
+#### Stage 5 — store_load_forward + heap-version activation
 
 - [ ] Activate the `FieldAccess` ValueKind with per-field heap versions.
       The builder bumps the appropriate field's version on each
@@ -228,11 +277,13 @@ predecessor is deleted. Stage 7 alters the NIR shape (pure
 - [ ] `store_load_forward`'s `KnownValues` walker collapses into a thin
       rule that consults `engine.value(local_read)` for a Literal kind.
 
-### Stage 6 — const_folding, condition_implication, licm
+#### Stage 6 — const_folding, condition_implication, licm
 
 - [ ] Env-free `const_folding` rewritten as algebraic rules over Value
       kinds (`Binary(Add, Int(a), Int(b)) → Int(a+b)`, `Binary(Add, ?x,
-      Int(0)) → ?x`, …).
+      Int(0)) → ?x`, …). Rules apply destructively against the
+      side-table; saturation is the optional Stage 8 driver, not a
+      prerequisite for this stage.
 - [ ] Env-bound `const_folding`: `niri.rs` refactored to stop mutating
       `Body` in place. `reduce_*_a` becomes a Value-returning pure
       function; the caller decides whether to commit via the engine.
@@ -248,7 +299,32 @@ predecessor is deleted. Stage 7 alters the NIR shape (pure
       bound-implication, and loop-invariant arithmetic detection. No
       cyclic Value graph at this stage.
 
-### Stage 7 — Skel pure-ExprKind retirement
+#### Stage 9 — Interprocedural worklist
+
+- [ ] Old per-pass walkers (stub-only after Stages 3 – 6) are deleted in
+      bulk.
+- [ ] `inline` / `dae` / `drve` / `sroa_param` / `value_copy_demote` move
+      to a call-graph worklist driver that re-runs the per-function
+      engine session for affected callers when a callee's signature or
+      body shrinks. `OptConfig::iterations` shrinks to the convergence
+      bound of the worklist, not a fixed-pass count.
+- [ ] Terminal / once-only stages stay explicit pre- or post-saturation,
+      not loop members: `multi_value_return`, `field_scalarize`,
+      `const_object_globalization`, `dce`.
+
+### Optional acceleration (measured-deferred)
+
+Stages 7 – 8 promote the ValueGraph from a side-table to an IR-level
+substrate and replace destructive rule application with equality
+saturation. They unlock algebraic exploration (re-association,
+distributive law, strength-reduction-per-use, cost-based
+share-vs-duplicate) that the required path cannot. The current Wado
+target — Wasm output JITted by the host — recovers most of those gains
+through the JIT anyway, so the optional path is deferred until
+measurement shows it justifies its cost. See "Why Layer 2 promotion is
+deferred" above.
+
+#### Stage 7 — Skel pure-ExprKind retirement _(optional)_
 
 - [ ] Remove pure `ExprKind` variants (`IntLiteral`, `FloatLiteral`,
       `BoolLiteral`, `CharLiteral`, `StringLiteral`, `Null`, `Unit`,
@@ -263,7 +339,7 @@ predecessor is deleted. Stage 7 alters the NIR shape (pure
       following `Operand` directly — rule logic unchanged, API surface
       adjusted.
 
-### Stage 8 — Saturation driver + cost-based extraction
+#### Stage 8 — Saturation driver + cost-based extraction _(optional)_
 
 - [ ] Per-function session runs all rules together to saturation,
       bounded by node count budget + per-ValueId rewrite count + outer
@@ -271,38 +347,27 @@ predecessor is deleted. Stage 7 alters the NIR shape (pure
 - [ ] Extraction walks the SkelTree picking a cost-minimal Skel form for
       each `Operand::Value`. Multi-use ValueIds are materialised via a
       hoisted `let __t = ...` only when the cost model favours sharing.
-- [ ] The global fixed-point loop, `OptConfig::iterations`, per-rule
-      `applied: Cell<bool>` guards, `peephole.rs` (the rule list lives
-      on the engine), and the per-pass dirty-set in `gate.rs` are
-      removed.
-
-### Stage 9 — Decommission and interprocedural worklist
-
-- [ ] Old per-pass walkers (stub-only after Stages 3 – 6) are deleted in
-      bulk.
-- [ ] `inline` / `dae` / `drve` / `sroa_param` / `value_copy_demote` move
-      to a call-graph worklist driver that re-runs the per-function
-      engine session for affected callers when a callee's signature or
-      body shrinks.
-- [ ] Terminal / once-only stages stay explicit pre- or post-saturation,
-      not loop members: `multi_value_return`, `field_scalarize`,
-      `const_object_globalization`, `dce`.
+- [ ] The global fixed-point loop, per-rule `applied: Cell<bool>`
+      guards, `peephole.rs` (the rule list lives on the engine), and
+      the per-pass dirty-set in `gate.rs` are removed in favour of the
+      saturation driver.
 
 ## Soundness invariants
 
 - Byte-identical co-existence per stage. Each Stage 3 – 6 rule migration
   must reproduce its standalone predecessor's output on the full suite
-  before the predecessor is deleted. Stage 7 is allowed to alter the NIR
-  shape but the WIR output stays byte-identical.
-- Rules are idempotent (a saturated graph does not regress on
-  re-application) and either confluent or priority-ordered.
-- Saturation has bounded budgets (node count + per-node rewrite + outer
-  iterations); a budget hit is a graceful fallback to the partially
-  saturated graph, never a panic. The fallback is monotone — never
-  produces worse output than the pre-saturation IR.
-- The SkelTree never holds `Operand::Value(v)` where `v` references an
-  effectful op. Purity classification is enforced at ValueGraph builder
-  time and at `apply_value` rule sites.
+  before the predecessor is deleted. If Stage 7 ever activates, it is
+  allowed to alter the NIR shape but the WIR output stays
+  byte-identical.
+- Rules are idempotent (re-running on the same input does not regress)
+  and either confluent or priority-ordered. Under the required path's
+  destructive driver, priorities are encoded by rule order in the
+  engine session, the way `peephole.rs` already does.
+- The ValueGraph builder classifies expressions as pure or impure at
+  build time. Impure expressions get no `ValueId` (they stay Skel-side);
+  pure expressions get a hash-cons-deduplicated `ValueId`. The
+  `Operand::Value(v)` form (when Stage 7 activates) is restricted to
+  pure values by construction.
 - Heap-version monotonicity: a `FieldAccess` value's `heap_ver` is the
   version before the read. A write Skel node that follows bumps to a
   fresh version; any later read at that field gets a fresh `ValueId`.
@@ -310,50 +375,71 @@ predecessor is deleted. Stage 7 alters the NIR shape (pure
   under-approximation drops an optimization — the same one-sided safety
   argument as the dirty-set gate (every loop pass is optional, so
   imprecision costs quality, never correctness).
+- Under the optional Stage 8 driver: saturation has bounded budgets
+  (node count + per-node rewrite + outer iterations). A budget hit is a
+  graceful fallback to the partially saturated graph, never a panic;
+  the fallback is monotone (never produces worse output than the
+  pre-saturation IR).
 
 ## Consequences
 
-### Expected effect
+### Expected effect — required path
 
-- Per-pass analysis reconstruction disappears: CSE keys, source-stability
-  walks, modified-locals caches, def maps, env / field_env all collapse
-  into one ValueGraph that every rule shares.
+- Per-pass analysis reconstruction disappears: CSE keys,
+  source-stability walks, modified-locals caches, def maps,
+  env / field_env all collapse into one ValueGraph that every rule
+  shares.
+- Reaching-def queries become O(1) (the side-table already encodes the
+  current value for every local at every program point).
+- Code reduction: the `optimize/` directory shrinks from ~13K lines to
+  an estimated ~8K (each migrated pass becomes a thinner rule querying
+  the ValueGraph; the structural rules and Skel-side logic still need
+  their walks).
+- Compile-time target: package-gale optimise phase ~1.5× faster than
+  the current substrate-only baseline. Aspirational, not committed.
+
+### Additional effect — if optional acceleration ever activates
+
 - Phase-ordering hazards dissolve: rules co-exist under saturation; the
   hand-tuned ordering in `run_optimization_passes` becomes irrelevant.
-- Compile-time target: package-gale optimise phase 2 – 3× faster than the
-  current substrate-only baseline. Aspirational, not committed.
-- Code reduction: the `optimize/` directory shrinks from ~13K lines to
-  an estimated 3 – 4K (each pass becomes a 50 – 150 line rule set).
+- Algebraic exploration enables re-association, distributive law,
+  strength-reduction-per-use, and cost-based share-vs-duplicate.
+- Code reduction further to an estimated ~3 – 4K (each pass becomes a
+  50 – 150 line declarative rule set; the global fixed-point loop and
+  per-pass dirty-set go away).
+- Compile-time impact is uncertain (saturation has tuning overhead).
 
 ### Risks
 
-- Equality-saturation tuning: rule sets can explode without confluence.
-  Budget-bounded; investigative — visualisation tooling
-  (`WADO_DUMP_VALUE_GRAPH`, `WADO_DUMP_AFTER_RULE=...`) is a hard
-  prerequisite to Stage 8.
 - Heap modeling precision: MVP per-field can be too coarse around calls.
   `mod_ref.rs` integration in Phase 2.
 - Loop induction recognition: pattern-matched at Stage 6; insufficient
   coverage costs `condition_implication` and `licm` quality. Measured.
-- Extraction cost tuning: picking when to share vs duplicate a multi-use
-  `ValueId` is heuristic. Tuned with benchmarks.
 - `niri.rs` refactor: the in-place `reduce_*_a` cluster is rewritten to
   return Value descriptions. CTFE step budgeting and effect handling
   carry over but the API surface changes.
+- (Optional Stage 8) Equality-saturation tuning: rule sets can explode
+  without confluence. Budget-bounded; investigative — visualisation
+  tooling (`WADO_DUMP_VALUE_GRAPH`, `WADO_DUMP_AFTER_RULE=...`) is a
+  hard prerequisite.
+- (Optional Stage 8) Extraction cost tuning: picking when to share vs
+  duplicate a multi-use `ValueId` is heuristic. Tuned with benchmarks.
 
 ### Trade-offs accepted
 
-- Two-tier IR is more sophisticated than a one-tier worklist. The
-  ValueGraph adds a hash-cons table, an explicit kind enum, and a
-  builder.
-- Stage 2 – 6 scaffolding (the `value_of` side-table; the
-  `engine.value(expr_id)` API surface) is retired at Stage 7. Real
-  throwaway code budget: ~200 – 300 lines of bridge logic; the
-  version-tracking algorithm, the rules, and the ValueGraph itself all
-  survive the transition.
+- The ValueGraph adds a hash-cons table, an explicit kind enum, and a
+  builder. Under the required path it is reachable as an
+  engine-maintained side-table (`engine.value(expr_id)`); under the
+  optional acceleration it promotes to IR-level operands. The same
+  data structures and builder algorithm carry over either way.
+- If the optional acceleration ever activates: the Stage 2 – 6
+  scaffolding (the `value_of` side-table; the `engine.value(expr_id)`
+  API surface) retires at Stage 7. Real throwaway code budget:
+  ~200 – 300 lines of bridge logic; the version-tracking algorithm, the
+  rules, and the ValueGraph itself survive the transition.
 - Arena compaction (dead nodes from in-place rewrites are not freed
   mid-run; ~1.66× bloat measured at end-of-optimize on `package-gale`)
-  becomes more worthwhile once saturation walks bodies fewer times;
+  becomes more worthwhile once the engine walks bodies fewer times;
   tracked as a follow-up.
 
 ## See also

--- a/docs/wep-2026-06-05-worklist-rewrite-engine.md
+++ b/docs/wep-2026-06-05-worklist-rewrite-engine.md
@@ -255,27 +255,34 @@ WIR output stays byte-identical.
 
 #### Stage 3 — CSE migration
 
-- [ ] `CseRule` uses `engine.value(e1) == engine.value(e2)` for
+- [x] `CseRule` uses `engine.value(e1) == engine.value(e2)` for
       equality. The structural `CseKey` and its supporting walks are
       deleted after byte-identical confirmation. First end-to-end proof
       that Stage 1 + 2 are correctly wired.
 
-#### Stage 4 — copy_prop migration
+#### Stage 4 — copy_prop migration _(deferred)_
 
-- [ ] `let x = y` where `engine.value(y_def) == engine.value(let_value)`
-      is a copy. Source-stability follows from ValueIds being equal
-      across the target's scope. The independent block-writes precompute
-      folds into ValueGraph maintenance.
+Skipped on the required path: `copy_prop`'s source-stability check is
+not subsumed by `ValueId` equality alone. A `let x = y` where the
+target `x` is later observed with the same `ValueId` as a literal does
+not imply the read is stable to substitute — write-once `x` whose
+reassigned source `y` invalidates can still see equal `ValueId`s at the
+two reads while being unsafe to fold. Revisit alongside Stage 6's
+algebraic rules over `Select` and `Opaque` provenance.
 
 #### Stage 5 — store_load_forward + heap-version activation
 
-- [ ] Activate the `FieldAccess` ValueKind with per-field heap versions.
+- [x] Activate the `FieldAccess` ValueKind with per-field heap versions.
       The builder bumps the appropriate field's version on each
       heap-write Skel node. `FieldAccess(r, f, v)` reads at the same
       `(r, f, v)` return the same `ValueId`, automatically forwarding
       stored literals.
-- [ ] `store_load_forward`'s `KnownValues` walker collapses into a thin
-      rule that consults `engine.value(local_read)` for a Literal kind.
+- [x] `store_load_forward`'s `KnownValues` / `ModifiedLocalsCache`
+      walker collapses into a thin rule: walk `Local` mentions, consult
+      `engine.value(read)`, replace with the source literal when the
+      `ValueKind` is `Int`/`Float`/`Bool`/`Char`. Address-taken locals
+      are excluded (the builder does not yet model writes through
+      pointers).
 
 #### Stage 6 — const_folding, condition_implication, licm
 

--- a/docs/wep-2026-06-05-worklist-rewrite-engine.md
+++ b/docs/wep-2026-06-05-worklist-rewrite-engine.md
@@ -1,214 +1,365 @@
 # WEP: Worklist-Driven NIR Rewrite Engine
 
-This WEP sets the terminal architecture for the NIR optimizer: a single
-worklist-driven rewrite engine — the _combine_ — over the structured NIR
-arena, with a call-graph-driven interprocedural driver replacing the global
-fixed-point loop. The engine substrate and a dirty-set gate over the old loop
-have landed (see the [detailed design](./wep-2026-06-05-nir-rewrite-engine-design.md)
-and the [NIR Skeleton Arena](./wep-2026-06-05-nir-skeleton-arena.md)); the
-combine itself — every intra-procedural rewrite as a rule on one worklist, and
-the global loop removed — is the open continuation specified here. Reaching it
-was the original intent of this WEP; the substrate was step one.
+This WEP sets the terminal architecture for the NIR optimizer: a two-tier IR
+(structured effect skeleton + hash-consed pure-value graph) driven by a
+single worklist engine, with optimizations expressed as declarative rewrite
+rules under equality-saturation semantics, and a call-graph-driven
+interprocedural driver replacing the global fixed-point loop.
+
+The engine substrate, the arena NIR, and the routing of every
+intra-procedural pass through the engine edit API have landed. The
+pure-value layer, the saturation driver, and the interprocedural worklist
+are the open continuation specified here.
 
 ## Context
 
 The optimizer was historically ~31 independent passes, each a full mutating
-walk over every function, run inside a global fixed-point loop. Two structural
-changes have since landed:
+walk over every function, run inside a global fixed-point loop. The engine
+substrate (`nir_engine.rs`) added a parent map, a local use index, a
+mutating edit API, a `Rule` trait, and a per-function dirty-set gate
+(`optimize/gate.rs`). Every intra-procedural pass has been migrated to run
+as a `Rule` (or per-function standalone session of one) on it, and every
+mutation goes through `Engine::*` so the parent map and use index stay
+coherent.
 
-- The `Body ↔ tree` bridge is gone; NIR is an arena (`nir_arena.rs`) and the
-  worklist engine (`nir_engine.rs`) exists, with a parent map, a local use
-  index, an edit API, and a `Rule`/`run` driver.
-- A per-function dirty-set gate (`optimize/gate.rs`) lets each pass skip
-  functions unchanged since it last ran.
+What that gave us:
 
-What did _not_ change is the architecture the first version of this WEP set out
-to replace. Only a handful of rewrites actually run as rules on the engine: the
-unified peephole session (`string_push`, `array_literal`, `elide_local`, the
-env-free subset of `const_folding`, `const_branch_prune`), plus the standalone
-`match_to_switch` and `select_lowering` sessions. The other ~15 intra-procedural
-passes — `sroa`, `copy_prop`, `cse`, the flow-sensitive `const_folding`,
-`store_load_forward`, `ref_elim`, `elide_box_local`, `labeled_block_fusion`,
-`container_sroa`, `value_copy_elide` / `value_copy_demote`, `tmpl_hoist`,
-`condition_implication`, `dae`, `drve` — are still standalone whole-tree passes,
-driven by the global fixed-point loop (`run_optimization_passes`). The gate made
-each sweep cheaper; it did not remove the `N passes × M iterations` shape.
+- Arena NIR (`nir_arena.rs`), parent map + use index per session.
+- `EngineBuffers` pooled across sessions; `Engine::new` allocations cut.
+- All intra-procedural rules routed through the engine edit API:
+  `ref_elim`, `elide_box_local`, `value_copy_elide`, `labeled_block_fusion`
+  in the shared peephole session; `sroa`, `container_sroa`,
+  `store_load_forward`, `copy_prop`, `cse`, `licm`,
+  `condition_implication`, `tmpl_hoist` in per-function standalone
+  sessions; `match_to_switch`, `select_lowering`, and the env-free
+  `const_folding` subset in the peephole session.
 
-A native profile of `wado compile` on `package-gale` (34.5k lines, the largest
-in-tree program) pins the cost to that surviving shape:
+What it has not yet given us is the architectural win the redesign exists
+for:
 
-- `optimize` is ~52% of the whole compile (~5.5s after engine-buffer pooling).
-- 1,572 functions carry a body; the median body is 31 NIR nodes (p90 209, p99
-  923, max 4,095) over 132,645 nodes total. Effective cost is ~41µs per node —
-  far above node-level work, because each node is walked tens of times.
-- The loop runs ~20 passes per iteration and converges in 5 iterations at `-O2`
-  (~85 whole-program sweeps), each pass reconstructing whatever per-function
-  analysis it needs.
-- Monomorphization duplicates only 13% of nodes, so "optimize each generic
-  once" is not the lever. The lever is the multiplicative constant —
-  `passes × iterations × per-function reconstruction` — not the IR size.
+- Pure-value identity is still expressed by ad-hoc per-pass keys
+  (`CseKey`, copy-prop binding match, `condition_implication`'s bound
+  shape). Structural equality is recomputed each time.
+- Reaching definitions are still rebuilt per pass —
+  `store_load_forward`'s `KnownValues`, `condition_implication`'s
+  `DefMap`, `const_folding`-flow-sensitive's `env` / `field_env` all run
+  their own walks.
+- The global fixed-point loop and `OptConfig::iterations` are still
+  present; intra-procedural saturation comes only from the loop re-running
+  each rule.
+- `niri.rs` (CTFE interpreter) still mutates `Body` in place via
+  `reduce_*_a`, blocking its integration with the engine.
 
-Incremental tuning (allocation pooling, the gate) removes constant factors but
-cannot change that the program is swept ~85 times. The remaining win is
-architectural: finish the combine.
+A native profile of `wado compile` on `package-gale` (34.5k lines) pins
+the surviving cost to per-pass analysis reconstruction: `optimize` is
+~52 % of the whole compile, with the loop sweeping the program ~85 times
+at `-O2`, each sweep rebuilding its own per-function dataflow.
 
 ## Decision
 
-The terminal optimizer architecture is the structured-NIR combine:
+The terminal optimizer architecture is a two-tier NIR + equality-saturation
+engine.
 
-- Intra-procedural: one per-function worklist runs _all_ local rules to a local
-  fixed point in a single traversal-with-revisits. A node is visited only when
-  an edit to its neighbourhood might have made it reducible. There is no
-  per-pass whole-tree walk and no global fixed-point sweep.
-- Interprocedural: `inline`, `dae`, `drve`, `sroa_param`, and globalization run
-  off a call-graph worklist. A function is combined once; an interprocedural
-  edit re-queues only the functions it can affect (a callee shrank → re-combine
-  its callers; a signature changed → re-combine its call sites), which are then
-  re-combined. The global "repeat ~20 passes M times" loop and
-  `OptConfig::iterations` are removed.
-- Flow-sensitive dataflow (const-prop across branches, copy propagation,
-  store-to-load forwarding, dominator-implied conditions) is served by a
-  value-numbering / reaching-def side-table the engine maintains incrementally
-  alongside the parent map and use index — not re-derived per pass, and not via
-  full SSA.
+### Two-tier IR
 
-One change, three wins, unchanged from the original framing but now concrete:
+- SkelTree (Layer 1) — the existing arena. Carries statements, control
+  flow, effectful expressions, and patterns. Document order = effect
+  order.
+- ValueGraph (Layer 2) — a hash-consed DAG of pure values, indexed by
+  `ValueId`. Two structurally equivalent pure expressions share one
+  `ValueId`; equality is `==` on a `u32`.
+- Operand bridge — a Skel node's child slot becomes
+  `Operand = Skel(NodeRef) | Value(ValueId)`. Pure operand positions
+  carry `Operand::Value(...)`; effectful and control-flow operands stay
+  `Operand::Skel(...)`.
 
-- Speed: removes the `passes × iterations` multiplier and the per-pass analysis
-  reconstruction; per function the work trends to `O(nodes + edits)` plus
-  interprocedural propagation, instead of ~85 sweeps.
-- Maintainability: one engine with one rule set replaces ~20 separately-driven
-  passes and their hand-tuned loop ordering; adding a rewrite is adding a rule.
-- Correctness: a single explicit worklist discipline (what re-enqueues what)
-  replaces emergent interactions between whole-tree passes and a global fixed
-  point; most phase-ordering hazards dissolve because rules co-exist.
+### ValueGraph kinds
 
-## Why the combine is the destination, not a stepping stone
+```
+ValueKind:
+  Int / Float (bit pattern) / Bool / Char / String / Null / Unit   (literals)
+  Opaque(OpaqueId)                                                 (params, unknown values)
+  Binary(NirBinaryOp, ValueId, ValueId)
+  Unary(NirUnaryOp, ValueId)
+  Cast(ValueId, TypeId)
+  Select(cond: ValueId, then: ValueId, else: ValueId)              (structural merge)
+  LoopPhi(entry: ValueId, body_iter: ValueId)                      (loop recurrence; tagged opaque in MVP)
+  FieldAccess(receiver: ValueId, field, heap_ver: HeapVersion)
+```
 
-The natural objection is that a fast optimizer "should" be SSA, making the
-structured-IR combine throwaway work. It is not, for a Wasm target:
+Notably absent: no `Local` kind. Locals are resolved at ValueGraph build
+time via a `current_value: HashMap<local_idx, ValueId>` the builder
+threads through its walk. At `Let` / `Assign` the entry is updated; at
+structural merges (If / Match / Switch endpoints) a fresh `Select` value
+is constructed; at `Loop` entry the local becomes a `LoopPhi` (tagged
+opaque in MVP, with simple-induction recognition added at the
+flow-sensitive migration stage). Function parameters seed
+`current_value` with `Opaque` values.
 
-- Wado emits structured Wasm (block / loop / if; no arbitrary CFG). Classical
-  SSA needs SSA construction plus a relooper / stackifier to re-emit structured
-  control flow — overhead that buys nothing for Wado's problem and dissolves the
-  structure the backend re-emits directly. This is the same reason NIR keeps its
-  tree shape (see [NIR Layer](./wep-2026-05-11-nir.md)).
-- Binaryen, the production-grade Wasm optimizer, is a structured-AST worklist
-  rewriter, not a classical SSA optimizer; it carries SSA-style _local_ analyses
-  (`LocalGraph`) only where they pay. That is exactly this design.
-- Where SSA genuinely wins — flow-sensitive value numbering — the engine takes
-  it locally via the reaching-def / numbering side-table, with no CFG
-  roundtrip.
+`StructLiteral` / `TupleLiteral` / `ArrayLiteral` stay Skel-side for the
+MVP. They are pure but allocation-bearing; `const_object_globalization`
+already covers the constant-sharing case, and Value-graph promotion
+needs an extraction policy that decides when two identical literals may
+share an allocation. Phase 2 measured follow-up.
 
-So the combine investment is terminal: the worklist discipline, the
-interprocedural driver, the Wado-specific rewrite semantics (value-copy
-elimination, aliasing, places), and the structured arena all persist regardless.
-Full SSA / sea-of-nodes stays rejected.
+### Heap modeling
 
-## IR substrate
+`FieldAccess` carries a heap version the builder bumps when a Skel node
+may write the heap (Assign-to-FieldAccess; non-pure Call / MethodCall /
+IndirectCall; LoopPhi body-iter when the body may write). MVP uses
+per-field granularity (a write to `obj.f` bumps the `f` slot only); a
+later stage promotes to per-(receiver-root, field) using `mod_ref.rs`.
+A global per-function heap counter is too coarse to make `FieldAccess`
+CSE useful in practice and is skipped.
 
-The substrate is the two layers the first version of this WEP proposed, split on
-the only distinction rewriting cares about — whether a node is a
-referentially-transparent value or an ordered effect.
+### Optimization as rewrite rules
 
-- Layer 1 — effect skeleton: a flat per-function arena (`NodeId` + parent + use
-  index) for statements, control flow, places, memory writes, and effectful
-  expressions. Parent is unique; the worklist is the classic tree walk. Landed:
-  this is the current `Body` (see [NIR Skeleton Arena](./wep-2026-06-05-nir-skeleton-arena.md)).
-- Layer 2 — pure-value e-graph: a hash-consed acyclic e-graph for
-  referentially-transparent expressions, whose value ids the skeleton's leaf
-  operands reference. Rewrites are non-destructive (add an equivalence), CSE /
-  GVN fall out for free, and a final extraction picks the best form. Optional
-  accelerator, on the reference of Cranelift's aegraph mid-end. It is revisited
-  only if the Layer-1 value-numbering side-table proves insufficient for CSE /
-  GVN; the combine does not depend on it.
+```rust
+trait Rule {
+    fn apply_value(&self, e: &mut Engine, v: ValueId) -> bool { false }
+    fn apply_skel(&self, e: &mut Engine, n: NodeRef) -> bool { false }
+}
+```
 
-The pure partition stays small because Wado's aliasing, places, and value-copy
-semantics make few reads referentially transparent (a `FieldAccess` read is not
-pure across an intervening write), gated by `optimize/mod_ref.rs`. So Layer 1
-plus a numbering side-table is expected to carry the flow-sensitive folds; Layer
-2 is a measured follow-up, not a prerequisite.
+`apply_value` rules pattern-match on a `ValueKind` and either add a new
+ValueId (an "equivalent representation" in e-graph terms) or replace the
+kind. `apply_skel` rules reshape the skeleton (block flattening, statement
+fusion, control-flow lowering).
+
+CSE / GVN / copy propagation / constant folding / store-load forwarding
+all reduce to one principle: same `ValueId` means same value. Two
+expressions sharing a `ValueId` need not both be computed; an operand
+reading the same `ValueId` as a known literal is itself that literal.
+
+### Saturation and extraction
+
+The engine runs all rules together until either no new ValueIds are
+produced and no Skel rewrites fire, or a budget hits (node count budget,
+per-ValueId rewrite count, outer iteration limit — all three). After
+saturation, an extraction pass walks the SkelTree picking a cost-minimal
+Skel form for each `Operand::Value(...)`. A multi-use `ValueId` is
+materialised once with a hoisted `let __t = ...` only when the cost model
+favours sharing over duplication — that is the "real CSE" decision.
+
+The global fixed-point loop, `OptConfig::iterations`, per-rule
+`applied: Cell<bool>` guards, the `peephole.rs` rule-list module, and the
+per-pass dirty-set in `gate.rs` are all retired in favour of the
+saturation driver.
+
+## Why two-tier (not classical SSA)
+
+- Wado emits structured Wasm. Classical SSA construction plus a relooper /
+  stackifier buys nothing for a target that already has block / loop / if,
+  and dissolves the structure the backend re-emits directly.
+- Two-tier keeps SkelTree as the source of structure — no SSA
+  construction, no relooper. The ValueGraph is a side representation that
+  coexists with the Skel, accessed via `Operand::Value`. Local versioning
+  is expressed by structural `Select` nodes at merges, never as explicit
+  phis.
+- Binaryen — the production-grade Wasm optimizer — is exactly this shape
+  (structured AST + side analyses). We are formalising what they already
+  do.
+
+Full SSA / sea-of-nodes stays rejected. So does building the ValueGraph
+without a SkelTree (it would lose the effect ordering Wasm codegen needs).
 
 ## Migration plan
 
-The engine, edit API, and gate exist. The remaining work moves each standalone
-intra-procedural pass into the shared combine session and then deletes the
-global loop. Each migrated rule must be byte-output-identical to the pass it
-replaces, on the full fixture + E2E suite and on `package-gale`, before the old
-pass is removed — the old and new paths co-exist during migration.
+Each migrated rule must be byte-output-identical to the pass it replaces,
+on the full fixture + E2E suite and on `package-gale`, before the
+predecessor is deleted. Stage 7 alters the NIR shape (pure
+`ExprKind` variants vanish) but the WIR output stays byte-identical.
 
-- [x] Engine substrate, edit API, `Rule`/`run`; arena-only NIR (Phases 4–5).
-- [x] Per-function dirty-set gate over the existing loop (Phase 6).
-- [x] Reduce per-session allocation (`EngineBuffers` pooling; `Engine::new`
-      allocations cut, byte-identical).
-- [x] Migrate the position-flexible structural rules to the engine:
+### Completed substrate
+
+- [x] Engine substrate, edit API, `Rule` / `run`; arena-only NIR.
+- [x] Per-function dirty-set gate over the existing loop.
+- [x] `EngineBuffers` pooling, allocation-cost reduction.
+- [x] All ~15 intra-procedural rules routed through the engine edit API:
       `ref_elim`, `elide_box_local`, `value_copy_elide`,
-      `labeled_block_fusion` (all four fold into the shared post-inline
-      peephole session); `sroa`, `container_sroa` (per-function standalone
-      engine sessions whose `apply_block` fires once at the body root). The
-      driver of every migrated pass routes its mutations through the engine
-      edit API so the parent map and use index stay coherent — preparation
-      for the interprocedural worklist below.
-- [x] Migrate the flow-sensitive intra-procedural passes onto per-function
-      standalone engine sessions: `store_load_forward`, `copy_prop`, `cse`,
-      `licm`, `condition_implication`, `tmpl_hoist`. Each one fires once at
-      the body root and runs its whole-function analysis + rewrite in one
-      shot, with mutations through the engine edit API. The value-numbering
-      / reaching-def side-table is still pending — these rules carry their
-      own dataflow walkers in the meantime.
-- [ ] Add the engine-maintained value-numbering / reaching-def side-table so
-      `copy_prop` / `store_load_forward` / `condition_implication` / the
-      flow-sensitive half of `const_folding` (which still has its own driver
-      and calls into the `niri` CTFE interpreter for in-place mutations)
-      consult it instead of reconstructing their own per-function dataflow.
-- [ ] CSE / GVN over the same numbering (or Layer 2, only if measured
-      necessary).
-- [ ] Replace the global fixed-point loop with the interprocedural call-graph
-      worklist driving `inline` / `dae` / `drve` / `sroa_param` /
-      `value_copy_demote` (the surviving interprocedural passes) plus
-      targeted re-combine; remove `OptConfig::iterations`.
-- [ ] Keep terminal / once-only stages explicit pre- or post-combine, not loop
-      members: `match_to_switch`, `select_lowering`, `multi_value_return`,
-      `field_scalarize`, `const_object_globalization`, and `dce`.
+      `labeled_block_fusion` (shared peephole session); `sroa`,
+      `container_sroa`, `store_load_forward`, `copy_prop`, `cse`, `licm`,
+      `condition_implication`, `tmpl_hoist` (per-function standalone
+      sessions); `match_to_switch`, `select_lowering`, env-free
+      `const_folding` (peephole session). Mutations all go through
+      `Engine::*`; parent map and use index invariants are upheld.
+
+### Stage 1 — ValueGraph foundation
+
+- [ ] `ValueId`, `ValueKind`, `ValuePool` with hash-cons; the full
+      `ValueKind` set above (heap-version-bearing kinds may be stubbed
+      until Stage 5). Standalone module, exhaustive unit tests, no engine
+      integration. SkelTree unchanged.
+
+### Stage 2 — Per-function builder
+
+- [ ] Walk the SkelTree assigning `ValueId` to every pure `ExprId`.
+      Maintain `current_value: HashMap<local_idx, ValueId>`; build
+      `Select` at If / Match / Switch endpoints; emit `Opaque` for loop
+      locals; seed parameters with `Opaque`.
+- [ ] Side table `value_of: IndexMap<ExprId, ValueId>` populated per
+      function. Engine exposes `engine.value(expr) -> Option<ValueId>`;
+      ValueGraph is built at session start. No incremental maintenance
+      under edits at this stage — a rule that edits invalidates the
+      table; rules either re-trigger the build or refrain from further
+      queries.
+
+### Stage 3 — CSE migration
+
+- [ ] `CseRule` uses `engine.value(e1) == engine.value(e2)` for
+      equality. The structural `CseKey` and its supporting walks are
+      deleted after byte-identical confirmation. First end-to-end proof
+      that Stage 1 + 2 are correctly wired.
+
+### Stage 4 — copy_prop migration
+
+- [ ] `let x = y` where `engine.value(y_def) == engine.value(let_value)`
+      is a copy. Source-stability follows from ValueIds being equal
+      across the target's scope. The independent block-writes precompute
+      folds into ValueGraph maintenance.
+
+### Stage 5 — store_load_forward + heap-version activation
+
+- [ ] Activate the `FieldAccess` ValueKind with per-field heap versions.
+      The builder bumps the appropriate field's version on each
+      heap-write Skel node. `FieldAccess(r, f, v)` reads at the same
+      `(r, f, v)` return the same `ValueId`, automatically forwarding
+      stored literals.
+- [ ] `store_load_forward`'s `KnownValues` walker collapses into a thin
+      rule that consults `engine.value(local_read)` for a Literal kind.
+
+### Stage 6 — const_folding, condition_implication, licm
+
+- [ ] Env-free `const_folding` rewritten as algebraic rules over Value
+      kinds (`Binary(Add, Int(a), Int(b)) → Int(a+b)`, `Binary(Add, ?x,
+      Int(0)) → ?x`, …).
+- [ ] Env-bound `const_folding`: `niri.rs` refactored to stop mutating
+      `Body` in place. `reduce_*_a` becomes a Value-returning pure
+      function; the caller decides whether to commit via the engine.
+- [ ] `condition_implication`'s bound comparisons collapse onto
+      `ValueId` equality; dominating-guard tracking stays Skel-side.
+- [ ] `licm` recognises loop-invariance as "this `ValueId` does not
+      depend on any `LoopPhi` for the current loop". Hoisting becomes a
+      Skel rewrite over invariant operand subgraphs.
+- [ ] Simple induction-variable recognition: a Loop body whose update
+      to local `i` is `Local + constant_step` and has no other writes
+      tags `current_value[i]` with `Opaque { induction: { base, step } }`.
+      Rules pattern-match on the tag for bounds-check elimination,
+      bound-implication, and loop-invariant arithmetic detection. No
+      cyclic Value graph at this stage.
+
+### Stage 7 — Skel pure-ExprKind retirement
+
+- [ ] Remove pure `ExprKind` variants (`IntLiteral`, `FloatLiteral`,
+      `BoolLiteral`, `CharLiteral`, `StringLiteral`, `Null`, `Unit`,
+      `Binary`, `Unary`, `Cast`) from the SkelTree. Skel child slots
+      that previously held an `ExprId` to a pure expression hold
+      `Operand::Value(ValueId)`.
+- [ ] `lower::translate` builds pure values directly in the ValueGraph
+      and stores `Operand::Value` on the parent's slot. `wir_build`'s
+      reads follow `Operand`; the WIR output shape is unchanged.
+- [ ] The `value_of: IndexMap<ExprId, ValueId>` side-table is removed.
+      Stage 3 – 6 rules that queried `engine.value(expr_id)` shift to
+      following `Operand` directly — rule logic unchanged, API surface
+      adjusted.
+
+### Stage 8 — Saturation driver + cost-based extraction
+
+- [ ] Per-function session runs all rules together to saturation,
+      bounded by node count budget + per-ValueId rewrite count + outer
+      iteration limit (defaults loose, env-var overridable).
+- [ ] Extraction walks the SkelTree picking a cost-minimal Skel form for
+      each `Operand::Value`. Multi-use ValueIds are materialised via a
+      hoisted `let __t = ...` only when the cost model favours sharing.
+- [ ] The global fixed-point loop, `OptConfig::iterations`, per-rule
+      `applied: Cell<bool>` guards, `peephole.rs` (the rule list lives
+      on the engine), and the per-pass dirty-set in `gate.rs` are
+      removed.
+
+### Stage 9 — Decommission and interprocedural worklist
+
+- [ ] Old per-pass walkers (stub-only after Stages 3 – 6) are deleted in
+      bulk.
+- [ ] `inline` / `dae` / `drve` / `sroa_param` / `value_copy_demote` move
+      to a call-graph worklist driver that re-runs the per-function
+      engine session for affected callers when a callee's signature or
+      body shrinks.
+- [ ] Terminal / once-only stages stay explicit pre- or post-saturation,
+      not loop members: `multi_value_return`, `field_scalarize`,
+      `const_object_globalization`, `dce`.
 
 ## Soundness invariants
 
-- Byte-identical co-existence: a pass is deleted only after its rule form
-  reproduces its output on the full suite, so a migration can never silently
-  regress codegen.
-- Rules are idempotent (the per-node retry terminates) and either confluent or
-  priority-ordered.
-- The interprocedural worklist must re-combine every function an edit can
-  affect; over-approximation only costs a redundant re-combine, under-
-  approximation drops an optimization — the same one-sided safety argument as
-  the gate (every loop pass is optional, so imprecision costs quality, never
-  correctness).
-- The few genuine ordering constraints today encoded as loop position (e.g.
-  value-copy wrappers must be visible before `inline` expands them) become
-  explicit rule priorities or named pre-stages, not emergent loop order.
+- Byte-identical co-existence per stage. Each Stage 3 – 6 rule migration
+  must reproduce its standalone predecessor's output on the full suite
+  before the predecessor is deleted. Stage 7 is allowed to alter the NIR
+  shape but the WIR output stays byte-identical.
+- Rules are idempotent (a saturated graph does not regress on
+  re-application) and either confluent or priority-ordered.
+- Saturation has bounded budgets (node count + per-node rewrite + outer
+  iterations); a budget hit is a graceful fallback to the partially
+  saturated graph, never a panic. The fallback is monotone — never
+  produces worse output than the pre-saturation IR.
+- The SkelTree never holds `Operand::Value(v)` where `v` references an
+  effectful op. Purity classification is enforced at ValueGraph builder
+  time and at `apply_value` rule sites.
+- Heap-version monotonicity: a `FieldAccess` value's `heap_ver` is the
+  version before the read. A write Skel node that follows bumps to a
+  fresh version; any later read at that field gets a fresh `ValueId`.
+- Interprocedural over-approximation only costs a redundant re-combine;
+  under-approximation drops an optimization — the same one-sided safety
+  argument as the dirty-set gate (every loop pass is optional, so
+  imprecision costs quality, never correctness).
 
 ## Consequences
 
-- Expected effect: the `passes × iterations` multiplier and per-pass analysis
-  reconstruction disappear; the realistic near-term target is 2–3× on the
-  optimize phase, with the numbering side-table and once-only interprocedural
-  driving carrying it further. "Optimize in ~1s" is the aspiration that motivates
-  the redesign, not a committed number.
-- Risk is concentrated in the flow-sensitive migration (value-numbering
-  correctness), de-risked by the byte-identical co-existence gate per pass.
-- Arena compaction (dead nodes from in-place rewrites are not freed mid-run;
-  ~1.66× bloat measured at end-of-optimize on `package-gale`) becomes more
-  worthwhile once the combine walks bodies fewer times; tracked as a separate
-  follow-up, wanted only if it measures.
+### Expected effect
 
-Out of scope: the resolver, monomorphizer, lowering, the WIR optimizer, and
-codegen. Codegen must not regress: the combine has to reach at least the current
-fixed point's result on existing fixtures.
+- Per-pass analysis reconstruction disappears: CSE keys, source-stability
+  walks, modified-locals caches, def maps, env / field_env all collapse
+  into one ValueGraph that every rule shares.
+- Phase-ordering hazards dissolve: rules co-exist under saturation; the
+  hand-tuned ordering in `run_optimization_passes` becomes irrelevant.
+- Compile-time target: package-gale optimise phase 2 – 3× faster than the
+  current substrate-only baseline. Aspirational, not committed.
+- Code reduction: the `optimize/` directory shrinks from ~13K lines to
+  an estimated 3 – 4K (each pass becomes a 50 – 150 line rule set).
+
+### Risks
+
+- Equality-saturation tuning: rule sets can explode without confluence.
+  Budget-bounded; investigative — visualisation tooling
+  (`WADO_DUMP_VALUE_GRAPH`, `WADO_DUMP_AFTER_RULE=...`) is a hard
+  prerequisite to Stage 8.
+- Heap modeling precision: MVP per-field can be too coarse around calls.
+  `mod_ref.rs` integration in Phase 2.
+- Loop induction recognition: pattern-matched at Stage 6; insufficient
+  coverage costs `condition_implication` and `licm` quality. Measured.
+- Extraction cost tuning: picking when to share vs duplicate a multi-use
+  `ValueId` is heuristic. Tuned with benchmarks.
+- `niri.rs` refactor: the in-place `reduce_*_a` cluster is rewritten to
+  return Value descriptions. CTFE step budgeting and effect handling
+  carry over but the API surface changes.
+
+### Trade-offs accepted
+
+- Two-tier IR is more sophisticated than a one-tier worklist. The
+  ValueGraph adds a hash-cons table, an explicit kind enum, and a
+  builder.
+- Stage 2 – 6 scaffolding (the `value_of` side-table; the
+  `engine.value(expr_id)` API surface) is retired at Stage 7. Real
+  throwaway code budget: ~200 – 300 lines of bridge logic; the
+  version-tracking algorithm, the rules, and the ValueGraph itself all
+  survive the transition.
+- Arena compaction (dead nodes from in-place rewrites are not freed
+  mid-run; ~1.66× bloat measured at end-of-optimize on `package-gale`)
+  becomes more worthwhile once saturation walks bodies fewer times;
+  tracked as a follow-up.
 
 ## See also
 
 - [NIR Rewrite Engine — Detailed Design](./wep-2026-06-05-nir-rewrite-engine-design.md) — the landed engine substrate, edit API, and gate.
-- [NIR Skeleton Arena (Layer 1)](./wep-2026-06-05-nir-skeleton-arena.md) — the substrate.
-- `docs/optimizer.md` — the current pass inventory the combine absorbs.
-- The profiling workflow behind the numbers above:
-  `.claude/skills/profiling-wado-compiler`.
+- [NIR Skeleton Arena (Layer 1)](./wep-2026-06-05-nir-skeleton-arena.md) — the SkelTree substrate.
+- [`docs/optimizer.md`](./optimizer.md) — the current pass inventory the two-tier engine absorbs.
+- Cranelift's aegraph mid-end and `egg` (https://egraphs-good.github.io/) — the e-graph mechanics this design adapts.
+- The profiling workflow behind the cost numbers above: `.claude/skills/profiling-wado-compiler`.

--- a/docs/wep-2026-06-05-worklist-rewrite-engine.md
+++ b/docs/wep-2026-06-05-worklist-rewrite-engine.md
@@ -7,13 +7,15 @@ rules under equality-saturation semantics, and a call-graph-driven
 interprocedural driver replacing the global fixed-point loop.
 
 The engine substrate, the arena NIR, the routing of every intra-procedural
-pass through the engine edit API, and the standalone ValueGraph
-foundation (kinds, hash-cons pool, per-function builder) have landed. The
-required-path rule migrations and interprocedural worklist remain. The
-full Layer-2 promotion (Skel pure-`ExprKind` retirement and saturation-
-driven engine) stays in this WEP as the terminal ideal but is gated
-behind measurement — see "Why Layer 2 promotion is deferred" and the
-"Optional acceleration" entries in the migration plan.
+pass through the engine edit API, and the ValueGraph foundation (kinds,
+hash-cons pool, per-function builder) have all landed, along with the
+Stage 3 (`cse`) and Stage 5 (`store_load_forward`) rule migrations onto
+the ValueGraph. The remaining required-path migrations and the
+interprocedural worklist are open. Full Layer-2 promotion (Skel
+pure-`ExprKind` retirement and saturation-driven engine) stays in this
+WEP as the terminal ideal but is gated behind measurement — see "Why
+Layer 2 promotion is deferred" and the "Optional acceleration" entries
+in the migration plan.
 
 ## Context
 
@@ -26,17 +28,10 @@ as a `Rule` (or per-function standalone session of one) on it, and every
 mutation goes through `Engine::*` so the parent map and use index stay
 coherent.
 
-What that gave us:
-
-- Arena NIR (`nir_arena.rs`), parent map + use index per session.
-- `EngineBuffers` pooled across sessions; `Engine::new` allocations cut.
-- All intra-procedural rules routed through the engine edit API:
-  `ref_elim`, `elide_box_local`, `value_copy_elide`, `labeled_block_fusion`
-  in the shared peephole session; `sroa`, `container_sroa`,
-  `store_load_forward`, `copy_prop`, `cse`, `licm`,
-  `condition_implication`, `tmpl_hoist` in per-function standalone
-  sessions; `match_to_switch`, `select_lowering`, and the env-free
-  `const_folding` subset in the peephole session.
+What that gave us is the arena NIR, the parent map + use index, the
+pooled `EngineBuffers`, and every intra-procedural rule running through
+the engine edit API (see the "Completed substrate" checklist below for
+the exact pass list).
 
 What it has not yet given us is the architectural win the redesign exists
 for:
@@ -51,8 +46,6 @@ for:
 - The global fixed-point loop and `OptConfig::iterations` are still
   present; intra-procedural saturation comes only from the loop re-running
   each rule.
-- `niri.rs` (CTFE interpreter) still mutates `Body` in place via
-  `reduce_*_a`, blocking its integration with the engine.
 
 A native profile of `wado compile` on `package-gale` (34.5k lines) pins
 the surviving cost to per-pass analysis reconstruction: `optimize` is
@@ -104,7 +97,7 @@ flow-sensitive migration stage). Function parameters seed
 MVP. They are pure but allocation-bearing; `const_object_globalization`
 already covers the constant-sharing case, and Value-graph promotion
 needs an extraction policy that decides when two identical literals may
-share an allocation. Phase 2 measured follow-up.
+share an allocation. Deferred until measurement justifies it.
 
 ### Heap modeling
 
@@ -146,35 +139,21 @@ a cost-minimal Skel form for each `Operand::Value(...)`. A multi-use
 the cost model favours sharing over duplication — that is the "real CSE"
 decision.
 
-Equality saturation is **optional acceleration**, not a required
-checkpoint. The required path runs the rules **destructively** as today
-— a rule that fires replaces the source node, the engine re-enqueues
-neighbours, and the global fixed-point loop converges (the existing
-`peephole.rs` / `gate.rs` model). The ValueGraph still buys
-hash-cons-based equality and reaching-def-by-construction in destructive
-mode; what only saturation unlocks is phase-ordering dissolution and
-algebraic exploration (e.g. re-association, distributive law,
-strength-reduction-per-use, cost-based share-vs-duplicate).
-
-Stage 8 below promotes the engine to saturation + extraction. It is
-deferred until measured wins justify the cost — see the rationale below.
+Equality saturation is optional acceleration: the required path runs
+rules destructively as today, with the ValueGraph supplying hash-cons
+equality and reaching-def-by-construction. Saturation (Stage 8) adds
+phase-ordering dissolution and algebraic exploration on top, and is
+deferred until measurement justifies it.
 
 ## Why two-tier (not classical SSA)
 
-- Wado emits structured Wasm. Classical SSA construction plus a relooper /
-  stackifier buys nothing for a target that already has block / loop / if,
-  and dissolves the structure the backend re-emits directly.
-- Two-tier keeps SkelTree as the source of structure — no SSA
-  construction, no relooper. The ValueGraph is a side representation that
-  coexists with the Skel, accessed via `Operand::Value`. Local versioning
-  is expressed by structural `Select` nodes at merges, never as explicit
-  phis.
-- Binaryen — the production-grade Wasm optimizer — is exactly this shape
-  (structured AST + side analyses). We are formalising what they already
-  do.
-
-Full SSA / sea-of-nodes stays rejected. So does building the ValueGraph
-without a SkelTree (it would lose the effect ordering Wasm codegen needs).
+Wado emits structured Wasm, so SSA + relooper buys nothing the backend
+doesn't already need. Two-tier keeps SkelTree as the effect-ordering
+substrate; the ValueGraph is a side representation accessed via
+`Operand::Value`, with local versioning expressed by structural `Select`
+nodes at merges rather than explicit phis. Full SSA / sea-of-nodes
+stays rejected, as does dropping the SkelTree (Wasm codegen needs the
+effect ordering it carries).
 
 ## Why Layer 2 promotion (Stages 7 – 8) is deferred
 
@@ -247,11 +226,10 @@ WIR output stays byte-identical.
       `Select` at If / Match / Switch endpoints; emit `Opaque` for loop
       locals; seed parameters with `Opaque`.
 - [x] Side table `value_of: IndexMap<ExprId, ValueId>` populated per
-      function. Engine exposes `engine.value(expr) -> Option<ValueId>`;
-      ValueGraph is built at session start. No incremental maintenance
-      under edits at this stage — a rule that edits invalidates the
-      table; rules either re-trigger the build or refrain from further
-      queries.
+      function. Engine exposes `engine.value(expr) -> Option<ValueId>`,
+      built lazily on first call. Edits do not invalidate the cache;
+      rules snapshot results before editing, or call
+      `Engine::invalidate_value_graph` to force a rebuild.
 
 #### Stage 3 — CSE migration
 
@@ -278,11 +256,11 @@ algebraic rules over `Select` and `Opaque` provenance.
       `(r, f, v)` return the same `ValueId`, automatically forwarding
       stored literals.
 - [x] `store_load_forward`'s `KnownValues` / `ModifiedLocalsCache`
-      walker collapses into a thin rule: walk `Local` mentions, consult
-      `engine.value(read)`, replace with the source literal when the
-      `ValueKind` is `Int`/`Float`/`Bool`/`Char`. Address-taken locals
-      are excluded (the builder does not yet model writes through
-      pointers).
+      walker collapsed into a thin rule: walks `Local` mentions, consults
+      `engine.value(read)`, replaces with the source literal when the
+      `ValueKind` is `Int`/`Float`/`Bool`/`Char`. Locals in
+      `NirFunction::address_taken_locals` or `stores_aliased_locals` are
+      excluded — the builder models writes through neither.
 
 #### Stage 6 — const_folding, condition_implication, licm
 
@@ -307,6 +285,9 @@ algebraic rules over `Select` and `Opaque` provenance.
       cyclic Value graph at this stage.
 
 #### Stage 9 — Interprocedural worklist
+
+Stages 7 – 8 belong to the optional acceleration path below; the required
+path jumps from Stage 6 directly to Stage 9.
 
 - [ ] Old per-pass walkers (stub-only after Stages 3 – 6) are deleted in
       bulk.

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -30,6 +30,7 @@ pub mod nir_arena;
 pub mod nir_engine;
 pub mod nir_package;
 pub mod nir_unparse;
+pub mod nir_value_graph;
 pub mod optimize;
 pub mod package;
 pub mod parser;

--- a/wado-compiler/src/nir.rs
+++ b/wado-compiler/src/nir.rs
@@ -149,7 +149,7 @@ pub enum NirBinaryOp {
     RefNotEq,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum NirUnaryOp {
     Neg,
     Not,

--- a/wado-compiler/src/nir_engine.rs
+++ b/wado-compiler/src/nir_engine.rs
@@ -92,11 +92,10 @@ pub struct Engine<'a> {
     /// pass a scratch `Vec`; those bodies have no locals and their rules never
     /// allocate, so it stays empty.
     locals: &'a mut Vec<NirLocal>,
-    /// Lazily-built ValueGraph for this session. `None` until the first call
-    /// to [`Engine::value`] / [`Engine::value_kind`]; cleared by
-    /// [`Engine::invalidate_value_graph`]. See
-    /// `docs/wep-2026-06-05-worklist-rewrite-engine.md` (Stage 1 – 2) and
-    /// [`crate::nir_value_graph`] for the data model.
+    /// Lazy per-session ValueGraph cache. `None` until the first
+    /// [`Engine::value`] / [`Engine::value_kind`] call; cleared by
+    /// [`Engine::invalidate_value_graph`]. See [`crate::nir_value_graph`]
+    /// for the data model.
     value_graph: Option<crate::nir_value_graph::builder::ValueGraphBuild>,
 }
 
@@ -124,30 +123,18 @@ impl<'a> Engine<'a> {
         engine
     }
 
-    /// Return the [`ValueId`] of `expr` if it is a pure expression that the
-    /// per-function ValueGraph builder assigned an id to. Returns `None` for
-    /// impure / allocation-bearing / control-flow expressions, and for any
-    /// `ExprId` allocated after the session's ValueGraph was built (the
-    /// builder runs once on first access; the side-table does not see
-    /// post-build edits).
-    ///
-    /// First call builds the ValueGraph on demand via
-    /// [`crate::nir_value_graph::builder::build`] (one walk of the body);
-    /// subsequent calls are O(1).
+    /// Return the [`ValueId`] of `expr` if the per-function ValueGraph
+    /// assigned one. Returns `None` for impure / allocation-bearing /
+    /// control-flow expressions and for any `ExprId` allocated after the
+    /// cache was built. Built lazily on first call.
     ///
     /// # Invalidation contract
     ///
-    /// **Edits via `replace_expr_kind` / `set_block_stmts` / `alloc_*` do
-    /// not invalidate this cache.** The side-table keyed on pre-edit
-    /// `ExprId`s continues to return its original VNs. A rule that wants
-    /// to re-query after structurally rewriting the body must call
-    /// [`Engine::invalidate_value_graph`] explicitly — otherwise the
-    /// cached VN is the value at *build time*, not at query time.
-    ///
-    /// The typical pattern is to consult the value graph once at the
-    /// start of a rule and snapshot any VN results you intend to act on,
-    /// then perform the edits. See `optimize/cse.rs` and
-    /// `optimize/store_load_forward.rs` for examples.
+    /// Edits via `replace_expr_kind` / `set_block_stmts` / `alloc_*` do
+    /// **not** invalidate this cache — it keeps returning the VNs from
+    /// build time. Snapshot any VN results before editing, or call
+    /// [`Engine::invalidate_value_graph`] to force a rebuild. See
+    /// `optimize/cse.rs` and `optimize/store_load_forward.rs`.
     pub fn value(&mut self, expr: ExprId) -> Option<crate::nir_value_graph::ValueId> {
         self.ensure_value_graph();
         self.value_graph.as_ref()?.value_of.get(&expr).copied()
@@ -184,11 +171,11 @@ impl<'a> Engine<'a> {
         if self.value_graph.is_some() {
             return;
         }
-        // The builder does not need parameter seeding to behave correctly —
-        // the first read of an unseeded local lazily allocates an `Opaque`
-        // and caches it, which is functionally equivalent to up-front
-        // seeding (every subsequent read of the same local returns the same
-        // `ValueId`).
+        // Pass `&[]` for params: the builder's `read_local` fallback caches
+        // an `Opaque` on first read, which is observationally identical to
+        // up-front seeding as long as the engine never needs non-`Opaque`
+        // parameter values. Wire `params` through `Engine::new` if that
+        // changes.
         let build = crate::nir_value_graph::builder::build(&*self.body, &[]);
         self.value_graph = Some(build);
     }

--- a/wado-compiler/src/nir_engine.rs
+++ b/wado-compiler/src/nir_engine.rs
@@ -113,6 +113,14 @@ impl<'a> Engine<'a> {
         engine
     }
 
+    /// Read-only view of the owning function's local list. Some rules
+    /// (`labeled_block_fusion`) need to inspect existing locals' declared types
+    /// (e.g. to confirm a pattern's payload binding slot matches the
+    /// constructed payload's type).
+    pub fn locals(&self) -> &[NirLocal] {
+        self.locals
+    }
+
     /// Allocate a fresh function local, returning its index. `locals.len()` is
     /// the local count (there is no separate counter — see
     /// [`crate::nir::NirFunction::local_count`]), so the new local takes the
@@ -448,7 +456,13 @@ impl<'a> Engine<'a> {
         self.alloc_expr(kind, node.type_id, node.span)
     }
 
-    fn clone_block(&mut self, id: BlockId) -> BlockId {
+    /// Deep-copy the block subtree rooted at `id` into fresh arena nodes,
+    /// returning the new root. Recurses through every nested stmt / expr / pat
+    /// via the engine's `alloc_*` and `clone_*` paths, so the new subtree is
+    /// fully registered in the parent map and use index. Needed for rewrites
+    /// like `labeled_block_fusion` that splice cloned THEN/ELSE branches at
+    /// each break site of an LB.
+    pub fn clone_block(&mut self, id: BlockId) -> BlockId {
         let node = self.body.blocks[id].clone();
         let stmts = node.stmts.iter().map(|s| self.clone_stmt(*s)).collect();
         self.alloc_block(stmts, node.span)

--- a/wado-compiler/src/nir_engine.rs
+++ b/wado-compiler/src/nir_engine.rs
@@ -92,7 +92,7 @@ pub struct Engine<'a> {
     /// pass a scratch `Vec`; those bodies have no locals and their rules never
     /// allocate, so it stays empty.
     locals: &'a mut Vec<NirLocal>,
-    /// Lazy per-session ValueGraph cache. `None` until the first
+    /// Lazy per-session `ValueGraph` cache. `None` until the first
     /// [`Engine::value`] / [`Engine::value_kind`] call; cleared by
     /// [`Engine::invalidate_value_graph`]. See [`crate::nir_value_graph`]
     /// for the data model.
@@ -123,7 +123,7 @@ impl<'a> Engine<'a> {
         engine
     }
 
-    /// Return the [`ValueId`] of `expr` if the per-function ValueGraph
+    /// Return the [`ValueId`] of `expr` if the per-function `ValueGraph`
     /// assigned one. Returns `None` for impure / allocation-bearing /
     /// control-flow expressions and for any `ExprId` allocated after the
     /// cache was built. Built lazily on first call.
@@ -160,7 +160,7 @@ impl<'a> Engine<'a> {
         self.value_graph.as_ref()?.literal_source.get(&id).copied()
     }
 
-    /// Drop the cached ValueGraph so the next [`Engine::value`] call
+    /// Drop the cached `ValueGraph` so the next [`Engine::value`] call
     /// rebuilds. Used by rules that intend to query the value graph again
     /// after a structural rewrite that would invalidate the prior build.
     pub fn invalidate_value_graph(&mut self) {

--- a/wado-compiler/src/nir_engine.rs
+++ b/wado-compiler/src/nir_engine.rs
@@ -135,10 +135,19 @@ impl<'a> Engine<'a> {
     /// [`crate::nir_value_graph::builder::build`] (one walk of the body);
     /// subsequent calls are O(1).
     ///
-    /// Rules that materially edit the body should call
-    /// [`Engine::invalidate_value_graph`] if they intend to re-query after
-    /// the edit, or simply consult the value graph once at the start of
-    /// their work (the typical pattern).
+    /// # Invalidation contract
+    ///
+    /// **Edits via `replace_expr_kind` / `set_block_stmts` / `alloc_*` do
+    /// not invalidate this cache.** The side-table keyed on pre-edit
+    /// `ExprId`s continues to return its original VNs. A rule that wants
+    /// to re-query after structurally rewriting the body must call
+    /// [`Engine::invalidate_value_graph`] explicitly — otherwise the
+    /// cached VN is the value at *build time*, not at query time.
+    ///
+    /// The typical pattern is to consult the value graph once at the
+    /// start of a rule and snapshot any VN results you intend to act on,
+    /// then perform the edits. See `optimize/cse.rs` and
+    /// `optimize/store_load_forward.rs` for examples.
     pub fn value(&mut self, expr: ExprId) -> Option<crate::nir_value_graph::ValueId> {
         self.ensure_value_graph();
         self.value_graph.as_ref()?.value_of.get(&expr).copied()

--- a/wado-compiler/src/nir_engine.rs
+++ b/wado-compiler/src/nir_engine.rs
@@ -147,9 +147,21 @@ impl<'a> Engine<'a> {
     /// Read-only view of a value's kind. The returned reference borrows the
     /// engine's value-graph cache; callers that need to hold the kind across
     /// further `engine` calls should clone it.
-    pub fn value_kind(&mut self, id: crate::nir_value_graph::ValueId) -> &crate::nir_value_graph::ValueKind {
+    pub fn value_kind(
+        &mut self,
+        id: crate::nir_value_graph::ValueId,
+    ) -> &crate::nir_value_graph::ValueKind {
         self.ensure_value_graph();
         self.value_graph.as_ref().unwrap().pool.kind(id)
+    }
+
+    /// First `ExprId` observed producing the given literal `ValueId`. Returns
+    /// `None` if `id` is not a literal kind (or no expression produced it).
+    /// Lets a rewrite reuse the original literal `ExprKind` — including its
+    /// source `repr` — when substituting a literal at a use site.
+    pub fn literal_source(&mut self, id: crate::nir_value_graph::ValueId) -> Option<ExprId> {
+        self.ensure_value_graph();
+        self.value_graph.as_ref()?.literal_source.get(&id).copied()
     }
 
     /// Drop the cached ValueGraph so the next [`Engine::value`] call

--- a/wado-compiler/src/nir_engine.rs
+++ b/wado-compiler/src/nir_engine.rs
@@ -92,6 +92,12 @@ pub struct Engine<'a> {
     /// pass a scratch `Vec`; those bodies have no locals and their rules never
     /// allocate, so it stays empty.
     locals: &'a mut Vec<NirLocal>,
+    /// Lazily-built ValueGraph for this session. `None` until the first call
+    /// to [`Engine::value`] / [`Engine::value_kind`]; cleared by
+    /// [`Engine::invalidate_value_graph`]. See
+    /// `docs/wep-2026-06-05-worklist-rewrite-engine.md` (Stage 1 – 2) and
+    /// [`crate::nir_value_graph`] for the data model.
+    value_graph: Option<crate::nir_value_graph::builder::ValueGraphBuild>,
 }
 
 impl<'a> Engine<'a> {
@@ -106,11 +112,64 @@ impl<'a> Engine<'a> {
         locals: &'a mut Vec<NirLocal>,
     ) -> Self {
         buf.reset_for(body);
-        let mut engine = Self { body, buf, locals };
+        let mut engine = Self {
+            body,
+            buf,
+            locals,
+            value_graph: None,
+        };
         engine.build_parents();
         engine.build_uses();
         engine.seed_post_order();
         engine
+    }
+
+    /// Return the [`ValueId`] of `expr` if it is a pure expression that the
+    /// per-function ValueGraph builder assigned an id to. Returns `None` for
+    /// impure / allocation-bearing / control-flow expressions, and for any
+    /// `ExprId` allocated after the session's ValueGraph was built (the
+    /// builder runs once on first access; the side-table does not see
+    /// post-build edits).
+    ///
+    /// First call builds the ValueGraph on demand via
+    /// [`crate::nir_value_graph::builder::build`] (one walk of the body);
+    /// subsequent calls are O(1).
+    ///
+    /// Rules that materially edit the body should call
+    /// [`Engine::invalidate_value_graph`] if they intend to re-query after
+    /// the edit, or simply consult the value graph once at the start of
+    /// their work (the typical pattern).
+    pub fn value(&mut self, expr: ExprId) -> Option<crate::nir_value_graph::ValueId> {
+        self.ensure_value_graph();
+        self.value_graph.as_ref()?.value_of.get(&expr).copied()
+    }
+
+    /// Read-only view of a value's kind. The returned reference borrows the
+    /// engine's value-graph cache; callers that need to hold the kind across
+    /// further `engine` calls should clone it.
+    pub fn value_kind(&mut self, id: crate::nir_value_graph::ValueId) -> &crate::nir_value_graph::ValueKind {
+        self.ensure_value_graph();
+        self.value_graph.as_ref().unwrap().pool.kind(id)
+    }
+
+    /// Drop the cached ValueGraph so the next [`Engine::value`] call
+    /// rebuilds. Used by rules that intend to query the value graph again
+    /// after a structural rewrite that would invalidate the prior build.
+    pub fn invalidate_value_graph(&mut self) {
+        self.value_graph = None;
+    }
+
+    fn ensure_value_graph(&mut self) {
+        if self.value_graph.is_some() {
+            return;
+        }
+        // The builder does not need parameter seeding to behave correctly —
+        // the first read of an unseeded local lazily allocates an `Opaque`
+        // and caches it, which is functionally equivalent to up-front
+        // seeding (every subsequent read of the same local returns the same
+        // `ValueId`).
+        let build = crate::nir_value_graph::builder::build(&*self.body, &[]);
+        self.value_graph = Some(build);
     }
 
     /// Read-only view of the owning function's local list. Some rules

--- a/wado-compiler/src/nir_value_graph.rs
+++ b/wado-compiler/src/nir_value_graph.rs
@@ -1,0 +1,631 @@
+//! NIR Value Graph (Layer 2 — pure-value e-graph).
+//!
+//! Hash-consed DAG of pure values. Each value has a [`ValueId`] (newtype
+//! over `u32`); two structurally-equivalent values share one `ValueId`. The
+//! SkelTree (Layer 1 — see [`crate::nir_arena`]) references pure operands by
+//! `ValueId`; pure values live exclusively here.
+//!
+//! See `docs/wep-2026-06-05-worklist-rewrite-engine.md` (Stage 1). This
+//! module is currently standalone: nothing in the optimizer references it
+//! yet. Stage 2 wires the per-function builder; the engine and rules pick it
+//! up in Stage 3+.
+
+use crate::hashmap::IndexMap;
+use crate::nir::{NirBinaryOp, NirUnaryOp};
+use crate::tir::TypeId;
+
+/// Opaque handle for a pure value. Two structurally-equivalent values share
+/// one `ValueId` (hash-consed). Allocated by [`ValuePool::intern`].
+///
+/// `ValueId`s are scoped to one [`ValuePool`] — passing an id from one pool
+/// into another is a logic bug. Pools are per-function in normal use.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub struct ValueId(u32);
+
+impl ValueId {
+    /// Raw `u32` view, mainly for debugging / dumping.
+    #[inline]
+    pub fn index(self) -> u32 {
+        self.0
+    }
+}
+
+/// Fresh anonymous value identity. Used to seed parameters, opaque loop
+/// locals, and other unknowns: every `OpaqueId` is unique within one
+/// [`ValuePool`], so two `ValueKind::Opaque(a)` and `ValueKind::Opaque(b)`
+/// are equal iff `a == b`.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub struct OpaqueId(u32);
+
+impl OpaqueId {
+    /// Raw `u32` view, mainly for debugging.
+    #[inline]
+    pub fn index(self) -> u32 {
+        self.0
+    }
+}
+
+/// Heap-version tag carried by [`ValueKind::FieldAccess`]. The Stage-2
+/// builder bumps the version on every SkelTree node that may write the heap;
+/// reads at the same `(receiver, field, heap_ver)` triple share a
+/// `ValueId`, automatically forwarding stored values. Granularity is
+/// per-field in the MVP.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Default)]
+pub struct HeapVersion(u32);
+
+impl HeapVersion {
+    /// The initial version, used at function entry / loop entry.
+    pub const INITIAL: HeapVersion = HeapVersion(0);
+
+    /// Monotonically advance to the next version.
+    #[inline]
+    pub fn bump(self) -> Self {
+        HeapVersion(self.0 + 1)
+    }
+
+    /// Raw `u32` view, mainly for debugging.
+    #[inline]
+    pub fn index(self) -> u32 {
+        self.0
+    }
+}
+
+/// A pure-value expression. Hash-consed by structural equality.
+///
+/// Anything with side effects (`Call`, `MethodCall`, `Assign`-to-heap, …)
+/// stays in the SkelTree. The Skel side references a pure operand via the
+/// `Operand::Value(ValueId)` enum that lands in Stage 7; until then a Stage-2
+/// side-table `value_of: IndexMap<ExprId, ValueId>` connects the SkelTree's
+/// pure `ExprKind` positions to their hash-consed values.
+///
+/// `String` literals are stored as `String` for now. Phase 2 may intern them
+/// behind an id table if it measures.
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub enum ValueKind {
+    // ---- Literals ----
+    Int(u64),
+    /// `f64` bit pattern. Same bit pattern → same `ValueId`; distinct bit
+    /// patterns (including different NaN payloads) are distinct values. This
+    /// is the safe definitional equality: runtime `==` on floats is not the
+    /// same relation (NaN is never `==` itself), and equality saturation
+    /// rules that rewrite over float values must take that into account
+    /// without help from the hash-cons.
+    Float(u64),
+    Bool(bool),
+    Char(char),
+    String(String),
+    Null,
+    Unit,
+
+    // ---- Opaque ----
+    /// Anonymous unknown. Parameters are seeded with one `Opaque` each at
+    /// function entry; loop locals are `Opaque` in the MVP. Stage 6 promotes
+    /// induction-pattern locals to a tagged form (added to this enum at
+    /// that stage; tracked in the migration plan in the WEP).
+    Opaque(OpaqueId),
+
+    // ---- Pure arithmetic ----
+    Binary {
+        op: NirBinaryOp,
+        lhs: ValueId,
+        rhs: ValueId,
+    },
+    Unary {
+        op: NirUnaryOp,
+        operand: ValueId,
+    },
+    Cast {
+        operand: ValueId,
+        target: TypeId,
+    },
+
+    // ---- Structural merge / loop recurrence ----
+    /// Result of a structural If / Match / Switch endpoint:
+    /// `if cond then then_v else else_v`. The Stage-2 builder constructs
+    /// these at merge points where a local's value differs across arms.
+    Select {
+        cond: ValueId,
+        then: ValueId,
+        else_: ValueId,
+    },
+    /// Loop-recurrence placeholder. `entry` is the value at loop entry;
+    /// `body_iter` is the value after one iteration of the loop body. MVP
+    /// keeps `body_iter` set to an `Opaque` (no induction recognition); the
+    /// kind exists so Stage 6 can fill it in without an enum change.
+    LoopPhi {
+        entry: ValueId,
+        body_iter: ValueId,
+    },
+
+    // ---- Heap-bearing reads ----
+    /// `receiver.field_index` at the given heap version. Two reads with the
+    /// same `(receiver, field_index, heap_ver)` triple share a `ValueId`,
+    /// automatically forwarding stored values. `field_index` rather than
+    /// `field_name` because the receiver `ValueId` already pins the type:
+    /// indices that collide across types belong to distinct receivers.
+    FieldAccess {
+        receiver: ValueId,
+        field_index: u32,
+        heap_ver: HeapVersion,
+    },
+}
+
+/// Hash-consed pure-value pool. One instance per function in normal use.
+///
+/// `ValueId`s allocated by one pool refer to that pool's `values` vector;
+/// mixing pools is a logic bug. The pool also owns the `OpaqueId` counter,
+/// so [`ValuePool::fresh_opaque`] returns a globally-unique-within-this-pool
+/// identity each call.
+#[derive(Debug, Default)]
+pub struct ValuePool {
+    /// Allocated values, in `ValueId` order. `values[id.index() as usize]`
+    /// is the kind for `id`.
+    values: Vec<ValueKind>,
+    /// Reverse index: kind → `ValueId`. The hash-cons key.
+    interned: IndexMap<ValueKind, ValueId>,
+    /// Next `OpaqueId` to allocate.
+    next_opaque: u32,
+}
+
+impl ValuePool {
+    /// A fresh, empty pool.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The number of distinct values allocated so far.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    /// Whether no values have been allocated.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+
+    /// Hash-cons: return the `ValueId` for `kind`, allocating a fresh one if
+    /// `kind` has not been seen before.
+    ///
+    /// `kind` is cloned only on a fresh allocation (the clone goes into the
+    /// `values` vector); a repeat lookup hits the index and returns the
+    /// existing id without copying.
+    pub fn intern(&mut self, kind: ValueKind) -> ValueId {
+        if let Some(&id) = self.interned.get(&kind) {
+            return id;
+        }
+        let id = ValueId(self.values.len() as u32);
+        self.values.push(kind.clone());
+        self.interned.insert(kind, id);
+        id
+    }
+
+    /// Allocate a fresh `Opaque` value. Each call returns a `ValueId`
+    /// distinct from every prior call to `fresh_opaque` on this pool.
+    pub fn fresh_opaque(&mut self) -> ValueId {
+        let opaque = OpaqueId(self.next_opaque);
+        self.next_opaque += 1;
+        // `Opaque(n)` for a fresh `n` is never present in `interned`, so the
+        // intern is guaranteed to allocate. Going through `intern` keeps
+        // `values` and `interned` in sync.
+        self.intern(ValueKind::Opaque(opaque))
+    }
+
+    /// Read the kind of an allocated `ValueId`. Panics if `id` is out of
+    /// range (i.e., came from a different pool).
+    #[inline]
+    pub fn kind(&self, id: ValueId) -> &ValueKind {
+        &self.values[id.0 as usize]
+    }
+
+    // ---- Convenience builders ----
+    //
+    // Tests and the Stage-2 builder use these to construct values without
+    // repeating the `ValueKind::` prefix on every line. Each one threads
+    // through `intern`, so hash-cons applies.
+
+    #[inline]
+    pub fn int(&mut self, value: u64) -> ValueId {
+        self.intern(ValueKind::Int(value))
+    }
+
+    /// Build a Float value from a raw `f64` bit pattern. Use this when the
+    /// caller already has bit-pattern semantics in hand (e.g. carrying a
+    /// NaN payload through a rewrite). For an `f64` value, prefer
+    /// [`ValuePool::float`].
+    #[inline]
+    pub fn float_bits(&mut self, bits: u64) -> ValueId {
+        self.intern(ValueKind::Float(bits))
+    }
+
+    /// Build a Float value from an `f64`. The pool keys on the bit pattern,
+    /// so `+0.0` and `-0.0` are distinct values, as are distinct NaN
+    /// payloads.
+    #[inline]
+    pub fn float(&mut self, value: f64) -> ValueId {
+        self.float_bits(value.to_bits())
+    }
+
+    #[inline]
+    pub fn bool(&mut self, value: bool) -> ValueId {
+        self.intern(ValueKind::Bool(value))
+    }
+
+    #[inline]
+    pub fn char(&mut self, value: char) -> ValueId {
+        self.intern(ValueKind::Char(value))
+    }
+
+    #[inline]
+    pub fn string(&mut self, value: String) -> ValueId {
+        self.intern(ValueKind::String(value))
+    }
+
+    #[inline]
+    pub fn null(&mut self) -> ValueId {
+        self.intern(ValueKind::Null)
+    }
+
+    #[inline]
+    pub fn unit(&mut self) -> ValueId {
+        self.intern(ValueKind::Unit)
+    }
+
+    #[inline]
+    pub fn binary(&mut self, op: NirBinaryOp, lhs: ValueId, rhs: ValueId) -> ValueId {
+        self.intern(ValueKind::Binary { op, lhs, rhs })
+    }
+
+    #[inline]
+    pub fn unary(&mut self, op: NirUnaryOp, operand: ValueId) -> ValueId {
+        self.intern(ValueKind::Unary { op, operand })
+    }
+
+    #[inline]
+    pub fn cast(&mut self, operand: ValueId, target: TypeId) -> ValueId {
+        self.intern(ValueKind::Cast { operand, target })
+    }
+
+    #[inline]
+    pub fn select(&mut self, cond: ValueId, then: ValueId, else_: ValueId) -> ValueId {
+        self.intern(ValueKind::Select { cond, then, else_ })
+    }
+
+    #[inline]
+    pub fn loop_phi(&mut self, entry: ValueId, body_iter: ValueId) -> ValueId {
+        self.intern(ValueKind::LoopPhi { entry, body_iter })
+    }
+
+    #[inline]
+    pub fn field_access(
+        &mut self,
+        receiver: ValueId,
+        field_index: u32,
+        heap_ver: HeapVersion,
+    ) -> ValueId {
+        self.intern(ValueKind::FieldAccess {
+            receiver,
+            field_index,
+            heap_ver,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::nir::{NirBinaryOp, NirUnaryOp};
+    use crate::tir::TypeId;
+
+    // ---- Hash-cons dedup ----
+
+    #[test]
+    fn fresh_pool_is_empty() {
+        let pool = ValuePool::new();
+        assert_eq!(pool.len(), 0);
+        assert!(pool.is_empty());
+    }
+
+    #[test]
+    fn intern_same_int_twice_returns_same_id() {
+        let mut pool = ValuePool::new();
+        let a = pool.int(42);
+        let b = pool.int(42);
+        assert_eq!(a, b);
+        assert_eq!(pool.len(), 1);
+    }
+
+    #[test]
+    fn intern_different_ints_returns_different_ids() {
+        let mut pool = ValuePool::new();
+        let a = pool.int(1);
+        let b = pool.int(2);
+        assert_ne!(a, b);
+        assert_eq!(pool.len(), 2);
+    }
+
+    #[test]
+    fn different_kinds_with_same_payload_are_distinct() {
+        let mut pool = ValuePool::new();
+        let i0 = pool.int(0);
+        let b_false = pool.bool(false);
+        // Same numeric "0" but different ValueKind variants — distinct ids.
+        assert_ne!(i0, b_false);
+        assert_eq!(pool.len(), 2);
+    }
+
+    #[test]
+    fn bool_true_and_false_are_distinct() {
+        let mut pool = ValuePool::new();
+        let t = pool.bool(true);
+        let f = pool.bool(false);
+        assert_ne!(t, f);
+    }
+
+    #[test]
+    fn null_and_unit_are_distinct_and_each_dedup() {
+        let mut pool = ValuePool::new();
+        let n1 = pool.null();
+        let n2 = pool.null();
+        let u1 = pool.unit();
+        let u2 = pool.unit();
+        assert_eq!(n1, n2);
+        assert_eq!(u1, u2);
+        assert_ne!(n1, u1);
+        assert_eq!(pool.len(), 2);
+    }
+
+    #[test]
+    fn kind_lookup_round_trips() {
+        let mut pool = ValuePool::new();
+        let id = pool.int(7);
+        assert_eq!(pool.kind(id), &ValueKind::Int(7));
+    }
+
+    // ---- Float bit-pattern semantics ----
+
+    #[test]
+    fn float_pos_zero_and_neg_zero_are_distinct() {
+        let mut pool = ValuePool::new();
+        let pz = pool.float(0.0);
+        let nz = pool.float(-0.0);
+        assert_ne!(pz, nz);
+    }
+
+    #[test]
+    fn float_same_bit_pattern_dedupes() {
+        let mut pool = ValuePool::new();
+        let a = pool.float_bits(0x7ff8_0000_0000_0001); // a NaN
+        let b = pool.float_bits(0x7ff8_0000_0000_0001);
+        assert_eq!(a, b);
+        assert_eq!(pool.len(), 1);
+    }
+
+    #[test]
+    fn float_distinct_nan_payloads_are_distinct_values() {
+        let mut pool = ValuePool::new();
+        let a = pool.float_bits(0x7ff8_0000_0000_0001);
+        let b = pool.float_bits(0x7ff8_0000_0000_0002);
+        assert_ne!(a, b);
+    }
+
+    // ---- Opaque ----
+
+    #[test]
+    fn opaque_is_always_fresh() {
+        let mut pool = ValuePool::new();
+        let a = pool.fresh_opaque();
+        let b = pool.fresh_opaque();
+        let c = pool.fresh_opaque();
+        assert_ne!(a, b);
+        assert_ne!(b, c);
+        assert_ne!(a, c);
+        assert_eq!(pool.len(), 3);
+    }
+
+    #[test]
+    fn opaque_kinds_carry_increasing_ids() {
+        let mut pool = ValuePool::new();
+        let a = pool.fresh_opaque();
+        let b = pool.fresh_opaque();
+        match (pool.kind(a), pool.kind(b)) {
+            (ValueKind::Opaque(ia), ValueKind::Opaque(ib)) => {
+                assert_eq!(ib.index(), ia.index() + 1);
+            }
+            other => panic!("unexpected kinds: {:?}", other),
+        }
+    }
+
+    // ---- Pure arithmetic ----
+
+    #[test]
+    fn same_binary_with_same_operands_dedupes() {
+        let mut pool = ValuePool::new();
+        let l = pool.int(1);
+        let r = pool.int(2);
+        let a = pool.binary(NirBinaryOp::Add, l, r);
+        let b = pool.binary(NirBinaryOp::Add, l, r);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn binary_operand_order_matters() {
+        let mut pool = ValuePool::new();
+        let l = pool.int(1);
+        let r = pool.int(2);
+        let lr = pool.binary(NirBinaryOp::Sub, l, r);
+        let rl = pool.binary(NirBinaryOp::Sub, r, l);
+        assert_ne!(lr, rl); // Sub is non-commutative; hash-cons just checks structure.
+    }
+
+    #[test]
+    fn binary_different_op_distinguishes() {
+        let mut pool = ValuePool::new();
+        let l = pool.int(1);
+        let r = pool.int(2);
+        let add = pool.binary(NirBinaryOp::Add, l, r);
+        let mul = pool.binary(NirBinaryOp::Mul, l, r);
+        assert_ne!(add, mul);
+    }
+
+    #[test]
+    fn unary_dedupes() {
+        let mut pool = ValuePool::new();
+        let inner = pool.int(5);
+        let a = pool.unary(NirUnaryOp::Neg, inner);
+        let b = pool.unary(NirUnaryOp::Neg, inner);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn unary_different_op_distinguishes() {
+        let mut pool = ValuePool::new();
+        let inner = pool.int(5);
+        let neg = pool.unary(NirUnaryOp::Neg, inner);
+        let not = pool.unary(NirUnaryOp::Not, inner);
+        assert_ne!(neg, not);
+    }
+
+    #[test]
+    fn cast_dedupes_per_target_type() {
+        let mut pool = ValuePool::new();
+        let inner = pool.int(5);
+        let t1 = TypeId(1);
+        let t2 = TypeId(2);
+        let a = pool.cast(inner, t1);
+        let b = pool.cast(inner, t1);
+        let c = pool.cast(inner, t2);
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    // ---- Structural merge ----
+
+    #[test]
+    fn select_dedupes_structurally() {
+        let mut pool = ValuePool::new();
+        let cond = pool.bool(true);
+        let t = pool.int(1);
+        let e = pool.int(2);
+        let s1 = pool.select(cond, t, e);
+        let s2 = pool.select(cond, t, e);
+        assert_eq!(s1, s2);
+    }
+
+    #[test]
+    fn select_distinguishes_arm_swap() {
+        let mut pool = ValuePool::new();
+        let cond = pool.bool(true);
+        let t = pool.int(1);
+        let e = pool.int(2);
+        let normal = pool.select(cond, t, e);
+        let swapped = pool.select(cond, e, t);
+        assert_ne!(normal, swapped);
+    }
+
+    #[test]
+    fn loop_phi_dedupes_structurally() {
+        let mut pool = ValuePool::new();
+        let entry = pool.int(0);
+        let next = pool.fresh_opaque();
+        let a = pool.loop_phi(entry, next);
+        let b = pool.loop_phi(entry, next);
+        assert_eq!(a, b);
+    }
+
+    // ---- Heap-bearing reads ----
+
+    #[test]
+    fn field_access_distinguishes_by_heap_version() {
+        let mut pool = ValuePool::new();
+        let recv = pool.fresh_opaque();
+        let v0 = HeapVersion::INITIAL;
+        let v1 = v0.bump();
+        let read0 = pool.field_access(recv, 0, v0);
+        let read1 = pool.field_access(recv, 0, v1);
+        assert_ne!(read0, read1);
+    }
+
+    #[test]
+    fn field_access_dedupes_at_same_heap_version() {
+        let mut pool = ValuePool::new();
+        let recv = pool.fresh_opaque();
+        let v = HeapVersion::INITIAL;
+        let a = pool.field_access(recv, 0, v);
+        let b = pool.field_access(recv, 0, v);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn field_access_distinguishes_by_receiver() {
+        let mut pool = ValuePool::new();
+        let r1 = pool.fresh_opaque();
+        let r2 = pool.fresh_opaque();
+        let v = HeapVersion::INITIAL;
+        let read1 = pool.field_access(r1, 0, v);
+        let read2 = pool.field_access(r2, 0, v);
+        assert_ne!(read1, read2);
+    }
+
+    #[test]
+    fn field_access_distinguishes_by_field_index() {
+        let mut pool = ValuePool::new();
+        let recv = pool.fresh_opaque();
+        let v = HeapVersion::INITIAL;
+        let read0 = pool.field_access(recv, 0, v);
+        let read1 = pool.field_access(recv, 1, v);
+        assert_ne!(read0, read1);
+    }
+
+    // ---- HeapVersion ----
+
+    #[test]
+    fn heap_version_bump_advances_monotonically() {
+        let v0 = HeapVersion::INITIAL;
+        let v1 = v0.bump();
+        let v2 = v1.bump();
+        assert_ne!(v0, v1);
+        assert_ne!(v1, v2);
+        assert!(v0.index() < v1.index());
+        assert!(v1.index() < v2.index());
+    }
+
+    // ---- Nested / mixed-kind sanity ----
+
+    #[test]
+    fn nested_arithmetic_dedupes() {
+        let mut pool = ValuePool::new();
+        let a = pool.int(1);
+        let b = pool.int(2);
+        let c = pool.int(3);
+        // (a + b) * c, twice.
+        let lhs1 = pool.binary(NirBinaryOp::Add, a, b);
+        let outer1 = pool.binary(NirBinaryOp::Mul, lhs1, c);
+        let lhs2 = pool.binary(NirBinaryOp::Add, a, b);
+        let outer2 = pool.binary(NirBinaryOp::Mul, lhs2, c);
+        assert_eq!(lhs1, lhs2);
+        assert_eq!(outer1, outer2);
+    }
+
+    #[test]
+    fn full_pipeline_keeps_pool_compact() {
+        let mut pool = ValuePool::new();
+        let _p = pool.fresh_opaque(); // a parameter
+        let _z = pool.int(0);
+        let _o = pool.int(1);
+        let _t = pool.int(2);
+        // Re-intern everything.
+        let p2 = pool.fresh_opaque();
+        let z2 = pool.int(0);
+        let o2 = pool.int(1);
+        let t2 = pool.int(2);
+        // `fresh_opaque` always allocates; the literals dedupe.
+        assert_ne!(_p, p2);
+        assert_eq!(_z, z2);
+        assert_eq!(_o, o2);
+        assert_eq!(_t, t2);
+        // 4 originals + 1 new opaque = 5 entries.
+        assert_eq!(pool.len(), 5);
+    }
+}

--- a/wado-compiler/src/nir_value_graph.rs
+++ b/wado-compiler/src/nir_value_graph.rs
@@ -5,10 +5,10 @@
 //! SkelTree (Layer 1 — see [`crate::nir_arena`]) references pure operands by
 //! `ValueId`; pure values live exclusively here.
 //!
-//! See `docs/wep-2026-06-05-worklist-rewrite-engine.md` (Stage 1). This
-//! module is currently standalone: nothing in the optimizer references it
-//! yet. Stage 2 wires the per-function builder; the engine and rules pick it
-//! up in Stage 3+.
+//! Consumed by [`crate::nir_engine::Engine::value`] (which lazily builds the
+//! per-function graph via [`builder::build`]) and through that by the CSE
+//! and store-load-forward rules. See
+//! `docs/wep-2026-06-05-worklist-rewrite-engine.md`.
 
 pub mod builder;
 
@@ -74,24 +74,19 @@ impl HeapVersion {
 
 /// A pure-value expression. Hash-consed by structural equality.
 ///
-/// Anything with side effects (`Call`, `MethodCall`, `Assign`-to-heap, …)
-/// stays in the SkelTree. The Skel side references a pure operand via the
-/// `Operand::Value(ValueId)` enum that lands in Stage 7; until then a Stage-2
-/// side-table `value_of: IndexMap<ExprId, ValueId>` connects the SkelTree's
-/// pure `ExprKind` positions to their hash-consed values.
-///
-/// `String` literals are stored as `String` for now. Phase 2 may intern them
-/// behind an id table if it measures.
+/// Side-effecting nodes (`Call`, `MethodCall`, `Assign`-to-heap, …) stay
+/// in the SkelTree. Pure operand positions connect to their `ValueId`s
+/// through the per-function side-table `value_of: IndexMap<ExprId,
+/// ValueId>` populated by [`crate::nir_value_graph::builder`]. Stage 7
+/// of the WEP would replace that table with `Operand::Value(ValueId)` on
+/// Skel slots, but is deferred.
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub enum ValueKind {
     // ---- Literals ----
     Int(u64),
-    /// `f64` bit pattern. Same bit pattern → same `ValueId`; distinct bit
-    /// patterns (including different NaN payloads) are distinct values. This
-    /// is the safe definitional equality: runtime `==` on floats is not the
-    /// same relation (NaN is never `==` itself), and equality saturation
-    /// rules that rewrite over float values must take that into account
-    /// without help from the hash-cons.
+    /// `f64` bit pattern: distinct NaN payloads and `+0.0` / `-0.0` are
+    /// distinct values. Algebraic rules over floats must consult numeric
+    /// equality separately — runtime `==` is not this relation.
     Float(u64),
     Bool(bool),
     Char(char),
@@ -100,10 +95,8 @@ pub enum ValueKind {
     Unit,
 
     // ---- Opaque ----
-    /// Anonymous unknown. Parameters are seeded with one `Opaque` each at
-    /// function entry; loop locals are `Opaque` in the MVP. Stage 6 promotes
-    /// induction-pattern locals to a tagged form (added to this enum at
-    /// that stage; tracked in the migration plan in the WEP).
+    /// Anonymous unknown. Used for parameters and loop locals; Stage 6
+    /// may promote recognised inductions to a tagged form.
     Opaque(OpaqueId),
 
     // ---- Pure arithmetic ----
@@ -140,11 +133,10 @@ pub enum ValueKind {
     },
 
     // ---- Heap-bearing reads ----
-    /// `receiver.field_index` at the given heap version. Two reads with the
-    /// same `(receiver, field_index, heap_ver)` triple share a `ValueId`,
-    /// automatically forwarding stored values. `field_index` rather than
-    /// `field_name` because the receiver `ValueId` already pins the type:
-    /// indices that collide across types belong to distinct receivers.
+    /// `receiver.field_index` at the given heap version. `field_index`
+    /// rather than `field_name` because the receiver `ValueId` already
+    /// pins the type: indices that collide across types belong to
+    /// distinct receivers.
     FieldAccess {
         receiver: ValueId,
         field_index: u32,
@@ -152,12 +144,9 @@ pub enum ValueKind {
     },
 }
 
-/// Hash-consed pure-value pool. One instance per function in normal use.
-///
-/// `ValueId`s allocated by one pool refer to that pool's `values` vector;
-/// mixing pools is a logic bug. The pool also owns the `OpaqueId` counter,
-/// so [`ValuePool::fresh_opaque`] returns a globally-unique-within-this-pool
-/// identity each call.
+/// Hash-consed pure-value pool. One instance per function. Also owns the
+/// `OpaqueId` counter, so [`ValuePool::fresh_opaque`] returns a
+/// pool-unique identity each call.
 #[derive(Debug, Default)]
 pub struct ValuePool {
     /// Allocated values, in `ValueId` order. `values[id.index() as usize]`
@@ -208,9 +197,6 @@ impl ValuePool {
     pub fn fresh_opaque(&mut self) -> ValueId {
         let opaque = OpaqueId(self.next_opaque);
         self.next_opaque += 1;
-        // `Opaque(n)` for a fresh `n` is never present in `interned`, so the
-        // intern is guaranteed to allocate. Going through `intern` keeps
-        // `values` and `interned` in sync.
         self.intern(ValueKind::Opaque(opaque))
     }
 
@@ -220,12 +206,6 @@ impl ValuePool {
     pub fn kind(&self, id: ValueId) -> &ValueKind {
         &self.values[id.0 as usize]
     }
-
-    // ---- Convenience builders ----
-    //
-    // Tests and the Stage-2 builder use these to construct values without
-    // repeating the `ValueKind::` prefix on every line. Each one threads
-    // through `intern`, so hash-cons applies.
 
     #[inline]
     pub fn int(&mut self, value: u64) -> ValueId {

--- a/wado-compiler/src/nir_value_graph.rs
+++ b/wado-compiler/src/nir_value_graph.rs
@@ -2,7 +2,7 @@
 //!
 //! Hash-consed DAG of pure values. Each value has a [`ValueId`] (newtype
 //! over `u32`); two structurally-equivalent values share one `ValueId`. The
-//! SkelTree (Layer 1 — see [`crate::nir_arena`]) references pure operands by
+//! `SkelTree` (Layer 1 — see [`crate::nir_arena`]) references pure operands by
 //! `ValueId`; pure values live exclusively here.
 //!
 //! Consumed by [`crate::nir_engine::Engine::value`] (which lazily builds the
@@ -48,7 +48,7 @@ impl OpaqueId {
 }
 
 /// Heap-version tag carried by [`ValueKind::FieldAccess`]. The Stage-2
-/// builder bumps the version on every SkelTree node that may write the heap;
+/// builder bumps the version on every `SkelTree` node that may write the heap;
 /// reads at the same `(receiver, field, heap_ver)` triple share a
 /// `ValueId`, automatically forwarding stored values. Granularity is
 /// per-field in the MVP.
@@ -75,7 +75,7 @@ impl HeapVersion {
 /// A pure-value expression. Hash-consed by structural equality.
 ///
 /// Side-effecting nodes (`Call`, `MethodCall`, `Assign`-to-heap, …) stay
-/// in the SkelTree. Pure operand positions connect to their `ValueId`s
+/// in the `SkelTree`. Pure operand positions connect to their `ValueId`s
 /// through the per-function side-table `value_of: IndexMap<ExprId,
 /// ValueId>` populated by [`crate::nir_value_graph::builder`]. Stage 7
 /// of the WEP would replace that table with `Operand::Value(ValueId)` on
@@ -415,7 +415,7 @@ mod tests {
             (ValueKind::Opaque(ia), ValueKind::Opaque(ib)) => {
                 assert_eq!(ib.index(), ia.index() + 1);
             }
-            other => panic!("unexpected kinds: {:?}", other),
+            other => panic!("unexpected kinds: {other:?}"),
         }
     }
 

--- a/wado-compiler/src/nir_value_graph.rs
+++ b/wado-compiler/src/nir_value_graph.rs
@@ -10,6 +10,8 @@
 //! yet. Stage 2 wires the per-function builder; the engine and rules pick it
 //! up in Stage 3+.
 
+pub mod builder;
+
 use crate::hashmap::IndexMap;
 use crate::nir::{NirBinaryOp, NirUnaryOp};
 use crate::tir::TypeId;

--- a/wado-compiler/src/nir_value_graph/builder.rs
+++ b/wado-compiler/src/nir_value_graph/builder.rs
@@ -101,6 +101,32 @@ impl HeapState {
         self.per_field.clear();
         self.default_version = v;
     }
+
+    /// Snapshot the read-visible part of the state (the `per_field` map and
+    /// `default_version`) so an arm walk can restore them on exit. `next` is
+    /// deliberately *not* part of the snapshot: it is a monotonic counter
+    /// shared across the entire function, so an arm's `bump_*` calls
+    /// continue to hand out unique versions even after restore. This keeps
+    /// VN equality across arms sound — no two distinct heap states ever
+    /// reuse a version — while preventing arm 1's bumps from forcing
+    /// arm 2's reads to spuriously distinct VNs.
+    fn snapshot(&self) -> HeapSnapshot {
+        HeapSnapshot {
+            per_field: self.per_field.clone(),
+            default_version: self.default_version,
+        }
+    }
+
+    fn restore(&mut self, snap: HeapSnapshot) {
+        self.per_field = snap.per_field;
+        self.default_version = snap.default_version;
+    }
+}
+
+#[derive(Clone)]
+struct HeapSnapshot {
+    per_field: IndexMap<u32, HeapVersion>,
+    default_version: HeapVersion,
 }
 
 /// The result of running [`build`] over a function body: the populated
@@ -235,13 +261,16 @@ impl<'a> Builder<'a> {
                 self.walk_loop(lb);
             }
             StmtKind::LabeledBlock { block, .. } => {
-                // Conservative: locals modified inside that may escape via
-                // `break` could disagree with the fall-through value. For
-                // MVP, take the snapshot before, walk, then any local that
-                // changed becomes Opaque after.
-                let saved = self.current_value.clone();
+                // Conservative: any local written anywhere in the labeled
+                // block's subtree could disagree with the fall-through
+                // value via a `break` (either to this label or to an
+                // enclosing one) that escapes before the write's effect
+                // propagates to the fall-through `current_value`. Mark
+                // every modified local Opaque post-LB. A fall-through-diff
+                // check alone would miss writes that occur only on a
+                // break-only path.
                 self.walk_block(block);
-                self.dirty_changed_locals(&saved);
+                self.dirty_all_writes_in_block(block);
                 self.heap_state.bump_all();
             }
         }
@@ -393,9 +422,11 @@ impl<'a> Builder<'a> {
                 None
             }
             ExprKind::LabeledBlock { block, .. } => {
-                let saved = self.current_value.clone();
+                // See the `StmtKind::LabeledBlock` arm for the rationale —
+                // a break-only-path write is invisible to a fall-through-
+                // diff check, so dirty every local written in the subtree.
                 self.walk_block(block);
-                self.dirty_changed_locals(&saved);
+                self.dirty_all_writes_in_block(block);
                 self.heap_state.bump_all();
                 None
             }
@@ -413,14 +444,17 @@ impl<'a> Builder<'a> {
             } => {
                 self.walk_expr(scrutinee);
                 let saved = self.current_value.clone();
+                let saved_heap = self.heap_state.snapshot();
                 let mut arm_states: Vec<IndexMap<u32, ValueId>> =
                     Vec::with_capacity(arms.len() + 1);
                 for arm in &arms {
                     self.current_value = saved.clone();
+                    self.heap_state.restore(saved_heap.clone());
                     self.walk_block(*arm);
                     arm_states.push(self.current_value.clone());
                 }
                 self.current_value = saved.clone();
+                self.heap_state.restore(saved_heap);
                 self.walk_block(default);
                 arm_states.push(std::mem::replace(&mut self.current_value, saved.clone()));
                 self.merge_n_arms(&saved, &arm_states);
@@ -639,9 +673,11 @@ impl<'a> Builder<'a> {
 
     fn walk_match_arms(&mut self, arms: &[ArmData]) {
         let saved = self.current_value.clone();
+        let saved_heap = self.heap_state.snapshot();
         let mut states: Vec<IndexMap<u32, ValueId>> = Vec::with_capacity(arms.len());
         for arm in arms {
             self.current_value = saved.clone();
+            self.heap_state.restore(saved_heap.clone());
             // Pattern bindings introduced by this arm are conservatively
             // Opaque. The arm body and guard are walked from that state.
             self.bind_pattern_opaque(arm.pattern);
@@ -652,6 +688,7 @@ impl<'a> Builder<'a> {
             states.push(self.current_value.clone());
         }
         self.current_value = saved.clone();
+        self.heap_state.restore(saved_heap);
         self.merge_n_arms(&saved, &states);
     }
 
@@ -689,24 +726,27 @@ impl<'a> Builder<'a> {
                 self.current_value.insert(*idx, opaque);
             }
         }
+        // Symmetric to the pre-loop bump: the body may have written to
+        // any field via `obj.f = ...` (or via an opaque heap-write event).
+        // Post-loop reads must not share heap versions with in-body reads,
+        // since the body's last iteration's stored value can't be known to
+        // reach the post-loop point in a 0-iteration execution.
         self.heap_state.bump_all();
     }
 
     /// After a flow-opaque construct (LabeledBlock with potential breaks),
-    /// any local that the construct changed becomes Opaque. Untouched locals
-    /// keep their saved value.
-    fn dirty_changed_locals(&mut self, saved: &IndexMap<u32, ValueId>) {
-        let to_dirty: Vec<u32> = self
-            .current_value
-            .iter()
-            .filter_map(|(&idx, &v)| {
-                let s = saved.get(&idx)?;
-                if *s != v { Some(idx) } else { None }
-            })
-            .collect();
-        for idx in to_dirty {
-            let opaque = self.pool.fresh_opaque();
-            self.current_value.insert(idx, opaque);
+    /// every local written anywhere in `block`'s subtree becomes Opaque —
+    /// including locals written on a `break`-only path that fall-through
+    /// never sees. Locals not written in the subtree keep their pre-block
+    /// value.
+    fn dirty_all_writes_in_block(&mut self, block: crate::nir_arena::BlockId) {
+        let mut writes: crate::hashmap::IndexSet<u32> = crate::hashmap::IndexSet::default();
+        collect_writes_in_block(self.body, block, &mut writes);
+        for idx in &writes {
+            if self.current_value.contains_key(idx) {
+                let opaque = self.pool.fresh_opaque();
+                self.current_value.insert(*idx, opaque);
+            }
         }
     }
 }
@@ -1307,5 +1347,114 @@ mod tests {
         root_with(&mut body, vec![s]);
         let r = build(&body, &[]);
         assert!(!r.value_of.contains_key(&fa));
+    }
+
+    // ----- Per-arm heap snapshot (P1-3) -----
+
+    #[test]
+    fn switch_arm_field_writes_do_not_leak_across_arms() {
+        // fn(obj) {
+        //     switch (0) {
+        //         0 => { obj.f = 1; }
+        //         1 => { obj.g; }                  // VN must match obj.g read at TOP
+        //         default => {}
+        //     }
+        // }
+        // The two `obj.g` reads (one inside arm 1, one before the switch) must
+        // share a VN: arm 0's `obj.f = 1` bumps field `f` only, but without
+        // per-arm snapshot the bump would leak into arm 1's heap state and
+        // give `obj.g` a fresh heap version.
+        let mut body = empty_body();
+        // Read obj.g before the switch.
+        let recv_pre = local_ref(&mut body, 0);
+        let read_pre = field_access(&mut body, recv_pre, 1);
+        let let_pre = let_stmt(&mut body, 1, read_pre, false);
+
+        // Arm 0: obj.f = 1
+        let recv_w = local_ref(&mut body, 0);
+        let one = int_lit(&mut body, 1);
+        let arm0_write = field_assign_stmt(&mut body, recv_w, 0, one);
+        let arm0 = block_with(&mut body, vec![arm0_write]);
+
+        // Arm 1: read obj.g
+        let recv_in = local_ref(&mut body, 0);
+        let read_in_arm = field_access(&mut body, recv_in, 1);
+        let let_in_arm = let_stmt(&mut body, 2, read_in_arm, false);
+        let arm1 = block_with(&mut body, vec![let_in_arm]);
+
+        // Default: empty
+        let default = block_with(&mut body, vec![]);
+
+        let scrut = int_lit(&mut body, 0);
+        let switch_e = alloc_expr(
+            &mut body,
+            ExprKind::Switch {
+                scrutinee: scrut,
+                min_value: 0,
+                arms: vec![arm0, arm1],
+                default,
+            },
+        );
+        let switch_s = alloc_stmt(&mut body, StmtKind::Expr(switch_e));
+
+        root_with(&mut body, vec![let_pre, switch_s]);
+        let r = build(&body, &[param_seed()]);
+        // The read inside arm 1 must share a VN with the pre-switch read.
+        assert_eq!(r.value_of[&read_pre], r.value_of[&read_in_arm]);
+    }
+
+    // ----- LabeledBlock break-only-path writes (P1-4) -----
+
+    #[test]
+    fn labeled_block_break_only_write_marks_local_opaque() {
+        // fn() {
+        //     let mut x = 1;
+        //     'lb: { if cond { x = 2; break 'lb; } else {} }
+        //     x   // must be Opaque — the break path wrote 2 but fall-through didn't
+        // }
+        let mut body = empty_body();
+        let one = int_lit(&mut body, 1);
+        let let_x = let_stmt(&mut body, 0, one, true);
+
+        // Inside the LB: `if true { x = 2; break 'lb; }`
+        let cond = bool_lit(&mut body, true);
+        let two = int_lit(&mut body, 2);
+        let assign_then = assign_stmt(&mut body, 0, two);
+        let break_stmt = alloc_stmt(
+            &mut body,
+            StmtKind::Break {
+                label: Some("lb".to_string()),
+                value: None,
+            },
+        );
+        let then_block = block_with(&mut body, vec![assign_then, break_stmt]);
+        let else_block = block_with(&mut body, vec![]);
+        let if_inside = alloc_stmt(
+            &mut body,
+            StmtKind::If {
+                condition: cond,
+                then_block,
+                else_block: Some(else_block),
+            },
+        );
+        let lb_block = block_with(&mut body, vec![if_inside]);
+        let lb_stmt = alloc_stmt(
+            &mut body,
+            StmtKind::LabeledBlock {
+                label: "lb".to_string(),
+                block: lb_block,
+            },
+        );
+
+        let read = local_ref(&mut body, 0);
+        let s_read = alloc_stmt(&mut body, StmtKind::Expr(read));
+        root_with(&mut body, vec![let_x, lb_stmt, s_read]);
+        let r = build(&body, &[]);
+        // Post-LB `x` must be Opaque — the break-path write of 2 means the
+        // value is unknown, even though fall-through never observes it.
+        assert!(matches!(
+            r.pool.kind(r.value_of[&read]),
+            ValueKind::Opaque(_)
+        ));
     }
 }

--- a/wado-compiler/src/nir_value_graph/builder.rs
+++ b/wado-compiler/src/nir_value_graph/builder.rs
@@ -2,38 +2,30 @@
 //!
 //! Walks the SkelTree (`Body`) once and assigns a [`ValueId`] to every pure
 //! [`ExprId`]. Impure or allocation-bearing expressions (calls, struct/array
-//! literals, control flow, etc.) get no entry in `value_of`; their Skel
-//! position carries the value at extraction time, not a ValueGraph node.
+//! literals, control flow, etc.) get no entry in `value_of`.
 //!
-//! See `docs/wep-2026-06-05-worklist-rewrite-engine.md` (Stage 2). The
-//! ValueGraph this builder produces is not yet consumed by any rule —
-//! Stages 3 – 6 migrate the existing passes onto it.
+//! Consumed lazily by [`crate::nir_engine::Engine::value`]; see the WEP at
+//! `docs/wep-2026-06-05-worklist-rewrite-engine.md`.
 //!
-//! # Flow handling (MVP)
+//! # Flow handling
 //!
-//! - Function parameters are seeded with a fresh `Opaque` value each.
+//! - Parameters seed `current_value` with a fresh `Opaque` each.
 //! - `Let` / `Assign`-to-bare-`Local` updates `current_value[local_idx]` to
 //!   the RHS's value (or `Opaque` if the RHS is impure).
-//! - `If` snapshots `current_value`, walks both branches, then merges: for
-//!   each local that diverged across the branches we hash-cons a
-//!   [`ValueKind::Select`] keyed on the condition's value. If the condition
-//!   is impure (no ValueGraph id), the merge falls back to a fresh
-//!   `Opaque`.
+//! - `If` snapshots `current_value`, walks both branches, then merges:
+//!   diverging locals hash-cons a [`ValueKind::Select`] keyed on the
+//!   condition's value, falling back to `Opaque` if the condition is impure.
 //! - `Match` / `Switch` walk every arm and merge n-ary: if every arm agrees
-//!   on a local, that value carries; otherwise the local goes `Opaque`. We
-//!   do not yet construct n-ary `Select` chains for them — that is Stage 6
-//!   territory (induction recognition + bound implication need the same
-//!   machinery and are tackled together).
+//!   on a local, that value carries; otherwise the local goes `Opaque`.
+//!   N-ary `Select` chains are not yet constructed.
 //! - `Loop` pre-scans the body for locals it may write and reassigns each
 //!   to a fresh `Opaque` before walking the body; post-loop those locals
 //!   stay `Opaque`. Stage 6 swaps recurring-pattern locals to `LoopPhi`.
-//! - `LabeledBlock` walks as a regular block. `Break` flow-merging into the
-//!   label target is conservative — locals modified inside that escape via
-//!   `Break` end up `Opaque` after the labeled block.
+//! - `LabeledBlock` marks every local written in its subtree `Opaque` on
+//!   exit, since `break` paths can carry writes the fall-through state
+//!   never observes.
 //! - Pattern bindings (`LetDestructure`, `Match` arm bindings) are seeded
-//!   with `Opaque`. Field destructuring will become real `FieldAccess` /
-//!   `VariantPayload` Value kinds once heap-version tracking activates in
-//!   Stage 5.
+//!   with `Opaque`.
 
 use crate::hashmap::IndexMap;
 use crate::nir::{NirParam, NirUnaryOp};
@@ -48,17 +40,12 @@ use super::{HeapVersion, ValueId, ValuePool};
 /// appropriate field's version (or every field's version, for opaque
 /// writes) bumps to a fresh value.
 ///
-/// Granularity is **per field_index** (Q3 / Stage 5). A direct write to
-/// `obj.f` bumps only the `f` slot — a subsequent read of `obj.g` keeps
-/// its previous version, so the hash-cons key
-/// `(receiver, field, heap_ver)` agrees with prior reads and they share a
-/// `ValueId`. An opaque write (a Call, an `Index` / `Deref` assign target,
-/// a Loop entry, an If/Match/Switch merge) calls [`HeapState::bump_all`],
-/// invalidating every field's version.
-///
-/// Phase 2 may refine to `(receiver_root, field)` granularity using
-/// `mod_ref.rs` — at that point a Call that provably cannot alias one
-/// receiver root would bump only the others. MVP keeps it field-only.
+/// Granularity is per `field_index`: a direct write to `obj.f` bumps the
+/// `f` slot only, so a later read of `obj.g` keeps its prior version and
+/// shares a `ValueId` with earlier reads. Opaque writes (Call,
+/// `Index` / `Deref` assign target, Loop entry, branch merge) call
+/// [`HeapState::bump_all`], invalidating every field. Refinement to
+/// `(receiver_root, field)` granularity via `mod_ref.rs` is a follow-up.
 struct HeapState {
     /// Next fresh version to hand out.
     next: HeapVersion,
@@ -102,14 +89,10 @@ impl HeapState {
         self.default_version = v;
     }
 
-    /// Snapshot the read-visible part of the state (the `per_field` map and
-    /// `default_version`) so an arm walk can restore them on exit. `next` is
-    /// deliberately *not* part of the snapshot: it is a monotonic counter
-    /// shared across the entire function, so an arm's `bump_*` calls
-    /// continue to hand out unique versions even after restore. This keeps
-    /// VN equality across arms sound — no two distinct heap states ever
-    /// reuse a version — while preventing arm 1's bumps from forcing
-    /// arm 2's reads to spuriously distinct VNs.
+    /// Snapshot the read-visible state (`per_field`, `default_version`)
+    /// only. `next` is a monotonic counter shared across the whole
+    /// function, so arms restored from the snapshot never reuse a version
+    /// another arm allocated.
     fn snapshot(&self) -> HeapSnapshot {
         HeapSnapshot {
             per_field: self.per_field.clone(),
@@ -197,10 +180,6 @@ impl<'a> Builder<'a> {
         }
     }
 
-    // ------------------------------------------------------------------
-    // Blocks / statements
-    // ------------------------------------------------------------------
-
     fn walk_block(&mut self, block: crate::nir_arena::BlockId) {
         let stmts = self.body.blocks[block].stmts.clone();
         for s in stmts {
@@ -220,9 +199,8 @@ impl<'a> Builder<'a> {
             }
             StmtKind::LetDestructure { pattern, value, .. } => {
                 self.walk_expr(value);
-                // MVP: destructured bindings are Opaque. Field-projection
-                // Value kinds will activate alongside `FieldAccess` in
-                // Stage 5.
+                // Destructured bindings are Opaque for now; field-projection
+                // Value kinds for them are a follow-up.
                 self.bind_pattern_opaque(pattern);
             }
             StmtKind::Expr(e) => {
@@ -253,32 +231,25 @@ impl<'a> Builder<'a> {
                 }
                 let else_state = std::mem::replace(&mut self.current_value, saved.clone());
                 self.merge_two_arms(cond_v, &saved, &then_state, &else_state);
-                // Branches may have written to heap; bump_all conservatively
-                // (Stage 5 MVP). Stage 6 may refine to per-arm join.
+                // Conservative bump_all after the merge — per-arm join is
+                // a follow-up.
                 self.heap_state.bump_all();
             }
             StmtKind::Loop { body: lb } => {
                 self.walk_loop(lb);
             }
             StmtKind::LabeledBlock { block, .. } => {
-                // Conservative: any local written anywhere in the labeled
-                // block's subtree could disagree with the fall-through
-                // value via a `break` (either to this label or to an
-                // enclosing one) that escapes before the write's effect
-                // propagates to the fall-through `current_value`. Mark
-                // every modified local Opaque post-LB. A fall-through-diff
-                // check alone would miss writes that occur only on a
-                // break-only path.
+                // A `break` to this label (or an enclosing one) can carry a
+                // write whose effect never reaches the fall-through state.
+                // Mark every local written anywhere in the subtree Opaque;
+                // a fall-through-diff check would miss break-only-path
+                // writes.
                 self.walk_block(block);
                 self.dirty_all_writes_in_block(block);
                 self.heap_state.bump_all();
             }
         }
     }
-
-    // ------------------------------------------------------------------
-    // Expressions
-    // ------------------------------------------------------------------
 
     /// Walk `expr` and return its ValueGraph id if the expression is pure.
     /// Impure expressions return `None`; their pure children are still walked
@@ -365,10 +336,6 @@ impl<'a> Builder<'a> {
                 let v = self
                     .walk_expr(value)
                     .unwrap_or_else(|| self.pool.fresh_opaque());
-                // Bare `Local` target = local reassignment (no heap write).
-                // `FieldAccess { field_index }` target = heap write to that
-                // field. `Index` / `Unary::Deref` targets are opaque heap
-                // writes — bump every field's version.
                 let target_kind = self.body.exprs[target].kind.clone();
                 match target_kind {
                     ExprKind::Local { index, .. } => {
@@ -398,9 +365,8 @@ impl<'a> Builder<'a> {
 
             // ---- Control-flow expressions ----
             ExprKind::Block(block) => {
-                // Walk every stmt for the side-table; the block expr itself
-                // is not currently Value-graph-able (Stage 6 may revisit for
-                // `Match`-replacement Selects).
+                // Block expressions are walked for the side-table but get
+                // no `ValueId`.
                 self.walk_block(block);
                 None
             }
@@ -422,9 +388,7 @@ impl<'a> Builder<'a> {
                 None
             }
             ExprKind::LabeledBlock { block, .. } => {
-                // See the `StmtKind::LabeledBlock` arm for the rationale —
-                // a break-only-path write is invisible to a fall-through-
-                // diff check, so dirty every local written in the subtree.
+                // Same break-only-write hazard as the `StmtKind::LabeledBlock` arm.
                 self.walk_block(block);
                 self.dirty_all_writes_in_block(block);
                 self.heap_state.bump_all();
@@ -557,18 +521,13 @@ impl<'a> Builder<'a> {
         if let Some(&v) = self.current_value.get(&idx) {
             v
         } else {
-            // First read of a local not yet bound by Let / param seeding —
-            // shouldn't happen on well-typed NIR, but stay graceful: emit an
-            // Opaque and record it so subsequent reads agree.
+            // Unbound locals shouldn't occur on well-typed NIR; cache a
+            // fresh Opaque so subsequent reads agree.
             let v = self.pool.fresh_opaque();
             self.current_value.insert(idx, v);
             v
         }
     }
-
-    // ------------------------------------------------------------------
-    // Pattern bindings
-    // ------------------------------------------------------------------
 
     fn bind_pattern_opaque(&mut self, pat: PatId) {
         match self.body.pats[pat].kind.clone() {
@@ -606,10 +565,6 @@ impl<'a> Builder<'a> {
         }
     }
 
-    // ------------------------------------------------------------------
-    // Control flow: branch merge and loop handling
-    // ------------------------------------------------------------------
-
     /// Merge an if-style two-arm structural endpoint. For each local that
     /// existed before the branch:
     /// - Both arms agree → keep that value.
@@ -640,9 +595,8 @@ impl<'a> Builder<'a> {
     }
 
     /// Merge n arms (Match / Switch). For each pre-branch local: if every
-    /// arm agrees, keep that value; otherwise fall back to `Opaque`. We do
-    /// not currently build n-ary `Select` chains — Stage 6 introduces the
-    /// machinery for that alongside induction recognition.
+    /// arm agrees, keep that value; otherwise fall back to `Opaque`. N-ary
+    /// `Select` chains are not yet constructed.
     fn merge_n_arms(
         &mut self,
         saved: &IndexMap<u32, ValueId>,
@@ -678,8 +632,6 @@ impl<'a> Builder<'a> {
         for arm in arms {
             self.current_value = saved.clone();
             self.heap_state.restore(saved_heap.clone());
-            // Pattern bindings introduced by this arm are conservatively
-            // Opaque. The arm body and guard are walked from that state.
             self.bind_pattern_opaque(arm.pattern);
             if let Some(g) = arm.guard {
                 self.walk_expr(g);
@@ -692,45 +644,29 @@ impl<'a> Builder<'a> {
         self.merge_n_arms(&saved, &states);
     }
 
-    /// Pre-scan a loop body for locals it may write and reassign each to a
-    /// fresh `Opaque` before walking. Locals untouched by the body keep
-    /// their pre-loop values. Post-loop, the modified locals are again
-    /// `Opaque` — the body may have run 0..N times and we cannot describe
-    /// the final value without a `LoopPhi`. (MVP — Stage 6 swaps in
-    /// `LoopPhi` for recognisable inductions.)
+    /// Reassign every local the body may write to a fresh `Opaque` before
+    /// and after the walk, and bump the heap state on both sides. The body
+    /// may run 0..N times, so in-body reads must not share `ValueId`s
+    /// with pre-loop reads, and post-loop reads must not share them with
+    /// in-body reads. (Locals declared inside the loop need no pre-seed:
+    /// they get fresh `Opaque`s as the body walks.)
     fn walk_loop(&mut self, body_block: crate::nir_arena::BlockId) {
         let mut writes: crate::hashmap::IndexSet<u32> = crate::hashmap::IndexSet::default();
         collect_writes_in_block(self.body, body_block, &mut writes);
         for idx in &writes {
-            // Locals not yet in `current_value` (e.g., declared inside the
-            // loop) get fresh Opaques as part of walking the body; we don't
-            // need to pre-seed those.
             if self.current_value.contains_key(idx) {
                 let opaque = self.pool.fresh_opaque();
                 self.current_value.insert(*idx, opaque);
             }
         }
-        // Same reasoning for heap: the body may have run 0..N times before
-        // the body walk begins, so reads inside the body must not share
-        // heap versions with pre-loop reads.
         self.heap_state.bump_all();
         self.walk_block(body_block);
-        // After the body walks, an in-loop `Assign` may have overwritten a
-        // pre-seeded Opaque with a derived value (e.g., `i = i + 1` writes
-        // `Binary(Add, OpaqueEntry, Int 1)`). The post-loop value is still
-        // unknown — there could have been 0, 1, or many iterations — so
-        // reset modified locals to a fresh Opaque again.
         for idx in &writes {
             if self.current_value.contains_key(idx) {
                 let opaque = self.pool.fresh_opaque();
                 self.current_value.insert(*idx, opaque);
             }
         }
-        // Symmetric to the pre-loop bump: the body may have written to
-        // any field via `obj.f = ...` (or via an opaque heap-write event).
-        // Post-loop reads must not share heap versions with in-body reads,
-        // since the body's last iteration's stored value can't be known to
-        // reach the post-loop point in a 0-iteration execution.
         self.heap_state.bump_all();
     }
 
@@ -752,9 +688,9 @@ impl<'a> Builder<'a> {
 }
 
 /// Collect every local index that an `Assign`-to-bare-`Local`, a `Let`, or
-/// a `LetDestructure` binding writes anywhere in `block`'s subtree. Used by
-/// `walk_loop` to identify the locals it must reset to `Opaque` at loop
-/// entry.
+/// a `LetDestructure` binding writes anywhere in `block`'s subtree. Used
+/// by `walk_loop` and `dirty_all_writes_in_block` to mark the right set
+/// of locals `Opaque` on entry/exit of flow-opaque constructs.
 fn collect_writes_in_block(
     body: &Body,
     block: crate::nir_arena::BlockId,
@@ -1253,7 +1189,7 @@ mod tests {
         assert!(!r.value_of.contains_key(&call));
     }
 
-    // ----- Stage 5: FieldAccess heap-version behavior -----
+    // ----- FieldAccess heap-version behavior -----
 
     #[test]
     fn two_field_reads_same_field_share_value_id() {
@@ -1349,7 +1285,7 @@ mod tests {
         assert!(!r.value_of.contains_key(&fa));
     }
 
-    // ----- Per-arm heap snapshot (P1-3) -----
+    // ----- Per-arm heap snapshot -----
 
     #[test]
     fn switch_arm_field_writes_do_not_leak_across_arms() {
@@ -1403,7 +1339,7 @@ mod tests {
         assert_eq!(r.value_of[&read_pre], r.value_of[&read_in_arm]);
     }
 
-    // ----- LabeledBlock break-only-path writes (P1-4) -----
+    // ----- LabeledBlock break-only-path writes -----
 
     #[test]
     fn labeled_block_break_only_write_marks_local_opaque() {

--- a/wado-compiler/src/nir_value_graph/builder.rs
+++ b/wado-compiler/src/nir_value_graph/builder.rs
@@ -1,6 +1,6 @@
-//! Per-function ValueGraph builder.
+//! Per-function `ValueGraph` builder.
 //!
-//! Walks the SkelTree (`Body`) once and assigns a [`ValueId`] to every pure
+//! Walks the `SkelTree` (`Body`) once and assigns a [`ValueId`] to every pure
 //! [`ExprId`]. Impure or allocation-bearing expressions (calls, struct/array
 //! literals, control flow, etc.) get no entry in `value_of`.
 //!
@@ -51,7 +51,7 @@ struct HeapState {
     next: HeapVersion,
     /// Current version of each `field_index` we have seen written.
     per_field: IndexMap<u32, HeapVersion>,
-    /// Version returned for field_indices not yet in `per_field`.
+    /// Version returned for `field_indices` not yet in `per_field`.
     /// `bump_all` advances this; `bump_field` does not.
     default_version: HeapVersion,
 }
@@ -130,7 +130,7 @@ pub struct ValueGraphBuild {
     pub literal_source: IndexMap<ValueId, ExprId>,
 }
 
-/// Build the ValueGraph for one function body.
+/// Build the `ValueGraph` for one function body.
 ///
 /// `params` seed `current_value` with one fresh `Opaque` per parameter, so a
 /// `Local { index: param.local_index }` read returns that Opaque every time
@@ -254,7 +254,7 @@ impl<'a> Builder<'a> {
         }
     }
 
-    /// Walk `expr` and return its ValueGraph id if the expression is pure.
+    /// Walk `expr` and return its `ValueGraph` id if the expression is pure.
     /// Impure expressions return `None`; their pure children are still walked
     /// for their side of the side-table.
     fn walk_expr(&mut self, expr: ExprId) -> Option<ValueId> {
@@ -680,8 +680,7 @@ impl<'a> Builder<'a> {
         // threading the post-guard state forward, conservatively dirty
         // every outer local any guard could write and bump the heap
         // once before walking arms.
-        let mut guard_writes: crate::hashmap::IndexSet<u32> =
-            crate::hashmap::IndexSet::default();
+        let mut guard_writes: crate::hashmap::IndexSet<u32> = crate::hashmap::IndexSet::default();
         let mut any_guard = false;
         for arm in arms {
             if let Some(g) = arm.guard {
@@ -743,7 +742,7 @@ impl<'a> Builder<'a> {
         self.heap_state.bump_all();
     }
 
-    /// After a flow-opaque construct (LabeledBlock with potential breaks),
+    /// After a flow-opaque construct (`LabeledBlock` with potential breaks),
     /// every local written anywhere in `block`'s subtree becomes Opaque —
     /// including locals written on a `break`-only path that fall-through
     /// never sees. Locals not written in the subtree keep their pre-block
@@ -821,19 +820,16 @@ fn collect_writes_in_expr(body: &Body, expr: ExprId, out: &mut crate::hashmap::I
 }
 
 fn collect_writes_in_pattern(body: &Body, pat: PatId, out: &mut crate::hashmap::IndexSet<u32>) {
-    match &body.pats[pat].kind {
-        PatKind::Binding { local_index, .. } => {
-            out.insert(*local_index);
-        }
-        _ => {
-            let mut kids = Vec::new();
-            body.for_each_child(NodeRef::Pat(pat), |c| kids.push(c));
-            for c in kids {
-                match c {
-                    NodeRef::Pat(p) => collect_writes_in_pattern(body, p, out),
-                    NodeRef::Expr(e) => collect_writes_in_expr(body, e, out),
-                    _ => {}
-                }
+    if let PatKind::Binding { local_index, .. } = &body.pats[pat].kind {
+        out.insert(*local_index);
+    } else {
+        let mut kids = Vec::new();
+        body.for_each_child(NodeRef::Pat(pat), |c| kids.push(c));
+        for c in kids {
+            match c {
+                NodeRef::Pat(p) => collect_writes_in_pattern(body, p, out),
+                NodeRef::Expr(e) => collect_writes_in_expr(body, e, out),
+                _ => {}
             }
         }
     }

--- a/wado-compiler/src/nir_value_graph/builder.rs
+++ b/wado-compiler/src/nir_value_graph/builder.rs
@@ -209,10 +209,7 @@ impl<'a> Builder<'a> {
                 // operations — not pure values. Walk the child (so pure
                 // subtrees still land in `value_of`) but do not assign an id
                 // to this expr.
-                if matches!(
-                    op,
-                    NirUnaryOp::Ref | NirUnaryOp::MutRef | NirUnaryOp::Deref
-                ) {
+                if matches!(op, NirUnaryOp::Ref | NirUnaryOp::MutRef | NirUnaryOp::Deref) {
                     self.walk_expr(inner);
                     None
                 } else {
@@ -295,7 +292,8 @@ impl<'a> Builder<'a> {
             } => {
                 self.walk_expr(scrutinee);
                 let saved = self.current_value.clone();
-                let mut arm_states: Vec<IndexMap<u32, ValueId>> = Vec::with_capacity(arms.len() + 1);
+                let mut arm_states: Vec<IndexMap<u32, ValueId>> =
+                    Vec::with_capacity(arms.len() + 1);
                 for arm in &arms {
                     self.current_value = saved.clone();
                     self.walk_block(*arm);
@@ -590,7 +588,9 @@ fn collect_writes_in_block(
 
 fn collect_writes_in_stmt(body: &Body, stmt: StmtId, out: &mut crate::hashmap::IndexSet<u32>) {
     match &body.stmts[stmt].kind {
-        StmtKind::Let { local_index, value, .. } => {
+        StmtKind::Let {
+            local_index, value, ..
+        } => {
             out.insert(*local_index);
             collect_writes_in_expr(body, *value, out);
         }
@@ -654,8 +654,8 @@ fn collect_writes_in_pattern(body: &Body, pat: PatId, out: &mut crate::hashmap::
 mod tests {
     use super::*;
     use crate::nir::{NirBinaryOp, NirParam};
-    use crate::nir_value_graph::ValueKind;
     use crate::nir_arena::{BlockNode, ExprNode, StmtNode};
+    use crate::nir_value_graph::ValueKind;
     use crate::tir::TypeTable;
     use crate::token::Span;
 

--- a/wado-compiler/src/nir_value_graph/builder.rs
+++ b/wado-compiler/src/nir_value_graph/builder.rs
@@ -224,12 +224,15 @@ impl<'a> Builder<'a> {
             } => {
                 let cond_v = self.walk_expr(condition);
                 let saved = self.current_value.clone();
+                let saved_heap = self.heap_state.snapshot();
                 self.walk_block(then_block);
                 let then_state = std::mem::replace(&mut self.current_value, saved.clone());
+                self.heap_state.restore(saved_heap.clone());
                 if let Some(eb) = else_block {
                     self.walk_block(eb);
                 }
                 let else_state = std::mem::replace(&mut self.current_value, saved.clone());
+                self.heap_state.restore(saved_heap);
                 self.merge_two_arms(cond_v, &saved, &then_state, &else_state);
                 // Conservative bump_all after the merge — per-arm join is
                 // a follow-up.
@@ -377,12 +380,15 @@ impl<'a> Builder<'a> {
             } => {
                 let cond_v = self.walk_expr(condition);
                 let saved = self.current_value.clone();
+                let saved_heap = self.heap_state.snapshot();
                 self.walk_block(then_branch);
                 let then_state = std::mem::replace(&mut self.current_value, saved.clone());
+                self.heap_state.restore(saved_heap.clone());
                 if let Some(eb) = else_branch {
                     self.walk_block(eb);
                 }
                 let else_state = std::mem::replace(&mut self.current_value, saved.clone());
+                self.heap_state.restore(saved_heap);
                 self.merge_two_arms(cond_v, &saved, &then_state, &else_state);
                 self.heap_state.bump_all();
                 None
@@ -1337,6 +1343,46 @@ mod tests {
         let r = build(&body, &[param_seed()]);
         // The read inside arm 1 must share a VN with the pre-switch read.
         assert_eq!(r.value_of[&read_pre], r.value_of[&read_in_arm]);
+    }
+
+    #[test]
+    fn if_branch_field_writes_do_not_leak_into_else() {
+        // fn(obj) {
+        //     let g_pre = obj.g;
+        //     if true { obj.f = 1; }
+        //     else    { let g_in_else = obj.g; }
+        // }
+        // The else-branch `obj.g` read must share a VN with the pre-If
+        // read: the then-branch's `bump_field(f)` is rolled back at the
+        // arm boundary so it does not pollute the else-branch heap state.
+        let mut body = empty_body();
+        let recv_pre = local_ref(&mut body, 0);
+        let read_pre = field_access(&mut body, recv_pre, 1);
+        let let_pre = let_stmt(&mut body, 1, read_pre, false);
+
+        let cond = bool_lit(&mut body, true);
+
+        let recv_w = local_ref(&mut body, 0);
+        let one = int_lit(&mut body, 1);
+        let then_write = field_assign_stmt(&mut body, recv_w, 0, one);
+        let then_block = block_with(&mut body, vec![then_write]);
+
+        let recv_else = local_ref(&mut body, 0);
+        let read_in_else = field_access(&mut body, recv_else, 1);
+        let let_in_else = let_stmt(&mut body, 2, read_in_else, false);
+        let else_block = block_with(&mut body, vec![let_in_else]);
+
+        let if_s = alloc_stmt(
+            &mut body,
+            StmtKind::If {
+                condition: cond,
+                then_block,
+                else_block: Some(else_block),
+            },
+        );
+        root_with(&mut body, vec![let_pre, if_s]);
+        let r = build(&body, &[param_seed()]);
+        assert_eq!(r.value_of[&read_pre], r.value_of[&read_in_else]);
     }
 
     // ----- LabeledBlock break-only-path writes -----

--- a/wado-compiler/src/nir_value_graph/builder.rs
+++ b/wado-compiler/src/nir_value_graph/builder.rs
@@ -1,0 +1,1030 @@
+//! Per-function ValueGraph builder.
+//!
+//! Walks the SkelTree (`Body`) once and assigns a [`ValueId`] to every pure
+//! [`ExprId`]. Impure or allocation-bearing expressions (calls, struct/array
+//! literals, control flow, etc.) get no entry in `value_of`; their Skel
+//! position carries the value at extraction time, not a ValueGraph node.
+//!
+//! See `docs/wep-2026-06-05-worklist-rewrite-engine.md` (Stage 2). The
+//! ValueGraph this builder produces is not yet consumed by any rule —
+//! Stages 3 – 6 migrate the existing passes onto it.
+//!
+//! # Flow handling (MVP)
+//!
+//! - Function parameters are seeded with a fresh `Opaque` value each.
+//! - `Let` / `Assign`-to-bare-`Local` updates `current_value[local_idx]` to
+//!   the RHS's value (or `Opaque` if the RHS is impure).
+//! - `If` snapshots `current_value`, walks both branches, then merges: for
+//!   each local that diverged across the branches we hash-cons a
+//!   [`ValueKind::Select`] keyed on the condition's value. If the condition
+//!   is impure (no ValueGraph id), the merge falls back to a fresh
+//!   `Opaque`.
+//! - `Match` / `Switch` walk every arm and merge n-ary: if every arm agrees
+//!   on a local, that value carries; otherwise the local goes `Opaque`. We
+//!   do not yet construct n-ary `Select` chains for them — that is Stage 6
+//!   territory (induction recognition + bound implication need the same
+//!   machinery and are tackled together).
+//! - `Loop` pre-scans the body for locals it may write and reassigns each
+//!   to a fresh `Opaque` before walking the body; post-loop those locals
+//!   stay `Opaque`. Stage 6 swaps recurring-pattern locals to `LoopPhi`.
+//! - `LabeledBlock` walks as a regular block. `Break` flow-merging into the
+//!   label target is conservative — locals modified inside that escape via
+//!   `Break` end up `Opaque` after the labeled block.
+//! - Pattern bindings (`LetDestructure`, `Match` arm bindings) are seeded
+//!   with `Opaque`. Field destructuring will become real `FieldAccess` /
+//!   `VariantPayload` Value kinds once heap-version tracking activates in
+//!   Stage 5.
+
+use crate::hashmap::IndexMap;
+use crate::nir::{NirParam, NirUnaryOp};
+use crate::nir_arena::{
+    ArmData, Body, ExprId, ExprKind, NodeRef, PatId, PatKind, StmtId, StmtKind,
+};
+
+use super::{ValueId, ValuePool};
+
+/// The result of running [`build`] over a function body: the populated
+/// pool plus the side-table mapping pure `ExprId`s to their `ValueId`.
+///
+/// Impure positions are absent from `value_of`. A rule that wants "this
+/// expression's value" should look it up and treat the absence as "no
+/// value-graph identity available" rather than panicking.
+#[derive(Debug)]
+pub struct ValueGraphBuild {
+    pub pool: ValuePool,
+    pub value_of: IndexMap<ExprId, ValueId>,
+}
+
+/// Build the ValueGraph for one function body.
+///
+/// `params` seed `current_value` with one fresh `Opaque` per parameter, so a
+/// `Local { index: param.local_index }` read returns that Opaque every time
+/// until the parameter is reassigned (which the builder picks up the same
+/// way as any other `Assign`).
+pub fn build(body: &Body, params: &[NirParam]) -> ValueGraphBuild {
+    let mut b = Builder::new(body);
+    b.seed_params(params);
+    b.walk_block(body.root);
+    ValueGraphBuild {
+        pool: b.pool,
+        value_of: b.value_of,
+    }
+}
+
+struct Builder<'a> {
+    body: &'a Body,
+    pool: ValuePool,
+    value_of: IndexMap<ExprId, ValueId>,
+    /// `local_index → current Value` at the current program point. Cloned at
+    /// branch entries so each arm walks from the pre-branch snapshot.
+    current_value: IndexMap<u32, ValueId>,
+}
+
+impl<'a> Builder<'a> {
+    fn new(body: &'a Body) -> Self {
+        Self {
+            body,
+            pool: ValuePool::new(),
+            value_of: IndexMap::default(),
+            current_value: IndexMap::default(),
+        }
+    }
+
+    fn seed_params(&mut self, params: &[NirParam]) {
+        for param in params {
+            let opaque = self.pool.fresh_opaque();
+            self.current_value.insert(param.local_index, opaque);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Blocks / statements
+    // ------------------------------------------------------------------
+
+    fn walk_block(&mut self, block: crate::nir_arena::BlockId) {
+        let stmts = self.body.blocks[block].stmts.clone();
+        for s in stmts {
+            self.walk_stmt(s);
+        }
+    }
+
+    fn walk_stmt(&mut self, stmt: StmtId) {
+        match self.body.stmts[stmt].kind.clone() {
+            StmtKind::Let {
+                local_index, value, ..
+            } => {
+                let v = self
+                    .walk_expr(value)
+                    .unwrap_or_else(|| self.pool.fresh_opaque());
+                self.current_value.insert(local_index, v);
+            }
+            StmtKind::LetDestructure { pattern, value, .. } => {
+                self.walk_expr(value);
+                // MVP: destructured bindings are Opaque. Field-projection
+                // Value kinds will activate alongside `FieldAccess` in
+                // Stage 5.
+                self.bind_pattern_opaque(pattern);
+            }
+            StmtKind::Expr(e) => {
+                self.walk_expr(e);
+            }
+            StmtKind::Return { value } => {
+                if let Some(v) = value {
+                    self.walk_expr(v);
+                }
+            }
+            StmtKind::Break { value, .. } => {
+                if let Some(v) = value {
+                    self.walk_expr(v);
+                }
+            }
+            StmtKind::Continue => {}
+            StmtKind::If {
+                condition,
+                then_block,
+                else_block,
+            } => {
+                let cond_v = self.walk_expr(condition);
+                let saved = self.current_value.clone();
+                self.walk_block(then_block);
+                let then_state = std::mem::replace(&mut self.current_value, saved.clone());
+                if let Some(eb) = else_block {
+                    self.walk_block(eb);
+                }
+                let else_state = std::mem::replace(&mut self.current_value, saved.clone());
+                self.merge_two_arms(cond_v, &saved, &then_state, &else_state);
+            }
+            StmtKind::Loop { body: lb } => {
+                self.walk_loop(lb);
+            }
+            StmtKind::LabeledBlock { block, .. } => {
+                // Conservative: locals modified inside that may escape via
+                // `break` could disagree with the fall-through value. For
+                // MVP, take the snapshot before, walk, then any local that
+                // changed becomes Opaque after.
+                let saved = self.current_value.clone();
+                self.walk_block(block);
+                self.dirty_changed_locals(&saved);
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Expressions
+    // ------------------------------------------------------------------
+
+    /// Walk `expr` and return its ValueGraph id if the expression is pure.
+    /// Impure expressions return `None`; their pure children are still walked
+    /// for their side of the side-table.
+    fn walk_expr(&mut self, expr: ExprId) -> Option<ValueId> {
+        let id = self.compute_value(expr);
+        if let Some(id) = id {
+            self.value_of.insert(expr, id);
+        }
+        id
+    }
+
+    fn compute_value(&mut self, expr: ExprId) -> Option<ValueId> {
+        match self.body.exprs[expr].kind.clone() {
+            // ---- Literals ----
+            ExprKind::IntLiteral { value, .. } => Some(self.pool.int(value)),
+            ExprKind::FloatLiteral { value, .. } => Some(self.pool.float(value)),
+            ExprKind::BoolLiteral(b) => Some(self.pool.bool(b)),
+            ExprKind::CharLiteral(c) => Some(self.pool.char(c)),
+            ExprKind::StringLiteral(s) => Some(self.pool.string(s)),
+            ExprKind::Null => Some(self.pool.null()),
+            ExprKind::Unit => Some(self.pool.unit()),
+
+            // ---- Local read ----
+            ExprKind::Local { index, .. } => Some(self.read_local(index)),
+
+            // ---- Pure arithmetic ----
+            ExprKind::Binary { left, op, right } => {
+                let lhs = self.walk_expr(left)?;
+                let rhs = self.walk_expr(right)?;
+                Some(self.pool.binary(op, lhs, rhs))
+            }
+            ExprKind::Unary { op, expr: inner } => {
+                // `Ref` / `MutRef` / `Deref` are address-taking / heap-bearing
+                // operations — not pure values. Walk the child (so pure
+                // subtrees still land in `value_of`) but do not assign an id
+                // to this expr.
+                if matches!(
+                    op,
+                    NirUnaryOp::Ref | NirUnaryOp::MutRef | NirUnaryOp::Deref
+                ) {
+                    self.walk_expr(inner);
+                    None
+                } else {
+                    let operand = self.walk_expr(inner)?;
+                    Some(self.pool.unary(op, operand))
+                }
+            }
+            ExprKind::Cast {
+                expr: inner,
+                target_type,
+            } => {
+                let operand = self.walk_expr(inner)?;
+                Some(self.pool.cast(operand, target_type))
+            }
+
+            // ---- Mutation: side-effect, never pure ----
+            ExprKind::Assign { target, value } => {
+                let v = self
+                    .walk_expr(value)
+                    .unwrap_or_else(|| self.pool.fresh_opaque());
+                // Bare `Local` target = local reassignment. Anything else
+                // (FieldAccess, Index, Unary::Deref) is a heap write — Stage
+                // 5 will bump heap_version here; for MVP we just walk the
+                // target's children.
+                match &self.body.exprs[target].kind {
+                    ExprKind::Local { index, .. } => {
+                        self.current_value.insert(*index, v);
+                    }
+                    _ => {
+                        self.walk_expr(target);
+                    }
+                }
+                None
+            }
+            ExprKind::GlobalVarSet { value, .. } => {
+                self.walk_expr(value);
+                None
+            }
+
+            // ---- Control-flow expressions ----
+            ExprKind::Block(block) => {
+                // Walk every stmt for the side-table; the block expr itself
+                // is not currently Value-graph-able (Stage 6 may revisit for
+                // `Match`-replacement Selects).
+                self.walk_block(block);
+                None
+            }
+            ExprKind::If {
+                condition,
+                then_branch,
+                else_branch,
+            } => {
+                let cond_v = self.walk_expr(condition);
+                let saved = self.current_value.clone();
+                self.walk_block(then_branch);
+                let then_state = std::mem::replace(&mut self.current_value, saved.clone());
+                if let Some(eb) = else_branch {
+                    self.walk_block(eb);
+                }
+                let else_state = std::mem::replace(&mut self.current_value, saved.clone());
+                self.merge_two_arms(cond_v, &saved, &then_state, &else_state);
+                None
+            }
+            ExprKind::LabeledBlock { block, .. } => {
+                let saved = self.current_value.clone();
+                self.walk_block(block);
+                self.dirty_changed_locals(&saved);
+                None
+            }
+            ExprKind::Match { expr: scrut, arms } => {
+                self.walk_expr(scrut);
+                self.walk_match_arms(&arms);
+                None
+            }
+            ExprKind::Switch {
+                scrutinee,
+                arms,
+                default,
+                ..
+            } => {
+                self.walk_expr(scrutinee);
+                let saved = self.current_value.clone();
+                let mut arm_states: Vec<IndexMap<u32, ValueId>> = Vec::with_capacity(arms.len() + 1);
+                for arm in &arms {
+                    self.current_value = saved.clone();
+                    self.walk_block(*arm);
+                    arm_states.push(self.current_value.clone());
+                }
+                self.current_value = saved.clone();
+                self.walk_block(default);
+                arm_states.push(std::mem::replace(&mut self.current_value, saved.clone()));
+                self.merge_n_arms(&saved, &arm_states);
+                None
+            }
+
+            // ---- Heap-bearing reads (MVP: Skel-side, no Value id) ----
+            ExprKind::FieldAccess { expr: inner, .. } => {
+                // Stage 5 activates `ValueKind::FieldAccess` with heap-version
+                // tracking. For now the receiver is walked but the read itself
+                // gets no id.
+                self.walk_expr(inner);
+                None
+            }
+            ExprKind::Index { expr: inner, index } => {
+                self.walk_expr(inner);
+                self.walk_expr(index);
+                None
+            }
+            ExprKind::VariantTag { expr: inner }
+            | ExprKind::VariantTest { expr: inner, .. }
+            | ExprKind::VariantPayload { expr: inner, .. } => {
+                self.walk_expr(inner);
+                None
+            }
+
+            // ---- Allocation-bearing constructors (Skel-side per Q1) ----
+            ExprKind::StructLiteral { fields, .. } => {
+                for f in fields {
+                    self.walk_expr(f.value);
+                }
+                None
+            }
+            ExprKind::TupleLiteral { elements } | ExprKind::ArrayLiteral { elements } => {
+                for e in elements {
+                    self.walk_expr(e);
+                }
+                None
+            }
+            ExprKind::VariantConstruct { payload, .. } => {
+                if let Some(p) = payload {
+                    self.walk_expr(p);
+                }
+                None
+            }
+            ExprKind::EnumConstruct { .. } => None,
+            ExprKind::ClosureToCanonical { functor, .. } => {
+                self.walk_expr(functor);
+                None
+            }
+
+            // ---- Calls (effectful) ----
+            ExprKind::Call { args, .. } => {
+                for a in args {
+                    self.walk_expr(a.expr);
+                }
+                None
+            }
+            ExprKind::CmRawCall { args, .. } => {
+                for a in args {
+                    self.walk_expr(a);
+                }
+                None
+            }
+            ExprKind::MethodCall { receiver, args, .. } => {
+                self.walk_expr(receiver);
+                for a in args {
+                    self.walk_expr(a.expr);
+                }
+                None
+            }
+            ExprKind::IndirectCall { callee, args } => {
+                self.walk_expr(callee);
+                for a in args {
+                    self.walk_expr(a);
+                }
+                None
+            }
+
+            // ---- Other Skel-side leaves ----
+            ExprKind::GlobalVarGet { .. } | ExprKind::BytesLiteral(_) => None,
+        }
+    }
+
+    fn read_local(&mut self, idx: u32) -> ValueId {
+        if let Some(&v) = self.current_value.get(&idx) {
+            v
+        } else {
+            // First read of a local not yet bound by Let / param seeding —
+            // shouldn't happen on well-typed NIR, but stay graceful: emit an
+            // Opaque and record it so subsequent reads agree.
+            let v = self.pool.fresh_opaque();
+            self.current_value.insert(idx, v);
+            v
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Pattern bindings
+    // ------------------------------------------------------------------
+
+    fn bind_pattern_opaque(&mut self, pat: PatId) {
+        match self.body.pats[pat].kind.clone() {
+            PatKind::Binding { local_index, .. } => {
+                let v = self.pool.fresh_opaque();
+                self.current_value.insert(local_index, v);
+            }
+            PatKind::Tuple(children, _) => {
+                for c in children {
+                    self.bind_pattern_opaque(c);
+                }
+            }
+            PatKind::Or(children) => {
+                for c in children {
+                    self.bind_pattern_opaque(c);
+                }
+            }
+            PatKind::Variant { bindings, .. } => {
+                for c in bindings {
+                    self.bind_pattern_opaque(c);
+                }
+            }
+            PatKind::Struct { fields, .. } => {
+                for f in fields {
+                    self.bind_pattern_opaque(f.pattern);
+                }
+            }
+            PatKind::ConstantValue { expr } => {
+                self.walk_expr(expr);
+            }
+            PatKind::Wildcard
+            | PatKind::Literal(_)
+            | PatKind::Enum { .. }
+            | PatKind::Range { .. } => {}
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Control flow: branch merge and loop handling
+    // ------------------------------------------------------------------
+
+    /// Merge an if-style two-arm structural endpoint. For each local that
+    /// existed before the branch:
+    /// - Both arms agree → keep that value.
+    /// - Arms differ AND `cond_v` is known → hash-cons a `Select`.
+    /// - Otherwise → fresh `Opaque` (the merged value is unknown).
+    ///
+    /// New bindings introduced inside a single arm are dropped from the
+    /// post-merge state — they are scoped to the arm in well-formed NIR.
+    fn merge_two_arms(
+        &mut self,
+        cond_v: Option<ValueId>,
+        saved: &IndexMap<u32, ValueId>,
+        then_state: &IndexMap<u32, ValueId>,
+        else_state: &IndexMap<u32, ValueId>,
+    ) {
+        for (&idx, &saved_v) in saved {
+            let then_v = then_state.get(&idx).copied().unwrap_or(saved_v);
+            let else_v = else_state.get(&idx).copied().unwrap_or(saved_v);
+            let merged = if then_v == else_v {
+                then_v
+            } else if let Some(cond) = cond_v {
+                self.pool.select(cond, then_v, else_v)
+            } else {
+                self.pool.fresh_opaque()
+            };
+            self.current_value.insert(idx, merged);
+        }
+    }
+
+    /// Merge n arms (Match / Switch). For each pre-branch local: if every
+    /// arm agrees, keep that value; otherwise fall back to `Opaque`. We do
+    /// not currently build n-ary `Select` chains — Stage 6 introduces the
+    /// machinery for that alongside induction recognition.
+    fn merge_n_arms(
+        &mut self,
+        saved: &IndexMap<u32, ValueId>,
+        arm_states: &[IndexMap<u32, ValueId>],
+    ) {
+        for (&idx, &saved_v) in saved {
+            let mut consensus: Option<ValueId> = None;
+            let mut diverged = false;
+            for arm in arm_states {
+                let arm_v = arm.get(&idx).copied().unwrap_or(saved_v);
+                match consensus {
+                    None => consensus = Some(arm_v),
+                    Some(c) if c == arm_v => {}
+                    Some(_) => {
+                        diverged = true;
+                        break;
+                    }
+                }
+            }
+            let merged = if diverged {
+                self.pool.fresh_opaque()
+            } else {
+                consensus.unwrap_or(saved_v)
+            };
+            self.current_value.insert(idx, merged);
+        }
+    }
+
+    fn walk_match_arms(&mut self, arms: &[ArmData]) {
+        let saved = self.current_value.clone();
+        let mut states: Vec<IndexMap<u32, ValueId>> = Vec::with_capacity(arms.len());
+        for arm in arms {
+            self.current_value = saved.clone();
+            // Pattern bindings introduced by this arm are conservatively
+            // Opaque. The arm body and guard are walked from that state.
+            self.bind_pattern_opaque(arm.pattern);
+            if let Some(g) = arm.guard {
+                self.walk_expr(g);
+            }
+            self.walk_expr(arm.body);
+            states.push(self.current_value.clone());
+        }
+        self.current_value = saved.clone();
+        self.merge_n_arms(&saved, &states);
+    }
+
+    /// Pre-scan a loop body for locals it may write and reassign each to a
+    /// fresh `Opaque` before walking. Locals untouched by the body keep
+    /// their pre-loop values. Post-loop, the modified locals are again
+    /// `Opaque` — the body may have run 0..N times and we cannot describe
+    /// the final value without a `LoopPhi`. (MVP — Stage 6 swaps in
+    /// `LoopPhi` for recognisable inductions.)
+    fn walk_loop(&mut self, body_block: crate::nir_arena::BlockId) {
+        let mut writes: crate::hashmap::IndexSet<u32> = crate::hashmap::IndexSet::default();
+        collect_writes_in_block(self.body, body_block, &mut writes);
+        for idx in &writes {
+            // Locals not yet in `current_value` (e.g., declared inside the
+            // loop) get fresh Opaques as part of walking the body; we don't
+            // need to pre-seed those.
+            if self.current_value.contains_key(idx) {
+                let opaque = self.pool.fresh_opaque();
+                self.current_value.insert(*idx, opaque);
+            }
+        }
+        self.walk_block(body_block);
+        // After the body walks, an in-loop `Assign` may have overwritten a
+        // pre-seeded Opaque with a derived value (e.g., `i = i + 1` writes
+        // `Binary(Add, OpaqueEntry, Int 1)`). The post-loop value is still
+        // unknown — there could have been 0, 1, or many iterations — so
+        // reset modified locals to a fresh Opaque again.
+        for idx in &writes {
+            if self.current_value.contains_key(idx) {
+                let opaque = self.pool.fresh_opaque();
+                self.current_value.insert(*idx, opaque);
+            }
+        }
+    }
+
+    /// After a flow-opaque construct (LabeledBlock with potential breaks),
+    /// any local that the construct changed becomes Opaque. Untouched locals
+    /// keep their saved value.
+    fn dirty_changed_locals(&mut self, saved: &IndexMap<u32, ValueId>) {
+        let to_dirty: Vec<u32> = self
+            .current_value
+            .iter()
+            .filter_map(|(&idx, &v)| {
+                let s = saved.get(&idx)?;
+                if *s != v { Some(idx) } else { None }
+            })
+            .collect();
+        for idx in to_dirty {
+            let opaque = self.pool.fresh_opaque();
+            self.current_value.insert(idx, opaque);
+        }
+    }
+}
+
+/// Collect every local index that an `Assign`-to-bare-`Local`, a `Let`, or
+/// a `LetDestructure` binding writes anywhere in `block`'s subtree. Used by
+/// `walk_loop` to identify the locals it must reset to `Opaque` at loop
+/// entry.
+fn collect_writes_in_block(
+    body: &Body,
+    block: crate::nir_arena::BlockId,
+    out: &mut crate::hashmap::IndexSet<u32>,
+) {
+    let stmts = body.blocks[block].stmts.clone();
+    for s in stmts {
+        collect_writes_in_stmt(body, s, out);
+    }
+}
+
+fn collect_writes_in_stmt(body: &Body, stmt: StmtId, out: &mut crate::hashmap::IndexSet<u32>) {
+    match &body.stmts[stmt].kind {
+        StmtKind::Let { local_index, value, .. } => {
+            out.insert(*local_index);
+            collect_writes_in_expr(body, *value, out);
+        }
+        StmtKind::LetDestructure { pattern, value, .. } => {
+            collect_writes_in_pattern(body, *pattern, out);
+            collect_writes_in_expr(body, *value, out);
+        }
+        _ => {
+            let mut kids = Vec::new();
+            body.for_each_child(NodeRef::Stmt(stmt), |c| kids.push(c));
+            for c in kids {
+                match c {
+                    NodeRef::Expr(e) => collect_writes_in_expr(body, e, out),
+                    NodeRef::Stmt(s) => collect_writes_in_stmt(body, s, out),
+                    NodeRef::Block(b) => collect_writes_in_block(body, b, out),
+                    NodeRef::Pat(p) => collect_writes_in_pattern(body, p, out),
+                }
+            }
+        }
+    }
+}
+
+fn collect_writes_in_expr(body: &Body, expr: ExprId, out: &mut crate::hashmap::IndexSet<u32>) {
+    if let ExprKind::Assign { target, .. } = &body.exprs[expr].kind
+        && let ExprKind::Local { index, .. } = &body.exprs[*target].kind
+    {
+        out.insert(*index);
+    }
+    let mut kids = Vec::new();
+    body.for_each_child(NodeRef::Expr(expr), |c| kids.push(c));
+    for c in kids {
+        match c {
+            NodeRef::Expr(e) => collect_writes_in_expr(body, e, out),
+            NodeRef::Stmt(s) => collect_writes_in_stmt(body, s, out),
+            NodeRef::Block(b) => collect_writes_in_block(body, b, out),
+            NodeRef::Pat(p) => collect_writes_in_pattern(body, p, out),
+        }
+    }
+}
+
+fn collect_writes_in_pattern(body: &Body, pat: PatId, out: &mut crate::hashmap::IndexSet<u32>) {
+    match &body.pats[pat].kind {
+        PatKind::Binding { local_index, .. } => {
+            out.insert(*local_index);
+        }
+        _ => {
+            let mut kids = Vec::new();
+            body.for_each_child(NodeRef::Pat(pat), |c| kids.push(c));
+            for c in kids {
+                match c {
+                    NodeRef::Pat(p) => collect_writes_in_pattern(body, p, out),
+                    NodeRef::Expr(e) => collect_writes_in_expr(body, e, out),
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::nir::{NirBinaryOp, NirParam};
+    use crate::nir_value_graph::ValueKind;
+    use crate::nir_arena::{BlockNode, ExprNode, StmtNode};
+    use crate::tir::TypeTable;
+    use crate::token::Span;
+
+    // ----- Body builders for tests -----
+
+    fn empty_body() -> Body {
+        Body::empty()
+    }
+
+    fn alloc_expr(body: &mut Body, kind: ExprKind) -> ExprId {
+        body.exprs.push(ExprNode {
+            kind,
+            type_id: TypeTable::UNIT,
+            span: Span::default(),
+        })
+    }
+
+    fn alloc_stmt(body: &mut Body, kind: StmtKind) -> StmtId {
+        body.stmts.push(StmtNode {
+            kind,
+            span: Span::default(),
+        })
+    }
+
+    fn root_with(body: &mut Body, stmts: Vec<StmtId>) {
+        body.root = body.blocks.push(BlockNode {
+            stmts,
+            span: Span::default(),
+        });
+    }
+
+    fn int_lit(body: &mut Body, value: u64) -> ExprId {
+        alloc_expr(
+            body,
+            ExprKind::IntLiteral {
+                value,
+                repr: value.to_string(),
+            },
+        )
+    }
+
+    fn local_ref(body: &mut Body, idx: u32) -> ExprId {
+        alloc_expr(
+            body,
+            ExprKind::Local {
+                index: idx,
+                name: format!("__l{idx}"),
+            },
+        )
+    }
+
+    fn let_stmt(body: &mut Body, idx: u32, value: ExprId, is_mut: bool) -> StmtId {
+        alloc_stmt(
+            body,
+            StmtKind::Let {
+                name: format!("__l{idx}"),
+                local_index: idx,
+                is_mut,
+                is_reactive: false,
+                type_id: TypeTable::UNIT,
+                value,
+                skip_value_copy: false,
+            },
+        )
+    }
+
+    fn assign_stmt(body: &mut Body, idx: u32, value: ExprId) -> StmtId {
+        let target = local_ref(body, idx);
+        let assign = alloc_expr(body, ExprKind::Assign { target, value });
+        alloc_stmt(body, StmtKind::Expr(assign))
+    }
+
+    fn binary(body: &mut Body, op: NirBinaryOp, left: ExprId, right: ExprId) -> ExprId {
+        alloc_expr(body, ExprKind::Binary { left, op, right })
+    }
+
+    fn bool_lit(body: &mut Body, b: bool) -> ExprId {
+        alloc_expr(body, ExprKind::BoolLiteral(b))
+    }
+
+    fn block_with(body: &mut Body, stmts: Vec<StmtId>) -> crate::nir_arena::BlockId {
+        body.blocks.push(BlockNode {
+            stmts,
+            span: Span::default(),
+        })
+    }
+
+    // ----- Tests -----
+
+    #[test]
+    fn literal_int_gets_value_id() {
+        let mut body = empty_body();
+        let lit = int_lit(&mut body, 42);
+        let s = alloc_stmt(&mut body, StmtKind::Expr(lit));
+        root_with(&mut body, vec![s]);
+        let r = build(&body, &[]);
+        let v = r.value_of[&lit];
+        assert_eq!(r.pool.kind(v), &ValueKind::Int(42));
+    }
+
+    #[test]
+    fn let_then_read_returns_same_value() {
+        // let x = 1; x
+        let mut body = empty_body();
+        let lit = int_lit(&mut body, 1);
+        let let_s = let_stmt(&mut body, 0, lit, false);
+        let read = local_ref(&mut body, 0);
+        let s2 = alloc_stmt(&mut body, StmtKind::Expr(read));
+        root_with(&mut body, vec![let_s, s2]);
+        let r = build(&body, &[]);
+        let lit_v = r.value_of[&lit];
+        let read_v = r.value_of[&read];
+        assert_eq!(lit_v, read_v);
+        assert_eq!(r.pool.kind(read_v), &ValueKind::Int(1));
+    }
+
+    #[test]
+    fn equivalent_arithmetic_dedupes() {
+        // let a = 1 + 2; let b = 1 + 2;
+        let mut body = empty_body();
+        let one_a = int_lit(&mut body, 1);
+        let two_a = int_lit(&mut body, 2);
+        let add_a = binary(&mut body, NirBinaryOp::Add, one_a, two_a);
+        let let_a = let_stmt(&mut body, 0, add_a, false);
+        let one_b = int_lit(&mut body, 1);
+        let two_b = int_lit(&mut body, 2);
+        let add_b = binary(&mut body, NirBinaryOp::Add, one_b, two_b);
+        let let_b = let_stmt(&mut body, 1, add_b, false);
+        root_with(&mut body, vec![let_a, let_b]);
+        let r = build(&body, &[]);
+        assert_eq!(r.value_of[&add_a], r.value_of[&add_b]);
+    }
+
+    #[test]
+    fn reassignment_updates_local_value() {
+        // let mut x = 1; x = 2; x
+        let mut body = empty_body();
+        let one = int_lit(&mut body, 1);
+        let let_s = let_stmt(&mut body, 0, one, true);
+        let two = int_lit(&mut body, 2);
+        let assign = assign_stmt(&mut body, 0, two);
+        let read = local_ref(&mut body, 0);
+        let s_read = alloc_stmt(&mut body, StmtKind::Expr(read));
+        root_with(&mut body, vec![let_s, assign, s_read]);
+        let r = build(&body, &[]);
+        assert_eq!(r.pool.kind(r.value_of[&read]), &ValueKind::Int(2));
+    }
+
+    #[test]
+    fn if_merge_builds_select() {
+        // let mut x = 1; if true { x = 2; } else { x = 3; }; x
+        let mut body = empty_body();
+        let one = int_lit(&mut body, 1);
+        let let_s = let_stmt(&mut body, 0, one, true);
+        let cond = bool_lit(&mut body, true);
+        let two = int_lit(&mut body, 2);
+        let assign_then = assign_stmt(&mut body, 0, two);
+        let then_block = block_with(&mut body, vec![assign_then]);
+        let three = int_lit(&mut body, 3);
+        let assign_else = assign_stmt(&mut body, 0, three);
+        let else_block = block_with(&mut body, vec![assign_else]);
+        let if_s = alloc_stmt(
+            &mut body,
+            StmtKind::If {
+                condition: cond,
+                then_block,
+                else_block: Some(else_block),
+            },
+        );
+        let read = local_ref(&mut body, 0);
+        let s_read = alloc_stmt(&mut body, StmtKind::Expr(read));
+        root_with(&mut body, vec![let_s, if_s, s_read]);
+        let r = build(&body, &[]);
+        let read_v = r.value_of[&read];
+        match r.pool.kind(read_v) {
+            ValueKind::Select { cond, then, else_ } => {
+                assert_eq!(r.pool.kind(*cond), &ValueKind::Bool(true));
+                assert_eq!(r.pool.kind(*then), &ValueKind::Int(2));
+                assert_eq!(r.pool.kind(*else_), &ValueKind::Int(3));
+            }
+            other => panic!("expected Select, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn if_without_else_merges_with_pre_value() {
+        // let mut x = 1; if true { x = 2; }; x
+        let mut body = empty_body();
+        let one = int_lit(&mut body, 1);
+        let let_s = let_stmt(&mut body, 0, one, true);
+        let cond = bool_lit(&mut body, true);
+        let two = int_lit(&mut body, 2);
+        let assign_then = assign_stmt(&mut body, 0, two);
+        let then_block = block_with(&mut body, vec![assign_then]);
+        let if_s = alloc_stmt(
+            &mut body,
+            StmtKind::If {
+                condition: cond,
+                then_block,
+                else_block: None,
+            },
+        );
+        let read = local_ref(&mut body, 0);
+        let s_read = alloc_stmt(&mut body, StmtKind::Expr(read));
+        root_with(&mut body, vec![let_s, if_s, s_read]);
+        let r = build(&body, &[]);
+        match r.pool.kind(r.value_of[&read]) {
+            ValueKind::Select { cond, then, else_ } => {
+                assert_eq!(r.pool.kind(*cond), &ValueKind::Bool(true));
+                assert_eq!(r.pool.kind(*then), &ValueKind::Int(2));
+                assert_eq!(r.pool.kind(*else_), &ValueKind::Int(1));
+            }
+            other => panic!("expected Select, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn if_with_agreeing_arms_skips_select() {
+        // let mut x = 1; if true { x = 2; } else { x = 2; }; x
+        let mut body = empty_body();
+        let one = int_lit(&mut body, 1);
+        let let_s = let_stmt(&mut body, 0, one, true);
+        let cond = bool_lit(&mut body, true);
+        let two_a = int_lit(&mut body, 2);
+        let assign_then = assign_stmt(&mut body, 0, two_a);
+        let then_block = block_with(&mut body, vec![assign_then]);
+        let two_b = int_lit(&mut body, 2);
+        let assign_else = assign_stmt(&mut body, 0, two_b);
+        let else_block = block_with(&mut body, vec![assign_else]);
+        let if_s = alloc_stmt(
+            &mut body,
+            StmtKind::If {
+                condition: cond,
+                then_block,
+                else_block: Some(else_block),
+            },
+        );
+        let read = local_ref(&mut body, 0);
+        let s_read = alloc_stmt(&mut body, StmtKind::Expr(read));
+        root_with(&mut body, vec![let_s, if_s, s_read]);
+        let r = build(&body, &[]);
+        // Both arms wrote Int(2); the merge picks that without a Select.
+        assert_eq!(r.pool.kind(r.value_of[&read]), &ValueKind::Int(2));
+    }
+
+    #[test]
+    fn loop_modified_local_becomes_opaque() {
+        // let mut i = 0; loop { i = i + 1; }; i
+        let mut body = empty_body();
+        let zero = int_lit(&mut body, 0);
+        let let_s = let_stmt(&mut body, 0, zero, true);
+        let i_read = local_ref(&mut body, 0);
+        let one = int_lit(&mut body, 1);
+        let plus = binary(&mut body, NirBinaryOp::Add, i_read, one);
+        let assign = assign_stmt(&mut body, 0, plus);
+        let lb = block_with(&mut body, vec![assign]);
+        let loop_s = alloc_stmt(&mut body, StmtKind::Loop { body: lb });
+        let read = local_ref(&mut body, 0);
+        let s_read = alloc_stmt(&mut body, StmtKind::Expr(read));
+        root_with(&mut body, vec![let_s, loop_s, s_read]);
+        let r = build(&body, &[]);
+        assert!(matches!(
+            r.pool.kind(r.value_of[&read]),
+            ValueKind::Opaque(_)
+        ));
+    }
+
+    #[test]
+    fn loop_unmodified_local_keeps_value() {
+        // let x = 1; let mut i = 0; loop { i = i + 1; }; x
+        let mut body = empty_body();
+        let one = int_lit(&mut body, 1);
+        let let_x = let_stmt(&mut body, 0, one, false);
+        let zero = int_lit(&mut body, 0);
+        let let_i = let_stmt(&mut body, 1, zero, true);
+        let i_read = local_ref(&mut body, 1);
+        let lit_one = int_lit(&mut body, 1);
+        let plus = binary(&mut body, NirBinaryOp::Add, i_read, lit_one);
+        let assign = assign_stmt(&mut body, 1, plus);
+        let lb = block_with(&mut body, vec![assign]);
+        let loop_s = alloc_stmt(&mut body, StmtKind::Loop { body: lb });
+        let read = local_ref(&mut body, 0);
+        let s_read = alloc_stmt(&mut body, StmtKind::Expr(read));
+        root_with(&mut body, vec![let_x, let_i, loop_s, s_read]);
+        let r = build(&body, &[]);
+        // `x` is not touched by the loop, so it retains its Int(1).
+        assert_eq!(r.pool.kind(r.value_of[&read]), &ValueKind::Int(1));
+    }
+
+    #[test]
+    fn function_parameter_is_opaque_and_reads_dedup() {
+        // fn(x: i32) { x; x; }
+        let mut body = empty_body();
+        let read1 = local_ref(&mut body, 0);
+        let read2 = local_ref(&mut body, 0);
+        let s1 = alloc_stmt(&mut body, StmtKind::Expr(read1));
+        let s2 = alloc_stmt(&mut body, StmtKind::Expr(read2));
+        root_with(&mut body, vec![s1, s2]);
+        let param = NirParam {
+            name: "x".to_string(),
+            type_id: TypeTable::I32,
+            local_index: 0,
+            is_mut: false,
+            span: Span::default(),
+        };
+        let r = build(&body, &[param]);
+        let v1 = r.value_of[&read1];
+        let v2 = r.value_of[&read2];
+        assert_eq!(v1, v2);
+        assert!(matches!(r.pool.kind(v1), ValueKind::Opaque(_)));
+    }
+
+    #[test]
+    fn binary_on_param_reads_dedupes() {
+        // fn(x: i32) { x + 1; x + 1; }
+        let mut body = empty_body();
+        let read1 = local_ref(&mut body, 0);
+        let one_a = int_lit(&mut body, 1);
+        let add_a = binary(&mut body, NirBinaryOp::Add, read1, one_a);
+        let read2 = local_ref(&mut body, 0);
+        let one_b = int_lit(&mut body, 1);
+        let add_b = binary(&mut body, NirBinaryOp::Add, read2, one_b);
+        let s1 = alloc_stmt(&mut body, StmtKind::Expr(add_a));
+        let s2 = alloc_stmt(&mut body, StmtKind::Expr(add_b));
+        root_with(&mut body, vec![s1, s2]);
+        let param = NirParam {
+            name: "x".to_string(),
+            type_id: TypeTable::I32,
+            local_index: 0,
+            is_mut: false,
+            span: Span::default(),
+        };
+        let r = build(&body, &[param]);
+        // Both `x + 1` expressions share a ValueId because `x` is a stable
+        // (write-once) Opaque and `1` is hash-consed.
+        assert_eq!(r.value_of[&add_a], r.value_of[&add_b]);
+    }
+
+    #[test]
+    fn impure_let_value_gets_opaque_binding() {
+        // let x = call(); x
+        // We synthesise a Call node here; the builder treats it as impure so
+        // `x` gets a fresh Opaque rather than tracking the Call's value.
+        use crate::module_source::ModuleSource;
+        use crate::nir::FunctionRef;
+        let mut body = empty_body();
+        let call = alloc_expr(
+            &mut body,
+            ExprKind::Call {
+                func: FunctionRef {
+                    module_source: ModuleSource::entry_point_synthetic(),
+                    name: "foo".to_string(),
+                    monomorph_info: None,
+                    method_info: None,
+                },
+                type_args: vec![],
+                args: vec![],
+            },
+        );
+        let let_s = let_stmt(&mut body, 0, call, false);
+        let read = local_ref(&mut body, 0);
+        let s = alloc_stmt(&mut body, StmtKind::Expr(read));
+        root_with(&mut body, vec![let_s, s]);
+        let r = build(&body, &[]);
+        assert!(matches!(
+            r.pool.kind(r.value_of[&read]),
+            ValueKind::Opaque(_)
+        ));
+        // The call itself has no value_of entry.
+        assert!(!r.value_of.contains_key(&call));
+    }
+}

--- a/wado-compiler/src/nir_value_graph/builder.rs
+++ b/wado-compiler/src/nir_value_graph/builder.rs
@@ -41,7 +41,67 @@ use crate::nir_arena::{
     ArmData, Body, ExprId, ExprKind, NodeRef, PatId, PatKind, StmtId, StmtKind,
 };
 
-use super::{ValueId, ValuePool};
+use super::{HeapVersion, ValueId, ValuePool};
+
+/// Per-function heap-version tracker. The builder threads one `HeapState`
+/// through the walk; on every Skel node that may write the heap, the
+/// appropriate field's version (or every field's version, for opaque
+/// writes) bumps to a fresh value.
+///
+/// Granularity is **per field_index** (Q3 / Stage 5). A direct write to
+/// `obj.f` bumps only the `f` slot — a subsequent read of `obj.g` keeps
+/// its previous version, so the hash-cons key
+/// `(receiver, field, heap_ver)` agrees with prior reads and they share a
+/// `ValueId`. An opaque write (a Call, an `Index` / `Deref` assign target,
+/// a Loop entry, an If/Match/Switch merge) calls [`HeapState::bump_all`],
+/// invalidating every field's version.
+///
+/// Phase 2 may refine to `(receiver_root, field)` granularity using
+/// `mod_ref.rs` — at that point a Call that provably cannot alias one
+/// receiver root would bump only the others. MVP keeps it field-only.
+struct HeapState {
+    /// Next fresh version to hand out.
+    next: HeapVersion,
+    /// Current version of each `field_index` we have seen written.
+    per_field: IndexMap<u32, HeapVersion>,
+    /// Version returned for field_indices not yet in `per_field`.
+    /// `bump_all` advances this; `bump_field` does not.
+    default_version: HeapVersion,
+}
+
+impl HeapState {
+    fn new() -> Self {
+        Self {
+            next: HeapVersion::INITIAL.bump(),
+            per_field: IndexMap::default(),
+            default_version: HeapVersion::INITIAL,
+        }
+    }
+
+    fn fresh(&mut self) -> HeapVersion {
+        let v = self.next;
+        self.next = self.next.bump();
+        v
+    }
+
+    fn version_of(&self, field_index: u32) -> HeapVersion {
+        self.per_field
+            .get(&field_index)
+            .copied()
+            .unwrap_or(self.default_version)
+    }
+
+    fn bump_field(&mut self, field_index: u32) {
+        let v = self.fresh();
+        self.per_field.insert(field_index, v);
+    }
+
+    fn bump_all(&mut self) {
+        let v = self.fresh();
+        self.per_field.clear();
+        self.default_version = v;
+    }
+}
 
 /// The result of running [`build`] over a function body: the populated
 /// pool plus the side-table mapping pure `ExprId`s to their `ValueId`.
@@ -53,6 +113,12 @@ use super::{ValueId, ValuePool};
 pub struct ValueGraphBuild {
     pub pool: ValuePool,
     pub value_of: IndexMap<ExprId, ValueId>,
+    /// For each literal `ValueId`, the first `ExprId` we observed producing
+    /// it. Lets a consumer (e.g. store-load-forward) clone the original
+    /// literal `ExprKind` — including its source `repr` — when replacing a
+    /// `Local` read with the forwarded literal, avoiding `repr` churn in
+    /// diagnostic output and NIR dumps.
+    pub literal_source: IndexMap<ValueId, ExprId>,
 }
 
 /// Build the ValueGraph for one function body.
@@ -68,6 +134,7 @@ pub fn build(body: &Body, params: &[NirParam]) -> ValueGraphBuild {
     ValueGraphBuild {
         pool: b.pool,
         value_of: b.value_of,
+        literal_source: b.literal_source,
     }
 }
 
@@ -78,6 +145,11 @@ struct Builder<'a> {
     /// `local_index → current Value` at the current program point. Cloned at
     /// branch entries so each arm walks from the pre-branch snapshot.
     current_value: IndexMap<u32, ValueId>,
+    /// Heap-version tracker. See [`HeapState`].
+    heap_state: HeapState,
+    /// `ValueId` → first source `ExprId` for literal values, so consumers can
+    /// reuse the original `repr`. See [`ValueGraphBuild::literal_source`].
+    literal_source: IndexMap<ValueId, ExprId>,
 }
 
 impl<'a> Builder<'a> {
@@ -87,6 +159,8 @@ impl<'a> Builder<'a> {
             pool: ValuePool::new(),
             value_of: IndexMap::default(),
             current_value: IndexMap::default(),
+            heap_state: HeapState::new(),
+            literal_source: IndexMap::default(),
         }
     }
 
@@ -153,6 +227,9 @@ impl<'a> Builder<'a> {
                 }
                 let else_state = std::mem::replace(&mut self.current_value, saved.clone());
                 self.merge_two_arms(cond_v, &saved, &then_state, &else_state);
+                // Branches may have written to heap; bump_all conservatively
+                // (Stage 5 MVP). Stage 6 may refine to per-arm join.
+                self.heap_state.bump_all();
             }
             StmtKind::Loop { body: lb } => {
                 self.walk_loop(lb);
@@ -165,6 +242,7 @@ impl<'a> Builder<'a> {
                 let saved = self.current_value.clone();
                 self.walk_block(block);
                 self.dirty_changed_locals(&saved);
+                self.heap_state.bump_all();
             }
         }
     }
@@ -187,13 +265,41 @@ impl<'a> Builder<'a> {
     fn compute_value(&mut self, expr: ExprId) -> Option<ValueId> {
         match self.body.exprs[expr].kind.clone() {
             // ---- Literals ----
-            ExprKind::IntLiteral { value, .. } => Some(self.pool.int(value)),
-            ExprKind::FloatLiteral { value, .. } => Some(self.pool.float(value)),
-            ExprKind::BoolLiteral(b) => Some(self.pool.bool(b)),
-            ExprKind::CharLiteral(c) => Some(self.pool.char(c)),
-            ExprKind::StringLiteral(s) => Some(self.pool.string(s)),
-            ExprKind::Null => Some(self.pool.null()),
-            ExprKind::Unit => Some(self.pool.unit()),
+            ExprKind::IntLiteral { value, .. } => {
+                let v = self.pool.int(value);
+                self.record_literal(expr, v);
+                Some(v)
+            }
+            ExprKind::FloatLiteral { value, .. } => {
+                let v = self.pool.float(value);
+                self.record_literal(expr, v);
+                Some(v)
+            }
+            ExprKind::BoolLiteral(b) => {
+                let v = self.pool.bool(b);
+                self.record_literal(expr, v);
+                Some(v)
+            }
+            ExprKind::CharLiteral(c) => {
+                let v = self.pool.char(c);
+                self.record_literal(expr, v);
+                Some(v)
+            }
+            ExprKind::StringLiteral(s) => {
+                let v = self.pool.string(s);
+                self.record_literal(expr, v);
+                Some(v)
+            }
+            ExprKind::Null => {
+                let v = self.pool.null();
+                self.record_literal(expr, v);
+                Some(v)
+            }
+            ExprKind::Unit => {
+                let v = self.pool.unit();
+                self.record_literal(expr, v);
+                Some(v)
+            }
 
             // ---- Local read ----
             ExprKind::Local { index, .. } => Some(self.read_local(index)),
@@ -230,22 +336,34 @@ impl<'a> Builder<'a> {
                 let v = self
                     .walk_expr(value)
                     .unwrap_or_else(|| self.pool.fresh_opaque());
-                // Bare `Local` target = local reassignment. Anything else
-                // (FieldAccess, Index, Unary::Deref) is a heap write — Stage
-                // 5 will bump heap_version here; for MVP we just walk the
-                // target's children.
-                match &self.body.exprs[target].kind {
+                // Bare `Local` target = local reassignment (no heap write).
+                // `FieldAccess { field_index }` target = heap write to that
+                // field. `Index` / `Unary::Deref` targets are opaque heap
+                // writes — bump every field's version.
+                let target_kind = self.body.exprs[target].kind.clone();
+                match target_kind {
                     ExprKind::Local { index, .. } => {
-                        self.current_value.insert(*index, v);
+                        self.current_value.insert(index, v);
+                    }
+                    ExprKind::FieldAccess {
+                        expr: recv,
+                        field_index,
+                        ..
+                    } => {
+                        self.walk_expr(recv);
+                        self.heap_state.bump_field(field_index);
                     }
                     _ => {
                         self.walk_expr(target);
+                        self.heap_state.bump_all();
                     }
                 }
                 None
             }
             ExprKind::GlobalVarSet { value, .. } => {
                 self.walk_expr(value);
+                // Globals share the heap from the optimizer's perspective.
+                self.heap_state.bump_all();
                 None
             }
 
@@ -271,17 +389,20 @@ impl<'a> Builder<'a> {
                 }
                 let else_state = std::mem::replace(&mut self.current_value, saved.clone());
                 self.merge_two_arms(cond_v, &saved, &then_state, &else_state);
+                self.heap_state.bump_all();
                 None
             }
             ExprKind::LabeledBlock { block, .. } => {
                 let saved = self.current_value.clone();
                 self.walk_block(block);
                 self.dirty_changed_locals(&saved);
+                self.heap_state.bump_all();
                 None
             }
             ExprKind::Match { expr: scrut, arms } => {
                 self.walk_expr(scrut);
                 self.walk_match_arms(&arms);
+                self.heap_state.bump_all();
                 None
             }
             ExprKind::Switch {
@@ -303,16 +424,22 @@ impl<'a> Builder<'a> {
                 self.walk_block(default);
                 arm_states.push(std::mem::replace(&mut self.current_value, saved.clone()));
                 self.merge_n_arms(&saved, &arm_states);
+                self.heap_state.bump_all();
                 None
             }
 
-            // ---- Heap-bearing reads (MVP: Skel-side, no Value id) ----
-            ExprKind::FieldAccess { expr: inner, .. } => {
-                // Stage 5 activates `ValueKind::FieldAccess` with heap-version
-                // tracking. For now the receiver is walked but the read itself
-                // gets no id.
-                self.walk_expr(inner);
-                None
+            // ---- Heap-bearing reads ----
+            ExprKind::FieldAccess {
+                expr: inner,
+                field_index,
+                ..
+            } => {
+                // The receiver must be a pure value for the FieldAccess to
+                // get a ValueId — an impure receiver (a Call result, for
+                // instance) propagates None.
+                let recv = self.walk_expr(inner)?;
+                let heap_ver = self.heap_state.version_of(field_index);
+                Some(self.pool.field_access(recv, field_index, heap_ver))
             }
             ExprKind::Index { expr: inner, index } => {
                 self.walk_expr(inner);
@@ -351,17 +478,19 @@ impl<'a> Builder<'a> {
                 None
             }
 
-            // ---- Calls (effectful) ----
+            // ---- Calls (effectful, may write the heap) ----
             ExprKind::Call { args, .. } => {
                 for a in args {
                     self.walk_expr(a.expr);
                 }
+                self.heap_state.bump_all();
                 None
             }
             ExprKind::CmRawCall { args, .. } => {
                 for a in args {
                     self.walk_expr(a);
                 }
+                self.heap_state.bump_all();
                 None
             }
             ExprKind::MethodCall { receiver, args, .. } => {
@@ -369,6 +498,7 @@ impl<'a> Builder<'a> {
                 for a in args {
                     self.walk_expr(a.expr);
                 }
+                self.heap_state.bump_all();
                 None
             }
             ExprKind::IndirectCall { callee, args } => {
@@ -376,12 +506,17 @@ impl<'a> Builder<'a> {
                 for a in args {
                     self.walk_expr(a);
                 }
+                self.heap_state.bump_all();
                 None
             }
 
             // ---- Other Skel-side leaves ----
             ExprKind::GlobalVarGet { .. } | ExprKind::BytesLiteral(_) => None,
         }
+    }
+
+    fn record_literal(&mut self, expr: ExprId, value: ValueId) {
+        self.literal_source.entry(value).or_insert(expr);
     }
 
     fn read_local(&mut self, idx: u32) -> ValueId {
@@ -538,6 +673,10 @@ impl<'a> Builder<'a> {
                 self.current_value.insert(*idx, opaque);
             }
         }
+        // Same reasoning for heap: the body may have run 0..N times before
+        // the body walk begins, so reads inside the body must not share
+        // heap versions with pre-loop reads.
+        self.heap_state.bump_all();
         self.walk_block(body_block);
         // After the body walks, an in-loop `Assign` may have overwritten a
         // pre-seeded Opaque with a derived value (e.g., `i = i + 1` writes
@@ -550,6 +689,7 @@ impl<'a> Builder<'a> {
                 self.current_value.insert(*idx, opaque);
             }
         }
+        self.heap_state.bump_all();
     }
 
     /// After a flow-opaque construct (LabeledBlock with potential breaks),
@@ -741,6 +881,51 @@ mod tests {
             stmts,
             span: Span::default(),
         })
+    }
+
+    fn field_access(body: &mut Body, expr: ExprId, field_index: u32) -> ExprId {
+        alloc_expr(
+            body,
+            ExprKind::FieldAccess {
+                expr,
+                field_index,
+                field_name: format!("__f{field_index}"),
+            },
+        )
+    }
+
+    fn field_assign_stmt(body: &mut Body, recv: ExprId, field_index: u32, value: ExprId) -> StmtId {
+        let target = field_access(body, recv, field_index);
+        let assign = alloc_expr(body, ExprKind::Assign { target, value });
+        alloc_stmt(body, StmtKind::Expr(assign))
+    }
+
+    fn call_void(body: &mut Body) -> ExprId {
+        use crate::module_source::ModuleSource;
+        use crate::nir::FunctionRef;
+        alloc_expr(
+            body,
+            ExprKind::Call {
+                func: FunctionRef {
+                    module_source: ModuleSource::entry_point_synthetic(),
+                    name: "foo".to_string(),
+                    monomorph_info: None,
+                    method_info: None,
+                },
+                type_args: vec![],
+                args: vec![],
+            },
+        )
+    }
+
+    fn param_seed() -> NirParam {
+        NirParam {
+            name: "obj".to_string(),
+            type_id: TypeTable::UNIT,
+            local_index: 0,
+            is_mut: false,
+            span: Span::default(),
+        }
     }
 
     // ----- Tests -----
@@ -1026,5 +1211,101 @@ mod tests {
         ));
         // The call itself has no value_of entry.
         assert!(!r.value_of.contains_key(&call));
+    }
+
+    // ----- Stage 5: FieldAccess heap-version behavior -----
+
+    #[test]
+    fn two_field_reads_same_field_share_value_id() {
+        // fn(obj) { obj.f; obj.f; }
+        let mut body = empty_body();
+        let recv1 = local_ref(&mut body, 0);
+        let read1 = field_access(&mut body, recv1, 0);
+        let recv2 = local_ref(&mut body, 0);
+        let read2 = field_access(&mut body, recv2, 0);
+        let s1 = alloc_stmt(&mut body, StmtKind::Expr(read1));
+        let s2 = alloc_stmt(&mut body, StmtKind::Expr(read2));
+        root_with(&mut body, vec![s1, s2]);
+        let r = build(&body, &[param_seed()]);
+        assert_eq!(r.value_of[&read1], r.value_of[&read2]);
+        assert!(matches!(
+            r.pool.kind(r.value_of[&read1]),
+            ValueKind::FieldAccess { .. }
+        ));
+    }
+
+    #[test]
+    fn field_write_invalidates_only_that_field() {
+        // fn(obj) {
+        //     let a = obj.f;
+        //     let b = obj.g;
+        //     obj.f = 1;
+        //     let a2 = obj.f;   // distinct VN from `a` (different heap_ver)
+        //     let b2 = obj.g;   // same VN as `b` (bump_field(f) did not touch g)
+        // }
+        let mut body = empty_body();
+        let recv_a = local_ref(&mut body, 0);
+        let read_a = field_access(&mut body, recv_a, 0);
+        let let_a = let_stmt(&mut body, 1, read_a, false);
+
+        let recv_b = local_ref(&mut body, 0);
+        let read_b = field_access(&mut body, recv_b, 1);
+        let let_b = let_stmt(&mut body, 2, read_b, false);
+
+        let one = int_lit(&mut body, 1);
+        let recv_w = local_ref(&mut body, 0);
+        let write = field_assign_stmt(&mut body, recv_w, 0, one);
+
+        let recv_a2 = local_ref(&mut body, 0);
+        let read_a2 = field_access(&mut body, recv_a2, 0);
+        let let_a2 = let_stmt(&mut body, 3, read_a2, false);
+
+        let recv_b2 = local_ref(&mut body, 0);
+        let read_b2 = field_access(&mut body, recv_b2, 1);
+        let let_b2 = let_stmt(&mut body, 4, read_b2, false);
+
+        root_with(&mut body, vec![let_a, let_b, write, let_a2, let_b2]);
+        let r = build(&body, &[param_seed()]);
+
+        // `obj.f` reads straddle a write of `f`: different heap versions, distinct VN.
+        assert_ne!(r.value_of[&read_a], r.value_of[&read_a2]);
+        // `obj.g` is not touched by writing `obj.f`: heap version unchanged, same VN.
+        assert_eq!(r.value_of[&read_b], r.value_of[&read_b2]);
+    }
+
+    #[test]
+    fn call_invalidates_all_fields() {
+        // fn(obj) {
+        //     let a = obj.f;
+        //     foo();
+        //     let a2 = obj.f;  // bump_all invalidates -> distinct VN
+        // }
+        let mut body = empty_body();
+        let recv1 = local_ref(&mut body, 0);
+        let read1 = field_access(&mut body, recv1, 0);
+        let let_1 = let_stmt(&mut body, 1, read1, false);
+
+        let call = call_void(&mut body);
+        let call_s = alloc_stmt(&mut body, StmtKind::Expr(call));
+
+        let recv2 = local_ref(&mut body, 0);
+        let read2 = field_access(&mut body, recv2, 0);
+        let let_2 = let_stmt(&mut body, 2, read2, false);
+
+        root_with(&mut body, vec![let_1, call_s, let_2]);
+        let r = build(&body, &[param_seed()]);
+        assert_ne!(r.value_of[&read1], r.value_of[&read2]);
+    }
+
+    #[test]
+    fn field_access_with_impure_receiver_yields_no_value() {
+        // fn() { call().f; }
+        let mut body = empty_body();
+        let call = call_void(&mut body);
+        let fa = field_access(&mut body, call, 0);
+        let s = alloc_stmt(&mut body, StmtKind::Expr(fa));
+        root_with(&mut body, vec![s]);
+        let r = build(&body, &[]);
+        assert!(!r.value_of.contains_key(&fa));
     }
 }

--- a/wado-compiler/src/nir_value_graph/builder.rs
+++ b/wado-compiler/src/nir_value_graph/builder.rs
@@ -28,7 +28,7 @@
 //!   with `Opaque`.
 
 use crate::hashmap::IndexMap;
-use crate::nir::{NirParam, NirUnaryOp};
+use crate::nir::{NirBinaryOp, NirParam, NirUnaryOp};
 use crate::nir_arena::{
     ArmData, Body, ExprId, ExprKind, NodeRef, PatId, PatKind, StmtId, StmtKind,
 };
@@ -309,8 +309,41 @@ impl<'a> Builder<'a> {
 
             // ---- Pure arithmetic ----
             ExprKind::Binary { left, op, right } => {
-                let lhs = self.walk_expr(left)?;
-                let rhs = self.walk_expr(right)?;
+                // Always walk both operands for their side effects on
+                // `current_value` and `heap_state`, even when one of them is
+                // impure (a `?` short-circuit on `lhs` would skip the rhs
+                // walk and miss any local assignments / heap writes inside
+                // it).
+                let lhs = self.walk_expr(left);
+                let rhs = if matches!(op, NirBinaryOp::And | NirBinaryOp::Or) {
+                    // Short-circuit logical ops: the rhs is conditionally
+                    // evaluated at runtime. Walk it inside a snapshot, then
+                    // model "may or may not have happened" by dirtying any
+                    // local the walk mutated and bumping the heap. Without
+                    // this, a write inside the rhs (e.g. `false && { x =
+                    // 2; true }`) would commit unconditionally to
+                    // `current_value` and let store-load forwarding
+                    // substitute later reads with the never-stored value.
+                    let saved_cur = self.current_value.clone();
+                    let rhs = self.walk_expr(right);
+                    let changed: Vec<u32> = self
+                        .current_value
+                        .iter()
+                        .filter_map(|(&k, &v)| {
+                            saved_cur.get(&k).and_then(|s| (*s != v).then_some(k))
+                        })
+                        .collect();
+                    for k in changed {
+                        let opaque = self.pool.fresh_opaque();
+                        self.current_value.insert(k, opaque);
+                    }
+                    self.heap_state.bump_all();
+                    rhs
+                } else {
+                    self.walk_expr(right)
+                };
+                let lhs = lhs?;
+                let rhs = rhs?;
                 Some(self.pool.binary(op, lhs, rhs))
             }
             ExprKind::Unary { op, expr: inner } => {
@@ -336,24 +369,31 @@ impl<'a> Builder<'a> {
 
             // ---- Mutation: side-effect, never pure ----
             ExprKind::Assign { target, value } => {
+                // Walk target operands FIRST: runtime evaluates the place
+                // (receiver / index / deref operand) before the stored
+                // value, so a write inside `value` must not be visible to
+                // those reads.
+                let target_kind = self.body.exprs[target].kind.clone();
+                match &target_kind {
+                    ExprKind::Local { .. } => {}
+                    ExprKind::FieldAccess { expr: recv, .. } => {
+                        self.walk_expr(*recv);
+                    }
+                    _ => {
+                        self.walk_expr(target);
+                    }
+                }
                 let v = self
                     .walk_expr(value)
                     .unwrap_or_else(|| self.pool.fresh_opaque());
-                let target_kind = self.body.exprs[target].kind.clone();
                 match target_kind {
                     ExprKind::Local { index, .. } => {
                         self.current_value.insert(index, v);
                     }
-                    ExprKind::FieldAccess {
-                        expr: recv,
-                        field_index,
-                        ..
-                    } => {
-                        self.walk_expr(recv);
+                    ExprKind::FieldAccess { field_index, .. } => {
                         self.heap_state.bump_field(field_index);
                     }
                     _ => {
-                        self.walk_expr(target);
                         self.heap_state.bump_all();
                     }
                 }
@@ -632,6 +672,33 @@ impl<'a> Builder<'a> {
     }
 
     fn walk_match_arms(&mut self, arms: &[ArmData]) {
+        // Guards are evaluated sequentially at runtime: when guard 0 has
+        // side effects and returns false, guard 1 and arm 1's body run
+        // with those effects visible. Restoring the heap state and
+        // outer locals to the pre-match snapshot between arms would
+        // hide those effects from later arms. To stay sound without
+        // threading the post-guard state forward, conservatively dirty
+        // every outer local any guard could write and bump the heap
+        // once before walking arms.
+        let mut guard_writes: crate::hashmap::IndexSet<u32> =
+            crate::hashmap::IndexSet::default();
+        let mut any_guard = false;
+        for arm in arms {
+            if let Some(g) = arm.guard {
+                any_guard = true;
+                collect_writes_in_expr(self.body, g, &mut guard_writes);
+            }
+        }
+        for idx in &guard_writes {
+            if self.current_value.contains_key(idx) {
+                let opaque = self.pool.fresh_opaque();
+                self.current_value.insert(*idx, opaque);
+            }
+        }
+        if any_guard {
+            self.heap_state.bump_all();
+        }
+
         let saved = self.current_value.clone();
         let saved_heap = self.heap_state.snapshot();
         let mut states: Vec<IndexMap<u32, ValueId>> = Vec::with_capacity(arms.len());

--- a/wado-compiler/src/optimize.rs
+++ b/wado-compiler/src/optimize.rs
@@ -21,22 +21,23 @@
 //! 5.  `inline` — function inlining.
 //! 6.  `peephole` (post-inline) — unified engine session: `RefElimRule` (drop
 //!     reference bindings inlining exposes), `ElideBoxLocalRule` (collapse
-//!     `let x = Box{value: inner}; … x.value …` shells), `array_literal`
-//!     (materialize `ArrayLiteral` from the `array_new + push` window),
-//!     `elide_local`, env-free `const_fold`, and `const_branch_prune`.
-//! 7.  `labeled_block_fusion` — collapse inlined-helper `Option<T>` allocations.
-//! 8.  `sroa` — Scalar Replacement of Aggregates.
-//! 9.  `copy_prop` — copy propagation.
-//! 10. `dae` — Dead Argument Elimination.
-//! 11. `drve` — Dead Return Value Elimination.
-//! 12. `cse` — Loop-level Common Subexpression Elimination.
-//! 13. `store_load_forward` — store-to-load forwarding.
-//! 14. `const_folding` — partial evaluation via [`crate::niri`] (also drives
+//!     `let x = Box{value: inner}; … x.value …` shells),
+//!     `LabeledBlockFusionRule` (collapse inlined-helper `Option<T>` /
+//!     `Result<T, E>` allocations into the consumer's `if-let` / `match` site),
+//!     `array_literal` (materialize `ArrayLiteral` from the `array_new + push`
+//!     window), `elide_local`, env-free `const_fold`, and `const_branch_prune`.
+//! 7.  `sroa` — Scalar Replacement of Aggregates.
+//! 8.  `copy_prop` — copy propagation.
+//! 9.  `dae` — Dead Argument Elimination.
+//! 10. `drve` — Dead Return Value Elimination.
+//! 11. `cse` — Loop-level Common Subexpression Elimination.
+//! 12. `store_load_forward` — store-to-load forwarding.
+//! 13. `const_folding` — partial evaluation via [`crate::niri`] (also drives
 //!     alias-aware field-knowledge tracking; see `alias`). The flow-sensitive
 //!     half; the env-free folds and trivial-block pruning run in `peephole`.
-//! 15. `licm` — Loop-Invariant Code Motion.
-//! 16. `condition_implication` — eliminate conditions implied by dominators.
-//! 17. `tmpl_hoist` — hoist template-string backing buffers out of loops.
+//! 14. `licm` — Loop-Invariant Code Motion.
+//! 15. `condition_implication` — eliminate conditions implied by dominators.
+//! 16. `tmpl_hoist` — hoist template-string backing buffers out of loops.
 //!
 //! Dense `Match` → `Switch` on global initializer bodies runs once before the
 //! loop (`match_to_switch_globals`); `-O0` skips the loop and lowers everything
@@ -104,7 +105,6 @@ use dce::{
 use drve::eliminate_dead_return_values;
 use field_scalarize::scalarize_hot_fields;
 use inline::inline_functions;
-use labeled_block_fusion::fuse_labeled_blocks;
 use licm::apply_licm;
 use match_to_switch::{match_to_switch_all, match_to_switch_globals};
 use sroa::scalar_replace_aggregates;
@@ -603,12 +603,8 @@ fn run_optimization_passes(
         // here (`include_match = false`): the pre-inline run already lowered
         // every reachable `Match`, and `inline` copies `Switch`-shaped bodies.
         gated!("nir/peephole", |p, g| peephole::run_peephole(p, g, false));
-        // Adjacent-use Box-local elision. After `sroa_param` reshapes
-        // `Box<T>` parameters into scalars and `inline` propagates the
-        // resulting `FieldAccess(Local(x), "value")` shape into call
-        // sites, this pass collapses the surrounding `let x = Box{value:
-        // inner}; … x.value …` shells. See `optimize/elide_box_local.rs`.
-        gated!("nir/labeled_block_fusion", fuse_labeled_blocks);
+        // `labeled_block_fusion` moved into the post-inline `nir/peephole`
+        // session as `LabeledBlockFusionRule`; see `optimize/peephole.rs`.
         gated!("nir/sroa", scalar_replace_aggregates);
         gated!("nir/copy_prop", propagate_copies);
         // DAE / DRVE after `copy_prop` shrinks signatures and discards unused

--- a/wado-compiler/src/optimize/condition_implication.rs
+++ b/wado-compiler/src/optimize/condition_implication.rs
@@ -11,14 +11,23 @@
 //! This subsumes the WIR-level `bounds_check` pass, handling both strict `<`
 //! and inclusive `<=` guard patterns.
 //!
-//! The pass reads and mutates the arena [`Body`] directly. The eliminators
-//! drive a small [`ArenaOptVisitor`] whose default `visit_*` recurse into every
-//! child; condition replacement is an in-place `kind` rewrite.
+//! Runs on the worklist rewrite engine (combine migration; see
+//! `docs/wep-2026-06-05-nir-rewrite-engine-design.md`) as a [`Rule`]: a
+//! per-function standalone engine session whose `apply_block` fires once at
+//! the body root and runs the whole-function dominator / loop-guard walk.
+//! The single rewrite point (`condition → BoolLiteral(false)`) routes through
+//! `engine.replace_expr_kind` so the parent map and use index stay coherent.
+//!
+//! The eliminators share a small in-file [`ArenaOptVisitor`] whose default
+//! `visit_*` recurse into every child; only `set_false` mutates.
+
+use std::cell::Cell;
 
 use crate::hashmap::IndexMap;
 use crate::hashmap::IndexSet;
 use crate::nir::{NirBinaryOp, NirFunction, NirUnaryOp};
 use crate::nir_arena::{BlockId, Body, ExprId, ExprKind, NodeRef, PatId, StmtId, StmtKind};
+use crate::nir_engine::{Engine, EngineBuffers, Rule};
 use crate::nir_package::NirPackage;
 
 use cranelift_entity::EntityRef;
@@ -91,20 +100,41 @@ type DefMap = IndexMap<u32, Def>;
 
 pub fn eliminate_implied_conditions(project: &mut NirPackage, gate: &mut FunctionGate) -> bool {
     let len = project.functions.len();
+    let mut buffers = EngineBuffers::default();
     gate.run_gated(GatedPass::ConditionImplication, len, |fid| {
         let mut func = project.functions[fid.index()].borrow_mut();
-        process_function(&mut func)
+        if func.body.is_none() {
+            return false;
+        }
+        let rule = ConditionImplicationRule {
+            applied: Cell::new(false),
+        };
+        let NirFunction { body, locals, .. } = &mut *func;
+        let body = body.as_mut().expect("checked above");
+        let mut engine = Engine::new(body, &mut buffers, locals);
+        engine.run(&[&rule])
     })
 }
 
-fn process_function(func: &mut NirFunction) -> bool {
-    let Some(body) = func.body.as_mut() else {
-        return false;
-    };
-    let tainted = collect_tainted_locals(body);
-    let mut defs = DefMap::default();
-    let root = body.root;
-    process_block(body, root, &mut defs, &tainted)
+/// Standalone-session rule whose single `apply_block` performs the whole-
+/// function condition-implication walk at the body root.
+pub(super) struct ConditionImplicationRule {
+    applied: Cell<bool>,
+}
+
+impl Rule for ConditionImplicationRule {
+    fn apply_block(&self, engine: &mut Engine, block: BlockId) -> bool {
+        if engine.parent_of(NodeRef::Block(block)).is_some() {
+            return false;
+        }
+        if self.applied.replace(true) {
+            return false;
+        }
+        let tainted = collect_tainted_locals(engine.body);
+        let mut defs = DefMap::default();
+        let root = engine.body.root;
+        process_block(engine, root, &mut defs, &tainted)
+    }
 }
 
 /// Per-function summary of locals and `(local, field_index)` pairs
@@ -252,33 +282,33 @@ fn taint_root_local(body: &Body, e: ExprId, taints: &mut Taints) {
     }
 }
 
-fn process_block(body: &mut Body, block: BlockId, defs: &mut DefMap, tainted: &Taints) -> bool {
+fn process_block(engine: &mut Engine, block: BlockId, defs: &mut DefMap, tainted: &Taints) -> bool {
     let mut changed = false;
     let mut guards: Vec<ShortCircuitGuard> = Vec::new();
-    let stmts = body.blocks[block].stmts.clone();
+    let stmts = engine.body.blocks[block].stmts.clone();
     for s in stmts {
-        record_def_from_stmt(body, s, defs, tainted);
-        record_defs_from_nested(body, s, defs, tainted);
+        record_def_from_stmt(engine.body, s, defs, tainted);
+        record_defs_from_nested(engine.body, s, defs, tainted);
         // Apply accumulated guards from previous early-exit stmts to this stmt
         for guard in &guards {
-            changed |= guard.eliminate_in_stmt(body, s, defs);
+            changed |= guard.eliminate_in_stmt(engine, s, defs);
         }
-        changed |= BitmaskEliminator { defs }.visit_stmt(body, s);
-        changed |= ShortCircuitEliminator { defs }.visit_stmt(body, s);
-        changed |= process_stmt(body, s, defs, tainted);
+        changed |= BitmaskEliminator { defs }.visit_stmt(engine, s);
+        changed |= ShortCircuitEliminator { defs }.visit_stmt(engine, s);
+        changed |= process_stmt(engine, s, defs, tainted);
         // If this is `if (var >= bound) { return/break }`, extract a guard
-        if let Some(guard) = extract_early_exit_guard(body, s, defs) {
+        if let Some(guard) = extract_early_exit_guard(engine.body, s, defs) {
             guards.push(guard);
         }
     }
     changed
 }
 
-fn process_stmt(body: &mut Body, s: StmtId, defs: &mut DefMap, tainted: &Taints) -> bool {
+fn process_stmt(engine: &mut Engine, s: StmtId, defs: &mut DefMap, tainted: &Taints) -> bool {
     // Record definitions from let bindings
-    record_def_from_stmt(body, s, defs, tainted);
+    record_def_from_stmt(engine.body, s, defs, tainted);
 
-    let shape = match &body.stmts[s].kind {
+    let shape = match &engine.body.stmts[s].kind {
         StmtKind::Loop { body: lb } => StmtShape::Loop(*lb),
         StmtKind::If {
             then_block,
@@ -289,15 +319,15 @@ fn process_stmt(body: &mut Body, s: StmtId, defs: &mut DefMap, tainted: &Taints)
         _ => StmtShape::None,
     };
     match shape {
-        StmtShape::Loop(lb) => process_loop(body, lb, defs, tainted),
+        StmtShape::Loop(lb) => process_loop(engine, lb, defs, tainted),
         StmtShape::If(then_b, else_b) => {
-            let mut changed = process_block(body, then_b, defs, tainted);
+            let mut changed = process_block(engine, then_b, defs, tainted);
             if let Some(eb) = else_b {
-                changed |= process_block(body, eb, defs, tainted);
+                changed |= process_block(engine, eb, defs, tainted);
             }
             changed
         }
-        StmtShape::Labeled(b) => process_block(body, b, defs, tainted),
+        StmtShape::Labeled(b) => process_block(engine, b, defs, tainted),
         StmtShape::None => false,
     }
 }
@@ -309,21 +339,21 @@ enum StmtShape {
     None,
 }
 
-fn process_loop(body: &mut Body, loop_body: BlockId, defs: &mut DefMap, tainted: &Taints) -> bool {
+fn process_loop(engine: &mut Engine, loop_body: BlockId, defs: &mut DefMap, tainted: &Taints) -> bool {
     // First, record defs inside the loop body (for copies like `let index = i`)
     // and recurse into nested structures
     let mut changed = false;
 
     // Collect defs from the loop body before eliminating
     let mut loop_defs = defs.clone();
-    let stmts = body.blocks[loop_body].stmts.clone();
+    let stmts = engine.body.blocks[loop_body].stmts.clone();
     for s in &stmts {
-        record_def_from_stmt(body, *s, &mut loop_defs, tainted);
-        record_defs_from_nested(body, *s, &mut loop_defs, tainted);
+        record_def_from_stmt(engine.body, *s, &mut loop_defs, tainted);
+        record_defs_from_nested(engine.body, *s, &mut loop_defs, tainted);
     }
 
     // Extract the loop guard from the first statement
-    let guard = extract_loop_guard(body, loop_body);
+    let guard = extract_loop_guard(engine.body, loop_body);
 
     if let Some(guard) = &guard {
         // Eliminate implied conditions in the loop body (skip the guard itself)
@@ -333,18 +363,18 @@ fn process_loop(body: &mut Body, loop_body: BlockId, defs: &mut DefMap, tainted:
             defs: &loop_defs,
         };
         for s in stmts.iter().skip(1) {
-            changed |= condition_elim.visit_stmt(body, *s);
+            changed |= condition_elim.visit_stmt(engine, *s);
         }
     }
 
     // Eliminate bitmask-bounded checks in the loop body
     for s in &stmts {
-        changed |= BitmaskEliminator { defs: &loop_defs }.visit_stmt(body, *s);
+        changed |= BitmaskEliminator { defs: &loop_defs }.visit_stmt(engine, *s);
     }
 
     // Recurse into nested loops
     for s in &stmts {
-        changed |= process_stmt_nested_loops(body, *s, defs, tainted);
+        changed |= process_stmt_nested_loops(engine, *s, defs, tainted);
     }
 
     changed
@@ -353,12 +383,12 @@ fn process_loop(body: &mut Body, loop_body: BlockId, defs: &mut DefMap, tainted:
 /// Recurse into nested structures to find inner loops, but don't re-process
 /// the current loop level.
 fn process_stmt_nested_loops(
-    body: &mut Body,
+    engine: &mut Engine,
     s: StmtId,
     defs: &mut DefMap,
     tainted: &Taints,
 ) -> bool {
-    let shape = match &body.stmts[s].kind {
+    let shape = match &engine.body.stmts[s].kind {
         StmtKind::Loop { body: lb } => StmtShape::Loop(*lb),
         StmtKind::If {
             then_block,
@@ -369,23 +399,23 @@ fn process_stmt_nested_loops(
         _ => StmtShape::None,
     };
     match shape {
-        StmtShape::Loop(lb) => process_loop(body, lb, defs, tainted),
+        StmtShape::Loop(lb) => process_loop(engine, lb, defs, tainted),
         StmtShape::If(then_b, else_b) => {
             let mut changed = false;
-            for s in body.blocks[then_b].stmts.clone() {
-                changed |= process_stmt_nested_loops(body, s, defs, tainted);
+            for s in engine.body.blocks[then_b].stmts.clone() {
+                changed |= process_stmt_nested_loops(engine, s, defs, tainted);
             }
             if let Some(eb) = else_b {
-                for s in body.blocks[eb].stmts.clone() {
-                    changed |= process_stmt_nested_loops(body, s, defs, tainted);
+                for s in engine.body.blocks[eb].stmts.clone() {
+                    changed |= process_stmt_nested_loops(engine, s, defs, tainted);
                 }
             }
             changed
         }
         StmtShape::Labeled(b) => {
             let mut changed = false;
-            for s in body.blocks[b].stmts.clone() {
-                changed |= process_stmt_nested_loops(body, s, defs, tainted);
+            for s in engine.body.blocks[b].stmts.clone() {
+                changed |= process_stmt_nested_loops(engine, s, defs, tainted);
             }
             changed
         }
@@ -904,8 +934,8 @@ fn record_defs_from_expr(body: &Body, e: ExprId, defs: &mut DefMap, tainted: &Ta
 }
 
 /// Replace the expression at `cond` with `false`, preserving its type and span.
-fn set_false(body: &mut Body, cond: ExprId) {
-    body.exprs[cond].kind = ExprKind::BoolLiteral(false);
+fn set_false(engine: &mut Engine, cond: ExprId) {
+    engine.replace_expr_kind(cond, ExprKind::BoolLiteral(false));
 }
 
 /// NIR visitor that eliminates loop-guard-implied false bounds checks.
@@ -920,8 +950,8 @@ struct ConditionEliminator<'a> {
 }
 
 impl ArenaOptVisitor for ConditionEliminator<'_> {
-    fn visit_stmt(&mut self, body: &mut Body, s: StmtId) -> bool {
-        let if_ids = match &body.stmts[s].kind {
+    fn visit_stmt(&mut self, engine: &mut Engine, s: StmtId) -> bool {
+        let if_ids = match &engine.body.stmts[s].kind {
             StmtKind::If {
                 condition,
                 then_block,
@@ -932,35 +962,41 @@ impl ArenaOptVisitor for ConditionEliminator<'_> {
         if let Some((condition, then_block, else_block)) = if_ids {
             // Check if this statement is a bounds check that can be eliminated.
             if else_block.is_none()
-                && is_panic_block(body, then_block)
-                && is_implied_false_by_any(body, condition, self.guard, &self.dom_guards, self.defs)
+                && is_panic_block(engine.body, then_block)
+                && is_implied_false_by_any(
+                    engine.body,
+                    condition,
+                    self.guard,
+                    &self.dom_guards,
+                    self.defs,
+                )
             {
-                set_false(body, condition);
+                set_false(engine, condition);
                 return true;
             }
 
             // Extract a dominating guard from the condition to extend
             // elimination into the then-block.
-            let mut changed = self.visit_expr(body, condition);
-            let dom = extract_dominating_guard(body, condition, self.defs);
+            let mut changed = self.visit_expr(engine, condition);
+            let dom = extract_dominating_guard(engine.body, condition, self.defs);
             let saved = self.dom_guards.clone();
             if let Some(dg) = dom {
                 self.dom_guards.push(dg);
             }
-            changed |= self.visit_block(body, then_block);
+            changed |= self.visit_block(engine, then_block);
             self.dom_guards = saved;
             if let Some(eb) = else_block {
-                changed |= self.visit_block(body, eb);
+                changed |= self.visit_block(engine, eb);
             }
             return changed;
         }
 
-        arena_opt_walk(self, body, NodeRef::Stmt(s))
+        arena_opt_walk(self, engine, NodeRef::Stmt(s))
     }
 
-    fn visit_expr(&mut self, body: &mut Body, e: ExprId) -> bool {
+    fn visit_expr(&mut self, engine: &mut Engine, e: ExprId) -> bool {
         // For If exprs: extract a dominating guard and propagate into then-branch.
-        let if_ids = match &body.exprs[e].kind {
+        let if_ids = match &engine.body.exprs[e].kind {
             ExprKind::If {
                 condition,
                 then_branch,
@@ -969,20 +1005,20 @@ impl ArenaOptVisitor for ConditionEliminator<'_> {
             _ => None,
         };
         if let Some((condition, then_branch, else_branch)) = if_ids {
-            let mut changed = self.visit_expr(body, condition);
-            let dom = extract_dominating_guard(body, condition, self.defs);
+            let mut changed = self.visit_expr(engine, condition);
+            let dom = extract_dominating_guard(engine.body, condition, self.defs);
             let saved = self.dom_guards.clone();
             if let Some(dg) = dom {
                 self.dom_guards.push(dg);
             }
-            changed |= self.visit_block(body, then_branch);
+            changed |= self.visit_block(engine, then_branch);
             self.dom_guards = saved;
             if let Some(eb) = else_branch {
-                changed |= self.visit_block(body, eb);
+                changed |= self.visit_block(engine, eb);
             }
             return changed;
         }
-        arena_opt_walk(self, body, NodeRef::Expr(e))
+        arena_opt_walk(self, engine, NodeRef::Expr(e))
     }
 }
 
@@ -995,8 +1031,8 @@ struct BitmaskEliminator<'a> {
 }
 
 impl ArenaOptVisitor for BitmaskEliminator<'_> {
-    fn visit_stmt(&mut self, body: &mut Body, s: StmtId) -> bool {
-        let if_ids = match &body.stmts[s].kind {
+    fn visit_stmt(&mut self, engine: &mut Engine, s: StmtId) -> bool {
+        let if_ids = match &engine.body.stmts[s].kind {
             StmtKind::If {
                 condition,
                 then_block,
@@ -1005,13 +1041,13 @@ impl ArenaOptVisitor for BitmaskEliminator<'_> {
             _ => None,
         };
         if let Some((condition, then_block)) = if_ids
-            && is_panic_block(body, then_block)
-            && is_bitmask_bounded(body, condition, self.defs)
+            && is_panic_block(engine.body, then_block)
+            && is_bitmask_bounded(engine.body, condition, self.defs)
         {
-            set_false(body, condition);
+            set_false(engine, condition);
             return true;
         }
-        arena_opt_walk(self, body, NodeRef::Stmt(s))
+        arena_opt_walk(self, engine, NodeRef::Stmt(s))
     }
 }
 
@@ -1061,8 +1097,8 @@ struct ShortCircuitEliminator<'a> {
 }
 
 impl ArenaOptVisitor for ShortCircuitEliminator<'_> {
-    fn visit_expr(&mut self, body: &mut Body, e: ExprId) -> bool {
-        let or_ids = match &body.exprs[e].kind {
+    fn visit_expr(&mut self, engine: &mut Engine, e: ExprId) -> bool {
+        let or_ids = match &engine.body.exprs[e].kind {
             ExprKind::Binary {
                 left,
                 op: NirBinaryOp::Or,
@@ -1071,14 +1107,14 @@ impl ArenaOptVisitor for ShortCircuitEliminator<'_> {
             _ => None,
         };
         if let Some((left, right)) = or_ids {
-            let mut changed = self.visit_expr(body, left);
-            if let Some(guard) = ShortCircuitGuard::extract(body, left, self.defs) {
-                changed |= guard.eliminate_in_expr(body, right, self.defs);
+            let mut changed = self.visit_expr(engine, left);
+            if let Some(guard) = ShortCircuitGuard::extract(engine.body, left, self.defs) {
+                changed |= guard.eliminate_in_expr(engine, right, self.defs);
             }
-            changed |= self.visit_expr(body, right);
+            changed |= self.visit_expr(engine, right);
             return changed;
         }
-        arena_opt_walk(self, body, NodeRef::Expr(e))
+        arena_opt_walk(self, engine, NodeRef::Expr(e))
     }
 }
 
@@ -1243,8 +1279,8 @@ impl ShortCircuitGuard {
         }
     }
 
-    fn eliminate_in_expr(&self, body: &mut Body, e: ExprId, defs: &DefMap) -> bool {
-        let walk = match &body.exprs[e].kind {
+    fn eliminate_in_expr(&self, engine: &mut Engine, e: ExprId, defs: &DefMap) -> bool {
+        let walk = match &engine.body.exprs[e].kind {
             ExprKind::LabeledBlock { block, .. } | ExprKind::Block(block) => ScWalk::Block(*block),
             ExprKind::Binary { left, right, .. } => ScWalk::Exprs2(*left, *right),
             ExprKind::Unary { expr: inner, .. }
@@ -1258,18 +1294,18 @@ impl ShortCircuitGuard {
             _ => ScWalk::None,
         };
         match walk {
-            ScWalk::Block(b) => self.eliminate_in_block(body, b, defs),
+            ScWalk::Block(b) => self.eliminate_in_block(engine, b, defs),
             ScWalk::Exprs2(left, right) => {
-                let mut changed = self.eliminate_in_expr(body, left, defs);
-                changed |= self.eliminate_in_expr(body, right, defs);
+                let mut changed = self.eliminate_in_expr(engine, left, defs);
+                changed |= self.eliminate_in_expr(engine, right, defs);
                 changed
             }
-            ScWalk::Expr1(inner) => self.eliminate_in_expr(body, inner, defs),
+            ScWalk::Expr1(inner) => self.eliminate_in_expr(engine, inner, defs),
             ScWalk::If(condition, then_branch, else_branch) => {
-                let mut changed = self.eliminate_in_expr(body, condition, defs);
-                changed |= self.eliminate_in_block(body, then_branch, defs);
+                let mut changed = self.eliminate_in_expr(engine, condition, defs);
+                changed |= self.eliminate_in_block(engine, then_branch, defs);
                 if let Some(eb) = else_branch {
-                    changed |= self.eliminate_in_block(body, eb, defs);
+                    changed |= self.eliminate_in_block(engine, eb, defs);
                 }
                 changed
             }
@@ -1277,17 +1313,17 @@ impl ShortCircuitGuard {
         }
     }
 
-    fn eliminate_in_block(&self, body: &mut Body, block: BlockId, defs: &DefMap) -> bool {
+    fn eliminate_in_block(&self, engine: &mut Engine, block: BlockId, defs: &DefMap) -> bool {
         let mut changed = false;
-        for s in body.blocks[block].stmts.clone() {
-            changed |= self.eliminate_in_stmt(body, s, defs);
+        for s in engine.body.blocks[block].stmts.clone() {
+            changed |= self.eliminate_in_stmt(engine, s, defs);
         }
         changed
     }
 
-    fn eliminate_in_stmt(&self, body: &mut Body, s: StmtId, defs: &DefMap) -> bool {
+    fn eliminate_in_stmt(&self, engine: &mut Engine, s: StmtId, defs: &DefMap) -> bool {
         // Check if this is a bounds-check `if (index >= bound) { panic() }` implied false
-        let if_ids = match &body.stmts[s].kind {
+        let if_ids = match &engine.body.stmts[s].kind {
             StmtKind::If {
                 condition,
                 then_block,
@@ -1296,15 +1332,15 @@ impl ShortCircuitGuard {
             _ => None,
         };
         if let Some((condition, then_block)) = if_ids
-            && is_panic_block(body, then_block)
-            && self.implies_false(body, condition, defs)
+            && is_panic_block(engine.body, then_block)
+            && self.implies_false(engine.body, condition, defs)
         {
-            set_false(body, condition);
+            set_false(engine, condition);
             return true;
         }
 
         // Recurse into sub-expressions and sub-statements
-        let walk = match &body.stmts[s].kind {
+        let walk = match &engine.body.stmts[s].kind {
             StmtKind::Let { value, .. } => ScStmt::Expr(*value),
             StmtKind::Expr(expr) => ScStmt::Expr(*expr),
             StmtKind::If {
@@ -1322,16 +1358,16 @@ impl ShortCircuitGuard {
             _ => ScStmt::None,
         };
         match walk {
-            ScStmt::Expr(e) => self.eliminate_in_expr(body, e, defs),
+            ScStmt::Expr(e) => self.eliminate_in_expr(engine, e, defs),
             ScStmt::If(condition, then_block, else_block) => {
-                let mut changed = self.eliminate_in_expr(body, condition, defs);
-                changed |= self.eliminate_in_block(body, then_block, defs);
+                let mut changed = self.eliminate_in_expr(engine, condition, defs);
+                changed |= self.eliminate_in_block(engine, then_block, defs);
                 if let Some(eb) = else_block {
-                    changed |= self.eliminate_in_block(body, eb, defs);
+                    changed |= self.eliminate_in_block(engine, eb, defs);
                 }
                 changed
             }
-            ScStmt::Block(b) => self.eliminate_in_block(body, b, defs),
+            ScStmt::Block(b) => self.eliminate_in_block(engine, b, defs),
             ScStmt::None => false,
         }
     }
@@ -1768,29 +1804,29 @@ fn is_panic_call(body: &Body, e: ExprId) -> bool {
 /// `visit_*` delegate to [`arena_opt_walk`], which recurses into every
 /// id-bearing child; the eliminators override the nodes they rewrite.
 trait ArenaOptVisitor {
-    fn visit_stmt(&mut self, body: &mut Body, s: StmtId) -> bool
+    fn visit_stmt(&mut self, engine: &mut Engine, s: StmtId) -> bool
     where
         Self: Sized,
     {
-        arena_opt_walk(self, body, NodeRef::Stmt(s))
+        arena_opt_walk(self, engine, NodeRef::Stmt(s))
     }
-    fn visit_expr(&mut self, body: &mut Body, e: ExprId) -> bool
+    fn visit_expr(&mut self, engine: &mut Engine, e: ExprId) -> bool
     where
         Self: Sized,
     {
-        arena_opt_walk(self, body, NodeRef::Expr(e))
+        arena_opt_walk(self, engine, NodeRef::Expr(e))
     }
-    fn visit_block(&mut self, body: &mut Body, b: BlockId) -> bool
+    fn visit_block(&mut self, engine: &mut Engine, b: BlockId) -> bool
     where
         Self: Sized,
     {
-        arena_opt_walk(self, body, NodeRef::Block(b))
+        arena_opt_walk(self, engine, NodeRef::Block(b))
     }
-    fn visit_pattern(&mut self, body: &mut Body, p: PatId) -> bool
+    fn visit_pattern(&mut self, engine: &mut Engine, p: PatId) -> bool
     where
         Self: Sized,
     {
-        arena_opt_walk(self, body, NodeRef::Pat(p))
+        arena_opt_walk(self, engine, NodeRef::Pat(p))
     }
 }
 
@@ -1798,16 +1834,16 @@ trait ArenaOptVisitor {
 /// OR the per-child change flags. The eliminators here only rewrite condition
 /// kinds in place (never add/remove nodes), so the upfront child snapshot stays
 /// valid through the walk.
-fn arena_opt_walk<V: ArenaOptVisitor>(v: &mut V, body: &mut Body, node: NodeRef) -> bool {
+fn arena_opt_walk<V: ArenaOptVisitor>(v: &mut V, engine: &mut Engine, node: NodeRef) -> bool {
     let mut kids = Vec::new();
-    body.for_each_child(node, |c| kids.push(c));
+    engine.body.for_each_child(node, |c| kids.push(c));
     let mut changed = false;
     for c in kids {
         changed |= match c {
-            NodeRef::Stmt(s) => v.visit_stmt(body, s),
-            NodeRef::Expr(e) => v.visit_expr(body, e),
-            NodeRef::Block(b) => v.visit_block(body, b),
-            NodeRef::Pat(p) => v.visit_pattern(body, p),
+            NodeRef::Stmt(s) => v.visit_stmt(engine, s),
+            NodeRef::Expr(e) => v.visit_expr(engine, e),
+            NodeRef::Block(b) => v.visit_block(engine, b),
+            NodeRef::Pat(p) => v.visit_pattern(engine, p),
         };
     }
     changed

--- a/wado-compiler/src/optimize/condition_implication.rs
+++ b/wado-compiler/src/optimize/condition_implication.rs
@@ -339,7 +339,12 @@ enum StmtShape {
     None,
 }
 
-fn process_loop(engine: &mut Engine, loop_body: BlockId, defs: &mut DefMap, tainted: &Taints) -> bool {
+fn process_loop(
+    engine: &mut Engine,
+    loop_body: BlockId,
+    defs: &mut DefMap,
+    tainted: &Taints,
+) -> bool {
     // First, record defs inside the loop body (for copies like `let index = i`)
     // and recurse into nested structures
     let mut changed = false;

--- a/wado-compiler/src/optimize/container_sroa.rs
+++ b/wado-compiler/src/optimize/container_sroa.rs
@@ -423,8 +423,7 @@ fn scalarize_at_root(engine: &mut Engine, rule: &ContainerSroaRule) -> bool {
     // Also track which `ListMethodKind`s were observed on each whitelisted use,
     // so step 3 can demand only the monomorphizations that will actually be
     // emitted per field (rather than unconditionally requiring all four kinds).
-    let (safe_indices, used_kinds_map) =
-        compute_safe_set(engine.body, &candidates, rule.sig_kinds);
+    let (safe_indices, used_kinds_map) = compute_safe_set(engine.body, &candidates, rule.sig_kinds);
     if safe_indices.is_empty() {
         return false;
     }
@@ -1538,8 +1537,7 @@ impl Rewriter<'_, '_> {
                 .cloned()
                 .expect("Query monomorphization must exist for decomposed element type");
             let span = engine.body.exprs[e].span;
-            let new_receiver =
-                build_receiver(engine, field_local, field_name, arr_ty, false, span);
+            let new_receiver = build_receiver(engine, field_local, field_name, arr_ty, false, span);
             engine.replace_expr_kind(
                 e,
                 ExprKind::MethodCall {

--- a/wado-compiler/src/optimize/container_sroa.rs
+++ b/wado-compiler/src/optimize/container_sroa.rs
@@ -62,16 +62,23 @@
 //! lets container SROA pick up new `List<Tuple<...>>` locals exposed by
 //! earlier-iteration inlining of helper functions.
 //!
-//! The pass reads and mutates the arena [`Body`] directly: analysis navigates
-//! by id, and the rewrite pushes the synthesized per-field calls into the arena
-//! (deep-cloning duplicated sub-expressions via [`Body::clone_expr`]).
+//! Runs on the worklist rewrite engine (combine migration; see
+//! `docs/wep-2026-06-05-nir-rewrite-engine-design.md`) as a [`Rule`]: a
+//! per-function standalone engine session whose `apply_block` fires once at
+//! the body root and performs the whole-function rewrite in one shot. The
+//! analysis phases (candidate collection, escape / used-kinds) stay read-only
+//! walks over `engine.body`; the rewrite routes every mutation through the
+//! engine edit API (`set_block_stmts`, `replace_expr_kind`, `become_expr`,
+//! `alloc_stmt`, `alloc_expr`, `alloc_local`, `clone_expr`) so the parent map
+//! and use index stay coherent.
+
+use std::cell::Cell;
 
 use crate::hashmap::{IndexMap, IndexSet};
 use crate::module_source::ModuleSource;
-use crate::nir::{FunctionRef, NirFunction, NirLocal, NirStruct, NirUnaryOp};
-use crate::nir_arena::{
-    ArenaCallArg, BlockId, Body, ExprId, ExprKind, ExprNode, NodeRef, StmtId, StmtKind, StmtNode,
-};
+use crate::nir::{FunctionRef, NirFunction, NirStruct, NirUnaryOp};
+use crate::nir_arena::{ArenaCallArg, BlockId, Body, ExprId, ExprKind, NodeRef, StmtId, StmtKind};
+use crate::nir_engine::{Engine, EngineBuffers, Rule};
 use crate::nir_package::NirPackage;
 use crate::tir::{ResolvedType, TypeId, TypeTable};
 use crate::token::Span;
@@ -280,13 +287,14 @@ pub fn scalarize_containers(project: &mut NirPackage, gate: &mut FunctionGate) -
     // `collect_candidates` to expand `List<UserStruct>` element types.
     let struct_index = build_struct_index(&project.structs);
 
-    // Per-function rewrite, gate-skipped. It mutates only the current function's
-    // body (and adds SoA types to the shared `type_table`). Retargeting some
-    // `List<Tuple>::m` calls to per-field `List<F>::m` callees shifts the
-    // function's call edges, which only costs propagation precision, not
-    // correctness.
+    // Per-function engine session, gate-skipped. Mutations route through the
+    // engine API; the rule fires once at the body root (whole-function shape).
+    // Retargeting some `List<Tuple>::m` calls to per-field `List<F>::m` callees
+    // shifts the function's call edges, which only costs propagation precision,
+    // not correctness.
     let type_table_rc = project.type_table.clone();
     let len = project.functions.len();
+    let mut buffers = EngineBuffers::default();
     gate.run_gated(GatedPass::ContainerSroa, len, |fid| {
         let func_rc = &project.functions[fid.index()];
         // Skip CM bindings (ABI bridges) and body-less declarations.
@@ -297,14 +305,44 @@ pub fn scalarize_containers(project: &mut NirPackage, gate: &mut FunctionGate) -
             }
         }
         let mut func = func_rc.borrow_mut();
-        scalarize_in_function(
-            &mut func,
-            &type_table_rc,
-            &catalog,
-            &sig_kinds,
-            &struct_index,
-        )
+        let rule = ContainerSroaRule {
+            catalog: &catalog,
+            sig_kinds: &sig_kinds,
+            struct_index: &struct_index,
+            type_table_rc: type_table_rc.clone(),
+            applied: Cell::new(false),
+        };
+        let NirFunction { body, locals, .. } = &mut *func;
+        let body = body.as_mut().expect("checked above");
+        let mut engine = Engine::new(body, &mut buffers, locals);
+        engine.run(&[&rule])
     })
+}
+
+/// Standalone-session rule whose single `apply_block` performs the whole-
+/// function container SROA at the body root.
+pub(super) struct ContainerSroaRule<'a> {
+    catalog: &'a MethodCatalog,
+    sig_kinds: &'a SigKindIndex,
+    struct_index: &'a StructIndex<'a>,
+    /// Shared `TypeTable` — `make_list(elem_ty)` interns per-field array types
+    /// during the local-allocation step. Borrowed through the `Rc` to avoid
+    /// holding a long mutable borrow across the rewrite.
+    type_table_rc: std::rc::Rc<std::cell::RefCell<TypeTable>>,
+    /// Whole-function rewrite: only run once per session.
+    applied: Cell<bool>,
+}
+
+impl Rule for ContainerSroaRule<'_> {
+    fn apply_block(&self, engine: &mut Engine, block: BlockId) -> bool {
+        if engine.parent_of(NodeRef::Block(block)).is_some() {
+            return false;
+        }
+        if self.applied.replace(true) {
+            return false;
+        }
+        scalarize_at_root(engine, self)
+    }
 }
 
 /// Lookup index for user-defined structs by (name, module source).
@@ -370,19 +408,12 @@ fn build_method_catalog(
     (catalog, sig_kinds)
 }
 
-/// Per-function driver: detect candidates, analyze uses, allocate parallel locals, rewrite.
-fn scalarize_in_function(
-    func: &mut NirFunction,
-    type_table_rc: &std::rc::Rc<std::cell::RefCell<TypeTable>>,
-    catalog: &MethodCatalog,
-    sig_kinds: &SigKindIndex,
-    struct_index: &StructIndex<'_>,
-) -> bool {
+/// Whole-function container SROA driven from the engine session root.
+fn scalarize_at_root(engine: &mut Engine, rule: &ContainerSroaRule) -> bool {
     // Step 1: collect candidates. Immutable borrow of type_table.
     let candidates = {
-        let type_table = type_table_rc.borrow();
-        let body = func.body.as_ref().expect("checked in caller");
-        collect_candidates(body, &type_table, struct_index, sig_kinds)
+        let type_table = rule.type_table_rc.borrow();
+        collect_candidates(engine.body, &type_table, rule.struct_index, rule.sig_kinds)
     };
     if candidates.is_empty() {
         return false;
@@ -392,10 +423,8 @@ fn scalarize_in_function(
     // Also track which `ListMethodKind`s were observed on each whitelisted use,
     // so step 3 can demand only the monomorphizations that will actually be
     // emitted per field (rather than unconditionally requiring all four kinds).
-    let (safe_indices, used_kinds_map) = {
-        let body = func.body.as_ref().expect("checked in caller");
-        compute_safe_set(body, &candidates, sig_kinds)
-    };
+    let (safe_indices, used_kinds_map) =
+        compute_safe_set(engine.body, &candidates, rule.sig_kinds);
     if safe_indices.is_empty() {
         return false;
     }
@@ -409,38 +438,28 @@ fn scalarize_in_function(
         .filter(|c| safe_indices.contains(&c.local_index))
         .filter(|c| {
             let used = used_kinds_map.get(&c.local_index).unwrap_or(&empty_used);
-            required_methods_available(c, used, catalog, sig_kinds)
+            required_methods_available(c, used, rule.catalog, rule.sig_kinds)
         })
         .collect();
     if safe_candidates.is_empty() {
         return false;
     }
 
-    // Step 4: allocate parallel `List<T_k>` locals. Mutable borrow of type_table.
-    // Map: (original local, field k) → new local index
+    // Step 4: allocate parallel `List<T_k>` locals through the engine. The
+    // type-table borrow is scoped so it does not overlap the engine's locals
+    // mutation (`alloc_local` takes `&mut self`).
     let mut field_local_map: IndexMap<(u32, u32), u32> = IndexMap::default();
-    // Map: (original local, field k) → (new name, array type id)
     let mut field_info_map: IndexMap<(u32, u32), (String, TypeId)> = IndexMap::default();
-    // The set of original locals we decided to decompose (final).
     let mut decomposed: IndexSet<u32> = IndexSet::default();
-    {
-        let mut type_table = type_table_rc.borrow_mut();
-        for c in &safe_candidates {
-            let base = func.local_count();
-            for (k, &elem_ty) in c.element_types.iter().enumerate() {
-                let arr_ty = type_table.make_list(elem_ty);
-                let new_index = base + k as u32;
-                let new_name = format!("__csroa_{}_{}", c.local_name, k);
-                field_local_map.insert((c.local_index, k as u32), new_index);
-                field_info_map.insert((c.local_index, k as u32), (new_name.clone(), arr_ty));
-                func.locals.push(NirLocal {
-                    name: new_name,
-                    type_id: arr_ty,
-                    is_mut: false,
-                });
-            }
-            decomposed.insert(c.local_index);
+    for c in &safe_candidates {
+        for (k, &elem_ty) in c.element_types.iter().enumerate() {
+            let arr_ty = rule.type_table_rc.borrow_mut().make_list(elem_ty);
+            let new_name = format!("__csroa_{}_{}", c.local_name, k);
+            let new_index = engine.alloc_local(new_name.clone(), arr_ty, /* is_mut */ false);
+            field_local_map.insert((c.local_index, k as u32), new_index);
+            field_info_map.insert((c.local_index, k as u32), (new_name, arr_ty));
         }
+        decomposed.insert(c.local_index);
     }
 
     // Build a lookup from local_index → candidate data needed during rewrite.
@@ -462,18 +481,17 @@ fn scalarize_in_function(
         })
         .collect();
 
-    // Step 5: rewrite the body.
+    // Step 5: rewrite the body via the engine edit API.
     let ctx = RewriteCtx {
         decomposed: &decomposed,
         field_local_map: &field_local_map,
         field_info_map: &field_info_map,
         candidate_data: &candidate_data,
-        catalog,
-        sig_kinds,
+        catalog: rule.catalog,
+        sig_kinds: rule.sig_kinds,
     };
-    let body = func.body.as_mut().expect("checked in caller");
-    let root = body.root;
-    Rewriter { ctx: &ctx }.rewrite_block(body, root);
+    let root = engine.body.root;
+    Rewriter { ctx: &ctx }.rewrite_block(engine, root);
 
     true
 }
@@ -1110,32 +1128,32 @@ impl Rewriter<'_, '_> {
     /// Replace candidate let-bindings and expression-statement-level
     /// `push` / `index_assign` calls with their per-field versions; recurse
     /// into everything else.
-    fn rewrite_block(&self, body: &mut Body, block: BlockId) {
-        let old_stmts = std::mem::take(&mut body.blocks[block].stmts);
+    fn rewrite_block(&self, engine: &mut Engine, block: BlockId) {
+        let old_stmts = engine.body.blocks[block].stmts.clone();
         let mut out: Vec<StmtId> = Vec::with_capacity(old_stmts.len());
         for s in old_stmts {
-            self.process_stmt(body, s, &mut out);
+            self.process_stmt(engine, s, &mut out);
         }
-        body.blocks[block].stmts = out;
+        engine.set_block_stmts(block, out);
     }
 
     /// Route a statement: either emit its per-field expansion or recurse + push as-is.
-    fn process_stmt(&self, body: &mut Body, s: StmtId, out: &mut Vec<StmtId>) {
+    fn process_stmt(&self, engine: &mut Engine, s: StmtId, out: &mut Vec<StmtId>) {
         let ctx = self.ctx;
         // Candidate Let: expand in place.
-        if let StmtKind::Let { local_index, .. } = &body.stmts[s].kind
+        if let StmtKind::Let { local_index, .. } = &engine.body.stmts[s].kind
             && ctx.decomposed.contains(local_index)
         {
             let local_index = *local_index;
-            self.expand_candidate_let(body, local_index, out);
+            self.expand_candidate_let(engine, local_index, out);
             return;
         }
 
         // Candidate push/index_assign as an ExprStmt at the statement level.
-        if let StmtKind::Expr(expr) = &body.stmts[s].kind {
+        if let StmtKind::Expr(expr) = &engine.body.stmts[s].kind {
             let expr = *expr;
-            let span = body.stmts[s].span;
-            if let Some(expanded) = self.try_expand_call_stmt(body, expr, span) {
+            let span = engine.body.stmts[s].span;
+            if let Some(expanded) = self.try_expand_call_stmt(engine, expr, span) {
                 out.extend(expanded);
                 return;
             }
@@ -1143,12 +1161,12 @@ impl Rewriter<'_, '_> {
 
         // Otherwise, recurse into the statement (rewriting any nested
         // expressions/blocks) and push it unchanged.
-        self.walk_children(body, NodeRef::Stmt(s));
+        self.walk_children(engine, NodeRef::Stmt(s));
         out.push(s);
     }
 
     /// Emit N per-field Let statements for a decomposed candidate.
-    fn expand_candidate_let(&self, body: &mut Body, local_index: u32, out: &mut Vec<StmtId>) {
+    fn expand_candidate_let(&self, engine: &mut Engine, local_index: u32, out: &mut Vec<StmtId>) {
         let ctx = self.ctx;
         let info = ctx
             .candidate_data
@@ -1162,10 +1180,10 @@ impl Rewriter<'_, '_> {
             let new_local_index = ctx.field_local_map[&(local_index, k as u32)];
             let (new_name, arr_ty) = ctx.field_info_map[&(local_index, k as u32)].clone();
             // Deep-clone the (duplicable) capacity once per field.
-            let cap = body.clone_expr(capacity);
-            let init = build_with_capacity_call(body, elem_ty, arr_ty, cap, span, ctx);
-            let let_stmt = body.stmts.push(StmtNode {
-                kind: StmtKind::Let {
+            let cap = engine.clone_expr(capacity);
+            let init = build_with_capacity_call(engine, elem_ty, arr_ty, cap, span, ctx);
+            let let_stmt = engine.alloc_stmt(
+                StmtKind::Let {
                     name: new_name,
                     local_index: new_local_index,
                     is_mut,
@@ -1175,7 +1193,7 @@ impl Rewriter<'_, '_> {
                     skip_value_copy: false,
                 },
                 span,
-            });
+            );
             out.push(let_stmt);
         }
     }
@@ -1185,12 +1203,12 @@ impl Rewriter<'_, '_> {
     /// decomposed candidate; `None` otherwise.
     fn try_expand_call_stmt(
         &self,
-        body: &mut Body,
+        engine: &mut Engine,
         expr: ExprId,
         span: Span,
     ) -> Option<Vec<StmtId>> {
         let ctx = self.ctx;
-        let (receiver, func, arg_ids) = match &body.exprs[expr].kind {
+        let (receiver, func, arg_ids) = match &engine.body.exprs[expr].kind {
             ExprKind::MethodCall {
                 receiver,
                 func,
@@ -1203,7 +1221,7 @@ impl Rewriter<'_, '_> {
             ),
             _ => return None,
         };
-        let rec_local = receiver_local(body, receiver)?;
+        let rec_local = receiver_local(engine.body, receiver)?;
         if !ctx.decomposed.contains(&rec_local) {
             return None;
         }
@@ -1216,7 +1234,7 @@ impl Rewriter<'_, '_> {
         match (kind, arg_ids.len()) {
             // Case 1: v.ElementWriter(source) — e.g. push
             (Some(ListMethodKind::ElementWriter), 1) => {
-                let per_field = self.decompose_source(body, arg_ids[0], arity, &layout)?;
+                let per_field = self.decompose_source(engine, arg_ids[0], arity, &layout)?;
                 let sig = sig_key_of(&func)?;
                 let mut out = Vec::with_capacity(arity);
                 for (k, elem_expr) in per_field.into_iter().enumerate() {
@@ -1224,7 +1242,7 @@ impl Rewriter<'_, '_> {
                     let (field_name, arr_ty) = ctx.field_info_map[&(rec_local, k as u32)].clone();
                     let elem_ty = element_types[k];
                     let call = build_element_writer_call(
-                        body,
+                        engine,
                         elem_ty,
                         arr_ty,
                         field_local,
@@ -1234,10 +1252,7 @@ impl Rewriter<'_, '_> {
                         span,
                         ctx,
                     );
-                    let st = body.stmts.push(StmtNode {
-                        kind: StmtKind::Expr(call),
-                        span,
-                    });
+                    let st = engine.alloc_stmt(StmtKind::Expr(call), span);
                     out.push(st);
                 }
                 Some(out)
@@ -1246,19 +1261,19 @@ impl Rewriter<'_, '_> {
             (Some(ListMethodKind::IndexWriter), 2) => {
                 let idx = arg_ids[0];
                 let src = arg_ids[1];
-                if !is_duplicable_expr(body, idx) {
+                if !is_duplicable_expr(engine.body, idx) {
                     return None;
                 }
-                let per_field = self.decompose_source(body, src, arity, &layout)?;
+                let per_field = self.decompose_source(engine, src, arity, &layout)?;
                 let sig = sig_key_of(&func)?;
                 let mut out = Vec::with_capacity(arity);
                 for (k, elem_expr) in per_field.into_iter().enumerate() {
                     let field_local = ctx.field_local_map[&(rec_local, k as u32)];
                     let (field_name, arr_ty) = ctx.field_info_map[&(rec_local, k as u32)].clone();
                     let elem_ty = element_types[k];
-                    let idx_clone = body.clone_expr(idx);
+                    let idx_clone = engine.clone_expr(idx);
                     let call = build_index_writer_call(
-                        body,
+                        engine,
                         elem_ty,
                         arr_ty,
                         field_local,
@@ -1269,10 +1284,7 @@ impl Rewriter<'_, '_> {
                         span,
                         ctx,
                     );
-                    let st = body.stmts.push(StmtNode {
-                        kind: StmtKind::Expr(call),
-                        span,
-                    });
+                    let st = engine.alloc_stmt(StmtKind::Expr(call), span);
                     out.push(st);
                 }
                 Some(out)
@@ -1284,7 +1296,7 @@ impl Rewriter<'_, '_> {
     /// Decompose a source expression into N per-field expression ids.
     fn decompose_source(
         &self,
-        body: &mut Body,
+        engine: &mut Engine,
         expr: ExprId,
         expected_arity: usize,
         expected_layout: &ElementLayout,
@@ -1301,7 +1313,7 @@ impl Rewriter<'_, '_> {
                 span: Span,
             },
         }
-        let source = match &body.exprs[expr].kind {
+        let source = match &engine.body.exprs[expr].kind {
             ExprKind::TupleLiteral { elements } => {
                 if !matches!(expected_layout, ElementLayout::Tuple) {
                     return None;
@@ -1338,7 +1350,7 @@ impl Rewriter<'_, '_> {
             } if list_method_kind(func, ctx.sig_kinds) == Some(ListMethodKind::IndexReader)
                 && args.len() == 1 =>
             {
-                let other = receiver_local(body, *receiver)?;
+                let other = receiver_local(engine.body, *receiver)?;
                 if !ctx.decomposed.contains(&other) {
                     return None;
                 }
@@ -1350,7 +1362,7 @@ impl Rewriter<'_, '_> {
                     return None;
                 }
                 let idx_expr = args[0].expr;
-                if !is_duplicable_expr(body, idx_expr) {
+                if !is_duplicable_expr(engine.body, idx_expr) {
                     return None;
                 }
                 let sig = sig_key_of(func)?;
@@ -1358,7 +1370,7 @@ impl Rewriter<'_, '_> {
                     other,
                     idx: idx_expr,
                     sig,
-                    span: body.exprs[expr].span,
+                    span: engine.body.exprs[expr].span,
                 }
             }
             _ => return None,
@@ -1370,8 +1382,8 @@ impl Rewriter<'_, '_> {
                 // rewritten to propagate nested decomposed reads.
                 let mut out = Vec::with_capacity(expected_arity);
                 for el in elements {
-                    let c = body.clone_expr(el);
-                    self.rewrite_expr(body, c);
+                    let c = engine.clone_expr(el);
+                    self.rewrite_expr(engine, c);
                     out.push(c);
                 }
                 Some(out)
@@ -1388,8 +1400,8 @@ impl Rewriter<'_, '_> {
                     if out[k].is_some() {
                         return None;
                     }
-                    let c = body.clone_expr(value);
-                    self.rewrite_expr(body, c);
+                    let c = engine.clone_expr(value);
+                    self.rewrite_expr(engine, c);
                     out[k] = Some(c);
                 }
                 out.into_iter().collect::<Option<Vec<_>>>()
@@ -1408,9 +1420,9 @@ impl Rewriter<'_, '_> {
                     let (other_field_name, other_arr_ty) =
                         ctx.field_info_map[&(other, k as u32)].clone();
                     let other_elem_ty = other_elem_types[k];
-                    let idx_clone = body.clone_expr(idx);
+                    let idx_clone = engine.clone_expr(idx);
                     let call = build_index_reader_call(
-                        body,
+                        engine,
                         other_elem_ty,
                         other_arr_ty,
                         other_field_local,
@@ -1429,7 +1441,7 @@ impl Rewriter<'_, '_> {
 
     /// Rewrite an expression in place: `v.len()`/`v.is_empty()` → field-0 call;
     /// `v.index_value(i).K` → `v_K.index_value(i)`. All other expressions recurse.
-    fn rewrite_expr(&self, body: &mut Body, e: ExprId) {
+    fn rewrite_expr(&self, engine: &mut Engine, e: ExprId) {
         let ctx = self.ctx;
 
         // Handle FieldAccess on IndexValue first (read pattern).
@@ -1437,7 +1449,7 @@ impl Rewriter<'_, '_> {
             expr: inner,
             field_index,
             ..
-        } = &body.exprs[e].kind
+        } = &engine.body.exprs[e].kind
         {
             let inner = *inner;
             let field_index = *field_index;
@@ -1446,10 +1458,10 @@ impl Rewriter<'_, '_> {
                 func,
                 args,
                 ..
-            } = &body.exprs[inner].kind
+            } = &engine.body.exprs[inner].kind
                 && list_method_kind(func, ctx.sig_kinds) == Some(ListMethodKind::IndexReader)
                 && args.len() == 1
-                && let Some(rec_local) = receiver_local(body, *receiver)
+                && let Some(rec_local) = receiver_local(engine.body, *receiver)
                 && ctx.decomposed.contains(&rec_local)
             {
                 sig_key_of(func).map(|sig| (rec_local, field_index, args[0].expr, sig))
@@ -1469,21 +1481,25 @@ impl Rewriter<'_, '_> {
                 let elem_ty = info.element_types[k];
                 let field_local = ctx.field_local_map[&(rec_local, k as u32)];
                 let (field_name, arr_ty) = ctx.field_info_map[&(rec_local, k as u32)].clone();
-                let idx_clone = body.clone_expr(idx_arg);
-                self.rewrite_expr(body, idx_clone);
+                let idx_clone = engine.clone_expr(idx_arg);
+                self.rewrite_expr(engine, idx_clone);
+                let span = engine.body.exprs[e].span;
                 let new_call = build_index_reader_call(
-                    body,
+                    engine,
                     elem_ty,
                     arr_ty,
                     field_local,
                     field_name,
                     idx_clone,
                     &sig,
-                    body.exprs[e].span,
+                    span,
                     ctx,
                 );
-                let node = body.exprs[new_call].clone();
-                body.exprs[e] = node;
+                // Promote `new_call`'s content into `e`, leaving `new_call`
+                // a dead `Unit`. Equivalent to the old `body.exprs[e] = node;`
+                // but registers the move in the engine's parent map and use
+                // index.
+                engine.become_expr(e, new_call);
                 return;
             }
         }
@@ -1494,9 +1510,9 @@ impl Rewriter<'_, '_> {
             func,
             args,
             ..
-        } = &body.exprs[e].kind
+        } = &engine.body.exprs[e].kind
         {
-            if let Some(rec_local) = receiver_local(body, *receiver)
+            if let Some(rec_local) = receiver_local(engine.body, *receiver)
                 && ctx.decomposed.contains(&rec_local)
                 && args.is_empty()
                 && list_method_kind(func, ctx.sig_kinds) == Some(ListMethodKind::Query)
@@ -1521,31 +1537,35 @@ impl Rewriter<'_, '_> {
                 .get(&(elem_ty, sig))
                 .cloned()
                 .expect("Query monomorphization must exist for decomposed element type");
-            let span = body.exprs[e].span;
-            let new_receiver = build_receiver(body, field_local, field_name, arr_ty, false, span);
-            body.exprs[e].kind = ExprKind::MethodCall {
-                receiver: new_receiver,
-                func: new_func,
-                type_args: Vec::new(),
-                args: Vec::new(),
-            };
+            let span = engine.body.exprs[e].span;
+            let new_receiver =
+                build_receiver(engine, field_local, field_name, arr_ty, false, span);
+            engine.replace_expr_kind(
+                e,
+                ExprKind::MethodCall {
+                    receiver: new_receiver,
+                    func: new_func,
+                    type_args: Vec::new(),
+                    args: Vec::new(),
+                },
+            );
             return;
         }
 
         // Default: recurse into children.
-        self.walk_children(body, NodeRef::Expr(e));
+        self.walk_children(engine, NodeRef::Expr(e));
     }
 
     /// Default mutating walk: recurse into every id-bearing child, dispatching
     /// blocks back through the statement-restructuring `rewrite_block`.
-    fn walk_children(&self, body: &mut Body, node: NodeRef) {
+    fn walk_children(&self, engine: &mut Engine, node: NodeRef) {
         let mut kids = Vec::new();
-        body.for_each_child(node, |c| kids.push(c));
+        engine.body.for_each_child(node, |c| kids.push(c));
         for c in kids {
             match c {
-                NodeRef::Block(b) => self.rewrite_block(body, b),
-                NodeRef::Expr(ex) => self.rewrite_expr(body, ex),
-                NodeRef::Stmt(_) | NodeRef::Pat(_) => self.walk_children(body, c),
+                NodeRef::Block(b) => self.rewrite_block(engine, b),
+                NodeRef::Expr(ex) => self.rewrite_expr(engine, ex),
+                NodeRef::Stmt(_) | NodeRef::Pat(_) => self.walk_children(engine, c),
             }
         }
     }
@@ -1553,36 +1573,32 @@ impl Rewriter<'_, '_> {
 
 /// Build a `Unary::{Ref|MutRef}(Local{field_local})` receiver expression.
 fn build_receiver(
-    body: &mut Body,
+    engine: &mut Engine,
     field_local: u32,
     field_name: String,
     arr_ty: TypeId,
     mut_ref: bool,
     span: Span,
 ) -> ExprId {
-    let local = body.exprs.push(ExprNode {
-        kind: ExprKind::Local {
+    let local = engine.alloc_expr(
+        ExprKind::Local {
             index: field_local,
             name: field_name,
         },
-        type_id: arr_ty,
+        arr_ty,
         span,
-    });
+    );
     let op = if mut_ref {
         NirUnaryOp::MutRef
     } else {
         NirUnaryOp::Ref
     };
-    body.exprs.push(ExprNode {
-        kind: ExprKind::Unary { op, expr: local },
-        type_id: arr_ty,
-        span,
-    })
+    engine.alloc_expr(ExprKind::Unary { op, expr: local }, arr_ty, span)
 }
 
 /// Build a `List<T_k>::Constructor(cap)` NIR call — e.g. `with_capacity(cap)`.
 fn build_with_capacity_call(
-    body: &mut Body,
+    engine: &mut Engine,
     elem_ty: TypeId,
     arr_ty: TypeId,
     cap: ExprId,
@@ -1601,8 +1617,8 @@ fn build_with_capacity_call(
         .get(&(elem_ty, sig))
         .expect("Constructor entry checked by required_methods_available")
         .clone();
-    body.exprs.push(ExprNode {
-        kind: ExprKind::Call {
+    engine.alloc_expr(
+        ExprKind::Call {
             func,
             type_args: Vec::new(),
             args: vec![ArenaCallArg {
@@ -1610,15 +1626,15 @@ fn build_with_capacity_call(
                 is_mut: false,
             }],
         },
-        type_id: arr_ty,
+        arr_ty,
         span,
-    })
+    )
 }
 
 /// Build `v_field.ElementWriter(value)` — e.g. `v_field.push(value)`.
 #[allow(clippy::too_many_arguments)]
 fn build_element_writer_call(
-    body: &mut Body,
+    engine: &mut Engine,
     elem_ty: TypeId,
     arr_ty: TypeId,
     field_local: u32,
@@ -1633,9 +1649,9 @@ fn build_element_writer_call(
         .get(&(elem_ty, sig.clone()))
         .expect("ElementWriter entry checked by required_methods_available")
         .clone();
-    let receiver = build_receiver(body, field_local, field_name, arr_ty, true, span);
-    body.exprs.push(ExprNode {
-        kind: ExprKind::MethodCall {
+    let receiver = build_receiver(engine, field_local, field_name, arr_ty, true, span);
+    engine.alloc_expr(
+        ExprKind::MethodCall {
             receiver,
             func,
             type_args: Vec::new(),
@@ -1644,15 +1660,15 @@ fn build_element_writer_call(
                 is_mut: false,
             }],
         },
-        type_id: TypeTable::UNIT,
+        TypeTable::UNIT,
         span,
-    })
+    )
 }
 
 /// Build `v_field.IndexWriter(index, value)` — e.g. `index_assign(index, value)`.
 #[allow(clippy::too_many_arguments)]
 fn build_index_writer_call(
-    body: &mut Body,
+    engine: &mut Engine,
     elem_ty: TypeId,
     arr_ty: TypeId,
     field_local: u32,
@@ -1668,9 +1684,9 @@ fn build_index_writer_call(
         .get(&(elem_ty, sig.clone()))
         .expect("IndexWriter entry checked by required_methods_available")
         .clone();
-    let receiver = build_receiver(body, field_local, field_name, arr_ty, true, span);
-    body.exprs.push(ExprNode {
-        kind: ExprKind::MethodCall {
+    let receiver = build_receiver(engine, field_local, field_name, arr_ty, true, span);
+    engine.alloc_expr(
+        ExprKind::MethodCall {
             receiver,
             func,
             type_args: Vec::new(),
@@ -1685,15 +1701,15 @@ fn build_index_writer_call(
                 },
             ],
         },
-        type_id: TypeTable::UNIT,
+        TypeTable::UNIT,
         span,
-    })
+    )
 }
 
 /// Build `v_field.IndexReader(index)` — e.g. `index_value(index)`, of type `elem_ty`.
 #[allow(clippy::too_many_arguments)]
 fn build_index_reader_call(
-    body: &mut Body,
+    engine: &mut Engine,
     elem_ty: TypeId,
     arr_ty: TypeId,
     field_local: u32,
@@ -1708,9 +1724,9 @@ fn build_index_reader_call(
         .get(&(elem_ty, sig.clone()))
         .expect("IndexReader entry checked by required_methods_available")
         .clone();
-    let receiver = build_receiver(body, field_local, field_name, arr_ty, false, span);
-    body.exprs.push(ExprNode {
-        kind: ExprKind::MethodCall {
+    let receiver = build_receiver(engine, field_local, field_name, arr_ty, false, span);
+    engine.alloc_expr(
+        ExprKind::MethodCall {
             receiver,
             func,
             type_args: Vec::new(),
@@ -1719,9 +1735,9 @@ fn build_index_reader_call(
                 is_mut: false,
             }],
         },
-        type_id: elem_ty,
+        elem_ty,
         span,
-    })
+    )
 }
 
 /// Returns true if the expression can be safely duplicated (cloned and

--- a/wado-compiler/src/optimize/copy_prop.rs
+++ b/wado-compiler/src/optimize/copy_prop.rs
@@ -511,7 +511,9 @@ fn apply_in_node(
         NodeRef::Block(b) => apply_in_block(engine, b, substitutions, dead_locals),
         NodeRef::Stmt(s) => {
             let mut kids = Vec::new();
-            engine.body.for_each_child(NodeRef::Stmt(s), |c| kids.push(c));
+            engine
+                .body
+                .for_each_child(NodeRef::Stmt(s), |c| kids.push(c));
             for c in kids {
                 apply_in_node(engine, c, substitutions, dead_locals);
             }
@@ -563,7 +565,9 @@ fn apply_in_expr(
     }
 
     let mut kids = Vec::new();
-    engine.body.for_each_child(NodeRef::Expr(id), |c| kids.push(c));
+    engine
+        .body
+        .for_each_child(NodeRef::Expr(id), |c| kids.push(c));
     for c in kids {
         apply_in_node(engine, c, substitutions, dead_locals);
     }
@@ -580,11 +584,7 @@ fn emit_ref(
     inner_type_id: TypeId,
 ) {
     let span = engine.body.exprs[id].span;
-    let inner = engine.alloc_expr(
-        ExprKind::Local { index, name },
-        inner_type_id,
-        span,
-    );
+    let inner = engine.alloc_expr(ExprKind::Local { index, name }, inner_type_id, span);
     engine.replace_expr_kind(id, ExprKind::Unary { op, expr: inner });
 }
 
@@ -598,8 +598,7 @@ fn propagate_at_root(
 ) -> bool {
     let mut ever_changed = false;
     loop {
-        let analysis =
-            analyze_function_body(engine.body, type_table, first_param_types);
+        let analysis = analyze_function_body(engine.body, type_table, first_param_types);
         if analysis.bindings.is_empty() {
             break;
         }

--- a/wado-compiler/src/optimize/copy_prop.rs
+++ b/wado-compiler/src/optimize/copy_prop.rs
@@ -4,17 +4,23 @@
 //! `let x = &y`, or `let x = &mut y` by propagating the source value to all
 //! uses of the target variable. See `can_propagate_copy` for the safety gates.
 //!
-//! Ported off the `Body ↔ tree` bridge (Phase 4 stage C; see
-//! `docs/wep-2026-06-05-nir-rewrite-engine-design.md`): the binding / usage
-//! analysis and the substitute-and-remove rewrite read and mutate the arena
-//! `Body` directly.
+//! Runs on the worklist rewrite engine (combine migration; see
+//! `docs/wep-2026-06-05-nir-rewrite-engine-design.md`) as a [`Rule`]: a
+//! per-function standalone engine session whose `apply_block` fires once at
+//! the body root and runs the analyse/substitute fixpoint to convergence in
+//! one shot. The substitute-and-remove rewrites route through
+//! `engine.replace_expr_kind`, `engine.alloc_expr`, and
+//! `engine.set_block_stmts` so the parent map and use index stay coherent.
+
+use std::cell::Cell;
 
 use cranelift_entity::EntityRef;
 
 use crate::hashmap::{IndexMap, IndexSet};
 use crate::module_source::ModuleSource;
 use crate::nir::{NirFunction, NirUnaryOp};
-use crate::nir_arena::{BlockId, Body, ExprId, ExprKind, ExprNode, NodeRef, StmtId, StmtKind};
+use crate::nir_arena::{BlockId, Body, ExprId, ExprKind, NodeRef, StmtId, StmtKind};
+use crate::nir_engine::{Engine, EngineBuffers, Rule};
 use crate::nir_package::NirPackage;
 use crate::tir::{ResolvedType, TypeId, TypeTable};
 
@@ -472,42 +478,42 @@ fn can_propagate_copy(
 }
 
 fn apply_in_block(
-    body: &mut Body,
+    engine: &mut Engine,
     block: BlockId,
     substitutions: &IndexMap<u32, CopySource>,
     dead_locals: &IndexSet<u32>,
 ) {
-    let kept: Vec<StmtId> = body.blocks[block]
+    let kept: Vec<StmtId> = engine.body.blocks[block]
         .stmts
         .iter()
         .copied()
-        .filter(|s| match &body.stmts[*s].kind {
+        .filter(|s| match &engine.body.stmts[*s].kind {
             StmtKind::Let { local_index, .. } => !dead_locals.contains(local_index),
             _ => true,
         })
         .collect();
-    body.blocks[block].stmts = kept;
+    engine.set_block_stmts(block, kept);
 
-    let stmts = body.blocks[block].stmts.clone();
+    let stmts = engine.body.blocks[block].stmts.clone();
     for stmt in stmts {
-        apply_in_node(body, NodeRef::Stmt(stmt), substitutions, dead_locals);
+        apply_in_node(engine, NodeRef::Stmt(stmt), substitutions, dead_locals);
     }
 }
 
 fn apply_in_node(
-    body: &mut Body,
+    engine: &mut Engine,
     node: NodeRef,
     substitutions: &IndexMap<u32, CopySource>,
     dead_locals: &IndexSet<u32>,
 ) {
     match node {
-        NodeRef::Expr(id) => apply_in_expr(body, id, substitutions, dead_locals),
-        NodeRef::Block(b) => apply_in_block(body, b, substitutions, dead_locals),
+        NodeRef::Expr(id) => apply_in_expr(engine, id, substitutions, dead_locals),
+        NodeRef::Block(b) => apply_in_block(engine, b, substitutions, dead_locals),
         NodeRef::Stmt(s) => {
             let mut kids = Vec::new();
-            body.for_each_child(NodeRef::Stmt(s), |c| kids.push(c));
+            engine.body.for_each_child(NodeRef::Stmt(s), |c| kids.push(c));
             for c in kids {
-                apply_in_node(body, c, substitutions, dead_locals);
+                apply_in_node(engine, c, substitutions, dead_locals);
             }
         }
         NodeRef::Pat(_) => {}
@@ -515,12 +521,12 @@ fn apply_in_node(
 }
 
 fn apply_in_expr(
-    body: &mut Body,
+    engine: &mut Engine,
     id: ExprId,
     substitutions: &IndexMap<u32, CopySource>,
     dead_locals: &IndexSet<u32>,
 ) {
-    let sub = if let ExprKind::Local { index, .. } = &body.exprs[id].kind {
+    let sub = if let ExprKind::Local { index, .. } = &engine.body.exprs[id].kind {
         substitutions.get(index).cloned()
     } else {
         None
@@ -528,75 +534,72 @@ fn apply_in_expr(
     if let Some(source) = sub {
         match source {
             CopySource::Local { index, name } => {
-                body.exprs[id].kind = ExprKind::Local { index, name };
+                engine.replace_expr_kind(id, ExprKind::Local { index, name });
             }
             CopySource::IntLiteral { value, repr } => {
-                body.exprs[id].kind = ExprKind::IntLiteral { value, repr };
+                engine.replace_expr_kind(id, ExprKind::IntLiteral { value, repr });
             }
             CopySource::FloatLiteral { value, repr } => {
-                body.exprs[id].kind = ExprKind::FloatLiteral { value, repr };
+                engine.replace_expr_kind(id, ExprKind::FloatLiteral { value, repr });
             }
             CopySource::BoolLiteral(b) => {
-                body.exprs[id].kind = ExprKind::BoolLiteral(b);
+                engine.replace_expr_kind(id, ExprKind::BoolLiteral(b));
             }
             CopySource::CharLiteral(c) => {
-                body.exprs[id].kind = ExprKind::CharLiteral(c);
+                engine.replace_expr_kind(id, ExprKind::CharLiteral(c));
             }
             CopySource::Ref {
                 index,
                 name,
                 inner_type_id,
-            } => emit_ref(body, id, NirUnaryOp::Ref, index, name, inner_type_id),
+            } => emit_ref(engine, id, NirUnaryOp::Ref, index, name, inner_type_id),
             CopySource::MutRef {
                 index,
                 name,
                 inner_type_id,
-            } => emit_ref(body, id, NirUnaryOp::MutRef, index, name, inner_type_id),
+            } => emit_ref(engine, id, NirUnaryOp::MutRef, index, name, inner_type_id),
         }
         return;
     }
 
     let mut kids = Vec::new();
-    body.for_each_child(NodeRef::Expr(id), |c| kids.push(c));
+    engine.body.for_each_child(NodeRef::Expr(id), |c| kids.push(c));
     for c in kids {
-        apply_in_node(body, c, substitutions, dead_locals);
+        apply_in_node(engine, c, substitutions, dead_locals);
     }
 }
 
 /// Replace expression `id` with `&src` / `&mut src` (the propagated ref source),
 /// keeping `id`'s own `type_id` / span.
 fn emit_ref(
-    body: &mut Body,
+    engine: &mut Engine,
     id: ExprId,
     op: NirUnaryOp,
     index: u32,
     name: String,
     inner_type_id: TypeId,
 ) {
-    let span = body.exprs[id].span;
-    let inner = body.exprs.push(ExprNode {
-        kind: ExprKind::Local { index, name },
-        type_id: inner_type_id,
+    let span = engine.body.exprs[id].span;
+    let inner = engine.alloc_expr(
+        ExprKind::Local { index, name },
+        inner_type_id,
         span,
-    });
-    body.exprs[id].kind = ExprKind::Unary { op, expr: inner };
+    );
+    engine.replace_expr_kind(id, ExprKind::Unary { op, expr: inner });
 }
 
-fn propagate_copies_in_function(
-    func: &mut NirFunction,
+/// Whole-function copy-propagation fixpoint driven from the engine session
+/// root. Mirrors the standalone driver's loop: analyse → filter → substitute
+/// until no further bindings can be propagated.
+fn propagate_at_root(
+    engine: &mut Engine,
     type_table: &TypeTable,
     first_param_types: &FirstParamTypes,
 ) -> bool {
-    if func.body.is_none() {
-        return false;
-    }
     let mut ever_changed = false;
-
     loop {
-        let analysis = {
-            let body = func.body.as_ref().unwrap();
-            analyze_function_body(body, type_table, first_param_types)
-        };
+        let analysis =
+            analyze_function_body(engine.body, type_table, first_param_types);
         if analysis.bindings.is_empty() {
             break;
         }
@@ -628,16 +631,34 @@ fn propagate_copies_in_function(
             break;
         }
         let dead_locals: IndexSet<u32> = substitutions.keys().copied().collect();
-        let body = func.body.as_mut().unwrap();
-        let root = body.root;
-        apply_in_block(body, root, &substitutions, &dead_locals);
+        let root = engine.body.root;
+        apply_in_block(engine, root, &substitutions, &dead_locals);
         ever_changed = true;
         if !has_deferred {
             break;
         }
     }
-
     ever_changed
+}
+
+/// Standalone-session rule whose single `apply_block` performs the whole-
+/// function copy-propagation fixpoint at the body root.
+pub(super) struct CopyPropRule<'a> {
+    type_table: &'a TypeTable,
+    first_param_types: &'a FirstParamTypes,
+    applied: Cell<bool>,
+}
+
+impl Rule for CopyPropRule<'_> {
+    fn apply_block(&self, engine: &mut Engine, block: BlockId) -> bool {
+        if engine.parent_of(NodeRef::Block(block)).is_some() {
+            return false;
+        }
+        if self.applied.replace(true) {
+            return false;
+        }
+        propagate_at_root(engine, self.type_table, self.first_param_types)
+    }
 }
 
 pub fn propagate_copies(project: &mut NirPackage, gate: &mut FunctionGate) -> bool {
@@ -651,8 +672,20 @@ pub fn propagate_copies(project: &mut NirPackage, gate: &mut FunctionGate) -> bo
         }
     }
     let len = project.functions.len();
+    let mut buffers = EngineBuffers::default();
     gate.run_gated(GatedPass::CopyProp, len, |fid| {
         let mut func = project.functions[fid.index()].borrow_mut();
-        propagate_copies_in_function(&mut func, &type_table, &first_param_types)
+        if func.body.is_none() {
+            return false;
+        }
+        let rule = CopyPropRule {
+            type_table: &type_table,
+            first_param_types: &first_param_types,
+            applied: Cell::new(false),
+        };
+        let NirFunction { body, locals, .. } = &mut *func;
+        let body = body.as_mut().expect("checked above");
+        let mut engine = Engine::new(body, &mut buffers, locals);
+        engine.run(&[&rule])
     })
 }

--- a/wado-compiler/src/optimize/cse.rs
+++ b/wado-compiler/src/optimize/cse.rs
@@ -23,71 +23,81 @@
 //! }
 //! ```
 //!
-//! Ported off the `Body ↔ tree` bridge (Phase 4 stage C; see
-//! `docs/wep-2026-06-05-nir-rewrite-engine-design.md`): a flow-sensitive
-//! whole-function pass, so it keeps its own walker but reads and mutates the
-//! arena `Body` directly. The helper recursion sets mirror the former tree
-//! helpers exactly (`expr_contains` / `expr_modifies_any` / `replace_in_expr`)
-//! so the rewrite stays bit-identical. The CSE'd value is always a
-//! `Binary` / `Local` / `IntLiteral` subtree, so cloning it into the hoisted
-//! `Let` is a small dedicated copy.
+//! Runs on the worklist rewrite engine (combine migration; see
+//! `docs/wep-2026-06-05-nir-rewrite-engine-design.md`) as a [`Rule`]: a
+//! per-function standalone engine session whose `apply_block` fires once at
+//! the body root and walks every loop in the function, applying the
+//! guard/body redundancy fold per loop. All mutations route through the
+//! engine edit API (`alloc_stmt`, `alloc_expr`, `clone_expr`,
+//! `set_block_stmts`, `replace_expr_kind`, `alloc_local`) so the parent map
+//! and use index stay coherent.
+
+use std::cell::Cell;
 
 use cranelift_entity::EntityRef;
 
 use super::gate::{FunctionGate, GatedPass};
 use crate::hashmap::IndexSet;
-use crate::nir::{NirBinaryOp, NirFunction, NirLocal};
-use crate::nir_arena::{BlockId, Body, ExprId, ExprKind, ExprNode, StmtId, StmtKind, StmtNode};
+use crate::nir::{NirBinaryOp, NirFunction};
+use crate::nir_arena::{BlockId, Body, ExprId, ExprKind, NodeRef, StmtId, StmtKind};
+use crate::nir_engine::{Engine, EngineBuffers, Rule};
 use crate::nir_package::NirPackage;
 use crate::tir::TypeId;
 use crate::token::Span;
 
 pub fn eliminate_common_subexprs(project: &mut NirPackage, gate: &mut FunctionGate) -> bool {
     let len = project.functions.len();
+    let mut buffers = EngineBuffers::default();
     gate.run_gated(GatedPass::Cse, len, |fid| {
         let mut func = project.functions[fid.index()].borrow_mut();
-        // Destructure into disjoint field borrows so the body arena and the
-        // local list can be mutated together. `locals.len()` is the next free
-        // local index; thread it as a counter and let the pushes below keep
-        // `locals` the source of truth.
-        let NirFunction { body, locals, .. } = &mut *func;
-        let Some(body) = body.as_mut() else {
+        if func.body.is_none() {
             return false;
+        }
+        let rule = CseRule {
+            applied: Cell::new(false),
         };
-        let mut local_count = locals.len() as u32;
-        let root = body.root;
-        let mut func_changed = false;
-        cse_in_block(body, root, &mut local_count, locals, &mut func_changed);
-        func_changed
+        let NirFunction { body, locals, .. } = &mut *func;
+        let body = body.as_mut().expect("checked above");
+        let mut engine = Engine::new(body, &mut buffers, locals);
+        engine.run(&[&rule])
     })
 }
 
-fn cse_in_block(
-    body: &mut Body,
-    block: BlockId,
-    local_count: &mut u32,
-    locals: &mut Vec<NirLocal>,
-    changed: &mut bool,
-) {
-    let stmts = body.blocks[block].stmts.clone();
-    for stmt in stmts {
-        cse_in_stmt(body, stmt, local_count, locals, changed);
+/// Standalone-session rule whose single `apply_block` performs the whole-
+/// function CSE walk at the body root.
+pub(super) struct CseRule {
+    applied: Cell<bool>,
+}
+
+impl Rule for CseRule {
+    fn apply_block(&self, engine: &mut Engine, block: BlockId) -> bool {
+        if engine.parent_of(NodeRef::Block(block)).is_some() {
+            return false;
+        }
+        if self.applied.replace(true) {
+            return false;
+        }
+        let root = engine.body.root;
+        let mut func_changed = false;
+        cse_in_block(engine, root, &mut func_changed);
+        func_changed
     }
 }
 
-fn cse_in_stmt(
-    body: &mut Body,
-    stmt: StmtId,
-    local_count: &mut u32,
-    locals: &mut Vec<NirLocal>,
-    changed: &mut bool,
-) {
-    match &body.stmts[stmt].kind {
+fn cse_in_block(engine: &mut Engine, block: BlockId, changed: &mut bool) {
+    let stmts = engine.body.blocks[block].stmts.clone();
+    for stmt in stmts {
+        cse_in_stmt(engine, stmt, changed);
+    }
+}
+
+fn cse_in_stmt(engine: &mut Engine, stmt: StmtId, changed: &mut bool) {
+    match &engine.body.stmts[stmt].kind {
         StmtKind::Loop { body: loop_block } => {
             let loop_block = *loop_block;
             // First recurse into inner loops, then apply CSE to this loop body.
-            cse_in_block(body, loop_block, local_count, locals, changed);
-            *changed |= cse_loop_body(body, loop_block, local_count, locals);
+            cse_in_block(engine, loop_block, changed);
+            *changed |= cse_loop_body(engine, loop_block);
         }
         StmtKind::If {
             then_block,
@@ -96,14 +106,14 @@ fn cse_in_stmt(
         } => {
             let then_block = *then_block;
             let else_block = *else_block;
-            cse_in_block(body, then_block, local_count, locals, changed);
+            cse_in_block(engine, then_block, changed);
             if let Some(eb) = else_block {
-                cse_in_block(body, eb, local_count, locals, changed);
+                cse_in_block(engine, eb, changed);
             }
         }
         StmtKind::LabeledBlock { block, .. } => {
             let block = *block;
-            cse_in_block(body, block, local_count, locals, changed);
+            cse_in_block(engine, block, changed);
         }
         _ => {}
     }
@@ -160,29 +170,24 @@ fn key_locals(key: &CseKey, locals: &mut IndexSet<u32>) {
 /// Apply CSE to a loop body. Looks for a pure binary subexpression that appears
 /// in the loop guard and again in the loop body, with no modification to operands
 /// between occurrences.
-fn cse_loop_body(
-    body: &mut Body,
-    loop_block: BlockId,
-    local_count: &mut u32,
-    locals: &mut Vec<NirLocal>,
-) -> bool {
+fn cse_loop_body(engine: &mut Engine, loop_block: BlockId) -> bool {
     // Pattern: first stmt is `if !(cond) { break; }` — extract subexprs from cond
-    if body.blocks[loop_block].stmts.is_empty() {
+    if engine.body.blocks[loop_block].stmts.is_empty() {
         return false;
     }
-    let first_stmt = body.blocks[loop_block].stmts[0];
+    let first_stmt = engine.body.blocks[loop_block].stmts[0];
 
     // Extract the guard condition expression (a break guard: `if !(cond) { break; }`).
-    let guard_expr = match &body.stmts[first_stmt].kind {
+    let guard_expr = match &engine.body.stmts[first_stmt].kind {
         StmtKind::If {
             condition,
             then_block,
             ..
         } => {
             let then_block = *then_block;
-            let is_break_guard = body.blocks[then_block].stmts.len() == 1
+            let is_break_guard = engine.body.blocks[then_block].stmts.len() == 1
                 && matches!(
-                    body.stmts[body.blocks[then_block].stmts[0]].kind,
+                    engine.body.stmts[engine.body.blocks[then_block].stmts[0]].kind,
                     StmtKind::Break { .. }
                 );
             if !is_break_guard {
@@ -194,12 +199,12 @@ fn cse_loop_body(
     };
 
     // Find binary subexpressions in the guard condition.
-    let candidates = collect_binary_subexprs(body, guard_expr);
+    let candidates = collect_binary_subexprs(engine.body, guard_expr);
     if candidates.is_empty() {
         return false;
     }
 
-    let remaining_stmts: Vec<StmtId> = body.blocks[loop_block].stmts[1..].to_vec();
+    let remaining_stmts: Vec<StmtId> = engine.body.blocks[loop_block].stmts[1..].to_vec();
     for (key, type_id, span) in &candidates {
         // Skip trivial single-local expressions (no benefit in CSE).
         if matches!(key, CseKey::Local { .. }) {
@@ -211,22 +216,19 @@ fn cse_loop_body(
 
         // Check if any of the remaining stmts contain the same expression AND
         // the used locals are not modified before that occurrence.
-        if has_matching_expr(body, &remaining_stmts, key, &used_locals) {
-            // Create a new local for the CSE'd expression.
-            let cse_local_idx = *local_count;
-            *local_count += 1;
-            let cse_local_name = format!("__cse_{cse_local_idx}");
-            locals.push(NirLocal {
-                name: cse_local_name.clone(),
-                type_id: *type_id,
-                is_mut: false,
-            });
+        if has_matching_expr(engine.body, &remaining_stmts, key, &used_locals) {
+            // Create a new local for the CSE'd expression via the engine, so
+            // the `locals` list grows coherently with the body.
+            let cse_local_name_seed = format!("__cse_{}", engine.locals().len());
+            let cse_local_idx =
+                engine.alloc_local(cse_local_name_seed.clone(), *type_id, /* is_mut */ false);
+            let cse_local_name = cse_local_name_seed;
 
             // Clone the matching expression out of the guard for the Let value.
-            let match_id = extract_matching_expr(body, guard_expr, key).unwrap();
-            let value = clone_cse_expr(body, match_id);
-            let let_stmt = body.stmts.push(StmtNode {
-                kind: StmtKind::Let {
+            let match_id = extract_matching_expr(engine.body, guard_expr, key).unwrap();
+            let value = engine.clone_expr(match_id);
+            let let_stmt = engine.alloc_stmt(
+                StmtKind::Let {
                     name: cse_local_name.clone(),
                     local_index: cse_local_idx,
                     is_mut: false,
@@ -235,13 +237,13 @@ fn cse_loop_body(
                     value,
                     skip_value_copy: false,
                 },
-                span: *span,
-            });
+                *span,
+            );
 
             // Replace the expression everywhere it occurs (guard + remaining
             // body) with a reference to the CSE local.
             replace_matching_stmt(
-                body,
+                engine,
                 first_stmt,
                 key,
                 cse_local_idx,
@@ -249,11 +251,22 @@ fn cse_loop_body(
                 *type_id,
             );
             for stmt in &remaining_stmts {
-                replace_matching_stmt(body, *stmt, key, cse_local_idx, &cse_local_name, *type_id);
+                replace_matching_stmt(
+                    engine,
+                    *stmt,
+                    key,
+                    cse_local_idx,
+                    &cse_local_name,
+                    *type_id,
+                );
             }
 
-            // Insert the Let at the beginning of the loop body.
-            body.blocks[loop_block].stmts.insert(0, let_stmt);
+            // Insert the Let at the beginning of the loop body. The
+            // `set_block_stmts` re-parents / re-enqueues the new statement
+            // list (the others stay parented to this block as before).
+            let mut new_stmts = engine.body.blocks[loop_block].stmts.clone();
+            new_stmts.insert(0, let_stmt);
+            engine.set_block_stmts(loop_block, new_stmts);
 
             return true; // One CSE per loop per pass (the outer loop iterates).
         }
@@ -475,45 +488,25 @@ fn extract_matching_expr(body: &Body, expr: ExprId, key: &CseKey) -> Option<Expr
     }
 }
 
-/// Deep-copy a CSE'able subtree (`Binary` / `Local` / `IntLiteral`) into fresh
-/// arena nodes, returning the new root.
-fn clone_cse_expr(body: &mut Body, id: ExprId) -> ExprId {
-    let node = body.exprs[id].clone();
-    let kind = match node.kind {
-        ExprKind::Binary { left, op, right } => ExprKind::Binary {
-            left: clone_cse_expr(body, left),
-            op,
-            right: clone_cse_expr(body, right),
-        },
-        // `Local` / `IntLiteral` leaves clone as-is.
-        other => other,
-    };
-    body.exprs.push(ExprNode {
-        kind,
-        type_id: node.type_id,
-        span: node.span,
-    })
-}
-
 /// Replace all occurrences of the expression matching `key` with a reference to
 /// the CSE local, throughout `stmt`. Recursion sets mirror the former tree
 /// `replace_matching_expr` / `replace_in_expr` exactly.
 fn replace_matching_stmt(
-    body: &mut Body,
+    engine: &mut Engine,
     stmt: StmtId,
     key: &CseKey,
     idx: u32,
     name: &str,
     type_id: TypeId,
 ) {
-    match &body.stmts[stmt].kind {
+    match &engine.body.stmts[stmt].kind {
         StmtKind::Expr(e) => {
             let e = *e;
-            replace_in_expr(body, e, key, idx, name, type_id);
+            replace_in_expr(engine, e, key, idx, name, type_id);
         }
         StmtKind::Let { value, .. } | StmtKind::LetDestructure { value, .. } => {
             let value = *value;
-            replace_in_expr(body, value, key, idx, name, type_id);
+            replace_in_expr(engine, value, key, idx, name, type_id);
         }
         StmtKind::If {
             condition,
@@ -521,10 +514,10 @@ fn replace_matching_stmt(
             else_block,
         } => {
             let (condition, then_block, else_block) = (*condition, *then_block, *else_block);
-            replace_in_expr(body, condition, key, idx, name, type_id);
-            replace_in_block(body, then_block, key, idx, name, type_id);
+            replace_in_expr(engine, condition, key, idx, name, type_id);
+            replace_in_block(engine, then_block, key, idx, name, type_id);
             if let Some(eb) = else_block {
-                replace_in_block(body, eb, key, idx, name, type_id);
+                replace_in_block(engine, eb, key, idx, name, type_id);
             }
         }
         // Nested Loop: do not descend (matches `stmt_contains_expr`'s opaque
@@ -532,11 +525,11 @@ fn replace_matching_stmt(
         StmtKind::Loop { .. } => {}
         StmtKind::LabeledBlock { block, .. } => {
             let block = *block;
-            replace_in_block(body, block, key, idx, name, type_id);
+            replace_in_block(engine, block, key, idx, name, type_id);
         }
         StmtKind::Return { value } | StmtKind::Break { value, .. } => {
             if let Some(v) = *value {
-                replace_in_expr(body, v, key, idx, name, type_id);
+                replace_in_expr(engine, v, key, idx, name, type_id);
             }
         }
         StmtKind::Continue => {}
@@ -544,64 +537,71 @@ fn replace_matching_stmt(
 }
 
 fn replace_in_block(
-    body: &mut Body,
+    engine: &mut Engine,
     block: BlockId,
     key: &CseKey,
     idx: u32,
     name: &str,
     type_id: TypeId,
 ) {
-    let stmts = body.blocks[block].stmts.clone();
+    let stmts = engine.body.blocks[block].stmts.clone();
     for stmt in stmts {
-        replace_matching_stmt(body, stmt, key, idx, name, type_id);
+        replace_matching_stmt(engine, stmt, key, idx, name, type_id);
     }
 }
 
 fn replace_in_expr(
-    body: &mut Body,
+    engine: &mut Engine,
     expr: ExprId,
     key: &CseKey,
     idx: u32,
     name: &str,
     type_id: TypeId,
 ) {
-    if expr_to_key(body, expr).as_ref() == Some(key) {
-        body.exprs[expr].kind = ExprKind::Local {
-            index: idx,
-            name: name.to_string(),
-        };
-        body.exprs[expr].type_id = type_id;
+    if expr_to_key(engine.body, expr).as_ref() == Some(key) {
+        // The CSE'd subtree's `type_id` may differ from the surrounding node's
+        // (the matched node had its own type before substitution). Set it
+        // directly on the arena — the engine tracks parent / use-index
+        // coherence on kinds only, so a type-id write is independent.
+        engine.body.exprs[expr].type_id = type_id;
+        engine.replace_expr_kind(
+            expr,
+            ExprKind::Local {
+                index: idx,
+                name: name.to_string(),
+            },
+        );
         return;
     }
-    match &body.exprs[expr].kind {
+    match &engine.body.exprs[expr].kind {
         ExprKind::Binary { left, right, .. } => {
             let (left, right) = (*left, *right);
-            replace_in_expr(body, left, key, idx, name, type_id);
-            replace_in_expr(body, right, key, idx, name, type_id);
+            replace_in_expr(engine, left, key, idx, name, type_id);
+            replace_in_expr(engine, right, key, idx, name, type_id);
         }
         ExprKind::Unary { expr: inner, .. }
         | ExprKind::FieldAccess { expr: inner, .. }
         | ExprKind::Cast { expr: inner, .. } => {
             let inner = *inner;
-            replace_in_expr(body, inner, key, idx, name, type_id);
+            replace_in_expr(engine, inner, key, idx, name, type_id);
         }
         ExprKind::Assign { target, value } => {
             let (target, value) = (*target, *value);
-            replace_in_expr(body, target, key, idx, name, type_id);
-            replace_in_expr(body, value, key, idx, name, type_id);
+            replace_in_expr(engine, target, key, idx, name, type_id);
+            replace_in_expr(engine, value, key, idx, name, type_id);
         }
         ExprKind::Call { args, .. } => {
             let args: Vec<ExprId> = args.iter().map(|a| a.expr).collect();
             for a in args {
-                replace_in_expr(body, a, key, idx, name, type_id);
+                replace_in_expr(engine, a, key, idx, name, type_id);
             }
         }
         ExprKind::MethodCall { receiver, args, .. } => {
             let receiver = *receiver;
             let args: Vec<ExprId> = args.iter().map(|a| a.expr).collect();
-            replace_in_expr(body, receiver, key, idx, name, type_id);
+            replace_in_expr(engine, receiver, key, idx, name, type_id);
             for a in args {
-                replace_in_expr(body, a, key, idx, name, type_id);
+                replace_in_expr(engine, a, key, idx, name, type_id);
             }
         }
         ExprKind::If {
@@ -610,44 +610,44 @@ fn replace_in_expr(
             else_branch,
         } => {
             let (condition, then_branch, else_branch) = (*condition, *then_branch, *else_branch);
-            replace_in_expr(body, condition, key, idx, name, type_id);
-            replace_in_block(body, then_branch, key, idx, name, type_id);
+            replace_in_expr(engine, condition, key, idx, name, type_id);
+            replace_in_block(engine, then_branch, key, idx, name, type_id);
             if let Some(eb) = else_branch {
-                replace_in_block(body, eb, key, idx, name, type_id);
+                replace_in_block(engine, eb, key, idx, name, type_id);
             }
         }
         ExprKind::Block(b) | ExprKind::LabeledBlock { block: b, .. } => {
             let b = *b;
-            replace_in_block(body, b, key, idx, name, type_id);
+            replace_in_block(engine, b, key, idx, name, type_id);
         }
         ExprKind::Index { expr: inner, index } => {
             let (inner, index) = (*inner, *index);
-            replace_in_expr(body, inner, key, idx, name, type_id);
-            replace_in_expr(body, index, key, idx, name, type_id);
+            replace_in_expr(engine, inner, key, idx, name, type_id);
+            replace_in_expr(engine, index, key, idx, name, type_id);
         }
         ExprKind::IndirectCall { callee, args } => {
             let callee = *callee;
             let args = args.clone();
-            replace_in_expr(body, callee, key, idx, name, type_id);
+            replace_in_expr(engine, callee, key, idx, name, type_id);
             for a in args {
-                replace_in_expr(body, a, key, idx, name, type_id);
+                replace_in_expr(engine, a, key, idx, name, type_id);
             }
         }
         ExprKind::StructLiteral { fields, .. } => {
             let fields: Vec<ExprId> = fields.iter().map(|f| f.value).collect();
             for f in fields {
-                replace_in_expr(body, f, key, idx, name, type_id);
+                replace_in_expr(engine, f, key, idx, name, type_id);
             }
         }
         ExprKind::TupleLiteral { elements, .. } => {
             let elements = elements.clone();
             for elem in elements {
-                replace_in_expr(body, elem, key, idx, name, type_id);
+                replace_in_expr(engine, elem, key, idx, name, type_id);
             }
         }
         ExprKind::VariantConstruct { payload, .. } => {
             if let Some(p) = *payload {
-                replace_in_expr(body, p, key, idx, name, type_id);
+                replace_in_expr(engine, p, key, idx, name, type_id);
             }
         }
         ExprKind::Match { expr: inner, arms } => {
@@ -659,9 +659,9 @@ fn replace_in_expr(
                 }
                 targets.push(arm.body);
             }
-            replace_in_expr(body, inner, key, idx, name, type_id);
+            replace_in_expr(engine, inner, key, idx, name, type_id);
             for t in targets {
-                replace_in_expr(body, t, key, idx, name, type_id);
+                replace_in_expr(engine, t, key, idx, name, type_id);
             }
         }
         ExprKind::Switch {
@@ -673,20 +673,20 @@ fn replace_in_expr(
             let scrutinee = *scrutinee;
             let arms = arms.clone();
             let default = *default;
-            replace_in_expr(body, scrutinee, key, idx, name, type_id);
+            replace_in_expr(engine, scrutinee, key, idx, name, type_id);
             for arm in arms {
-                replace_in_block(body, arm, key, idx, name, type_id);
+                replace_in_block(engine, arm, key, idx, name, type_id);
             }
-            replace_in_block(body, default, key, idx, name, type_id);
+            replace_in_block(engine, default, key, idx, name, type_id);
         }
         ExprKind::GlobalVarSet { value, .. } => {
             let value = *value;
-            replace_in_expr(body, value, key, idx, name, type_id);
+            replace_in_expr(engine, value, key, idx, name, type_id);
         }
         ExprKind::CmRawCall { args, .. } => {
             let args = args.clone();
             for a in args {
-                replace_in_expr(body, a, key, idx, name, type_id);
+                replace_in_expr(engine, a, key, idx, name, type_id);
             }
         }
         _ => {}

--- a/wado-compiler/src/optimize/cse.rs
+++ b/wado-compiler/src/optimize/cse.rs
@@ -201,7 +201,14 @@ fn cse_loop_body(engine: &mut Engine, loop_block: BlockId) -> bool {
 
         // Replace every matching subexpression (in the guard's stmt and in
         // every remaining stmt) with a `Local(cse_local_idx)` read.
-        replace_matching_in_stmt(engine, first_stmt, cand_vn, cse_local_idx, &cse_local_name, type_id);
+        replace_matching_in_stmt(
+            engine,
+            first_stmt,
+            cand_vn,
+            cse_local_idx,
+            &cse_local_name,
+            type_id,
+        );
         for s in &remaining_stmts {
             replace_matching_in_stmt(engine, *s, cand_vn, cse_local_idx, &cse_local_name, type_id);
         }

--- a/wado-compiler/src/optimize/cse.rs
+++ b/wado-compiler/src/optimize/cse.rs
@@ -24,7 +24,7 @@
 //! ```
 //!
 //! Identity check: two expressions are "the same" iff `engine.value(e1) ==
-//! engine.value(e2)`. The ValueGraph already encodes reassignment between
+//! engine.value(e2)`. The `ValueGraph` already encodes reassignment between
 //! occurrences, so this pass needs no separate modification guard.
 //!
 //! Runs as a per-function standalone engine session whose `apply_block`
@@ -214,10 +214,10 @@ fn cse_loop_body(engine: &mut Engine, loop_block: BlockId) -> bool {
     false
 }
 
-/// Collect every `Binary` subexpression of `expr` paired with its ValueId.
+/// Collect every `Binary` subexpression of `expr` paired with its `ValueId`.
 /// Recurses through Binary/Unary so candidates like `!(p * p <= limit)`
 /// are reached. Two-pass: pass 1 collects candidates under `&body`;
-/// pass 2 attaches ValueIds (which needs `&mut engine`).
+/// pass 2 attaches `ValueIds` (which needs `&mut engine`).
 fn collect_binary_candidates(
     engine: &mut Engine,
     expr: ExprId,
@@ -262,7 +262,7 @@ fn any_stmt_contains_value(engine: &mut Engine, stmts: &[StmtId], target: ValueI
     false
 }
 
-/// Replace every expression in `stmt`'s subtree whose ValueId equals
+/// Replace every expression in `stmt`'s subtree whose `ValueId` equals
 /// `target` with a `Local { cse_local_idx, cse_local_name }` read. Re-asserts
 /// the new type on the rewritten node (Local takes a `TypeId` and the
 /// CSE'd value may differ from the surrounding context's type).

--- a/wado-compiler/src/optimize/cse.rs
+++ b/wado-compiler/src/optimize/cse.rs
@@ -23,23 +23,13 @@
 //! }
 //! ```
 //!
-//! Identity check (Stage 3 migration to the engine's ValueGraph
-//! side-table; see `docs/wep-2026-06-05-worklist-rewrite-engine.md`):
-//! two expressions are "the same" iff `engine.value(e1) == engine.value(e2)`.
-//! The ValueGraph builder threads each local's reaching definition through
-//! `current_value` and merges at If / Match / Switch endpoints, so two
-//! syntactically identical `Local` reads at points where the local has been
-//! reassigned in between resolve to different `ValueId`s — making the
-//! `stmt_modifies_any` / `block_modifies_any` reassignment guard from the
-//! pre-Stage-3 pass redundant (the equality check already encodes it).
+//! Identity check: two expressions are "the same" iff `engine.value(e1) ==
+//! engine.value(e2)`. The ValueGraph already encodes reassignment between
+//! occurrences, so this pass needs no separate modification guard.
 //!
-//! Runs on the worklist rewrite engine as a [`Rule`]: a per-function
-//! standalone engine session whose `apply_block` fires once at the body
-//! root and walks every loop in the function, applying the guard/body
-//! redundancy fold per loop. All mutations route through the engine edit
-//! API (`alloc_stmt`, `alloc_expr`, `clone_expr`, `set_block_stmts`,
-//! `replace_expr_kind`, `alloc_local`) so the parent map and use index
-//! stay coherent.
+//! Runs as a per-function standalone engine session whose `apply_block`
+//! fires once at the body root and walks every loop in the function,
+//! applying the guard/body redundancy fold per loop.
 
 use std::cell::Cell;
 
@@ -225,15 +215,13 @@ fn cse_loop_body(engine: &mut Engine, loop_block: BlockId) -> bool {
 }
 
 /// Collect every `Binary` subexpression of `expr` paired with its ValueId.
-/// Recurses into Binary's children (left/right) and Unary's inner expr to
-/// match the pre-Stage-3 collector's reach (which keyed on `Binary` while
-/// peering through one level of Unary, e.g., `!(p * p <= limit)`).
+/// Recurses through Binary/Unary so candidates like `!(p * p <= limit)`
+/// are reached. Two-pass: pass 1 collects candidates under `&body`;
+/// pass 2 attaches ValueIds (which needs `&mut engine`).
 fn collect_binary_candidates(
     engine: &mut Engine,
     expr: ExprId,
 ) -> Vec<(ExprId, ValueId, TypeId, Span)> {
-    // Pass 1 — walk under an immutable borrow of body and collect Binary
-    // candidate metadata. The value-graph query is deferred to pass 2.
     let mut binary_exprs: Vec<(ExprId, TypeId, Span)> = Vec::new();
     {
         let body: &Body = &*engine.body;
@@ -252,9 +240,8 @@ fn collect_binary_candidates(
             }
         }
     }
-    // Pass 2 — attach ValueIds. An expr whose ValueId is `None` is impure
-    // by the builder's classification (a `Binary` over a non-pure child
-    // such as a `Call`) and is filtered out here.
+    // Drop impure candidates (a `Binary` whose ValueId is `None` has an
+    // impure child like a `Call`).
     binary_exprs
         .into_iter()
         .filter_map(|(e, type_id, span)| engine.value(e).map(|vn| (e, vn, type_id, span)))
@@ -287,13 +274,8 @@ fn replace_matching_in_stmt(
     cse_local_name: &str,
     type_id: TypeId,
 ) {
-    // Snapshot the matching ExprIds *before* any rewrite. The engine's
-    // ValueGraph cache is built lazily and not invalidated by
-    // `replace_expr_kind`, so post-rewrite `engine.value(e)` queries
-    // happen to still return the original VNs today — but relying on that
-    // makes CSE depend on an implementation detail of the cache.
-    // Snapshotting up-front decouples us: this loop is now correct
-    // regardless of any future change to invalidation policy.
+    // Snapshot matches before rewriting — see `Engine::value`'s
+    // invalidation contract.
     let mut exprs: Vec<ExprId> = Vec::new();
     collect_exprs_in_stmt(engine.body, stmt, &mut exprs);
     let matches: Vec<ExprId> = exprs
@@ -301,9 +283,7 @@ fn replace_matching_in_stmt(
         .filter(|&e| engine.value(e) == Some(target))
         .collect();
     for e in matches {
-        // The CSE'd subtree's type matches the hoisted local's type; the
-        // engine tracks parent / use-index coherence on kinds only, so a
-        // direct type-id write is independent of `replace_expr_kind`.
+        // `replace_expr_kind` doesn't touch `type_id`; write it directly.
         engine.body.exprs[e].type_id = type_id;
         engine.replace_expr_kind(
             e,
@@ -315,16 +295,10 @@ fn replace_matching_in_stmt(
     }
 }
 
-// ---------------------------------------------------------------------------
-// Subtree enumeration
-// ---------------------------------------------------------------------------
-//
-// These mirror the pre-Stage-3 `stmt_contains_expr` / `block_contains` /
-// `expr_contains` walk shape (including the deliberate opaque treatment of
-// nested `Loop` statements — CSE in an outer loop does not reach into inner
-// loops, where the same expression would compute a different value per
-// iteration).
-
+/// Walk `stmt`'s subtree, collecting `ExprId`s of every node CSE may
+/// rewrite. Nested `Loop` statements are deliberately opaque: an outer
+/// loop's CSE does not reach into them, since the same expression
+/// computes different values per inner-loop iteration.
 fn collect_exprs_in_stmt(body: &Body, stmt: StmtId, out: &mut Vec<ExprId>) {
     match &body.stmts[stmt].kind {
         StmtKind::Expr(e) => collect_exprs_in_expr(body, *e, out),
@@ -342,7 +316,7 @@ fn collect_exprs_in_stmt(body: &Body, stmt: StmtId, out: &mut Vec<ExprId>) {
                 collect_exprs_in_block(body, *eb, out);
             }
         }
-        // Nested loops are opaque (matches the pre-Stage-3 `stmt_contains_expr`).
+        // Inner loops are opaque per the rationale on `collect_exprs_in_stmt`.
         StmtKind::Loop { .. } => {}
         StmtKind::LabeledBlock { block, .. } => collect_exprs_in_block(body, *block, out),
         StmtKind::Return { value } | StmtKind::Break { value, .. } => {

--- a/wado-compiler/src/optimize/cse.rs
+++ b/wado-compiler/src/optimize/cse.rs
@@ -220,8 +220,11 @@ fn cse_loop_body(engine: &mut Engine, loop_block: BlockId) -> bool {
             // Create a new local for the CSE'd expression via the engine, so
             // the `locals` list grows coherently with the body.
             let cse_local_name_seed = format!("__cse_{}", engine.locals().len());
-            let cse_local_idx =
-                engine.alloc_local(cse_local_name_seed.clone(), *type_id, /* is_mut */ false);
+            let cse_local_idx = engine.alloc_local(
+                cse_local_name_seed.clone(),
+                *type_id,
+                /* is_mut */ false,
+            );
             let cse_local_name = cse_local_name_seed;
 
             // Clone the matching expression out of the guard for the Let value.
@@ -251,14 +254,7 @@ fn cse_loop_body(engine: &mut Engine, loop_block: BlockId) -> bool {
                 *type_id,
             );
             for stmt in &remaining_stmts {
-                replace_matching_stmt(
-                    engine,
-                    *stmt,
-                    key,
-                    cse_local_idx,
-                    &cse_local_name,
-                    *type_id,
-                );
+                replace_matching_stmt(engine, *stmt, key, cse_local_idx, &cse_local_name, *type_id);
             }
 
             // Insert the Let at the beginning of the loop body. The

--- a/wado-compiler/src/optimize/cse.rs
+++ b/wado-compiler/src/optimize/cse.rs
@@ -1,8 +1,8 @@
 //! Common Subexpression Elimination (CSE) for Wado NIR
 //!
 //! Eliminates duplicate pure expressions within loop bodies. When the same
-//! pure binary expression appears multiple times within a single loop iteration
-//! and the operand locals are not modified between occurrences, the expression
+//! pure binary expression appears in both the loop guard and the body, and
+//! the operand locals are not reassigned between occurrences, the expression
 //! is computed once and reused via a local variable.
 //!
 //! Example:
@@ -23,25 +23,34 @@
 //! }
 //! ```
 //!
-//! Runs on the worklist rewrite engine (combine migration; see
-//! `docs/wep-2026-06-05-nir-rewrite-engine-design.md`) as a [`Rule`]: a
-//! per-function standalone engine session whose `apply_block` fires once at
-//! the body root and walks every loop in the function, applying the
-//! guard/body redundancy fold per loop. All mutations route through the
-//! engine edit API (`alloc_stmt`, `alloc_expr`, `clone_expr`,
-//! `set_block_stmts`, `replace_expr_kind`, `alloc_local`) so the parent map
-//! and use index stay coherent.
+//! Identity check (Stage 3 migration to the engine's ValueGraph
+//! side-table; see `docs/wep-2026-06-05-worklist-rewrite-engine.md`):
+//! two expressions are "the same" iff `engine.value(e1) == engine.value(e2)`.
+//! The ValueGraph builder threads each local's reaching definition through
+//! `current_value` and merges at If / Match / Switch endpoints, so two
+//! syntactically identical `Local` reads at points where the local has been
+//! reassigned in between resolve to different `ValueId`s — making the
+//! `stmt_modifies_any` / `block_modifies_any` reassignment guard from the
+//! pre-Stage-3 pass redundant (the equality check already encodes it).
+//!
+//! Runs on the worklist rewrite engine as a [`Rule`]: a per-function
+//! standalone engine session whose `apply_block` fires once at the body
+//! root and walks every loop in the function, applying the guard/body
+//! redundancy fold per loop. All mutations route through the engine edit
+//! API (`alloc_stmt`, `alloc_expr`, `clone_expr`, `set_block_stmts`,
+//! `replace_expr_kind`, `alloc_local`) so the parent map and use index
+//! stay coherent.
 
 use std::cell::Cell;
 
 use cranelift_entity::EntityRef;
 
 use super::gate::{FunctionGate, GatedPass};
-use crate::hashmap::IndexSet;
-use crate::nir::{NirBinaryOp, NirFunction};
+use crate::nir::NirFunction;
 use crate::nir_arena::{BlockId, Body, ExprId, ExprKind, NodeRef, StmtId, StmtKind};
 use crate::nir_engine::{Engine, EngineBuffers, Rule};
 use crate::nir_package::NirPackage;
+use crate::nir_value_graph::ValueId;
 use crate::tir::TypeId;
 use crate::token::Span;
 
@@ -119,59 +128,10 @@ fn cse_in_stmt(engine: &mut Engine, stmt: StmtId, changed: &mut bool) {
     }
 }
 
-/// A pure expression that can be CSE'd, identified by its structure.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-enum CseKey {
-    Binary {
-        op: NirBinaryOp,
-        left: Box<CseKey>,
-        right: Box<CseKey>,
-    },
-    Local {
-        index: u32,
-    },
-    IntLiteral {
-        value: u64,
-    },
-}
-
-/// Try to build a `CseKey` from an arena expression (only for pure expressions).
-fn expr_to_key(body: &Body, id: ExprId) -> Option<CseKey> {
-    match &body.exprs[id].kind {
-        ExprKind::Binary { left, op, right } => {
-            let left_key = expr_to_key(body, *left)?;
-            let right_key = expr_to_key(body, *right)?;
-            Some(CseKey::Binary {
-                op: *op,
-                left: Box::new(left_key),
-                right: Box::new(right_key),
-            })
-        }
-        ExprKind::Local { index, .. } => Some(CseKey::Local { index: *index }),
-        ExprKind::IntLiteral { value, .. } => Some(CseKey::IntLiteral { value: *value }),
-        _ => None,
-    }
-}
-
-/// Collect all locals referenced in a `CseKey`.
-fn key_locals(key: &CseKey, locals: &mut IndexSet<u32>) {
-    match key {
-        CseKey::Binary { left, right, .. } => {
-            key_locals(left, locals);
-            key_locals(right, locals);
-        }
-        CseKey::Local { index } => {
-            locals.insert(*index);
-        }
-        CseKey::IntLiteral { .. } => {}
-    }
-}
-
-/// Apply CSE to a loop body. Looks for a pure binary subexpression that appears
-/// in the loop guard and again in the loop body, with no modification to operands
-/// between occurrences.
+/// Apply CSE to a single loop body. Looks for a pure binary subexpression
+/// that appears in the loop guard and again in the loop body and shares the
+/// same engine [`ValueId`] (i.e., no reassignment of any operand between).
 fn cse_loop_body(engine: &mut Engine, loop_block: BlockId) -> bool {
-    // Pattern: first stmt is `if !(cond) { break; }` — extract subexprs from cond
     if engine.body.blocks[loop_block].stmts.is_empty() {
         return false;
     }
@@ -198,493 +158,204 @@ fn cse_loop_body(engine: &mut Engine, loop_block: BlockId) -> bool {
         _ => return false,
     };
 
-    // Find binary subexpressions in the guard condition.
-    let candidates = collect_binary_subexprs(engine.body, guard_expr);
+    // Collect every pure binary subexpression of the guard, paired with its
+    // ValueId. We intentionally restrict candidates to `Binary` so a single-
+    // local read (whose VN is just an `Opaque` / `Local` reaching def) does
+    // not get hoisted — there is no benefit in CSE'ing a single local read.
+    let candidates = collect_binary_candidates(engine, guard_expr);
     if candidates.is_empty() {
         return false;
     }
 
     let remaining_stmts: Vec<StmtId> = engine.body.blocks[loop_block].stmts[1..].to_vec();
-    for (key, type_id, span) in &candidates {
-        // Skip trivial single-local expressions (no benefit in CSE).
-        if matches!(key, CseKey::Local { .. }) {
+    for (cand_expr, cand_vn, type_id, span) in candidates {
+        // Walk the remaining stmts looking for any expression that resolves
+        // to the same ValueId. The VN already encodes reaching-def info, so
+        // there is no separate "are the operands still unchanged?" check —
+        // a reassignment between guard and use would produce a different VN
+        // for the later use.
+        if !any_stmt_contains_value(engine, &remaining_stmts, cand_vn) {
             continue;
         }
 
-        let mut used_locals = IndexSet::default();
-        key_locals(key, &mut used_locals);
+        // Create a fresh `__cse_N` local through the engine so the locals
+        // list grows coherently.
+        let cse_local_name = format!("__cse_{}", engine.locals().len());
+        let cse_local_idx =
+            engine.alloc_local(cse_local_name.clone(), type_id, /* is_mut */ false);
 
-        // Check if any of the remaining stmts contain the same expression AND
-        // the used locals are not modified before that occurrence.
-        if has_matching_expr(engine.body, &remaining_stmts, key, &used_locals) {
-            // Create a new local for the CSE'd expression via the engine, so
-            // the `locals` list grows coherently with the body.
-            let cse_local_name_seed = format!("__cse_{}", engine.locals().len());
-            let cse_local_idx = engine.alloc_local(
-                cse_local_name_seed.clone(),
-                *type_id,
-                /* is_mut */ false,
-            );
-            let cse_local_name = cse_local_name_seed;
+        // Clone the matching expression out of the guard for the Let value.
+        let value = engine.clone_expr(cand_expr);
+        let let_stmt = engine.alloc_stmt(
+            StmtKind::Let {
+                name: cse_local_name.clone(),
+                local_index: cse_local_idx,
+                is_mut: false,
+                is_reactive: false,
+                type_id,
+                value,
+                skip_value_copy: false,
+            },
+            span,
+        );
 
-            // Clone the matching expression out of the guard for the Let value.
-            let match_id = extract_matching_expr(engine.body, guard_expr, key).unwrap();
-            let value = engine.clone_expr(match_id);
-            let let_stmt = engine.alloc_stmt(
-                StmtKind::Let {
-                    name: cse_local_name.clone(),
-                    local_index: cse_local_idx,
-                    is_mut: false,
-                    is_reactive: false,
-                    type_id: *type_id,
-                    value,
-                    skip_value_copy: false,
-                },
-                *span,
-            );
-
-            // Replace the expression everywhere it occurs (guard + remaining
-            // body) with a reference to the CSE local.
-            replace_matching_stmt(
-                engine,
-                first_stmt,
-                key,
-                cse_local_idx,
-                &cse_local_name,
-                *type_id,
-            );
-            for stmt in &remaining_stmts {
-                replace_matching_stmt(engine, *stmt, key, cse_local_idx, &cse_local_name, *type_id);
-            }
-
-            // Insert the Let at the beginning of the loop body. The
-            // `set_block_stmts` re-parents / re-enqueues the new statement
-            // list (the others stay parented to this block as before).
-            let mut new_stmts = engine.body.blocks[loop_block].stmts.clone();
-            new_stmts.insert(0, let_stmt);
-            engine.set_block_stmts(loop_block, new_stmts);
-
-            return true; // One CSE per loop per pass (the outer loop iterates).
+        // Replace every matching subexpression (in the guard's stmt and in
+        // every remaining stmt) with a `Local(cse_local_idx)` read.
+        replace_matching_in_stmt(engine, first_stmt, cand_vn, cse_local_idx, &cse_local_name, type_id);
+        for s in &remaining_stmts {
+            replace_matching_in_stmt(engine, *s, cand_vn, cse_local_idx, &cse_local_name, type_id);
         }
+
+        // Insert the Let at the start of the loop body.
+        let mut new_stmts = engine.body.blocks[loop_block].stmts.clone();
+        new_stmts.insert(0, let_stmt);
+        engine.set_block_stmts(loop_block, new_stmts);
+
+        return true; // One CSE per loop per pass (the outer loop iterates).
     }
 
     false
 }
 
-/// Collect all pure binary subexpressions from an expression.
-fn collect_binary_subexprs(body: &Body, expr: ExprId) -> Vec<(CseKey, TypeId, Span)> {
-    let mut result = Vec::new();
-    collect_binary_subexprs_rec(body, expr, &mut result);
-    result
-}
-
-fn collect_binary_subexprs_rec(
-    body: &Body,
+/// Collect every `Binary` subexpression of `expr` paired with its ValueId.
+/// Recurses into Binary's children (left/right) and Unary's inner expr to
+/// match the pre-Stage-3 collector's reach (which keyed on `Binary` while
+/// peering through one level of Unary, e.g., `!(p * p <= limit)`).
+fn collect_binary_candidates(
+    engine: &mut Engine,
     expr: ExprId,
-    result: &mut Vec<(CseKey, TypeId, Span)>,
-) {
-    if let ExprKind::Binary { left, right, .. } = &body.exprs[expr].kind {
-        let (left, right) = (*left, *right);
-        if let Some(key) = expr_to_key(body, expr) {
-            result.push((key, body.exprs[expr].type_id, body.exprs[expr].span));
+) -> Vec<(ExprId, ValueId, TypeId, Span)> {
+    // Pass 1 — walk under an immutable borrow of body and collect Binary
+    // candidate metadata. The value-graph query is deferred to pass 2.
+    let mut binary_exprs: Vec<(ExprId, TypeId, Span)> = Vec::new();
+    {
+        let body: &Body = &*engine.body;
+        let mut stack: Vec<ExprId> = vec![expr];
+        while let Some(e) = stack.pop() {
+            match &body.exprs[e].kind {
+                ExprKind::Binary { left, right, .. } => {
+                    binary_exprs.push((e, body.exprs[e].type_id, body.exprs[e].span));
+                    stack.push(*left);
+                    stack.push(*right);
+                }
+                ExprKind::Unary { expr: inner, .. } => {
+                    stack.push(*inner);
+                }
+                _ => {}
+            }
         }
-        collect_binary_subexprs_rec(body, left, result);
-        collect_binary_subexprs_rec(body, right, result);
     }
-    // Also recurse into Unary (e.g. `!(p * p <= limit)`).
-    if let ExprKind::Unary { expr: inner, .. } = &body.exprs[expr].kind {
-        collect_binary_subexprs_rec(body, *inner, result);
-    }
+    // Pass 2 — attach ValueIds. An expr whose ValueId is `None` is impure
+    // by the builder's classification (a `Binary` over a non-pure child
+    // such as a `Call`) and is filtered out here.
+    binary_exprs
+        .into_iter()
+        .filter_map(|(e, type_id, span)| engine.value(e).map(|vn| (e, vn, type_id, span)))
+        .collect()
 }
 
-/// Check if any statement in the list contains the same expression, and the
-/// used locals are not modified before that occurrence.
-fn has_matching_expr(
-    body: &Body,
-    stmts: &[StmtId],
-    key: &CseKey,
-    used_locals: &IndexSet<u32>,
-) -> bool {
-    for &stmt in stmts {
-        if stmt_modifies_any(body, stmt, used_locals) {
-            // Locals modified before a match — only safe if the expression
-            // appears in this stmt before the modification; conservatively
-            // check this stmt for the expression first.
-            if stmt_contains_expr(body, stmt, key) {
+/// Does any expression in any of `stmts` resolve to `target`?
+fn any_stmt_contains_value(engine: &mut Engine, stmts: &[StmtId], target: ValueId) -> bool {
+    for &s in stmts {
+        let mut exprs: Vec<ExprId> = Vec::new();
+        collect_exprs_in_stmt(engine.body, s, &mut exprs);
+        for e in exprs {
+            if engine.value(e) == Some(target) {
                 return true;
             }
-            return false;
-        }
-        if stmt_contains_expr(body, stmt, key) {
-            return true;
         }
     }
     false
 }
 
-fn stmt_modifies_any(body: &Body, stmt: StmtId, locals: &IndexSet<u32>) -> bool {
-    match &body.stmts[stmt].kind {
-        StmtKind::Expr(e) => expr_modifies_any(body, *e, locals),
-        StmtKind::Let { value, .. } => expr_modifies_any(body, *value, locals),
-        StmtKind::If {
-            condition,
-            then_block,
-            else_block,
-        } => {
-            expr_modifies_any(body, *condition, locals)
-                || block_modifies_any(body, *then_block, locals)
-                || else_block.is_some_and(|eb| block_modifies_any(body, eb, locals))
-        }
-        StmtKind::Loop { body: b } | StmtKind::LabeledBlock { block: b, .. } => {
-            block_modifies_any(body, *b, locals)
-        }
-        StmtKind::Return { value } | StmtKind::Break { value, .. } => {
-            value.is_some_and(|v| expr_modifies_any(body, v, locals))
-        }
-        StmtKind::LetDestructure { value, .. } => expr_modifies_any(body, *value, locals),
-        StmtKind::Continue => false,
-    }
-}
-
-fn block_modifies_any(body: &Body, block: BlockId, locals: &IndexSet<u32>) -> bool {
-    body.blocks[block]
-        .stmts
-        .iter()
-        .any(|s| stmt_modifies_any(body, *s, locals))
-}
-
-fn expr_modifies_any(body: &Body, expr: ExprId, locals: &IndexSet<u32>) -> bool {
-    match &body.exprs[expr].kind {
-        ExprKind::Assign { target, value } => {
-            if let ExprKind::Local { index, .. } = &body.exprs[*target].kind
-                && locals.contains(index)
-            {
-                return true;
-            }
-            expr_modifies_any(body, *target, locals) || expr_modifies_any(body, *value, locals)
-        }
-        ExprKind::Binary { left, right, .. } => {
-            expr_modifies_any(body, *left, locals) || expr_modifies_any(body, *right, locals)
-        }
-        ExprKind::Unary { expr: inner, .. }
-        | ExprKind::FieldAccess { expr: inner, .. }
-        | ExprKind::Cast { expr: inner, .. } => expr_modifies_any(body, *inner, locals),
-        ExprKind::Call { args, .. } => args.iter().any(|a| expr_modifies_any(body, a.expr, locals)),
-        ExprKind::MethodCall { receiver, args, .. } => {
-            expr_modifies_any(body, *receiver, locals)
-                || args.iter().any(|a| expr_modifies_any(body, a.expr, locals))
-        }
-        ExprKind::If {
-            condition,
-            then_branch,
-            else_branch,
-        } => {
-            expr_modifies_any(body, *condition, locals)
-                || block_modifies_any(body, *then_branch, locals)
-                || else_branch.is_some_and(|eb| block_modifies_any(body, eb, locals))
-        }
-        ExprKind::Block(b) | ExprKind::LabeledBlock { block: b, .. } => {
-            block_modifies_any(body, *b, locals)
-        }
-        ExprKind::Index { expr: inner, index } => {
-            expr_modifies_any(body, *inner, locals) || expr_modifies_any(body, *index, locals)
-        }
-        _ => false,
-    }
-}
-
-/// Check if a statement contains an expression matching the given key.
-fn stmt_contains_expr(body: &Body, stmt: StmtId, key: &CseKey) -> bool {
-    match &body.stmts[stmt].kind {
-        StmtKind::Expr(e) => expr_contains(body, *e, key),
-        StmtKind::Let { value, .. } | StmtKind::LetDestructure { value, .. } => {
-            expr_contains(body, *value, key)
-        }
-        StmtKind::If {
-            condition,
-            then_block,
-            else_block,
-        } => {
-            expr_contains(body, *condition, key)
-                || block_contains(body, *then_block, key)
-                || else_block.is_some_and(|eb| block_contains(body, eb, key))
-        }
-        // Nested Loop: treat as opaque (an inner loop may modify operands
-        // across its own iterations, which a pre-computed cache can't see).
-        StmtKind::Loop { .. } => false,
-        StmtKind::LabeledBlock { block, .. } => block_contains(body, *block, key),
-        StmtKind::Return { value } | StmtKind::Break { value, .. } => {
-            value.is_some_and(|v| expr_contains(body, v, key))
-        }
-        StmtKind::Continue => false,
-    }
-}
-
-fn block_contains(body: &Body, block: BlockId, key: &CseKey) -> bool {
-    body.blocks[block]
-        .stmts
-        .iter()
-        .any(|s| stmt_contains_expr(body, *s, key))
-}
-
-fn expr_contains(body: &Body, expr: ExprId, key: &CseKey) -> bool {
-    if expr_to_key(body, expr).as_ref() == Some(key) {
-        return true;
-    }
-    match &body.exprs[expr].kind {
-        ExprKind::Binary { left, right, .. } => {
-            expr_contains(body, *left, key) || expr_contains(body, *right, key)
-        }
-        ExprKind::Unary { expr: inner, .. }
-        | ExprKind::FieldAccess { expr: inner, .. }
-        | ExprKind::Cast { expr: inner, .. } => expr_contains(body, *inner, key),
-        ExprKind::Assign { target, value } => {
-            expr_contains(body, *target, key) || expr_contains(body, *value, key)
-        }
-        ExprKind::Call { args, .. } => args.iter().any(|a| expr_contains(body, a.expr, key)),
-        ExprKind::MethodCall { receiver, args, .. } => {
-            expr_contains(body, *receiver, key)
-                || args.iter().any(|a| expr_contains(body, a.expr, key))
-        }
-        ExprKind::If {
-            condition,
-            then_branch,
-            else_branch,
-        } => {
-            expr_contains(body, *condition, key)
-                || block_contains(body, *then_branch, key)
-                || else_branch.is_some_and(|eb| block_contains(body, eb, key))
-        }
-        ExprKind::Block(b) | ExprKind::LabeledBlock { block: b, .. } => {
-            block_contains(body, *b, key)
-        }
-        ExprKind::Index { expr: inner, index } => {
-            expr_contains(body, *inner, key) || expr_contains(body, *index, key)
-        }
-        _ => false,
-    }
-}
-
-/// Find the first arena expression matching `key`, returning its id.
-fn extract_matching_expr(body: &Body, expr: ExprId, key: &CseKey) -> Option<ExprId> {
-    if expr_to_key(body, expr).as_ref() == Some(key) {
-        return Some(expr);
-    }
-    match &body.exprs[expr].kind {
-        ExprKind::Binary { left, right, .. } => {
-            let (left, right) = (*left, *right);
-            extract_matching_expr(body, left, key)
-                .or_else(|| extract_matching_expr(body, right, key))
-        }
-        ExprKind::Unary { expr: inner, .. } => {
-            let inner = *inner;
-            extract_matching_expr(body, inner, key)
-        }
-        _ => None,
-    }
-}
-
-/// Replace all occurrences of the expression matching `key` with a reference to
-/// the CSE local, throughout `stmt`. Recursion sets mirror the former tree
-/// `replace_matching_expr` / `replace_in_expr` exactly.
-fn replace_matching_stmt(
+/// Replace every expression in `stmt`'s subtree whose ValueId equals
+/// `target` with a `Local { cse_local_idx, cse_local_name }` read. Re-asserts
+/// the new type on the rewritten node (Local takes a `TypeId` and the
+/// CSE'd value may differ from the surrounding context's type).
+fn replace_matching_in_stmt(
     engine: &mut Engine,
     stmt: StmtId,
-    key: &CseKey,
-    idx: u32,
-    name: &str,
+    target: ValueId,
+    cse_local_idx: u32,
+    cse_local_name: &str,
     type_id: TypeId,
 ) {
-    match &engine.body.stmts[stmt].kind {
-        StmtKind::Expr(e) => {
-            let e = *e;
-            replace_in_expr(engine, e, key, idx, name, type_id);
+    let mut exprs: Vec<ExprId> = Vec::new();
+    collect_exprs_in_stmt(engine.body, stmt, &mut exprs);
+    for e in exprs {
+        if engine.value(e) != Some(target) {
+            continue;
         }
+        // The CSE'd subtree's type matches the hoisted local's type; the
+        // engine tracks parent / use-index coherence on kinds only, so a
+        // direct type-id write is independent of `replace_expr_kind`.
+        engine.body.exprs[e].type_id = type_id;
+        engine.replace_expr_kind(
+            e,
+            ExprKind::Local {
+                index: cse_local_idx,
+                name: cse_local_name.to_string(),
+            },
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Subtree enumeration
+// ---------------------------------------------------------------------------
+//
+// These mirror the pre-Stage-3 `stmt_contains_expr` / `block_contains` /
+// `expr_contains` walk shape (including the deliberate opaque treatment of
+// nested `Loop` statements — CSE in an outer loop does not reach into inner
+// loops, where the same expression would compute a different value per
+// iteration).
+
+fn collect_exprs_in_stmt(body: &Body, stmt: StmtId, out: &mut Vec<ExprId>) {
+    match &body.stmts[stmt].kind {
+        StmtKind::Expr(e) => collect_exprs_in_expr(body, *e, out),
         StmtKind::Let { value, .. } | StmtKind::LetDestructure { value, .. } => {
-            let value = *value;
-            replace_in_expr(engine, value, key, idx, name, type_id);
+            collect_exprs_in_expr(body, *value, out);
         }
         StmtKind::If {
             condition,
             then_block,
             else_block,
         } => {
-            let (condition, then_block, else_block) = (*condition, *then_block, *else_block);
-            replace_in_expr(engine, condition, key, idx, name, type_id);
-            replace_in_block(engine, then_block, key, idx, name, type_id);
+            collect_exprs_in_expr(body, *condition, out);
+            collect_exprs_in_block(body, *then_block, out);
             if let Some(eb) = else_block {
-                replace_in_block(engine, eb, key, idx, name, type_id);
+                collect_exprs_in_block(body, *eb, out);
             }
         }
-        // Nested Loop: do not descend (matches `stmt_contains_expr`'s opaque
-        // treatment).
+        // Nested loops are opaque (matches the pre-Stage-3 `stmt_contains_expr`).
         StmtKind::Loop { .. } => {}
-        StmtKind::LabeledBlock { block, .. } => {
-            let block = *block;
-            replace_in_block(engine, block, key, idx, name, type_id);
-        }
+        StmtKind::LabeledBlock { block, .. } => collect_exprs_in_block(body, *block, out),
         StmtKind::Return { value } | StmtKind::Break { value, .. } => {
-            if let Some(v) = *value {
-                replace_in_expr(engine, v, key, idx, name, type_id);
+            if let Some(v) = value {
+                collect_exprs_in_expr(body, *v, out);
             }
         }
         StmtKind::Continue => {}
     }
 }
 
-fn replace_in_block(
-    engine: &mut Engine,
-    block: BlockId,
-    key: &CseKey,
-    idx: u32,
-    name: &str,
-    type_id: TypeId,
-) {
-    let stmts = engine.body.blocks[block].stmts.clone();
-    for stmt in stmts {
-        replace_matching_stmt(engine, stmt, key, idx, name, type_id);
+fn collect_exprs_in_block(body: &Body, block: BlockId, out: &mut Vec<ExprId>) {
+    let stmts = body.blocks[block].stmts.clone();
+    for s in stmts {
+        collect_exprs_in_stmt(body, s, out);
     }
 }
 
-fn replace_in_expr(
-    engine: &mut Engine,
-    expr: ExprId,
-    key: &CseKey,
-    idx: u32,
-    name: &str,
-    type_id: TypeId,
-) {
-    if expr_to_key(engine.body, expr).as_ref() == Some(key) {
-        // The CSE'd subtree's `type_id` may differ from the surrounding node's
-        // (the matched node had its own type before substitution). Set it
-        // directly on the arena — the engine tracks parent / use-index
-        // coherence on kinds only, so a type-id write is independent.
-        engine.body.exprs[expr].type_id = type_id;
-        engine.replace_expr_kind(
-            expr,
-            ExprKind::Local {
-                index: idx,
-                name: name.to_string(),
-            },
-        );
-        return;
-    }
-    match &engine.body.exprs[expr].kind {
-        ExprKind::Binary { left, right, .. } => {
-            let (left, right) = (*left, *right);
-            replace_in_expr(engine, left, key, idx, name, type_id);
-            replace_in_expr(engine, right, key, idx, name, type_id);
+fn collect_exprs_in_expr(body: &Body, expr: ExprId, out: &mut Vec<ExprId>) {
+    out.push(expr);
+    let mut kids: Vec<NodeRef> = Vec::new();
+    body.for_each_child(NodeRef::Expr(expr), |c| kids.push(c));
+    for c in kids {
+        match c {
+            NodeRef::Expr(e) => collect_exprs_in_expr(body, e, out),
+            NodeRef::Block(b) => collect_exprs_in_block(body, b, out),
+            NodeRef::Stmt(s) => collect_exprs_in_stmt(body, s, out),
+            NodeRef::Pat(_) => {}
         }
-        ExprKind::Unary { expr: inner, .. }
-        | ExprKind::FieldAccess { expr: inner, .. }
-        | ExprKind::Cast { expr: inner, .. } => {
-            let inner = *inner;
-            replace_in_expr(engine, inner, key, idx, name, type_id);
-        }
-        ExprKind::Assign { target, value } => {
-            let (target, value) = (*target, *value);
-            replace_in_expr(engine, target, key, idx, name, type_id);
-            replace_in_expr(engine, value, key, idx, name, type_id);
-        }
-        ExprKind::Call { args, .. } => {
-            let args: Vec<ExprId> = args.iter().map(|a| a.expr).collect();
-            for a in args {
-                replace_in_expr(engine, a, key, idx, name, type_id);
-            }
-        }
-        ExprKind::MethodCall { receiver, args, .. } => {
-            let receiver = *receiver;
-            let args: Vec<ExprId> = args.iter().map(|a| a.expr).collect();
-            replace_in_expr(engine, receiver, key, idx, name, type_id);
-            for a in args {
-                replace_in_expr(engine, a, key, idx, name, type_id);
-            }
-        }
-        ExprKind::If {
-            condition,
-            then_branch,
-            else_branch,
-        } => {
-            let (condition, then_branch, else_branch) = (*condition, *then_branch, *else_branch);
-            replace_in_expr(engine, condition, key, idx, name, type_id);
-            replace_in_block(engine, then_branch, key, idx, name, type_id);
-            if let Some(eb) = else_branch {
-                replace_in_block(engine, eb, key, idx, name, type_id);
-            }
-        }
-        ExprKind::Block(b) | ExprKind::LabeledBlock { block: b, .. } => {
-            let b = *b;
-            replace_in_block(engine, b, key, idx, name, type_id);
-        }
-        ExprKind::Index { expr: inner, index } => {
-            let (inner, index) = (*inner, *index);
-            replace_in_expr(engine, inner, key, idx, name, type_id);
-            replace_in_expr(engine, index, key, idx, name, type_id);
-        }
-        ExprKind::IndirectCall { callee, args } => {
-            let callee = *callee;
-            let args = args.clone();
-            replace_in_expr(engine, callee, key, idx, name, type_id);
-            for a in args {
-                replace_in_expr(engine, a, key, idx, name, type_id);
-            }
-        }
-        ExprKind::StructLiteral { fields, .. } => {
-            let fields: Vec<ExprId> = fields.iter().map(|f| f.value).collect();
-            for f in fields {
-                replace_in_expr(engine, f, key, idx, name, type_id);
-            }
-        }
-        ExprKind::TupleLiteral { elements, .. } => {
-            let elements = elements.clone();
-            for elem in elements {
-                replace_in_expr(engine, elem, key, idx, name, type_id);
-            }
-        }
-        ExprKind::VariantConstruct { payload, .. } => {
-            if let Some(p) = *payload {
-                replace_in_expr(engine, p, key, idx, name, type_id);
-            }
-        }
-        ExprKind::Match { expr: inner, arms } => {
-            let inner = *inner;
-            let mut targets: Vec<ExprId> = Vec::new();
-            for arm in arms {
-                if let Some(guard) = arm.guard {
-                    targets.push(guard);
-                }
-                targets.push(arm.body);
-            }
-            replace_in_expr(engine, inner, key, idx, name, type_id);
-            for t in targets {
-                replace_in_expr(engine, t, key, idx, name, type_id);
-            }
-        }
-        ExprKind::Switch {
-            scrutinee,
-            arms,
-            default,
-            ..
-        } => {
-            let scrutinee = *scrutinee;
-            let arms = arms.clone();
-            let default = *default;
-            replace_in_expr(engine, scrutinee, key, idx, name, type_id);
-            for arm in arms {
-                replace_in_block(engine, arm, key, idx, name, type_id);
-            }
-            replace_in_block(engine, default, key, idx, name, type_id);
-        }
-        ExprKind::GlobalVarSet { value, .. } => {
-            let value = *value;
-            replace_in_expr(engine, value, key, idx, name, type_id);
-        }
-        ExprKind::CmRawCall { args, .. } => {
-            let args = args.clone();
-            for a in args {
-                replace_in_expr(engine, a, key, idx, name, type_id);
-            }
-        }
-        _ => {}
     }
 }

--- a/wado-compiler/src/optimize/cse.rs
+++ b/wado-compiler/src/optimize/cse.rs
@@ -287,12 +287,20 @@ fn replace_matching_in_stmt(
     cse_local_name: &str,
     type_id: TypeId,
 ) {
+    // Snapshot the matching ExprIds *before* any rewrite. The engine's
+    // ValueGraph cache is built lazily and not invalidated by
+    // `replace_expr_kind`, so post-rewrite `engine.value(e)` queries
+    // happen to still return the original VNs today — but relying on that
+    // makes CSE depend on an implementation detail of the cache.
+    // Snapshotting up-front decouples us: this loop is now correct
+    // regardless of any future change to invalidation policy.
     let mut exprs: Vec<ExprId> = Vec::new();
     collect_exprs_in_stmt(engine.body, stmt, &mut exprs);
-    for e in exprs {
-        if engine.value(e) != Some(target) {
-            continue;
-        }
+    let matches: Vec<ExprId> = exprs
+        .into_iter()
+        .filter(|&e| engine.value(e) == Some(target))
+        .collect();
+    for e in matches {
         // The CSE'd subtree's type matches the hoisted local's type; the
         // engine tracks parent / use-index coherence on kinds only, so a
         // direct type-id write is independent of `replace_expr_kind`.

--- a/wado-compiler/src/optimize/gate.rs
+++ b/wado-compiler/src/optimize/gate.rs
@@ -68,11 +68,10 @@ pub enum GatedPass {
     StoreLoadForward,
     TmplHoist,
     ContainerSroa,
-    LabeledBlockFusion,
 }
 
 impl GatedPass {
-    const COUNT: usize = 11;
+    const COUNT: usize = 10;
 }
 
 /// Static call graph over [`FunctionId`]s, built once at loop start.
@@ -254,7 +253,6 @@ mod tests {
             GatedPass::StoreLoadForward,
             GatedPass::TmplHoist,
             GatedPass::ContainerSroa,
-            GatedPass::LabeledBlockFusion,
         ];
         for p in all {
             match p {
@@ -267,8 +265,7 @@ mod tests {
                 | GatedPass::ConditionImplication
                 | GatedPass::StoreLoadForward
                 | GatedPass::TmplHoist
-                | GatedPass::ContainerSroa
-                | GatedPass::LabeledBlockFusion => {}
+                | GatedPass::ContainerSroa => {}
             }
         }
         assert_eq!(all.len(), GatedPass::COUNT);

--- a/wado-compiler/src/optimize/labeled_block_fusion.rs
+++ b/wado-compiler/src/optimize/labeled_block_fusion.rs
@@ -1486,7 +1486,7 @@ fn recurse_block(
 /// Replace `VariantPayload { expr: Local(temp_local), case_index }` with
 /// `Local(payload_local)` throughout a block. Engine-routed so each rewrite
 /// updates the use index (the new Local mention is registered, the old
-/// VariantPayload's children are orphaned but never queried again).
+/// `VariantPayload`'s children are orphaned but never queried again).
 fn subst_variant_payload_in_block(
     engine: &mut Engine,
     block: BlockId,

--- a/wado-compiler/src/optimize/labeled_block_fusion.rs
+++ b/wado-compiler/src/optimize/labeled_block_fusion.rs
@@ -144,9 +144,7 @@ fn node_yields_value(engine: &Engine, node: NodeRef) -> bool {
             StmtKind::Let { .. }
             | StmtKind::LetDestructure { .. }
             | StmtKind::Return { value: Some(_) }
-            | StmtKind::Break {
-                value: Some(_), ..
-            } => true,
+            | StmtKind::Break { value: Some(_), .. } => true,
             StmtKind::Expr(_) => node_yields_value(engine, NodeRef::Stmt(ps)),
             // For a block under a stmt-form `If` (a branch), mirror the
             // standalone driver's Shape::If propagation: the branch yields iff
@@ -1161,9 +1159,8 @@ fn transform_lb_stmt(
             let ExprKind::VariantConstruct { payload, .. } = &engine.body.exprs[v].kind else {
                 unreachable!()
             };
-            let payload_expr = payload.unwrap_or_else(|| {
-                engine.alloc_expr(ExprKind::Unit, payload_type, span)
-            });
+            let payload_expr =
+                payload.unwrap_or_else(|| engine.alloc_expr(ExprKind::Unit, payload_type, span));
 
             // Emit: let __payload = payload_expr;
             let let_stmt = engine.alloc_stmt(
@@ -1851,4 +1848,3 @@ fn expr_has_free_unlabeled_loop_exit(body: &Body, e: ExprId, loop_depth: u32) ->
         _ => false,
     }
 }
-

--- a/wado-compiler/src/optimize/labeled_block_fusion.rs
+++ b/wado-compiler/src/optimize/labeled_block_fusion.rs
@@ -1,8 +1,9 @@
-//! LabeledBlock-IfVariant fusion pass.
+//! LabeledBlock-IfVariant fusion rule.
 //!
-//! This pass detects the pattern produced by inlining `Option<T>`/`Result<T, E>`-returning
-//! functions into if-let call sites, where an intermediate GC allocation is created for the
-//! variant result and then immediately unpacked by a `VariantTest`/`VariantPayload` pair.
+//! Detects the pattern produced by inlining `Option<T>`/`Result<T, E>`-returning
+//! functions into if-let call sites, where an intermediate GC allocation is
+//! created for the variant result and then immediately unpacked by a
+//! `VariantTest`/`VariantPayload` pair (or a two-arm `Match`).
 //!
 //! ## Pattern detected
 //!
@@ -35,324 +36,149 @@
 //! }
 //! ```
 //!
-//! This eliminates the GC-allocated `temp: Option<T>` entirely. Subsequent passes
-//! (copy propagation, DCE) clean up the remaining `break '__fused_L;` bookkeeping.
+//! This eliminates the GC-allocated `temp: Option<T>` entirely. Subsequent
+//! rules (`elide_local`, `copy_prop`, `branch_prune`) clean up the
+//! `break '__fused_L;` bookkeeping.
 //!
-//! The pass reads and mutates the arena [`Body`] directly. Fusion moves the
-//! labeled block's statements (reusing their ids) and deep-clones the THEN/ELSE
-//! blocks into each break site via [`Body::clone_block`].
+//! ## Architecture
+//!
+//! Runs as a [`Rule`] on the unified post-inline peephole session (combine
+//! migration; formerly the standalone `nir/labeled_block_fusion` pass). The
+//! engine seeds every block in post-order, so each `apply_block` only has to
+//! find the first `(let-LB, consumer)` adjacent pair in *this* block; the
+//! worklist's `set_block_stmts` re-enqueue propagates fusion outwards
+//! naturally. All mutations route through the engine edit API so the parent
+//! map and use index stay coherent — `engine.clone_block` for THEN/ELSE
+//! clones, `engine.replace_expr_kind` for the `VariantPayload → Local`
+//! substitution, `engine.alloc_*` for fresh nodes, `engine.set_block_stmts`
+//! for the final block-list commit, and `engine.alloc_local` for the fresh
+//! `__fused_payload_N` slot.
+//!
+//! The pre-inline session does not include this rule — the
+//! `let temp = LB; if VariantTest(temp, …)` shape it matches is exposed by
+//! `inline` copying the helper body into the caller.
 
-use crate::nir::{NirFunction, NirLocal};
-use crate::nir_arena::{
-    BlockId, Body, ExprId, ExprKind, ExprNode, NodeRef, PatKind, StmtId, StmtKind, StmtNode,
-};
-use crate::nir_package::NirPackage;
+use crate::nir::NirLocal;
+use crate::nir_arena::{BlockId, Body, ExprId, ExprKind, NodeRef, PatKind, StmtId, StmtKind};
+use crate::nir_engine::{Engine, Rule};
 use crate::tir::TypeId;
 use crate::token::Span;
 
 use super::arena_query::{has_break_to, is_local};
-use super::gate::{FunctionGate, GatedPass};
-use cranelift_entity::EntityRef;
 
 /// `expr_has_break_to` arena adapter.
 fn expr_has_break_to(body: &Body, label: &str, e: ExprId) -> bool {
     has_break_to(body, NodeRef::Expr(e), label)
 }
 
-pub fn fuse_labeled_blocks(project: &mut NirPackage, gate: &mut FunctionGate) -> bool {
-    let len = project.functions.len();
-    gate.run_gated(GatedPass::LabeledBlockFusion, len, |fid| {
-        let mut func = project.functions[fid.index()].borrow_mut();
-        fuse_in_function(&mut func)
-    })
+/// Block-level fusion rule for the unified post-inline peephole session.
+/// The rule keeps no per-function state: every precondition is re-derived from
+/// the current body on each `apply_block`, since fusion candidates appear and
+/// disappear as neighbouring rewrites land.
+pub(super) struct LabeledBlockFusionRule;
+
+/// Build a [`LabeledBlockFusionRule`] for one function. Mirrors the
+/// `build_ref_elim` / `build_elide_box_local` constructors so the peephole
+/// wiring is uniform; no per-function analysis is needed yet.
+pub(super) fn build_labeled_block_fusion() -> LabeledBlockFusionRule {
+    LabeledBlockFusionRule
 }
 
-fn fuse_in_function(func: &mut NirFunction) -> bool {
-    if func.body.is_none() {
-        return false;
-    }
-    let mut local_count = func.local_count();
-    // The local list is read (binding-type checks) and grown (fused payload
-    // slots), so thread an owned clone and write it back once the body borrow
-    // ends.
-    let mut locals = func.locals.clone();
-    let r = {
-        let body = func.body.as_mut().unwrap();
-        let root = body.root;
-        fuse_in_block(
-            body,
-            root,
-            /* yields_value */ false,
-            &mut local_count,
-            &mut locals,
-        )
-    };
-    func.locals = locals;
-    r
-}
-
-/// `yields_value` is `true` when the value of `block`'s terminal statement is
-/// consumed by the enclosing context (e.g. `let x = { …; if-let-expr }`).
-fn fuse_in_block(
-    body: &mut Body,
-    block: BlockId,
-    yields_value: bool,
-    local_count: &mut u32,
-    locals: &mut Vec<NirLocal>,
-) -> bool {
-    let mut changed = false;
-    let stmts = body.blocks[block].stmts.clone();
-    let last_idx = stmts.len().saturating_sub(1);
-    for (i, s) in stmts.iter().enumerate() {
-        let stmt_yields_value = yields_value && i == last_idx;
-        changed |= fuse_in_stmt(body, *s, stmt_yields_value, local_count, locals);
-    }
-    changed |= fuse_adjacent_pairs(body, block, yields_value, local_count, locals);
-    changed
-}
-
-fn fuse_in_stmt(
-    body: &mut Body,
-    s: StmtId,
-    yields_value: bool,
-    local_count: &mut u32,
-    locals: &mut Vec<NirLocal>,
-) -> bool {
-    enum Shape {
-        Expr(ExprId),
-        If(ExprId, BlockId, Option<BlockId>),
-        Block(BlockId),
-        None,
-    }
-    let shape = match &body.stmts[s].kind {
-        StmtKind::Let { value, .. } | StmtKind::LetDestructure { value, .. } => Shape::Expr(*value),
-        StmtKind::Expr(expr) => Shape::Expr(*expr),
-        StmtKind::If {
-            condition,
-            then_block,
-            else_block,
-        } => Shape::If(*condition, *then_block, *else_block),
-        StmtKind::Loop { body: b } | StmtKind::LabeledBlock { block: b, .. } => Shape::Block(*b),
-        StmtKind::Break { value, .. } | StmtKind::Return { value } => match value {
-            Some(v) => Shape::Expr(*v),
-            None => Shape::None,
-        },
-        StmtKind::Continue => Shape::None,
-    };
-    match shape {
-        Shape::Expr(e) => fuse_in_expr(body, e, local_count, locals),
-        Shape::If(cond, tb, eb) => {
-            let mut changed = fuse_in_expr(body, cond, local_count, locals);
-            changed |= fuse_in_block(body, tb, yields_value, local_count, locals);
-            if let Some(eb) = eb {
-                changed |= fuse_in_block(body, eb, yields_value, local_count, locals);
-            }
-            changed
+impl Rule for LabeledBlockFusionRule {
+    fn apply_block(&self, engine: &mut Engine, block: BlockId) -> bool {
+        let stmts = engine.body.blocks[block].stmts.clone();
+        if stmts.len() < 2 {
+            return false;
         }
-        // Loop / statement-level labeled blocks discard their value.
-        Shape::Block(b) => fuse_in_block(body, b, false, local_count, locals),
-        Shape::None => false,
-    }
-}
-
-/// Check if a labeled block expression is trivially a single `break label: value`
-/// statement; if so, inline the break value, eliminating the labeled block.
-fn try_inline_trivial_labeled_block(body: &mut Body, e: ExprId) -> bool {
-    let (label, block) = match &body.exprs[e].kind {
-        ExprKind::LabeledBlock { label, block, .. } => (label.clone(), *block),
-        _ => return false,
-    };
-    if body.blocks[block].stmts.len() != 1 {
-        return false;
-    }
-    let s0 = body.blocks[block].stmts[0];
-    let break_value = match &body.stmts[s0].kind {
-        StmtKind::Break {
-            label: Some(break_label),
-            value: Some(break_value),
-        } if *break_label == label => *break_value,
-        _ => return false,
-    };
-    // Don't inline if the break value itself contains breaks to the same label.
-    if expr_has_break_to(body, &label, break_value) {
-        return false;
-    }
-    // Replace `e` with the break value's kind, keeping `e`'s own type/span.
-    let bv_kind = body.exprs[break_value].kind.clone();
-    body.exprs[e].kind = bv_kind;
-    true
-}
-
-fn fuse_in_expr(
-    body: &mut Body,
-    e: ExprId,
-    local_count: &mut u32,
-    locals: &mut Vec<NirLocal>,
-) -> bool {
-    enum Shape {
-        LabeledBlock(BlockId),
-        Block(BlockId),
-        If(ExprId, BlockId, Option<BlockId>),
-        Exprs(Vec<ExprId>),
-        None,
-    }
-    let shape = match &body.exprs[e].kind {
-        ExprKind::LabeledBlock { block, .. } => Shape::LabeledBlock(*block),
-        ExprKind::Block(block) => Shape::Block(*block),
-        ExprKind::If {
-            condition,
-            then_branch,
-            else_branch,
-        } => Shape::If(*condition, *then_branch, *else_branch),
-        ExprKind::Binary { left, right, .. }
-        | ExprKind::Assign {
-            target: left,
-            value: right,
-        }
-        | ExprKind::Index {
-            expr: left,
-            index: right,
-        } => Shape::Exprs(vec![*left, *right]),
-        ExprKind::Unary { expr: inner, .. }
-        | ExprKind::Cast { expr: inner, .. }
-        | ExprKind::FieldAccess { expr: inner, .. }
-        | ExprKind::VariantTag { expr: inner }
-        | ExprKind::VariantTest { expr: inner, .. }
-        | ExprKind::VariantPayload { expr: inner, .. }
-        | ExprKind::ClosureToCanonical { functor: inner, .. }
-        | ExprKind::GlobalVarSet { value: inner, .. } => Shape::Exprs(vec![*inner]),
-        ExprKind::Call { args, .. } | ExprKind::MethodCall { args, .. } => {
-            // (MethodCall handled together; receiver added below if present.)
-            let mut v: Vec<ExprId> = args.iter().map(|a| a.expr).collect();
-            if let ExprKind::MethodCall { receiver, .. } = &body.exprs[e].kind {
-                v.insert(0, *receiver);
-            }
-            Shape::Exprs(v)
-        }
-        ExprKind::CmRawCall { args, .. } => Shape::Exprs(args.clone()),
-        ExprKind::IndirectCall { callee, args } => {
-            let mut v = vec![*callee];
-            v.extend(args.iter().copied());
-            Shape::Exprs(v)
-        }
-        ExprKind::StructLiteral { fields, .. } => {
-            Shape::Exprs(fields.iter().map(|f| f.value).collect())
-        }
-        ExprKind::TupleLiteral { elements } | ExprKind::ArrayLiteral { elements } => {
-            Shape::Exprs(elements.clone())
-        }
-        ExprKind::VariantConstruct { payload, .. } => {
-            Shape::Exprs(payload.iter().copied().collect())
-        }
-        ExprKind::Match { expr, arms } => {
-            let mut v = vec![*expr];
-            for arm in arms {
-                v.push(arm.body);
-                if let Some(g) = arm.guard {
-                    v.push(g);
-                }
-            }
-            Shape::Exprs(v)
-        }
-        ExprKind::Switch { .. } => {
-            // Switch arms are blocks; recurse via a dedicated path.
-            Shape::None
-        }
-        _ => Shape::None,
-    };
-    match shape {
-        Shape::LabeledBlock(block) => {
-            let changed = fuse_in_block(
-                body,
-                block,
-                /* yields_value */ true,
-                local_count,
-                locals,
-            );
-            try_inline_trivial_labeled_block(body, e) || changed
-        }
-        Shape::Block(block) => fuse_in_block(body, block, true, local_count, locals),
-        Shape::If(cond, tb, eb) => {
-            let mut changed = fuse_in_expr(body, cond, local_count, locals);
-            changed |= fuse_in_block(body, tb, true, local_count, locals);
-            if let Some(eb) = eb {
-                changed |= fuse_in_block(body, eb, true, local_count, locals);
-            }
-            changed
-        }
-        Shape::Exprs(v) => {
-            let mut changed = false;
-            for id in v {
-                changed |= fuse_in_expr(body, id, local_count, locals);
-            }
-            changed
-        }
-        Shape::None => {
-            // Switch: recurse into scrutinee + arm/default blocks.
-            if let ExprKind::Switch {
-                scrutinee,
-                arms,
-                default,
-                ..
-            } = &body.exprs[e].kind
-            {
-                let scrutinee = *scrutinee;
-                let arms = arms.clone();
-                let default = *default;
-                // Switch is an expression: each arm contributes the value.
-                let mut changed = fuse_in_expr(body, scrutinee, local_count, locals);
-                for a in arms {
-                    changed |= fuse_in_block(body, a, true, local_count, locals);
-                }
-                changed |= fuse_in_block(body, default, true, local_count, locals);
-                changed
-            } else {
-                false
-            }
-        }
-    }
-}
-
-fn fuse_adjacent_pairs(
-    body: &mut Body,
-    block: BlockId,
-    yields_value: bool,
-    local_count: &mut u32,
-    locals: &mut Vec<NirLocal>,
-) -> bool {
-    let stmts = std::mem::take(&mut body.blocks[block].stmts);
-    let mut new_stmts = Vec::with_capacity(stmts.len());
-    let mut changed = false;
-    let mut i = 0;
-    while i < stmts.len() {
-        let let_s = stmts[i];
-        let info = if i + 1 < stmts.len() {
-            check_fusion_preconditions(body, let_s, stmts[i + 1], locals)
-        } else {
-            None
-        };
-        if let Some(info) = info {
-            let if_s = stmts[i + 1];
-            // Refuse to fuse when the If is the last statement of a
-            // value-yielding block (the fused block's breaks carry no value).
-            if yields_value && i + 2 == stmts.len() {
-                new_stmts.push(let_s);
-                new_stmts.push(if_s);
-                i += 2;
+        // The fused block uses value-less `break __fused_L;` to terminate each
+        // arm, so the original consumer site cannot be in a position where its
+        // value is observed. Refusing fusion here matches the standalone pass's
+        // `yields_value && i + 2 == stmts.len()` guard.
+        let yields = block_yields_value(engine, block);
+        for i in 0..stmts.len() - 1 {
+            let Some(info) =
+                check_fusion_preconditions(engine.body, stmts[i], stmts[i + 1], engine.locals())
+            else {
+                continue;
+            };
+            if yields && i + 2 == stmts.len() {
                 continue;
             }
-            let fused = perform_fusion(body, let_s, if_s, info, local_count, locals);
-            new_stmts.extend(fused);
-            changed = true;
-            i += 2;
-        } else {
-            new_stmts.push(let_s);
-            i += 1;
+            perform_fusion(engine, block, &stmts, i, info);
+            return true;
         }
+        false
     }
-    body.blocks[block].stmts = new_stmts;
-    changed
 }
+
+// ---------------------------------------------------------------------------
+// yields-value walker (replaces the standalone pass's recursive flag)
+// ---------------------------------------------------------------------------
+
+/// True iff the tail value of `block` reaches a consumer (a `let` initializer,
+/// a function argument, a returned expression, …). Walks up the parent map; the
+/// chain is bounded by tree depth. Mirrors the `yields_value` flag the
+/// standalone recursive driver threaded through `fuse_in_block`.
+fn block_yields_value(engine: &Engine, block: BlockId) -> bool {
+    node_yields_value(engine, NodeRef::Block(block))
+}
+
+fn node_yields_value(engine: &Engine, node: NodeRef) -> bool {
+    let Some(parent) = engine.parent_of(node) else {
+        return false;
+    };
+    match parent {
+        NodeRef::Expr(pe) => match &engine.body.exprs[pe].kind {
+            // Wrappers / control-flow expressions: yield iff the wrapper
+            // itself is in a value-consuming position.
+            ExprKind::Block(_)
+            | ExprKind::LabeledBlock { .. }
+            | ExprKind::If { .. }
+            | ExprKind::Match { .. }
+            | ExprKind::Switch { .. } => node_yields_value(engine, NodeRef::Expr(pe)),
+            // Any other expression parent (Binary, Call, FieldAccess, …):
+            // this node's value is consumed by the surrounding expression.
+            _ => true,
+        },
+        NodeRef::Stmt(ps) => match &engine.body.stmts[ps].kind {
+            StmtKind::Let { .. }
+            | StmtKind::LetDestructure { .. }
+            | StmtKind::Return { value: Some(_) }
+            | StmtKind::Break {
+                value: Some(_), ..
+            } => true,
+            StmtKind::Expr(_) => node_yields_value(engine, NodeRef::Stmt(ps)),
+            // For a block under a stmt-form `If` (a branch), mirror the
+            // standalone driver's Shape::If propagation: the branch yields iff
+            // the If statement itself yields (tail of a yielding outer block).
+            // For the condition expression, the value is always consumed.
+            StmtKind::If { .. } => match node {
+                NodeRef::Expr(_) => true,
+                NodeRef::Block(_) => node_yields_value(engine, NodeRef::Stmt(ps)),
+                _ => false,
+            },
+            // Stmt-form Loop / LabeledBlock discard their body's value.
+            StmtKind::Loop { .. } | StmtKind::LabeledBlock { .. } => false,
+            StmtKind::Break { value: None, .. }
+            | StmtKind::Return { value: None }
+            | StmtKind::Continue => false,
+        },
+        NodeRef::Block(pb) => {
+            // A stmt under a block yields iff it is the tail AND the block does.
+            let stmts = &engine.body.blocks[pb].stmts;
+            let s_id = match node {
+                NodeRef::Stmt(s) => s,
+                _ => return false,
+            };
+            stmts.last().copied() == Some(s_id) && node_yields_value(engine, NodeRef::Block(pb))
+        }
+        NodeRef::Pat(_) => false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fusion driver
+// ---------------------------------------------------------------------------
 
 /// Information extracted from the two statements during the precondition check.
 struct FusionInfo {
@@ -709,19 +535,14 @@ fn arm_body_has_free_unlabeled_loop_exit(body: &Body, e: ExprId) -> bool {
 }
 
 /// Unwrap a Match arm body to the block it produced, creating a one-stmt block
-/// when the body is not already a `Block`.
-fn arm_body_into_block(body: &mut Body, arm_body: ExprId, fallback_span: Span) -> BlockId {
-    if let ExprKind::Block(block) = &body.exprs[arm_body].kind {
+/// when the body is not already a `Block`. Engine-routed so the new
+/// stmt/block ids are registered in the parent map.
+fn arm_body_into_block(engine: &mut Engine, arm_body: ExprId, fallback_span: Span) -> BlockId {
+    if let ExprKind::Block(block) = &engine.body.exprs[arm_body].kind {
         *block
     } else {
-        let stmt = body.stmts.push(StmtNode {
-            kind: StmtKind::Expr(arm_body),
-            span: fallback_span,
-        });
-        body.blocks.push(crate::nir_arena::BlockNode {
-            stmts: vec![stmt],
-            span: fallback_span,
-        })
+        let stmt = engine.alloc_stmt(StmtKind::Expr(arm_body), fallback_span);
+        engine.alloc_block(vec![stmt], fallback_span)
     }
 }
 
@@ -1165,49 +986,53 @@ fn count_variant_payload_uses_in_expr(
     }
 }
 
-/// Perform the actual fusion transformation, returning the fused statement id(s).
+// ---------------------------------------------------------------------------
+// Fusion (engine-routed)
+// ---------------------------------------------------------------------------
+
 fn perform_fusion(
-    body: &mut Body,
-    let_s: StmtId,
-    if_s: StmtId,
+    engine: &mut Engine,
+    outer_block: BlockId,
+    stmts: &[StmtId],
+    i: usize,
     info: FusionInfo,
-    local_count: &mut u32,
-    locals: &mut Vec<NirLocal>,
-) -> Vec<StmtId> {
-    let span = body.stmts[let_s].span;
+) {
+    let let_s = stmts[i];
+    let if_s = stmts[i + 1];
+    let span = engine.body.stmts[let_s].span;
 
     // Extract the LabeledBlock body from the Let statement.
     let StmtKind::Let {
         value: let_value, ..
-    } = &body.stmts[let_s].kind
+    } = &engine.body.stmts[let_s].kind
     else {
-        unreachable!()
+        unreachable!("guarded by check_fusion_preconditions")
     };
     let ExprKind::LabeledBlock {
         block: lb_block, ..
-    } = &body.exprs[*let_value].kind
+    } = &engine.body.exprs[*let_value].kind
     else {
-        unreachable!()
+        unreachable!("guarded by check_fusion_preconditions")
     };
     let lb_block = *lb_block;
 
     // Extract the then/else blocks from the consumer statement.
-    let (then_block, else_block) = match &body.stmts[if_s].kind {
+    let (then_block, else_block) = match &engine.body.stmts[if_s].kind {
         StmtKind::If {
             then_block,
             else_block,
             ..
         } => (*then_block, *else_block),
         StmtKind::Expr(match_expr) => {
-            let ExprKind::Match { arms, .. } = &body.exprs[*match_expr].kind else {
+            let ExprKind::Match { arms, .. } = &engine.body.exprs[*match_expr].kind else {
                 unreachable!()
             };
             let variant_body = arms[0].body;
             let else_body = arms[1].body;
-            let then_block = arm_body_into_block(body, variant_body, span);
-            let else_block = match &body.exprs[else_body].kind {
+            let then_block = arm_body_into_block(engine, variant_body, span);
+            let else_block = match &engine.body.exprs[else_body].kind {
                 ExprKind::Unit => None,
-                _ => Some(arm_body_into_block(body, else_body, span)),
+                _ => Some(arm_body_into_block(engine, else_body, span)),
             };
             (then_block, else_block)
         }
@@ -1215,25 +1040,27 @@ fn perform_fusion(
     };
 
     // Pick the payload local — reuse the Match arm's pattern binding slot if any,
-    // else allocate a fresh `__fused_payload_N`.
+    // else allocate a fresh `__fused_payload_N` through the engine (so the
+    // function's local list grows coherently).
     let payload_local = if let Some(b_idx) = info.pattern_payload_binding {
         b_idx
     } else {
-        let payload_local = *local_count;
-        *local_count += 1;
-        locals.push(NirLocal {
-            name: format!("__fused_payload_{payload_local}"),
-            type_id: info.payload_type,
-            is_mut: false,
-        });
-        payload_local
+        let next = engine.locals().len() as u32;
+        engine.alloc_local(
+            format!("__fused_payload_{next}"),
+            info.payload_type,
+            /* is_mut */ false,
+        )
     };
 
     let fused_label = format!("__fused_{}", info.label);
 
-    let lb_stmts = std::mem::take(&mut body.blocks[lb_block].stmts);
+    // Reuse the LB block's stmt ids by clearing its list (the LB block becomes
+    // unreachable after `set_block_stmts` on the outer block; freeing the slot
+    // here is a Vec take, not an arena free).
+    let lb_stmts = std::mem::take(&mut engine.body.blocks[lb_block].stmts);
     let fused_stmts = transform_lb_stmts(
-        body,
+        engine,
         lb_stmts,
         &info.label,
         &fused_label,
@@ -1246,23 +1073,26 @@ fn perform_fusion(
         span,
     );
 
-    let fused_body = body.blocks.push(crate::nir_arena::BlockNode {
-        stmts: fused_stmts,
-        span,
-    });
-    let fused_stmt = body.stmts.push(StmtNode {
-        kind: StmtKind::LabeledBlock {
+    let fused_body = engine.alloc_block(fused_stmts, span);
+    let fused_stmt = engine.alloc_stmt(
+        StmtKind::LabeledBlock {
             label: fused_label,
             block: fused_body,
         },
         span,
-    });
-    vec![fused_stmt]
+    );
+
+    // Replace the (let, if/match) pair with the single fused LabeledBlock stmt.
+    let mut kept = Vec::with_capacity(stmts.len() - 1);
+    kept.extend_from_slice(&stmts[..i]);
+    kept.push(fused_stmt);
+    kept.extend_from_slice(&stmts[i + 2..]);
+    engine.set_block_stmts(outer_block, kept);
 }
 
 #[allow(clippy::too_many_arguments)]
 fn transform_lb_stmts(
-    body: &mut Body,
+    engine: &mut Engine,
     stmts: Vec<StmtId>,
     orig_label: &str,
     fused_label: &str,
@@ -1277,7 +1107,7 @@ fn transform_lb_stmts(
     let mut out = Vec::new();
     for s in stmts {
         transform_lb_stmt(
-            body,
+            engine,
             s,
             orig_label,
             fused_label,
@@ -1296,7 +1126,7 @@ fn transform_lb_stmts(
 
 #[allow(clippy::too_many_arguments)]
 fn transform_lb_stmt(
-    body: &mut Body,
+    engine: &mut Engine,
     s: StmtId,
     orig_label: &str,
     fused_label: &str,
@@ -1310,7 +1140,7 @@ fn transform_lb_stmt(
     out: &mut Vec<StmtId>,
 ) {
     // Check for `break orig_label: v` first.
-    let break_value = match &body.stmts[s].kind {
+    let break_value = match &engine.body.stmts[s].kind {
         StmtKind::Break {
             label: Some(l),
             value,
@@ -1320,7 +1150,7 @@ fn transform_lb_stmt(
 
     if let Some(value) = break_value {
         let is_some_case = match value {
-            Some(v) => matches!(&body.exprs[v].kind,
+            Some(v) => matches!(&engine.body.exprs[v].kind,
                 ExprKind::VariantConstruct { case_index: ci, .. } if *ci == case_index),
             None => false,
         };
@@ -1328,20 +1158,16 @@ fn transform_lb_stmt(
         if is_some_case {
             // Extract payload expression from the VariantConstruct.
             let v = value.unwrap();
-            let ExprKind::VariantConstruct { payload, .. } = &body.exprs[v].kind else {
+            let ExprKind::VariantConstruct { payload, .. } = &engine.body.exprs[v].kind else {
                 unreachable!()
             };
             let payload_expr = payload.unwrap_or_else(|| {
-                body.exprs.push(ExprNode {
-                    kind: ExprKind::Unit,
-                    type_id: payload_type,
-                    span,
-                })
+                engine.alloc_expr(ExprKind::Unit, payload_type, span)
             });
 
             // Emit: let __payload = payload_expr;
-            let let_stmt = body.stmts.push(StmtNode {
-                kind: StmtKind::Let {
+            let let_stmt = engine.alloc_stmt(
+                StmtKind::Let {
                     name: format!("__fused_payload_{payload_local}"),
                     local_index: payload_local,
                     is_mut: false,
@@ -1351,35 +1177,44 @@ fn transform_lb_stmt(
                     skip_value_copy: false,
                 },
                 span,
-            });
+            );
             out.push(let_stmt);
 
-            // Emit then_block stmts (a fresh clone) with the variant payload subst.
-            let subst_then = body.clone_block(then_block);
-            subst_variant_payload_in_block(body, subst_then, temp_local, case_index, payload_local);
-            out.extend(body.blocks[subst_then].stmts.clone());
+            // Emit a fresh clone of `then_block`'s stmts, with the
+            // `VariantPayload(temp, case)` subst applied through the engine.
+            let subst_then = engine.clone_block(then_block);
+            subst_variant_payload_in_block(
+                engine,
+                subst_then,
+                temp_local,
+                case_index,
+                payload_local,
+            );
+            let cloned_stmts = engine.body.blocks[subst_then].stmts.clone();
+            out.extend(cloned_stmts);
         } else if let Some(eb) = else_block {
             // None / non-matching case → emit a clone of the else block.
-            let cloned = body.clone_block(eb);
-            out.extend(body.blocks[cloned].stmts.clone());
+            let cloned = engine.clone_block(eb);
+            let cloned_stmts = engine.body.blocks[cloned].stmts.clone();
+            out.extend(cloned_stmts);
         }
 
         // Emit `break fused_label;` unless the last emitted statement already
         // terminates control flow.
         let last_terminates = out.last().is_some_and(|s| {
             matches!(
-                body.stmts[*s].kind,
+                engine.body.stmts[*s].kind,
                 StmtKind::Break { .. } | StmtKind::Return { .. } | StmtKind::Continue
             )
         });
         if !last_terminates {
-            let brk = body.stmts.push(StmtNode {
-                kind: StmtKind::Break {
+            let brk = engine.alloc_stmt(
+                StmtKind::Break {
                     label: Some(fused_label.to_owned()),
                     value: None,
                 },
                 span,
-            });
+            );
             out.push(brk);
         }
         return;
@@ -1390,7 +1225,7 @@ fn transform_lb_stmt(
         Blocks(Vec<BlockId>),
         Other,
     }
-    let shape = match &body.stmts[s].kind {
+    let shape = match &engine.body.stmts[s].kind {
         StmtKind::If {
             then_block: tb,
             else_block: eb,
@@ -1411,9 +1246,9 @@ fn transform_lb_stmt(
     match shape {
         Shape::Blocks(blocks) => {
             for b in blocks {
-                let inner = std::mem::take(&mut body.blocks[b].stmts);
+                let inner = std::mem::take(&mut engine.body.blocks[b].stmts);
                 let transformed = transform_lb_stmts(
-                    body,
+                    engine,
                     inner,
                     orig_label,
                     fused_label,
@@ -1425,13 +1260,13 @@ fn transform_lb_stmt(
                     else_block,
                     span,
                 );
-                body.blocks[b].stmts = transformed;
+                engine.set_block_stmts(b, transformed);
             }
             out.push(s);
         }
         Shape::Other => {
             transform_lb_in_stmt_kind(
-                body,
+                engine,
                 s,
                 orig_label,
                 fused_label,
@@ -1450,7 +1285,7 @@ fn transform_lb_stmt(
 
 #[allow(clippy::too_many_arguments)]
 fn transform_lb_in_stmt_kind(
-    body: &mut Body,
+    engine: &mut Engine,
     s: StmtId,
     orig_label: &str,
     fused_label: &str,
@@ -1462,7 +1297,7 @@ fn transform_lb_in_stmt_kind(
     else_block: Option<BlockId>,
     span: Span,
 ) {
-    let target = match &body.stmts[s].kind {
+    let target = match &engine.body.stmts[s].kind {
         StmtKind::Let { value, .. }
         | StmtKind::LetDestructure { value, .. }
         | StmtKind::Expr(value) => Some(*value),
@@ -1474,7 +1309,7 @@ fn transform_lb_in_stmt_kind(
     };
     if let Some(v) = target {
         transform_lb_in_expr(
-            body,
+            engine,
             v,
             orig_label,
             fused_label,
@@ -1491,7 +1326,7 @@ fn transform_lb_in_stmt_kind(
 
 #[allow(clippy::too_many_arguments)]
 fn transform_lb_in_expr(
-    body: &mut Body,
+    engine: &mut Engine,
     e: ExprId,
     orig_label: &str,
     fused_label: &str,
@@ -1509,7 +1344,7 @@ fn transform_lb_in_expr(
         ExprsAndBlocks(Vec<ExprId>, Vec<BlockId>),
         None,
     }
-    let shape = match &body.exprs[e].kind {
+    let shape = match &engine.body.exprs[e].kind {
         ExprKind::Block(block) => Shape::Block(*block),
         ExprKind::LabeledBlock {
             label: l, block, ..
@@ -1553,11 +1388,10 @@ fn transform_lb_in_expr(
         }
         _ => Shape::None,
     };
-    let recurse_block = |body: &mut Body, b: BlockId| {
-        let inner = std::mem::take(&mut body.blocks[b].stmts);
-        let transformed = transform_lb_stmts(
-            body,
-            inner,
+    match shape {
+        Shape::Block(b) => recurse_block(
+            engine,
+            b,
             orig_label,
             fused_label,
             case_index,
@@ -1567,15 +1401,11 @@ fn transform_lb_in_expr(
             then_block,
             else_block,
             span,
-        );
-        body.blocks[b].stmts = transformed;
-    };
-    match shape {
-        Shape::Block(b) => recurse_block(body, b),
+        ),
         Shape::Exprs(exprs) => {
             for ex in exprs {
                 transform_lb_in_expr(
-                    body,
+                    engine,
                     ex,
                     orig_label,
                     fused_label,
@@ -1592,7 +1422,7 @@ fn transform_lb_in_expr(
         Shape::ExprsAndBlocks(exprs, blocks) => {
             for ex in exprs {
                 transform_lb_in_expr(
-                    body,
+                    engine,
                     ex,
                     orig_label,
                     fused_label,
@@ -1606,29 +1436,74 @@ fn transform_lb_in_expr(
                 );
             }
             for b in blocks {
-                recurse_block(body, b);
+                recurse_block(
+                    engine,
+                    b,
+                    orig_label,
+                    fused_label,
+                    case_index,
+                    temp_local,
+                    payload_local,
+                    payload_type,
+                    then_block,
+                    else_block,
+                    span,
+                );
             }
         }
         Shape::None => {}
     }
 }
 
+#[allow(clippy::too_many_arguments)]
+fn recurse_block(
+    engine: &mut Engine,
+    b: BlockId,
+    orig_label: &str,
+    fused_label: &str,
+    case_index: u32,
+    temp_local: u32,
+    payload_local: u32,
+    payload_type: TypeId,
+    then_block: BlockId,
+    else_block: Option<BlockId>,
+    span: Span,
+) {
+    let inner = std::mem::take(&mut engine.body.blocks[b].stmts);
+    let transformed = transform_lb_stmts(
+        engine,
+        inner,
+        orig_label,
+        fused_label,
+        case_index,
+        temp_local,
+        payload_local,
+        payload_type,
+        then_block,
+        else_block,
+        span,
+    );
+    engine.set_block_stmts(b, transformed);
+}
+
 /// Replace `VariantPayload { expr: Local(temp_local), case_index }` with
-/// `Local(payload_local)` throughout a block.
+/// `Local(payload_local)` throughout a block. Engine-routed so each rewrite
+/// updates the use index (the new Local mention is registered, the old
+/// VariantPayload's children are orphaned but never queried again).
 fn subst_variant_payload_in_block(
-    body: &mut Body,
+    engine: &mut Engine,
     block: BlockId,
     temp_local: u32,
     case_index: u32,
     payload_local: u32,
 ) {
-    for s in body.blocks[block].stmts.clone() {
-        subst_variant_payload_in_stmt(body, s, temp_local, case_index, payload_local);
+    for s in engine.body.blocks[block].stmts.clone() {
+        subst_variant_payload_in_stmt(engine, s, temp_local, case_index, payload_local);
     }
 }
 
 fn subst_variant_payload_in_stmt(
-    body: &mut Body,
+    engine: &mut Engine,
     s: StmtId,
     temp_local: u32,
     case_index: u32,
@@ -1639,7 +1514,7 @@ fn subst_variant_payload_in_stmt(
         ExprAndBlocks(Option<ExprId>, Vec<BlockId>),
         None,
     }
-    let shape = match &body.stmts[s].kind {
+    let shape = match &engine.body.stmts[s].kind {
         StmtKind::Let { value, .. } | StmtKind::LetDestructure { value, .. } => Shape::Expr(*value),
         StmtKind::Expr(expr) => Shape::Expr(*expr),
         StmtKind::Return { value } => match value {
@@ -1668,14 +1543,14 @@ fn subst_variant_payload_in_stmt(
     };
     match shape {
         Shape::Expr(e) => {
-            subst_variant_payload_in_expr(body, e, temp_local, case_index, payload_local);
+            subst_variant_payload_in_expr(engine, e, temp_local, case_index, payload_local);
         }
         Shape::ExprAndBlocks(cond, blocks) => {
             if let Some(c) = cond {
-                subst_variant_payload_in_expr(body, c, temp_local, case_index, payload_local);
+                subst_variant_payload_in_expr(engine, c, temp_local, case_index, payload_local);
             }
             for b in blocks {
-                subst_variant_payload_in_block(body, b, temp_local, case_index, payload_local);
+                subst_variant_payload_in_block(engine, b, temp_local, case_index, payload_local);
             }
         }
         Shape::None => {}
@@ -1683,7 +1558,7 @@ fn subst_variant_payload_in_stmt(
 }
 
 fn subst_variant_payload_in_expr(
-    body: &mut Body,
+    engine: &mut Engine,
     e: ExprId,
     temp_local: u32,
     case_index: u32,
@@ -1694,18 +1569,21 @@ fn subst_variant_payload_in_expr(
         expr: inner,
         case_index: ci,
         ..
-    } = &body.exprs[e].kind
+    } = &engine.body.exprs[e].kind
     {
         *ci == case_index
-            && matches!(&body.exprs[*inner].kind, ExprKind::Local { index, .. } if *index == temp_local)
+            && matches!(&engine.body.exprs[*inner].kind, ExprKind::Local { index, .. } if *index == temp_local)
     } else {
         false
     };
     if is_target {
-        body.exprs[e].kind = ExprKind::Local {
-            index: payload_local,
-            name: format!("__fused_payload_{payload_local}"),
-        };
+        engine.replace_expr_kind(
+            e,
+            ExprKind::Local {
+                index: payload_local,
+                name: format!("__fused_payload_{payload_local}"),
+            },
+        );
         return;
     }
 
@@ -1716,7 +1594,7 @@ fn subst_variant_payload_in_expr(
         Block(BlockId),
         None,
     }
-    let walk = match &body.exprs[e].kind {
+    let walk = match &engine.body.exprs[e].kind {
         ExprKind::Binary { left, right, .. }
         | ExprKind::Assign {
             target: left,
@@ -1792,19 +1670,19 @@ fn subst_variant_payload_in_expr(
     match walk {
         Walk::Exprs(v) => {
             for id in v {
-                subst_variant_payload_in_expr(body, id, temp_local, case_index, payload_local);
+                subst_variant_payload_in_expr(engine, id, temp_local, case_index, payload_local);
             }
         }
         Walk::ExprsAndBlocks(exprs, blocks) => {
             for id in exprs {
-                subst_variant_payload_in_expr(body, id, temp_local, case_index, payload_local);
+                subst_variant_payload_in_expr(engine, id, temp_local, case_index, payload_local);
             }
             for b in blocks {
-                subst_variant_payload_in_block(body, b, temp_local, case_index, payload_local);
+                subst_variant_payload_in_block(engine, b, temp_local, case_index, payload_local);
             }
         }
         Walk::Block(b) => {
-            subst_variant_payload_in_block(body, b, temp_local, case_index, payload_local);
+            subst_variant_payload_in_block(engine, b, temp_local, case_index, payload_local);
         }
         Walk::None => {}
     }
@@ -1973,3 +1851,4 @@ fn expr_has_free_unlabeled_loop_exit(body: &Body, e: ExprId, loop_depth: u32) ->
         _ => false,
     }
 }
+

--- a/wado-compiler/src/optimize/labeled_block_fusion.rs
+++ b/wado-compiler/src/optimize/labeled_block_fusion.rs
@@ -1187,12 +1187,19 @@ fn transform_lb_stmt(
                 case_index,
                 payload_local,
             );
-            let cloned_stmts = engine.body.blocks[subst_then].stmts.clone();
+            // Move the cloned stmts into `out` and empty the source block.
+            // Leaving them parented to `subst_then` AND a new block at the
+            // same time double-claims the stmt ids: the engine still
+            // enqueues `subst_then` for `apply_block`, and downstream
+            // rules (e.g. `const_branch_prune::eliminate_dead_stmts`'s
+            // void-block flatten) see the now-orphaned stmts a second
+            // time, which can erase live work.
+            let cloned_stmts = std::mem::take(&mut engine.body.blocks[subst_then].stmts);
             out.extend(cloned_stmts);
         } else if let Some(eb) = else_block {
             // None / non-matching case → emit a clone of the else block.
             let cloned = engine.clone_block(eb);
-            let cloned_stmts = engine.body.blocks[cloned].stmts.clone();
+            let cloned_stmts = std::mem::take(&mut engine.body.blocks[cloned].stmts);
             out.extend(cloned_stmts);
         }
 

--- a/wado-compiler/src/optimize/licm.rs
+++ b/wado-compiler/src/optimize/licm.rs
@@ -221,8 +221,7 @@ fn licm_block(
         match shape {
             Shape::Loop(lb) => {
                 let empty_set = IndexSet::default();
-                let hoist_stmts =
-                    licm_loop(engine, lb, type_table, &empty_set, outer_aliases);
+                let hoist_stmts = licm_loop(engine, lb, type_table, &empty_set, outer_aliases);
                 if !hoist_stmts.is_empty() {
                     changed = true;
                 }
@@ -323,12 +322,7 @@ fn licm_loop(
             // every iteration). Runs here, after field-hoisting, so the
             // `_licm_*` locals it created are visible as loop-invariant
             // operands.
-            if hoist_invariant_arith(
-                engine,
-                loop_body,
-                &modified_vars,
-                &mut all_hoist_stmts,
-            ) {
+            if hoist_invariant_arith(engine, loop_body, &modified_vars, &mut all_hoist_stmts) {
                 continue;
             }
             break;
@@ -348,11 +342,7 @@ fn licm_loop(
                 }
             };
 
-            let hoist_name = format!(
-                "_licm_{}_{}",
-                candidate.field_name,
-                engine.locals().len()
-            );
+            let hoist_name = format!("_licm_{}_{}", candidate.field_name, engine.locals().len());
             let new_local_index = engine.alloc_local(
                 hoist_name.clone(),
                 candidate.type_id,

--- a/wado-compiler/src/optimize/licm.rs
+++ b/wado-compiler/src/optimize/licm.rs
@@ -4,18 +4,26 @@
 //! It identifies field accesses on variables that don't change within a loop and moves
 //! those accesses before the loop.
 //!
-//! The pass reads and mutates the arena [`Body`] directly. The hoist-candidate
-//! and replacement walks share a `*_child_nodes` enumerator that mirrors the
-//! tree walk's child set exactly (expression and block children, excluding
-//! patterns); `collect_modified_vars` keeps its own walk because it special-
-//! cases assignments, calls, and pattern bindings.
+//! Runs on the worklist rewrite engine (combine migration; see
+//! `docs/wep-2026-06-05-nir-rewrite-engine-design.md`) as a [`Rule`]: a
+//! per-function standalone engine session whose `apply_block` fires once at
+//! the body root and applies LICM to every loop in the function. All
+//! mutations route through the engine edit API (`alloc_expr`, `alloc_stmt`,
+//! `alloc_local`, `clone_expr`, `set_block_stmts`, `replace_expr_kind`) so
+//! the parent map and use index stay coherent.
+//!
+//! The hoist-candidate and replacement walks share a `*_child_nodes`
+//! enumerator that mirrors the tree walk's child set exactly (expression and
+//! block children, excluding patterns); `collect_modified_vars` keeps its own
+//! walk because it special-cases assignments, calls, and pattern bindings.
+
+use std::cell::Cell;
 
 use crate::hashmap::IndexMap;
 use crate::hashmap::IndexSet;
-use crate::nir::{NirFunction, NirLocal, NirUnaryOp};
-use crate::nir_arena::{
-    BlockId, Body, ExprId, ExprKind, ExprNode, PatKind, StmtId, StmtKind, StmtNode,
-};
+use crate::nir::{NirFunction, NirUnaryOp};
+use crate::nir_arena::{BlockId, Body, ExprId, ExprKind, NodeRef, PatKind, StmtId, StmtKind};
+use crate::nir_engine::{Engine, EngineBuffers, Rule};
 use crate::nir_package::NirPackage;
 use crate::tir::{ResolvedType, TypeId, TypeTable};
 use crate::token::Span;
@@ -133,37 +141,42 @@ impl ModifiedVars {
 pub fn apply_licm(project: &mut NirPackage, gate: &mut FunctionGate) -> bool {
     let type_table = project.type_table.borrow();
     let len = project.functions.len();
+    let mut buffers = EngineBuffers::default();
     gate.run_gated(GatedPass::Licm, len, |fid| {
         let mut func = project.functions[fid.index()].borrow_mut();
-        licm_function(&mut func, &type_table)
+        if func.body.is_none() {
+            return false;
+        }
+        let rule = LicmRule {
+            type_table: &type_table,
+            applied: Cell::new(false),
+        };
+        let NirFunction { body, locals, .. } = &mut *func;
+        let body = body.as_mut().expect("checked above");
+        let mut engine = Engine::new(body, &mut buffers, locals);
+        engine.run(&[&rule])
     })
 }
 
-/// Apply LICM to a function
-fn licm_function(func: &mut NirFunction, type_table: &TypeTable) -> bool {
-    if func.body.is_none() {
-        return false;
+/// Standalone-session rule whose single `apply_block` performs the whole-
+/// function LICM walk at the body root.
+pub(super) struct LicmRule<'a> {
+    type_table: &'a TypeTable,
+    applied: Cell<bool>,
+}
+
+impl Rule for LicmRule<'_> {
+    fn apply_block(&self, engine: &mut Engine, block: BlockId) -> bool {
+        if engine.parent_of(NodeRef::Block(block)).is_some() {
+            return false;
+        }
+        if self.applied.replace(true) {
+            return false;
+        }
+        let root = engine.body.root;
+        let mut outer_aliases: Vec<(u32, u32)> = Vec::new();
+        licm_block(engine, root, self.type_table, &mut outer_aliases)
     }
-    let mut local_count = func.local_count();
-    // The local list is read (original local types) *and* grown (hoist locals,
-    // including second-level ones) during the walk, so thread an owned clone and
-    // write it back once the body borrow ends.
-    let mut locals = func.locals.clone();
-    let mut outer_aliases: Vec<(u32, u32)> = Vec::new();
-    let changed = {
-        let body = func.body.as_mut().unwrap();
-        let root = body.root;
-        licm_block(
-            body,
-            root,
-            &mut local_count,
-            &mut locals,
-            type_table,
-            &mut outer_aliases,
-        )
-    };
-    func.locals = locals;
-    changed
 }
 
 /// Apply LICM to all loops in a block.
@@ -174,17 +187,15 @@ fn licm_function(func: &mut NirFunction, type_table: &TypeTable) -> bool {
 /// that a write to one alias inside the loop body invalidates hoist
 /// candidates targeting the other alias.
 fn licm_block(
-    body: &mut Body,
+    engine: &mut Engine,
     block: BlockId,
-    local_count: &mut u32,
-    locals: &mut Vec<NirLocal>,
     type_table: &TypeTable,
     outer_aliases: &mut Vec<(u32, u32)>,
 ) -> bool {
     let mut changed = false;
     let mut new_stmts = Vec::new();
 
-    for s in std::mem::take(&mut body.blocks[block].stmts) {
+    for s in std::mem::take(&mut engine.body.blocks[block].stmts) {
         // Classify without holding the borrow across the mutable recursion.
         enum Shape {
             Loop(BlockId),
@@ -193,7 +204,7 @@ fn licm_block(
             Let(u32, ExprId),
             Other,
         }
-        let shape = match &body.stmts[s].kind {
+        let shape = match &engine.body.stmts[s].kind {
             StmtKind::Loop { body: lb } => Shape::Loop(*lb),
             StmtKind::If {
                 then_block,
@@ -210,15 +221,8 @@ fn licm_block(
         match shape {
             Shape::Loop(lb) => {
                 let empty_set = IndexSet::default();
-                let hoist_stmts = licm_loop(
-                    body,
-                    lb,
-                    local_count,
-                    locals,
-                    type_table,
-                    &empty_set,
-                    outer_aliases,
-                );
+                let hoist_stmts =
+                    licm_loop(engine, lb, type_table, &empty_set, outer_aliases);
                 if !hoist_stmts.is_empty() {
                     changed = true;
                 }
@@ -229,20 +233,20 @@ fn licm_block(
                 // Sharing the alias accumulator across sibling branches is safe:
                 // aliasing is monotone-correct (extra aliases only cause
                 // conservative misses, never wrong hoists).
-                changed |= licm_block(body, then_b, local_count, locals, type_table, outer_aliases);
+                changed |= licm_block(engine, then_b, type_table, outer_aliases);
                 if let Some(eb) = else_b {
-                    changed |= licm_block(body, eb, local_count, locals, type_table, outer_aliases);
+                    changed |= licm_block(engine, eb, type_table, outer_aliases);
                 }
                 new_stmts.push(s);
             }
             Shape::Labeled(inner) => {
-                changed |= licm_block(body, inner, local_count, locals, type_table, outer_aliases);
+                changed |= licm_block(engine, inner, type_table, outer_aliases);
                 new_stmts.push(s);
             }
             Shape::Let(local_index, value) => {
                 // Track outer-scope aliases so a subsequent loop's LICM can see them.
-                if let Some(src_idx) = extract_alias_source(body, value)
-                    && is_gc_heap_type(body.exprs[value].type_id, type_table)
+                if let Some(src_idx) = extract_alias_source(engine.body, value)
+                    && is_gc_heap_type(engine.body.exprs[value].type_id, type_table)
                 {
                     outer_aliases.push((local_index, src_idx));
                 }
@@ -254,16 +258,14 @@ fn licm_block(
         }
     }
 
-    body.blocks[block].stmts = new_stmts;
+    engine.set_block_stmts(block, new_stmts);
     changed
 }
 
 /// Apply LICM to a single loop, returning hoisting statement ids to prepend.
 fn licm_loop(
-    body: &mut Body,
+    engine: &mut Engine,
     loop_body: BlockId,
-    local_count: &mut u32,
-    locals: &mut Vec<NirLocal>,
     type_table: &TypeTable,
     extra_modified: &IndexSet<u32>,
     outer_aliases: &[(u32, u32)],
@@ -280,17 +282,20 @@ fn licm_loop(
         for &(a, b) in outer_aliases {
             modified_vars.add_alias(a, b);
         }
-        collect_modified_vars_in_block(body, loop_body, &mut modified_vars, type_table);
+        collect_modified_vars_in_block(engine.body, loop_body, &mut modified_vars, type_table);
 
         // Step 2: Collect immutable reference bindings for look-through.
-        let ref_bindings = collect_immutable_ref_bindings(body, loop_body, type_table);
+        let ref_bindings = collect_immutable_ref_bindings(engine.body, loop_body, type_table);
 
-        // Step 3: Find field accesses that can be hoisted.
+        // Step 3: Find field accesses that can be hoisted. `next_local` is a
+        // local placeholder counter that `find_hoist_candidates_in_block`
+        // increments to dedup candidates by (local, field); the actual local
+        // indices are assigned at allocation time in step 4.
         let mut candidates = Vec::new();
         let mut seen = IndexSet::default();
-        let mut next_local = *local_count;
+        let mut next_local = engine.locals().len() as u32;
         find_hoist_candidates_in_block(
-            body,
+            engine.body,
             loop_body,
             &modified_vars,
             &ref_bindings,
@@ -302,6 +307,7 @@ fn licm_loop(
         // Step 3.5: Drop `x.f` candidates where `x` is a reference and that
         // pointee field is written elsewhere in the loop.
         candidates.retain(|c| {
+            let locals = engine.locals();
             let root_ty = if (c.local_index as usize) < locals.len() {
                 locals[c.local_index as usize].type_id
             } else {
@@ -318,11 +324,9 @@ fn licm_loop(
             // `_licm_*` locals it created are visible as loop-invariant
             // operands.
             if hoist_invariant_arith(
-                body,
+                engine,
                 loop_body,
                 &modified_vars,
-                local_count,
-                locals,
                 &mut all_hoist_stmts,
             ) {
                 continue;
@@ -330,83 +334,73 @@ fn licm_loop(
             break;
         }
 
-        // Renumber the surviving hoist locals contiguously from `*local_count`.
-        next_local = *local_count;
+        // Step 4: Create hoisting statements. Each candidate gets its actual
+        // `new_local_index` from `engine.alloc_local` (which also pushes the
+        // `NirLocal` entry), so the surviving hoist locals are contiguous
+        // from the function's current local count.
         for candidate in &mut candidates {
-            candidate.new_local_index = next_local;
-            next_local += 1;
-        }
-
-        // Step 4: Create hoisting statements.
-        for candidate in &candidates {
-            let local_type_id = if (candidate.local_index as usize) < locals.len() {
-                locals[candidate.local_index as usize].type_id
-            } else {
-                candidate.type_id
+            let local_type_id = {
+                let locals = engine.locals();
+                if (candidate.local_index as usize) < locals.len() {
+                    locals[candidate.local_index as usize].type_id
+                } else {
+                    candidate.type_id
+                }
             };
 
-            // Build `local.field` as fresh arena nodes.
-            let local_expr = body.exprs.push(ExprNode {
-                kind: ExprKind::Local {
+            let hoist_name = format!(
+                "_licm_{}_{}",
+                candidate.field_name,
+                engine.locals().len()
+            );
+            let new_local_index = engine.alloc_local(
+                hoist_name.clone(),
+                candidate.type_id,
+                /* is_mut */ false,
+            );
+            candidate.new_local_index = new_local_index;
+
+            // Build `local.field` as fresh arena nodes via the engine.
+            let local_expr = engine.alloc_expr(
+                ExprKind::Local {
                     index: candidate.local_index,
                     name: candidate.local_name.clone(),
                 },
-                type_id: local_type_id,
-                span: Span::new(0, 0, 0, 0),
-            });
-            let field_access_expr = body.exprs.push(ExprNode {
-                kind: ExprKind::FieldAccess {
+                local_type_id,
+                Span::new(0, 0, 0, 0),
+            );
+            let field_access_expr = engine.alloc_expr(
+                ExprKind::FieldAccess {
                     expr: local_expr,
                     field_index: candidate.field_index,
                     field_name: candidate.field_name.clone(),
                 },
-                type_id: candidate.type_id,
-                span: Span::new(0, 0, 0, 0),
-            });
-
-            let hoist_name = format!(
-                "_licm_{}_{}",
-                candidate.field_name, candidate.new_local_index
+                candidate.type_id,
+                Span::new(0, 0, 0, 0),
             );
-            let hoist_stmt = body.stmts.push(StmtNode {
-                kind: StmtKind::Let {
-                    name: hoist_name.clone(),
-                    local_index: candidate.new_local_index,
+            let hoist_stmt = engine.alloc_stmt(
+                StmtKind::Let {
+                    name: hoist_name,
+                    local_index: new_local_index,
                     is_mut: false,
                     is_reactive: false,
                     type_id: candidate.type_id,
                     value: field_access_expr,
                     skip_value_copy: true,
                 },
-                span: Span::new(0, 0, 0, 0),
-            });
+                Span::new(0, 0, 0, 0),
+            );
             all_hoist_stmts.push(hoist_stmt);
-
-            // Add the local entry mirroring the let above.
-            locals.push(NirLocal {
-                name: hoist_name,
-                type_id: candidate.type_id,
-                is_mut: false,
-            });
         }
 
-        *local_count = next_local;
-
         // Step 5: Replace field accesses in the loop body with the hoisted locals.
-        replace_hoisted_in_block(body, loop_body, &candidates, &ref_bindings);
+        replace_hoisted_in_block(engine, loop_body, &candidates, &ref_bindings);
     }
 
     // Nested loops: recurse. The nested `licm_block` accumulates aliases from
     // the outer loop's `let` statements on its own walk.
     let mut nested_aliases: Vec<(u32, u32)> = outer_aliases.to_vec();
-    licm_block(
-        body,
-        loop_body,
-        local_count,
-        locals,
-        type_table,
-        &mut nested_aliases,
-    );
+    licm_block(engine, loop_body, type_table, &mut nested_aliases);
 
     all_hoist_stmts
 }
@@ -1420,15 +1414,13 @@ fn collect_invariant_arith_in_expr(
 /// Returns whether anything was hoisted. The pre-header `let`s are appended
 /// to `all_hoist_stmts` (prepended before the loop by the caller).
 fn hoist_invariant_arith(
-    body: &mut Body,
+    engine: &mut Engine,
     loop_body: BlockId,
     modified: &ModifiedVars,
-    local_count: &mut u32,
-    locals: &mut Vec<NirLocal>,
     all_hoist_stmts: &mut Vec<StmtId>,
 ) -> bool {
     let mut found = Vec::new();
-    collect_invariant_arith_in_block(body, loop_body, modified, &mut found);
+    collect_invariant_arith_in_block(engine.body, loop_body, modified, &mut found);
     if found.is_empty() {
         return false;
     }
@@ -1437,7 +1429,7 @@ fn hoist_invariant_arith(
     let mut groups: Vec<Vec<ExprId>> = Vec::new();
     'next: for e in found {
         for g in &mut groups {
-            if arith_exprs_equal(body, g[0], e) {
+            if arith_exprs_equal(engine.body, g[0], e) {
                 g.push(e);
                 continue 'next;
             }
@@ -1447,16 +1439,15 @@ fn hoist_invariant_arith(
 
     for occ in groups {
         let rep = occ[0];
-        let type_id = body.exprs[rep].type_id;
-        let new_idx = *local_count;
-        *local_count += 1;
-        let name = format!("_licm_arith_{new_idx}");
+        let type_id = engine.body.exprs[rep].type_id;
+        let name = format!("_licm_arith_{}", engine.locals().len());
+        let new_idx = engine.alloc_local(name.clone(), type_id, /* is_mut */ false);
 
         // Clone the representative into the pre-header `let` *before* rewriting
         // the in-loop occurrences (which include `rep` itself) to a `Local`.
-        let value = body.clone_expr(rep);
-        let let_stmt = body.stmts.push(StmtNode {
-            kind: StmtKind::Let {
+        let value = engine.clone_expr(rep);
+        let let_stmt = engine.alloc_stmt(
+            StmtKind::Let {
                 name: name.clone(),
                 local_index: new_idx,
                 is_mut: false,
@@ -1465,20 +1456,18 @@ fn hoist_invariant_arith(
                 value,
                 skip_value_copy: true,
             },
-            span: Span::new(0, 0, 0, 0),
-        });
+            Span::new(0, 0, 0, 0),
+        );
         all_hoist_stmts.push(let_stmt);
-        locals.push(NirLocal {
-            name: name.clone(),
-            type_id,
-            is_mut: false,
-        });
 
         for o in occ {
-            body.exprs[o].kind = ExprKind::Local {
-                index: new_idx,
-                name: name.clone(),
-            };
+            engine.replace_expr_kind(
+                o,
+                ExprKind::Local {
+                    index: new_idx,
+                    name: name.clone(),
+                },
+            );
         }
     }
 
@@ -1490,32 +1479,32 @@ fn hoist_invariant_arith(
 // ---------------------------------------------------------------------------
 
 fn replace_hoisted_in_block(
-    body: &mut Body,
+    engine: &mut Engine,
     block: BlockId,
     candidates: &[HoistCandidate],
     ref_bindings: &IndexMap<u32, LicmRefBinding>,
 ) {
-    for s in body.blocks[block].stmts.clone() {
-        replace_hoisted_in_stmt(body, s, candidates, ref_bindings);
+    for s in engine.body.blocks[block].stmts.clone() {
+        replace_hoisted_in_stmt(engine, s, candidates, ref_bindings);
     }
 }
 
 fn replace_hoisted_in_stmt(
-    body: &mut Body,
+    engine: &mut Engine,
     s: StmtId,
     candidates: &[HoistCandidate],
     ref_bindings: &IndexMap<u32, LicmRefBinding>,
 ) {
-    for child in stmt_child_nodes(body, s) {
+    for child in stmt_child_nodes(engine.body, s) {
         match child {
-            Child::Expr(e) => replace_hoisted_in_expr(body, e, candidates, ref_bindings),
-            Child::Block(b) => replace_hoisted_in_block(body, b, candidates, ref_bindings),
+            Child::Expr(e) => replace_hoisted_in_expr(engine, e, candidates, ref_bindings),
+            Child::Block(b) => replace_hoisted_in_block(engine, b, candidates, ref_bindings),
         }
     }
 }
 
 fn replace_hoisted_in_expr(
-    body: &mut Body,
+    engine: &mut Engine,
     e: ExprId,
     candidates: &[HoistCandidate],
     ref_bindings: &IndexMap<u32, LicmRefBinding>,
@@ -1525,8 +1514,8 @@ fn replace_hoisted_in_expr(
         expr: inner,
         field_index,
         ..
-    } = &body.exprs[e].kind
-        && let ExprKind::Local { index, .. } = &body.exprs[*inner].kind
+    } = &engine.body.exprs[e].kind
+        && let ExprKind::Local { index, .. } = &engine.body.exprs[*inner].kind
     {
         let index = *index;
         let field_index = *field_index;
@@ -1549,18 +1538,21 @@ fn replace_hoisted_in_expr(
         None
     };
     if let Some((new_local_index, field_name)) = matched {
-        body.exprs[e].kind = ExprKind::Local {
-            index: new_local_index,
-            name: format!("_licm_{field_name}_{new_local_index}"),
-        };
+        engine.replace_expr_kind(
+            e,
+            ExprKind::Local {
+                index: new_local_index,
+                name: format!("_licm_{field_name}_{new_local_index}"),
+            },
+        );
         return;
     }
 
     // Recurse into sub-expressions / sub-blocks.
-    for child in expr_child_nodes(body, e) {
+    for child in expr_child_nodes(engine.body, e) {
         match child {
-            Child::Expr(c) => replace_hoisted_in_expr(body, c, candidates, ref_bindings),
-            Child::Block(b) => replace_hoisted_in_block(body, b, candidates, ref_bindings),
+            Child::Expr(c) => replace_hoisted_in_expr(engine, c, candidates, ref_bindings),
+            Child::Block(b) => replace_hoisted_in_block(engine, b, candidates, ref_bindings),
         }
     }
 }

--- a/wado-compiler/src/optimize/peephole.rs
+++ b/wado-compiler/src/optimize/peephole.rs
@@ -32,9 +32,12 @@
 //! (where `ValueCopyElideRule` runs in the same session, so `string_push` sees
 //! the value-copy-stripped receiver via the shared worklist; `value_copy_demote`
 //! then runs after) and after `inline` (so `array_literal` sees the exposed
-//! `array_new + push` window). `array_literal` no-ops in the first run and
-//! `string_push` no-ops in the second; both bail immediately on a non-matching
-//! node, so the wasted dispatch is negligible.
+//! `array_new + push` window, `RefElimRule` cleans up the ref bindings
+//! inlining exposes, `ElideBoxLocalRule` collapses the `Box<T>` shells, and
+//! `LabeledBlockFusionRule` folds inlined `Option`/`Result` allocations into
+//! the consumer's `if-let`/`match` site). `array_literal` no-ops in the first
+//! run and `string_push` no-ops in the second; both bail immediately on a
+//! non-matching node, so the wasted dispatch is negligible.
 
 use cranelift_entity::EntityRef;
 
@@ -48,6 +51,7 @@ use super::const_folding::{ConstFoldRule, build_callee_map};
 use super::elide_box_local::build_elide_box_local;
 use super::elide_local::ElideRule;
 use super::gate::{FunctionGate, GatedPass};
+use super::labeled_block_fusion::build_labeled_block_fusion;
 use super::match_to_switch::MatchToSwitchRule;
 use super::ref_elim::build_ref_elim;
 use super::string_push::{ShortPushStrRule, resolve_ctx};
@@ -120,13 +124,20 @@ pub(super) fn run_peephole(
                     .map(|b| build_elide_box_local(b, &func.address_taken_locals, &stores_aliased))
             })
             .flatten();
+        // Labeled-block fusion runs post-inline only: the `let temp = LB { ...;
+        // break L: Some(v); }; if VariantTest(temp, …)` shape it folds is what
+        // `inline` exposes when an `Option`/`Result`-returning helper is copied
+        // into an if-let caller. The rule allocates fresh `__fused_payload_N`
+        // locals via the engine, so it sits next to the other block-level
+        // rules.
+        let labeled_block_fusion_rule = (!pre_inline).then(build_labeled_block_fusion);
         // Disjoint borrow of the body arena and the local list so rules can
         // both rewrite the body and allocate fresh locals via the engine.
         let NirFunction { body, locals, .. } = &mut *func;
         let Some(body) = body.as_mut() else {
             return false;
         };
-        let mut rules: Vec<&dyn Rule> = Vec::with_capacity(9);
+        let mut rules: Vec<&dyn Rule> = Vec::with_capacity(10);
         if pre_inline {
             rules.push(&match_rule);
         }
@@ -138,6 +149,9 @@ pub(super) fn run_peephole(
         }
         if let Some(elide_box_rule) = elide_box_rule.as_ref() {
             rules.push(elide_box_rule);
+        }
+        if let Some(labeled_block_fusion_rule) = labeled_block_fusion_rule.as_ref() {
+            rules.push(labeled_block_fusion_rule);
         }
         rules.extend([
             &array_rule as &dyn Rule,

--- a/wado-compiler/src/optimize/sroa.rs
+++ b/wado-compiler/src/optimize/sroa.rs
@@ -205,10 +205,7 @@ fn sroa_at_root(engine: &mut Engine, rule: &SroaRule) -> bool {
             let new_name = format!("__sroa_{}_{}", candidate.local_name, field_name);
             let new_index = engine.alloc_local(new_name.clone(), *field_type, candidate.is_mut);
             field_local_map.insert((candidate.local_index, i as u32), new_index);
-            field_info_map.insert(
-                (candidate.local_index, i as u32),
-                (new_name, *field_type),
-            );
+            field_info_map.insert((candidate.local_index, i as u32), (new_name, *field_type));
         }
     }
 
@@ -915,7 +912,9 @@ fn rewrite_expr(engine: &mut Engine, id: ExprId, ctx: &Rewrite) {
     }
 
     let mut kids = Vec::new();
-    engine.body.for_each_child(NodeRef::Expr(id), |c| kids.push(c));
+    engine
+        .body
+        .for_each_child(NodeRef::Expr(id), |c| kids.push(c));
     for c in kids {
         rewrite_node(engine, c, ctx);
     }

--- a/wado-compiler/src/optimize/sroa.rs
+++ b/wado-compiler/src/optimize/sroa.rs
@@ -20,22 +20,30 @@
 //!
 //! Copy propagation then eliminates the trivial copies.
 //!
-//! Ported off the `Body ↔ tree` bridge (Phase 4 stage C; see
-//! `docs/wep-2026-06-05-nir-rewrite-engine-design.md`): candidate collection,
-//! escape analysis, and the decomposition rewrite read and mutate the arena
-//! `Body` directly. New scalar locals are pushed to `func.locals` (reached via
-//! disjoint-field access from `func.body`).
+//! Runs on the worklist rewrite engine (combine migration; see
+//! `docs/wep-2026-06-05-nir-rewrite-engine-design.md`) as a [`Rule`]: a
+//! per-function standalone engine session whose `apply_block` fires once at
+//! the function root and performs the whole-function decomposition in one
+//! shot. The analysis phases (candidate collection, escape / soft-escape) read
+//! `engine.body` directly; the rewrite routes every mutation through the
+//! engine edit API (`set_block_stmts`, `replace_expr_kind`, `alloc_stmt`,
+//! `alloc_expr`, `alloc_local`) so the parent map and use index stay
+//! coherent. Locals discovered to be `&local`-aliased by a decomposed field
+//! flow back into `func.stores_aliased_locals` via a `RefCell` the driver
+//! merges after `engine.run` returns.
+
+use std::cell::{Cell, RefCell};
 
 use cranelift_entity::EntityRef;
 
 use super::gate::{FunctionGate, GatedPass};
 use crate::hashmap::{IndexMap, IndexSet};
 use crate::module_source::ModuleSource;
-use crate::nir::{FunctionRef, NirFunction, NirLocal};
+use crate::nir::{FunctionRef, NirFunction};
 use crate::nir_arena::{
-    ArenaStructField, BlockId, Body, ExprId, ExprKind, ExprNode, NodeRef, StmtId, StmtKind,
-    StmtNode,
+    ArenaStructField, BlockId, Body, ExprId, ExprKind, NodeRef, StmtId, StmtKind,
 };
+use crate::nir_engine::{Engine, EngineBuffers, Rule};
 use crate::nir_package::NirPackage;
 use crate::tir::TypeId;
 use crate::token::Span;
@@ -82,43 +90,91 @@ fn build_stores_lookup(project: &NirPackage) -> StoresLookup {
 pub fn scalar_replace_aggregates(project: &mut NirPackage, gate: &mut FunctionGate) -> bool {
     let stores_lookup = build_stores_lookup(project);
     let len = project.functions.len();
+    let mut buffers = EngineBuffers::default();
     gate.run_gated(GatedPass::Sroa, len, |fid| {
         let mut func = project.functions[fid.index()].borrow_mut();
+        if func.body.is_none() {
+            return false;
+        }
         let module_source = func.module_source.clone();
-        sroa_in_function(&mut func, &stores_lookup, &module_source)
+        let stores_aliased_snapshot = func.stores_aliased_locals.clone();
+        let rule = SroaRule {
+            stores_lookup: &stores_lookup,
+            current_module: module_source,
+            stores_aliased: stores_aliased_snapshot,
+            newly_aliased: RefCell::new(IndexSet::default()),
+            applied: Cell::new(false),
+        };
+        let changed = {
+            let NirFunction { body, locals, .. } = &mut *func;
+            let body = body.as_mut().expect("checked above");
+            let mut engine = Engine::new(body, &mut buffers, locals);
+            engine.run(&[&rule])
+        };
+        let newly = rule.newly_aliased.into_inner();
+        if !newly.is_empty() {
+            func.stores_aliased_locals.extend(newly);
+        }
+        changed
     })
 }
 
-fn sroa_in_function(
-    func: &mut NirFunction,
-    stores_lookup: &StoresLookup,
-    current_module: &ModuleSource,
-) -> bool {
-    if func.body.is_none() {
-        return false;
-    }
+// -----------------------------------------------------------------------
+// Rule
+// -----------------------------------------------------------------------
 
+/// Standalone-session rule whose single `apply_block` performs the whole-
+/// function SROA at the body root.
+pub(super) struct SroaRule<'a> {
+    stores_lookup: &'a StoresLookup,
+    current_module: ModuleSource,
+    /// Snapshot of `func.stores_aliased_locals` at session start. Used as a
+    /// blacklist when picking candidates so a local that the existing alias
+    /// analysis already flagged is never decomposed.
+    stores_aliased: IndexSet<u32>,
+    /// Locals discovered to be aliased by a decomposed candidate's `&local`
+    /// field value (step 3b). Merged into `func.stores_aliased_locals` by the
+    /// driver after the engine session ends.
+    newly_aliased: RefCell<IndexSet<u32>>,
+    /// Whole-function rewrite: only run once per session. The engine's
+    /// re-try-after-success loop and any block re-enqueue triggered by edits
+    /// could otherwise call `apply_block` at the root again.
+    applied: Cell<bool>,
+}
+
+impl Rule for SroaRule<'_> {
+    fn apply_block(&self, engine: &mut Engine, block: BlockId) -> bool {
+        if engine.parent_of(NodeRef::Block(block)).is_some() {
+            return false;
+        }
+        if self.applied.replace(true) {
+            return false;
+        }
+        sroa_at_root(engine, self)
+    }
+}
+
+fn sroa_at_root(engine: &mut Engine, rule: &SroaRule) -> bool {
     // Step 1: identify candidate Let bindings (struct/tuple literals).
-    let candidates = collect_candidates(func.body.as_ref().unwrap());
+    let candidates = collect_candidates(engine.body);
     if candidates.is_empty() {
         return false;
     }
 
     // Step 2: escape analysis.
-    let body_ref = func.body.as_ref().unwrap();
-    let escaped = find_escaped_locals(body_ref, &candidates);
+    let escaped = find_escaped_locals(engine.body, &candidates);
     let soft_escaped = find_soft_escaped_locals(
-        body_ref,
+        engine.body,
         &candidates,
         &escaped,
-        stores_lookup,
-        current_module,
+        rule.stores_lookup,
+        &rule.current_module,
     );
 
     let mut safe_set: IndexSet<u32> = IndexSet::default();
     let mut reconstruct_set: IndexSet<u32> = IndexSet::default();
     for c in &candidates {
-        if func.stores_aliased_locals.contains(&c.local_index) {
+        if rule.stores_aliased.contains(&c.local_index) {
             continue;
         }
         if !escaped.contains(&c.local_index) {
@@ -137,27 +193,22 @@ fn sroa_in_function(
         return false;
     }
 
-    // Step 3: allocate scalar locals for each field of each SROA'd candidate.
+    // Step 3: allocate scalar locals for each field of each SROA'd candidate,
+    // through the engine so the locals list grows coherently.
     let mut field_local_map: IndexMap<(u32, u32), u32> = IndexMap::default();
     let mut field_info_map: IndexMap<(u32, u32), (String, TypeId)> = IndexMap::default();
     for candidate in &candidates {
         if !all_sroa.contains(&candidate.local_index) {
             continue;
         }
-        let base = func.local_count();
         for (i, (field_name, field_type)) in candidate.fields.iter().enumerate() {
-            let new_index = base + i as u32;
-            field_local_map.insert((candidate.local_index, i as u32), new_index);
             let new_name = format!("__sroa_{}_{}", candidate.local_name, field_name);
+            let new_index = engine.alloc_local(new_name.clone(), *field_type, candidate.is_mut);
+            field_local_map.insert((candidate.local_index, i as u32), new_index);
             field_info_map.insert(
                 (candidate.local_index, i as u32),
-                (new_name.clone(), *field_type),
+                (new_name, *field_type),
             );
-            func.locals.push(NirLocal {
-                name: new_name,
-                type_id: *field_type,
-                is_mut: candidate.is_mut,
-            });
         }
     }
 
@@ -181,11 +232,12 @@ fn sroa_in_function(
     }
 
     // Step 3b: mark locals referenced via &local in decomposed struct fields.
+    // The delta is collected here and merged into `func.stores_aliased_locals`
+    // by the driver after the session closes (rules can't touch
+    // function-scope fields directly).
     {
-        let body = func.body.as_ref().unwrap();
-        let mut newly_aliased: IndexSet<u32> = IndexSet::default();
-        mark_ref_field_locals_as_aliased(body, body.root, &all_sroa, &mut newly_aliased);
-        func.stores_aliased_locals.extend(newly_aliased);
+        let mut newly = rule.newly_aliased.borrow_mut();
+        mark_ref_field_locals_as_aliased(engine.body, engine.body.root, &all_sroa, &mut newly);
     }
 
     // Step 4: rewrite — expand candidate Lets and replace field accesses.
@@ -196,9 +248,8 @@ fn sroa_in_function(
         candidate_mut: &candidate_mut,
         reconstruct_info: &reconstruct_info,
     };
-    let body = func.body.as_mut().unwrap();
-    let root = body.root;
-    rewrite_block(body, root, &ctx);
+    let root = engine.body.root;
+    rewrite_block(engine, root, &ctx);
 
     true
 }
@@ -750,7 +801,7 @@ fn callee_stores_param_at(
 }
 
 // -----------------------------------------------------------------------
-// Rewrite
+// Rewrite (engine-routed)
 // -----------------------------------------------------------------------
 
 struct Rewrite<'a> {
@@ -761,87 +812,93 @@ struct Rewrite<'a> {
     reconstruct_info: &'a IndexMap<u32, ReconstructInfo>,
 }
 
-fn rewrite_block(body: &mut Body, block: BlockId, ctx: &Rewrite) {
-    let old_stmts = body.blocks[block].stmts.clone();
+fn rewrite_block(engine: &mut Engine, block: BlockId, ctx: &Rewrite) {
+    let old_stmts = engine.body.blocks[block].stmts.clone();
     let mut new_stmts: Vec<StmtId> = Vec::with_capacity(old_stmts.len());
     for stmt in old_stmts {
-        let candidate = match &body.stmts[stmt].kind {
+        let candidate = match &engine.body.stmts[stmt].kind {
             StmtKind::Let { local_index, .. } if ctx.safe_set.contains(local_index) => {
                 Some(*local_index)
             }
             _ => None,
         };
         if let Some(local_idx) = candidate {
-            let span = body.stmts[stmt].span;
+            let span = engine.body.stmts[stmt].span;
             let is_mut = ctx.candidate_mut.get(&local_idx).copied().unwrap_or(false);
-            let StmtKind::Let { value, .. } = &body.stmts[stmt].kind else {
+            let StmtKind::Let { value, .. } = &engine.body.stmts[stmt].kind else {
                 unreachable!("candidate must be Let statement");
             };
             let value = *value;
-            expand_struct_let(body, value, local_idx, is_mut, span, ctx, &mut new_stmts);
+            expand_struct_let(engine, value, local_idx, is_mut, span, ctx, &mut new_stmts);
             continue;
         }
-        rewrite_node(body, NodeRef::Stmt(stmt), ctx);
+        rewrite_node(engine, NodeRef::Stmt(stmt), ctx);
         new_stmts.push(stmt);
     }
-    body.blocks[block].stmts = new_stmts;
+    engine.set_block_stmts(block, new_stmts);
 }
 
-fn rewrite_node(body: &mut Body, node: NodeRef, ctx: &Rewrite) {
+fn rewrite_node(engine: &mut Engine, node: NodeRef, ctx: &Rewrite) {
     match node {
-        NodeRef::Expr(id) => rewrite_expr(body, id, ctx),
-        NodeRef::Block(b) => rewrite_block(body, b, ctx),
+        NodeRef::Expr(id) => rewrite_expr(engine, id, ctx),
+        NodeRef::Block(b) => rewrite_block(engine, b, ctx),
         _ => {
             let mut kids = Vec::new();
-            body.for_each_child(node, |c| kids.push(c));
+            engine.body.for_each_child(node, |c| kids.push(c));
             for c in kids {
-                rewrite_node(body, c, ctx);
+                rewrite_node(engine, c, ctx);
             }
         }
     }
 }
 
-fn rewrite_expr(body: &mut Body, id: ExprId, ctx: &Rewrite) {
+fn rewrite_expr(engine: &mut Engine, id: ExprId, ctx: &Rewrite) {
     // Field read: candidate.field -> scalar local.
     if let ExprKind::FieldAccess {
         expr: inner,
         field_index,
         ..
-    } = &body.exprs[id].kind
+    } = &engine.body.exprs[id].kind
     {
         let (inner, field_index) = (*inner, *field_index);
-        if let Some(local_idx) = is_candidate_local(body, inner, ctx.safe_set) {
+        if let Some(local_idx) = is_candidate_local(engine.body, inner, ctx.safe_set) {
             let key = (local_idx, field_index);
             if let Some(&new_local) = ctx.field_map.get(&key) {
                 let new_name = ctx.info_map[&key].0.clone();
-                body.exprs[id].kind = ExprKind::Local {
-                    index: new_local,
-                    name: new_name,
-                };
+                engine.replace_expr_kind(
+                    id,
+                    ExprKind::Local {
+                        index: new_local,
+                        name: new_name,
+                    },
+                );
                 return;
             }
         }
     }
 
     // Field write: candidate.field = value -> scalar_local = value.
-    if let ExprKind::Assign { target, value } = &body.exprs[id].kind {
+    if let ExprKind::Assign { target, value } = &engine.body.exprs[id].kind {
         let (target, value) = (*target, *value);
         if let ExprKind::FieldAccess {
             expr: inner,
             field_index,
             ..
-        } = &body.exprs[target].kind
+        } = &engine.body.exprs[target].kind
         {
             let (inner, field_index) = (*inner, *field_index);
-            if let Some(local_idx) = is_candidate_local(body, inner, ctx.safe_set) {
+            if let Some(local_idx) = is_candidate_local(engine.body, inner, ctx.safe_set) {
                 let key = (local_idx, field_index);
                 if let Some(&new_local) = ctx.field_map.get(&key) {
                     let new_name = ctx.info_map[&key].0.clone();
-                    body.exprs[target].kind = ExprKind::Local {
-                        index: new_local,
-                        name: new_name,
-                    };
-                    rewrite_expr(body, value, ctx);
+                    engine.replace_expr_kind(
+                        target,
+                        ExprKind::Local {
+                            index: new_local,
+                            name: new_name,
+                        },
+                    );
+                    rewrite_expr(engine, value, ctx);
                     return;
                 }
             }
@@ -849,25 +906,25 @@ fn rewrite_expr(body: &mut Body, id: ExprId, ctx: &Rewrite) {
     }
 
     // Reconstruct: bare Local of a soft-escape candidate -> re-materialize.
-    if let ExprKind::Local { index, .. } = &body.exprs[id].kind {
+    if let ExprKind::Local { index, .. } = &engine.body.exprs[id].kind {
         let index = *index;
         if ctx.reconstruct_info.contains_key(&index) {
-            reconstruct_aggregate(body, id, index, ctx);
+            reconstruct_aggregate(engine, id, index, ctx);
             return;
         }
     }
 
     let mut kids = Vec::new();
-    body.for_each_child(NodeRef::Expr(id), |c| kids.push(c));
+    engine.body.for_each_child(NodeRef::Expr(id), |c| kids.push(c));
     for c in kids {
-        rewrite_node(body, c, ctx);
+        rewrite_node(engine, c, ctx);
     }
 }
 
 /// Expand a candidate `Let` value into one per-field `Let`, rewriting each
 /// field expression as it goes.
 fn expand_struct_let(
-    body: &mut Body,
+    engine: &mut Engine,
     value: ExprId,
     local_idx: u32,
     is_mut: bool,
@@ -876,7 +933,7 @@ fn expand_struct_let(
     new_stmts: &mut Vec<StmtId>,
 ) {
     // (field_index, value_expr) pairs in field-index order.
-    let mut pairs: Vec<(u32, ExprId)> = match &body.exprs[value].kind {
+    let mut pairs: Vec<(u32, ExprId)> = match &engine.body.exprs[value].kind {
         ExprKind::StructLiteral { fields, .. } => {
             fields.iter().map(|f| (f.field_index, f.value)).collect()
         }
@@ -889,9 +946,9 @@ fn expand_struct_let(
     };
     pairs.sort_by_key(|(fi, _)| *fi);
     for (field_index, field_value) in pairs {
-        rewrite_expr(body, field_value, ctx);
+        rewrite_expr(engine, field_value, ctx);
         push_field_let(
-            body,
+            engine,
             (local_idx, field_index),
             is_mut,
             span,
@@ -903,7 +960,7 @@ fn expand_struct_let(
 }
 
 fn push_field_let(
-    body: &mut Body,
+    engine: &mut Engine,
     key: (u32, u32),
     is_mut: bool,
     span: Span,
@@ -913,8 +970,8 @@ fn push_field_let(
 ) {
     let new_local = ctx.field_map[&key];
     let (new_name, field_type) = ctx.info_map[&key].clone();
-    let stmt = body.stmts.push(StmtNode {
-        kind: StmtKind::Let {
+    let stmt = engine.alloc_stmt(
+        StmtKind::Let {
             name: new_name,
             local_index: new_local,
             is_mut,
@@ -926,15 +983,15 @@ fn push_field_let(
             skip_value_copy: true,
         },
         span,
-    });
+    );
     new_stmts.push(stmt);
 }
 
 /// Build a reconstructed struct or tuple literal from SROA'd scalar locals,
 /// replacing the bare-`Local` node `id` in place (keeping its `type_id` / span).
-fn reconstruct_aggregate(body: &mut Body, id: ExprId, local_idx: u32, ctx: &Rewrite) {
+fn reconstruct_aggregate(engine: &mut Engine, id: ExprId, local_idx: u32, ctx: &Rewrite) {
     let info = &ctx.reconstruct_info[&local_idx];
-    let span = body.exprs[id].span;
+    let span = engine.body.exprs[id].span;
     let is_tuple = info.struct_name.is_empty();
     let field_specs: Vec<(String, TypeId)> = info.fields.clone();
     let struct_name = info.struct_name.clone();
@@ -946,41 +1003,44 @@ fn reconstruct_aggregate(body: &mut Body, id: ExprId, local_idx: u32, ctx: &Rewr
             let key = (local_idx, i as u32);
             let field_local = ctx.field_map[&key];
             let field_name = ctx.info_map[&key].0.clone();
-            let e = body.exprs.push(ExprNode {
-                kind: ExprKind::Local {
+            let e = engine.alloc_expr(
+                ExprKind::Local {
                     index: field_local,
                     name: field_name,
                 },
-                type_id: *type_id,
+                *type_id,
                 span,
-            });
+            );
             elements.push(e);
         }
-        body.exprs[id].kind = ExprKind::TupleLiteral { elements };
+        engine.replace_expr_kind(id, ExprKind::TupleLiteral { elements });
     } else {
         let mut fields: Vec<ArenaStructField> = Vec::with_capacity(field_specs.len());
         for (i, (name, type_id)) in field_specs.iter().enumerate() {
             let key = (local_idx, i as u32);
             let field_local = ctx.field_map[&key];
             let field_name = ctx.info_map[&key].0.clone();
-            let value = body.exprs.push(ExprNode {
-                kind: ExprKind::Local {
+            let value = engine.alloc_expr(
+                ExprKind::Local {
                     index: field_local,
                     name: field_name,
                 },
-                type_id: *type_id,
+                *type_id,
                 span,
-            });
+            );
             fields.push(ArenaStructField {
                 name: name.clone(),
                 value,
                 field_index: i as u32,
             });
         }
-        body.exprs[id].kind = ExprKind::StructLiteral {
-            struct_type,
-            struct_name,
-            fields,
-        };
+        engine.replace_expr_kind(
+            id,
+            ExprKind::StructLiteral {
+                struct_type,
+                struct_name,
+                fields,
+            },
+        );
     }
 }

--- a/wado-compiler/src/optimize/store_load_forward.rs
+++ b/wado-compiler/src/optimize/store_load_forward.rs
@@ -285,7 +285,7 @@ fn forward_in_stmt(
             local_index, value, ..
         } => {
             let (local_index, value) = (*local_index, *value);
-            let changed = forward_in_expr(engine,value, known, unsafe_locals, type_table, cache);
+            let changed = forward_in_expr(engine, value, known, unsafe_locals, type_table, cache);
             if !unsafe_locals.contains(&local_index)
                 && let Some(fv) = ForwardValue::from_expr(engine.body, value)
             {
@@ -295,13 +295,13 @@ fn forward_in_stmt(
         }
         StmtKind::Expr(e) => {
             let e = *e;
-            let changed = forward_in_expr(engine,e, known, unsafe_locals, type_table, cache);
+            let changed = forward_in_expr(engine, e, known, unsafe_locals, type_table, cache);
             update_known_from_assign(engine.body, e, known, unsafe_locals);
             changed
         }
         StmtKind::Return { value } | StmtKind::Break { value, .. } => {
             if let Some(v) = *value {
-                forward_in_expr(engine,v, known, unsafe_locals, type_table, cache)
+                forward_in_expr(engine, v, known, unsafe_locals, type_table, cache)
             } else {
                 false
             }
@@ -313,7 +313,7 @@ fn forward_in_stmt(
         } => {
             let (condition, then_block, else_block) = (*condition, *then_block, *else_block);
             let mut changed =
-                forward_in_expr(engine,condition, known, unsafe_locals, type_table, cache);
+                forward_in_expr(engine, condition, known, unsafe_locals, type_table, cache);
             let mut modified = lookup_modified(cache, then_block);
             if let Some(eb) = else_block {
                 modified.extend(lookup_modified(cache, eb));
@@ -329,8 +329,14 @@ fn forward_in_stmt(
             );
             if let Some(eb) = else_block {
                 let mut else_known = known.clone();
-                changed |=
-                    forward_in_block(engine,eb, &mut else_known, unsafe_locals, type_table, cache);
+                changed |= forward_in_block(
+                    engine,
+                    eb,
+                    &mut else_known,
+                    unsafe_locals,
+                    type_table,
+                    cache,
+                );
             }
             known.invalidate_modified(&modified);
             changed
@@ -341,21 +347,21 @@ fn forward_in_stmt(
             known.invalidate_modified(&modified);
             let mut loop_known = known.clone();
             let changed =
-                forward_in_block(engine,b, &mut loop_known, unsafe_locals, type_table, cache);
+                forward_in_block(engine, b, &mut loop_known, unsafe_locals, type_table, cache);
             known.invalidate_modified(&modified);
             changed
         }
         StmtKind::LabeledBlock { block: b, .. } => {
             let b = *b;
             let modified = lookup_modified(cache, b);
-            let changed = forward_in_block(engine,b, known, unsafe_locals, type_table, cache);
+            let changed = forward_in_block(engine, b, known, unsafe_locals, type_table, cache);
             known.invalidate_modified(&modified);
             changed
         }
         StmtKind::Continue => false,
         StmtKind::LetDestructure { value, .. } => {
             let value = *value;
-            forward_in_expr(engine,value, known, unsafe_locals, type_table, cache)
+            forward_in_expr(engine, value, known, unsafe_locals, type_table, cache)
         }
     }
 }
@@ -373,12 +379,12 @@ fn forward_in_expr(
     match &engine.body.exprs[id].kind {
         ExprKind::Binary { left, right, .. } => {
             let (left, right) = (*left, *right);
-            changed |= forward_in_expr(engine,left, known, unsafe_locals, type_table, cache);
-            changed |= forward_in_expr(engine,right, known, unsafe_locals, type_table, cache);
+            changed |= forward_in_expr(engine, left, known, unsafe_locals, type_table, cache);
+            changed |= forward_in_expr(engine, right, known, unsafe_locals, type_table, cache);
         }
         ExprKind::Unary { expr: inner, .. } => {
             let inner = *inner;
-            changed |= forward_in_expr(engine,inner, known, unsafe_locals, type_table, cache);
+            changed |= forward_in_expr(engine, inner, known, unsafe_locals, type_table, cache);
         }
         ExprKind::Assign { target, value } => {
             let (target, value) = (*target, *value);
@@ -388,52 +394,52 @@ fn forward_in_expr(
         ExprKind::Call { args, .. } => {
             let args: Vec<ExprId> = args.iter().map(|a| a.expr).collect();
             for a in args {
-                changed |= forward_in_expr(engine,a, known, unsafe_locals, type_table, cache);
+                changed |= forward_in_expr(engine, a, known, unsafe_locals, type_table, cache);
             }
         }
         ExprKind::CmRawCall { args, .. } => {
             let args = args.clone();
             for a in args {
-                changed |= forward_in_expr(engine,a, known, unsafe_locals, type_table, cache);
+                changed |= forward_in_expr(engine, a, known, unsafe_locals, type_table, cache);
             }
         }
         ExprKind::MethodCall { receiver, args, .. } => {
             let receiver = *receiver;
             let args: Vec<ExprId> = args.iter().map(|a| a.expr).collect();
-            changed |= forward_in_expr(engine,receiver, known, unsafe_locals, type_table, cache);
+            changed |= forward_in_expr(engine, receiver, known, unsafe_locals, type_table, cache);
             for a in args {
-                changed |= forward_in_expr(engine,a, known, unsafe_locals, type_table, cache);
+                changed |= forward_in_expr(engine, a, known, unsafe_locals, type_table, cache);
             }
         }
         ExprKind::IndirectCall { callee, args, .. } => {
             let callee = *callee;
             let args = args.clone();
-            changed |= forward_in_expr(engine,callee, known, unsafe_locals, type_table, cache);
+            changed |= forward_in_expr(engine, callee, known, unsafe_locals, type_table, cache);
             for a in args {
-                changed |= forward_in_expr(engine,a, known, unsafe_locals, type_table, cache);
+                changed |= forward_in_expr(engine, a, known, unsafe_locals, type_table, cache);
             }
         }
         ExprKind::ClosureToCanonical { functor, .. } => {
             let functor = *functor;
-            changed |= forward_in_expr(engine,functor, known, unsafe_locals, type_table, cache);
+            changed |= forward_in_expr(engine, functor, known, unsafe_locals, type_table, cache);
         }
         ExprKind::FieldAccess { expr: inner, .. } | ExprKind::Cast { expr: inner, .. } => {
             let inner = *inner;
-            changed |= forward_in_expr(engine,inner, known, unsafe_locals, type_table, cache);
+            changed |= forward_in_expr(engine, inner, known, unsafe_locals, type_table, cache);
         }
         ExprKind::Index { expr: inner, index } => {
             let (inner, index) = (*inner, *index);
-            changed |= forward_in_expr(engine,inner, known, unsafe_locals, type_table, cache);
-            changed |= forward_in_expr(engine,index, known, unsafe_locals, type_table, cache);
+            changed |= forward_in_expr(engine, inner, known, unsafe_locals, type_table, cache);
+            changed |= forward_in_expr(engine, index, known, unsafe_locals, type_table, cache);
         }
         ExprKind::Block(b) => {
             let b = *b;
-            changed |= forward_in_block(engine,b, known, unsafe_locals, type_table, cache);
+            changed |= forward_in_block(engine, b, known, unsafe_locals, type_table, cache);
         }
         ExprKind::LabeledBlock { block: b, .. } => {
             let b = *b;
             let modified = lookup_modified(cache, b);
-            changed |= forward_in_block(engine,b, known, unsafe_locals, type_table, cache);
+            changed |= forward_in_block(engine, b, known, unsafe_locals, type_table, cache);
             known.invalidate_modified(&modified);
         }
         ExprKind::If {
@@ -442,7 +448,7 @@ fn forward_in_expr(
             else_branch,
         } => {
             let (condition, then_branch, else_branch) = (*condition, *then_branch, *else_branch);
-            changed |= forward_in_expr(engine,condition, known, unsafe_locals, type_table, cache);
+            changed |= forward_in_expr(engine, condition, known, unsafe_locals, type_table, cache);
             let mut modified = lookup_modified(cache, then_branch);
             if let Some(eb) = else_branch {
                 modified.extend(lookup_modified(cache, eb));
@@ -458,26 +464,32 @@ fn forward_in_expr(
             );
             if let Some(eb) = else_branch {
                 let mut else_known = known.clone();
-                changed |=
-                    forward_in_block(engine,eb, &mut else_known, unsafe_locals, type_table, cache);
+                changed |= forward_in_block(
+                    engine,
+                    eb,
+                    &mut else_known,
+                    unsafe_locals,
+                    type_table,
+                    cache,
+                );
             }
             known.invalidate_modified(&modified);
         }
         ExprKind::StructLiteral { fields, .. } => {
             let vals: Vec<ExprId> = fields.iter().map(|f| f.value).collect();
             for v in vals {
-                changed |= forward_in_expr(engine,v, known, unsafe_locals, type_table, cache);
+                changed |= forward_in_expr(engine, v, known, unsafe_locals, type_table, cache);
             }
         }
         ExprKind::TupleLiteral { elements, .. } | ExprKind::ArrayLiteral { elements, .. } => {
             let elems = elements.clone();
             for e in elems {
-                changed |= forward_in_expr(engine,e, known, unsafe_locals, type_table, cache);
+                changed |= forward_in_expr(engine, e, known, unsafe_locals, type_table, cache);
             }
         }
         ExprKind::VariantConstruct { payload, .. } => {
             if let Some(p) = *payload {
-                changed |= forward_in_expr(engine,p, known, unsafe_locals, type_table, cache);
+                changed |= forward_in_expr(engine, p, known, unsafe_locals, type_table, cache);
             }
         }
         ExprKind::Match { expr: inner, arms } => {
@@ -495,8 +507,14 @@ fn forward_in_expr(
             for (guard, arm_body) in arm_data {
                 let mut arm_known = known.clone();
                 if let Some(g) = guard {
-                    changed |=
-                        forward_in_expr(engine, g, &mut arm_known, unsafe_locals, type_table, cache);
+                    changed |= forward_in_expr(
+                        engine,
+                        g,
+                        &mut arm_known,
+                        unsafe_locals,
+                        type_table,
+                        cache,
+                    );
                 }
                 changed |= forward_in_expr(
                     engine,
@@ -511,13 +529,13 @@ fn forward_in_expr(
         }
         ExprKind::GlobalVarSet { value, .. } => {
             let value = *value;
-            changed |= forward_in_expr(engine,value, known, unsafe_locals, type_table, cache);
+            changed |= forward_in_expr(engine, value, known, unsafe_locals, type_table, cache);
         }
         ExprKind::VariantTag { expr }
         | ExprKind::VariantTest { expr, .. }
         | ExprKind::VariantPayload { expr, .. } => {
             let expr = *expr;
-            changed |= forward_in_expr(engine,expr, known, unsafe_locals, type_table, cache);
+            changed |= forward_in_expr(engine, expr, known, unsafe_locals, type_table, cache);
         }
         ExprKind::Switch {
             scrutinee,
@@ -528,7 +546,7 @@ fn forward_in_expr(
             let scrutinee = *scrutinee;
             let arms = arms.clone();
             let default = *default;
-            changed |= forward_in_expr(engine,scrutinee, known, unsafe_locals, type_table, cache);
+            changed |= forward_in_expr(engine, scrutinee, known, unsafe_locals, type_table, cache);
             let mut modified = IndexSet::default();
             for &arm in &arms {
                 modified.extend(lookup_modified(cache, arm));
@@ -536,8 +554,14 @@ fn forward_in_expr(
             modified.extend(lookup_modified(cache, default));
             for arm in arms {
                 let mut arm_known = known.clone();
-                changed |=
-                    forward_in_block(engine,arm, &mut arm_known, unsafe_locals, type_table, cache);
+                changed |= forward_in_block(
+                    engine,
+                    arm,
+                    &mut arm_known,
+                    unsafe_locals,
+                    type_table,
+                    cache,
+                );
             }
             let mut default_known = known.clone();
             changed |= forward_in_block(

--- a/wado-compiler/src/optimize/store_load_forward.rs
+++ b/wado-compiler/src/optimize/store_load_forward.rs
@@ -15,7 +15,7 @@
 use std::cell::Cell;
 
 use crate::hashmap::IndexSet;
-use crate::nir::NirFunction;
+use crate::nir::{NirFunction, NirUnaryOp};
 use crate::nir_arena::{BlockId, Body, ExprId, ExprKind, NodeRef};
 use crate::nir_engine::{Engine, EngineBuffers, Rule};
 use crate::nir_package::NirPackage;
@@ -33,11 +33,17 @@ pub fn forward_stores_to_loads(project: &mut NirPackage, gate: &mut FunctionGate
         if func.body.is_none() {
             return false;
         }
-        // Forwarding-ineligible locals: address-taken (`&x` / `&mut x`)
-        // plus those flowing through a `stores` clause. The builder models
-        // writes through neither.
+        // Forwarding-ineligible locals: the canonical `address_taken_locals`
+        // / `stores_aliased_locals` sets, plus a body re-scan for live
+        // `&x` / `&mut x` over `Local`. The canonical sets are static
+        // records from elaboration and are stale after `inline` /
+        // `ref_elim` may have copied `Ref` / `MutRef` nodes for remapped
+        // callee locals (see the comment on `elide_local::ElideRule`).
+        // The body scan catches those transient post-inline aliases.
         let mut unsafe_locals = func.address_taken_locals.clone();
         unsafe_locals.extend(func.stores_aliased_locals.iter().copied());
+        let body_ref = func.body.as_ref().expect("checked above");
+        collect_address_taken_in_body(body_ref, &mut unsafe_locals);
         let rule = StoreLoadForwardRule {
             applied: Cell::new(false),
             unsafe_locals,
@@ -47,6 +53,32 @@ pub fn forward_stores_to_loads(project: &mut NirPackage, gate: &mut FunctionGate
         let mut engine = Engine::new(body, &mut buffers, locals);
         engine.run(&[&rule])
     })
+}
+
+/// Scan `body` for `Unary::Ref(Local)` / `Unary::MutRef(Local)` and insert
+/// every targeted local into `out`. Mirrors the live-`&local` source used
+/// by `elide_local`; catches locals whose address-taken status is not in
+/// the function's static `address_taken_locals` set (e.g. callee locals
+/// that the inliner remapped into this body without updating the set).
+fn collect_address_taken_in_body(body: &Body, out: &mut IndexSet<u32>) {
+    collect_address_taken_node(body, NodeRef::Block(body.root), out);
+}
+
+fn collect_address_taken_node(body: &Body, node: NodeRef, out: &mut IndexSet<u32>) {
+    if let NodeRef::Expr(id) = node
+        && let ExprKind::Unary {
+            op: NirUnaryOp::Ref | NirUnaryOp::MutRef,
+            expr: inner,
+        } = &body.exprs[id].kind
+        && let ExprKind::Local { index, .. } = &body.exprs[*inner].kind
+    {
+        out.insert(*index);
+    }
+    let mut kids = Vec::new();
+    body.for_each_child(node, |c| kids.push(c));
+    for c in kids {
+        collect_address_taken_node(body, c, out);
+    }
 }
 
 /// Standalone-session rule whose single `apply_block` performs the whole-

--- a/wado-compiler/src/optimize/store_load_forward.rs
+++ b/wado-compiler/src/optimize/store_load_forward.rs
@@ -9,15 +9,20 @@
 //! (`&x` / `&mut x`) or it is captured by a closure. At control-flow
 //! boundaries only locals modified within branches are invalidated.
 //!
-//! Ported off the `Body ↔ tree` bridge (Phase 4 stage C; see
-//! `docs/wep-2026-06-05-nir-rewrite-engine-design.md`): the unsafe-locals scan,
-//! the per-block modified-locals precompute, and the flow-sensitive forward
-//! traversal read and mutate the arena `Body` directly. The modified-locals
-//! cache is keyed by `BlockId` (cleaner than the old block raw pointer).
+//! Runs on the worklist rewrite engine (combine migration; see
+//! `docs/wep-2026-06-05-nir-rewrite-engine-design.md`) as a [`Rule`]: a
+//! per-function standalone engine session whose `apply_block` fires once at
+//! the body root and runs the whole-function flow-sensitive forward pass.
+//! The single rewrite point (`Local → ForwardValue`-derived literal) routes
+//! through the engine edit API (`replace_expr_kind`) so the parent map and
+//! use index stay coherent.
+
+use std::cell::Cell;
 
 use crate::hashmap::{IndexMap, IndexSet};
 use crate::nir::{NirFunction, NirUnaryOp};
 use crate::nir_arena::{BlockId, Body, ExprId, ExprKind, NodeRef, StmtId, StmtKind};
+use crate::nir_engine::{Engine, EngineBuffers, Rule};
 use crate::nir_package::NirPackage;
 use crate::tir::TypeTable;
 
@@ -203,21 +208,48 @@ fn collect_unsafe_node(body: &Body, node: NodeRef, unsafe_locals: &mut IndexSet<
 pub fn forward_stores_to_loads(project: &mut NirPackage, gate: &mut FunctionGate) -> bool {
     let type_table = project.type_table.borrow();
     let len = project.functions.len();
+    let mut buffers = EngineBuffers::default();
     gate.run_gated(GatedPass::StoreLoadForward, len, |fid| {
         let mut func = project.functions[fid.index()].borrow_mut();
-        forward_in_function(&mut func, &type_table)
+        if func.body.is_none() {
+            return false;
+        }
+        let rule = StoreLoadForwardRule {
+            type_table: &type_table,
+            applied: Cell::new(false),
+        };
+        let NirFunction { body, locals, .. } = &mut *func;
+        let body = body.as_mut().expect("checked above");
+        let mut engine = Engine::new(body, &mut buffers, locals);
+        engine.run(&[&rule])
     })
 }
 
-fn forward_in_function(func: &mut NirFunction, type_table: &TypeTable) -> bool {
-    let Some(body) = func.body.as_mut() else {
-        return false;
-    };
-    let unsafe_locals = collect_unsafe_locals(body);
-    let cache = precompute_all_modified_locals(body);
+/// Standalone-session rule whose single `apply_block` performs the whole-
+/// function flow-sensitive forward pass at the body root.
+pub(super) struct StoreLoadForwardRule<'a> {
+    type_table: &'a TypeTable,
+    applied: Cell<bool>,
+}
+
+impl Rule for StoreLoadForwardRule<'_> {
+    fn apply_block(&self, engine: &mut Engine, block: BlockId) -> bool {
+        if engine.parent_of(NodeRef::Block(block)).is_some() {
+            return false;
+        }
+        if self.applied.replace(true) {
+            return false;
+        }
+        forward_at_root(engine, self.type_table)
+    }
+}
+
+fn forward_at_root(engine: &mut Engine, type_table: &TypeTable) -> bool {
+    let unsafe_locals = collect_unsafe_locals(engine.body);
+    let cache = precompute_all_modified_locals(engine.body);
     let mut known = KnownValues::default();
-    let root = body.root;
-    forward_in_block(body, root, &mut known, &unsafe_locals, type_table, &cache)
+    let root = engine.body.root;
+    forward_in_block(engine, root, &mut known, &unsafe_locals, type_table, &cache)
 }
 
 fn lookup_modified(cache: &ModifiedLocalsCache, block: BlockId) -> IndexSet<u32> {
@@ -225,7 +257,7 @@ fn lookup_modified(cache: &ModifiedLocalsCache, block: BlockId) -> IndexSet<u32>
 }
 
 fn forward_in_block(
-    body: &mut Body,
+    engine: &mut Engine,
     block: BlockId,
     known: &mut KnownValues,
     unsafe_locals: &IndexSet<u32>,
@@ -233,29 +265,29 @@ fn forward_in_block(
     cache: &ModifiedLocalsCache,
 ) -> bool {
     let mut changed = false;
-    let stmts = body.blocks[block].stmts.clone();
+    let stmts = engine.body.blocks[block].stmts.clone();
     for stmt in stmts {
-        changed |= forward_in_stmt(body, stmt, known, unsafe_locals, type_table, cache);
+        changed |= forward_in_stmt(engine, stmt, known, unsafe_locals, type_table, cache);
     }
     changed
 }
 
 fn forward_in_stmt(
-    body: &mut Body,
+    engine: &mut Engine,
     stmt: StmtId,
     known: &mut KnownValues,
     unsafe_locals: &IndexSet<u32>,
     type_table: &TypeTable,
     cache: &ModifiedLocalsCache,
 ) -> bool {
-    match &body.stmts[stmt].kind {
+    match &engine.body.stmts[stmt].kind {
         StmtKind::Let {
             local_index, value, ..
         } => {
             let (local_index, value) = (*local_index, *value);
-            let changed = forward_in_expr(body, value, known, unsafe_locals, type_table, cache);
+            let changed = forward_in_expr(engine,value, known, unsafe_locals, type_table, cache);
             if !unsafe_locals.contains(&local_index)
-                && let Some(fv) = ForwardValue::from_expr(body, value)
+                && let Some(fv) = ForwardValue::from_expr(engine.body, value)
             {
                 known.set_local(local_index, fv);
             }
@@ -263,13 +295,13 @@ fn forward_in_stmt(
         }
         StmtKind::Expr(e) => {
             let e = *e;
-            let changed = forward_in_expr(body, e, known, unsafe_locals, type_table, cache);
-            update_known_from_assign(body, e, known, unsafe_locals);
+            let changed = forward_in_expr(engine,e, known, unsafe_locals, type_table, cache);
+            update_known_from_assign(engine.body, e, known, unsafe_locals);
             changed
         }
         StmtKind::Return { value } | StmtKind::Break { value, .. } => {
             if let Some(v) = *value {
-                forward_in_expr(body, v, known, unsafe_locals, type_table, cache)
+                forward_in_expr(engine,v, known, unsafe_locals, type_table, cache)
             } else {
                 false
             }
@@ -281,14 +313,14 @@ fn forward_in_stmt(
         } => {
             let (condition, then_block, else_block) = (*condition, *then_block, *else_block);
             let mut changed =
-                forward_in_expr(body, condition, known, unsafe_locals, type_table, cache);
+                forward_in_expr(engine,condition, known, unsafe_locals, type_table, cache);
             let mut modified = lookup_modified(cache, then_block);
             if let Some(eb) = else_block {
                 modified.extend(lookup_modified(cache, eb));
             }
             let mut then_known = known.clone();
             changed |= forward_in_block(
-                body,
+                engine,
                 then_block,
                 &mut then_known,
                 unsafe_locals,
@@ -298,7 +330,7 @@ fn forward_in_stmt(
             if let Some(eb) = else_block {
                 let mut else_known = known.clone();
                 changed |=
-                    forward_in_block(body, eb, &mut else_known, unsafe_locals, type_table, cache);
+                    forward_in_block(engine,eb, &mut else_known, unsafe_locals, type_table, cache);
             }
             known.invalidate_modified(&modified);
             changed
@@ -309,99 +341,99 @@ fn forward_in_stmt(
             known.invalidate_modified(&modified);
             let mut loop_known = known.clone();
             let changed =
-                forward_in_block(body, b, &mut loop_known, unsafe_locals, type_table, cache);
+                forward_in_block(engine,b, &mut loop_known, unsafe_locals, type_table, cache);
             known.invalidate_modified(&modified);
             changed
         }
         StmtKind::LabeledBlock { block: b, .. } => {
             let b = *b;
             let modified = lookup_modified(cache, b);
-            let changed = forward_in_block(body, b, known, unsafe_locals, type_table, cache);
+            let changed = forward_in_block(engine,b, known, unsafe_locals, type_table, cache);
             known.invalidate_modified(&modified);
             changed
         }
         StmtKind::Continue => false,
         StmtKind::LetDestructure { value, .. } => {
             let value = *value;
-            forward_in_expr(body, value, known, unsafe_locals, type_table, cache)
+            forward_in_expr(engine,value, known, unsafe_locals, type_table, cache)
         }
     }
 }
 
 fn forward_in_expr(
-    body: &mut Body,
+    engine: &mut Engine,
     id: ExprId,
     known: &mut KnownValues,
     unsafe_locals: &IndexSet<u32>,
     type_table: &TypeTable,
     cache: &ModifiedLocalsCache,
 ) -> bool {
-    let mut changed = try_forward_expr(body, id, known);
+    let mut changed = try_forward_expr(engine, id, known);
 
-    match &body.exprs[id].kind {
+    match &engine.body.exprs[id].kind {
         ExprKind::Binary { left, right, .. } => {
             let (left, right) = (*left, *right);
-            changed |= forward_in_expr(body, left, known, unsafe_locals, type_table, cache);
-            changed |= forward_in_expr(body, right, known, unsafe_locals, type_table, cache);
+            changed |= forward_in_expr(engine,left, known, unsafe_locals, type_table, cache);
+            changed |= forward_in_expr(engine,right, known, unsafe_locals, type_table, cache);
         }
         ExprKind::Unary { expr: inner, .. } => {
             let inner = *inner;
-            changed |= forward_in_expr(body, inner, known, unsafe_locals, type_table, cache);
+            changed |= forward_in_expr(engine,inner, known, unsafe_locals, type_table, cache);
         }
         ExprKind::Assign { target, value } => {
             let (target, value) = (*target, *value);
-            changed |= forward_in_expr(body, value, known, unsafe_locals, type_table, cache);
-            update_known_from_target(body, target, value, known, unsafe_locals);
+            changed |= forward_in_expr(engine, value, known, unsafe_locals, type_table, cache);
+            update_known_from_target(engine.body, target, value, known, unsafe_locals);
         }
         ExprKind::Call { args, .. } => {
             let args: Vec<ExprId> = args.iter().map(|a| a.expr).collect();
             for a in args {
-                changed |= forward_in_expr(body, a, known, unsafe_locals, type_table, cache);
+                changed |= forward_in_expr(engine,a, known, unsafe_locals, type_table, cache);
             }
         }
         ExprKind::CmRawCall { args, .. } => {
             let args = args.clone();
             for a in args {
-                changed |= forward_in_expr(body, a, known, unsafe_locals, type_table, cache);
+                changed |= forward_in_expr(engine,a, known, unsafe_locals, type_table, cache);
             }
         }
         ExprKind::MethodCall { receiver, args, .. } => {
             let receiver = *receiver;
             let args: Vec<ExprId> = args.iter().map(|a| a.expr).collect();
-            changed |= forward_in_expr(body, receiver, known, unsafe_locals, type_table, cache);
+            changed |= forward_in_expr(engine,receiver, known, unsafe_locals, type_table, cache);
             for a in args {
-                changed |= forward_in_expr(body, a, known, unsafe_locals, type_table, cache);
+                changed |= forward_in_expr(engine,a, known, unsafe_locals, type_table, cache);
             }
         }
         ExprKind::IndirectCall { callee, args, .. } => {
             let callee = *callee;
             let args = args.clone();
-            changed |= forward_in_expr(body, callee, known, unsafe_locals, type_table, cache);
+            changed |= forward_in_expr(engine,callee, known, unsafe_locals, type_table, cache);
             for a in args {
-                changed |= forward_in_expr(body, a, known, unsafe_locals, type_table, cache);
+                changed |= forward_in_expr(engine,a, known, unsafe_locals, type_table, cache);
             }
         }
         ExprKind::ClosureToCanonical { functor, .. } => {
             let functor = *functor;
-            changed |= forward_in_expr(body, functor, known, unsafe_locals, type_table, cache);
+            changed |= forward_in_expr(engine,functor, known, unsafe_locals, type_table, cache);
         }
         ExprKind::FieldAccess { expr: inner, .. } | ExprKind::Cast { expr: inner, .. } => {
             let inner = *inner;
-            changed |= forward_in_expr(body, inner, known, unsafe_locals, type_table, cache);
+            changed |= forward_in_expr(engine,inner, known, unsafe_locals, type_table, cache);
         }
         ExprKind::Index { expr: inner, index } => {
             let (inner, index) = (*inner, *index);
-            changed |= forward_in_expr(body, inner, known, unsafe_locals, type_table, cache);
-            changed |= forward_in_expr(body, index, known, unsafe_locals, type_table, cache);
+            changed |= forward_in_expr(engine,inner, known, unsafe_locals, type_table, cache);
+            changed |= forward_in_expr(engine,index, known, unsafe_locals, type_table, cache);
         }
         ExprKind::Block(b) => {
             let b = *b;
-            changed |= forward_in_block(body, b, known, unsafe_locals, type_table, cache);
+            changed |= forward_in_block(engine,b, known, unsafe_locals, type_table, cache);
         }
         ExprKind::LabeledBlock { block: b, .. } => {
             let b = *b;
             let modified = lookup_modified(cache, b);
-            changed |= forward_in_block(body, b, known, unsafe_locals, type_table, cache);
+            changed |= forward_in_block(engine,b, known, unsafe_locals, type_table, cache);
             known.invalidate_modified(&modified);
         }
         ExprKind::If {
@@ -410,14 +442,14 @@ fn forward_in_expr(
             else_branch,
         } => {
             let (condition, then_branch, else_branch) = (*condition, *then_branch, *else_branch);
-            changed |= forward_in_expr(body, condition, known, unsafe_locals, type_table, cache);
+            changed |= forward_in_expr(engine,condition, known, unsafe_locals, type_table, cache);
             let mut modified = lookup_modified(cache, then_branch);
             if let Some(eb) = else_branch {
                 modified.extend(lookup_modified(cache, eb));
             }
             let mut then_known = known.clone();
             changed |= forward_in_block(
-                body,
+                engine,
                 then_branch,
                 &mut then_known,
                 unsafe_locals,
@@ -427,47 +459,47 @@ fn forward_in_expr(
             if let Some(eb) = else_branch {
                 let mut else_known = known.clone();
                 changed |=
-                    forward_in_block(body, eb, &mut else_known, unsafe_locals, type_table, cache);
+                    forward_in_block(engine,eb, &mut else_known, unsafe_locals, type_table, cache);
             }
             known.invalidate_modified(&modified);
         }
         ExprKind::StructLiteral { fields, .. } => {
             let vals: Vec<ExprId> = fields.iter().map(|f| f.value).collect();
             for v in vals {
-                changed |= forward_in_expr(body, v, known, unsafe_locals, type_table, cache);
+                changed |= forward_in_expr(engine,v, known, unsafe_locals, type_table, cache);
             }
         }
         ExprKind::TupleLiteral { elements, .. } | ExprKind::ArrayLiteral { elements, .. } => {
             let elems = elements.clone();
             for e in elems {
-                changed |= forward_in_expr(body, e, known, unsafe_locals, type_table, cache);
+                changed |= forward_in_expr(engine,e, known, unsafe_locals, type_table, cache);
             }
         }
         ExprKind::VariantConstruct { payload, .. } => {
             if let Some(p) = *payload {
-                changed |= forward_in_expr(body, p, known, unsafe_locals, type_table, cache);
+                changed |= forward_in_expr(engine,p, known, unsafe_locals, type_table, cache);
             }
         }
         ExprKind::Match { expr: inner, arms } => {
             let inner = *inner;
             let arm_data: Vec<(Option<ExprId>, ExprId)> =
                 arms.iter().map(|a| (a.guard, a.body)).collect();
-            changed |= forward_in_expr(body, inner, known, unsafe_locals, type_table, cache);
+            changed |= forward_in_expr(engine, inner, known, unsafe_locals, type_table, cache);
             let mut modified = IndexSet::default();
             for (guard, arm_body) in &arm_data {
                 if let Some(g) = guard {
-                    modified.extend(collect_modified_expr(body, *g));
+                    modified.extend(collect_modified_expr(engine.body, *g));
                 }
-                modified.extend(collect_modified_expr(body, *arm_body));
+                modified.extend(collect_modified_expr(engine.body, *arm_body));
             }
             for (guard, arm_body) in arm_data {
                 let mut arm_known = known.clone();
                 if let Some(g) = guard {
                     changed |=
-                        forward_in_expr(body, g, &mut arm_known, unsafe_locals, type_table, cache);
+                        forward_in_expr(engine, g, &mut arm_known, unsafe_locals, type_table, cache);
                 }
                 changed |= forward_in_expr(
-                    body,
+                    engine,
                     arm_body,
                     &mut arm_known,
                     unsafe_locals,
@@ -479,13 +511,13 @@ fn forward_in_expr(
         }
         ExprKind::GlobalVarSet { value, .. } => {
             let value = *value;
-            changed |= forward_in_expr(body, value, known, unsafe_locals, type_table, cache);
+            changed |= forward_in_expr(engine,value, known, unsafe_locals, type_table, cache);
         }
         ExprKind::VariantTag { expr }
         | ExprKind::VariantTest { expr, .. }
         | ExprKind::VariantPayload { expr, .. } => {
             let expr = *expr;
-            changed |= forward_in_expr(body, expr, known, unsafe_locals, type_table, cache);
+            changed |= forward_in_expr(engine,expr, known, unsafe_locals, type_table, cache);
         }
         ExprKind::Switch {
             scrutinee,
@@ -496,7 +528,7 @@ fn forward_in_expr(
             let scrutinee = *scrutinee;
             let arms = arms.clone();
             let default = *default;
-            changed |= forward_in_expr(body, scrutinee, known, unsafe_locals, type_table, cache);
+            changed |= forward_in_expr(engine,scrutinee, known, unsafe_locals, type_table, cache);
             let mut modified = IndexSet::default();
             for &arm in &arms {
                 modified.extend(lookup_modified(cache, arm));
@@ -505,11 +537,11 @@ fn forward_in_expr(
             for arm in arms {
                 let mut arm_known = known.clone();
                 changed |=
-                    forward_in_block(body, arm, &mut arm_known, unsafe_locals, type_table, cache);
+                    forward_in_block(engine,arm, &mut arm_known, unsafe_locals, type_table, cache);
             }
             let mut default_known = known.clone();
             changed |= forward_in_block(
-                body,
+                engine,
                 default,
                 &mut default_known,
                 unsafe_locals,
@@ -524,14 +556,14 @@ fn forward_in_expr(
     changed
 }
 
-fn try_forward_expr(body: &mut Body, id: ExprId, known: &KnownValues) -> bool {
-    let fv = if let ExprKind::Local { index, .. } = &body.exprs[id].kind {
+fn try_forward_expr(engine: &mut Engine, id: ExprId, known: &KnownValues) -> bool {
+    let fv = if let ExprKind::Local { index, .. } = &engine.body.exprs[id].kind {
         known.get_local(*index).cloned()
     } else {
         None
     };
     if let Some(fv) = fv {
-        body.exprs[id].kind = fv.to_expr_kind();
+        engine.replace_expr_kind(id, fv.to_expr_kind());
         return true;
     }
     false

--- a/wado-compiler/src/optimize/store_load_forward.rs
+++ b/wado-compiler/src/optimize/store_load_forward.rs
@@ -1,7 +1,7 @@
 //! Store-to-Load Forwarding optimization for Wado NIR.
 //!
 //! Replace `Local` reads with the literal that reaches them. The engine's
-//! ValueGraph handles flow-sensitive reaching-defs, branch merges, loop
+//! `ValueGraph` handles flow-sensitive reaching-defs, branch merges, loop
 //! and heap-write invalidation, so this rule only inspects each read's
 //! `ValueKind` and substitutes when it is a literal.
 //!

--- a/wado-compiler/src/optimize/store_load_forward.rs
+++ b/wado-compiler/src/optimize/store_load_forward.rs
@@ -28,7 +28,7 @@
 use std::cell::Cell;
 
 use crate::hashmap::IndexSet;
-use crate::nir::{NirFunction, NirUnaryOp};
+use crate::nir::NirFunction;
 use crate::nir_arena::{BlockId, Body, ExprId, ExprKind, NodeRef};
 use crate::nir_engine::{Engine, EngineBuffers, Rule};
 use crate::nir_package::NirPackage;
@@ -46,8 +46,16 @@ pub fn forward_stores_to_loads(project: &mut NirPackage, gate: &mut FunctionGate
         if func.body.is_none() {
             return false;
         }
+        // Canonical alias set: locals whose address is taken (`&x` / `&mut x`)
+        // plus those that flow through a `stores` clause. Mirrors `alias.rs`'s
+        // seeding; the rule treats their reads as forwarding-ineligible
+        // because the ValueGraph builder does not model writes through
+        // pointers or `stores`-aliased references.
+        let mut unsafe_locals = func.address_taken_locals.clone();
+        unsafe_locals.extend(func.stores_aliased_locals.iter().copied());
         let rule = StoreLoadForwardRule {
             applied: Cell::new(false),
+            unsafe_locals,
         };
         let NirFunction { body, locals, .. } = &mut *func;
         let body = body.as_mut().expect("checked above");
@@ -60,6 +68,9 @@ pub fn forward_stores_to_loads(project: &mut NirPackage, gate: &mut FunctionGate
 /// function literal-forwarding pass at the body root.
 pub(super) struct StoreLoadForwardRule {
     applied: Cell<bool>,
+    /// Pre-computed forwarding-ineligible locals; see the caller for how
+    /// this set is built.
+    unsafe_locals: IndexSet<u32>,
 }
 
 impl Rule for StoreLoadForwardRule {
@@ -70,12 +81,11 @@ impl Rule for StoreLoadForwardRule {
         if self.applied.replace(true) {
             return false;
         }
-        forward_at_root(engine)
+        forward_at_root(engine, &self.unsafe_locals)
     }
 }
 
-fn forward_at_root(engine: &mut Engine) -> bool {
-    let unsafe_locals = collect_unsafe_locals(engine.body);
+fn forward_at_root(engine: &mut Engine, unsafe_locals: &IndexSet<u32>) -> bool {
     // Collect every `Local` read expression first; iterating while the
     // engine rewrites would invalidate body/expr indices we're walking.
     let mut local_reads: Vec<(ExprId, u32)> = Vec::new();
@@ -104,37 +114,18 @@ fn forward_at_root(engine: &mut Engine) -> bool {
         let Some(src) = engine.literal_source(vid) else {
             continue;
         };
+        // We clone the original literal `ExprKind` so the substituted node
+        // keeps its source `repr` and span. When several distinct literal
+        // expressions hash-cons to the same `ValueId` (e.g. `0` and `0x0`),
+        // `literal_source` returns the first one observed; the other
+        // literals' reprs are lost on substitution. This is sound — VN
+        // equality implies semantic equality — but may surface in NIR
+        // dumps and diagnostic spans for edge-case literals.
         let new_kind = engine.body.exprs[src].kind.clone();
         engine.replace_expr_kind(expr, new_kind);
         changed = true;
     }
     changed
-}
-
-/// Locals whose address is taken anywhere in the body. The ValueGraph
-/// builder does not yet model writes through pointers, so we treat these
-/// as forwarding-ineligible at the rule level.
-fn collect_unsafe_locals(body: &Body) -> IndexSet<u32> {
-    let mut unsafe_locals = IndexSet::default();
-    collect_unsafe_node(body, NodeRef::Block(body.root), &mut unsafe_locals);
-    unsafe_locals
-}
-
-fn collect_unsafe_node(body: &Body, node: NodeRef, unsafe_locals: &mut IndexSet<u32>) {
-    if let NodeRef::Expr(id) = node
-        && let ExprKind::Unary {
-            op: NirUnaryOp::Ref | NirUnaryOp::MutRef,
-            expr: inner,
-        } = &body.exprs[id].kind
-        && let ExprKind::Local { index, .. } = &body.exprs[*inner].kind
-    {
-        unsafe_locals.insert(*index);
-    }
-    let mut kids = Vec::new();
-    body.for_each_child(node, |c| kids.push(c));
-    for c in kids {
-        collect_unsafe_node(body, c, unsafe_locals);
-    }
 }
 
 fn collect_local_reads(body: &Body, out: &mut Vec<(ExprId, u32)>) {

--- a/wado-compiler/src/optimize/store_load_forward.rs
+++ b/wado-compiler/src/optimize/store_load_forward.rs
@@ -1,29 +1,16 @@
 //! Store-to-Load Forwarding optimization for Wado NIR.
 //!
-//! When a literal value reaches a `Local` read at its program point — with
-//! no intervening aliasing write — substitute the literal directly,
-//! eliminating the load. Particularly useful after SROA decomposes struct
-//! fields into scalar locals.
+//! Replace `Local` reads with the literal that reaches them. The engine's
+//! ValueGraph handles flow-sensitive reaching-defs, branch merges, loop
+//! and heap-write invalidation, so this rule only inspects each read's
+//! `ValueKind` and substitutes when it is a literal.
 //!
-//! Implementation: a thin wrapper over the engine's ValueGraph. For each
-//! `Local` read expression in the body, ask the engine for the read's
-//! `ValueId`; if its kind is a literal (`Int`, `Float`, `Bool`, `Char`),
-//! clone the original defining literal expression's `ExprKind` and replace
-//! the `Local`. The ValueGraph builder is responsible for flow-sensitive
-//! reaching-def tracking, branch merging (`Select`), loop invalidation,
-//! and heap-write invalidation — this rule contains none of that.
+//! Address-taken and `stores`-aliased locals are excluded — the builder
+//! does not model writes through references. Particularly useful after
+//! SROA decomposes struct fields into scalar locals.
 //!
-//! Safety carve-out: `Local`s whose address is taken (`&x` / `&mut x`) are
-//! excluded — the ValueGraph builder does not yet model writes through
-//! pointers, so a literal reaching such a local is unsound to forward.
-//! Other invalidation (calls, opaque writes, branches) is already encoded
-//! in the ValueGraph's per-point reaching-def state.
-//!
-//! Runs on the worklist rewrite engine: a per-function standalone session
-//! whose `apply_block` fires once at the body root and runs the
-//! whole-function substitution pass. The single rewrite point routes through
-//! the engine edit API (`replace_expr_kind`) so the parent map and use
-//! index stay coherent.
+//! Runs as a per-function standalone engine session whose `apply_block`
+//! fires once at the body root.
 
 use std::cell::Cell;
 
@@ -46,11 +33,9 @@ pub fn forward_stores_to_loads(project: &mut NirPackage, gate: &mut FunctionGate
         if func.body.is_none() {
             return false;
         }
-        // Canonical alias set: locals whose address is taken (`&x` / `&mut x`)
-        // plus those that flow through a `stores` clause. Mirrors `alias.rs`'s
-        // seeding; the rule treats their reads as forwarding-ineligible
-        // because the ValueGraph builder does not model writes through
-        // pointers or `stores`-aliased references.
+        // Forwarding-ineligible locals: address-taken (`&x` / `&mut x`)
+        // plus those flowing through a `stores` clause. The builder models
+        // writes through neither.
         let mut unsafe_locals = func.address_taken_locals.clone();
         unsafe_locals.extend(func.stores_aliased_locals.iter().copied());
         let rule = StoreLoadForwardRule {
@@ -68,8 +53,6 @@ pub fn forward_stores_to_loads(project: &mut NirPackage, gate: &mut FunctionGate
 /// function literal-forwarding pass at the body root.
 pub(super) struct StoreLoadForwardRule {
     applied: Cell<bool>,
-    /// Pre-computed forwarding-ineligible locals; see the caller for how
-    /// this set is built.
     unsafe_locals: IndexSet<u32>,
 }
 
@@ -96,9 +79,7 @@ fn forward_at_root(engine: &mut Engine, unsafe_locals: &IndexSet<u32>) -> bool {
         if unsafe_locals.contains(&local_index) {
             continue;
         }
-        // Skip if this Local is itself an assign target (LHS) — `x = ...`
-        // is a write, not a read, and rewriting the target with a literal
-        // makes no sense.
+        // Skip `Assign` LHS reads — they are writes, not reads.
         if is_assign_target(engine, expr) {
             continue;
         }
@@ -114,13 +95,12 @@ fn forward_at_root(engine: &mut Engine, unsafe_locals: &IndexSet<u32>) -> bool {
         let Some(src) = engine.literal_source(vid) else {
             continue;
         };
-        // We clone the original literal `ExprKind` so the substituted node
-        // keeps its source `repr` and span. When several distinct literal
-        // expressions hash-cons to the same `ValueId` (e.g. `0` and `0x0`),
-        // `literal_source` returns the first one observed; the other
-        // literals' reprs are lost on substitution. This is sound — VN
-        // equality implies semantic equality — but may surface in NIR
-        // dumps and diagnostic spans for edge-case literals.
+        // Cloning the source `ExprKind` keeps the substituted node's
+        // `repr` and span. When distinct literal exprs hash-cons to one
+        // `ValueId` (e.g. `0` vs `0x0`), `literal_source` returns the
+        // first one — the others' reprs are lost on substitution. Sound
+        // (VN equality ⇒ semantic equality), but visible in NIR dumps and
+        // diagnostic spans for these edge-case literals.
         let new_kind = engine.body.exprs[src].kind.clone();
         engine.replace_expr_kind(expr, new_kind);
         changed = true;

--- a/wado-compiler/src/optimize/store_load_forward.rs
+++ b/wado-compiler/src/optimize/store_load_forward.rs
@@ -1,187 +1,119 @@
-//! Store-to-Load Forwarding optimization for Wado NIR
+//! Store-to-Load Forwarding optimization for Wado NIR.
 //!
-//! When a literal value is stored to a local and then loaded with no
-//! intervening aliasing write, this pass forwards the stored value directly,
+//! When a literal value reaches a `Local` read at its program point — with
+//! no intervening aliasing write — substitute the literal directly,
 //! eliminating the load. Particularly useful after SROA decomposes struct
 //! fields into scalar locals.
 //!
-//! Safety: a local is excluded from forwarding when its address is taken
-//! (`&x` / `&mut x`) or it is captured by a closure. At control-flow
-//! boundaries only locals modified within branches are invalidated.
+//! Implementation: a thin wrapper over the engine's ValueGraph. For each
+//! `Local` read expression in the body, ask the engine for the read's
+//! `ValueId`; if its kind is a literal (`Int`, `Float`, `Bool`, `Char`),
+//! clone the original defining literal expression's `ExprKind` and replace
+//! the `Local`. The ValueGraph builder is responsible for flow-sensitive
+//! reaching-def tracking, branch merging (`Select`), loop invalidation,
+//! and heap-write invalidation — this rule contains none of that.
 //!
-//! Runs on the worklist rewrite engine (combine migration; see
-//! `docs/wep-2026-06-05-nir-rewrite-engine-design.md`) as a [`Rule`]: a
-//! per-function standalone engine session whose `apply_block` fires once at
-//! the body root and runs the whole-function flow-sensitive forward pass.
-//! The single rewrite point (`Local → ForwardValue`-derived literal) routes
-//! through the engine edit API (`replace_expr_kind`) so the parent map and
-//! use index stay coherent.
+//! Safety carve-out: `Local`s whose address is taken (`&x` / `&mut x`) are
+//! excluded — the ValueGraph builder does not yet model writes through
+//! pointers, so a literal reaching such a local is unsound to forward.
+//! Other invalidation (calls, opaque writes, branches) is already encoded
+//! in the ValueGraph's per-point reaching-def state.
+//!
+//! Runs on the worklist rewrite engine: a per-function standalone session
+//! whose `apply_block` fires once at the body root and runs the
+//! whole-function substitution pass. The single rewrite point routes through
+//! the engine edit API (`replace_expr_kind`) so the parent map and use
+//! index stay coherent.
 
 use std::cell::Cell;
 
-use crate::hashmap::{IndexMap, IndexSet};
+use crate::hashmap::IndexSet;
 use crate::nir::{NirFunction, NirUnaryOp};
-use crate::nir_arena::{BlockId, Body, ExprId, ExprKind, NodeRef, StmtId, StmtKind};
+use crate::nir_arena::{BlockId, Body, ExprId, ExprKind, NodeRef};
 use crate::nir_engine::{Engine, EngineBuffers, Rule};
 use crate::nir_package::NirPackage;
-use crate::tir::TypeTable;
+use crate::nir_value_graph::ValueKind;
 
 use cranelift_entity::EntityRef;
 
 use super::gate::{FunctionGate, GatedPass};
 
-/// Precomputed per-block modified-locals cache, keyed by `BlockId`.
-type ModifiedLocalsCache = IndexMap<BlockId, IndexSet<u32>>;
-
-/// Insert the assigned local for an `Assign` target (bare `Local` or
-/// `FieldAccess(Local)`), matching the original modified-locals logic.
-fn insert_assign_target(body: &Body, target: ExprId, modified: &mut IndexSet<u32>) {
-    if let ExprKind::Local { index, .. } = &body.exprs[target].kind {
-        modified.insert(*index);
-    }
-    if let ExprKind::FieldAccess { expr: inner, .. } = &body.exprs[target].kind
-        && let ExprKind::Local { index, .. } = &body.exprs[*inner].kind
-    {
-        modified.insert(*index);
-    }
-}
-
-fn precompute_all_modified_locals(body: &Body) -> ModifiedLocalsCache {
-    let mut cache = ModifiedLocalsCache::default();
-    precompute_block(body, body.root, &mut cache);
-    cache
-}
-
-fn precompute_block(body: &Body, block: BlockId, cache: &mut ModifiedLocalsCache) -> IndexSet<u32> {
-    let mut modified = IndexSet::default();
-    let stmts = body.blocks[block].stmts.clone();
-    for s in stmts {
-        precompute_node(body, NodeRef::Stmt(s), &mut modified, cache);
-    }
-    cache.insert(block, modified.clone());
-    modified
-}
-
-fn precompute_node(
-    body: &Body,
-    node: NodeRef,
-    modified: &mut IndexSet<u32>,
-    cache: &mut ModifiedLocalsCache,
-) {
-    match node {
-        NodeRef::Block(b) => {
-            let inner = precompute_block(body, b, cache);
-            modified.extend(inner);
+pub fn forward_stores_to_loads(project: &mut NirPackage, gate: &mut FunctionGate) -> bool {
+    let len = project.functions.len();
+    let mut buffers = EngineBuffers::default();
+    gate.run_gated(GatedPass::StoreLoadForward, len, |fid| {
+        let mut func = project.functions[fid.index()].borrow_mut();
+        if func.body.is_none() {
+            return false;
         }
-        NodeRef::Expr(id) => {
-            if let ExprKind::Assign { target, .. } = &body.exprs[id].kind {
-                let target = *target;
-                insert_assign_target(body, target, modified);
-            }
-            let mut kids = Vec::new();
-            body.for_each_child(NodeRef::Expr(id), |c| kids.push(c));
-            for c in kids {
-                precompute_node(body, c, modified, cache);
-            }
+        let rule = StoreLoadForwardRule {
+            applied: Cell::new(false),
+        };
+        let NirFunction { body, locals, .. } = &mut *func;
+        let body = body.as_mut().expect("checked above");
+        let mut engine = Engine::new(body, &mut buffers, locals);
+        engine.run(&[&rule])
+    })
+}
+
+/// Standalone-session rule whose single `apply_block` performs the whole-
+/// function literal-forwarding pass at the body root.
+pub(super) struct StoreLoadForwardRule {
+    applied: Cell<bool>,
+}
+
+impl Rule for StoreLoadForwardRule {
+    fn apply_block(&self, engine: &mut Engine, block: BlockId) -> bool {
+        if engine.parent_of(NodeRef::Block(block)).is_some() {
+            return false;
         }
-        NodeRef::Stmt(s) => {
-            let mut kids = Vec::new();
-            body.for_each_child(NodeRef::Stmt(s), |c| kids.push(c));
-            for c in kids {
-                precompute_node(body, c, modified, cache);
-            }
+        if self.applied.replace(true) {
+            return false;
         }
-        NodeRef::Pat(_) => {}
+        forward_at_root(engine)
     }
 }
 
-/// Collect assign-target locals in an expression subtree (no caching). Used for
-/// `Match` arms, whose bodies are expressions (not blocks).
-fn collect_modified_expr(body: &Body, expr: ExprId) -> IndexSet<u32> {
-    let mut modified = IndexSet::default();
-    collect_modified_node(body, NodeRef::Expr(expr), &mut modified);
-    modified
-}
+fn forward_at_root(engine: &mut Engine) -> bool {
+    let unsafe_locals = collect_unsafe_locals(engine.body);
+    // Collect every `Local` read expression first; iterating while the
+    // engine rewrites would invalidate body/expr indices we're walking.
+    let mut local_reads: Vec<(ExprId, u32)> = Vec::new();
+    collect_local_reads(engine.body, &mut local_reads);
 
-fn collect_modified_node(body: &Body, node: NodeRef, modified: &mut IndexSet<u32>) {
-    if let NodeRef::Expr(id) = node
-        && let ExprKind::Assign { target, .. } = &body.exprs[id].kind
-    {
-        let target = *target;
-        insert_assign_target(body, target, modified);
-    }
-    let mut kids = Vec::new();
-    body.for_each_child(node, |c| kids.push(c));
-    for c in kids {
-        collect_modified_node(body, c, modified);
-    }
-}
-
-/// A forwardable value: a scalar literal.
-#[derive(Debug, Clone)]
-enum ForwardValue {
-    Int { value: u64, repr: String },
-    Float { value: f64, repr: String },
-    Bool(bool),
-    Char(char),
-}
-
-impl ForwardValue {
-    fn from_expr(body: &Body, expr: ExprId) -> Option<Self> {
-        match &body.exprs[expr].kind {
-            ExprKind::IntLiteral { value, repr } => Some(Self::Int {
-                value: *value,
-                repr: repr.clone(),
-            }),
-            ExprKind::FloatLiteral { value, repr } => Some(Self::Float {
-                value: *value,
-                repr: repr.clone(),
-            }),
-            ExprKind::BoolLiteral(b) => Some(Self::Bool(*b)),
-            ExprKind::CharLiteral(c) => Some(Self::Char(*c)),
-            _ => None,
+    let mut changed = false;
+    for (expr, local_index) in local_reads {
+        if unsafe_locals.contains(&local_index) {
+            continue;
         }
-    }
-
-    fn to_expr_kind(&self) -> ExprKind {
-        match self {
-            Self::Int { value, repr } => ExprKind::IntLiteral {
-                value: *value,
-                repr: repr.clone(),
-            },
-            Self::Float { value, repr } => ExprKind::FloatLiteral {
-                value: *value,
-                repr: repr.clone(),
-            },
-            Self::Bool(b) => ExprKind::BoolLiteral(*b),
-            Self::Char(c) => ExprKind::CharLiteral(*c),
+        // Skip if this Local is itself an assign target (LHS) — `x = ...`
+        // is a write, not a read, and rewriting the target with a literal
+        // makes no sense.
+        if is_assign_target(engine, expr) {
+            continue;
         }
-    }
-}
-
-#[derive(Debug, Clone, Default)]
-struct KnownValues {
-    locals: IndexMap<u32, ForwardValue>,
-}
-
-impl KnownValues {
-    fn set_local(&mut self, index: u32, value: ForwardValue) {
-        self.locals.insert(index, value);
-    }
-    fn get_local(&self, index: u32) -> Option<&ForwardValue> {
-        self.locals.get(&index)
-    }
-    fn invalidate_local(&mut self, index: u32) {
-        self.locals.swap_remove(&index);
-    }
-    fn invalidate_modified(&mut self, modified: &IndexSet<u32>) {
-        for &idx in modified {
-            self.invalidate_local(idx);
+        let Some(vid) = engine.value(expr) else {
+            continue;
+        };
+        if !matches!(
+            engine.value_kind(vid),
+            ValueKind::Int(_) | ValueKind::Float(_) | ValueKind::Bool(_) | ValueKind::Char(_)
+        ) {
+            continue;
         }
+        let Some(src) = engine.literal_source(vid) else {
+            continue;
+        };
+        let new_kind = engine.body.exprs[src].kind.clone();
+        engine.replace_expr_kind(expr, new_kind);
+        changed = true;
     }
+    changed
 }
 
-/// Collect locals that are unsafe for forwarding: address taken (`&` / `&mut`).
+/// Locals whose address is taken anywhere in the body. The ValueGraph
+/// builder does not yet model writes through pointers, so we treat these
+/// as forwarding-ineligible at the rule level.
 fn collect_unsafe_locals(body: &Body) -> IndexSet<u32> {
     let mut unsafe_locals = IndexSet::default();
     collect_unsafe_node(body, NodeRef::Block(body.root), &mut unsafe_locals);
@@ -205,422 +137,31 @@ fn collect_unsafe_node(body: &Body, node: NodeRef, unsafe_locals: &mut IndexSet<
     }
 }
 
-pub fn forward_stores_to_loads(project: &mut NirPackage, gate: &mut FunctionGate) -> bool {
-    let type_table = project.type_table.borrow();
-    let len = project.functions.len();
-    let mut buffers = EngineBuffers::default();
-    gate.run_gated(GatedPass::StoreLoadForward, len, |fid| {
-        let mut func = project.functions[fid.index()].borrow_mut();
-        if func.body.is_none() {
-            return false;
-        }
-        let rule = StoreLoadForwardRule {
-            type_table: &type_table,
-            applied: Cell::new(false),
-        };
-        let NirFunction { body, locals, .. } = &mut *func;
-        let body = body.as_mut().expect("checked above");
-        let mut engine = Engine::new(body, &mut buffers, locals);
-        engine.run(&[&rule])
-    })
+fn collect_local_reads(body: &Body, out: &mut Vec<(ExprId, u32)>) {
+    collect_local_reads_node(body, NodeRef::Block(body.root), out);
 }
 
-/// Standalone-session rule whose single `apply_block` performs the whole-
-/// function flow-sensitive forward pass at the body root.
-pub(super) struct StoreLoadForwardRule<'a> {
-    type_table: &'a TypeTable,
-    applied: Cell<bool>,
-}
-
-impl Rule for StoreLoadForwardRule<'_> {
-    fn apply_block(&self, engine: &mut Engine, block: BlockId) -> bool {
-        if engine.parent_of(NodeRef::Block(block)).is_some() {
-            return false;
-        }
-        if self.applied.replace(true) {
-            return false;
-        }
-        forward_at_root(engine, self.type_table)
+fn collect_local_reads_node(body: &Body, node: NodeRef, out: &mut Vec<(ExprId, u32)>) {
+    if let NodeRef::Expr(id) = node
+        && let ExprKind::Local { index, .. } = &body.exprs[id].kind
+    {
+        out.push((id, *index));
+    }
+    let mut kids = Vec::new();
+    body.for_each_child(node, |c| kids.push(c));
+    for c in kids {
+        collect_local_reads_node(body, c, out);
     }
 }
 
-fn forward_at_root(engine: &mut Engine, type_table: &TypeTable) -> bool {
-    let unsafe_locals = collect_unsafe_locals(engine.body);
-    let cache = precompute_all_modified_locals(engine.body);
-    let mut known = KnownValues::default();
-    let root = engine.body.root;
-    forward_in_block(engine, root, &mut known, &unsafe_locals, type_table, &cache)
-}
-
-fn lookup_modified(cache: &ModifiedLocalsCache, block: BlockId) -> IndexSet<u32> {
-    cache.get(&block).cloned().unwrap_or_default()
-}
-
-fn forward_in_block(
-    engine: &mut Engine,
-    block: BlockId,
-    known: &mut KnownValues,
-    unsafe_locals: &IndexSet<u32>,
-    type_table: &TypeTable,
-    cache: &ModifiedLocalsCache,
-) -> bool {
-    let mut changed = false;
-    let stmts = engine.body.blocks[block].stmts.clone();
-    for stmt in stmts {
-        changed |= forward_in_stmt(engine, stmt, known, unsafe_locals, type_table, cache);
-    }
-    changed
-}
-
-fn forward_in_stmt(
-    engine: &mut Engine,
-    stmt: StmtId,
-    known: &mut KnownValues,
-    unsafe_locals: &IndexSet<u32>,
-    type_table: &TypeTable,
-    cache: &ModifiedLocalsCache,
-) -> bool {
-    match &engine.body.stmts[stmt].kind {
-        StmtKind::Let {
-            local_index, value, ..
-        } => {
-            let (local_index, value) = (*local_index, *value);
-            let changed = forward_in_expr(engine, value, known, unsafe_locals, type_table, cache);
-            if !unsafe_locals.contains(&local_index)
-                && let Some(fv) = ForwardValue::from_expr(engine.body, value)
-            {
-                known.set_local(local_index, fv);
-            }
-            changed
-        }
-        StmtKind::Expr(e) => {
-            let e = *e;
-            let changed = forward_in_expr(engine, e, known, unsafe_locals, type_table, cache);
-            update_known_from_assign(engine.body, e, known, unsafe_locals);
-            changed
-        }
-        StmtKind::Return { value } | StmtKind::Break { value, .. } => {
-            if let Some(v) = *value {
-                forward_in_expr(engine, v, known, unsafe_locals, type_table, cache)
-            } else {
-                false
-            }
-        }
-        StmtKind::If {
-            condition,
-            then_block,
-            else_block,
-        } => {
-            let (condition, then_block, else_block) = (*condition, *then_block, *else_block);
-            let mut changed =
-                forward_in_expr(engine, condition, known, unsafe_locals, type_table, cache);
-            let mut modified = lookup_modified(cache, then_block);
-            if let Some(eb) = else_block {
-                modified.extend(lookup_modified(cache, eb));
-            }
-            let mut then_known = known.clone();
-            changed |= forward_in_block(
-                engine,
-                then_block,
-                &mut then_known,
-                unsafe_locals,
-                type_table,
-                cache,
-            );
-            if let Some(eb) = else_block {
-                let mut else_known = known.clone();
-                changed |= forward_in_block(
-                    engine,
-                    eb,
-                    &mut else_known,
-                    unsafe_locals,
-                    type_table,
-                    cache,
-                );
-            }
-            known.invalidate_modified(&modified);
-            changed
-        }
-        StmtKind::Loop { body: b } => {
-            let b = *b;
-            let modified = lookup_modified(cache, b);
-            known.invalidate_modified(&modified);
-            let mut loop_known = known.clone();
-            let changed =
-                forward_in_block(engine, b, &mut loop_known, unsafe_locals, type_table, cache);
-            known.invalidate_modified(&modified);
-            changed
-        }
-        StmtKind::LabeledBlock { block: b, .. } => {
-            let b = *b;
-            let modified = lookup_modified(cache, b);
-            let changed = forward_in_block(engine, b, known, unsafe_locals, type_table, cache);
-            known.invalidate_modified(&modified);
-            changed
-        }
-        StmtKind::Continue => false,
-        StmtKind::LetDestructure { value, .. } => {
-            let value = *value;
-            forward_in_expr(engine, value, known, unsafe_locals, type_table, cache)
-        }
-    }
-}
-
-fn forward_in_expr(
-    engine: &mut Engine,
-    id: ExprId,
-    known: &mut KnownValues,
-    unsafe_locals: &IndexSet<u32>,
-    type_table: &TypeTable,
-    cache: &ModifiedLocalsCache,
-) -> bool {
-    let mut changed = try_forward_expr(engine, id, known);
-
-    match &engine.body.exprs[id].kind {
-        ExprKind::Binary { left, right, .. } => {
-            let (left, right) = (*left, *right);
-            changed |= forward_in_expr(engine, left, known, unsafe_locals, type_table, cache);
-            changed |= forward_in_expr(engine, right, known, unsafe_locals, type_table, cache);
-        }
-        ExprKind::Unary { expr: inner, .. } => {
-            let inner = *inner;
-            changed |= forward_in_expr(engine, inner, known, unsafe_locals, type_table, cache);
-        }
-        ExprKind::Assign { target, value } => {
-            let (target, value) = (*target, *value);
-            changed |= forward_in_expr(engine, value, known, unsafe_locals, type_table, cache);
-            update_known_from_target(engine.body, target, value, known, unsafe_locals);
-        }
-        ExprKind::Call { args, .. } => {
-            let args: Vec<ExprId> = args.iter().map(|a| a.expr).collect();
-            for a in args {
-                changed |= forward_in_expr(engine, a, known, unsafe_locals, type_table, cache);
-            }
-        }
-        ExprKind::CmRawCall { args, .. } => {
-            let args = args.clone();
-            for a in args {
-                changed |= forward_in_expr(engine, a, known, unsafe_locals, type_table, cache);
-            }
-        }
-        ExprKind::MethodCall { receiver, args, .. } => {
-            let receiver = *receiver;
-            let args: Vec<ExprId> = args.iter().map(|a| a.expr).collect();
-            changed |= forward_in_expr(engine, receiver, known, unsafe_locals, type_table, cache);
-            for a in args {
-                changed |= forward_in_expr(engine, a, known, unsafe_locals, type_table, cache);
-            }
-        }
-        ExprKind::IndirectCall { callee, args, .. } => {
-            let callee = *callee;
-            let args = args.clone();
-            changed |= forward_in_expr(engine, callee, known, unsafe_locals, type_table, cache);
-            for a in args {
-                changed |= forward_in_expr(engine, a, known, unsafe_locals, type_table, cache);
-            }
-        }
-        ExprKind::ClosureToCanonical { functor, .. } => {
-            let functor = *functor;
-            changed |= forward_in_expr(engine, functor, known, unsafe_locals, type_table, cache);
-        }
-        ExprKind::FieldAccess { expr: inner, .. } | ExprKind::Cast { expr: inner, .. } => {
-            let inner = *inner;
-            changed |= forward_in_expr(engine, inner, known, unsafe_locals, type_table, cache);
-        }
-        ExprKind::Index { expr: inner, index } => {
-            let (inner, index) = (*inner, *index);
-            changed |= forward_in_expr(engine, inner, known, unsafe_locals, type_table, cache);
-            changed |= forward_in_expr(engine, index, known, unsafe_locals, type_table, cache);
-        }
-        ExprKind::Block(b) => {
-            let b = *b;
-            changed |= forward_in_block(engine, b, known, unsafe_locals, type_table, cache);
-        }
-        ExprKind::LabeledBlock { block: b, .. } => {
-            let b = *b;
-            let modified = lookup_modified(cache, b);
-            changed |= forward_in_block(engine, b, known, unsafe_locals, type_table, cache);
-            known.invalidate_modified(&modified);
-        }
-        ExprKind::If {
-            condition,
-            then_branch,
-            else_branch,
-        } => {
-            let (condition, then_branch, else_branch) = (*condition, *then_branch, *else_branch);
-            changed |= forward_in_expr(engine, condition, known, unsafe_locals, type_table, cache);
-            let mut modified = lookup_modified(cache, then_branch);
-            if let Some(eb) = else_branch {
-                modified.extend(lookup_modified(cache, eb));
-            }
-            let mut then_known = known.clone();
-            changed |= forward_in_block(
-                engine,
-                then_branch,
-                &mut then_known,
-                unsafe_locals,
-                type_table,
-                cache,
-            );
-            if let Some(eb) = else_branch {
-                let mut else_known = known.clone();
-                changed |= forward_in_block(
-                    engine,
-                    eb,
-                    &mut else_known,
-                    unsafe_locals,
-                    type_table,
-                    cache,
-                );
-            }
-            known.invalidate_modified(&modified);
-        }
-        ExprKind::StructLiteral { fields, .. } => {
-            let vals: Vec<ExprId> = fields.iter().map(|f| f.value).collect();
-            for v in vals {
-                changed |= forward_in_expr(engine, v, known, unsafe_locals, type_table, cache);
-            }
-        }
-        ExprKind::TupleLiteral { elements, .. } | ExprKind::ArrayLiteral { elements, .. } => {
-            let elems = elements.clone();
-            for e in elems {
-                changed |= forward_in_expr(engine, e, known, unsafe_locals, type_table, cache);
-            }
-        }
-        ExprKind::VariantConstruct { payload, .. } => {
-            if let Some(p) = *payload {
-                changed |= forward_in_expr(engine, p, known, unsafe_locals, type_table, cache);
-            }
-        }
-        ExprKind::Match { expr: inner, arms } => {
-            let inner = *inner;
-            let arm_data: Vec<(Option<ExprId>, ExprId)> =
-                arms.iter().map(|a| (a.guard, a.body)).collect();
-            changed |= forward_in_expr(engine, inner, known, unsafe_locals, type_table, cache);
-            let mut modified = IndexSet::default();
-            for (guard, arm_body) in &arm_data {
-                if let Some(g) = guard {
-                    modified.extend(collect_modified_expr(engine.body, *g));
-                }
-                modified.extend(collect_modified_expr(engine.body, *arm_body));
-            }
-            for (guard, arm_body) in arm_data {
-                let mut arm_known = known.clone();
-                if let Some(g) = guard {
-                    changed |= forward_in_expr(
-                        engine,
-                        g,
-                        &mut arm_known,
-                        unsafe_locals,
-                        type_table,
-                        cache,
-                    );
-                }
-                changed |= forward_in_expr(
-                    engine,
-                    arm_body,
-                    &mut arm_known,
-                    unsafe_locals,
-                    type_table,
-                    cache,
-                );
-            }
-            known.invalidate_modified(&modified);
-        }
-        ExprKind::GlobalVarSet { value, .. } => {
-            let value = *value;
-            changed |= forward_in_expr(engine, value, known, unsafe_locals, type_table, cache);
-        }
-        ExprKind::VariantTag { expr }
-        | ExprKind::VariantTest { expr, .. }
-        | ExprKind::VariantPayload { expr, .. } => {
-            let expr = *expr;
-            changed |= forward_in_expr(engine, expr, known, unsafe_locals, type_table, cache);
-        }
-        ExprKind::Switch {
-            scrutinee,
-            arms,
-            default,
-            ..
-        } => {
-            let scrutinee = *scrutinee;
-            let arms = arms.clone();
-            let default = *default;
-            changed |= forward_in_expr(engine, scrutinee, known, unsafe_locals, type_table, cache);
-            let mut modified = IndexSet::default();
-            for &arm in &arms {
-                modified.extend(lookup_modified(cache, arm));
-            }
-            modified.extend(lookup_modified(cache, default));
-            for arm in arms {
-                let mut arm_known = known.clone();
-                changed |= forward_in_block(
-                    engine,
-                    arm,
-                    &mut arm_known,
-                    unsafe_locals,
-                    type_table,
-                    cache,
-                );
-            }
-            let mut default_known = known.clone();
-            changed |= forward_in_block(
-                engine,
-                default,
-                &mut default_known,
-                unsafe_locals,
-                type_table,
-                cache,
-            );
-            known.invalidate_modified(&modified);
-        }
-        _ => {}
-    }
-
-    changed
-}
-
-fn try_forward_expr(engine: &mut Engine, id: ExprId, known: &KnownValues) -> bool {
-    let fv = if let ExprKind::Local { index, .. } = &engine.body.exprs[id].kind {
-        known.get_local(*index).cloned()
-    } else {
-        None
+/// True when `expr`'s immediate parent is an `Assign` and `expr` is the
+/// assign's `target` (LHS).
+fn is_assign_target(engine: &Engine, expr: ExprId) -> bool {
+    let Some(NodeRef::Expr(parent)) = engine.parent_of(NodeRef::Expr(expr)) else {
+        return false;
     };
-    if let Some(fv) = fv {
-        engine.replace_expr_kind(id, fv.to_expr_kind());
-        return true;
-    }
-    false
-}
-
-fn update_known_from_target(
-    body: &Body,
-    target: ExprId,
-    value: ExprId,
-    known: &mut KnownValues,
-    unsafe_locals: &IndexSet<u32>,
-) {
-    if let ExprKind::Local { index, .. } = &body.exprs[target].kind {
-        let idx = *index;
-        if unsafe_locals.contains(&idx) {
-            return;
-        }
-        if let Some(fv) = ForwardValue::from_expr(body, value) {
-            known.set_local(idx, fv);
-        } else {
-            known.invalidate_local(idx);
-        }
-    }
-}
-
-fn update_known_from_assign(
-    body: &Body,
-    expr: ExprId,
-    known: &mut KnownValues,
-    unsafe_locals: &IndexSet<u32>,
-) {
-    if let ExprKind::Assign { target, value } = &body.exprs[expr].kind {
-        let (target, value) = (*target, *value);
-        update_known_from_target(body, target, value, known, unsafe_locals);
-    }
+    matches!(
+        &engine.body.exprs[parent].kind,
+        ExprKind::Assign { target, .. } if *target == expr
+    )
 }

--- a/wado-compiler/src/optimize/tmpl_hoist.rs
+++ b/wado-compiler/src/optimize/tmpl_hoist.rs
@@ -100,11 +100,7 @@ impl Rule for TmplHoistRule<'_> {
     }
 }
 
-fn hoist_in_block(
-    engine: &mut Engine,
-    block: BlockId,
-    type_table: &RefCell<TypeTable>,
-) -> bool {
+fn hoist_in_block(engine: &mut Engine, block: BlockId, type_table: &RefCell<TypeTable>) -> bool {
     let mut changed = false;
     let mut new_stmts: Vec<StmtId> = Vec::new();
 
@@ -1265,8 +1261,11 @@ fn transform_fmts_in_tmpl_block(
         // fallback when no `Let` is found, so matching names mainly
         // improves fallback / debug output consistency.
         let hoisted_name = format!("__fmt_buf_{}", engine.locals().len());
-        let fmt_local_index =
-            engine.alloc_local(hoisted_name.clone(), candidate.formatter_type, /* is_mut */ true);
+        let fmt_local_index = engine.alloc_local(
+            hoisted_name.clone(),
+            candidate.formatter_type,
+            /* is_mut */ true,
+        );
 
         // Find the next candidate that shares the same fmt_local_index
         let rename_end = sorted_candidates[pos + 1..]

--- a/wado-compiler/src/optimize/tmpl_hoist.rs
+++ b/wado-compiler/src/optimize/tmpl_hoist.rs
@@ -34,17 +34,23 @@
 //! the result must be bound to a Let variable that is only used as a method
 //! receiver (`self`), never passed as a regular function argument.
 //!
-//! The pass reads and mutates the arena [`Body`] directly. New nodes (the
-//! hoisted `Let`, the field-reset `Assign`, the normalized Formatter literal)
-//! are pushed straight into the arena; the analysis and rename walks navigate
-//! by id.
+//! Runs on the worklist rewrite engine (combine migration; see
+//! `docs/wep-2026-06-05-nir-rewrite-engine-design.md`) as a [`Rule`]: a
+//! per-function standalone engine session whose `apply_block` fires once at
+//! the body root and walks every loop in the function, applying the template-
+//! string buffer hoist per loop. All mutations route through the engine edit
+//! API (`alloc_expr`, `alloc_stmt`, `alloc_local`, `set_block_stmts`,
+//! `replace_expr_kind`) so the parent map and use index stay coherent.
+
+use std::cell::{Cell, RefCell};
 
 use crate::compiler_item::SeqField;
 use crate::hashmap::IndexSet;
-use crate::nir::{NirFunction, NirLocal, NirUnaryOp};
+use crate::nir::{NirFunction, NirUnaryOp};
 use crate::nir_arena::{
-    ArenaStructField, BlockId, Body, ExprId, ExprKind, ExprNode, StmtId, StmtKind, StmtNode,
+    ArenaStructField, BlockId, Body, ExprId, ExprKind, NodeRef, StmtId, StmtKind,
 };
+use crate::nir_engine::{Engine, EngineBuffers, Rule};
 use crate::nir_package::NirPackage;
 use crate::tir::{TypeId, TypeTable};
 use crate::token::Span;
@@ -57,40 +63,54 @@ use cranelift_entity::EntityRef;
 pub fn hoist_template_buffers(project: &mut NirPackage, gate: &mut FunctionGate) -> bool {
     let type_table = project.type_table.clone();
     let len = project.functions.len();
+    let mut buffers = EngineBuffers::default();
     gate.run_gated(GatedPass::TmplHoist, len, |fid| {
         let mut func = project.functions[fid.index()].borrow_mut();
-        hoist_in_function(&mut func, &type_table)
+        if func.body.is_none() {
+            return false;
+        }
+        let rule = TmplHoistRule {
+            type_table: &type_table,
+            applied: Cell::new(false),
+        };
+        let NirFunction { body, locals, .. } = &mut *func;
+        let body = body.as_mut().expect("checked above");
+        let mut engine = Engine::new(body, &mut buffers, locals);
+        engine.run(&[&rule])
     })
 }
 
-fn hoist_in_function(func: &mut NirFunction, type_table: &std::cell::RefCell<TypeTable>) -> bool {
-    if func.body.is_none() {
-        return false;
+/// Standalone-session rule whose single `apply_block` performs the whole-
+/// function template-buffer hoist at the body root.
+pub(super) struct TmplHoistRule<'a> {
+    type_table: &'a RefCell<TypeTable>,
+    applied: Cell<bool>,
+}
+
+impl Rule for TmplHoistRule<'_> {
+    fn apply_block(&self, engine: &mut Engine, block: BlockId) -> bool {
+        if engine.parent_of(NodeRef::Block(block)).is_some() {
+            return false;
+        }
+        if self.applied.replace(true) {
+            return false;
+        }
+        let root = engine.body.root;
+        hoist_in_block(engine, root, self.type_table)
     }
-    let mut local_count = func.local_count();
-    // New locals are append-only, so collect them separately and extend the
-    // function's list once the body borrow ends (the body borrows `func` too).
-    let mut new_locals: Vec<NirLocal> = Vec::new();
-    let body = func.body.as_mut().unwrap();
-    let root = body.root;
-    let changed = hoist_in_block(body, root, &mut local_count, &mut new_locals, type_table);
-    func.locals.extend(new_locals);
-    changed
 }
 
 fn hoist_in_block(
-    body: &mut Body,
+    engine: &mut Engine,
     block: BlockId,
-    local_count: &mut u32,
-    new_locals: &mut Vec<NirLocal>,
-    type_table: &std::cell::RefCell<TypeTable>,
+    type_table: &RefCell<TypeTable>,
 ) -> bool {
     let mut changed = false;
     let mut new_stmts: Vec<StmtId> = Vec::new();
 
-    for s in body.blocks[block].stmts.clone() {
+    for s in engine.body.blocks[block].stmts.clone() {
         // Classify without holding the borrow across the mutable recursion.
-        let (loop_b, if_blocks, lab_b) = match &body.stmts[s].kind {
+        let (loop_b, if_blocks, lab_b) = match &engine.body.stmts[s].kind {
             StmtKind::Loop { body } => (Some(*body), None, None),
             StmtKind::If {
                 then_block,
@@ -103,29 +123,29 @@ fn hoist_in_block(
 
         if let Some(lb) = loop_b {
             // Recurse into loop body first (for nested loops).
-            changed |= hoist_in_block(body, lb, local_count, new_locals, type_table);
+            changed |= hoist_in_block(engine, lb, type_table);
             // Try to hoist template buffers out of this loop.
-            let hoist_stmts = hoist_tmpl_from_loop(body, lb, local_count, new_locals, type_table);
+            let hoist_stmts = hoist_tmpl_from_loop(engine, lb, type_table);
             if !hoist_stmts.is_empty() {
                 changed = true;
                 new_stmts.extend(hoist_stmts);
             }
             new_stmts.push(s);
         } else if let Some((tb, eb)) = if_blocks {
-            changed |= hoist_in_block(body, tb, local_count, new_locals, type_table);
+            changed |= hoist_in_block(engine, tb, type_table);
             if let Some(eb) = eb {
-                changed |= hoist_in_block(body, eb, local_count, new_locals, type_table);
+                changed |= hoist_in_block(engine, eb, type_table);
             }
             new_stmts.push(s);
         } else if let Some(inner) = lab_b {
-            changed |= hoist_in_block(body, inner, local_count, new_locals, type_table);
+            changed |= hoist_in_block(engine, inner, type_table);
             new_stmts.push(s);
         } else {
             new_stmts.push(s);
         }
     }
 
-    body.blocks[block].stmts = new_stmts;
+    engine.set_block_stmts(block, new_stmts);
     changed
 }
 
@@ -163,25 +183,21 @@ struct FmtCandidate {
 /// Scan a loop body for `__tmpl` labeled blocks and hoist their buffer allocations.
 /// Returns hoisting statements to prepend before the loop.
 fn hoist_tmpl_from_loop(
-    body: &mut Body,
+    engine: &mut Engine,
     loop_body: BlockId,
-    local_count: &mut u32,
-    new_locals: &mut Vec<NirLocal>,
-    type_table: &std::cell::RefCell<TypeTable>,
+    type_table: &RefCell<TypeTable>,
 ) -> Vec<StmtId> {
     // Phase 1: Collect all Let bindings whose value is a __tmpl LabeledBlock,
     // and check if the bound variable escapes (used as a non-self argument).
-    let escaping_locals = collect_escaping_locals(body, loop_body);
+    let escaping_locals = collect_escaping_locals(engine.body, loop_body);
 
     // Phase 2: Transform safe __tmpl blocks
     let mut hoist_stmts = Vec::new();
     transform_stmts_in_block(
-        body,
+        engine,
         loop_body,
         &escaping_locals,
         &mut hoist_stmts,
-        local_count,
-        new_locals,
         type_table,
     );
     hoist_stmts
@@ -464,82 +480,56 @@ fn collect_local_refs(body: &Body, e: ExprId, locals: &mut IndexSet<u32>) {
 
 /// Recursively transform statements, looking for Let bindings with __tmpl blocks.
 fn transform_stmts_in_block(
-    body: &mut Body,
+    engine: &mut Engine,
     block: BlockId,
     escaping_locals: &IndexSet<u32>,
     hoist_stmts: &mut Vec<StmtId>,
-    local_count: &mut u32,
-    new_locals: &mut Vec<NirLocal>,
-    type_table: &std::cell::RefCell<TypeTable>,
+    type_table: &RefCell<TypeTable>,
 ) {
-    for s in body.blocks[block].stmts.clone() {
-        transform_stmt(
-            body,
-            s,
-            escaping_locals,
-            hoist_stmts,
-            local_count,
-            new_locals,
-            type_table,
-        );
+    for s in engine.body.blocks[block].stmts.clone() {
+        transform_stmt(engine, s, escaping_locals, hoist_stmts, type_table);
     }
 }
 
 fn transform_stmt(
-    body: &mut Body,
+    engine: &mut Engine,
     s: StmtId,
     escaping_locals: &IndexSet<u32>,
     hoist_stmts: &mut Vec<StmtId>,
-    local_count: &mut u32,
-    new_locals: &mut Vec<NirLocal>,
-    type_table: &std::cell::RefCell<TypeTable>,
+    type_table: &RefCell<TypeTable>,
 ) {
     // `let x = __tmpl: { ... }` — the only statement shape that can hoist.
     let let_info = if let StmtKind::Let {
         local_index, value, ..
-    } = &body.stmts[s].kind
+    } = &engine.body.stmts[s].kind
     {
         Some((*local_index, *value))
     } else {
         None
     };
     if let Some((local_index, value)) = let_info {
-        let tmpl_block = match &body.exprs[value].kind {
+        let tmpl_block = match &engine.body.exprs[value].kind {
             ExprKind::LabeledBlock { label, block, .. } if label == "__tmpl" => Some(*block),
             _ => None,
         };
         if let Some(tb) = tmpl_block
             && !escaping_locals.contains(&local_index)
-            && let Some(candidate) = extract_tmpl_candidate(body, tb)
+            && let Some(candidate) = extract_tmpl_candidate(engine.body, tb)
         {
-            transform_tmpl_block(
-                body,
-                tb,
-                &candidate,
-                hoist_stmts,
-                local_count,
-                new_locals,
-                type_table,
-            );
+            transform_tmpl_block(engine, tb, &candidate, hoist_stmts, type_table);
             // The hoisted String is reused; skip deep copy so `s` aliases `__tmpl_buf`.
+            // This is a non-id field on `Let` and does not affect the engine's
+            // parent map / use index, so the in-place write is safe.
             if let StmtKind::Let {
                 skip_value_copy, ..
-            } = &mut body.stmts[s].kind
+            } = &mut engine.body.stmts[s].kind
             {
                 *skip_value_copy = true;
             }
             return;
         }
         // Recurse into the value expression
-        transform_expr(
-            body,
-            value,
-            escaping_locals,
-            hoist_stmts,
-            local_count,
-            new_locals,
-            type_table,
-        );
+        transform_expr(engine, value, escaping_locals, hoist_stmts, type_table);
         return;
     }
 
@@ -551,7 +541,7 @@ fn transform_stmt(
         Break(ExprId),
         None,
     }
-    let shape = match &body.stmts[s].kind {
+    let shape = match &engine.body.stmts[s].kind {
         StmtKind::Expr(e) => Shape::Expr(*e),
         StmtKind::If {
             condition,
@@ -564,67 +554,29 @@ fn transform_stmt(
         _ => Shape::None,
     };
     match shape {
-        Shape::Expr(e) | Shape::Break(e) => transform_expr(
-            body,
-            e,
-            escaping_locals,
-            hoist_stmts,
-            local_count,
-            new_locals,
-            type_table,
-        ),
+        Shape::Expr(e) | Shape::Break(e) => {
+            transform_expr(engine, e, escaping_locals, hoist_stmts, type_table)
+        }
         Shape::If(cond, tb, eb) => {
-            transform_expr(
-                body,
-                cond,
-                escaping_locals,
-                hoist_stmts,
-                local_count,
-                new_locals,
-                type_table,
-            );
-            transform_stmts_in_block(
-                body,
-                tb,
-                escaping_locals,
-                hoist_stmts,
-                local_count,
-                new_locals,
-                type_table,
-            );
+            transform_expr(engine, cond, escaping_locals, hoist_stmts, type_table);
+            transform_stmts_in_block(engine, tb, escaping_locals, hoist_stmts, type_table);
             if let Some(eb) = eb {
-                transform_stmts_in_block(
-                    body,
-                    eb,
-                    escaping_locals,
-                    hoist_stmts,
-                    local_count,
-                    new_locals,
-                    type_table,
-                );
+                transform_stmts_in_block(engine, eb, escaping_locals, hoist_stmts, type_table);
             }
         }
-        Shape::Labeled(b) => transform_stmts_in_block(
-            body,
-            b,
-            escaping_locals,
-            hoist_stmts,
-            local_count,
-            new_locals,
-            type_table,
-        ),
+        Shape::Labeled(b) => {
+            transform_stmts_in_block(engine, b, escaping_locals, hoist_stmts, type_table)
+        }
         Shape::None => {}
     }
 }
 
 fn transform_expr(
-    body: &mut Body,
+    engine: &mut Engine,
     e: ExprId,
     escaping_locals: &IndexSet<u32>,
     hoist_stmts: &mut Vec<StmtId>,
-    local_count: &mut u32,
-    new_locals: &mut Vec<NirLocal>,
-    type_table: &std::cell::RefCell<TypeTable>,
+    type_table: &RefCell<TypeTable>,
 ) {
     // Mirror the original's restricted arm set: __tmpl in non-Let contexts is
     // not hoisted, so only these shapes recurse.
@@ -634,7 +586,7 @@ fn transform_expr(
         Block(BlockId),
         None,
     }
-    let walk = match &body.exprs[e].kind {
+    let walk = match &engine.body.exprs[e].kind {
         ExprKind::Call { args, .. } => Walk::Exprs(args.iter().map(|a| a.expr).collect()),
         ExprKind::MethodCall { receiver, args, .. } => {
             let mut v = vec![*receiver];
@@ -657,57 +609,19 @@ fn transform_expr(
     match walk {
         Walk::Exprs(v) => {
             for id in v {
-                transform_expr(
-                    body,
-                    id,
-                    escaping_locals,
-                    hoist_stmts,
-                    local_count,
-                    new_locals,
-                    type_table,
-                );
+                transform_expr(engine, id, escaping_locals, hoist_stmts, type_table);
             }
         }
         Walk::CondBlocks(cond, tb, eb) => {
-            transform_expr(
-                body,
-                cond,
-                escaping_locals,
-                hoist_stmts,
-                local_count,
-                new_locals,
-                type_table,
-            );
-            transform_stmts_in_block(
-                body,
-                tb,
-                escaping_locals,
-                hoist_stmts,
-                local_count,
-                new_locals,
-                type_table,
-            );
+            transform_expr(engine, cond, escaping_locals, hoist_stmts, type_table);
+            transform_stmts_in_block(engine, tb, escaping_locals, hoist_stmts, type_table);
             if let Some(eb) = eb {
-                transform_stmts_in_block(
-                    body,
-                    eb,
-                    escaping_locals,
-                    hoist_stmts,
-                    local_count,
-                    new_locals,
-                    type_table,
-                );
+                transform_stmts_in_block(engine, eb, escaping_locals, hoist_stmts, type_table);
             }
         }
-        Walk::Block(b) => transform_stmts_in_block(
-            body,
-            b,
-            escaping_locals,
-            hoist_stmts,
-            local_count,
-            new_locals,
-            type_table,
-        ),
+        Walk::Block(b) => {
+            transform_stmts_in_block(engine, b, escaping_locals, hoist_stmts, type_table)
+        }
         Walk::None => {}
     }
 }
@@ -825,10 +739,10 @@ struct FmtFields {
 ///      `let __f = label: { let buf = &mut __tmpl_buf; break: Formatter { ..., buf } }`
 ///      or `__local_N = label: { ... break: Formatter { ... } }`
 fn extract_fmt_candidates(
-    body: &mut Body,
+    engine: &mut Engine,
     block: BlockId,
     hoisted_buf_index: u32,
-    type_table: &std::cell::RefCell<TypeTable>,
+    type_table: &RefCell<TypeTable>,
 ) -> Vec<FmtCandidate> {
     // Phase A (read): decide candidacy without mutating the arena.
     struct Raw {
@@ -840,7 +754,7 @@ fn extract_fmt_candidates(
     let mut raws: Vec<Raw> = Vec::new();
     {
         let type_table = type_table.borrow();
-        let stmts = body.blocks[block].stmts.clone();
+        let stmts = engine.body.blocks[block].stmts.clone();
         let len = stmts.len();
         for (i, s) in stmts.iter().enumerate() {
             if i == 0 || i == len - 1 {
@@ -848,12 +762,12 @@ fn extract_fmt_candidates(
             }
 
             // Try to extract (local_index, value_expr_id) from the statement.
-            let (fmt_local_index, value_expr): (u32, ExprId) = match &body.stmts[*s].kind {
+            let (fmt_local_index, value_expr): (u32, ExprId) = match &engine.body.stmts[*s].kind {
                 StmtKind::Expr(expr) => {
-                    let ExprKind::Assign { target, value } = &body.exprs[*expr].kind else {
+                    let ExprKind::Assign { target, value } = &engine.body.exprs[*expr].kind else {
                         continue;
                     };
-                    let ExprKind::Local { index, .. } = &body.exprs[*target].kind else {
+                    let ExprKind::Local { index, .. } = &engine.body.exprs[*target].kind else {
                         continue;
                     };
                     (*index, *value)
@@ -864,7 +778,8 @@ fn extract_fmt_candidates(
                 _ => continue,
             };
 
-            let Some(ff) = extract_formatter_fields(body, value_expr, hoisted_buf_index) else {
+            let Some(ff) = extract_formatter_fields(engine.body, value_expr, hoisted_buf_index)
+            else {
                 continue;
             };
 
@@ -885,7 +800,7 @@ fn extract_fmt_candidates(
                 if name == "buf" {
                     return true;
                 }
-                is_constant_expr(body, *value)
+                is_constant_expr(engine.body, *value)
             });
             if !all_const {
                 continue;
@@ -916,27 +831,27 @@ fn extract_fmt_candidates(
         for (name, field_index, value) in &raw.ff.fields {
             let new_value = if name == "buf" {
                 // Normalize buf to &mut __tmpl_buf
-                let buf_ty = body.exprs[*value].type_id;
-                let local = body.exprs.push(ExprNode {
-                    kind: ExprKind::Local {
+                let buf_ty = engine.body.exprs[*value].type_id;
+                let local = engine.alloc_expr(
+                    ExprKind::Local {
                         index: hoisted_buf_index,
                         name: format!("__tmpl_buf_{hoisted_buf_index}"),
                     },
-                    type_id: buf_ty,
-                    span: value_span,
-                });
-                body.exprs.push(ExprNode {
-                    kind: ExprKind::Unary {
+                    buf_ty,
+                    value_span,
+                );
+                engine.alloc_expr(
+                    ExprKind::Unary {
                         op: NirUnaryOp::MutRef,
                         expr: local,
                     },
-                    type_id: buf_ty,
-                    span: value_span,
-                })
+                    buf_ty,
+                    value_span,
+                )
             } else {
                 // A verified constant leaf — a shallow node copy is a full copy.
-                let node = body.exprs[*value].clone();
-                body.exprs.push(node)
+                let node = engine.body.exprs[*value].clone();
+                engine.alloc_expr(node.kind, node.type_id, node.span)
             };
             init_fields.push(ArenaStructField {
                 name: name.clone(),
@@ -944,15 +859,15 @@ fn extract_fmt_candidates(
                 field_index: *field_index,
             });
         }
-        let init_value = body.exprs.push(ExprNode {
-            kind: ExprKind::StructLiteral {
+        let init_value = engine.alloc_expr(
+            ExprKind::StructLiteral {
                 struct_type,
                 struct_name: raw.ff.struct_name.clone(),
                 fields: init_fields,
             },
-            type_id: value_type_id,
-            span: value_span,
-        });
+            value_type_id,
+            value_span,
+        );
         candidates.push(FmtCandidate {
             stmt_index: raw.stmt_index,
             fmt_local_index: raw.fmt_local_index,
@@ -1198,31 +1113,24 @@ fn array_new_has_capacity(body: &Body, e: ExprId) -> bool {
 /// renamed to `__tmpl_buf`. The outer Let binding gets `skip_value_copy = true`
 /// so the bound variable aliases the hoisted String directly.
 fn transform_tmpl_block(
-    body: &mut Body,
+    engine: &mut Engine,
     block: BlockId,
     candidate: &TmplCandidate,
     hoist_stmts: &mut Vec<StmtId>,
-    local_count: &mut u32,
-    new_locals: &mut Vec<NirLocal>,
-    type_table: &std::cell::RefCell<TypeTable>,
+    type_table: &RefCell<TypeTable>,
 ) {
     let span = candidate.span;
     let string_type = candidate.string_type;
 
-    // Allocate a new local for the hoisted String
-    let buf_local_index = *local_count;
-    *local_count += 1;
-    let buf_local_name = format!("__tmpl_buf_{buf_local_index}");
-    new_locals.push(NirLocal {
-        name: buf_local_name.clone(),
-        type_id: string_type,
-        is_mut: true,
-    });
+    // Allocate a new local for the hoisted String via the engine.
+    let buf_local_name = format!("__tmpl_buf_{}", engine.locals().len());
+    let buf_local_index =
+        engine.alloc_local(buf_local_name.clone(), string_type, /* is_mut */ true);
 
     // Hoist statement: let mut __tmpl_buf_N = String { repr: array_new(N), used: 0 };
     // Reuse the original init-value subtree (its old `Let` is replaced below).
-    let hoist_let = body.stmts.push(StmtNode {
-        kind: StmtKind::Let {
+    let hoist_let = engine.alloc_stmt(
+        StmtKind::Let {
             name: buf_local_name.clone(),
             local_index: buf_local_index,
             is_mut: true,
@@ -1232,13 +1140,13 @@ fn transform_tmpl_block(
             skip_value_copy: false,
         },
         span,
-    });
+    );
     hoist_stmts.push(hoist_let);
 
     // Replace the first statement (let mut __r = String { ... }) with a field reset:
     // __tmpl_buf_N.used = 0;
     let reset_stmt = build_field_reset(
-        body,
+        engine,
         buf_local_index,
         &buf_local_name,
         string_type,
@@ -1246,35 +1154,30 @@ fn transform_tmpl_block(
         SeqField::Len.field_name(),
         span,
     );
-    body.blocks[block].stmts[0] = reset_stmt;
+    let mut new_stmts = engine.body.blocks[block].stmts.clone();
+    new_stmts[0] = reset_stmt;
+    engine.set_block_stmts(block, new_stmts);
 
     // Rename all references from __r (old local index) to __tmpl_buf_N (new local index)
     let old_index = candidate.buf_local_index;
-    for s in body.blocks[block].stmts.clone() {
-        rename_local_in_stmt(body, s, old_index, buf_local_index, &buf_local_name);
+    for s in engine.body.blocks[block].stmts.clone() {
+        rename_local_in_stmt(engine, s, old_index, buf_local_index, &buf_local_name);
     }
 
     // Phase 2: Hoist Formatter struct literals as well.
     // After the String rename above, the block may contain one or more Formatter
     // creations (direct struct literals or inlined Formatter::new LabeledBlocks).
     // Each distinct Formatter is hoisted to its own local before the loop.
-    let fmt_candidates = extract_fmt_candidates(body, block, buf_local_index, type_table);
+    let fmt_candidates = extract_fmt_candidates(engine, block, buf_local_index, type_table);
     if !fmt_candidates.is_empty() {
-        transform_fmts_in_tmpl_block(
-            body,
-            block,
-            &fmt_candidates,
-            hoist_stmts,
-            local_count,
-            new_locals,
-        );
+        transform_fmts_in_tmpl_block(engine, block, &fmt_candidates, hoist_stmts);
     }
 }
 
 /// Build a `target_local.<field> = 0` statement (an `Expr(Assign)` over a
 /// `FieldAccess`), returning its arena id.
 fn build_field_reset(
-    body: &mut Body,
+    engine: &mut Engine,
     local_index: u32,
     local_name: &str,
     local_type: TypeId,
@@ -1282,43 +1185,40 @@ fn build_field_reset(
     field_name: &str,
     span: Span,
 ) -> StmtId {
-    let local = body.exprs.push(ExprNode {
-        kind: ExprKind::Local {
+    let local = engine.alloc_expr(
+        ExprKind::Local {
             index: local_index,
             name: local_name.to_string(),
         },
-        type_id: local_type,
+        local_type,
         span,
-    });
-    let field = body.exprs.push(ExprNode {
-        kind: ExprKind::FieldAccess {
+    );
+    let field = engine.alloc_expr(
+        ExprKind::FieldAccess {
             expr: local,
             field_index,
             field_name: field_name.to_string(),
         },
-        type_id: TypeTable::I32,
+        TypeTable::I32,
         span,
-    });
-    let zero = body.exprs.push(ExprNode {
-        kind: ExprKind::IntLiteral {
+    );
+    let zero = engine.alloc_expr(
+        ExprKind::IntLiteral {
             value: 0,
             repr: "0".to_string(),
         },
-        type_id: TypeTable::I32,
+        TypeTable::I32,
         span,
-    });
-    let assign = body.exprs.push(ExprNode {
-        kind: ExprKind::Assign {
+    );
+    let assign = engine.alloc_expr(
+        ExprKind::Assign {
             target: field,
             value: zero,
         },
-        type_id: TypeTable::UNIT,
+        TypeTable::UNIT,
         span,
-    });
-    body.stmts.push(StmtNode {
-        kind: StmtKind::Expr(assign),
-        span,
-    })
+    );
+    engine.alloc_stmt(StmtKind::Expr(assign), span)
 }
 
 /// Hoist Formatter struct literals out of a `__tmpl` block.
@@ -1329,12 +1229,10 @@ fn build_field_reset(
 /// Processes candidates in reverse order so that `stmt_index` values remain valid
 /// as we replace statements.
 fn transform_fmts_in_tmpl_block(
-    body: &mut Body,
+    engine: &mut Engine,
     block: BlockId,
     candidates: &[FmtCandidate],
     hoist_stmts: &mut Vec<StmtId>,
-    local_count: &mut u32,
-    new_locals: &mut Vec<NirLocal>,
 ) {
     // Sort by stmt_index ascending to compute rename ranges
     let mut sorted_candidates: Vec<_> = candidates.iter().collect();
@@ -1357,22 +1255,18 @@ fn transform_fmts_in_tmpl_block(
         init_value: ExprId,
         span: Span,
     }
-    let block_len = body.blocks[block].stmts.len();
+    let block_len = engine.body.blocks[block].stmts.len();
     let mut hoist_infos = Vec::new();
 
     for (pos, candidate) in sorted_candidates.iter().enumerate() {
-        let fmt_local_index = *local_count;
-        *local_count += 1;
         // Keep this name aligned with the corresponding `Let` statement
         // built below. WIR naming is primarily derived from discovered
         // `Let`s by local index, with `tir_func.locals[idx].name` used as a
         // fallback when no `Let` is found, so matching names mainly
         // improves fallback / debug output consistency.
-        new_locals.push(NirLocal {
-            name: format!("__fmt_buf_{fmt_local_index}"),
-            type_id: candidate.formatter_type,
-            is_mut: true,
-        });
+        let hoisted_name = format!("__fmt_buf_{}", engine.locals().len());
+        let fmt_local_index =
+            engine.alloc_local(hoisted_name.clone(), candidate.formatter_type, /* is_mut */ true);
 
         // Find the next candidate that shares the same fmt_local_index
         let rename_end = sorted_candidates[pos + 1..]
@@ -1383,7 +1277,7 @@ fn transform_fmts_in_tmpl_block(
 
         hoist_infos.push(HoistInfo {
             hoisted_index: fmt_local_index,
-            hoisted_name: format!("__fmt_buf_{fmt_local_index}"),
+            hoisted_name,
             stmt_index: candidate.stmt_index,
             rename_start: candidate.stmt_index,
             rename_end,
@@ -1398,8 +1292,8 @@ fn transform_fmts_in_tmpl_block(
     for info in &hoist_infos {
         // Hoist statement: let mut __fmt_buf_N = Formatter { fill: ..., buf: ... };
         // Reuse the normalized Formatter literal built during extraction.
-        let hoist_let = body.stmts.push(StmtNode {
-            kind: StmtKind::Let {
+        let hoist_let = engine.alloc_stmt(
+            StmtKind::Let {
                 name: info.hoisted_name.clone(),
                 local_index: info.hoisted_index,
                 is_mut: true,
@@ -1408,8 +1302,8 @@ fn transform_fmts_in_tmpl_block(
                 value: info.init_value,
                 skip_value_copy: false,
             },
-            span: info.span,
-        });
+            info.span,
+        );
         hoist_stmts.push(hoist_let);
 
         // Replace the Formatter struct literal with an indent field reset:
@@ -1420,7 +1314,7 @@ fn transform_fmts_in_tmpl_block(
         // during formatting. Without this reset, the indent value would
         // accumulate across loop iterations, causing incorrect indentation.
         let indent_reset = build_field_reset(
-            body,
+            engine,
             info.hoisted_index,
             &info.hoisted_name,
             info.formatter_type,
@@ -1428,16 +1322,18 @@ fn transform_fmts_in_tmpl_block(
             "indent",
             info.span,
         );
-        body.blocks[block].stmts[info.stmt_index] = indent_reset;
+        let mut new_stmts = engine.body.blocks[block].stmts.clone();
+        new_stmts[info.stmt_index] = indent_reset;
+        engine.set_block_stmts(block, new_stmts);
 
         // Rename references from the old Formatter local to the hoisted one,
         // only within [rename_start, rename_end) to avoid clobbering other
         // candidates that share the same original local.
         let range_stmts: Vec<StmtId> =
-            body.blocks[block].stmts[info.rename_start..info.rename_end].to_vec();
+            engine.body.blocks[block].stmts[info.rename_start..info.rename_end].to_vec();
         for s in range_stmts {
             rename_local_in_stmt(
-                body,
+                engine,
                 s,
                 info.old_fmt_index,
                 info.hoisted_index,
@@ -1448,7 +1344,7 @@ fn transform_fmts_in_tmpl_block(
 }
 
 fn rename_local_in_stmt(
-    body: &mut Body,
+    engine: &mut Engine,
     s: StmtId,
     old_index: u32,
     new_index: u32,
@@ -1460,7 +1356,7 @@ fn rename_local_in_stmt(
         Block(BlockId),
         None,
     }
-    let shape = match &body.stmts[s].kind {
+    let shape = match &engine.body.stmts[s].kind {
         StmtKind::Let { value, .. } => Shape::Expr(*value),
         StmtKind::Expr(expr) => Shape::Expr(*expr),
         StmtKind::Return { value: Some(expr) } => Shape::Expr(*expr),
@@ -1477,33 +1373,33 @@ fn rename_local_in_stmt(
         _ => Shape::None,
     };
     match shape {
-        Shape::Expr(e) => rename_local_in_expr(body, e, old_index, new_index, new_name),
+        Shape::Expr(e) => rename_local_in_expr(engine, e, old_index, new_index, new_name),
         Shape::If(cond, tb, eb) => {
-            rename_local_in_expr(body, cond, old_index, new_index, new_name);
-            rename_local_in_block(body, tb, old_index, new_index, new_name);
+            rename_local_in_expr(engine, cond, old_index, new_index, new_name);
+            rename_local_in_block(engine, tb, old_index, new_index, new_name);
             if let Some(eb) = eb {
-                rename_local_in_block(body, eb, old_index, new_index, new_name);
+                rename_local_in_block(engine, eb, old_index, new_index, new_name);
             }
         }
-        Shape::Block(b) => rename_local_in_block(body, b, old_index, new_index, new_name),
+        Shape::Block(b) => rename_local_in_block(engine, b, old_index, new_index, new_name),
         Shape::None => {}
     }
 }
 
 fn rename_local_in_block(
-    body: &mut Body,
+    engine: &mut Engine,
     block: BlockId,
     old_index: u32,
     new_index: u32,
     new_name: &str,
 ) {
-    for s in body.blocks[block].stmts.clone() {
-        rename_local_in_stmt(body, s, old_index, new_index, new_name);
+    for s in engine.body.blocks[block].stmts.clone() {
+        rename_local_in_stmt(engine, s, old_index, new_index, new_name);
     }
 }
 
 fn rename_local_in_expr(
-    body: &mut Body,
+    engine: &mut Engine,
     e: ExprId,
     old_index: u32,
     new_index: u32,
@@ -1516,7 +1412,7 @@ fn rename_local_in_expr(
         Block(BlockId),
         None,
     }
-    let walk = match &body.exprs[e].kind {
+    let walk = match &engine.body.exprs[e].kind {
         ExprKind::Local { index, .. } if *index == old_index => Walk::Local,
         ExprKind::Call { args, .. } => Walk::Exprs(args.iter().map(|a| a.expr).collect()),
         ExprKind::MethodCall { receiver, args, .. } => {
@@ -1548,24 +1444,31 @@ fn rename_local_in_expr(
     };
     match walk {
         Walk::Local => {
-            if let ExprKind::Local { index, name } = &mut body.exprs[e].kind {
-                *index = new_index;
-                *name = new_name.to_string();
-            }
+            // The Local kind's `index` field is what the engine's use index
+            // is keyed on, so route the rename through `replace_expr_kind`
+            // to drop the old `old_index` mention and register a new
+            // `new_index` mention.
+            engine.replace_expr_kind(
+                e,
+                ExprKind::Local {
+                    index: new_index,
+                    name: new_name.to_string(),
+                },
+            );
         }
         Walk::Exprs(v) => {
             for id in v {
-                rename_local_in_expr(body, id, old_index, new_index, new_name);
+                rename_local_in_expr(engine, id, old_index, new_index, new_name);
             }
         }
         Walk::CondBlocks(cond, tb, eb) => {
-            rename_local_in_expr(body, cond, old_index, new_index, new_name);
-            rename_local_in_block(body, tb, old_index, new_index, new_name);
+            rename_local_in_expr(engine, cond, old_index, new_index, new_name);
+            rename_local_in_block(engine, tb, old_index, new_index, new_name);
             if let Some(eb) = eb {
-                rename_local_in_block(body, eb, old_index, new_index, new_name);
+                rename_local_in_block(engine, eb, old_index, new_index, new_name);
             }
         }
-        Walk::Block(b) => rename_local_in_block(body, b, old_index, new_index, new_name),
+        Walk::Block(b) => rename_local_in_block(engine, b, old_index, new_index, new_name),
         Walk::None => {}
     }
 }
@@ -1573,7 +1476,7 @@ fn rename_local_in_expr(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::nir_arena::{BlockNode, StmtNode};
+    use crate::nir_arena::{BlockNode, ExprNode, StmtNode};
     use crate::tir::TypeId;
 
     /// Build a `Body` whose root holds a single expression (built by `build`)

--- a/wado-compiler/src/optimize/tmpl_hoist.rs
+++ b/wado-compiler/src/optimize/tmpl_hoist.rs
@@ -551,7 +551,7 @@ fn transform_stmt(
     };
     match shape {
         Shape::Expr(e) | Shape::Break(e) => {
-            transform_expr(engine, e, escaping_locals, hoist_stmts, type_table)
+            transform_expr(engine, e, escaping_locals, hoist_stmts, type_table);
         }
         Shape::If(cond, tb, eb) => {
             transform_expr(engine, cond, escaping_locals, hoist_stmts, type_table);
@@ -561,7 +561,7 @@ fn transform_stmt(
             }
         }
         Shape::Labeled(b) => {
-            transform_stmts_in_block(engine, b, escaping_locals, hoist_stmts, type_table)
+            transform_stmts_in_block(engine, b, escaping_locals, hoist_stmts, type_table);
         }
         Shape::None => {}
     }
@@ -616,7 +616,7 @@ fn transform_expr(
             }
         }
         Walk::Block(b) => {
-            transform_stmts_in_block(engine, b, escaping_locals, hoist_stmts, type_table)
+            transform_stmts_in_block(engine, b, escaping_locals, hoist_stmts, type_table);
         }
         Walk::None => {}
     }


### PR DESCRIPTION
## Summary

Implements Stages 1, 2, 3, and 5 of the worklist-engine WEP
(`docs/wep-2026-06-05-worklist-rewrite-engine.md`). Stage 4 (`copy_prop`)
is deferred — `ValueId` equality doesn't subsume copy-prop's
source-stability check. Stages 7-8 remain optional acceleration.

- **Stage 1** — `wado_compiler::nir_value_graph`: hash-consed pure-value
  pool keyed by structural equality. `ValueKind` covers literals,
  `Opaque`, `Binary` / `Unary` / `Cast`, `Select` (structural merge),
  `LoopPhi`, and `FieldAccess { receiver, field_index, heap_ver }`.

- **Stage 2** — per-function ValueGraph builder. One walk of the
  SkelTree populates `value_of: IndexMap<ExprId, ValueId>`. Local
  reaching-defs are threaded through `current_value`; If/Match/Switch
  merges build `Select` (or `Opaque`); loops conservatively reset
  modified locals.

- **Stage 3** — `optimize::cse` rewritten on top of `engine.value(e1)
  == engine.value(e2)`. The structural `CseKey` and `stmt_modifies_any`
  / `block_modifies_any` walks (~360 lines) deleted — the ValueGraph
  already encodes reassignment between occurrences.

- **Stage 5** — `optimize::store_load_forward` rewritten as a thin rule
  over the engine's ValueGraph. The 600-line `KnownValues` +
  `ModifiedLocalsCache` flow-sensitive walker collapses to ~170 lines:
  for each `Local` read, ask `engine.value(read)`, and when its kind is
  a literal, clone the source `ExprKind` (via `literal_source`) and
  substitute. Address-taken and `stores`-aliased locals are excluded —
  the builder does not model writes through references. Heap-version
  bookkeeping (`HeapState` + `bump_field` / `bump_all`) activates at
  heap-write events.

## Code-review follow-ups (already applied)

- `Engine::value` invalidation contract spelled out; passes snapshot VN
  results before editing.
- Per-arm `HeapState` snapshot/restore in `Match` / `Switch` (was
  leaking arm-N bumps into arm-N+1).
- `LabeledBlock` exit now marks every local written in the subtree
  `Opaque` (covers `break`-only-path writes that fall-through misses).
- Doc/comment sweep: stage-number archaeology removed, decorative
  section banners deleted, narration comments dropped.

## Diff

```
docs/wep-2026-06-05-worklist-rewrite-engine.md   ~270 lines net
wado-compiler/src/nir_value_graph.rs             new, ~660 lines
wado-compiler/src/nir_value_graph/builder.rs     new, ~1350 lines (incl. 18 tests)
wado-compiler/src/nir_engine.rs                  +90 lines (value graph API)
wado-compiler/src/optimize/cse.rs                694 → 332 lines
wado-compiler/src/optimize/store_load_forward.rs 600 → 165 lines
```

## Test plan

- [x] `cargo test -p wado-compiler --lib` — 687 unit tests pass (46
  ValueGraph + 18 builder + 23 CSE + the existing suite).
- [x] `mise run test` — full E2E (2890 fixtures + downstream crate
  suites) green, 0 failures.
- [ ] Quick `wado dump --nir -O2` spot-check on `package-gale` to
  confirm no surprising NIR-output drift.

## Next

- Stage 6 — `const_folding`, `condition_implication`, `licm` refinement
  + induction recognition.
- Stage 9 — interprocedural worklist driver (`inline` / `dae` / `drve`
  / `sroa_param` / `value_copy_demote`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01J8vzfJDJqP1bDRMNPH5vZg)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wado-lang/wado/pull/1341" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->