### PR TITLE
fix(vscode): show core:/wasi: scheme in stdlib editor tab labels

### DIFF
--- a/wado-vscode/package.json
+++ b/wado-vscode/package.json
@@ -49,6 +49,22 @@
         "path": "./syntaxes/wado.tmLanguage.json"
       }
     ],
+    "resourceLabelFormatters": [
+      {
+        "scheme": "core",
+        "formatting": {
+          "label": "${scheme}:${path}",
+          "separator": "/"
+        }
+      },
+      {
+        "scheme": "wasi",
+        "formatting": {
+          "label": "${scheme}:${path}",
+          "separator": "/"
+        }
+      }
+    ],
     "commands": [
       {
         "command": "wado.restartLanguageServer",

--- a/wado-vscode/src/extension.ts
+++ b/wado-vscode/src/extension.ts
@@ -92,14 +92,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 // `wado` language is forced on documents we served because opaque URIs
 // (e.g. `core:cli`) carry no extension for VS Code's language detector.
 //
-// The editor tab/breadcrumb label for these URIs is set by the
-// `resourceLabelFormatters` contribution in `package.json`: without it VS Code
-// shows only the basename (`json`), whereas the formatter renders the full
-// `core:json` / `wasi:io` so the scheme is visible. Submodules whose path has
-// a `/` (e.g. `core:prelude/types.wado`) still show just the basename in the
-// tab — VS Code basenames the formatted label — while the breadcrumb / path
-// view keeps the full scheme-qualified path. This is intentional: a real `/`
-// separator keeps the tab a clean ASCII basename.
+// The `resourceLabelFormatters` contribution in `package.json` renders the
+// tab label as `core:json` / `wasi:io` instead of the bare basename `json`.
+// Submodules with a `/` (e.g. `core:prelude/types.wado`) still show just the
+// basename, since VS Code basenames the label; the full path stays in the
+// breadcrumb.
 function registerStdlibContentProvider(context: vscode.ExtensionContext): void {
     // Track URIs our provider has actually served, so we only override the
     // language on documents we own — other extensions could conceivably

--- a/wado-vscode/src/extension.ts
+++ b/wado-vscode/src/extension.ts
@@ -91,6 +91,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 // request, so VS Code can open them as read-only virtual documents. The
 // `wado` language is forced on documents we served because opaque URIs
 // (e.g. `core:cli`) carry no extension for VS Code's language detector.
+//
+// The editor tab/breadcrumb label for these URIs is set by the
+// `resourceLabelFormatters` contribution in `package.json`: without it VS Code
+// shows only the basename (`json`), whereas the formatter renders the full
+// `core:json` / `wasi:io` so the scheme is visible.
 function registerStdlibContentProvider(context: vscode.ExtensionContext): void {
     // Track URIs our provider has actually served, so we only override the
     // language on documents we own — other extensions could conceivably

--- a/wado-vscode/src/extension.ts
+++ b/wado-vscode/src/extension.ts
@@ -95,7 +95,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 // The editor tab/breadcrumb label for these URIs is set by the
 // `resourceLabelFormatters` contribution in `package.json`: without it VS Code
 // shows only the basename (`json`), whereas the formatter renders the full
-// `core:json` / `wasi:io` so the scheme is visible.
+// `core:json` / `wasi:io` so the scheme is visible. Submodules whose path has
+// a `/` (e.g. `core:prelude/types.wado`) still show just the basename in the
+// tab — VS Code basenames the formatted label — while the breadcrumb / path
+// view keeps the full scheme-qualified path. This is intentional: a real `/`
+// separator keeps the tab a clean ASCII basename.
 function registerStdlibContentProvider(context: vscode.ExtensionContext): void {
     // Track URIs our provider has actually served, so we only override the
     // language on documents we own — other extensions could conceivably

--- a/wado-vscode/src/test/suite/lsp-stdlib-label.test.ts
+++ b/wado-vscode/src/test/suite/lsp-stdlib-label.test.ts
@@ -65,10 +65,7 @@ suite('Wado LSP (stdlib editor label)', () => {
         }
     });
 
-    // The bundled stdlib modules are served as virtual `core:` / `wasi:`
-    // documents. Without the `resourceLabelFormatters` contribution VS Code
-    // would label the tab with the URI basename only (`json`); the formatter
-    // renders the full `core:json` so the scheme stays visible.
+    // `resourceLabelFormatters` renders the tab as `core:json`, not `json`.
     test('labels a core: stdlib document with its scheme', async function () {
         this.timeout(120_000);
 
@@ -84,13 +81,7 @@ suite('Wado LSP (stdlib editor label)', () => {
         );
     });
 
-    // Submodules carry a path with a `/` (e.g. `core:prelude/types.wado`).
-    // VS Code derives the tab name from the basename of the formatted label,
-    // so the directory and scheme are stripped down to the file name. We
-    // deliberately keep this native behaviour (the formatter uses a real `/`
-    // separator) rather than swapping in a look-alike glyph: the full
-    // `core:prelude/types.wado` still shows in the breadcrumb / quick-open
-    // path, while the tab stays a clean ASCII basename.
+    // Submodules with a `/` keep the basename: VS Code basenames the label.
     test('labels a core: submodule document with its basename', async function () {
         this.timeout(120_000);
 

--- a/wado-vscode/src/test/suite/lsp-stdlib-label.test.ts
+++ b/wado-vscode/src/test/suite/lsp-stdlib-label.test.ts
@@ -83,4 +83,26 @@ suite('Wado LSP (stdlib editor label)', () => {
             `Expected the editor tab label to include the scheme, got: ${tab.label}`,
         );
     });
+
+    // Submodules carry a path with a `/` (e.g. `core:prelude/types.wado`).
+    // VS Code derives the tab name from the basename of the formatted label,
+    // so the directory and scheme are stripped down to the file name. We
+    // deliberately keep this native behaviour (the formatter uses a real `/`
+    // separator) rather than swapping in a look-alike glyph: the full
+    // `core:prelude/types.wado` still shows in the breadcrumb / quick-open
+    // path, while the tab stays a clean ASCII basename.
+    test('labels a core: submodule document with its basename', async function () {
+        this.timeout(120_000);
+
+        const uri = vscode.Uri.parse('core:prelude/types.wado');
+        const doc = await vscode.workspace.openTextDocument(uri);
+        await vscode.window.showTextDocument(doc);
+
+        const tab = await waitForTab(uri, 90_000);
+        assert.strictEqual(
+            tab.label,
+            'types.wado',
+            `Expected the submodule tab label to be the basename, got: ${tab.label}`,
+        );
+    });
 });

--- a/wado-vscode/src/test/suite/lsp-stdlib-label.test.ts
+++ b/wado-vscode/src/test/suite/lsp-stdlib-label.test.ts
@@ -1,0 +1,86 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+const WASM_ARTIFACT_RELATIVE = path.join('out', 'wado_lsp.wasm');
+
+function extensionRoot(): string {
+    return path.resolve(__dirname, '..', '..', '..');
+}
+
+function wasmArtifactExists(): boolean {
+    return fs.existsSync(path.join(extensionRoot(), WASM_ARTIFACT_RELATIVE));
+}
+
+/** Find the open tab whose input resolves to `uri`, if any. */
+function findTabFor(uri: vscode.Uri): vscode.Tab | undefined {
+    for (const group of vscode.window.tabGroups.all) {
+        for (const tab of group.tabs) {
+            const input = tab.input;
+            if (
+                input instanceof vscode.TabInputText &&
+                input.uri.toString() === uri.toString()
+            ) {
+                return tab;
+            }
+        }
+    }
+    return undefined;
+}
+
+async function waitForTab(
+    uri: vscode.Uri,
+    timeoutMs: number,
+): Promise<vscode.Tab> {
+    const existing = findTabFor(uri);
+    if (existing) {
+        return existing;
+    }
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+            subscription.dispose();
+            reject(new Error(`Timed out after ${timeoutMs}ms waiting for a tab for ${uri.toString()}`));
+        }, timeoutMs);
+        const subscription = vscode.window.tabGroups.onDidChangeTabs(() => {
+            const tab = findTabFor(uri);
+            if (tab) {
+                clearTimeout(timer);
+                subscription.dispose();
+                resolve(tab);
+            }
+        });
+    });
+}
+
+suite('Wado LSP (stdlib editor label)', () => {
+    suiteSetup(async function () {
+        if (!wasmArtifactExists()) {
+            this.skip();
+        }
+        const extension = vscode.extensions.getExtension('wado-lang.wado');
+        assert.ok(extension, 'Extension should be present');
+        if (!extension.isActive) {
+            await extension.activate();
+        }
+    });
+
+    // The bundled stdlib modules are served as virtual `core:` / `wasi:`
+    // documents. Without the `resourceLabelFormatters` contribution VS Code
+    // would label the tab with the URI basename only (`json`); the formatter
+    // renders the full `core:json` so the scheme stays visible.
+    test('labels a core: stdlib document with its scheme', async function () {
+        this.timeout(120_000);
+
+        const uri = vscode.Uri.parse('core:json');
+        const doc = await vscode.workspace.openTextDocument(uri);
+        await vscode.window.showTextDocument(doc);
+
+        const tab = await waitForTab(uri, 90_000);
+        assert.strictEqual(
+            tab.label,
+            'core:json',
+            `Expected the editor tab label to include the scheme, got: ${tab.label}`,
+        );
+    });
+});

--- a/wado-vscode/src/test/suite/lsp-stdlib-label.test.ts
+++ b/wado-vscode/src/test/suite/lsp-stdlib-label.test.ts
@@ -29,6 +29,36 @@ function findTabFor(uri: vscode.Uri): vscode.Tab | undefined {
     return undefined;
 }
 
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Open a stdlib virtual document, retrying while the language client is still
+ * starting up. The `core:`/`wasi:` content provider throws "Wado language
+ * server is not running" until the client is ready, and across the full test
+ * run our suite may execute before the client has finished launching.
+ */
+async function openStdlibDocument(
+    uri: vscode.Uri,
+    timeoutMs: number,
+): Promise<vscode.TextDocument> {
+    const deadline = Date.now() + timeoutMs;
+    let lastError: unknown;
+    for (;;) {
+        try {
+            return await vscode.workspace.openTextDocument(uri);
+        } catch (err) {
+            lastError = err;
+            if (Date.now() >= deadline) {
+                break;
+            }
+            await sleep(500);
+        }
+    }
+    throw new Error(
+        `Timed out after ${timeoutMs}ms opening ${uri.toString()}: ${String(lastError)}`,
+    );
+}
+
 async function waitForTab(
     uri: vscode.Uri,
     timeoutMs: number,
@@ -70,7 +100,7 @@ suite('Wado LSP (stdlib editor label)', () => {
         this.timeout(120_000);
 
         const uri = vscode.Uri.parse('core:json');
-        const doc = await vscode.workspace.openTextDocument(uri);
+        const doc = await openStdlibDocument(uri, 90_000);
         await vscode.window.showTextDocument(doc);
 
         const tab = await waitForTab(uri, 90_000);
@@ -86,7 +116,7 @@ suite('Wado LSP (stdlib editor label)', () => {
         this.timeout(120_000);
 
         const uri = vscode.Uri.parse('core:prelude/types.wado');
-        const doc = await vscode.workspace.openTextDocument(uri);
+        const doc = await openStdlibDocument(uri, 90_000);
         await vscode.window.showTextDocument(doc);
 
         const tab = await waitForTab(uri, 90_000);


### PR DESCRIPTION
## Summary

Jump-to-definition into a bundled stdlib module opens a virtual document with a `core:<name>` / `wasi:<interface>` URI (served via `workspace/textDocumentContent`). VS Code derives the editor tab name from the URI basename, so `core:json` was displayed as just `json`, hiding which scheme the module came from.

This adds a `resourceLabelFormatters` contribution for the `core` and `wasi` schemes so the tab/breadcrumb renders the full `${scheme}:${path}`:

- `core:json` → tab shows **`core:json`** (was `json`)
- `wasi:io` → tab shows **`wasi:io`**

### Submodules

Modules whose path contains a `/` (e.g. `core:prelude/types.wado`) keep the plain basename `types.wado` in the tab, because VS Code basenames the formatted label. The scheme-qualified path still appears in the breadcrumb / quick-open. This is intentional — a real `/` separator keeps the tab a clean ASCII basename rather than relying on a look-alike glyph.

## Testing

Added e2e tests (`wado-vscode/src/test/suite/lsp-stdlib-label.test.ts`) that open the virtual documents and assert the editor tab label via `vscode.window.tabGroups`. Verified against VS Code 1.124.2 under xvfb with the wasm LSP serving the in-memory stdlib content:

```
Wado LSP (stdlib editor label)
  ✔ labels a core: stdlib document with its scheme   (core:json)
  ✔ labels a core: submodule document with its basename   (types.wado)
2 passing
```

https://claude.ai/code/session_01YEHPZLuAHTsZSn1GiKALpz

---
_Generated by [Claude Code](https://claude.ai/code/session_01YEHPZLuAHTsZSn1GiKALpz)_