### PR TITLE
docs: Jade (JSON Schema) and Reflect-derivation WEPs (+ CI docs-only fast-pass)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,57 @@ env:
   CARGO_INCREMENTAL: 0
 
 jobs:
+  # Detects whether the change touches anything other than Markdown. A
+  # docs-only (*.md) change skips every heavy test job below, and the
+  # aggregator `test` short-circuits to success so the required "Test"
+  # check goes green immediately.
+  #
+  # The skip is done with a job-level `if`, NOT a workflow-level
+  # `paths-ignore`: a path-ignored workflow never creates the "Test" check
+  # run, so a required check would stay stuck "Expected" and block the PR.
+  # A job-level-skipped required check, by contrast, is treated as passing.
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: filter
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          base="${BASE_SHA:-$BEFORE_SHA}"
+          # Fall back to the full suite if the base ref is missing or unknown.
+          if [ -z "$base" ] || ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
+            echo "No usable base ref; running full CI."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          files="$(git diff --name-only "${base}...HEAD")"
+          echo "Changed files:"
+          echo "$files"
+          if [ -z "$files" ]; then
+            # No detectable diff — be safe and run everything.
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          elif printf '%s\n' "$files" | grep -qvE '\.md$'; then
+            # At least one non-Markdown file changed.
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Docs-only (*.md) change: skipping test jobs."
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          fi
+
   test-core:
     name: Test (Core)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -30,6 +79,8 @@ jobs:
 
   test-e2e-o0:
     name: Test (E2E O0)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -47,6 +98,8 @@ jobs:
 
   test-e2e-o1:
     name: Test (E2E O1)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -64,6 +117,8 @@ jobs:
 
   test-e2e-o2:
     name: Test (E2E O2)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -81,6 +136,8 @@ jobs:
 
   test-e2e-o3:
     name: Test (E2E O3)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -98,6 +155,8 @@ jobs:
 
   test-e2e-os:
     name: Test (E2E Os)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -115,6 +174,8 @@ jobs:
 
   test-wado:
     name: Test (Wado)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -139,6 +200,8 @@ jobs:
 
   test-gale-o1:
     name: Test (Gale O1)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -163,6 +226,8 @@ jobs:
 
   test-gale-o2:
     name: Test (Gale O2)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -187,6 +252,8 @@ jobs:
 
   test-gale-o3:
     name: Test (Gale O3)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -217,6 +284,8 @@ jobs:
   # — while removing a runner slot.
   check:
     name: Check (deps + wasm32)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -243,6 +312,7 @@ jobs:
     if: always()
     needs:
       [
+        changes,
         test-core,
         test-wado,
         test-gale-o1,
@@ -260,6 +330,17 @@ jobs:
     steps:
       - name: Check all jobs passed
         run: |
+          # Fail closed if the change detector itself did not succeed.
+          if [ "${{ needs.changes.result }}" != "success" ]; then
+            echo "Change detector did not succeed (${{ needs.changes.result }})."
+            exit 1
+          fi
+          # Docs-only (*.md) change: the heavy jobs were skipped on purpose, so
+          # report success and let the required "Test" check go green at once.
+          if [ "${{ needs.changes.outputs.code }}" != "true" ]; then
+            echo "Docs-only change: test jobs skipped, reporting success."
+            exit 0
+          fi
           results="${{ needs.test-core.result }} ${{ needs.test-wado.result }} ${{ needs.test-gale-o1.result }} ${{ needs.test-gale-o2.result }} ${{ needs.test-gale-o3.result }} ${{ needs.test-e2e-o0.result }} ${{ needs.test-e2e-o1.result }} ${{ needs.test-e2e-o2.result }} ${{ needs.test-e2e-o3.result }} ${{ needs.test-e2e-os.result }} ${{ needs.check.result }}"
           for result in $results; do
             if [ "$result" != "success" ]; then

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -125,3 +125,4 @@ It may include TODOs on WIP.
 - [NIR Rewrite Engine — Detailed Design](./wep-2026-06-05-nir-rewrite-engine-design.md)
 - [Reference Representation and Mutation Write-Back](./wep-2026-06-13-reference-representation.md)
 - [Jade — JSON Schema for Wado](./wep-2026-06-13-jade.md)
+- [Library-Defined Derivation: `Reflect` Extensions and the `#[validate]` Attribute](./wep-2026-06-13-reflect-derivation.md)

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -124,3 +124,4 @@ It may include TODOs on WIP.
 - [NIR Skeleton Arena (Layer 1)](./wep-2026-06-05-nir-skeleton-arena.md)
 - [NIR Rewrite Engine — Detailed Design](./wep-2026-06-05-nir-rewrite-engine-design.md)
 - [Reference Representation and Mutation Write-Back](./wep-2026-06-13-reference-representation.md)
+- [Jade — JSON Schema for Wado](./wep-2026-06-13-jade.md)

--- a/docs/wep-2026-06-13-jade.md
+++ b/docs/wep-2026-06-13-jade.md
@@ -31,7 +31,7 @@ The two ecosystems weight these differently, and the contrast is instructive:
   skip)]` flows straight into the emitted schema, so the wire shape and its
   description never drift.
 - **Go** is a struct-tag-reflection culture, so B (`invopop/jsonschema`,
-  reading `json:"…"` + `jsonschema:"…"` tags) is the centre of gravity.
+  reading `json:"…"` + `jsonschema:"…"` tags) is the center of gravity.
   Validation compliance peaks in `santhosh-tekuri/jsonschema`: full Draft
   2020-12, `$ref` / `$dynamicRef`, format assertions, and pluggable remote-ref
   loaders, returning errors keyed by JSON Pointer.
@@ -45,9 +45,9 @@ ecosystems bolt on after the fact already exist as first-class infrastructure:
   consistent.
 - **`Reflect` — compile-time structural introspection**
   ([`wep-2026-03-14-variadic-type-parameters.md`](./wep-2026-03-14-variadic-type-parameters.md),
-  §10) — a compiler-synthesised trait exposing a struct's fields as a typed
+  §10) — a compiler-synthesized trait exposing a struct's fields as a typed
   tuple (`type Fields = [..F]`, `field_names()`). This is the static,
-  monomorphised, _no-dynamic-reflection_ mechanism — the same lineage as tuple
+  monomorphized, _no-dynamic-reflection_ mechanism — the same lineage as tuple
   `for-of` and `[..T::default()]` — that lets capability B be written as
   ordinary library code rather than compiler magic. It is the linchpin (see
   "Language dependency").
@@ -121,7 +121,7 @@ A  model        Schema  (Serialize + Deserialize via core:json)
 #### Layer A — schema document model
 
 A single `Schema` type that round-trips through `core:json` with no per-type
-work, modelling Draft 2020-12. The open question (see "Consequences") is
+work, modeling Draft 2020-12. The open question (see "Consequences") is
 _typed tree vs. `Value`-backed_; the decision is a **hybrid**: a typed
 `struct Schema` for the known keywords plus a `TreeMap<String, Value>` escape
 hatch (`extra`) so unknown / vocabulary-specific keywords survive a
@@ -175,7 +175,7 @@ schema" is impossible as plain library code _unless the compiler exposes a
 type's structure at compile time_. It does — or will: `Reflect`
 ([`wep-2026-03-14-variadic-type-parameters.md`](./wep-2026-03-14-variadic-type-parameters.md),
 §10). `JsonSchema` is therefore an **ordinary generic library trait that Jade
-writes on top of `Reflect`**, not a compiler-synthesised one. The compiler
+writes on top of `Reflect`**, not a compiler-synthesized one. The compiler
 knows nothing about Jade.
 
 ```wado
@@ -195,18 +195,29 @@ pub fn schema_for<T: JsonSchema>() -> Schema;
 The structural `impl JsonSchema` for any struct is written once, generically,
 by walking `Reflect`'s field pack — the same compile-time `[..F::method()]`
 expansion `[..T::default()]` already uses, with no runtime cost and no
-per-struct boilerplate:
+per-struct boilerplate. The `where`-clause pack binding is the form established
+by WEP 2026-03-14 §11:
 
 ```wado
 // Jade library code (illustrative): structure from Reflect, value-free.
-impl<T: Reflect<Fields = [..F]>, ..F: JsonSchema> JsonSchema for T {
+impl<T, ..F: JsonSchema> JsonSchema for T
+where T: Reflect<Fields = [..F]>
+{
+    fn schema_name() -> String { return T::type_name(); }
+
     fn json_schema(gen: &mut SchemaGenerator) -> Schema {
-        let names = T::wire_field_names();     // serde rename applied (see below)
-        let props = [..F::json_schema(gen)];   // recurse per field type, no instance
-        return object_schema(names, props, T::required_fields());
+        let meta = T::field_meta();                  // wire_name, has_default, doc, validate
+        let field_schemas = [..F::json_schema(gen)]; // recurse per field type, no instance
+        return object_schema(meta, field_schemas);   // required = fields without a default
     }
 }
 ```
+
+`field_meta()` is the per-field metadata `Reflect` exposes (see "Language
+dependency"): the wire name, whether the field has a default, its doc string,
+and its `#[validate]` entries. A `variant` / `enum` / `flags` type derives
+through the analogous `ReflectVariant` / `ReflectEnum` / `ReflectFlags` blanket
+impls — a `variant` to `oneOf`, an `enum` to a string `enum`.
 
 It _shares the serde metadata_: `#[serde(rename_all = "camelCase")]` renames
 `properties` keys, `#[serde(default)]` / `f: T = expr` drops a field from
@@ -224,7 +235,7 @@ Constraints and annotations come from two non-`#[jade]` sources:
   _not_ a Jade-owned namespace. `#[validate]` is a generic, language-blessed
   attribute (added by the companion language WEP) with a **closed declarative
   vocabulary** (`min_length`, `minimum`, `pattern`, `format`, …). It is _not
-  inert_: the compiler-synthesised `Deserialize` enforces it at the
+  inert_: the compiler-synthesized `Deserialize` enforces it at the
   deserialization boundary, so an out-of-range external value is rejected even
   without Jade. Jade additionally reads the same keywords via `Reflect` and
   emits them into the schema. A closed vocabulary is precisely what lets one
@@ -326,8 +337,9 @@ Required of the language (in rough order of necessity for Layer B):
 1. **`Reflect` synthesis + `where`-clause pack binding** — already designed,
    not yet implemented (WEP 2026-03-14 checklist: `Reflect` per-struct
    synthesis and `T: Trait<Assoc = [..F]>` extraction are the two unchecked
-   items). Unlocks the value-free `impl<T: Reflect<Fields = [..F]>, ..F> …`
-   above. Nothing Jade-specific.
+   items). Unlocks the value-free
+   `impl<T, ..F> … where T: Reflect<Fields = [..F]>` above. Nothing
+   Jade-specific.
 2. **Per-field metadata on `Reflect`** — the wire name (serde `rename` /
    `rename_all` applied), whether the field has a default (→ drop from
    `required`), and its `///` doc string (→ `description`). Today these live in
@@ -339,7 +351,7 @@ Required of the language (in rough order of necessity for Layer B):
 4. **A single generic, built-in `#[validate(…)]` attribute with a closed
    declarative vocabulary** — the compiler does two things with it, and they are
    what keep it from being inert:
-   - **Enforces** the vocabulary at the `Deserialize` boundary: the synthesised
+   - **Enforces** the vocabulary at the `Deserialize` boundary: the synthesized
      `Deserialize` runs each field's checks after reading it, rejecting an
      out-of-range external value with a `DeserializeError`. This holds for
      anyone deserializing, with or without Jade — the trust boundary is the
@@ -348,7 +360,7 @@ Required of the language (in rough order of necessity for Layer B):
      library (Jade) can read them and emit the corresponding schema keywords.
 
    `#[validate]` is _not_ Jade-owned and is the principled replacement for the
-   rejected `#[jade(…)]`: a library cannot own a compiler-recognised attribute,
+   rejected `#[jade(…)]`: a library cannot own a compiler-recognized attribute,
    but a generic built-in serves every validation/schema library equally.
 
 Future directions (gestured at, not built here):
@@ -370,14 +382,23 @@ Future directions (gestured at, not built here):
 
 ### Phasing
 
-1. **A + B** first — the schema model and `JsonSchema` derivation. Highest
-   reuse of existing serde infrastructure, and immediately useful: emit JSON
-   Schema / OpenAPI component schemas for a `wasi:http/service` API.
-2. **C** — the validator on top of the Layer A model.
-3. **D** — the Kiln generator, reusing the Layer A model as its output target.
+The layers differ in what they depend on, and the phasing follows that, not a
+fixed numeric order:
 
-Each phase is its own follow-up WEP/PR; this document fixes the end state so
-the phases compose rather than collide.
+1. **A — schema model** first. Pure library over `core:serde` / `core:json` /
+   `core:value`; shippable immediately and the foundation every other layer
+   builds on.
+2. **C — validation** and **D — codegen** are also pure library (on top of A and
+   Kiln respectively) and need no compiler change, so they can proceed in
+   parallel once A exists.
+3. **B — derivation** is the only layer gated on the companion language WEP
+   (`Reflect` synthesis, per-field metadata, `#[validate]`). It lands as those
+   pieces land; until then a schema is hand-authored on the Layer A model. B is
+   the headline feature — API-doc / OpenAPI emission for a `wasi:http/service` —
+   so it is what drives the companion WEP's priority.
+
+Each phase is its own follow-up WEP/PR; this document fixes the end state so the
+phases compose rather than collide.
 
 ## Consequences
 
@@ -396,8 +417,8 @@ the phases compose rather than collide.
 ### Costs and trade-offs
 
 - A conformant Draft 2020-12 validator is a large surface (`$dynamicRef`,
-  `unevaluatedProperties`, annotation collection). Phasing C after A+B contains
-  the risk but does not remove it.
+  `unevaluatedProperties`, annotation collection). Phasing the validator (C)
+  after the model (A) contains the risk but does not remove it.
 - Shipping a regex engine — even an ECMA-262 subset — is real work and a
   permanent maintenance item. The alternative (no `pattern` support) is not
   credible for a JSON Schema tool.
@@ -414,8 +435,9 @@ the phases compose rather than collide.
 - **`#[validate]` keyword surface.** Which JSON Schema assertions are worth a
   first-class `key = value` (`min_length`, `maximum`, `pattern`, `format`,
   `multiple_of`, …) versus left to hand-authoring on the `Schema` value. The
-  attribute mechanism is settled (a single generic built-in carried opaquely by
-  the compiler, read via `Reflect`); only the recognised key set is open.
+  attribute mechanism is settled (a single generic built-in, enforced at the
+  `Deserialize` boundary and read via `Reflect`); only the recognized key set is
+  open.
 - **Output format units.** Whether to emit the spec's standardized
   verbose/hierarchical validation _output_ (for tooling interop) or keep Jade's
   own flat `ValidationError` list. Tentatively: flat list first, standardized
@@ -424,7 +446,7 @@ the phases compose rather than collide.
 ### Resolved during design
 
 - **No `#[jade(…)]` attribute.** A package that merely lives in this repo is an
-  ordinary library; it cannot own a compiler-recognised attribute, and Wado has
+  ordinary library; it cannot own a compiler-recognized attribute, and Wado has
   no reflection or macros for it to read one itself. Constraints therefore come
   from a generic built-in `#[validate(…)]` — enforced at the `Deserialize`
   boundary so it is never silently inert, and read via `Reflect` for schema
@@ -432,5 +454,5 @@ the phases compose rather than collide.
   dependency".
 - **Capability B is library code, not compiler magic.** It is built on the
   compile-time `Reflect` introspection, in the same no-dynamic-reflection,
-  monomorphised lineage as tuple `for-of`. The compiler gains general type
+  monomorphized lineage as tuple `for-of`. The compiler gains general type
   introspection; it never learns about Jade.

--- a/docs/wep-2026-06-13-jade.md
+++ b/docs/wep-2026-06-13-jade.md
@@ -222,9 +222,15 @@ Constraints and annotations come from two non-`#[jade]` sources:
   (schemars does the same); no attribute needed.
 - **Validation keywords from a single generic `#[validate(…)]` attribute** —
   _not_ a Jade-owned namespace. `#[validate]` is a generic, language-blessed
-  attribute (added by the companion language WEP) that any schema/validation
-  library reads via `Reflect`; the compiler carries its key/values but does not
-  interpret them.
+  attribute (added by the companion language WEP) with a **closed declarative
+  vocabulary** (`min_length`, `minimum`, `pattern`, `format`, …). It is _not
+  inert_: the compiler-synthesised `Deserialize` enforces it at the
+  deserialization boundary, so an out-of-range external value is rejected even
+  without Jade. Jade additionally reads the same keywords via `Reflect` and
+  emits them into the schema. A closed vocabulary is precisely what lets one
+  annotation be both enforced (boundary check) and introspected (schema). It is
+  a wire-contract guard, not a whole-program invariant — that is the future
+  `where` refinement's job (see "Language dependency").
 
 ```wado
 #[serde(rename_all = "camelCase")]
@@ -308,9 +314,11 @@ Jade itself ships zero compiler changes; everything in Layers A, C, D is plain
 library code. But Layer B (and, longer-term, moving serde derivation out of
 `synthesis/serde_synth.rs` into library code) needs the compiler to expose type
 structure. That work is _not_ Jade's to define inline — it is general language
-infrastructure, specified in a companion WEP that evolves
+infrastructure, specified in the companion WEP
+[`wep-2026-06-13-reflect-derivation.md`](./wep-2026-06-13-reflect-derivation.md)
+(which evolves
 [`wep-2026-03-14-variadic-type-parameters.md`](./wep-2026-03-14-variadic-type-parameters.md)
-§10. Jade _depends on_ it; this section only records what Layer B requires of
+§10). Jade _depends on_ it; this section only records what Layer B requires of
 it, so the two designs compose.
 
 Required of the language (in rough order of necessity for Layer B):
@@ -328,20 +336,37 @@ Required of the language (in rough order of necessity for Layer B):
 3. **Variant / enum / flags reflection** — `Reflect` as designed is struct
    only; a `variant` → `oneOf`, an `enum` → string `enum`, and `flags` need the
    analogous compile-time introspection.
-4. **A single generic `#[validate(…)]` attribute, exposed via `Reflect`** — the
-   compiler carries its `key = value` pairs as opaque compile-time metadata and
-   makes them readable per field; it does _not_ interpret them. Jade (and any
-   other validation/schema library) reads and gives them meaning. This is the
-   principled replacement for the rejected `#[jade(…)]`: a library cannot own a
-   compiler-recognised attribute, but it _can_ read a generic one the compiler
-   merely carries.
+4. **A single generic, built-in `#[validate(…)]` attribute with a closed
+   declarative vocabulary** — the compiler does two things with it, and they are
+   what keep it from being inert:
+   - **Enforces** the vocabulary at the `Deserialize` boundary: the synthesised
+     `Deserialize` runs each field's checks after reading it, rejecting an
+     out-of-range external value with a `DeserializeError`. This holds for
+     anyone deserializing, with or without Jade — the trust boundary is the
+     natural and honest place to enforce a wire contract.
+   - **Exposes** the same `key = value` pairs per field via `Reflect`, so a
+     library (Jade) can read them and emit the corresponding schema keywords.
 
-Future direction (gestured at, not built here): user-defined attributes under a
-**distinct `@[foo(…)]` syntax**, kept syntactically separate from built-in
-`#[…]` so it is always clear which attributes are compiler-known and which are
-library-interpreted — the ambiguity Rust never resolved (`#[serde(…)]` and a
-built-in `#[inline]` are indistinguishable at a glance). `#[validate]` is the
-single built-in stepping stone toward that system, not its final form.
+   `#[validate]` is _not_ Jade-owned and is the principled replacement for the
+   rejected `#[jade(…)]`: a library cannot own a compiler-recognised attribute,
+   but a generic built-in serves every validation/schema library equally.
+
+Future directions (gestured at, not built here):
+
+- **Refinement predicates `foo: i32 where <predicate>`** — for true _in-memory
+  invariants_ (enforced at construction / `as` conversion in the `assert`
+  doctrine: "cannot be disabled, always reliable"), distinct from `#[validate]`'s
+  wire-boundary guard. General predicates are enforced but opaque to schema
+  derivation; only a structured subset (comparisons, length) could map to schema
+  keywords. Anchoring a refinement to a `newtype` bounds _when_ the check fires
+  (conversion only), à la Ada subtype predicates.
+- **User-defined attributes under a distinct `@[foo(…)]` syntax** — kept
+  syntactically separate from built-in `#[…]` so it is always clear which
+  attributes are compiler-known and which are library-interpreted, resolving the
+  ambiguity Rust never did (`#[serde(…)]` and a built-in `#[inline]` are
+  indistinguishable at a glance). `#[validate]` is a built-in that demonstrates
+  the generic, non-library-owned principle now; the open user-defined system is
+  this later syntax.
 
 ### Phasing
 
@@ -401,8 +426,9 @@ the phases compose rather than collide.
 - **No `#[jade(…)]` attribute.** A package that merely lives in this repo is an
   ordinary library; it cannot own a compiler-recognised attribute, and Wado has
   no reflection or macros for it to read one itself. Constraints therefore come
-  from a generic built-in `#[validate(…)]` (carried opaquely by the compiler,
-  read via `Reflect`), and `description` from `///` doc comments. See "Language
+  from a generic built-in `#[validate(…)]` — enforced at the `Deserialize`
+  boundary so it is never silently inert, and read via `Reflect` for schema
+  emission — and `description` from `///` doc comments. See "Language
   dependency".
 - **Capability B is library code, not compiler magic.** It is built on the
   compile-time `Reflect` introspection, in the same no-dynamic-reflection,

--- a/docs/wep-2026-06-13-jade.md
+++ b/docs/wep-2026-06-13-jade.md
@@ -1,0 +1,324 @@
+# Jade — JSON Schema for Wado
+
+## Context
+
+Wado programs increasingly sit at the boundary between Wado's static type
+system and the dynamically-typed JSON world: a `wasi:http/service` handler
+must document and validate the request bodies it accepts, a client must check
+a third-party response before trusting it, and a project that already owns a
+hand-written JSON Schema wants idiomatic Wado types generated from it. Today
+none of this is served: `core:json` round-trips bytes through `Serialize` /
+`Deserialize`, and `core:value::Value` models an arbitrary document, but there
+is no way to _describe the permitted shape_ of a document — let alone derive
+that description from a Wado type, check a value against it, or turn it into
+Wado source.
+
+"JSON Schema" is a single phrase that, across the Go and Rust ecosystems,
+actually names four independent capabilities. Conflating them produces a
+muddled API; separating them is the first design act.
+
+|       | Capability                  | Input → output                     | Rust prior art                         | Go prior art                                             |
+| ----- | --------------------------- | ---------------------------------- | -------------------------------------- | -------------------------------------------------------- |
+| **A** | Schema document model + I/O | JSON Schema document ⇄ typed tree  | `schemars::schema`                     | `invopop/jsonschema` `Schema`                            |
+| **B** | Type → schema derivation    | Wado type → schema document        | **schemars** (`#[derive(JsonSchema)]`) | `invopop/jsonschema` (struct-tag reflection)             |
+| **C** | Schema → value validation   | (schema, JSON value) → result      | **`jsonschema`** crate, `valico`       | **`santhosh-tekuri/jsonschema`**, `xeipuuv/gojsonschema` |
+| **D** | Schema → Wado type codegen  | `.json` schema → generated `.wado` | **typify**, `quicktype`                | `go-jsonschema`, `quicktype`                             |
+
+The two ecosystems weight these differently, and the contrast is instructive:
+
+- **Rust** keeps B (schemars) and C (the `jsonschema` crate) in separate
+  crates. schemars is tightly coupled to serde — `#[serde(rename_all, default,
+  skip)]` flows straight into the emitted schema, so the wire shape and its
+  description never drift.
+- **Go** is a struct-tag-reflection culture, so B (`invopop/jsonschema`,
+  reading `json:"…"` + `jsonschema:"…"` tags) is the centre of gravity.
+  Validation compliance peaks in `santhosh-tekuri/jsonschema`: full Draft
+  2020-12, `$ref` / `$dynamicRef`, format assertions, and pluggable remote-ref
+  loaders, returning errors keyed by JSON Pointer.
+
+Wado is positioned to do better than either, because the pieces these
+ecosystems bolt on after the fact already exist as first-class infrastructure:
+
+- **serde derive + attributes** (`#[serde(rename_all)]`, `#[serde(default)]`,
+  `f: T = expr`) — capability B reuses them exactly as schemars reuses serde,
+  so the derived schema and the `Serialize` wire form are guaranteed
+  consistent.
+- **`core:value::Value`** — the validation instance model for capability C;
+  the role `serde_json::Value` plays in Rust and `interface{}` in Go.
+- **`core:json` (`from_bytes` / `to_bytes`)** — capability A's schema documents
+  are themselves `Serialize + Deserialize`, so I/O is free.
+- **Kiln** ([`wep-2026-04-12-kiln.md`](./wep-2026-04-12-kiln.md)) — capability D
+  is _exactly_ a Kiln generator (`use { User } from "./user.schema.json" with
+  { generator: … }`), the same mechanism as Gale (`.g4`) and Tide (WebIDL).
+- **Format-bearing stdlib** — `core:temporal` (`date-time`), `core:url`
+  (`uri`), `core:uuid` (`uuid`) supply the `format` assertions other
+  ecosystems reimplement.
+
+### Scope
+
+In scope (the eventual whole): all four capabilities A–D, targeting JSON
+Schema **Draft 2020-12**, delivered as an independent package `wado:jade`
+(directory `package-jade/`), not bundled into `core:`.
+
+Out of scope:
+
+- Drafts other than 2020-12 at first. Draft 7 / OpenAPI 3.0 compatibility
+  (notably `nullable`, `definitions`, no `$defs`) is a later additive reader,
+  not a parallel validator.
+- Hyper-Schema (`links`, `base`), and the full output-format vocabulary
+  (`unevaluatedProperties` interactions are in scope; the standardized
+  verbose/hierarchical _output_ units are a later refinement).
+- Fetching remote `$ref` targets by default. Remote resolution is exposed only
+  through an explicit effect-carrying loader (see "Validation").
+
+### Why a package, not `core:`
+
+Jade is heavy (a validator, a derive surface, and a Kiln generator), evolves on
+the JSON Schema spec's cadence rather than the compiler's, and mirrors
+`package-gale` precisely: a Wado package that is _also_ a Kiln generator. Same
+rationale Kiln used to keep Gale out of the compiler binary. `core:json` /
+`core:value` / `core:serde` stay the minimal, always-present substrate; Jade is
+opt-in.
+
+## Decision
+
+### Name
+
+**Jade** — **J**SON **A**ssertion & **D**efinition **E**ngine.
+
+- **J**SON — the format it serves; the leading `j` makes that legible at a
+  glance.
+- **A**ssertion — capability C, validating a value against a schema.
+- **D**efinition — capabilities A and B (authoring / deriving a schema
+  document) and D (defining Wado types from one).
+- **E**ngine — the unifying runtime + generator.
+
+Jade is a gemstone that is _carved to shape_ — the act a schema performs on
+data. It echoes the gem/craft register of the ecosystem's tool names (the
+"facet" of a cut stone is XSD's own word for a schema constraint) and sits at
+four letters alongside Gale, Kiln, and Tide. Imported as `wado:jade@0.1`.
+
+### Layering
+
+Jade is four layers, each usable on its own and stacked so that the layer below
+never depends on the layer above.
+
+```
+D  codegen      .json schema → .wado types        (Kiln generator)
+C  validation   (Schema, Value) → ValidationResult
+B  derivation   JsonSchema trait: T → Schema
+A  model        Schema  (Serialize + Deserialize via core:json)
+```
+
+#### Layer A — schema document model
+
+A single `Schema` type that round-trips through `core:json` with no per-type
+work, modelling Draft 2020-12. The open question (see "Consequences") is
+_typed tree vs. `Value`-backed_; the decision is a **hybrid**: a typed
+`struct Schema` for the known keywords plus a `TreeMap<String, Value>` escape
+hatch (`extra`) so unknown / vocabulary-specific keywords survive a
+round-trip — the same pattern `core:value::Value::Unknown` uses for opaque
+bytes.
+
+```wado
+// package-jade/src/model.wado  (sketch)
+pub struct Schema {
+    // A boolean schema (`true` / `false`) is the degenerate case.
+    bool_schema: Option<bool>,
+
+    // Core
+    id: Option<String>,          // $id
+    schema: Option<String>,      // $schema
+    ref_: Option<String>,        // $ref
+    defs: TreeMap<String, Schema>,   // $defs
+
+    // Applicators
+    type_: Option<TypeSet>,      // "string" | ["string","null"]
+    properties: TreeMap<String, Schema>,
+    required: List<String>,
+    items: Option<Schema>,
+    prefix_items: List<Schema>,
+    all_of: List<Schema>, any_of: List<Schema>, one_of: List<Schema>,
+    not_: Option<Schema>,
+
+    // Assertions (validation vocabulary)
+    enum_: List<Value>, const_: Option<Value>,
+    minimum: Option<f64>, maximum: Option<f64>,
+    min_length: Option<i64>, max_length: Option<i64>,
+    pattern: Option<String>, format: Option<String>,
+    // … (full keyword set elided)
+
+    // Annotations
+    title: Option<String>, description: Option<String>,
+    default_: Option<Value>, examples: List<Value>,
+
+    // Anything Jade does not model, preserved verbatim.
+    extra: TreeMap<String, Value>,
+}
+```
+
+The `_`-suffixed fields (`type_`, `ref_`, …) carry `#[serde(rename = "type")]`
+etc., reusing the serde rename machinery so the wire form is exact JSON Schema.
+
+#### Layer B — `JsonSchema` derivation (schemars-equivalent)
+
+A `JsonSchema` trait, auto-derived for every `struct` / `variant` / `enum` /
+`flags`, that produces the `Schema` describing a type's `Serialize` form. It
+_shares the serde metadata_: `#[serde(rename_all = "camelCase")]` renames
+`properties` keys, `#[serde(default)]` / `f: T = expr` drops a field from
+`required`, and a `variant` lowers to `oneOf` with the same tag representation
+`core:json` emits.
+
+```wado
+pub trait JsonSchema {
+    // Stable name used as the $defs key and $ref target.
+    fn schema_name() -> String;
+    // Whether to inline or emit a $ref into $defs (true for named composites).
+    fn is_referenceable() -> bool { return true; }
+    // Build the schema, registering dependencies into the generator.
+    fn json_schema(gen: &mut SchemaGenerator) -> Schema;
+}
+
+// Driver: a single type → a self-contained root schema with $defs.
+pub fn schema_for<T: JsonSchema>() -> Schema;
+```
+
+`SchemaGenerator` carries settings (target draft, inline-vs-`$ref` policy) and
+accumulates `$defs`, exactly as schemars' `SchemaGenerator` does — this is how
+recursive types (`struct Node { next: Option<Node> }`) terminate via a `$ref`.
+
+A new attribute namespace `#[jade(…)]` supplies the constraints serde has no
+opinion on, layered on top of the serde-derived skeleton:
+
+```wado
+#[serde(rename_all = "camelCase")]
+struct CreateUser {
+    #[jade(min_length = 1, max_length = 64)]
+    user_name: String,           // → {"type":"string","minLength":1,"maxLength":64}
+    #[jade(format = "email")]
+    email: String,
+    #[jade(minimum = 0, maximum = 150)]
+    age: i32 = 0,                // default ⇒ not required
+    #[jade(description = "ISO-4217 code")]
+    currency: String,
+}
+```
+
+The compiler already routes `#[serde(...)]` through the derive synthesiser;
+`#[jade(...)]` is parsed by the Jade generator's own attribute reader (it does
+not need a compiler change beyond attributes being preserved on the AST, which
+they already are).
+
+#### Layer C — validation (santhosh-tekuri-equivalent)
+
+Validate a `Value` (or raw bytes, parsed via `core:json` into a `Value`)
+against a compiled `Schema`, returning every failure keyed by **JSON Pointer**,
+mirroring the `offset`-carrying discipline of `DeserializeError`.
+
+```wado
+pub struct Validator { /* compiled schema + $ref resolution table */ }
+
+pub fn compile(schema: &Schema) -> Result<Validator, SchemaError>;
+
+impl Validator {
+    pub fn validate(&self, instance: &Value) -> ValidationResult;
+}
+
+pub struct ValidationError {
+    instance_path: String,   // JSON Pointer into the instance: "/items/2/age"
+    schema_path: String,     // JSON Pointer into the schema:   "/properties/age/minimum"
+    keyword: String,         // "minimum"
+    message: String,
+}
+pub variant ValidationResult { Valid, Invalid(List<ValidationError>) }
+```
+
+Design commitments:
+
+- **Compile once, validate many.** `compile` resolves all local `$ref` /
+  `$defs` / anchors into a flat table up front; `validate` is allocation-light.
+- **`format` is asserting and pluggable.** Built-in assertions delegate:
+  `date-time` → `core:temporal`, `uri` → `core:url`, `uuid` → `core:uuid`,
+  `regex` → the pattern engine below. Per the spec, `format` is _annotation by
+  default_; Jade exposes a flag to make it asserting.
+- **Remote `$ref` is an effect.** `compile` resolves only local references.
+  Schemas that reference external documents take an explicit loader:
+  `compile_with(schema, loader)` where `loader: fn(uri) -> Result<Schema, …>
+  with E`. The default is a registry of pre-supplied documents (no I/O); a
+  user wires `with Http` (or filesystem) themselves. This keeps the validator
+  pure and Wasm-sandbox-friendly by construction.
+- **Regex.** `pattern` / `format: regex` need an engine. Jade ships a small
+  ECMA-262-subset matcher rather than taking a heavy dependency; the subset is
+  documented and unsupported constructs error at `compile`, not silently pass.
+
+#### Layer D — codegen (typify-equivalent, via Kiln)
+
+A Kiln generator (`package-jade/src/generator.wado`, declared `generator =`
+in `wado.toml`) that lowers a `.json` schema into Wado type declarations,
+identical in shape to how `package-gale` lowers `.g4`:
+
+```wado
+use { CreateUser } from "./create-user.schema.json" with {
+    generator: { module: "wado:jade@0.1" },
+};
+```
+
+`object` → `struct` (with `#[jade]` / `#[serde]` attributes reconstructed from
+the keywords), `oneOf` of tagged objects → `variant`, `enum` of strings →
+`enum`, `$ref` → a named type reference, `$defs` → sibling declarations. This
+closes the loop: Layer B turns Wado types into schemas, Layer D turns schemas
+back into Wado types, and the two are designed to round-trip.
+
+### Phasing
+
+1. **A + B** first — the schema model and `JsonSchema` derivation. Highest
+   reuse of existing serde infrastructure, and immediately useful: emit JSON
+   Schema / OpenAPI component schemas for a `wasi:http/service` API.
+2. **C** — the validator on top of the Layer A model.
+3. **D** — the Kiln generator, reusing the Layer A model as its output target.
+
+Each phase is its own follow-up WEP/PR; this document fixes the end state so
+the phases compose rather than collide.
+
+## Consequences
+
+### Benefits
+
+- One coherent package spanning describe / derive / validate / generate, each
+  layer independently useful, no layer depending upward.
+- Derived schemas cannot drift from the `Serialize` wire form, because both are
+  generated from the same serde metadata — a guarantee neither schemars (manual
+  re-annotation possible) nor Go reflection fully provides.
+- Validation and codegen reuse `core:value` / `core:json` / Kiln rather than
+  reinventing a parser, a document model, or a build pipeline.
+- `format` assertions lean on `core:temporal` / `core:url` / `core:uuid`,
+  turning a notorious interoperability weak point into a strength.
+
+### Costs and trade-offs
+
+- A conformant Draft 2020-12 validator is a large surface (`$dynamicRef`,
+  `unevaluatedProperties`, annotation collection). Phasing C after A+B contains
+  the risk but does not remove it.
+- Shipping a regex engine — even an ECMA-262 subset — is real work and a
+  permanent maintenance item. The alternative (no `pattern` support) is not
+  credible for a JSON Schema tool.
+- The hybrid `Schema` model (typed fields + `extra` escape hatch) trades a
+  little type-safety for round-trip fidelity of unknown keywords. The
+  fully-typed alternative loses vocabulary extensions; the `Value`-only
+  alternative loses ergonomics for the 95% common case. The hybrid matches the
+  precedent already set by `core:value::Value::Unknown`.
+
+### Open questions
+
+- **Draft 7 / OpenAPI reader.** Additive (a normaliser into the 2020-12 model)
+  or a separate parse path? Deferred until A+B land.
+- **`#[jade(...)]` vs. extending `#[serde(...)]`.** A separate namespace keeps
+  serde focused on the wire form and Jade on the schema, but means two
+  attributes on one field. Tentatively: separate namespace.
+- **Output format units.** Whether to emit the spec's standardized
+  verbose/hierarchical validation _output_ (for tooling interop) or keep Jade's
+  own flat `ValidationError` list. Tentatively: flat list first, standardized
+  output later if a consumer needs it.
+
+```
+```

--- a/docs/wep-2026-06-13-jade.md
+++ b/docs/wep-2026-06-13-jade.md
@@ -43,6 +43,14 @@ ecosystems bolt on after the fact already exist as first-class infrastructure:
   `f: T = expr`) — capability B reuses them exactly as schemars reuses serde,
   so the derived schema and the `Serialize` wire form are guaranteed
   consistent.
+- **`Reflect` — compile-time structural introspection**
+  ([`wep-2026-03-14-variadic-type-parameters.md`](./wep-2026-03-14-variadic-type-parameters.md),
+  §10) — a compiler-synthesised trait exposing a struct's fields as a typed
+  tuple (`type Fields = [..F]`, `field_names()`). This is the static,
+  monomorphised, _no-dynamic-reflection_ mechanism — the same lineage as tuple
+  `for-of` and `[..T::default()]` — that lets capability B be written as
+  ordinary library code rather than compiler magic. It is the linchpin (see
+  "Language dependency").
 - **`core:value::Value`** — the validation instance model for capability C;
   the role `serde_json::Value` plays in Rust and `interface{}` in Go.
 - **`core:json` (`from_bytes` / `to_bytes`)** — capability A's schema documents
@@ -106,7 +114,7 @@ never depends on the layer above.
 ```
 D  codegen      .json schema → .wado types        (Kiln generator)
 C  validation   (Schema, Value) → ValidationResult
-B  derivation   JsonSchema trait: T → Schema
+B  derivation   JsonSchema: T → Schema             (library code over `Reflect`)
 A  model        Schema  (Serialize + Deserialize via core:json)
 ```
 
@@ -162,12 +170,13 @@ etc., reusing the serde rename machinery so the wire form is exact JSON Schema.
 
 #### Layer B — `JsonSchema` derivation (schemars-equivalent)
 
-A `JsonSchema` trait, auto-derived for every `struct` / `variant` / `enum` /
-`flags`, that produces the `Schema` describing a type's `Serialize` form. It
-_shares the serde metadata_: `#[serde(rename_all = "camelCase")]` renames
-`properties` keys, `#[serde(default)]` / `f: T = expr` drops a field from
-`required`, and a `variant` lowers to `oneOf` with the same tag representation
-`core:json` emits.
+Wado has no dynamic reflection and no macros, so "given a type, produce its
+schema" is impossible as plain library code _unless the compiler exposes a
+type's structure at compile time_. It does — or will: `Reflect`
+([`wep-2026-03-14-variadic-type-parameters.md`](./wep-2026-03-14-variadic-type-parameters.md),
+§10). `JsonSchema` is therefore an **ordinary generic library trait that Jade
+writes on top of `Reflect`**, not a compiler-synthesised one. The compiler
+knows nothing about Jade.
 
 ```wado
 pub trait JsonSchema {
@@ -183,31 +192,55 @@ pub trait JsonSchema {
 pub fn schema_for<T: JsonSchema>() -> Schema;
 ```
 
-`SchemaGenerator` carries settings (target draft, inline-vs-`$ref` policy) and
-accumulates `$defs`, exactly as schemars' `SchemaGenerator` does — this is how
-recursive types (`struct Node { next: Option<Node> }`) terminate via a `$ref`.
+The structural `impl JsonSchema` for any struct is written once, generically,
+by walking `Reflect`'s field pack — the same compile-time `[..F::method()]`
+expansion `[..T::default()]` already uses, with no runtime cost and no
+per-struct boilerplate:
 
-A new attribute namespace `#[jade(…)]` supplies the constraints serde has no
-opinion on, layered on top of the serde-derived skeleton:
+```wado
+// Jade library code (illustrative): structure from Reflect, value-free.
+impl<T: Reflect<Fields = [..F]>, ..F: JsonSchema> JsonSchema for T {
+    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+        let names = T::wire_field_names();     // serde rename applied (see below)
+        let props = [..F::json_schema(gen)];   // recurse per field type, no instance
+        return object_schema(names, props, T::required_fields());
+    }
+}
+```
+
+It _shares the serde metadata_: `#[serde(rename_all = "camelCase")]` renames
+`properties` keys, `#[serde(default)]` / `f: T = expr` drops a field from
+`required`, and a `variant` lowers to `oneOf` with the same tag representation
+`core:json` emits. `SchemaGenerator` carries settings (target draft,
+inline-vs-`$ref` policy) and accumulates `$defs`, exactly as schemars'
+`SchemaGenerator` does — this is how recursive types
+(`struct Node { next: Option<Node> }`) terminate via a `$ref`.
+
+Constraints and annotations come from two non-`#[jade]` sources:
+
+- **`description` / `title` from `///` doc comments** — the idiomatic source
+  (schemars does the same); no attribute needed.
+- **Validation keywords from a single generic `#[validate(…)]` attribute** —
+  _not_ a Jade-owned namespace. `#[validate]` is a generic, language-blessed
+  attribute (added by the companion language WEP) that any schema/validation
+  library reads via `Reflect`; the compiler carries its key/values but does not
+  interpret them.
 
 ```wado
 #[serde(rename_all = "camelCase")]
 struct CreateUser {
-    #[jade(min_length = 1, max_length = 64)]
-    user_name: String,           // → {"type":"string","minLength":1,"maxLength":64}
-    #[jade(format = "email")]
+    /// The user's login name.
+    #[validate(min_length = 1, max_length = 64)]
+    user_name: String,           // → {"type":"string","minLength":1,"maxLength":64,
+                                 //    "description":"The user's login name."}
+    #[validate(format = "email")]
     email: String,
-    #[jade(minimum = 0, maximum = 150)]
+    #[validate(minimum = 0, maximum = 150)]
     age: i32 = 0,                // default ⇒ not required
-    #[jade(description = "ISO-4217 code")]
+    /// ISO-4217 code.
     currency: String,
 }
 ```
-
-The compiler already routes `#[serde(...)]` through the derive synthesiser;
-`#[jade(...)]` is parsed by the Jade generator's own attribute reader (it does
-not need a compiler change beyond attributes being preserved on the AST, which
-they already are).
 
 #### Layer C — validation (santhosh-tekuri-equivalent)
 
@@ -263,11 +296,52 @@ use { CreateUser } from "./create-user.schema.json" with {
 };
 ```
 
-`object` → `struct` (with `#[jade]` / `#[serde]` attributes reconstructed from
-the keywords), `oneOf` of tagged objects → `variant`, `enum` of strings →
+`object` → `struct` (with `#[validate]` / `#[serde]` attributes reconstructed
+from the keywords), `oneOf` of tagged objects → `variant`, `enum` of strings →
 `enum`, `$ref` → a named type reference, `$defs` → sibling declarations. This
 closes the loop: Layer B turns Wado types into schemas, Layer D turns schemas
 back into Wado types, and the two are designed to round-trip.
+
+### Language dependency — `Reflect` and `#[validate]`
+
+Jade itself ships zero compiler changes; everything in Layers A, C, D is plain
+library code. But Layer B (and, longer-term, moving serde derivation out of
+`synthesis/serde_synth.rs` into library code) needs the compiler to expose type
+structure. That work is _not_ Jade's to define inline — it is general language
+infrastructure, specified in a companion WEP that evolves
+[`wep-2026-03-14-variadic-type-parameters.md`](./wep-2026-03-14-variadic-type-parameters.md)
+§10. Jade _depends on_ it; this section only records what Layer B requires of
+it, so the two designs compose.
+
+Required of the language (in rough order of necessity for Layer B):
+
+1. **`Reflect` synthesis + `where`-clause pack binding** — already designed,
+   not yet implemented (WEP 2026-03-14 checklist: `Reflect` per-struct
+   synthesis and `T: Trait<Assoc = [..F]>` extraction are the two unchecked
+   items). Unlocks the value-free `impl<T: Reflect<Fields = [..F]>, ..F> …`
+   above. Nothing Jade-specific.
+2. **Per-field metadata on `Reflect`** — the wire name (serde `rename` /
+   `rename_all` applied), whether the field has a default (→ drop from
+   `required`), and its `///` doc string (→ `description`). Today these live in
+   compiler TIR consumed by `serde_synth`; exposing them through `Reflect` is
+   what lets derivation become library code.
+3. **Variant / enum / flags reflection** — `Reflect` as designed is struct
+   only; a `variant` → `oneOf`, an `enum` → string `enum`, and `flags` need the
+   analogous compile-time introspection.
+4. **A single generic `#[validate(…)]` attribute, exposed via `Reflect`** — the
+   compiler carries its `key = value` pairs as opaque compile-time metadata and
+   makes them readable per field; it does _not_ interpret them. Jade (and any
+   other validation/schema library) reads and gives them meaning. This is the
+   principled replacement for the rejected `#[jade(…)]`: a library cannot own a
+   compiler-recognised attribute, but it _can_ read a generic one the compiler
+   merely carries.
+
+Future direction (gestured at, not built here): user-defined attributes under a
+**distinct `@[foo(…)]` syntax**, kept syntactically separate from built-in
+`#[…]` so it is always clear which attributes are compiler-known and which are
+library-interpreted — the ambiguity Rust never resolved (`#[serde(…)]` and a
+built-in `#[inline]` are indistinguishable at a glance). `#[validate]` is the
+single built-in stepping stone toward that system, not its final form.
 
 ### Phasing
 
@@ -312,13 +386,25 @@ the phases compose rather than collide.
 
 - **Draft 7 / OpenAPI reader.** Additive (a normaliser into the 2020-12 model)
   or a separate parse path? Deferred until A+B land.
-- **`#[jade(...)]` vs. extending `#[serde(...)]`.** A separate namespace keeps
-  serde focused on the wire form and Jade on the schema, but means two
-  attributes on one field. Tentatively: separate namespace.
+- **`#[validate]` keyword surface.** Which JSON Schema assertions are worth a
+  first-class `key = value` (`min_length`, `maximum`, `pattern`, `format`,
+  `multiple_of`, …) versus left to hand-authoring on the `Schema` value. The
+  attribute mechanism is settled (a single generic built-in carried opaquely by
+  the compiler, read via `Reflect`); only the recognised key set is open.
 - **Output format units.** Whether to emit the spec's standardized
   verbose/hierarchical validation _output_ (for tooling interop) or keep Jade's
   own flat `ValidationError` list. Tentatively: flat list first, standardized
   output later if a consumer needs it.
 
-```
-```
+### Resolved during design
+
+- **No `#[jade(…)]` attribute.** A package that merely lives in this repo is an
+  ordinary library; it cannot own a compiler-recognised attribute, and Wado has
+  no reflection or macros for it to read one itself. Constraints therefore come
+  from a generic built-in `#[validate(…)]` (carried opaquely by the compiler,
+  read via `Reflect`), and `description` from `///` doc comments. See "Language
+  dependency".
+- **Capability B is library code, not compiler magic.** It is built on the
+  compile-time `Reflect` introspection, in the same no-dynamic-reflection,
+  monomorphised lineage as tuple `for-of`. The compiler gains general type
+  introspection; it never learns about Jade.

--- a/docs/wep-2026-06-13-jade.md
+++ b/docs/wep-2026-06-13-jade.md
@@ -231,17 +231,11 @@ Constraints and annotations come from two non-`#[jade]` sources:
 
 - **`description` / `title` from `///` doc comments** — the idiomatic source
   (schemars does the same); no attribute needed.
-- **Validation keywords from a single generic `#[validate(…)]` attribute** —
-  _not_ a Jade-owned namespace. `#[validate]` is a generic, language-blessed
-  attribute (added by the companion language WEP) with a **closed declarative
-  vocabulary** (`min_length`, `minimum`, `pattern`, `format`, …). It is _not
-  inert_: the compiler-synthesized `Deserialize` enforces it at the
-  deserialization boundary, so an out-of-range external value is rejected even
-  without Jade. Jade additionally reads the same keywords via `Reflect` and
-  emits them into the schema. A closed vocabulary is precisely what lets one
-  annotation be both enforced (boundary check) and introspected (schema). It is
-  a wire-contract guard, not a whole-program invariant — that is the future
-  `where` refinement's job (see "Language dependency").
+- **Validation keywords (`min_length`, `minimum`, `pattern`, `format`, …) from
+  the generic, built-in `#[validate(…)]` attribute** — not a Jade-owned
+  namespace. Jade reads its entries via `Reflect`; the same attribute is
+  enforced at the `Deserialize` boundary, so it is never inert. The attribute is
+  specified in the companion WEP (see "Language dependency").
 
 ```wado
 #[serde(rename_all = "camelCase")]
@@ -332,53 +326,21 @@ infrastructure, specified in the companion WEP
 §10). Jade _depends on_ it; this section only records what Layer B requires of
 it, so the two designs compose.
 
-Required of the language (in rough order of necessity for Layer B):
+What Layer B consumes from the companion WEP:
 
-1. **`Reflect` synthesis + `where`-clause pack binding** — already designed,
-   not yet implemented (WEP 2026-03-14 checklist: `Reflect` per-struct
-   synthesis and `T: Trait<Assoc = [..F]>` extraction are the two unchecked
-   items). Unlocks the value-free
-   `impl<T, ..F> … where T: Reflect<Fields = [..F]>` above. Nothing
-   Jade-specific.
-2. **Per-field metadata on `Reflect`** — the wire name (serde `rename` /
-   `rename_all` applied), whether the field has a default (→ drop from
-   `required`), and its `///` doc string (→ `description`). Today these live in
-   compiler TIR consumed by `serde_synth`; exposing them through `Reflect` is
-   what lets derivation become library code.
-3. **Variant / enum / flags reflection** — `Reflect` as designed is struct
-   only; a `variant` → `oneOf`, an `enum` → string `enum`, and `flags` need the
-   analogous compile-time introspection.
-4. **A single generic, built-in `#[validate(…)]` attribute with a closed
-   declarative vocabulary** — the compiler does two things with it, and they are
-   what keep it from being inert:
-   - **Enforces** the vocabulary at the `Deserialize` boundary: the synthesized
-     `Deserialize` runs each field's checks after reading it, rejecting an
-     out-of-range external value with a `DeserializeError`. This holds for
-     anyone deserializing, with or without Jade — the trust boundary is the
-     natural and honest place to enforce a wire contract.
-   - **Exposes** the same `key = value` pairs per field via `Reflect`, so a
-     library (Jade) can read them and emit the corresponding schema keywords.
+- **`Reflect` synthesis + `where`-clause pack binding** — powers the value-free
+  `impl<T, ..F> … where T: Reflect<Fields = [..F]>` above.
+- **Per-field `Reflect` metadata** — wire name (serde rename), has-default
+  (→ `required`), doc string (→ `description`).
+- **Variant / enum / flags reflection** — for `oneOf` and string `enum`.
+- **The generic, built-in `#[validate(…)]` attribute** — Jade reads its entries
+  via `Reflect` for schema keywords; it is also enforced at the `Deserialize`
+  boundary, so it is never inert.
 
-   `#[validate]` is _not_ Jade-owned and is the principled replacement for the
-   rejected `#[jade(…)]`: a library cannot own a compiler-recognized attribute,
-   but a generic built-in serves every validation/schema library equally.
-
-Future directions (gestured at, not built here):
-
-- **Refinement predicates `foo: i32 where <predicate>`** — for true _in-memory
-  invariants_ (enforced at construction / `as` conversion in the `assert`
-  doctrine: "cannot be disabled, always reliable"), distinct from `#[validate]`'s
-  wire-boundary guard. General predicates are enforced but opaque to schema
-  derivation; only a structured subset (comparisons, length) could map to schema
-  keywords. Anchoring a refinement to a `newtype` bounds _when_ the check fires
-  (conversion only), à la Ada subtype predicates.
-- **User-defined attributes under a distinct `@[foo(…)]` syntax** — kept
-  syntactically separate from built-in `#[…]` so it is always clear which
-  attributes are compiler-known and which are library-interpreted, resolving the
-  ambiguity Rust never did (`#[serde(…)]` and a built-in `#[inline]` are
-  indistinguishable at a glance). `#[validate]` is a built-in that demonstrates
-  the generic, non-library-owned principle now; the open user-defined system is
-  this later syntax.
+The companion WEP owns the full design and the future directions it implies —
+refinement `foo: T where …` predicates (in-memory invariants, distinct from
+`#[validate]`'s wire-boundary guard) and the user-defined `@[foo(…)]` attribute
+syntax.
 
 ### Phasing
 

--- a/docs/wep-2026-06-13-reflect-derivation.md
+++ b/docs/wep-2026-06-13-reflect-derivation.md
@@ -1,0 +1,265 @@
+# Library-Defined Derivation: `Reflect` Extensions and the `#[validate]` Attribute
+
+## Context
+
+Wado derives a growing set of type-directed traits — `Eq`, `Ord`, `Inspect`,
+`Serialize`, `Deserialize`, `Default` — by **bespoke compiler synthesis** (each
+hand-written into `synthesis/`, e.g. `serde_synth.rs`). Every new type-directed
+capability has so far meant another hardcoded synthesiser. That model has two
+limits that a concrete new requirement now makes acute:
+
+1. It does not scale: each capability is compiler work, and the compiler grows
+   a special case per trait.
+2. It is closed to libraries. A third-party package cannot get a synthesiser,
+   and Wado has **no macros and no dynamic reflection**, so it cannot introspect
+   a type itself.
+
+The forcing function is [`wep-2026-06-13-jade.md`](./wep-2026-06-13-jade.md)
+(JSON Schema for Wado). Jade's capability B — "given a Wado type, produce its
+JSON Schema" — is exactly a type-directed derivation, but Jade is an ordinary
+package (`wado:jade`), not the compiler. It cannot be a synthesiser. Either
+type→schema is impossible as library code, or the language grows a general
+facility that lets libraries derive over a type's structure.
+
+The escape was already chosen, in
+[`wep-2026-03-14-variadic-type-parameters.md`](./wep-2026-03-14-variadic-type-parameters.md)
+§10: **`Reflect`**, a compiler-synthesised trait that exposes a struct's fields
+as a typed tuple at compile time (`type Fields = [..F]`, `field_names()`), in
+the same static, monomorphised, no-dynamic-reflection lineage as tuple `for-of`
+and `[..T::default()]`. That WEP's stated goal is to "remove compiler-magic
+struct `Inspect`; replace with the `Reflect`-based impl" — i.e. move derivation
+out of the compiler into library code. The variadic substrate (type packs,
+tuple `for-of`, `[..T::method()]` expansion, variadic trait impls) is
+implemented; the two pieces derivation most needs are designed but **unbuilt**
+(WEP 2026-03-14 checklist): `Reflect` per-struct synthesis, and `where`-clause
+pack binding `T: Trait<Assoc = [..F]>`.
+
+Bringing Jade's needs to that design surfaced gaps. Current `Reflect` exposes
+only field name + type + value. Schema derivation (and, once migrated, serde
+itself) additionally needs each field's **wire name** (serde `rename` /
+`rename_all` applied), **whether it has a default** (→ JSON Schema `required`),
+its **doc string** (→ `description`), and the **validation constraints**
+(`minLength`, `minimum`, `pattern`, `format`, …) that no type metadata carries
+today — and that a library cannot add via an attribute of its own.
+
+This WEP evolves WEP 2026-03-14 §10 to close those gaps generically, and adds a
+single generic built-in `#[validate(…)]` attribute. It is the language-side
+dependency of the Jade WEP; Jade ships no compiler change and consumes only
+what is decided here.
+
+### Scope
+
+In scope:
+
+- Finishing `Reflect` (per-struct synthesis + `where`-clause pack binding).
+- Extending `Reflect` with per-field metadata (wire name, has-default, doc,
+  `#[validate]` entries) and value-free type-level projection.
+- Variant / enum / flags reflection.
+- A generic built-in `#[validate(…)]` attribute with a closed vocabulary,
+  enforced at the `Deserialize` boundary and exposed via `Reflect`.
+- A staged migration of bespoke synthesisers to library code over `Reflect`.
+
+Out of scope (recorded as future directions, not built here):
+
+- Refinement predicates (`foo: T where <predicate>`).
+- User-defined attributes under the `@[foo(…)]` syntax.
+- Static (SMT-style) verification of any constraint.
+
+## Decision
+
+### Principle: derivation is library code over `Reflect`
+
+The compiler's only job is to expose a type's structure at compile time. Every
+derivation — the built-in `Inspect` / serde / `Default`, Jade's `JsonSchema`,
+and future user-written ones — is a generic library `impl` over `Reflect`,
+resolved at monomorphisation. No per-capability synthesiser, no macros, no
+dynamic reflection. The canonical shape:
+
+```wado
+impl<T: Reflect<Fields = [..F]>, ..F: SomeTrait> SomeTrait for T {
+    fn method(&self) -> R {
+        let meta = T::field_meta();        // value-level per-field metadata
+        let parts = [..F::method_of()];    // type-level, value-free, per field type
+        // combine meta + parts …
+    }
+}
+```
+
+### 1. Finish `Reflect` (the two unbuilt items from WEP 2026-03-14)
+
+- **Per-struct synthesis.** The compiler synthesises `impl Reflect for S` for
+  every struct `S`, with `type Fields = [F_0, F_1, …]`, `fields(&self)`
+  returning the value tuple, `field_names()` the source names.
+- **`where`-clause pack binding.** `T: Reflect<Fields = [..F]>` extracts the
+  pack `F` from the concrete `Fields` tuple at monomorphisation, so a derivation
+  can expand `[..F::method()]`. This is the mechanism that makes derivation
+  **value-free**: `schema_for::<T>()` has no instance, yet `[..F::json_schema()]`
+  still expands per field type.
+
+### 2. Extend `Reflect` with derivation metadata
+
+`Reflect` gains value-level, per-field metadata, kept in index correspondence
+with the type-level `Fields` pack:
+
+```wado
+pub struct FieldMeta {
+    name: String,            // source name, e.g. "user_name"
+    wire_name: String,       // serde rename / rename_all applied, e.g. "userName"
+    has_default: bool,       // #[serde(default)] or `f: T = expr`
+    doc: String,             // /// doc comment ("" if none)
+    validate: List<ValidateEntry>,   // parsed #[validate(...)] (see §4)
+}
+
+pub trait Reflect {
+    type Fields;                       // [F_0, F_1, …]  — type-level pack
+    fn fields(&self) -> Self::Fields;  // value tuple (when an instance exists)
+    fn field_meta() -> List<FieldMeta>;
+    fn type_name() -> String;
+    fn type_doc() -> String;
+}
+```
+
+Two channels are unavoidable and intentional: field **types** must stay a
+type-level pack (`Fields = [..F]`) so `[..F::method()]` can expand; everything
+else is value-level metadata (`field_meta()`). A derivation zips the two by
+index.
+
+### 3. Variant / enum / flags reflection
+
+`Reflect` as designed is struct-only. Sum and bitmask types get analogous
+compile-time introspection so a derivation can lower a `variant` to JSON
+Schema `oneOf`, an `enum` to a string `enum`, and `flags` to its bit set:
+
+```wado
+pub trait ReflectVariant {
+    type Cases;                          // payload types as a pack ([P_0, P_1, …])
+    fn case_meta() -> List<CaseMeta>;    // name, wire_name, discriminant, is_unit, doc
+    fn type_name() -> String;
+}
+// ReflectEnum (discriminants + names), ReflectFlags (bit names) likewise.
+```
+
+The exact unification (one `Reflect` that reports a type kind, vs. three
+traits) is an API question (see "Open questions"); the capability set is fixed
+here.
+
+### 4. The `#[validate(…)]` attribute
+
+A single generic, built-in attribute with a **closed declarative vocabulary** —
+not owned by any library:
+
+```wado
+struct CreateUser {
+    #[validate(min_length = 1, max_length = 64)]
+    user_name: String,
+    #[validate(format = "email")]
+    email: String,
+    #[validate(minimum = 0, maximum = 150)]
+    age: i32 = 0,
+}
+```
+
+Recognised keys (initial set): `min_length` / `max_length`, `minimum` /
+`maximum` / `exclusive_minimum` / `exclusive_maximum`, `multiple_of`,
+`pattern`, `format`, `min_items` / `max_items`, `unique_items`. The compiler
+parses these into `ValidateEntry` values and does **two** things with them — and
+together they are what stop the attribute from being silently inert, the
+failure mode of Rust's `validator` crate (annotate, but nothing runs unless you
+remember to call `.validate()`):
+
+- **Enforce at the `Deserialize` boundary.** The synthesised `Deserialize`, after
+  reading each field, runs that field's checks; a violation returns a
+  `DeserializeError` (kind `InvalidValue`) with the field's offset. This holds
+  for _anyone_ deserialising, with or without Jade. The trust boundary —
+  untrusted external data entering the program's types — is the natural and
+  honest place to enforce a wire contract. Values constructed in trusted code
+  (a struct literal) are deliberately _not_ checked here; whole-program
+  invariants are the future `where` refinement's job, not this attribute's.
+- **Expose via `Reflect`.** The same entries appear in `FieldMeta::validate`, so
+  Jade (and any schema/validation library) reads them and emits the
+  corresponding schema keywords. A _closed_ vocabulary is exactly what lets one
+  annotation be both enforced (the compiler knows each key's boundary check) and
+  introspected (the compiler/library knows each key's schema mapping).
+
+`description` is _not_ a `#[validate]` concern: it comes from `///` doc
+comments, surfaced as `FieldMeta::doc` / `type_doc()`.
+
+### 5. Migrate bespoke synthesisers to library code (staged)
+
+Once §1–§3 land, the hand-written synthesisers become generic library impls
+over `Reflect`, shrinking the compiler's special-case surface:
+
+1. **`Inspect` / `InspectAlt`** first — already the stated goal of WEP
+   2026-03-14; the lowest-risk proof.
+2. **serde `Serialize` / `Deserialize`** — the struct/variant walks move to
+   library code; the compiler retains only `Reflect` synthesis plus the
+   `#[validate]` boundary enforcement hook.
+3. **`Default`** — `[..F::default()]` over the field pack.
+
+Each migration is its own PR with golden-output parity against the current
+synthesiser. The end state: the compiler synthesises `Reflect` (and enforces
+`#[validate]`); everything else is library code.
+
+## Future directions
+
+- **Refinement predicates — `foo: T where <predicate>`.** For true _in-memory
+  invariants_, enforced at construction / `as` conversion in the `assert`
+  doctrine ("cannot be disabled, always reliable"), distinct from
+  `#[validate]`'s wire-boundary guard. Anchoring a refinement to a `newtype`
+  bounds _when_ the check fires (conversion only), à la Ada subtype predicates.
+  General predicates are enforced but opaque to schema derivation; only a
+  structured subset (comparisons, length) could map to schema keywords. This is
+  the deliberate division of labour: `#[validate]` guards data crossing the
+  boundary; `where` guards data already in memory.
+- **User-defined attributes — `@[foo(…)]`.** A distinct syntax for
+  library-interpreted attributes, kept visually separate from built-in `#[…]`
+  so it is always clear which attributes the compiler knows and which a library
+  gives meaning to — the ambiguity Rust never resolved (`#[serde(…)]` and
+  built-in `#[inline]` look identical). Exposed via `Reflect` as opaque
+  per-field metadata. `#[validate]` is the built-in that demonstrates the
+  generic, non-library-owned principle now; `@[…]` is the open system later.
+
+## Consequences
+
+### Benefits
+
+- One mechanism (`Reflect`) replaces an open-ended series of bespoke
+  synthesisers; new type-directed derivations are ordinary library code.
+- Jade's capability B becomes pure library code; the compiler never learns
+  about Jade.
+- The compiler's special-case surface _shrinks_ over time as `Inspect` / serde /
+  `Default` migrate onto `Reflect`.
+- No macros, no dynamic reflection; everything stays static and monomorphised,
+  consistent with Wado's existing compile-time-expansion idioms.
+- `#[validate]` is generic and enforced, so a constraint is never silently
+  ignored — consistent with the `assert` "always reliable" doctrine.
+
+### Costs and trade-offs
+
+- `Reflect` must thread serde naming and `#[validate]` into its metadata, so the
+  trait is coupled to those vocabularies. This is the price of moving derivation
+  out of the compiler: the metadata the synthesisers read internally must become
+  part of the exposed surface.
+- Variant / enum / flags reflection is real new compiler work beyond the
+  struct-only design of WEP 2026-03-14.
+- Enforcing `#[validate]` in `Deserialize` grows core serde with a closed
+  validation vocabulary. It is generic (not Jade-specific) and bounded by the
+  recognised key set, but it is core surface nonetheless.
+- A generic field-walk derivation may monomorphise to less tight code than a
+  hand-written synthesiser. Each migration in §5 must check generated-code
+  parity (size and speed), not just output parity.
+
+### Open questions
+
+- **`Reflect` metadata API shape.** Parallel `List`s vs. a single
+  `List<FieldMeta>` descriptor (chosen here) vs. associated consts; and whether
+  variant/enum/flags fold into one kind-reporting `Reflect` or stay separate
+  traits.
+- **`#[validate]` recognised key set.** Which JSON Schema assertions earn a
+  first-class key versus being left to hand-authoring on a `Schema` value.
+- **Coherence.** Interaction with the variadic coherence rules still unchecked
+  in WEP 2026-03-14 (non-VG-wins / VG-overlap-forbidden) when a blanket
+  `impl<T: Reflect<…>> Trait for T` meets concrete impls.
+- **Enforcement breadth.** Whether `#[validate]` should ever also fire at
+  construction. Deferred: that is the refinement `where` feature's domain, kept
+  separate on purpose.

--- a/docs/wep-2026-06-13-reflect-derivation.md
+++ b/docs/wep-2026-06-13-reflect-derivation.md
@@ -184,11 +184,9 @@ remember to call `.validate()`):
   honest place to enforce a wire contract. Values constructed in trusted code
   (a struct literal) are deliberately _not_ checked here; whole-program
   invariants are the future `where` refinement's job, not this attribute's.
-  _Where_ this check lives follows the serde migration in §5: while
-  `Deserialize` is compiler-synthesized, the synthesizer emits the checks; once
-  `Deserialize` is library code over `Reflect`, the generic impl reads
-  `FieldMeta::validate` and enforces — the same guarantee, with the compiler's
-  only permanent job being to _expose_ the entries via `Reflect`.
+  (Where the check physically lives — synthesized `Deserialize` now, generic
+  library `Deserialize` after §5 — is a migration detail; the guarantee is the
+  same either way.)
 - **Expose via `Reflect`.** The same entries appear in `FieldMeta::validate`, so
   Jade (and any schema/validation library) reads them and emits the
   corresponding schema keywords. A _closed_ vocabulary is exactly what lets one

--- a/docs/wep-2026-06-13-reflect-derivation.md
+++ b/docs/wep-2026-06-13-reflect-derivation.md
@@ -5,27 +5,27 @@
 Wado derives a growing set of type-directed traits — `Eq`, `Ord`, `Inspect`,
 `Serialize`, `Deserialize`, `Default` — by **bespoke compiler synthesis** (each
 hand-written into `synthesis/`, e.g. `serde_synth.rs`). Every new type-directed
-capability has so far meant another hardcoded synthesiser. That model has two
+capability has so far meant another hardcoded synthesizer. That model has two
 limits that a concrete new requirement now makes acute:
 
 1. It does not scale: each capability is compiler work, and the compiler grows
    a special case per trait.
-2. It is closed to libraries. A third-party package cannot get a synthesiser,
+2. It is closed to libraries. A third-party package cannot get a synthesizer,
    and Wado has **no macros and no dynamic reflection**, so it cannot introspect
    a type itself.
 
 The forcing function is [`wep-2026-06-13-jade.md`](./wep-2026-06-13-jade.md)
 (JSON Schema for Wado). Jade's capability B — "given a Wado type, produce its
 JSON Schema" — is exactly a type-directed derivation, but Jade is an ordinary
-package (`wado:jade`), not the compiler. It cannot be a synthesiser. Either
+package (`wado:jade`), not the compiler. It cannot be a synthesizer. Either
 type→schema is impossible as library code, or the language grows a general
 facility that lets libraries derive over a type's structure.
 
 The escape was already chosen, in
 [`wep-2026-03-14-variadic-type-parameters.md`](./wep-2026-03-14-variadic-type-parameters.md)
-§10: **`Reflect`**, a compiler-synthesised trait that exposes a struct's fields
+§10: **`Reflect`**, a compiler-synthesized trait that exposes a struct's fields
 as a typed tuple at compile time (`type Fields = [..F]`, `field_names()`), in
-the same static, monomorphised, no-dynamic-reflection lineage as tuple `for-of`
+the same static, monomorphized, no-dynamic-reflection lineage as tuple `for-of`
 and `[..T::default()]`. That WEP's stated goal is to "remove compiler-magic
 struct `Inspect`; replace with the `Reflect`-based impl" — i.e. move derivation
 out of the compiler into library code. The variadic substrate (type packs,
@@ -57,7 +57,7 @@ In scope:
 - Variant / enum / flags reflection.
 - A generic built-in `#[validate(…)]` attribute with a closed vocabulary,
   enforced at the `Deserialize` boundary and exposed via `Reflect`.
-- A staged migration of bespoke synthesisers to library code over `Reflect`.
+- A staged migration of bespoke synthesizers to library code over `Reflect`.
 
 Out of scope (recorded as future directions, not built here):
 
@@ -72,11 +72,14 @@ Out of scope (recorded as future directions, not built here):
 The compiler's only job is to expose a type's structure at compile time. Every
 derivation — the built-in `Inspect` / serde / `Default`, Jade's `JsonSchema`,
 and future user-written ones — is a generic library `impl` over `Reflect`,
-resolved at monomorphisation. No per-capability synthesiser, no macros, no
-dynamic reflection. The canonical shape:
+resolved at monomorphization. No per-capability synthesizer, no macros, no
+dynamic reflection. The canonical shape, using the `where`-clause pack binding
+established by WEP 2026-03-14 §11:
 
 ```wado
-impl<T: Reflect<Fields = [..F]>, ..F: SomeTrait> SomeTrait for T {
+impl<T, ..F: SomeTrait> SomeTrait for T
+where T: Reflect<Fields = [..F]>
+{
     fn method(&self) -> R {
         let meta = T::field_meta();        // value-level per-field metadata
         let parts = [..F::method_of()];    // type-level, value-free, per field type
@@ -87,42 +90,48 @@ impl<T: Reflect<Fields = [..F]>, ..F: SomeTrait> SomeTrait for T {
 
 ### 1. Finish `Reflect` (the two unbuilt items from WEP 2026-03-14)
 
-- **Per-struct synthesis.** The compiler synthesises `impl Reflect for S` for
+- **Per-struct synthesis.** The compiler synthesizes `impl Reflect for S` for
   every struct `S`, with `type Fields = [F_0, F_1, …]`, `fields(&self)`
   returning the value tuple, `field_names()` the source names.
 - **`where`-clause pack binding.** `T: Reflect<Fields = [..F]>` extracts the
-  pack `F` from the concrete `Fields` tuple at monomorphisation, so a derivation
+  pack `F` from the concrete `Fields` tuple at monomorphization, so a derivation
   can expand `[..F::method()]`. This is the mechanism that makes derivation
   **value-free**: `schema_for::<T>()` has no instance, yet `[..F::json_schema()]`
   still expands per field type.
 
 ### 2. Extend `Reflect` with derivation metadata
 
-`Reflect` gains value-level, per-field metadata, kept in index correspondence
-with the type-level `Fields` pack:
+The extension is **purely additive** over the §10 signature — `type Fields`,
+`fields(&self)`, `field_names()`, and `type_name()` are retained verbatim (so
+the §11 struct-`Inspect` example keeps compiling), and two members are added:
 
 ```wado
 pub struct FieldMeta {
-    name: String,            // source name, e.g. "user_name"
+    name: String,            // source name, e.g. "user_name" (== field_names()[i])
     wire_name: String,       // serde rename / rename_all applied, e.g. "userName"
     has_default: bool,       // #[serde(default)] or `f: T = expr`
     doc: String,             // /// doc comment ("" if none)
     validate: List<ValidateEntry>,   // parsed #[validate(...)] (see §4)
 }
 
+#[comp_feature("reflect")]
 pub trait Reflect {
-    type Fields;                       // [F_0, F_1, …]  — type-level pack
-    fn fields(&self) -> Self::Fields;  // value tuple (when an instance exists)
-    fn field_meta() -> List<FieldMeta>;
-    fn type_name() -> String;
-    fn type_doc() -> String;
+    type Fields;                       // [F_0, F_1, …]  — type-level pack  (§10)
+    fn fields(&self) -> Self::Fields;  // value tuple (when an instance exists)  (§10)
+    fn field_names() -> List<String>;  // source names  (§10)
+    fn type_name() -> String;          // (§10)
+    fn field_meta() -> List<FieldMeta>;  // added: wire name, default, doc, validate
+    fn type_doc() -> String;             // added: /// on the type itself
 }
 ```
 
-Two channels are unavoidable and intentional: field **types** must stay a
-type-level pack (`Fields = [..F]`) so `[..F::method()]` can expand; everything
-else is value-level metadata (`field_meta()`). A derivation zips the two by
-index.
+`field_meta()` keeps index correspondence with `field_names()` and the
+type-level `Fields` pack. Two channels are unavoidable and intentional: field
+**types** must stay a type-level pack (`Fields = [..F]`) so `[..F::method()]`
+can expand; everything else is value-level metadata (`field_meta()`). A
+derivation zips the two by index. Like the original, `Reflect` is
+compiler-synthesized, cannot be user-implemented, and is callable only in
+monomorphized contexts.
 
 ### 3. Variant / enum / flags reflection
 
@@ -159,7 +168,7 @@ struct CreateUser {
 }
 ```
 
-Recognised keys (initial set): `min_length` / `max_length`, `minimum` /
+Recognized keys (initial set): `min_length` / `max_length`, `minimum` /
 `maximum` / `exclusive_minimum` / `exclusive_maximum`, `multiple_of`,
 `pattern`, `format`, `min_items` / `max_items`, `unique_items`. The compiler
 parses these into `ValidateEntry` values and does **two** things with them — and
@@ -167,14 +176,19 @@ together they are what stop the attribute from being silently inert, the
 failure mode of Rust's `validator` crate (annotate, but nothing runs unless you
 remember to call `.validate()`):
 
-- **Enforce at the `Deserialize` boundary.** The synthesised `Deserialize`, after
-  reading each field, runs that field's checks; a violation returns a
+- **Enforce at the `Deserialize` boundary.** After reading each field,
+  `Deserialize` runs that field's checks; a violation returns a
   `DeserializeError` (kind `InvalidValue`) with the field's offset. This holds
-  for _anyone_ deserialising, with or without Jade. The trust boundary —
+  for _anyone_ deserializing, with or without Jade. The trust boundary —
   untrusted external data entering the program's types — is the natural and
   honest place to enforce a wire contract. Values constructed in trusted code
   (a struct literal) are deliberately _not_ checked here; whole-program
   invariants are the future `where` refinement's job, not this attribute's.
+  _Where_ this check lives follows the serde migration in §5: while
+  `Deserialize` is compiler-synthesized, the synthesizer emits the checks; once
+  `Deserialize` is library code over `Reflect`, the generic impl reads
+  `FieldMeta::validate` and enforces — the same guarantee, with the compiler's
+  only permanent job being to _expose_ the entries via `Reflect`.
 - **Expose via `Reflect`.** The same entries appear in `FieldMeta::validate`, so
   Jade (and any schema/validation library) reads them and emits the
   corresponding schema keywords. A _closed_ vocabulary is exactly what lets one
@@ -184,21 +198,47 @@ remember to call `.validate()`):
 `description` is _not_ a `#[validate]` concern: it comes from `///` doc
 comments, surfaced as `FieldMeta::doc` / `type_doc()`.
 
-### 5. Migrate bespoke synthesisers to library code (staged)
+### 5. Migrate bespoke synthesizers to library code (staged)
 
-Once §1–§3 land, the hand-written synthesisers become generic library impls
+Once §1–§3 land, the hand-written synthesizers become generic library impls
 over `Reflect`, shrinking the compiler's special-case surface:
 
 1. **`Inspect` / `InspectAlt`** first — already the stated goal of WEP
    2026-03-14; the lowest-risk proof.
 2. **serde `Serialize` / `Deserialize`** — the struct/variant walks move to
-   library code; the compiler retains only `Reflect` synthesis plus the
-   `#[validate]` boundary enforcement hook.
+   library code. `Deserialize`'s `#[validate]` enforcement moves with it, now
+   reading `FieldMeta::validate`; the compiler is left exposing the entries via
+   `Reflect`, nothing more.
 3. **`Default`** — `[..F::default()]` over the field pack.
 
 Each migration is its own PR with golden-output parity against the current
-synthesiser. The end state: the compiler synthesises `Reflect` (and enforces
-`#[validate]`); everything else is library code.
+synthesizer. The end state: the compiler synthesizes `Reflect` (and exposes
+`#[validate]` through it); everything else, enforcement included, is library
+code.
+
+## Implementation checklist
+
+Ordered so each step is independently testable; Layer-B-of-Jade is unblocked
+after the first three.
+
+- [ ] `Reflect` per-struct synthesis — `Fields`, `fields`, `field_names`,
+      `type_name` (the unbuilt item from WEP 2026-03-14 §10).
+- [ ] `where`-clause pack binding `T: Reflect<Fields = [..F]>` (the unbuilt
+      item from WEP 2026-03-14 §11).
+- [ ] `Reflect` metadata extension — `field_meta()` (`wire_name`,
+      `has_default`, `doc`, `validate`) and `type_doc()`.
+- [ ] `#[validate(…)]` attribute — parse the closed vocabulary into
+      `ValidateEntry`; surface it on `FieldMeta::validate`.
+- [ ] `#[validate]` enforcement in the synthesized `Deserialize`
+      (`DeserializeError` / `InvalidValue` on violation).
+- [ ] `ReflectVariant` / `ReflectEnum` / `ReflectFlags` synthesis.
+- [ ] Migrate `Inspect` / `InspectAlt` to the `Reflect`-based impl; remove the
+      compiler-magic struct path (WEP 2026-03-14's stated goal).
+- [ ] Migrate serde struct/variant `Serialize` / `Deserialize` to library code;
+      move `#[validate]` enforcement into the generic `Deserialize`.
+- [ ] Migrate `Default` to `[..F::default()]`.
+- [ ] Coherence rules for a blanket `Reflect` impl vs. concrete impls
+      (depends on the unchecked coherence items in WEP 2026-03-14).
 
 ## Future directions
 
@@ -209,7 +249,7 @@ synthesiser. The end state: the compiler synthesises `Reflect` (and enforces
   bounds _when_ the check fires (conversion only), à la Ada subtype predicates.
   General predicates are enforced but opaque to schema derivation; only a
   structured subset (comparisons, length) could map to schema keywords. This is
-  the deliberate division of labour: `#[validate]` guards data crossing the
+  the deliberate division of labor: `#[validate]` guards data crossing the
   boundary; `where` guards data already in memory.
 - **User-defined attributes — `@[foo(…)]`.** A distinct syntax for
   library-interpreted attributes, kept visually separate from built-in `#[…]`
@@ -224,12 +264,12 @@ synthesiser. The end state: the compiler synthesises `Reflect` (and enforces
 ### Benefits
 
 - One mechanism (`Reflect`) replaces an open-ended series of bespoke
-  synthesisers; new type-directed derivations are ordinary library code.
+  synthesizers; new type-directed derivations are ordinary library code.
 - Jade's capability B becomes pure library code; the compiler never learns
   about Jade.
 - The compiler's special-case surface _shrinks_ over time as `Inspect` / serde /
   `Default` migrate onto `Reflect`.
-- No macros, no dynamic reflection; everything stays static and monomorphised,
+- No macros, no dynamic reflection; everything stays static and monomorphized,
   consistent with Wado's existing compile-time-expansion idioms.
 - `#[validate]` is generic and enforced, so a constraint is never silently
   ignored — consistent with the `assert` "always reliable" doctrine.
@@ -238,15 +278,15 @@ synthesiser. The end state: the compiler synthesises `Reflect` (and enforces
 
 - `Reflect` must thread serde naming and `#[validate]` into its metadata, so the
   trait is coupled to those vocabularies. This is the price of moving derivation
-  out of the compiler: the metadata the synthesisers read internally must become
+  out of the compiler: the metadata the synthesizers read internally must become
   part of the exposed surface.
 - Variant / enum / flags reflection is real new compiler work beyond the
   struct-only design of WEP 2026-03-14.
 - Enforcing `#[validate]` in `Deserialize` grows core serde with a closed
   validation vocabulary. It is generic (not Jade-specific) and bounded by the
-  recognised key set, but it is core surface nonetheless.
-- A generic field-walk derivation may monomorphise to less tight code than a
-  hand-written synthesiser. Each migration in §5 must check generated-code
+  recognized key set, but it is core surface nonetheless.
+- A generic field-walk derivation may monomorphize to less tight code than a
+  hand-written synthesizer. Each migration in §5 must check generated-code
   parity (size and speed), not just output parity.
 
 ### Open questions
@@ -255,11 +295,12 @@ synthesiser. The end state: the compiler synthesises `Reflect` (and enforces
   `List<FieldMeta>` descriptor (chosen here) vs. associated consts; and whether
   variant/enum/flags fold into one kind-reporting `Reflect` or stay separate
   traits.
-- **`#[validate]` recognised key set.** Which JSON Schema assertions earn a
+- **`#[validate]` recognized key set.** Which JSON Schema assertions earn a
   first-class key versus being left to hand-authoring on a `Schema` value.
 - **Coherence.** Interaction with the variadic coherence rules still unchecked
   in WEP 2026-03-14 (non-VG-wins / VG-overlap-forbidden) when a blanket
-  `impl<T: Reflect<…>> Trait for T` meets concrete impls.
+  `impl<T, ..F> Trait for T where T: Reflect<Fields = [..F]>` meets concrete
+  impls (e.g. a primitive's own `impl Trait`).
 - **Enforcement breadth.** Whether `#[validate]` should ever also fire at
   construction. Deferred: that is the refinement `where` feature's domain, kept
   separate on purpose.


### PR DESCRIPTION
Two design WEPs plus a CI ergonomics change. Concerns are deliberately mixed in one branch.

## WEPs

### Jade — JSON Schema for Wado (`docs/wep-2026-06-13-jade.md`)

Designs **Jade** (JSON Assertion & Definition Engine), an independent package `wado:jade` (directory `package-jade/`, **not** bundled into `core:`) providing JSON Schema support for **Draft 2020-12**. Four composable layers, grounded in Go/Rust prior art (schemars, the `jsonschema` crate, invopop, santhosh-tekuri, typify):

- **A — model:** a serde-round-trippable `Schema` document type (hybrid: typed fields + a `TreeMap<String, Value>` `extra` escape hatch for unknown keywords).
- **B — derivation:** `JsonSchema` as ordinary library code over the compiler's compile-time `Reflect` introspection; shares serde metadata (`rename`/`default`); constraints from the generic `#[validate]` attribute, `description` from `///` doc comments.
- **C — validation:** validate a `core:value::Value` against a compiled `Schema`, JSON-Pointer error paths; `format` delegated to `core:temporal` / `core:url` / `core:uuid`; remote `$ref` behind an explicit effect.
- **D — codegen:** a Kiln generator lowering `.json` schemas to `.wado` types (the `package-gale` model), closing the loop with B.

Phasing: A (pure library) first; C and D in parallel; B is the only layer gated on the companion WEP.

### Library-Defined Derivation: `Reflect` + `#[validate]` (`docs/wep-2026-06-13-reflect-derivation.md`)

The language-side dependency of Jade's Layer B, evolving WEP 2026-03-14 §10. Makes type-directed derivation (`Inspect`, serde, `Default`, Jade's `JsonSchema`, future user ones) ordinary library code over the compiler-synthesized `Reflect` — no macros, no dynamic reflection. Adds:

- `Reflect` synthesis + `where`-clause pack binding (finishing the two unbuilt 2026-03-14 items); per-field metadata (wire name, has-default, doc, validate); variant / enum / flags reflection.
- A single generic, built-in `#[validate(…)]` attribute (closed vocabulary), enforced at the `Deserialize` boundary so it is never inert, and exposed via `Reflect` for schema emission.
- A staged migration of the bespoke synthesizers to library code.
- Future directions: refinement `foo: T where …` predicates (in-memory invariants) and the user-defined `@[foo(…)]` attribute syntax.

Both WEPs are registered in the WEP index (`docs/CLAUDE.md`).

## CI — docs-only fast-pass (`.github/workflows/ci.yml`)

A `changes` detector job flags whether anything other than Markdown changed. Every heavy test job gates on it, and the required `Test` aggregator short-circuits to success for docs-only (`*.md`) changes. The skip is intentionally **job-level**, not a workflow-level `paths-ignore` (which would leave a required check stuck "Expected" and block the PR). The detector fails closed on an unknown base ref, an empty diff, or its own failure.

Note: this PR itself changes `ci.yml`, so it is not docs-only and runs the full suite; the fast-pass takes effect for subsequent docs-only changes once this lands.

https://claude.ai/code/session_017ur1Y3i4aXn6HHusTPQWMV

---
_Generated by [Claude Code](https://claude.ai/code/session_017ur1Y3i4aXn6HHusTPQWMV)_