### PR TITLE
refactor(elaborator): decompose the God Object — TypeSystem ops, TraitEnv digests, AnnotateCtx

### DIFF
--- a/docs/wep-2026-05-26-elaborator-rearchitecture.md
+++ b/docs/wep-2026-05-26-elaborator-rearchitecture.md
@@ -463,313 +463,169 @@ The change touches every file under `elaborator/` and lands incrementally,
 with the suite (E2E, WIR golden, LSP query) green at every step, in
 dependency order. Stages are guidelines, not PR boundaries.
 
-Stages 1–5 and 7a are DONE:
+Phase 1 (Stages 1–5, 7a, 7-A, 7-B) is DONE: `TypeSystem` / `ModuleSemantics` /
+per-`AstId` `TypeAnnotations` extracted from the God Object; `reify` split out
+as the sole TIR producer reading recorded facts; the combined `annotate` walk
+builds no TIR (every `resolve_*` returns a `TypeId`), so LSP runs `annotate`
+alone. The premise the WEP existed to fix — LSP building and discarding TIR —
+is resolved. Detail in the Status section below and in git.
 
-- **Stages 1–4** — extract `TypeSystem`, `ModuleSemantics`, and per-`AstId`
-  `TypeAnnotations` from the `Elaborator` God Object.
-- **Stage 5** — split `reify` out as a second walk reading
-  `ModuleSemantics.types`; it is the sole TIR source for every module. It
-  landed still re-deriving some decisions (types, mangled names); Stage 7
-  cleans that.
-- **Stage 7a** — routing removed (`module_uses_reify`, the snapshot bypass,
-  the combined walk's TIR-output branch).
+Remaining in Phase 1:
 
-Remaining:
+**Stage 6 — Liveness and DCE.** `liveness::compute(&Semantics)` and the
+`Liveness` field on `Semantics` have landed (computed in WEP phase order; the
+`DeadFunction` / `DeadGlobal` diagnostics consume `dead_items`). The reify
+gate on `live_items` is wired but **disabled** (`None` live set) pending two
+prerequisites: (1) every semantic diagnostic that can fire on dead code is
+produced from `Semantics` rather than the emitted TIR (the "diagnostics from
+`Semantics`" move — see the Prerequisite section above and
+`wep-2026-05-16-unused-diagnostics.md` Phase 3b), and (2) cross-module graph
+completeness. Until both land, reify passes `None` (gating off) while
+`liveness` still feeds the dead-code diagnostics. Independent of Phase 2.
 
-**Stage 6 — Liveness and DCE.** `liveness::compute(&Semantics)` is
-added (see the DCE / Liveness section above), its result stored on
-`Semantics` as a non-optional `Liveness`, and reify gates item emission
-on `live_items`. A single reachability result feeds both the reify gate
-and the user-facing unused diagnostics (per the unused-diagnostics
-WEP); `optimize/dce.rs` retires from the diagnostic role but stays as
-silent post-monomorphization cleanup. The pass is fail-loud: a
-dropped-live item ICEs downstream and is fixed as a graph bug, never
-masked by over-approximation. Not started. Independent of Stage 7 —
-either may land first.
+Each stage keeps `mise run test`, the WIR golden fixtures, and the LSP query
+tests green. Performance is not tracked during migration; see Trade-offs.
 
-**Stage 7 — Make reify mechanical, then `annotate` TIR-free.** This is
-the structural completion of the annotate/reify split, in two sub-steps
-gated only on Stage 5 (now done). The premise the whole WEP exists to
-fix — that LSP builds and discards TIR just to obtain `Semantics` — is
-satisfied at the end of 7-B.
+### Stage 7-B execution plan (done)
 
-- **7-A — Reify becomes mechanical (incremental, low-risk).** Close the
-  completeness-rule gap one decision at a time: have `annotate` record
-  what reify re-derives (resolved types per `AstId`, impl identity /
-  mangled name) and switch reify from re-computation to a fact read.
-  Each step keeps E2E green; reify's output is unchanged, only its
-  source. When reify re-derives nothing decision-bearing it depends on
-  `&Semantics` alone — the two-walk parity-bug class is gone.
-- **7-B — `annotate` stops building TIR.** Strip TIR construction from
-  the combined walk (`resolve_*` returns resolved types + records facts,
-  no `TirExpr`), file by file (`expr.rs` → `stmt.rs` → `item.rs` → …),
-  keeping every `record_*`. After 7-A the contract is pinned (the facts
-  reify reads), so the target is exact: record the contract, drop the
-  TIR. LSP then runs `annotate` only — no TIR built or discarded. The
-  old `Elaborator` / `AnnotateState` TIR-emission halves and the
-  duplicate TIR construction are deleted; the pipeline diagrams in
-  `CLAUDE.md` / `docs/compiler.md` and the `elaborator/` file layout are
-  updated to match.
-
-Order is 7-A → 7-B: 7-A is incremental and de-risks 7-B, and while 7-A
-runs the combined walk's TIR stays live as reify's reference. The E2E
-suite and WIR golden fixtures carry the equivalence guarantee at every
-step.
-
-Each stage keeps `mise run test`, the WIR golden fixtures, and the LSP
-query tests green. Performance is not tracked during migration; see
-Trade-offs.
-
-### Stage 7-B execution plan
-
-7-B is not a single mechanical edit. The combined walk's TIR is already
-dead (reify is the sole producer since Stage 5/7a), so an arm's only
-reason to still build a real `TirExpr` is that some _analysis or
-diagnostic inside the combined walk_ reads the structure (`.kind`) of
-the resolved value. Those readers must move to the AST + recorded facts
-before the arm that feeds them can return a placeholder. Hence two
-phases:
-
-Phase 1 — port each structural reader off combined-walk TIR. Each is a
-behaviour-preserving refactor (the recorded values are unchanged, so
-reify's output is byte-identical) verified green on its own. Precedent:
-`control_flow.rs` (Stage 5 moved missing-return off the body TIR).
-
-Phase 2 — once no analysis reads resolved TIR structure, convert every
-`resolve_*` arm to a placeholder, then change signatures
-(`resolve_expr -> TypeId`, `resolve_stmt` records only) file by file,
-make `build_tir_from_state` TIR-free, and run LSP through `annotate`
-alone. Reify is the only TIR.
-
-The Phase 1 readers, grouped by the analysis to port (the arm each
-unblocks in parentheses):
-
-- [x] **assign l-value + ref validity** — `assign_to_target`'s l-value
-      match on `target.kind` and `resolve_unary`'s `&mut`-on-primitive-field
-      check ported to the AST target shape + recorded dispatch facts
-      (`operator_dispatch` / `expression_types`); `Local` and the
-      `&mut`-captured-ident deref still read `target.kind` (their resolvers
-      are not placeholders yet). (`resolve_field_access`, `resolve_index`,
-      and the assign side of `resolve_unary` are now placeholders)
-- [x] **null / unknown inference** — `patch_unresolved_null` /
-      `NullBreakPatcher` replaced by AST walks
-      (`control_flow::collect_unresolved_null_tails` /
-      `collect_unresolved_null_breaks`); the TIR-mutating machinery is
-      deleted. Required the `expression_types` UNKNOWN-faithfulness change
-      (see the note below) so the AST walk sees an unresolved-null branch.
-- [x] **block result type** — `crate::tir::block_result_type` callers in the
-      `Block` / `If` (no-expected-type inference and post-null checks) arms,
-      `with … do`, for-of, and the trailing-match path ported to
-      `control_flow::block_result_type` over `expression_types`. The
-      if-let-chain / let-chain lowerings still call the TIR version on their
-      _synthetic_ blocks (no 1:1 AST block); those readers remain.
-- [x] **unary constant folding** — the `-literal` fold and native `Unary`
-      construction are deleted; reify owns the fold (it reads
-      `expression_types[unary.id]` + the AST). (`resolve_unary` is a
-      placeholder)
-- [x] **tuple spread** — `resolve_tuple_literal` resolves the elements,
-      collects their types (incl. the concrete-tuple-spread inline
-      expansion), keeps the spread diagnostic, and returns a placeholder;
-      reify's `reify_tuple_literal` owns the actual node / temporary
-      construction.
-- [x] **struct-literal deferred coercion** — the `value.kind == TupleLiteral`
-      gate is read from the AST (a spread-free tuple-literal field), so the
-      deferred second pass still records the coercion via
-      `try_coerce_tuple_to_sequence`.
-- [x] **pattern variant const literals** — the const body AST is classified
-      directly (`Number`/`Bool`/`Char` → `Literal` pattern, else
-      `ConstantValue`), unblocking `resolve_literal` and `resolve_cast`
-      placeholders.
-- [x] **for-of `TupleZip`** — `resolve_for_of` no longer reads the resolved
-      `iterable.kind == TupleZip`. `TupleZip` is produced only by the tuple
-      `.zip()` arm, so an AST shape check (a `.zip()` call) plus the existing
-      `type_contains_pack` on the result type is equivalent.
-- [x] **if-let-chain / let-chain result type** — ported to the AST. The
-      `resolve_if_expr` LetChain arm computes its result type as
-      `agree_branch_types(ast_block_result_type(then_block), else_type)
-      .unwrap_or(UNIT)`, which is byte-identical to `block_result_type` over the
-      synthetic chain block (the per-level `unwrap_or(UNIT)` recursion collapses
-      to exactly this for single- and multi-element chains).
-      `resolve_let_chain_stmts` is records-only and no longer builds the chain
-      `Match` / `If` TIR; the `block_result_type(&TirBlock)` helper is deleted.
-- [x] **assign target ident classification** — `resolve_ident` records an
-      `AssignPlace` fact (`Local` / `DerefCapture { through_mut_ref }` /
-      `Global { name, mutable }`) keyed by the ident's `AstId`;
-      `assign_to_target` reads it to validate the l-value and global
-      mutability from the AST + fact instead of the resolved `target.kind`.
-      The address-taken-local marking the unary / method-call readers did is
-      owned by reify (it marks `TirFunction::address_taken_locals` on the TIR
-      it emits), so the combined-walk marking was deleted as dead; the
-      `&mut`-on-immutable-local diagnostic moved to a read-only `ctx.lookup`
-      over the AST target. This unblocked the `resolve_ident` placeholder.
-
-Arms now returning placeholders: range, field-access, index, unary, cast,
-tuple-literal, literal, ident, match, struct-literal, anonymous-struct, `?`
-(option + result), if-expr (both arms), block, labeled-block, with-handler,
-resume (joining binary / call / method-call / operators / coercion / assert /
-matches / template / item / module from earlier stages). Still building TIR:
-`resolve_block` / `resolve_stmt` with the stmt-level builders (the Phase 2
-signature sweep). The combined walk no longer builds any `TirExpr` outside the
-statement-level scaffolding.
-
-`adjust_receiver_for_self_kind` (method-call receiver wrapping) reads
-`ResolvedType`, not a TIR `kind`, and reify does its own adjustment, so
-it needs no port.
-
-Foundational note (discovered porting "block result type"):
-`record_expression_type` deliberately drops `ERROR` and
-UNKNOWN-containing types, but the combined walk's TIR carries them in
-`expr.type_id` (a bare `null` is `Option<UNKNOWN>`). An AST analysis
-reading `expression_types` therefore cannot see an unresolved-null
-branch and mistypes the block as `Unit`. So the null/unknown handling is
-a prerequisite for the block-result-type port: either `expression_types`
-must faithfully carry the combined walk's types (including UNKNOWN), or
-the null inference must be recorded as an explicit fact. This reorders
-Phase 1 so the null/unknown reader is handled before (or with) the
-block-result-type reader.
+7-B landed in two phases. Phase 1 ported every combined-walk analysis that read
+resolved-TIR structure onto the AST + recorded facts (assign l-value / ref
+validity, null-unknown inference, block result type, unary constant folding,
+tuple spread, struct-literal deferred coercion, pattern-variant const literals,
+for-of `TupleZip`, if-let-chain result type, assign-target ident classification)
+— each behaviour-preserving and green on its own. Phase 2 then converted every
+`resolve_*` arm to return a `TypeId`, made `build_tir_from_state` TIR-free, and
+routed LSP through `annotate` alone. One foundational ordering constraint
+surfaced: `record_expression_type` drops `ERROR`/UNKNOWN types, so the
+null/unknown reader had to be ported before the block-result-type reader.
 
 ## Status
 
 - [x] **Stages 1–4** — God Object decomposed; `TypeAnnotations` is the
-      per-`AstId` fact store, `SymbolKey`-keyed.
-- [x] **Stage 5** — reify is the sole TIR source for every module (user /
-      stdlib / snapshot), 2692/2692 E2E. It still re-derived some types /
-      mangled names; Stage 7 cleans that. The trait default-method
-      synthesis path (the combined walk pushing pre-built `TirFunction`s
-      onto `pending_default_methods` for reify to drain) was the last
-      hold-out and was resolved by a follow-up: combined walk records a
-      per-impl `ModuleSemantics` snapshot on `default_method_semantics`,
-      and reify's `reify_impl_default_methods` synthesises the
-      `TirFunction` from those snapshots — reify is now the sole producer
-      of every `TirFunction`, including default methods.
+      per-`AstId` fact store (bare `AstId`-keyed since the identity rework).
+- [x] **Stage 5** — reify is the sole TIR source for every module (incl. trait
+      default-method synthesis, via per-impl `ModuleSemantics` snapshots on
+      `default_method_semantics`).
 - [x] **Stage 7a** — routing removed; the combined walk survives only as the
-      (still TIR-building) `annotate` fact-recorder.
-- [~] **Stage 6** — Liveness / DCE. Landed: `elaborator/liveness.rs`
-  and the `Liveness` field on `Semantics`, computed in the WEP phase
-  order (`build_tir_from_state` runs all `annotate_bodies` →
-  `liveness::compute` → all `reify`); the `DeadFunction` /
-  `DeadGlobal` diagnostics consume `dead_items`. Reify gating is
-  wired but disabled (`None` live set) pending the
-  diagnostics-from-`Semantics` move (see "Prerequisite" above) and
-  cross-module graph completeness. Independent of Stage 7.
-- [x] **Stage 7-A** — reify is mechanical. Every decision-bearing read goes
-      through a recorded fact:
-  - [x] Function / method signatures — params, return, type params, impl
-        type-param scheme, self type, mangled / display names — read from
-        recorded facts.
-  - [x] Effect / resource op signatures — read from `effect_ops`.
-  - [x] Struct / variant type-param defaults — read from `decl_type_params`.
-  - [x] Struct field types (including `pub use` re-export recovery) — read
-        from `struct_field_types`.
-  - [x] Fixed a latent bug the reads exposed: a method generic on an impl that
-        binds a concrete trait arg started at the wrong type-param index and
-        reached codegen unsubstituted (`trait_method_generic_concrete_trait_arg`).
-  - [x] Method-call type args — `MethodDispatch.method_type_args` carries
-        the resolved vector verbatim (covers the IndexMut rewrite too).
-  - [x] Const types — `sem.decls.associated_constants` stores the resolved
-        `TypeId` directly; reify and the combined walk both read it.
-  - [x] Let-statement annotated types — `let_annotated_types` carries the
-        resolved whole-pattern type for destructuring bindings.
-  - [x] Closure param types — read from `local_types` via the binding's
-        `AstId`; the expected-fn-type peel survives only for the body's
-        return-type forwarding.
-  - [x] Cast target types — read from `expression_types[cast.id]`.
-  - [x] Free-function call type args — `generic_instantiations.type_args`
-        is the single source for both turbofish and inferred forms; reify
-        no longer branches on `call.type_args.is_empty()`.
-  - [x] Mangled-name class — `ImplFacts.struct_name`,
-        `GenericInstantiation.mangled_name` (struct literal / range / anon),
-        per-method `MethodNames`, `SequenceCoercionFacts` / `KeyValueCoercionFacts`
-        method names, and `FromCallFacts` (?-op + static `T::from`) all
-        carry the elaborator-computed strings; reify is a pure read.
-  - [x] From-conversion shapes — `DesugarKind::NewtypeFromCollapse` /
-        `NewtypeFromUnwrap` / `NewtypeFromWrap` tag the three "no explicit
-        impl" `from` paths; the bodyless `impl From<X> for T;` synthesis is
-        detected via `from_call_facts[call.id]`. Reify no longer compares
-        `type_name(arg)` against the prefix to recognise them.
-  - [x] Namespace static methods — `ns::Type::method(x)` records
-        `static_method_dispatch` like every other static call; reify's
-        ns-arm in-line reconstruction is gone.
-  - [x] Static-call / Type::method recovery paths in reify deleted (every
-        non-variant static call is dispatched via the recorded
-        `static_method_dispatch` early return).
-- [x] **Stage 5 completion — trait default-method synthesis moved to
-      reify.** Originally, the combined walk's `resolve_module` synthesised
-      per-impl `TirFunction`s for trait default methods and pushed them
-      onto `pending_default_methods` for reify to drain — making combined-
-      walk TIR for those bodies live, not dead. Stage 7-B leaves dropping
-      TIR construction in the body walk would corrupt the synthesised
-      default-method TIR (proven by an aborted `template.rs` slice that
-      trapped Wasm validation on `trait_default` fixtures).
-      Resolution: the body walk now snapshots each
-      `(impl_block.id, default_method.id)` synthesis as a full
-      `ModuleSemantics` on `default_method_semantics`, and reify's
-      `reify_impl_default_methods` swaps `self.sem` to that snapshot to
-      synthesise the `TirFunction` the same way it processes explicit impl
-      methods. Per-impl snapshots avoid the `(trait_module, ast_id)`
-      overwrite that happens when the same trait body is synthesised
-      across many impls. `pending_default_methods` + the
-      `record_pending_default_method` helper are gone. Reify is now the
-      sole producer of every `TirFunction` in every emitted `TirModule`.
-- [x] **Stage 5 completion — missing-return analysis moved off the
-      combined walk's body TIR.** `validate_missing_return`,
-      `block_always_exits`, and `find_return_type_in_*` previously
-      walked the combined walk's `TirBlock` from `resolve_function` /
-      `resolve_method` / `resolve_closure`, which forced Stage 7-B
-      leaves to keep producing `TirStmtKind::Return` /
-      `TirExprKind::Block` / `LabeledBlock` / `If` / `Match` /
-      `Resume` / `WithHandler` shapes the analysis could read.
-      Resolution: `elaborator/control_flow.rs` ports the eight walkers
-      to operate on the parsed AST, reading
-      `expression_types[(module, expr.id)]` for the `type_id == NEVER`
-      check the TIR version did on `TirExpr::type_id`. Both phases
-      consult it via a small `CtrlFlowCtx { expression_types, module }`
-      view — the combined walk through `Elaborator::ctrl_flow_ctx`,
-      reify through a direct construction over `self.sem.types`. The
-      TIR walkers (~330 lines in `expr.rs`) and the
-      `validate_missing_return(TirBlock)` helper are deleted.
-- [x] **Stage 7-B — `annotate` builds no TIR; LSP runs `annotate` only.**
-  - [x] Every expression arm returns a placeholder — literal / ident / binary
-        / unary / call / method-call / static-call / field / index / cast /
-        range / tuple-literal / struct + anonymous-struct literal / `match` /
-        `?` (option + result) / if-expr (both arms) / block / labeled-block /
-        `with` / `resume` / template / matches / assert-capture / closure. The
-        `ident` arm was unblocked by the `AssignPlace` fact (`assign_to_target`
-        classifies l-values from it + the AST instead of the resolved kind).
-  - [x] Every statement is records-only: `resolve_block` / `resolve_stmt` and
-        all helpers (let, return, task-return, if, while, C-style for, for-of
-        + tuple/variadic/iterator, loop, break, continue, assert,
-        labeled-block, let-chain) record facts (types, dispatch, desugar tags,
-        `ForOfIteratorInfo`, `tuple_overlays`, local symbols) and build no
-        `TirStmt` / `TirBlock`. The if-let-chain result type is computed on the
-        AST (`agree_branch_types(ast_block_result_type(then), else)`).
-  - [x] `resolve_module` is records-only (returns `Result<(), Bail>`); it
-        walks every item for its facts and assembles no `TirModule`. Synthesis
-        requests flow through `pending_synthesis_requests`, anon structs
-        through `pending_anonymous_structs` — both read by reify.
-  - [x] `build_tir_from_state` gates reify (and stdlib-snapshot `TirModule`
-        rehydration) on a `build_tir` flag. The LSP engine
-        (`wado-lsp::build_semantics` → `semantics_of(.., false)`) runs only the
-        body fact-walk and never builds or reads TIR; the batch path, the
-        general `semantics()` entry, and kiln options extraction pass `true`.
-  - [x] **`resolve_expr -> TypeId`.** Every body-walk resolver returns the
-        resolved `TypeId` (the `placeholder` `TirExpr` sentinels are gone).
-        The TIR builders that reify shares (`build_tir_method_call`,
-        `adjust_receiver_for_self_kind`, `resolve_from_call`, …) keep returning
-        `TirExpr` — they are reify's real producers — and the few combined-walk
-        sites that still call them read `.type_id` (wrapping `placeholder` only
-        where a shared builder needs a `TirExpr` operand). reify (`reify.rs`) is
-        untouched and remains the sole TIR producer.
+      `annotate` fact-recorder.
+- [~] **Stage 6** — Liveness / DCE: landed but the reify gate is disabled (see
+  the Migration Plan "Remaining in Phase 1" above for the two prerequisites).
+- [x] **Stage 7-A — reify is mechanical.** Every decision-bearing read goes
+      through a recorded fact (signatures, effect/resource ops, decl type-param
+      defaults, struct field types, method-call/free-call type args, const and
+      let-annotated types, closure param types, cast targets, the mangled-name
+      class, from-conversion shapes, namespace/static-method dispatch). Per-fact
+      detail in git.
+- [x] **Stage 5 completions.** Trait default-method synthesis moved to reify
+      (the body walk snapshots a per-impl `ModuleSemantics` on
+      `default_method_semantics`; `reify_impl_default_methods` consumes it —
+      reify is the sole `TirFunction` producer). Missing-return analysis ported
+      off the combined walk's body TIR onto the parsed AST
+      (`elaborator/control_flow.rs` via `CtrlFlowCtx`).
+- [x] **Stage 7-B — `annotate` builds no TIR; LSP runs `annotate` only.** Every
+      expression resolver returns a `TypeId` and every statement is records-only;
+      `resolve_module` assembles no `TirModule`; `build_tir_from_state` gates
+      reify on a `build_tir` flag (LSP passes `false`). Reify is the sole TIR
+      producer; the duplicate combined-walk TIR construction is deleted.
 
 ### Landing log
 
-The per-map detail and the gap-by-gap parity history (user 1765 → 2692, then
-stdlib) live in git. The one load-bearing rule that remains:
+The per-map detail and the gap-by-gap parity history live in git. The identity
+model has since moved to globally-unique `AstId` (`SymbolKey` retired — see the
+header note); every per-`AstId` fact map keys by bare `AstId`.
 
-Annotation maps are keyed by `SymbolKey` (`(ModuleSource, AstId)`). Inlined
-foreign AST (assoc-const bodies, callee-module default args, trait
-default-method bodies) is keyed to its _owning_ module, so a colliding dense
-`AstId` in the consumer never overwrites its facts.
+## Phase 2 — God Object operation decomposition (2026-06)
+
+Phase 1 (above) split the **data** out of the `Elaborator` God Object
+(`TypeSystem`, `ModuleSemantics`, `reify`). Phase 2 moves the **operations**:
+the trait/method-resolution queries still live as `impl Elaborator` methods and
+still read the borrowed `loaded_modules` AST map and the per-function
+`trait_ctx` scope, so none of them can move to `TypeSystem`. Phase 2 removes
+those two couplings so the queries become `impl TypeSystem` operations taking
+only type IDs, names, pre-digested decl facts, and an explicit scope.
+
+Three independent tracks; each slice keeps `mise run test` green (E2E 2934/0).
+
+### Done
+
+- [x] **Pure type-system ops → `impl TypeSystem`.** Operations answerable from
+      the type table alone moved off `impl Elaborator`: impl-type matching
+      (`build_type_param_mapping`, `verify_impl_type_compatibility`,
+      `impl_type_matches_concrete`), the type-shape helpers
+      (`struct_name_for_type`, `get_base_type`, `get_ultimate_base_struct_name`,
+      `newtype_base_lookup`, `substitute_newtype_in_type`, `type_id_to_string`,
+      `build_declared_type_params`, `auto_derive_eligible_kind`), and
+      `inherent_impl_type_args_match` / `concrete_arg_mangled`. They read
+      `self.type_table` directly; both the body walk and reify reach them via
+      `self.tysys`.
+- [x] **`TraitEnv` build-time decl digests (the "read facts, not ASTs" track).**
+      So resolution queries stop scanning `loaded_modules`, `TraitEnv::build`
+      now pre-computes, keyed by `(ModuleSource, item_idx)` or type/fn name:
+      `ImplHeader` (trait_name / ty / type_params / methods / associated_types),
+      `TraitDeclHeader` (name / type_params / methods{name,type_params,has_body}),
+      `function_type_params`, `struct_like_decl_modules` + `newtype_decl_modules`,
+      and `module_import_scopes` (the per-module `use`-derived
+      `imported_type_sources` / `import_original_names`, lifted to the free fn
+      `trait_env::module_import_scope`). Queries converted to read the digests:
+      `find_trait_impl_for_type_with_args` (+ blanket loop),
+      `register_assoc_types_for_concrete_type_and_trait`,
+      `find_method_type_params_in_trait_bounds`, `find_method_type_param_names`,
+      `find_struct_module_source`, `lookup_function_type_params`,
+      `find_trait_decl_type_params`, `collect_trait_impl_refs(_multi)`,
+      `lookup_static_method_type_params`, the `find_trait_method_for_type_uncached`
+      blanket loop, and the **nine dispatch-core import-context sites**
+      (`lookup_method_info_uncached`, `method_call`, `call`, `expr`) now read
+      `trait_env.import_scope(module)`. `check_impl_block_bounds` takes the
+      digest fields (`&type_params`, `&impl_ty`) rather than `&ImplBlock`.
+- [x] **Track B Stage A — bundle the per-function scope.**
+      `trait_env::AnnotateCtx { trait_ctx, trait_check_stack }` replaces the two
+      Elaborator fields with a single `annotate_ctx`; the `TypeParamScope` guard
+      saves/restores `annotate_ctx.trait_ctx`.
+- [x] **Track B Stage B — thread the scope through the recursion guard.**
+      `type_implements_trait` / `type_implements_trait_inner` take an explicit
+      `ctx: &AnnotateCtx` (recursion guard = `ctx.trait_check_stack`, type-param
+      bound check = `ctx.trait_ctx.type_param_bounds`); the inner fn forwards
+      `ctx` through its nine recursive calls; every external caller passes
+      `&self.annotate_ctx` (identical behaviour, since `ctx` _is_
+      `&self.annotate_ctx` until Stage D).
+
+### Remaining (next to pick up, in order)
+
+- [ ] **Track B Stage C — thread `&AnnotateCtx` through the resolution
+      subgraph.** Convert the connected query graph
+      (`find_trait_impl_for_type_with_args` → `check_impl_block_bounds` →
+      `type_implements_trait`, plus the `self.annotate_ctx.trait_ctx` readers:
+      `self_type`, `type_params`, `assoc_type_bindings`, `type_param_bounds` —
+      ~50 methods / ~120 read sites across `method_lookup` / `method_call` /
+      `item` / `module` / `call` / `type_resolution` / `operators` / `expr`) to
+      take `ctx: &AnnotateCtx` instead of reading `self.annotate_ctx`. Leaf-first,
+      one file per commit, green at each step. Scope **mutation**
+      (`enter_inherited_type_param_scope`, `register_generic_params`,
+      `bind_trait_type_params_from_impl`) stays on `Elaborator` and owns/produces
+      the scope.
+- [ ] **Track B Stage D — move the now-Elaborator-free queries to
+      `impl TypeSystem`.** Once they read only `self.tysys.*` + the passed `ctx`:
+      `type_implements_trait(_inner)`, `find_trait_impl_for_type(_with_args)`,
+      `check_impl_block_bounds`, the type-param-bound resolver in
+      `type_resolution.rs`, and the operator-trait bound lookups in
+      `operators.rs`. Signature `fn …(&self /* TypeSystem */, ctx: &AnnotateCtx, …)`.
+- [ ] **Track B Stage E — fold the manual scope save/restores into the guard.**
+      Replace the hand-rolled `trait_ctx` clone/restore in `resolve_module`'s
+      `Item::Impl` arm (`elaborator.rs`) and the `self_type`-only save/restore in
+      `method_lookup.rs` with `enter_inherited_type_param_scope` (clearing the
+      relevant fields after entry), for one panic-safe restore path.
+- [ ] **Remaining `loaded_modules` consumers needing a method/body digest.**
+      `lookup_method_info_uncached` and the `call.rs` / `method_call.rs` dispatch
+      paths still fetch the impl block + method-signature AST to `resolve_type`
+      it — they need a method-signature digest on `ImplHeader` (params / return /
+      self_kind) plus Stage C's scope. `get_impl_block` is the lazy-fetch
+      accessor that disappears once its callers are converted.
+      `find_trait_decl_methods_with_module` and `find_method_in_trait_bounds`
+      clone full method ASTs (bodies included) and need a heavier digest; defer.
+      `reify`'s `loaded_modules` reads are legitimate (it emits TIR) and are out
+      of scope. Progress metric: Elaborator `self.loaded_modules` sites (was ~57
+      across `method_lookup`/`method_call`/`call`/`trait_query`/…; the dispatch
+      core + the heavy trait-decl readers remain).
 
 ## Consequences
 

--- a/wado-compiler/src/elaborator.rs
+++ b/wado-compiler/src/elaborator.rs
@@ -1419,7 +1419,8 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                         {
                             // Concrete type in explicit params (e.g., `impl<i32, T>`): skip
                             if !param.bounds.is_empty() {
-                                self.annotate_ctx.trait_ctx
+                                self.annotate_ctx
+                                    .trait_ctx
                                     .type_param_bounds
                                     .entry(param.name.clone())
                                     .or_default()
@@ -1427,7 +1428,12 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                             }
                             continue;
                         }
-                        if !self.annotate_ctx.trait_ctx.type_params.contains_key(&param.name) {
+                        if !self
+                            .annotate_ctx
+                            .trait_ctx
+                            .type_params
+                            .contains_key(&param.name)
+                        {
                             let type_id = if param.is_pack {
                                 self.tysys
                                     .type_table
@@ -1439,12 +1445,14 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                                     .borrow_mut()
                                     .make_type_param(param.name.clone(), actual_idx)
                             };
-                            self.annotate_ctx.trait_ctx
+                            self.annotate_ctx
+                                .trait_ctx
                                 .type_params
                                 .insert(param.name.clone(), (actual_idx, type_id));
                         }
                         if !param.bounds.is_empty() {
-                            self.annotate_ctx.trait_ctx
+                            self.annotate_ctx
+                                .trait_ctx
                                 .type_param_bounds
                                 .entry(param.name.clone())
                                 .or_default()
@@ -1474,7 +1482,8 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                                         .type_table
                                         .borrow_mut()
                                         .make_type_param(name.clone(), i as u32);
-                                    self.annotate_ctx.trait_ctx
+                                    self.annotate_ctx
+                                        .trait_ctx
                                         .type_params
                                         .insert(name.clone(), (i as u32, type_id));
                                 }
@@ -1491,7 +1500,8 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                             let synth_trait_name = self.get_type_name_full(trait_type);
                             let target_type_id = self.resolve_type(&impl_block.ty);
                             let type_params: Vec<_> = self
-                                .annotate_ctx.trait_ctx
+                                .annotate_ctx
+                                .trait_ctx
                                 .type_params
                                 .iter()
                                 .map(|(name, &(index, type_id))| (name.clone(), index, type_id))
@@ -1523,7 +1533,8 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
 
                         for binding in &impl_block.associated_types {
                             let type_id = self.resolve_type(&binding.ty);
-                            self.annotate_ctx.trait_ctx
+                            self.annotate_ctx
+                                .trait_ctx
                                 .assoc_type_bindings
                                 .insert(binding.name.clone(), type_id);
 

--- a/wado-compiler/src/elaborator.rs
+++ b/wado-compiler/src/elaborator.rs
@@ -127,13 +127,10 @@ pub struct Elaborator<'a, H: CompilerHost> {
     entry_module_source: ModuleSource,
     /// Current module items (for local function parameter lookup)
     current_module_items: &'a [Item],
-    /// Per-function annotate-time scope: the trait-resolution context
-    /// (`trait_ctx`: type params, bounds, associated type bindings, self type)
-    /// and the `type_implements_trait` recursion guard (`trait_check_stack`),
-    /// bundled so they save/restore and (eventually) thread as one unit. See
+    /// Per-function annotate-time scope (trait context + recursion guard); see
     /// [`trait_env::AnnotateCtx`].
-    // MIGRATION: transient annotate-time scope (Stage 5 carries it as an
-    //   explicit argument to `annotate_*` walkers).
+    // MIGRATION: transient annotate-time scope; to be threaded explicitly into
+    //   the resolution queries as `&AnnotateCtx` rather than read off the driver.
     annotate_ctx: trait_env::AnnotateCtx,
     /// Effect parameter names currently in scope (from enclosing function's `<effect E>`)
     // MIGRATION: transient annotate-time scope (per-function, not per-module).

--- a/wado-compiler/src/elaborator.rs
+++ b/wado-compiler/src/elaborator.rs
@@ -127,11 +127,14 @@ pub struct Elaborator<'a, H: CompilerHost> {
     entry_module_source: ModuleSource,
     /// Current module items (for local function parameter lookup)
     current_module_items: &'a [Item],
-    /// Mutable trait resolution context: type params, bounds, associated type bindings, self type.
-    /// Grouped together so scope entry/exit can save/restore the whole context at once.
+    /// Per-function annotate-time scope: the trait-resolution context
+    /// (`trait_ctx`: type params, bounds, associated type bindings, self type)
+    /// and the `type_implements_trait` recursion guard (`trait_check_stack`),
+    /// bundled so they save/restore and (eventually) thread as one unit. See
+    /// [`trait_env::AnnotateCtx`].
     // MIGRATION: transient annotate-time scope (Stage 5 carries it as an
     //   explicit argument to `annotate_*` walkers).
-    trait_ctx: trait_env::TraitContext,
+    annotate_ctx: trait_env::AnnotateCtx,
     /// Effect parameter names currently in scope (from enclosing function's `<effect E>`)
     // MIGRATION: transient annotate-time scope (per-function, not per-module).
     current_effect_params: IndexSet<String>,
@@ -139,21 +142,6 @@ pub struct Elaborator<'a, H: CompilerHost> {
     /// Used to record use→def edges for effect parameter references in `with` clauses.
     // MIGRATION: transient annotate-time scope (per-function, not per-module).
     current_effect_param_decls: IndexMap<String, crate::ast::AstId>,
-    /// Recursion guard for `type_implements_trait` to avoid infinite recursion
-    /// on recursive types (e.g., variant Elem containing struct `RepeatElem` with field Elem).
-    /// Frames are pushed on entry and popped on return; the stack is empty
-    /// at every quiescent point.
-    // MIGRATION: transient annotate-time scope. Despite the `RefCell<Vec<…>>`
-    //   shape this is NOT a type-system cache (whose entries would persist
-    //   across calls) — it is a per-call frame stack. Sharing it across
-    //   modules via `TypeSystem` would either leak stale frames (producing
-    //   wrong "recursive, optimistically true" answers from
-    //   `type_implements_trait` — a soundness bug) or require per-call
-    //   save/restore plumbing that defeats the move. Belongs with
-    //   `trait_ctx` in Stage 5's per-function walker argument bag, not on
-    //   `TypeSystem`. See the `tysys.rs` module docs (the `trait_check_stack`
-    //   discussion) for the full rationale.
-    trait_check_stack: RefCell<Vec<(TypeId, String)>>,
     /// When resolving a default-expression AST at a call site, fall back to
     /// looking up unresolved identifiers in this module's global scope. This
     /// preserves the callee's lexical scope for defaults that reference
@@ -461,7 +449,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
     /// to share the name. Falls through to the symbol-table lookup
     /// otherwise.
     pub(super) fn record_type_name_reference(&mut self, use_id: crate::ast::AstId, name: &str) {
-        if let Some(&decl_id) = self.trait_ctx.type_param_decls.get(name) {
+        if let Some(&decl_id) = self.annotate_ctx.trait_ctx.type_param_decls.get(name) {
             self.record_reference(use_id, decl_id);
         } else {
             self.record_item_reference_by_name(use_id, name);
@@ -1415,9 +1403,9 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
 
                     // Register type parameters from impl block's generic type FIRST
                     // e.g., impl IndexValue<i32> for Triple<T> needs T registered
-                    let saved_trait_ctx = self.trait_ctx.clone();
-                    self.trait_ctx.type_params.clear();
-                    self.trait_ctx.type_param_bounds.clear();
+                    let saved_trait_ctx = self.annotate_ctx.trait_ctx.clone();
+                    self.annotate_ctx.trait_ctx.type_params.clear();
+                    self.annotate_ctx.trait_ctx.type_param_bounds.clear();
 
                     // Register explicit type params from impl<T: Bound> declarations,
                     // skipping concrete types (e.g., `impl<i32, T>` — skip "i32").
@@ -1431,7 +1419,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                         {
                             // Concrete type in explicit params (e.g., `impl<i32, T>`): skip
                             if !param.bounds.is_empty() {
-                                self.trait_ctx
+                                self.annotate_ctx.trait_ctx
                                     .type_param_bounds
                                     .entry(param.name.clone())
                                     .or_default()
@@ -1439,7 +1427,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                             }
                             continue;
                         }
-                        if !self.trait_ctx.type_params.contains_key(&param.name) {
+                        if !self.annotate_ctx.trait_ctx.type_params.contains_key(&param.name) {
                             let type_id = if param.is_pack {
                                 self.tysys
                                     .type_table
@@ -1451,12 +1439,12 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                                     .borrow_mut()
                                     .make_type_param(param.name.clone(), actual_idx)
                             };
-                            self.trait_ctx
+                            self.annotate_ctx.trait_ctx
                                 .type_params
                                 .insert(param.name.clone(), (actual_idx, type_id));
                         }
                         if !param.bounds.is_empty() {
-                            self.trait_ctx
+                            self.annotate_ctx.trait_ctx
                                 .type_param_bounds
                                 .entry(param.name.clone())
                                 .or_default()
@@ -1476,7 +1464,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                         for (i, arg) in generic.args.iter().enumerate() {
                             if let ast::Type::Named(named) = arg {
                                 let name = &named.name;
-                                if !self.trait_ctx.type_params.contains_key(name)
+                                if !self.annotate_ctx.trait_ctx.type_params.contains_key(name)
                                     && !self
                                         .tysys
                                         .is_known_type_name_in(&self.current_module_source, name)
@@ -1486,7 +1474,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                                         .type_table
                                         .borrow_mut()
                                         .make_type_param(name.clone(), i as u32);
-                                    self.trait_ctx
+                                    self.annotate_ctx.trait_ctx
                                         .type_params
                                         .insert(name.clone(), (i as u32, type_id));
                                 }
@@ -1503,7 +1491,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                             let synth_trait_name = self.get_type_name_full(trait_type);
                             let target_type_id = self.resolve_type(&impl_block.ty);
                             let type_params: Vec<_> = self
-                                .trait_ctx
+                                .annotate_ctx.trait_ctx
                                 .type_params
                                 .iter()
                                 .map(|(name, &(index, type_id))| (name.clone(), index, type_id))
@@ -1517,13 +1505,13 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                             };
                             self.record_pending_synthesis_request(req);
                         }
-                        self.trait_ctx = saved_trait_ctx;
+                        self.annotate_ctx.trait_ctx = saved_trait_ctx;
                         continue;
                     }
 
                     // Set up associated type bindings for trait implementations
                     // This now works because type params (like T) are registered above
-                    self.trait_ctx.assoc_type_bindings.clear();
+                    self.annotate_ctx.trait_ctx.assoc_type_bindings.clear();
                     if impl_block.trait_type.is_some() {
                         // Resolve the target type for registering associated type resolutions
                         let target_type_id = self.resolve_type(&impl_block.ty);
@@ -1535,7 +1523,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
 
                         for binding in &impl_block.associated_types {
                             let type_id = self.resolve_type(&binding.ty);
-                            self.trait_ctx
+                            self.annotate_ctx.trait_ctx
                                 .assoc_type_bindings
                                 .insert(binding.name.clone(), type_id);
 
@@ -1749,7 +1737,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                     }
 
                     // Restore trait context
-                    self.trait_ctx = saved_trait_ctx;
+                    self.annotate_ctx.trait_ctx = saved_trait_ctx;
                 }
                 Item::Trait(_trait_decl) => {
                     // Trait declarations are handled in the first pass (signature registration)

--- a/wado-compiler/src/elaborator.rs
+++ b/wado-compiler/src/elaborator.rs
@@ -151,8 +151,8 @@ pub struct Elaborator<'a, H: CompilerHost> {
     //   `type_implements_trait` — a soundness bug) or require per-call
     //   save/restore plumbing that defeats the move. Belongs with
     //   `trait_ctx` in Stage 5's per-function walker argument bag, not on
-    //   `TypeSystem`. See `tysys.rs` module docs ("Deferred fields") for
-    //   the full rationale.
+    //   `TypeSystem`. See the `tysys.rs` module docs (the `trait_check_stack`
+    //   discussion) for the full rationale.
     trait_check_stack: RefCell<Vec<(TypeId, String)>>,
     /// When resolving a default-expression AST at a call site, fall back to
     /// looking up unresolved identifiers in this module's global scope. This

--- a/wado-compiler/src/elaborator/call.rs
+++ b/wado-compiler/src/elaborator/call.rs
@@ -480,7 +480,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                         &bound.name.clone(),
                                     );
                                 } else {
-                                    let type_name = self.type_id_to_string(type_arg);
+                                    let type_name = self.tysys.type_id_to_string(type_arg);
                                     let reason =
                                         self.trait_unimpl_reason_chain(type_arg, &bound.name);
                                     let _ = self.logger.error(TypeError::TraitBoundNotSatisfied {

--- a/wado-compiler/src/elaborator/call.rs
+++ b/wado-compiler/src/elaborator/call.rs
@@ -1794,7 +1794,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 let (imported_type_sources, import_original_names) =
                     self.tysys.trait_env.import_scope(&src);
                 return self.with_module_perspective(
-                    src.clone(),
+                    src,
                     imported_type_sources,
                     import_original_names,
                     |s| params.iter().map(|p| s.resolve_type(&p.ty)).collect(),

--- a/wado-compiler/src/elaborator/call.rs
+++ b/wado-compiler/src/elaborator/call.rs
@@ -1325,19 +1325,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 // Build the callee module's import context so type names in the
                 // callee's signature resolve to the callee's types, not the
                 // caller's (which may have same-named different types).
-                let callee_module_ast = self.loaded_modules.get(callee_module);
-                let (callee_imported, callee_original_names) = callee_module_ast.map_or_else(
-                    || (IndexMap::default(), IndexMap::default()),
-                    |m| {
-                        Self::build_imported_type_sources(
-                            &mut self.interner.borrow_mut(),
-                            m,
-                            callee_module,
-                            Some(&self.entry_module_source),
-                            &self.invocations,
-                        )
-                    },
-                );
+                let (callee_imported, callee_original_names) =
+                    self.tysys.trait_env.import_scope(callee_module);
 
                 // Set up the function's type parameters in an inherited scope so we
                 // can resolve type parameter references (like T -> TypeParam { index: 0 }).
@@ -1797,23 +1786,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 // Resolve types in the definition module's perspective
                 // so that type names resolve to the correct module's types
                 // (e.g., "Direction" resolves to module B's Direction, not module A's)
-                let callee_module = self
-                    .loaded_modules
-                    .iter()
-                    .find(|(ms, _)| **ms == src)
-                    .map(|(_, m)| m);
                 let (imported_type_sources, import_original_names) =
-                    if let Some(module) = callee_module {
-                        Self::build_imported_type_sources(
-                            &mut self.interner.borrow_mut(),
-                            module,
-                            &src,
-                            Some(&self.entry_module_source),
-                            &self.invocations,
-                        )
-                    } else {
-                        (IndexMap::default(), IndexMap::default())
-                    };
+                    self.tysys.trait_env.import_scope(&src);
                 return self.with_module_perspective(
                     src.clone(),
                     imported_type_sources,
@@ -1839,17 +1813,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             .map(|func| func.params.clone());
             if let Some(params) = params {
                 let (imported_type_sources, import_original_names) =
-                    if let Some(module) = self.loaded_modules.get(&fallback) {
-                        Self::build_imported_type_sources(
-                            &mut self.interner.borrow_mut(),
-                            module,
-                            &fallback,
-                            Some(&self.entry_module_source),
-                            &self.invocations,
-                        )
-                    } else {
-                        (IndexMap::default(), IndexMap::default())
-                    };
+                    self.tysys.trait_env.import_scope(&fallback);
                 return self.with_module_perspective(
                     fallback,
                     imported_type_sources,

--- a/wado-compiler/src/elaborator/call.rs
+++ b/wado-compiler/src/elaborator/call.rs
@@ -160,13 +160,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let suffix = &ident.name[pos + 2..];
 
         if prefix == "Self"
-            && let Some(self_type_id) = self.trait_ctx.self_type
+            && let Some(self_type_id) = self.annotate_ctx.trait_ctx.self_type
         {
             let self_name = self.tysys.type_table.borrow().type_name(self_type_id);
             return CalleeIdentKind::Rewritten(format!("{self_name}::{suffix}"));
         }
 
-        if let Some(&(_, type_param_type_id)) = self.trait_ctx.type_params.get(prefix) {
+        if let Some(&(_, type_param_type_id)) = self.annotate_ctx.trait_ctx.type_params.get(prefix) {
             // If the type parameter is bound to a concrete type (e.g. a
             // trait default method synthesised for an impl binds the
             // trait's `T` to the impl's concrete arg), dispatch
@@ -1331,7 +1331,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 // Set up the function's type parameters in an inherited scope so we
                 // can resolve type parameter references (like T -> TypeParam { index: 0 }).
                 let mut scope = self.enter_inherited_type_param_scope();
-                scope.trait_ctx.type_params.clear();
+                scope.annotate_ctx.trait_ctx.type_params.clear();
                 scope.register_generic_params(&type_params, 0);
 
                 // Swap the elaborator's "current module" perspective onto the
@@ -1750,7 +1750,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 // `register_generic_params` and consults that channel
                 // to recognise `E` as `EffectRef::Param`.
                 let mut scope = self.enter_inherited_type_param_scope();
-                scope.trait_ctx.type_params.clear();
+                scope.annotate_ctx.trait_ctx.type_params.clear();
                 let old_effect_params = std::mem::take(&mut scope.current_effect_params);
                 let old_effect_param_decls = std::mem::take(&mut scope.current_effect_param_decls);
                 let effect_params: Vec<&ast::GenericParam> =
@@ -2179,7 +2179,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             return;
         }
         let scope_params: Vec<TypeId> = self
-            .trait_ctx
+            .annotate_ctx.trait_ctx
             .type_params
             .values()
             .map(|&(_, tid)| tid)
@@ -2323,10 +2323,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // TypeParam ids for parameter types like `T`. Inherited scope; only
         // `type_params` is replaced, matching the original `mem::take` semantics.
         let mut scope = self.enter_inherited_type_param_scope();
-        scope.trait_ctx.type_params.clear();
+        scope.annotate_ctx.trait_ctx.type_params.clear();
         scope.register_generic_params(&type_params, 0);
         let type_param_list: Vec<(String, TypeId)> = scope
-            .trait_ctx
+            .annotate_ctx.trait_ctx
             .type_params
             .iter()
             .map(|(name, &(_, id))| (name.clone(), id))
@@ -2465,7 +2465,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // `resolve_static_method_params_in_scope`, so substitution by a single
         // flat `[impl_args.., method_args..]` list lines up correctly.
         let mut scope = self.enter_inherited_type_param_scope();
-        scope.trait_ctx.type_params.clear();
+        scope.annotate_ctx.trait_ctx.type_params.clear();
 
         let mut impl_param_ids: Vec<TypeId> = Vec::with_capacity(impl_type_param_names.len());
         for (i, name) in impl_type_param_names.iter().enumerate() {
@@ -2475,7 +2475,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 .borrow_mut()
                 .make_type_param(name.clone(), i as u32);
             scope
-                .trait_ctx
+                .annotate_ctx.trait_ctx
                 .type_params
                 .insert(name.clone(), (i as u32, type_id));
             impl_param_ids.push(type_id);
@@ -2503,7 +2503,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     .make_type_param(tp.name.clone(), idx)
             };
             scope
-                .trait_ctx
+                .annotate_ctx.trait_ctx
                 .type_params
                 .insert(tp.name.clone(), (idx, type_id));
             method_param_ids.push(type_id);
@@ -2598,7 +2598,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // `EffectRef::Concrete { name: "E" }` and leak out as a phantom
         // local effect.
         let mut scope = self.enter_inherited_type_param_scope();
-        scope.trait_ctx.type_params.clear();
+        scope.annotate_ctx.trait_ctx.type_params.clear();
         let old_effect_params = std::mem::take(&mut scope.current_effect_params);
         let old_effect_param_decls = std::mem::take(&mut scope.current_effect_param_decls);
         let effect_params: Vec<&ast::GenericParam> =
@@ -2692,7 +2692,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             .iter()
             .any(|&t| self.tysys.type_table.borrow().contains_type_param(t));
 
-        if has_unresolved && self.trait_ctx.type_params.is_empty() {
+        if has_unresolved && self.annotate_ctx.trait_ctx.type_params.is_empty() {
             return self.tysys.type_table.borrow_mut().make_variant(
                 variant_info.name.clone(),
                 variant_info.module_source.clone(),
@@ -2718,7 +2718,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         _ctx: &mut FunctionContext,
     ) -> TypeId {
         let bounds = self
-            .trait_ctx
+            .annotate_ctx.trait_ctx
             .type_param_bounds
             .get(type_param_name)
             .cloned();

--- a/wado-compiler/src/elaborator/call.rs
+++ b/wado-compiler/src/elaborator/call.rs
@@ -166,7 +166,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             return CalleeIdentKind::Rewritten(format!("{self_name}::{suffix}"));
         }
 
-        if let Some(&(_, type_param_type_id)) = self.annotate_ctx.trait_ctx.type_params.get(prefix) {
+        if let Some(&(_, type_param_type_id)) = self.annotate_ctx.trait_ctx.type_params.get(prefix)
+        {
             // If the type parameter is bound to a concrete type (e.g. a
             // trait default method synthesised for an impl binds the
             // trait's `T` to the impl's concrete arg), dispatch
@@ -474,7 +475,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 if bound.fn_signature.is_some() {
                                     continue;
                                 }
-                                if self.type_implements_trait(&self.annotate_ctx, type_arg, &bound.name) {
+                                if self.type_implements_trait(
+                                    &self.annotate_ctx,
+                                    type_arg,
+                                    &bound.name,
+                                ) {
                                     self.register_assoc_types_for_concrete_type_and_trait(
                                         type_arg,
                                         &bound.name.clone(),
@@ -2179,7 +2184,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             return;
         }
         let scope_params: Vec<TypeId> = self
-            .annotate_ctx.trait_ctx
+            .annotate_ctx
+            .trait_ctx
             .type_params
             .values()
             .map(|&(_, tid)| tid)
@@ -2326,7 +2332,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         scope.annotate_ctx.trait_ctx.type_params.clear();
         scope.register_generic_params(&type_params, 0);
         let type_param_list: Vec<(String, TypeId)> = scope
-            .annotate_ctx.trait_ctx
+            .annotate_ctx
+            .trait_ctx
             .type_params
             .iter()
             .map(|(name, &(_, id))| (name.clone(), id))
@@ -2475,7 +2482,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 .borrow_mut()
                 .make_type_param(name.clone(), i as u32);
             scope
-                .annotate_ctx.trait_ctx
+                .annotate_ctx
+                .trait_ctx
                 .type_params
                 .insert(name.clone(), (i as u32, type_id));
             impl_param_ids.push(type_id);
@@ -2503,7 +2511,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     .make_type_param(tp.name.clone(), idx)
             };
             scope
-                .annotate_ctx.trait_ctx
+                .annotate_ctx
+                .trait_ctx
                 .type_params
                 .insert(tp.name.clone(), (idx, type_id));
             method_param_ids.push(type_id);
@@ -2718,7 +2727,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         _ctx: &mut FunctionContext,
     ) -> TypeId {
         let bounds = self
-            .annotate_ctx.trait_ctx
+            .annotate_ctx
+            .trait_ctx
             .type_param_bounds
             .get(type_param_name)
             .cloned();

--- a/wado-compiler/src/elaborator/call.rs
+++ b/wado-compiler/src/elaborator/call.rs
@@ -474,7 +474,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 if bound.fn_signature.is_some() {
                                     continue;
                                 }
-                                if self.type_implements_trait(type_arg, &bound.name) {
+                                if self.type_implements_trait(&self.annotate_ctx, type_arg, &bound.name) {
                                     self.register_assoc_types_for_concrete_type_and_trait(
                                         type_arg,
                                         &bound.name.clone(),

--- a/wado-compiler/src/elaborator/coercion.rs
+++ b/wado-compiler/src/elaborator/coercion.rs
@@ -475,7 +475,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // where the monomorphizer expects to find the template. Fall back to
         // the receiver type's module for inherent / auto-derived impls; if
         // neither resolves, panic (no current-module fallback per #1110 (2)).
-        let builder_name_for_lookup = self.tysys
+        let builder_name_for_lookup = self
+            .tysys
             .struct_name_for_type(builder_type)
             .unwrap_or_else(|| base_name.clone());
         let builder_type_module = match self.tysys.type_table.borrow().get(builder_type) {
@@ -522,7 +523,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             .make_compiler_struct(crate::compiler_item::CompilerItem::String);
 
         // Get type args for monomorphization from builder type
-        let builder_base_name = self.tysys
+        let builder_base_name = self
+            .tysys
             .struct_name_for_type(builder_type)
             .unwrap_or_else(|| base_name.clone());
         let (type_arg_names, type_arg_ids): (Vec<String>, Vec<TypeId>) = {
@@ -685,7 +687,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let builder_type = seq_info.builder_type;
         let output_type = seq_info.output_type;
         let impl_module_source = seq_info.impl_module_source;
-        let builder_base_name = self.tysys
+        let builder_base_name = self
+            .tysys
             .struct_name_for_type(builder_type)
             .unwrap_or_else(|| base_name.clone());
 

--- a/wado-compiler/src/elaborator/coercion.rs
+++ b/wado-compiler/src/elaborator/coercion.rs
@@ -461,7 +461,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
 
         // Get base struct name from target type
-        let base_name = self.struct_name_for_type(target_type)?;
+        let base_name = self.tysys.struct_name_for_type(target_type)?;
 
         // Check if target type implements KeyValueLiteralBuilder (or legacy KeyValueLiteral)
         let from_literal_info = self.find_key_value_literal_trait_impl(&base_name, target_type)?;
@@ -475,7 +475,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // where the monomorphizer expects to find the template. Fall back to
         // the receiver type's module for inherent / auto-derived impls; if
         // neither resolves, panic (no current-module fallback per #1110 (2)).
-        let builder_name_for_lookup = self
+        let builder_name_for_lookup = self.tysys
             .struct_name_for_type(builder_type)
             .unwrap_or_else(|| base_name.clone());
         let builder_type_module = match self.tysys.type_table.borrow().get(builder_type) {
@@ -522,7 +522,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             .make_compiler_struct(crate::compiler_item::CompilerItem::String);
 
         // Get type args for monomorphization from builder type
-        let builder_base_name = self
+        let builder_base_name = self.tysys
             .struct_name_for_type(builder_type)
             .unwrap_or_else(|| base_name.clone());
         let (type_arg_names, type_arg_ids): (Vec<String>, Vec<TypeId>) = {
@@ -664,7 +664,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             _ => return None,
         };
 
-        let base_name = self.struct_name_for_type(target_type)?;
+        let base_name = self.tysys.struct_name_for_type(target_type)?;
         let (seq_info, needs_newtype_cast) = self
             .find_sequence_literal_trait_impl(&base_name, target_type)
             .map(|info| (info, false))
@@ -675,7 +675,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     .type_table
                     .borrow()
                     .get_newtype_base(target_type)?;
-                let base_name = self.struct_name_for_type(base_type)?;
+                let base_name = self.tysys.struct_name_for_type(base_type)?;
                 self.find_sequence_literal_trait_impl(&base_name, base_type)
                     .map(|info| (info, true))
             })?;
@@ -685,7 +685,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let builder_type = seq_info.builder_type;
         let output_type = seq_info.output_type;
         let impl_module_source = seq_info.impl_module_source;
-        let builder_base_name = self
+        let builder_base_name = self.tysys
             .struct_name_for_type(builder_type)
             .unwrap_or_else(|| base_name.clone());
 

--- a/wado-compiler/src/elaborator/expr.rs
+++ b/wado-compiler/src/elaborator/expr.rs
@@ -1380,7 +1380,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         };
 
         // For newtypes, also resolve the base type name for trait impl lookup
-        let (lookup_name, lookup_type_id) = self.newtype_base_lookup(&struct_name, base_type_id);
+        let (lookup_name, lookup_type_id) = self.tysys.newtype_base_lookup(&struct_name, base_type_id);
 
         if !struct_name.is_empty() {
             let index_type = self.resolve_expr(&index.index, ctx, None);
@@ -3238,7 +3238,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     if let Some(&type_arg) = type_args.get(i) {
                         for bound in bounds {
                             if !self.type_implements_trait(type_arg, bound) {
-                                let type_name = self.type_id_to_string(type_arg);
+                                let type_name = self.tysys.type_id_to_string(type_arg);
                                 let reason = self.trait_unimpl_reason_chain(type_arg, bound);
                                 let _ = self.logger.error(TypeError::TraitBoundNotSatisfied {
                                     type_name,
@@ -3970,7 +3970,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         if element_type != TypeTable::ERROR
             && !self.type_implements_trait(element_type, &ord_trait_name)
         {
-            let type_name = self.type_id_to_string(element_type);
+            let type_name = self.tysys.type_id_to_string(element_type);
             let reason = self.trait_unimpl_reason_chain(element_type, &ord_trait_name);
             let _ = self.logger.error(TypeError::TraitBoundNotSatisfied {
                 type_name,

--- a/wado-compiler/src/elaborator/expr.rs
+++ b/wado-compiler/src/elaborator/expr.rs
@@ -707,7 +707,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             };
             if needs_param_scope {
                 let mut scope = s.enter_inherited_type_param_scope();
-                scope.trait_ctx.type_params.clear();
+                scope.annotate_ctx.trait_ctx.type_params.clear();
                 scope.register_generic_params(&type_params_for_scope, 0);
                 inner(&mut scope)
             } else {
@@ -966,10 +966,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let func_return_type = func.return_type.clone();
         let resolve = move |s: &mut Self| -> (Vec<TypeId>, TypeId, Vec<TypeId>) {
             let mut scope = s.enter_inherited_type_param_scope();
-            scope.trait_ctx.type_params.clear();
+            scope.annotate_ctx.trait_ctx.type_params.clear();
             scope.register_generic_params(&type_params_for_scope, 0);
             let type_param_ids: Vec<TypeId> = scope
-                .trait_ctx
+                .annotate_ctx.trait_ctx
                 .type_params
                 .iter()
                 .map(|(_, &(_, id))| id)

--- a/wado-compiler/src/elaborator/expr.rs
+++ b/wado-compiler/src/elaborator/expr.rs
@@ -969,7 +969,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             scope.annotate_ctx.trait_ctx.type_params.clear();
             scope.register_generic_params(&type_params_for_scope, 0);
             let type_param_ids: Vec<TypeId> = scope
-                .annotate_ctx.trait_ctx
+                .annotate_ctx
+                .trait_ctx
                 .type_params
                 .iter()
                 .map(|(_, &(_, id))| id)
@@ -1358,7 +1359,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         };
 
         // For newtypes, also resolve the base type name for trait impl lookup
-        let (lookup_name, lookup_type_id) = self.tysys.newtype_base_lookup(&struct_name, base_type_id);
+        let (lookup_name, lookup_type_id) =
+            self.tysys.newtype_base_lookup(&struct_name, base_type_id);
 
         if !struct_name.is_empty() {
             let index_type = self.resolve_expr(&index.index, ctx, None);

--- a/wado-compiler/src/elaborator/expr.rs
+++ b/wado-compiler/src/elaborator/expr.rs
@@ -717,19 +717,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let (mut param_types, mut return_type, effects) = if same_module {
             resolve(self)
         } else {
-            let callee_module = self.loaded_modules.get(def_module);
-            let (imported_type_sources, import_original_names) = if let Some(module) = callee_module
-            {
-                Self::build_imported_type_sources(
-                    &mut self.interner.borrow_mut(),
-                    module,
-                    def_module,
-                    Some(&self.entry_module_source),
-                    &self.invocations,
-                )
-            } else {
-                (IndexMap::default(), IndexMap::default())
-            };
+            let (imported_type_sources, import_original_names) =
+                self.tysys.trait_env.import_scope(def_module);
             self.with_module_perspective(
                 def_module.clone(),
                 imported_type_sources,
@@ -999,19 +988,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let (decl_params, decl_return, type_param_ids) = if same_module {
             resolve(self)
         } else {
-            let callee_module = self.loaded_modules.get(def_module);
-            let (imported_type_sources, import_original_names) = if let Some(module) = callee_module
-            {
-                Self::build_imported_type_sources(
-                    &mut self.interner.borrow_mut(),
-                    module,
-                    def_module,
-                    Some(&self.entry_module_source),
-                    &self.invocations,
-                )
-            } else {
-                (IndexMap::default(), IndexMap::default())
-            };
+            let (imported_type_sources, import_original_names) =
+                self.tysys.trait_env.import_scope(def_module);
             self.with_module_perspective(
                 def_module.clone(),
                 imported_type_sources,

--- a/wado-compiler/src/elaborator/expr.rs
+++ b/wado-compiler/src/elaborator/expr.rs
@@ -3215,7 +3215,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 for (i, (param_name, bounds)) in struct_info.type_param_bounds.iter().enumerate() {
                     if let Some(&type_arg) = type_args.get(i) {
                         for bound in bounds {
-                            if !self.type_implements_trait(type_arg, bound) {
+                            if !self.type_implements_trait(&self.annotate_ctx, type_arg, bound) {
                                 let type_name = self.tysys.type_id_to_string(type_arg);
                                 let reason = self.trait_unimpl_reason_chain(type_arg, bound);
                                 let _ = self.logger.error(TypeError::TraitBoundNotSatisfied {
@@ -3946,7 +3946,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             .trait_name(crate::compiler_item::CompilerItem::Ord)
             .to_string();
         if element_type != TypeTable::ERROR
-            && !self.type_implements_trait(element_type, &ord_trait_name)
+            && !self.type_implements_trait(&self.annotate_ctx, element_type, &ord_trait_name)
         {
             let type_name = self.tysys.type_id_to_string(element_type);
             let reason = self.trait_unimpl_reason_chain(element_type, &ord_trait_name);

--- a/wado-compiler/src/elaborator/item.rs
+++ b/wado-compiler/src/elaborator/item.rs
@@ -644,7 +644,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     .filter(|p| !p.is_effect)
                     .map(|p| {
                         scope
-                            .annotate_ctx.trait_ctx
+                            .annotate_ctx
+                            .trait_ctx
                             .type_params
                             .get(&p.name)
                             .map(|(_, id)| *id)
@@ -954,7 +955,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             .filter(|p| !p.is_effect)
             .filter(|p| !p.bounds.iter().any(|b| b.fn_signature.is_some()))
             .filter_map(|p| {
-                self.annotate_ctx.trait_ctx
+                self.annotate_ctx
+                    .trait_ctx
                     .type_params
                     .get(&p.name)
                     .map(|&(_, id)| (p.name.clone(), id))
@@ -1407,7 +1409,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             .borrow_mut()
                             .make_type_param(name.clone(), i as u32);
                         scope
-                            .annotate_ctx.trait_ctx
+                            .annotate_ctx
+                            .trait_ctx
                             .type_params
                             .insert(name.clone(), (i as u32, type_id));
                         // Store impl type param info for later monomorphization
@@ -1433,7 +1436,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     .borrow_mut()
                     .make_type_param(named.name.clone(), idx);
                 scope
-                    .annotate_ctx.trait_ctx
+                    .annotate_ctx
+                    .trait_ctx
                     .type_params
                     .insert(named.name.clone(), (idx, type_id));
                 let bounds = scope
@@ -1463,7 +1467,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     .borrow_mut()
                     .make_type_param(named.name.clone(), idx);
                 scope
-                    .annotate_ctx.trait_ctx
+                    .annotate_ctx
+                    .trait_ctx
                     .type_params
                     .insert(named.name.clone(), (idx, type_id));
                 let bounds = scope
@@ -1494,7 +1499,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         .borrow_mut()
                         .make_type_pack(name.clone(), idx);
                     scope
-                        .annotate_ctx.trait_ctx
+                        .annotate_ctx
+                        .trait_ctx
                         .type_params
                         .insert(name.clone(), (idx, type_id));
                     let bounds = scope
@@ -1611,7 +1617,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 )
             };
             scope
-                .annotate_ctx.trait_ctx
+                .annotate_ctx
+                .trait_ctx
                 .type_params
                 .insert(param.name.clone(), (idx, type_id));
             // Only push *real* type params (TypeParam-ids) into the
@@ -1630,7 +1637,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 .collect();
             if !real_bounds.is_empty() {
                 scope
-                    .annotate_ctx.trait_ctx
+                    .annotate_ctx
+                    .trait_ctx
                     .type_param_bounds
                     .insert(param.name.clone(), real_bounds);
             }

--- a/wado-compiler/src/elaborator/item.rs
+++ b/wado-compiler/src/elaborator/item.rs
@@ -531,9 +531,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Set up type parameters in scope before resolving fields. Use an
         // inherited scope so that any caller-provided `assoc_type_bindings` or
         // `self_type` remain visible — only `type_params` are replaced, matching
-        // the original `mem::take(&mut self.trait_ctx.type_params)` semantics.
+        // the original `mem::take(&mut self.annotate_ctx.trait_ctx.type_params)` semantics.
         let mut scope = self.enter_inherited_type_param_scope();
-        scope.trait_ctx.type_params.clear();
+        scope.annotate_ctx.trait_ctx.type_params.clear();
         scope.register_generic_params(&struct_decl.type_params, 0);
 
         // Resolve field types (recorded below as `struct_field_types`) and
@@ -629,7 +629,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         resource_self: Option<(&str, ModuleSource)>,
     ) -> Vec<TirEffectOp> {
         let mut scope = self.enter_inherited_type_param_scope();
-        scope.trait_ctx.type_params.clear();
+        scope.annotate_ctx.trait_ctx.type_params.clear();
         scope.register_generic_params(type_params, 0);
 
         // Construct the resource's `Self` type after type params are in
@@ -644,7 +644,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     .filter(|p| !p.is_effect)
                     .map(|p| {
                         scope
-                            .trait_ctx
+                            .annotate_ctx.trait_ctx
                             .type_params
                             .get(&p.name)
                             .map(|(_, id)| *id)
@@ -807,9 +807,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Set up type parameters in scope before resolving field types. Use an
         // inherited scope so any caller-provided `assoc_type_bindings`/`self_type`
         // stay visible — only `type_params` are replaced, matching the original
-        // `mem::take(&mut self.trait_ctx.type_params)` semantics.
+        // `mem::take(&mut self.annotate_ctx.trait_ctx.type_params)` semantics.
         let mut scope = self.enter_inherited_type_param_scope();
-        scope.trait_ctx.type_params.clear();
+        scope.annotate_ctx.trait_ctx.type_params.clear();
         scope.register_generic_params(&variant_decl.type_params, 0);
 
         // Convert AST type params to TIR type params (while type params still in scope)
@@ -913,8 +913,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             return;
         }
         let mut scope = self.enter_inherited_type_param_scope();
-        scope.trait_ctx.type_params.clear();
-        scope.trait_ctx.type_param_bounds.clear();
+        scope.annotate_ctx.trait_ctx.type_params.clear();
+        scope.annotate_ctx.trait_ctx.type_param_bounds.clear();
         // Install effect params before `register_generic_params` so eager
         // `<F: fn() with E>` bound resolution sees `E` as `EffectRef::Param`.
         let old_effect_params = std::mem::take(&mut scope.current_effect_params);
@@ -936,7 +936,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// (`generic_function_params`, `generic_function_resolved_param_types`,
     /// `generic_function_resolved_return_types`) for `func`, keyed by its
     /// name. Type parameters must already be registered in
-    /// `self.trait_ctx.type_params` before calling this.
+    /// `self.annotate_ctx.trait_ctx.type_params` before calling this.
     ///
     /// Returns the resolved declared return type so callers that need it
     /// (e.g. `resolve_function` for `task_return_type`) can avoid resolving
@@ -954,7 +954,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             .filter(|p| !p.is_effect)
             .filter(|p| !p.bounds.iter().any(|b| b.fn_signature.is_some()))
             .filter_map(|p| {
-                self.trait_ctx
+                self.annotate_ctx.trait_ctx
                     .type_params
                     .get(&p.name)
                     .map(|&(_, id)| (p.name.clone(), id))
@@ -993,8 +993,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // stay visible — only `type_params` and `type_param_bounds` are replaced,
         // matching the original `mem::take` semantics for those two fields.
         let mut scope = self.enter_inherited_type_param_scope();
-        scope.trait_ctx.type_params.clear();
-        scope.trait_ctx.type_param_bounds.clear();
+        scope.annotate_ctx.trait_ctx.type_params.clear();
+        scope.annotate_ctx.trait_ctx.type_param_bounds.clear();
 
         // Set effect params in scope before `register_generic_params`. Eager
         // `<F: fn() with E>` bound resolution runs inside
@@ -1373,7 +1373,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // and bounds get rebuilt below to match the original `mem::take`
         // behavior.
         let mut scope = self.enter_inherited_type_param_scope();
-        scope.trait_ctx.type_params.clear();
+        scope.annotate_ctx.trait_ctx.type_params.clear();
         let mut type_param_list = Vec::new();
 
         // Bare base trait name (e.g. `"Stream"` for an `impl Stream<u8>`).
@@ -1400,14 +1400,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             for (i, arg) in generic.args.iter().enumerate() {
                 if let ast::Type::Named(named) = arg {
                     let name = &named.name;
-                    if !scope.trait_ctx.type_params.contains_key(name) {
+                    if !scope.annotate_ctx.trait_ctx.type_params.contains_key(name) {
                         let type_id = scope
                             .tysys
                             .type_table
                             .borrow_mut()
                             .make_type_param(name.clone(), i as u32);
                         scope
-                            .trait_ctx
+                            .annotate_ctx.trait_ctx
                             .type_params
                             .insert(name.clone(), (i as u32, type_id));
                         // Store impl type param info for later monomorphization
@@ -1433,7 +1433,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     .borrow_mut()
                     .make_type_param(named.name.clone(), idx);
                 scope
-                    .trait_ctx
+                    .annotate_ctx.trait_ctx
                     .type_params
                     .insert(named.name.clone(), (idx, type_id));
                 let bounds = scope
@@ -1463,7 +1463,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     .borrow_mut()
                     .make_type_param(named.name.clone(), idx);
                 scope
-                    .trait_ctx
+                    .annotate_ctx.trait_ctx
                     .type_params
                     .insert(named.name.clone(), (idx, type_id));
                 let bounds = scope
@@ -1494,7 +1494,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         .borrow_mut()
                         .make_type_pack(name.clone(), idx);
                     scope
-                        .trait_ctx
+                        .annotate_ctx.trait_ctx
                         .type_params
                         .insert(name.clone(), (idx, type_id));
                     let bounds = scope
@@ -1533,7 +1533,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // scope contains the caller's bounds. We start from those and add
         // method-level bounds on top.
         let saved_bounds = scope.saved().type_param_bounds.clone();
-        scope.trait_ctx.type_param_bounds = saved_bounds;
+        scope.annotate_ctx.trait_ctx.type_param_bounds = saved_bounds;
 
         // Bind the trait's own type parameters to the impl's concrete trait
         // args so that references like `T` inside a default method body resolve
@@ -1611,7 +1611,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 )
             };
             scope
-                .trait_ctx
+                .annotate_ctx.trait_ctx
                 .type_params
                 .insert(param.name.clone(), (idx, type_id));
             // Only push *real* type params (TypeParam-ids) into the
@@ -1630,7 +1630,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 .collect();
             if !real_bounds.is_empty() {
                 scope
-                    .trait_ctx
+                    .annotate_ctx.trait_ctx
                     .type_param_bounds
                     .insert(param.name.clone(), real_bounds);
             }
@@ -1641,8 +1641,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Set up Self type for the impl block
         // This allows `&Self` to resolve correctly in method parameters
-        let old_self_type = scope.trait_ctx.self_type;
-        scope.trait_ctx.self_type = Some(scope.resolve_type(impl_type));
+        let old_self_type = scope.annotate_ctx.trait_ctx.self_type;
+        scope.annotate_ctx.trait_ctx.self_type = Some(scope.resolve_type(impl_type));
 
         // Resolve return type
         let return_type = func
@@ -1830,7 +1830,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // `drop(scope)`, which replaces everything set up above.
         scope.current_effect_params = old_effect_params;
         scope.current_effect_param_decls = old_effect_param_decls;
-        scope.trait_ctx.self_type = old_self_type;
+        scope.annotate_ctx.trait_ctx.self_type = old_self_type;
         drop(scope);
 
         // Record the resolved param/return types for reify to read back

--- a/wado-compiler/src/elaborator/method_call.rs
+++ b/wado-compiler/src/elaborator/method_call.rs
@@ -282,7 +282,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 }
             };
             if let Some(name) = type_param_name
-                && let Some(bounds) = self.annotate_ctx.trait_ctx.type_param_bounds.get(&name).cloned()
+                && let Some(bounds) = self
+                    .annotate_ctx
+                    .trait_ctx
+                    .type_param_bounds
+                    .get(&name)
+                    .cloned()
                 && let Some((found_trait, info)) = {
                     let bound_names: Vec<String> = bounds.iter().map(|b| b.name.clone()).collect();
                     self.find_method_in_trait_bounds(&bound_names, method_name, base_type_id)
@@ -491,7 +496,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // Substitute base type with newtype in all parameter types
             param_types
                 .iter()
-                .map(|&ty| self.tysys.substitute_newtype_in_type(ty, base_type_id, newtype_id))
+                .map(|&ty| {
+                    self.tysys
+                        .substitute_newtype_in_type(ty, base_type_id, newtype_id)
+                })
                 .collect()
         } else {
             param_types
@@ -545,7 +553,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // e.g., Point::clone_point() -> Point becomes Location::clone_point() -> Location
         if let Some(base_type_id) = inherited_from_base {
             let newtype_id = self.tysys.get_base_type(receiver.type_id);
-            return_type = self.tysys.substitute_newtype_in_type(return_type, base_type_id, newtype_id);
+            return_type =
+                self.tysys
+                    .substitute_newtype_in_type(return_type, base_type_id, newtype_id);
         }
 
         // Address-taken tracking for an implicit `&mut self` borrow on a
@@ -1042,7 +1052,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     for (i, name) in impl_type_param_names.iter().enumerate() {
                         if let Some(&concrete) = call_site_impl_args.get(i) {
                             scope
-                                .annotate_ctx.trait_ctx
+                                .annotate_ctx
+                                .trait_ctx
                                 .type_params
                                 .insert(name.clone(), (i as u32, concrete));
                         }
@@ -1051,7 +1062,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     for (i, tp) in method_def.type_params.iter().enumerate() {
                         if let Some(&concrete) = method_type_args.get(i) {
                             scope
-                                .annotate_ctx.trait_ctx
+                                .annotate_ctx
+                                .trait_ctx
                                 .type_params
                                 .insert(tp.name.clone(), ((impl_offset + i) as u32, concrete));
                         }
@@ -1703,14 +1715,20 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                     for (i, arg) in generic.args.iter().enumerate() {
                                         if let ast::Type::Named(named) = arg {
                                             let name = &named.name;
-                                            if !scope.annotate_ctx.trait_ctx.type_params.contains_key(name) {
+                                            if !scope
+                                                .annotate_ctx
+                                                .trait_ctx
+                                                .type_params
+                                                .contains_key(name)
+                                            {
                                                 let type_id = scope
                                                     .tysys
                                                     .type_table
                                                     .borrow_mut()
                                                     .make_type_param(name.clone(), i as u32);
                                                 scope
-                                                    .annotate_ctx.trait_ctx
+                                                    .annotate_ctx
+                                                    .trait_ctx
                                                     .type_params
                                                     .insert(name.clone(), (i as u32, type_id));
                                             }
@@ -1726,7 +1744,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                     .filter(|p| !p.is_effect)
                                     .enumerate()
                                 {
-                                    if scope.annotate_ctx.trait_ctx.type_params.contains_key(&tp.name) {
+                                    if scope
+                                        .annotate_ctx
+                                        .trait_ctx
+                                        .type_params
+                                        .contains_key(&tp.name)
+                                    {
                                         continue;
                                     }
                                     let idx = (m_offset + i) as u32;
@@ -1744,7 +1767,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                             .make_type_param(tp.name.clone(), idx)
                                     };
                                     scope
-                                        .annotate_ctx.trait_ctx
+                                        .annotate_ctx
+                                        .trait_ctx
                                         .type_params
                                         .insert(tp.name.clone(), (idx, type_id));
                                 }
@@ -1805,7 +1829,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                         .borrow_mut()
                                         .make_type_param(name.clone(), i as u32);
                                     scope
-                                        .annotate_ctx.trait_ctx
+                                        .annotate_ctx
+                                        .trait_ctx
                                         .type_params
                                         .insert(name.clone(), (i as u32, type_id));
                                 }
@@ -1867,7 +1892,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 .borrow_mut()
                                 .make_type_param(name.clone(), i as u32);
                             scope
-                                .annotate_ctx.trait_ctx
+                                .annotate_ctx
+                                .trait_ctx
                                 .type_params
                                 .insert(name.clone(), (i as u32, type_id));
                         }
@@ -1883,7 +1909,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 .filter(|p| !p.is_effect)
                 .enumerate()
             {
-                if scope.annotate_ctx.trait_ctx.type_params.contains_key(&tp.name) {
+                if scope
+                    .annotate_ctx
+                    .trait_ctx
+                    .type_params
+                    .contains_key(&tp.name)
+                {
                     continue;
                 }
                 let idx = (m_offset + i) as u32;
@@ -1901,7 +1932,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         .make_type_param(tp.name.clone(), idx)
                 };
                 scope
-                    .annotate_ctx.trait_ctx
+                    .annotate_ctx
+                    .trait_ctx
                     .type_params
                     .insert(tp.name.clone(), (idx, type_id));
             }
@@ -1956,7 +1988,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 .borrow_mut()
                                 .make_type_param(name.clone(), i as u32);
                             scope
-                                .annotate_ctx.trait_ctx
+                                .annotate_ctx
+                                .trait_ctx
                                 .type_params
                                 .insert(name.clone(), (i as u32, type_id));
                         }
@@ -2013,7 +2046,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 for binding in &impl_assoc_types {
                     let type_id = scope.resolve_type(&binding.ty);
                     scope
-                        .annotate_ctx.trait_ctx
+                        .annotate_ctx
+                        .trait_ctx
                         .assoc_type_bindings
                         .insert(binding.name.clone(), type_id);
                 }
@@ -2188,7 +2222,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         if let ast::Type::Generic(generic) = impl_ty {
             for (i, arg) in generic.args.iter().enumerate() {
                 if let ast::Type::Named(named) = arg
-                    && !scope.annotate_ctx.trait_ctx.type_params.contains_key(&named.name)
+                    && !scope
+                        .annotate_ctx
+                        .trait_ctx
+                        .type_params
+                        .contains_key(&named.name)
                 {
                     let type_id = scope
                         .tysys
@@ -2196,7 +2234,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         .borrow_mut()
                         .make_type_param(named.name.clone(), i as u32);
                     scope
-                        .annotate_ctx.trait_ctx
+                        .annotate_ctx
+                        .trait_ctx
                         .type_params
                         .insert(named.name.clone(), (i as u32, type_id));
                 }
@@ -2211,7 +2250,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             .filter(|p| !p.is_effect)
             .enumerate()
         {
-            if scope.annotate_ctx.trait_ctx.type_params.contains_key(&tp.name) {
+            if scope
+                .annotate_ctx
+                .trait_ctx
+                .type_params
+                .contains_key(&tp.name)
+            {
                 continue;
             }
             let idx = (offset + i) as u32;
@@ -2229,7 +2273,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     .make_type_param(tp.name.clone(), idx)
             };
             scope
-                .annotate_ctx.trait_ctx
+                .annotate_ctx
+                .trait_ctx
                 .type_params
                 .insert(tp.name.clone(), (idx, type_id));
         }

--- a/wado-compiler/src/elaborator/method_call.rs
+++ b/wado-compiler/src/elaborator/method_call.rs
@@ -2179,19 +2179,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // module B resolves against the caller's perspective (which only
         // knows about `CounterA` / `CounterB` aliases) and falls back to
         // `Unknown`, breaking arg-type coercion at the call site.
-        let (imports, originals) = self
-            .loaded_modules
-            .get(impl_module)
-            .map(|m| {
-                Self::build_imported_type_sources(
-                    &mut self.interner.borrow_mut(),
-                    m,
-                    impl_module,
-                    Some(&self.entry_module_source),
-                    &self.invocations,
-                )
-            })
-            .unwrap_or_default();
+        let (imports, originals) = self.tysys.trait_env.import_scope(impl_module);
         // Inherited scope; only `type_params` is replaced.
         let mut scope = self.enter_inherited_type_param_scope();
         scope.trait_ctx.type_params.clear();
@@ -2481,16 +2469,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 .cloned()
                 .unwrap_or_else(fallback);
         }
-        let Some(ast_module) = self.loaded_modules.get(module) else {
-            return fallback();
-        };
-        let (_, originals) = Self::build_imported_type_sources(
-            &mut self.interner.borrow_mut(),
-            ast_module,
-            module,
-            Some(&self.entry_module_source),
-            &self.invocations,
-        );
+        let (_, originals) = self.tysys.trait_env.import_scope(module);
         originals.get(name).cloned().unwrap_or_else(fallback)
     }
 

--- a/wado-compiler/src/elaborator/method_call.rs
+++ b/wado-compiler/src/elaborator/method_call.rs
@@ -282,7 +282,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 }
             };
             if let Some(name) = type_param_name
-                && let Some(bounds) = self.trait_ctx.type_param_bounds.get(&name).cloned()
+                && let Some(bounds) = self.annotate_ctx.trait_ctx.type_param_bounds.get(&name).cloned()
                 && let Some((found_trait, info)) = {
                     let bound_names: Vec<String> = bounds.iter().map(|b| b.name.clone()).collect();
                     self.find_method_in_trait_bounds(&bound_names, method_name, base_type_id)
@@ -1038,11 +1038,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     // Temporarily map type param names directly to concrete types
                     // (inherited scope; only `type_params` is replaced).
                     let mut scope = self.enter_inherited_type_param_scope();
-                    scope.trait_ctx.type_params.clear();
+                    scope.annotate_ctx.trait_ctx.type_params.clear();
                     for (i, name) in impl_type_param_names.iter().enumerate() {
                         if let Some(&concrete) = call_site_impl_args.get(i) {
                             scope
-                                .trait_ctx
+                                .annotate_ctx.trait_ctx
                                 .type_params
                                 .insert(name.clone(), (i as u32, concrete));
                         }
@@ -1051,7 +1051,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     for (i, tp) in method_def.type_params.iter().enumerate() {
                         if let Some(&concrete) = method_type_args.get(i) {
                             scope
-                                .trait_ctx
+                                .annotate_ctx.trait_ctx
                                 .type_params
                                 .insert(tp.name.clone(), ((impl_offset + i) as u32, concrete));
                         }
@@ -1696,21 +1696,21 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 // Set up type parameters from impl block before resolving.
                                 // Inherited scope; only `type_params` is replaced.
                                 let mut scope = self.enter_inherited_type_param_scope();
-                                scope.trait_ctx.type_params.clear();
+                                scope.annotate_ctx.trait_ctx.type_params.clear();
 
                                 // Extract type params from impl block type (e.g., impl List<T>)
                                 if let ast::Type::Generic(generic) = &impl_block.ty {
                                     for (i, arg) in generic.args.iter().enumerate() {
                                         if let ast::Type::Named(named) = arg {
                                             let name = &named.name;
-                                            if !scope.trait_ctx.type_params.contains_key(name) {
+                                            if !scope.annotate_ctx.trait_ctx.type_params.contains_key(name) {
                                                 let type_id = scope
                                                     .tysys
                                                     .type_table
                                                     .borrow_mut()
                                                     .make_type_param(name.clone(), i as u32);
                                                 scope
-                                                    .trait_ctx
+                                                    .annotate_ctx.trait_ctx
                                                     .type_params
                                                     .insert(name.clone(), (i as u32, type_id));
                                             }
@@ -1719,14 +1719,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 }
 
                                 // Method-level type params (e.g. fn make<T>(...) -> T)
-                                let m_offset = scope.trait_ctx.type_params.len();
+                                let m_offset = scope.annotate_ctx.trait_ctx.type_params.len();
                                 for (i, tp) in method
                                     .type_params
                                     .iter()
                                     .filter(|p| !p.is_effect)
                                     .enumerate()
                                 {
-                                    if scope.trait_ctx.type_params.contains_key(&tp.name) {
+                                    if scope.annotate_ctx.trait_ctx.type_params.contains_key(&tp.name) {
                                         continue;
                                     }
                                     let idx = (m_offset + i) as u32;
@@ -1744,7 +1744,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                             .make_type_param(tp.name.clone(), idx)
                                     };
                                     scope
-                                        .trait_ctx
+                                        .annotate_ctx.trait_ctx
                                         .type_params
                                         .insert(tp.name.clone(), (idx, type_id));
                                 }
@@ -1760,7 +1760,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                     .as_ref()
                                     .is_some_and(|t| Self::ast_type_mentions_self(t))
                                 {
-                                    scope.trait_ctx.self_type =
+                                    scope.annotate_ctx.trait_ctx.self_type =
                                         Some(scope.resolve_return_type_in_module(
                                             struct_module,
                                             Some(&impl_block.ty),
@@ -1794,18 +1794,18 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             // Set up type parameters from resource declaration before resolving.
                             // Inherited scope; only `type_params` is replaced.
                             let mut scope = self.enter_inherited_type_param_scope();
-                            scope.trait_ctx.type_params.clear();
+                            scope.annotate_ctx.trait_ctx.type_params.clear();
 
                             for (i, param) in resource.type_params.iter().enumerate() {
                                 let name = &param.name;
-                                if !scope.trait_ctx.type_params.contains_key(name) {
+                                if !scope.annotate_ctx.trait_ctx.type_params.contains_key(name) {
                                     let type_id = scope
                                         .tysys
                                         .type_table
                                         .borrow_mut()
                                         .make_type_param(name.clone(), i as u32);
                                     scope
-                                        .trait_ctx
+                                        .annotate_ctx.trait_ctx
                                         .type_params
                                         .insert(name.clone(), (i as u32, type_id));
                                 }
@@ -1854,20 +1854,20 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         if let Some((ms, impl_ty, method)) = indexed {
             // Inherited scope; only `type_params` is replaced.
             let mut scope = self.enter_inherited_type_param_scope();
-            scope.trait_ctx.type_params.clear();
+            scope.annotate_ctx.trait_ctx.type_params.clear();
 
             if let ast::Type::Generic(generic) = &impl_ty {
                 for (i, arg) in generic.args.iter().enumerate() {
                     if let ast::Type::Named(named) = arg {
                         let name = &named.name;
-                        if !scope.trait_ctx.type_params.contains_key(name) {
+                        if !scope.annotate_ctx.trait_ctx.type_params.contains_key(name) {
                             let type_id = scope
                                 .tysys
                                 .type_table
                                 .borrow_mut()
                                 .make_type_param(name.clone(), i as u32);
                             scope
-                                .trait_ctx
+                                .annotate_ctx.trait_ctx
                                 .type_params
                                 .insert(name.clone(), (i as u32, type_id));
                         }
@@ -1876,14 +1876,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             }
 
             // Method-level type params (e.g. fn make<T>(...) -> T)
-            let m_offset = scope.trait_ctx.type_params.len();
+            let m_offset = scope.annotate_ctx.trait_ctx.type_params.len();
             for (i, tp) in method
                 .type_params
                 .iter()
                 .filter(|p| !p.is_effect)
                 .enumerate()
             {
-                if scope.trait_ctx.type_params.contains_key(&tp.name) {
+                if scope.annotate_ctx.trait_ctx.type_params.contains_key(&tp.name) {
                     continue;
                 }
                 let idx = (m_offset + i) as u32;
@@ -1901,7 +1901,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         .make_type_param(tp.name.clone(), idx)
                 };
                 scope
-                    .trait_ctx
+                    .annotate_ctx.trait_ctx
                     .type_params
                     .insert(tp.name.clone(), (idx, type_id));
             }
@@ -1919,7 +1919,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 .as_ref()
                 .is_some_and(|t| Self::ast_type_mentions_self(t))
             {
-                scope.trait_ctx.self_type =
+                scope.annotate_ctx.trait_ctx.self_type =
                     Some(scope.resolve_return_type_in_module(&ms, Some(&impl_ty)));
             }
             let result = scope.resolve_return_type_in_module(&ms, method.return_type.as_ref());
@@ -1945,18 +1945,18 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
                     // Inherited scope; only `type_params` is replaced.
                     let mut scope = self.enter_inherited_type_param_scope();
-                    scope.trait_ctx.type_params.clear();
+                    scope.annotate_ctx.trait_ctx.type_params.clear();
 
                     for (i, param) in resource.type_params.iter().enumerate() {
                         let name = &param.name;
-                        if !scope.trait_ctx.type_params.contains_key(name) {
+                        if !scope.annotate_ctx.trait_ctx.type_params.contains_key(name) {
                             let type_id = scope
                                 .tysys
                                 .type_table
                                 .borrow_mut()
                                 .make_type_param(name.clone(), i as u32);
                             scope
-                                .trait_ctx
+                                .annotate_ctx.trait_ctx
                                 .type_params
                                 .insert(name.clone(), (i as u32, type_id));
                         }
@@ -2003,8 +2003,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     continue;
                 }
                 let mut scope = self.enter_inherited_type_param_scope();
-                scope.trait_ctx.type_params.clear();
-                scope.trait_ctx.assoc_type_bindings.clear();
+                scope.annotate_ctx.trait_ctx.type_params.clear();
+                scope.annotate_ctx.trait_ctx.assoc_type_bindings.clear();
                 // Bind `Self::AssocName` projections that may appear in the
                 // trait default body's return type (e.g. FromStr's
                 // `Result<Self, Self::Err>`). Pull the bindings from the
@@ -2013,7 +2013,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 for binding in &impl_assoc_types {
                     let type_id = scope.resolve_type(&binding.ty);
                     scope
-                        .trait_ctx
+                        .annotate_ctx.trait_ctx
                         .assoc_type_bindings
                         .insert(binding.name.clone(), type_id);
                 }
@@ -2021,14 +2021,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 // `resolve_named_type` maps primitives to their canonical
                 // TypeTable id rather than a struct wrapper.
                 let self_type_id = scope.resolve_named_type(struct_name, Span::default());
-                let old_self = scope.trait_ctx.self_type;
-                scope.trait_ctx.self_type = Some(self_type_id);
+                let old_self = scope.annotate_ctx.trait_ctx.self_type;
+                scope.annotate_ctx.trait_ctx.self_type = Some(self_type_id);
                 let result = default_method
                     .return_type
                     .as_ref()
                     .map(|t| scope.resolve_type(t))
                     .unwrap_or(TypeTable::UNIT);
-                scope.trait_ctx.self_type = old_self;
+                scope.annotate_ctx.trait_ctx.self_type = old_self;
                 drop(scope);
                 return result;
             }
@@ -2182,13 +2182,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let (imports, originals) = self.tysys.trait_env.import_scope(impl_module);
         // Inherited scope; only `type_params` is replaced.
         let mut scope = self.enter_inherited_type_param_scope();
-        scope.trait_ctx.type_params.clear();
+        scope.annotate_ctx.trait_ctx.type_params.clear();
 
         // Impl-level type params (e.g. `impl Box<T>` -> register T)
         if let ast::Type::Generic(generic) = impl_ty {
             for (i, arg) in generic.args.iter().enumerate() {
                 if let ast::Type::Named(named) = arg
-                    && !scope.trait_ctx.type_params.contains_key(&named.name)
+                    && !scope.annotate_ctx.trait_ctx.type_params.contains_key(&named.name)
                 {
                     let type_id = scope
                         .tysys
@@ -2196,7 +2196,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         .borrow_mut()
                         .make_type_param(named.name.clone(), i as u32);
                     scope
-                        .trait_ctx
+                        .annotate_ctx.trait_ctx
                         .type_params
                         .insert(named.name.clone(), (i as u32, type_id));
                 }
@@ -2204,14 +2204,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
 
         // Method-level type params (e.g. `fn make<T>(x: T)` -> register T)
-        let offset = scope.trait_ctx.type_params.len();
+        let offset = scope.annotate_ctx.trait_ctx.type_params.len();
         for (i, tp) in method
             .type_params
             .iter()
             .filter(|p| !p.is_effect)
             .enumerate()
         {
-            if scope.trait_ctx.type_params.contains_key(&tp.name) {
+            if scope.annotate_ctx.trait_ctx.type_params.contains_key(&tp.name) {
                 continue;
             }
             let idx = (offset + i) as u32;
@@ -2229,7 +2229,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     .make_type_param(tp.name.clone(), idx)
             };
             scope
-                .trait_ctx
+                .annotate_ctx.trait_ctx
                 .type_params
                 .insert(tp.name.clone(), (idx, type_id));
         }

--- a/wado-compiler/src/elaborator/method_call.rs
+++ b/wado-compiler/src/elaborator/method_call.rs
@@ -118,7 +118,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // using the method's parameter types as expected types.
 
         // Get the base (non-ref) type for method lookup and struct name extraction
-        let base_type_id = self.get_base_type(receiver.type_id);
+        let base_type_id = self.tysys.get_base_type(receiver.type_id);
 
         // Get struct name and module source from base type
         // The struct_module is where the struct is defined (and inherent methods live)
@@ -487,11 +487,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // If method was inherited from a newtype's base type, substitute base->newtype in params
         let expected_param_types: Vec<TypeId> = if let Some(base_type_id) = inherited_from_base {
             // Get the newtype that the method is being called on
-            let newtype_id = self.get_base_type(receiver.type_id);
+            let newtype_id = self.tysys.get_base_type(receiver.type_id);
             // Substitute base type with newtype in all parameter types
             param_types
                 .iter()
-                .map(|&ty| self.substitute_newtype_in_type(ty, base_type_id, newtype_id))
+                .map(|&ty| self.tysys.substitute_newtype_in_type(ty, base_type_id, newtype_id))
                 .collect()
         } else {
             param_types
@@ -544,8 +544,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Substitute return type for inherited newtype methods
         // e.g., Point::clone_point() -> Point becomes Location::clone_point() -> Location
         if let Some(base_type_id) = inherited_from_base {
-            let newtype_id = self.get_base_type(receiver.type_id);
-            return_type = self.substitute_newtype_in_type(return_type, base_type_id, newtype_id);
+            let newtype_id = self.tysys.get_base_type(receiver.type_id);
+            return_type = self.tysys.substitute_newtype_in_type(return_type, base_type_id, newtype_id);
         }
 
         // Address-taken tracking for an implicit `&mut self` borrow on a
@@ -2777,7 +2777,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 } else {
                     let base_name = match self.tysys.type_table.borrow().get(newtype_id).clone() {
                         ResolvedType::Newtype { base_type, .. } => {
-                            Some(self.get_ultimate_base_struct_name(base_type))
+                            Some(self.tysys.get_ultimate_base_struct_name(base_type))
                         }
                         ResolvedType::Flags { .. } => Some("u32".to_string()),
                         _ => None,

--- a/wado-compiler/src/elaborator/method_lookup.rs
+++ b/wado-compiler/src/elaborator/method_lookup.rs
@@ -161,12 +161,15 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     fn collect_trait_impl_refs(&self, type_name: &str) -> Vec<ImplBlockRef> {
         let mut refs = Vec::new();
         if let Some(entries) = self.tysys.trait_env.impl_index.get(type_name) {
-            for (module_src, item_idx) in entries {
-                let module = &self.loaded_modules[module_src];
-                if let Item::Impl(impl_block) = &module.items[*item_idx]
-                    && impl_block.trait_type.is_some()
+            for entry in entries {
+                if self
+                    .tysys
+                    .trait_env
+                    .impl_headers
+                    .get(entry)
+                    .is_some_and(|h| h.trait_name.is_some())
                 {
-                    refs.push(ImplBlockRef(module_src.clone(), *item_idx));
+                    refs.push(ImplBlockRef(entry.0.clone(), entry.1));
                 }
             }
         }
@@ -178,12 +181,15 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let mut refs = Vec::new();
         for name in type_names {
             if let Some(entries) = self.tysys.trait_env.impl_index.get(name.as_str()) {
-                for (module_src, item_idx) in entries {
-                    let module = &self.loaded_modules[module_src];
-                    if let Item::Impl(impl_block) = &module.items[*item_idx]
-                        && impl_block.trait_type.is_some()
+                for entry in entries {
+                    if self
+                        .tysys
+                        .trait_env
+                        .impl_headers
+                        .get(entry)
+                        .is_some_and(|h| h.trait_name.is_some())
                     {
-                        refs.push(ImplBlockRef(module_src.clone(), *item_idx));
+                        refs.push(ImplBlockRef(entry.0.clone(), entry.1));
                     }
                 }
             }
@@ -2736,33 +2742,17 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         None
     }
 
-    /// Look up the type parameters of a static method from its AST definition.
-    /// Searches impl blocks in loaded modules for `impl StructName { fn method_name<...> }`.
+    /// Look up the type parameters of a static method from its impl header.
+    /// Scans the pre-digested impl headers for `impl StructName { fn method_name<...> }`;
+    /// `impl_headers` already covers every loaded module (including the current one).
     pub(super) fn lookup_static_method_type_params(
         &self,
         struct_name: &str,
         method_name: &str,
     ) -> Vec<ast::GenericParam> {
-        // Search loaded modules
-        for (_, module) in self.loaded_modules {
-            for item in &module.items {
-                if let Item::Impl(impl_block) = item
-                    && Self::get_type_name_static(&impl_block.ty) == struct_name
-                {
-                    for method in &impl_block.methods {
-                        if method.name == method_name && !method.type_params.is_empty() {
-                            return method.type_params.clone();
-                        }
-                    }
-                }
-            }
-        }
-        // Search current module items
-        for item in self.current_module_items {
-            if let Item::Impl(impl_block) = item
-                && Self::get_type_name_static(&impl_block.ty) == struct_name
-            {
-                for method in &impl_block.methods {
+        for header in self.tysys.trait_env.impl_headers.values() {
+            if Self::get_type_name_static(&header.ty) == struct_name {
+                for method in &header.methods {
                     if method.name == method_name && !method.type_params.is_empty() {
                         return method.type_params.clone();
                     }

--- a/wado-compiler/src/elaborator/method_lookup.rs
+++ b/wado-compiler/src/elaborator/method_lookup.rs
@@ -13,11 +13,11 @@ use crate::token::Span;
 
 use super::Elaborator;
 use super::infer::InferCtx;
-use super::tysys::TypeSystem;
 use super::types::{
     ArithmeticTraitInfo, FunctionContext, IndexAssignTraitInfo, IndexMutTraitInfo, IndexTraitInfo,
     IndexValueTraitInfo, KeyValueLiteralTraitInfo, MethodInfo, SequenceLiteralTraitInfo, TypeError,
 };
+use super::tysys::TypeSystem;
 
 use super::util::placeholder;
 
@@ -232,7 +232,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         self.find_arithmetic_trait_impl(&struct_name, rhs_type_id, &trait_name, method_name)?;
         Some(rhs_type_id)
     }
-
 
     /// Return `Some(struct_type)` when `struct_name` is a non-generic struct
     /// whose fields all carry a declared default expression, making it
@@ -573,8 +572,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     &impl_block.type_params,
                     receiver_type_args.as_deref(),
                     impl_module,
-                ) && self.check_impl_block_bounds(&impl_block.type_params, &impl_block.ty, receiver_type_args.as_deref()))
-                {
+                ) && self.check_impl_block_bounds(
+                    &impl_block.type_params,
+                    &impl_block.ty,
+                    receiver_type_args.as_deref(),
+                )) {
                     continue;
                 }
 
@@ -598,7 +600,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             && i < type_args.len()
                         {
                             scope
-                                .annotate_ctx.trait_ctx
+                                .annotate_ctx
+                                .trait_ctx
                                 .type_params
                                 .insert(named.name.clone(), (i as u32, type_args[i]));
                         }
@@ -669,7 +672,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                     true,
                                 )
                             };
-                            s.annotate_ctx.trait_ctx
+                            s.annotate_ctx
+                                .trait_ctx
                                 .type_params
                                 .insert(tp.name.clone(), (idx, type_id));
                             if consumed_index {
@@ -763,7 +767,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         receiver_type_args.as_deref(),
                         search_module_source,
                     )
-                    && self.check_impl_block_bounds(&impl_block.type_params, &impl_block.ty, receiver_type_args.as_deref())
+                    && self.check_impl_block_bounds(
+                        &impl_block.type_params,
+                        &impl_block.ty,
+                        receiver_type_args.as_deref(),
+                    )
                 {
                     for method in &impl_block.methods {
                         if method.name == method_name {
@@ -781,7 +789,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                         && i < type_args.len()
                                     {
                                         scope
-                                            .annotate_ctx.trait_ctx
+                                            .annotate_ctx
+                                            .trait_ctx
                                             .type_params
                                             .insert(named.name.clone(), (i as u32, type_args[i]));
                                     }
@@ -799,7 +808,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                     },
                                 );
                                 scope
-                                    .annotate_ctx.trait_ctx
+                                    .annotate_ctx
+                                    .trait_ctx
                                     .type_params
                                     .insert(type_param.name.clone(), (index, type_param_id));
                             }
@@ -943,7 +953,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 for (i, param) in resource.type_params.iter().enumerate() {
                     if i < type_args.len() {
                         scope
-                            .annotate_ctx.trait_ctx
+                            .annotate_ctx
+                            .trait_ctx
                             .type_params
                             .insert(param.name.clone(), (i as u32, type_args[i]));
                     }
@@ -1001,7 +1012,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         None
     }
 
-
     /// Extract parameter types (excluding self) from method parameters
     pub(super) fn extract_param_types(&mut self, params: &[ast::Param]) -> Vec<TypeId> {
         params
@@ -1010,7 +1020,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             .map(|p| self.resolve_type(&p.ty))
             .collect()
     }
-
 
     /// Infer method-level type arguments for an instance method call using
     /// the method's already-resolved parameter and return types.
@@ -1067,7 +1076,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 ..
             } => self.find_method_type_param_names(name, Some(module_source), method_name),
             ResolvedType::TypeParam { name, .. } | ResolvedType::TypePack { name, .. } => self
-                .annotate_ctx.trait_ctx
+                .annotate_ctx
+                .trait_ctx
                 .type_param_bounds
                 .get(name)
                 .cloned()
@@ -1116,7 +1126,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // knows about — would leave a dangling id at the call site, so
         // drop the inference and let the caller fall back to `vec![]`.
         let scope_params: Vec<TypeId> = self
-            .annotate_ctx.trait_ctx
+            .annotate_ctx
+            .trait_ctx
             .type_params
             .values()
             .map(|&(_, tid)| tid)
@@ -1191,7 +1202,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             if trait_names.iter().any(|n| n == &header.name) {
                 for trait_method in &header.methods {
                     if trait_method.name == method_name
-                        && let Some(params) = Self::non_effect_generic_params(&trait_method.type_params)
+                        && let Some(params) =
+                            Self::non_effect_generic_params(&trait_method.type_params)
                     {
                         return Some(params);
                     }
@@ -1247,12 +1259,17 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // current-module scans are redundant). Inherent impls are tried first
         // (include_trait = false), preferring the receiver's home module.
         if let Some(module_source) = struct_module_source
-            && let Some(names) =
-                self.search_impl_headers_method_tps(struct_name, method_name, false, Some(module_source))
+            && let Some(names) = self.search_impl_headers_method_tps(
+                struct_name,
+                method_name,
+                false,
+                Some(module_source),
+            )
         {
             return Some(names);
         }
-        if let Some(names) = self.search_impl_headers_method_tps(struct_name, method_name, false, None)
+        if let Some(names) =
+            self.search_impl_headers_method_tps(struct_name, method_name, false, None)
         {
             return Some(names);
         }
@@ -1274,12 +1291,17 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // (e.g. `fn put<T: Display>(&mut self, v: &T)`), which the inference
         // solver needs to materialise.
         if let Some(module_source) = struct_module_source
-            && let Some(names) =
-                self.search_impl_headers_method_tps(struct_name, method_name, true, Some(module_source))
+            && let Some(names) = self.search_impl_headers_method_tps(
+                struct_name,
+                method_name,
+                true,
+                Some(module_source),
+            )
         {
             return Some(names);
         }
-        if let Some(names) = self.search_impl_headers_method_tps(struct_name, method_name, true, None)
+        if let Some(names) =
+            self.search_impl_headers_method_tps(struct_name, method_name, true, None)
         {
             return Some(names);
         }
@@ -1659,8 +1681,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     .find(|tp| tp.name == impl_ty_name && !tp.bounds.is_empty());
                 if let Some(param) = blanket_param {
                     let bounds_ok = param.bounds.iter().all(|bound| {
-                        receiver_type_id
-                            .is_some_and(|rt| self.type_implements_trait(&self.annotate_ctx, rt, &bound.name))
+                        receiver_type_id.is_some_and(|rt| {
+                            self.type_implements_trait(&self.annotate_ctx, rt, &bound.name)
+                        })
                     });
                     if !bounds_ok {
                         continue;
@@ -1853,7 +1876,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     let i = *idx as usize;
                     if i < type_args.len() {
                         scope
-                            .annotate_ctx.trait_ctx
+                            .annotate_ctx
+                            .trait_ctx
                             .type_params
                             .insert(name.clone(), (*idx, type_args[i]));
                     }
@@ -1867,7 +1891,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         .borrow_mut()
                         .make_tuple(type_args.to_vec());
                     scope
-                        .annotate_ctx.trait_ctx
+                        .annotate_ctx
+                        .trait_ctx
                         .type_params
                         .insert(pack_name.clone(), (*pack_idx, pack_type));
                 }
@@ -1880,7 +1905,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             {
                 if let Some(recv_id) = receiver_type_id {
                     scope
-                        .annotate_ctx.trait_ctx
+                        .annotate_ctx
+                        .trait_ctx
                         .type_params
                         .insert(name.clone(), (0, recv_id));
                 } else {
@@ -1890,7 +1916,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         .borrow_mut()
                         .make_type_param(name.clone(), 0);
                     scope
-                        .annotate_ctx.trait_ctx
+                        .annotate_ctx
+                        .trait_ctx
                         .type_params
                         .insert(name.clone(), (0, type_id));
                 }
@@ -1900,7 +1927,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             for (name, ty) in &assoc_bindings {
                 let type_id = scope.resolve_type(ty);
                 scope
-                    .annotate_ctx.trait_ctx
+                    .annotate_ctx
+                    .trait_ctx
                     .assoc_type_bindings
                     .insert(name.clone(), type_id);
             }
@@ -1973,12 +2001,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 index,
                             });
                     scope
-                        .annotate_ctx.trait_ctx
+                        .annotate_ctx
+                        .trait_ctx
                         .type_params
                         .insert(type_param.name.clone(), (index, type_param_id));
                     if !type_param.bounds.is_empty() {
                         scope
-                            .annotate_ctx.trait_ctx
+                            .annotate_ctx
+                            .trait_ctx
                             .type_param_bounds
                             .insert(type_param.name.clone(), type_param.bounds.clone());
                     }
@@ -2009,9 +2039,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
                 // Remove method-level type params from scope
                 for type_param in &method_type_params {
-                    scope.annotate_ctx.trait_ctx.type_params.shift_remove(&type_param.name);
                     scope
-                        .annotate_ctx.trait_ctx
+                        .annotate_ctx
+                        .trait_ctx
+                        .type_params
+                        .shift_remove(&type_param.name);
+                    scope
+                        .annotate_ctx
+                        .trait_ctx
                         .type_param_bounds
                         .shift_remove(&type_param.name);
                 }
@@ -2107,12 +2142,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                     },
                                 );
                                 scope
-                                    .annotate_ctx.trait_ctx
+                                    .annotate_ctx
+                                    .trait_ctx
                                     .type_params
                                     .insert(type_param.name.clone(), (index, type_param_id));
                                 if !type_param.bounds.is_empty() {
                                     scope
-                                        .annotate_ctx.trait_ctx
+                                        .annotate_ctx
+                                        .trait_ctx
                                         .type_param_bounds
                                         .insert(type_param.name.clone(), type_param.bounds.clone());
                                 }
@@ -2150,9 +2187,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
                             // Remove method-level type params from scope
                             for type_param in &default_method.type_params {
-                                scope.annotate_ctx.trait_ctx.type_params.shift_remove(&type_param.name);
                                 scope
-                                    .annotate_ctx.trait_ctx
+                                    .annotate_ctx
+                                    .trait_ctx
+                                    .type_params
+                                    .shift_remove(&type_param.name);
+                                scope
+                                    .annotate_ctx
+                                    .trait_ctx
                                     .type_param_bounds
                                     .shift_remove(&type_param.name);
                             }
@@ -2580,7 +2622,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 continue;
                             }
                             for bound in bounds {
-                                if !self.type_implements_trait(&self.annotate_ctx, type_arg, bound) {
+                                if !self.type_implements_trait(&self.annotate_ctx, type_arg, bound)
+                                {
                                     bounds_satisfied = false;
                                     break;
                                 }
@@ -2713,7 +2756,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         Vec::new()
     }
 
-
     /// Helper to find indexing trait implementations (Index, `IndexMut`, or `IndexAssign`)
     pub(super) fn find_indexing_trait_impl(
         &mut self,
@@ -2815,14 +2857,16 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 for (name, ty) in &assoc_bindings {
                     let type_id = scope.resolve_type_with_param_mapping(ty, &type_param_mapping);
                     scope
-                        .annotate_ctx.trait_ctx
+                        .annotate_ctx
+                        .trait_ctx
                         .assoc_type_bindings
                         .insert(name.clone(), type_id);
                 }
 
                 // Get the associated type (Output or Input)
                 let assoc_type = scope
-                    .annotate_ctx.trait_ctx
+                    .annotate_ctx
+                    .trait_ctx
                     .assoc_type_bindings
                     .get(assoc_type_name)
                     .copied()

--- a/wado-compiler/src/elaborator/method_lookup.rs
+++ b/wado-compiler/src/elaborator/method_lookup.rs
@@ -113,50 +113,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         refs
     }
 
-    /// Build declared type params for an impl block, filtering out known type names.
-    fn build_declared_type_params(&self, impl_block: &ast::ImplBlock) -> IndexSet<String> {
-        let mut declared: IndexSet<String> = impl_block
-            .type_params
-            .iter()
-            .map(|p| p.name.clone())
-            .filter(|name| !self.tysys.is_known_type_name(name))
-            .collect();
-        if let Type::Generic(g) = &impl_block.ty {
-            for arg in &g.args {
-                if let Type::Named(n) = arg
-                    && !self.tysys.is_known_type_name(&n.name)
-                {
-                    declared.insert(n.name.clone());
-                }
-            }
-        }
-        declared
-    }
-
-    /// Get the struct name from a type ID, if it's a struct, generic instance, newtype, or flags.
-    pub(super) fn struct_name_for_type(&self, type_id: TypeId) -> Option<String> {
-        match self.tysys.type_table.borrow().get(type_id) {
-            ResolvedType::Struct { name, .. }
-            | ResolvedType::GenericInstance { name, .. }
-            | ResolvedType::Newtype { name, .. }
-            | ResolvedType::Flags { name, .. } => Some(name.clone()),
-            _ => None,
-        }
-    }
-
-    /// For newtypes, get the base type name and ID for trait impl lookup fallback.
-    /// Returns (`base_name`, `base_type_id`) if the type is a newtype; otherwise returns the same name/id.
-    pub(super) fn newtype_base_lookup(&self, name: &str, type_id: TypeId) -> (String, TypeId) {
-        let tt = self.tysys.type_table.borrow();
-        if let Some(base_id) = tt.get_newtype_base(type_id) {
-            drop(tt);
-            if let Some(base_name) = self.struct_name_for_type(base_id) {
-                return (base_name, base_id);
-            }
-        }
-        (name.to_string(), type_id)
-    }
-
     /// Find the rhs parameter type for an operator trait on a struct type.
     /// Used to determine what type a literal rhs should be coerced to.
     pub(super) fn find_operator_rhs_type(
@@ -164,7 +120,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         self_type_id: TypeId,
         op: &BinaryOp,
     ) -> Option<TypeId> {
-        let struct_name = self.struct_name_for_type(self_type_id)?;
+        let struct_name = self.tysys.struct_name_for_type(self_type_id)?;
         let (trait_name, method_name) = self.tysys.operator_trait_method(op)?;
         let trait_info =
             self.find_arithmetic_trait_impl(&struct_name, self_type_id, &trait_name, method_name)?;
@@ -186,30 +142,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         rhs_type_id: TypeId,
         op: &BinaryOp,
     ) -> Option<TypeId> {
-        let struct_name = self.struct_name_for_type(rhs_type_id)?;
+        let struct_name = self.tysys.struct_name_for_type(rhs_type_id)?;
         let (trait_name, method_name) = self.tysys.operator_trait_method(op)?;
         // Verify the trait impl exists; the self type is the struct type itself
         self.find_arithmetic_trait_impl(&struct_name, rhs_type_id, &trait_name, method_name)?;
         Some(rhs_type_id)
     }
 
-    /// Check if a qualified name `struct_name::method_name` is a static method
-    pub(super) fn get_ultimate_base_struct_name(&self, type_id: TypeId) -> String {
-        let mut current = type_id;
-        loop {
-            match self.tysys.type_table.borrow().get(current).clone() {
-                ResolvedType::Struct { name, .. } => return name,
-                ResolvedType::GenericInstance { name, .. } => return name,
-                ResolvedType::Newtype { base_type, .. } => current = base_type,
-                ResolvedType::Flags { .. } => return "u32".to_string(),
-                // The raw GC array's base method-owner name is "Array"
-                // (its type args are carried separately), not the full
-                // `type_name` spelling `Array<T>`.
-                ResolvedType::BuiltinArray(_) => return TypeTable::ARRAY_TYPE_NAME.to_string(),
-                _ => return self.tysys.type_table.borrow().type_name(current),
-            }
-        }
-    }
 
     /// Return `Some(struct_type)` when `struct_name` is a non-generic struct
     /// whose fields all carry a declared default expression, making it
@@ -349,7 +288,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         method_name: &str,
     ) -> Option<MethodInfo> {
         // First, get the base (non-reference) type for method lookup
-        let base_type_id = self.get_base_type(receiver_type);
+        let base_type_id = self.tysys.get_base_type(receiver_type);
         // Resolving the method's signature here walks a (possibly foreign)
         // declaration's parameter / return type AST. Those nodes are owned by
         // the declaring module and already have their use→def edges recorded
@@ -1104,74 +1043,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             .collect()
     }
 
-    /// Substitute a base type with a newtype in a type (handles references)
-    /// For example: if `base_type` is Point and newtype is Location:
-    ///   - Point -> Location
-    ///   - &Point -> &Location
-    ///   - &mut Point -> &mut Location
-    pub(super) fn substitute_newtype_in_type(
-        &mut self,
-        type_id: TypeId,
-        base_type: TypeId,
-        newtype: TypeId,
-    ) -> TypeId {
-        let ty = self.tysys.type_table.borrow().get(type_id).clone();
-        match ty {
-            // Direct match: base type -> newtype
-            _ if type_id == base_type => newtype,
-
-            // Reference: substitute the inner type
-            ResolvedType::Ref(inner) => {
-                let new_inner = self.substitute_newtype_in_type(inner, base_type, newtype);
-                if new_inner == inner {
-                    type_id
-                } else {
-                    self.tysys
-                        .type_table
-                        .borrow_mut()
-                        .intern(ResolvedType::Ref(new_inner))
-                }
-            }
-            ResolvedType::MutRef(inner) => {
-                let new_inner = self.substitute_newtype_in_type(inner, base_type, newtype);
-                if new_inner == inner {
-                    type_id
-                } else {
-                    self.tysys
-                        .type_table
-                        .borrow_mut()
-                        .intern(ResolvedType::MutRef(new_inner))
-                }
-            }
-
-            // Generic instance (e.g., Option<T>, List<T>): substitute in type args
-            ResolvedType::GenericInstance {
-                name,
-                module_source,
-                type_args,
-            } => {
-                let new_args: Vec<TypeId> = type_args
-                    .iter()
-                    .map(|&arg| self.substitute_newtype_in_type(arg, base_type, newtype))
-                    .collect();
-                if new_args == type_args {
-                    type_id
-                } else {
-                    self.tysys
-                        .type_table
-                        .borrow_mut()
-                        .intern(ResolvedType::GenericInstance {
-                            name,
-                            module_source,
-                            type_args: new_args,
-                        })
-                }
-            }
-
-            // Other types: no substitution
-            _ => type_id,
-        }
-    }
 
     /// Infer method-level type arguments for an instance method call using
     /// the method's already-resolved parameter and return types.
@@ -1209,7 +1080,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             span,
         } = input;
 
-        let base_type_id = self.get_base_type(receiver_type);
+        let base_type_id = self.tysys.get_base_type(receiver_type);
         let base_type = self.tysys.type_table.borrow().get(base_type_id).clone();
 
         // Locate the method's AST just to recover the list of type parameter
@@ -1518,18 +1389,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         None
     }
 
-    /// Get the base (non-reference) type by stripping all Ref/MutRef wrappers
-    pub(super) fn get_base_type(&self, type_id: TypeId) -> TypeId {
-        let mut current = type_id;
-        loop {
-            match self.tysys.type_table.borrow().get(current).clone() {
-                ResolvedType::Ref(inner) | ResolvedType::MutRef(inner) => {
-                    current = inner;
-                }
-                _ => return current,
-            }
-        }
-    }
     /// Adjust the receiver expression to match what the method's self parameter expects.
     ///
     /// When `is_ref_impl` is true, the method was found on a reference type impl
@@ -2490,7 +2349,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             "KeyValueLiteral",
             "Builder",
         )?;
-        let builder_name = self.struct_name_for_type(builder_type)?;
+        let builder_name = self.tysys.struct_name_for_type(builder_type)?;
         if let Some((value_type, self_kind, trait_name, _)) = self.find_indexing_trait_impl(
             &builder_name,
             builder_type,
@@ -2545,7 +2404,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 Some(b) => b.ty.clone(),
                 None => continue,
             };
-            let declared_type_params = self.build_declared_type_params(impl_block);
+            let declared_type_params = self.tysys.build_declared_type_params(impl_block);
             let type_param_mapping = TypeSystem::build_type_param_mapping(
                 &impl_block.ty,
                 &concrete_type_args,
@@ -2609,7 +2468,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             "SequenceLiteral",
             "Builder",
         )?;
-        let builder_name = self.struct_name_for_type(builder_type)?;
+        let builder_name = self.tysys.struct_name_for_type(builder_type)?;
         if let Some((element_type, self_kind, trait_name, impl_source)) = self
             .find_indexing_trait_impl(
                 &builder_name,
@@ -2942,56 +2801,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         Vec::new()
     }
 
-    /// Convert a `TypeId` to a human-readable string for error messages
-    pub(super) fn type_id_to_string(&self, type_id: TypeId) -> String {
-        let resolved = self.tysys.type_table.borrow().get(type_id).clone();
-        match resolved {
-            ResolvedType::Primitive(prim) => format!("{prim:?}").to_lowercase(),
-            ResolvedType::Struct { name, .. } => name,
-            ResolvedType::GenericInstance {
-                name,
-                module_source,
-                type_args,
-            } => {
-                if TypeTable::is_tuple_type(&name, &module_source) {
-                    let parts: Vec<String> = type_args
-                        .iter()
-                        .map(|&t| self.type_id_to_string(t))
-                        .collect();
-                    format!("[{}]", parts.join(", "))
-                } else if type_args.is_empty() {
-                    name
-                } else {
-                    let args: Vec<String> = type_args
-                        .iter()
-                        .map(|&t| self.type_id_to_string(t))
-                        .collect();
-                    format!("{}<{}>", name, args.join(", "))
-                }
-            }
-            ResolvedType::BuiltinArray(elem) => {
-                format!("Array<{}>", self.type_id_to_string(elem))
-            }
-            ResolvedType::Ref(inner) => format!("&{}", self.type_id_to_string(inner)),
-            ResolvedType::MutRef(inner) => format!("&mut {}", self.type_id_to_string(inner)),
-            ResolvedType::Function {
-                params,
-                return_type,
-                ..
-            } => {
-                let param_strs: Vec<String> =
-                    params.iter().map(|&t| self.type_id_to_string(t)).collect();
-                let ret_str = self.type_id_to_string(return_type);
-                format!("fn({}) -> {}", param_strs.join(", "), ret_str)
-            }
-            ResolvedType::TypeParam { name, .. } => name,
-            ResolvedType::Unit => "()".to_string(),
-            ResolvedType::Never => "!".to_string(),
-            ResolvedType::Unknown => "<unknown>".to_string(),
-            ResolvedType::Error => "<error>".to_string(),
-            _ => format!("{resolved:?}"),
-        }
-    }
 
     /// Helper to find indexing trait implementations (Index, `IndexMut`, or `IndexAssign`)
     pub(super) fn find_indexing_trait_impl(
@@ -3032,7 +2841,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             let trait_name = self.get_type_name_full(impl_block.trait_type.as_ref().unwrap());
 
             let impl_block = self.get_impl_block(impl_ref);
-            let declared_type_params = self.build_declared_type_params(impl_block);
+            let declared_type_params = self.tysys.build_declared_type_params(impl_block);
 
             let impl_block = self.get_impl_block(impl_ref);
             let type_param_mapping = TypeSystem::build_type_param_mapping(
@@ -3213,7 +3022,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         type_id: TypeId,
         assoc_name: &str,
     ) -> Option<TypeId> {
-        let struct_name = self.struct_name_for_type(type_id)?;
+        let struct_name = self.tysys.struct_name_for_type(type_id)?;
         let concrete_type_args: Vec<TypeId> =
             if let ResolvedType::GenericInstance { type_args, .. } =
                 self.tysys.type_table.borrow().get(type_id).clone()
@@ -3236,7 +3045,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 None => continue,
             };
 
-            let declared_type_params = self.build_declared_type_params(impl_block);
+            let declared_type_params = self.tysys.build_declared_type_params(impl_block);
             let type_param_mapping = TypeSystem::build_type_param_mapping(
                 &impl_block.ty,
                 &concrete_type_args,

--- a/wado-compiler/src/elaborator/method_lookup.rs
+++ b/wado-compiler/src/elaborator/method_lookup.rs
@@ -62,6 +62,84 @@ pub(super) struct MethodInferenceInput<'a> {
     pub span: Span,
 }
 
+impl TypeSystem {
+    /// For an inherent `impl` on a possibly-generic type, check that any
+    /// concrete type arguments written in the impl header (e.g. the `u8` in
+    /// `impl List<u8>`) match the receiver's actual type arguments. Type
+    /// parameters (e.g. `T` in `impl List<T>`) match any argument. This is
+    /// what keeps `impl List<u8>` from applying to a `List<i32>` receiver.
+    ///
+    /// Non-generic impls (e.g. `impl i32`) impose no constraint here; the
+    /// struct-name match already pinned the receiver type.
+    pub(crate) fn inherent_impl_type_args_match(
+        &self,
+        impl_ty: &Type,
+        impl_params: &[ast::GenericParam],
+        receiver_type_args: Option<&[TypeId]>,
+        impl_module: &ModuleSource,
+    ) -> bool {
+        let inner = match impl_ty {
+            Type::Reference(i) | Type::MutReference(i) => i.as_ref(),
+            other => other,
+        };
+        let Type::Generic(generic) = inner else {
+            return true;
+        };
+        // No receiver type args supplied (an existence/bounds check that did not
+        // thread them) — nothing to constrain against, so don't reject.
+        let Some(args) = receiver_type_args else {
+            return true;
+        };
+        for (i, arg) in generic.args.iter().enumerate() {
+            // A concrete arg (recursing into nested generics, excluding declared
+            // impl params) must equal the receiver's arg; a free type param
+            // matches anything.
+            if let Some(expected) = self.concrete_arg_mangled(arg, impl_params, impl_module) {
+                let Some(&recv) = args.get(i) else {
+                    return false;
+                };
+                if self.type_table.borrow().mangle_type_name(recv) != expected {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+
+    /// The mangled type name a concrete impl argument must equal in the
+    /// receiver (`u8` → `"u8"`, `Box<u8>` → `"Box<u8>"`), or `None` when the
+    /// argument is a free type parameter (declared `impl<T>` or an unknown
+    /// name) that should match any receiver argument. Recurses so nested
+    /// generic args (`List<Box<u8>>`) are constrained, not silently accepted.
+    fn concrete_arg_mangled(
+        &self,
+        arg: &Type,
+        impl_params: &[ast::GenericParam],
+        impl_module: &ModuleSource,
+    ) -> Option<String> {
+        match arg {
+            Type::Named(named) => {
+                if self.is_known_type_name_in(impl_module, &named.name)
+                    && !impl_params.iter().any(|p| p.name == named.name)
+                {
+                    Some(named.name.clone())
+                } else {
+                    None
+                }
+            }
+            Type::Generic(g) => {
+                let parts: Vec<String> = g
+                    .args
+                    .iter()
+                    .map(|a| self.concrete_arg_mangled(a, impl_params, impl_module))
+                    .collect::<Option<Vec<String>>>()?;
+                Some(format!("{}<{}>", g.name, parts.join(",")))
+            }
+            _ => None,
+        }
+    }
+}
+
 impl<H: CompilerHost> Elaborator<'_, H> {
     /// Get a reference to the `ImplBlock` from an `ImplBlockRef`.
     fn get_impl_block<'b>(&'b self, r: &ImplBlockRef) -> &'b ast::ImplBlock {
@@ -525,7 +603,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 if !targets_receiver {
                     continue;
                 }
-                if !(self.inherent_impl_type_args_match(
+                if !(self.tysys.inherent_impl_type_args_match(
                     &impl_block.ty,
                     &impl_block.type_params,
                     receiver_type_args.as_deref(),
@@ -714,7 +792,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 };
                 let impl_struct_name = self.get_type_name(&impl_block.ty);
                 if impl_struct_name == struct_name
-                    && self.inherent_impl_type_args_match(
+                    && self.tysys.inherent_impl_type_args_match(
                         &impl_block.ty,
                         &impl_block.type_params,
                         receiver_type_args.as_deref(),
@@ -958,81 +1036,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         None
     }
 
-    /// For an inherent `impl` on a possibly-generic type, check that any
-    /// concrete type arguments written in the impl header (e.g. the `u8` in
-    /// `impl List<u8>`) match the receiver's actual type arguments. Type
-    /// parameters (e.g. `T` in `impl List<T>`) match any argument. This is
-    /// what keeps `impl List<u8>` from applying to a `List<i32>` receiver.
-    ///
-    /// Non-generic impls (e.g. `impl i32`) impose no constraint here; the
-    /// struct-name match already pinned the receiver type.
-    pub(super) fn inherent_impl_type_args_match(
-        &self,
-        impl_ty: &Type,
-        impl_params: &[ast::GenericParam],
-        receiver_type_args: Option<&[TypeId]>,
-        impl_module: &ModuleSource,
-    ) -> bool {
-        let inner = match impl_ty {
-            Type::Reference(i) | Type::MutReference(i) => i.as_ref(),
-            other => other,
-        };
-        let Type::Generic(generic) = inner else {
-            return true;
-        };
-        // No receiver type args supplied (an existence/bounds check that did not
-        // thread them) — nothing to constrain against, so don't reject.
-        let Some(args) = receiver_type_args else {
-            return true;
-        };
-        for (i, arg) in generic.args.iter().enumerate() {
-            // A concrete arg (recursing into nested generics, excluding declared
-            // impl params) must equal the receiver's arg; a free type param
-            // matches anything.
-            if let Some(expected) = self.concrete_arg_mangled(arg, impl_params, impl_module) {
-                let Some(&recv) = args.get(i) else {
-                    return false;
-                };
-                if self.tysys.type_table.borrow().mangle_type_name(recv) != expected {
-                    return false;
-                }
-            }
-        }
-        true
-    }
-
-    /// The mangled type name a concrete impl argument must equal in the
-    /// receiver (`u8` → `"u8"`, `Box<u8>` → `"Box<u8>"`), or `None` when the
-    /// argument is a free type parameter (declared `impl<T>` or an unknown
-    /// name) that should match any receiver argument. Recurses so nested
-    /// generic args (`List<Box<u8>>`) are constrained, not silently accepted.
-    fn concrete_arg_mangled(
-        &self,
-        arg: &Type,
-        impl_params: &[ast::GenericParam],
-        impl_module: &ModuleSource,
-    ) -> Option<String> {
-        match arg {
-            Type::Named(named) => {
-                if self.tysys.is_known_type_name_in(impl_module, &named.name)
-                    && !impl_params.iter().any(|p| p.name == named.name)
-                {
-                    Some(named.name.clone())
-                } else {
-                    None
-                }
-            }
-            Type::Generic(g) => {
-                let parts: Vec<String> = g
-                    .args
-                    .iter()
-                    .map(|a| self.concrete_arg_mangled(a, impl_params, impl_module))
-                    .collect::<Option<Vec<String>>>()?;
-                Some(format!("{}<{}>", g.name, parts.join(",")))
-            }
-            _ => None,
-        }
-    }
 
     /// Extract parameter types (excluding self) from method parameters
     pub(super) fn extract_param_types(&mut self, params: &[ast::Param]) -> Vec<TypeId> {

--- a/wado-compiler/src/elaborator/method_lookup.rs
+++ b/wado-compiler/src/elaborator/method_lookup.rs
@@ -1660,7 +1660,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 if let Some(param) = blanket_param {
                     let bounds_ok = param.bounds.iter().all(|bound| {
                         receiver_type_id
-                            .is_some_and(|rt| self.type_implements_trait(rt, &bound.name))
+                            .is_some_and(|rt| self.type_implements_trait(&self.annotate_ctx, rt, &bound.name))
                     });
                     if !bounds_ok {
                         continue;
@@ -2580,7 +2580,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 continue;
                             }
                             for bound in bounds {
-                                if !self.type_implements_trait(type_arg, bound) {
+                                if !self.type_implements_trait(&self.annotate_ctx, type_arg, bound) {
                                     bounds_satisfied = false;
                                     break;
                                 }

--- a/wado-compiler/src/elaborator/method_lookup.rs
+++ b/wado-compiler/src/elaborator/method_lookup.rs
@@ -584,7 +584,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 // params, so its method type params start at index 0 — matching
                 // the monomorphizer's substitution map.
                 let mut scope = self.enter_inherited_type_param_scope();
-                scope.trait_ctx.type_params.clear();
+                scope.annotate_ctx.trait_ctx.type_params.clear();
                 let from_concrete_impl =
                     scope.impl_is_concrete_instantiation(impl_block, impl_module);
                 let mut impl_offset = 0u32;
@@ -598,7 +598,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             && i < type_args.len()
                         {
                             scope
-                                .trait_ctx
+                                .annotate_ctx.trait_ctx
                                 .type_params
                                 .insert(named.name.clone(), (i as u32, type_args[i]));
                         }
@@ -642,7 +642,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
                         let mut idx = impl_offset;
                         for tp in method.type_params.iter().filter(|p| !p.is_effect) {
-                            if s.trait_ctx.type_params.contains_key(&tp.name) {
+                            if s.annotate_ctx.trait_ctx.type_params.contains_key(&tp.name) {
                                 continue;
                             }
                             let fn_bound_sig = if tp.is_pack {
@@ -669,7 +669,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                     true,
                                 )
                             };
-                            s.trait_ctx
+                            s.annotate_ctx.trait_ctx
                                 .type_params
                                 .insert(tp.name.clone(), (idx, type_id));
                             if consumed_index {
@@ -770,7 +770,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             // Set up type params for generic impls (e.g., impl List<T>).
                             // Inherited scope; only `type_params` is replaced.
                             let mut scope = self.enter_inherited_type_param_scope();
-                            scope.trait_ctx.type_params.clear();
+                            scope.annotate_ctx.trait_ctx.type_params.clear();
                             let mut impl_offset = 0u32;
                             if let Some(ref type_args) = receiver_type_args
                                 && let Type::Generic(generic) = &impl_block.ty
@@ -781,7 +781,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                         && i < type_args.len()
                                     {
                                         scope
-                                            .trait_ctx
+                                            .annotate_ctx.trait_ctx
                                             .type_params
                                             .insert(named.name.clone(), (i as u32, type_args[i]));
                                     }
@@ -799,7 +799,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                     },
                                 );
                                 scope
-                                    .trait_ctx
+                                    .annotate_ctx.trait_ctx
                                     .type_params
                                     .insert(type_param.name.clone(), (index, type_param_id));
                             }
@@ -938,12 +938,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // Set up type params for generic resources (e.g., resource Stream<T>).
             // Inherited scope; only `type_params` is replaced.
             let mut scope = self.enter_inherited_type_param_scope();
-            scope.trait_ctx.type_params.clear();
+            scope.annotate_ctx.trait_ctx.type_params.clear();
             if let Some(type_args) = receiver_type_args {
                 for (i, param) in resource.type_params.iter().enumerate() {
                     if i < type_args.len() {
                         scope
-                            .trait_ctx
+                            .annotate_ctx.trait_ctx
                             .type_params
                             .insert(param.name.clone(), (i as u32, type_args[i]));
                     }
@@ -1067,7 +1067,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 ..
             } => self.find_method_type_param_names(name, Some(module_source), method_name),
             ResolvedType::TypeParam { name, .. } | ResolvedType::TypePack { name, .. } => self
-                .trait_ctx
+                .annotate_ctx.trait_ctx
                 .type_param_bounds
                 .get(name)
                 .cloned()
@@ -1116,7 +1116,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // knows about — would leave a dangling id at the call site, so
         // drop the inference and let the caller fall back to `vec![]`.
         let scope_params: Vec<TypeId> = self
-            .trait_ctx
+            .annotate_ctx.trait_ctx
             .type_params
             .values()
             .map(|&(_, tid)| tid)
@@ -1844,8 +1844,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // just type_params and assoc_type_bindings — other parts (bounds,
             // self_type, …) are kept from the parent for this lookup.
             let mut scope = self.enter_inherited_type_param_scope();
-            scope.trait_ctx.type_params.clear();
-            scope.trait_ctx.assoc_type_bindings.clear();
+            scope.annotate_ctx.trait_ctx.type_params.clear();
+            scope.annotate_ctx.trait_ctx.assoc_type_bindings.clear();
 
             // Set up type parameters for resolving generic associated types
             if let Some(type_args) = receiver_type_args {
@@ -1853,7 +1853,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     let i = *idx as usize;
                     if i < type_args.len() {
                         scope
-                            .trait_ctx
+                            .annotate_ctx.trait_ctx
                             .type_params
                             .insert(name.clone(), (*idx, type_args[i]));
                     }
@@ -1867,7 +1867,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         .borrow_mut()
                         .make_tuple(type_args.to_vec());
                     scope
-                        .trait_ctx
+                        .annotate_ctx.trait_ctx
                         .type_params
                         .insert(pack_name.clone(), (*pack_idx, pack_type));
                 }
@@ -1875,12 +1875,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
             // For blanket impls where impl_ty is a free type parameter
             if let Some(ref name) = blanket_name
-                && !scope.trait_ctx.type_params.contains_key(name)
+                && !scope.annotate_ctx.trait_ctx.type_params.contains_key(name)
                 && !scope.tysys.is_known_type_name(name)
             {
                 if let Some(recv_id) = receiver_type_id {
                     scope
-                        .trait_ctx
+                        .annotate_ctx.trait_ctx
                         .type_params
                         .insert(name.clone(), (0, recv_id));
                 } else {
@@ -1890,7 +1890,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         .borrow_mut()
                         .make_type_param(name.clone(), 0);
                     scope
-                        .trait_ctx
+                        .annotate_ctx.trait_ctx
                         .type_params
                         .insert(name.clone(), (0, type_id));
                 }
@@ -1900,7 +1900,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             for (name, ty) in &assoc_bindings {
                 let type_id = scope.resolve_type(ty);
                 scope
-                    .trait_ctx
+                    .annotate_ctx.trait_ctx
                     .assoc_type_bindings
                     .insert(name.clone(), type_id);
             }
@@ -1960,7 +1960,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 let trait_name = scope.get_type_name_full(&trait_type_for_name);
 
                 // Set up method-level type params (e.g., V in deserialize_any<V: Visitor>)
-                let impl_offset = scope.trait_ctx.type_params.len() as u32;
+                let impl_offset = scope.annotate_ctx.trait_ctx.type_params.len() as u32;
                 for (i, type_param) in method_type_params.iter().enumerate() {
                     let index = impl_offset + i as u32;
                     let type_param_id =
@@ -1973,12 +1973,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 index,
                             });
                     scope
-                        .trait_ctx
+                        .annotate_ctx.trait_ctx
                         .type_params
                         .insert(type_param.name.clone(), (index, type_param_id));
                     if !type_param.bounds.is_empty() {
                         scope
-                            .trait_ctx
+                            .annotate_ctx.trait_ctx
                             .type_param_bounds
                             .insert(type_param.name.clone(), type_param.bounds.clone());
                     }
@@ -1990,9 +1990,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 // Without this, `resolve_type("Self")` falls through to
                 // UNKNOWN and the caller's argument typecheck silently
                 // accepts anything, surfacing as an ICE at codegen.
-                let old_self_type = scope.trait_ctx.self_type;
+                let old_self_type = scope.annotate_ctx.trait_ctx.self_type;
                 if let Some(recv_id) = receiver_type_id {
-                    scope.trait_ctx.self_type = Some(recv_id);
+                    scope.annotate_ctx.trait_ctx.self_type = Some(recv_id);
                 }
 
                 let return_type = return_type_ast
@@ -2005,13 +2005,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 // the proper `TypeParam` id that inference expects.
                 let param_types = scope.extract_param_types(&params);
 
-                scope.trait_ctx.self_type = old_self_type;
+                scope.annotate_ctx.trait_ctx.self_type = old_self_type;
 
                 // Remove method-level type params from scope
                 for type_param in &method_type_params {
-                    scope.trait_ctx.type_params.shift_remove(&type_param.name);
+                    scope.annotate_ctx.trait_ctx.type_params.shift_remove(&type_param.name);
                     scope
-                        .trait_ctx
+                        .annotate_ctx.trait_ctx
                         .type_param_bounds
                         .shift_remove(&type_param.name);
                 }
@@ -2083,9 +2083,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         if default_method.name == method_name && default_method.body.is_some() {
                             // Set up Self type so that `Self` in the default method's
                             // return type resolves to the concrete receiver type
-                            let old_self_type = scope.trait_ctx.self_type;
+                            let old_self_type = scope.annotate_ctx.trait_ctx.self_type;
                             if let Some(recv_id) = receiver_type_id {
-                                scope.trait_ctx.self_type = Some(recv_id);
+                                scope.annotate_ctx.trait_ctx.self_type = Some(recv_id);
                             }
 
                             // Bind the trait's own type parameters to the impl's
@@ -2097,7 +2097,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             scope.bind_trait_type_params_from_impl(&trait_type_for_name);
 
                             // Set up method-level type params (e.g., U in map<U>)
-                            let impl_offset = scope.trait_ctx.type_params.len() as u32;
+                            let impl_offset = scope.annotate_ctx.trait_ctx.type_params.len() as u32;
                             for (i, type_param) in default_method.type_params.iter().enumerate() {
                                 let index = impl_offset + i as u32;
                                 let type_param_id = scope.tysys.type_table.borrow_mut().intern(
@@ -2107,12 +2107,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                     },
                                 );
                                 scope
-                                    .trait_ctx
+                                    .annotate_ctx.trait_ctx
                                     .type_params
                                     .insert(type_param.name.clone(), (index, type_param_id));
                                 if !type_param.bounds.is_empty() {
                                     scope
-                                        .trait_ctx
+                                        .annotate_ctx.trait_ctx
                                         .type_param_bounds
                                         .insert(type_param.name.clone(), type_param.bounds.clone());
                                 }
@@ -2150,13 +2150,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
                             // Remove method-level type params from scope
                             for type_param in &default_method.type_params {
-                                scope.trait_ctx.type_params.shift_remove(&type_param.name);
+                                scope.annotate_ctx.trait_ctx.type_params.shift_remove(&type_param.name);
                                 scope
-                                    .trait_ctx
+                                    .annotate_ctx.trait_ctx
                                     .type_param_bounds
                                     .shift_remove(&type_param.name);
                             }
-                            scope.trait_ctx.self_type = old_self_type;
+                            scope.annotate_ctx.trait_ctx.self_type = old_self_type;
 
                             found_traits.push(TraitMethodMatch {
                                 trait_name: trait_name_str.clone(),
@@ -2636,8 +2636,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // single-source-of-truth for `Self` substitution is
             // `trait_ctx.self_type` (consulted by both `resolve_type` and
             // the `resolve_type_with_param_mapping` fallback above).
-            let saved_self_type = self.trait_ctx.self_type;
-            self.trait_ctx.self_type = Some(base_type_id);
+            let saved_self_type = self.annotate_ctx.trait_ctx.self_type;
+            self.annotate_ctx.trait_ctx.self_type = Some(base_type_id);
 
             // Process associated types (e.g., `type Output = Self`)
             let mut assoc_type_map: IndexMap<String, TypeId> = IndexMap::default();
@@ -2657,7 +2657,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 .as_ref()
                 .map(|ty| self.resolve_type_with_param_mapping(ty, &type_param_mapping));
 
-            self.trait_ctx.self_type = saved_self_type;
+            self.annotate_ctx.trait_ctx.self_type = saved_self_type;
 
             return Some(ArithmeticTraitInfo {
                 output_type,
@@ -2811,18 +2811,18 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
                 // Set up associated type bindings (auto-restored on scope drop)
                 let mut scope = self.enter_inherited_type_param_scope();
-                scope.trait_ctx.assoc_type_bindings.clear();
+                scope.annotate_ctx.trait_ctx.assoc_type_bindings.clear();
                 for (name, ty) in &assoc_bindings {
                     let type_id = scope.resolve_type_with_param_mapping(ty, &type_param_mapping);
                     scope
-                        .trait_ctx
+                        .annotate_ctx.trait_ctx
                         .assoc_type_bindings
                         .insert(name.clone(), type_id);
                 }
 
                 // Get the associated type (Output or Input)
                 let assoc_type = scope
-                    .trait_ctx
+                    .annotate_ctx.trait_ctx
                     .assoc_type_bindings
                     .get(assoc_type_name)
                     .copied()
@@ -2859,7 +2859,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 // that could drift.  Channeling Self through `trait_ctx`
                 // here closes that gap.
                 if n.name == "Self"
-                    && let Some(self_type) = self.trait_ctx.self_type
+                    && let Some(self_type) = self.annotate_ctx.trait_ctx.self_type
                 {
                     return self_type;
                 }

--- a/wado-compiler/src/elaborator/method_lookup.rs
+++ b/wado-compiler/src/elaborator/method_lookup.rs
@@ -280,11 +280,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             return ModuleSource::primitive();
         }
 
-        // Struct / resource / variant / enum / builtin declarations, read from
-        // the digested index (covers every loaded module including the current
-        // one). The current module wins when it declares the type, matching the
-        // previous current-module-first scan; otherwise the first declaring
-        // module in build order is returned.
+        // Struct / resource / variant / enum / builtin declarations from the
+        // digest (covers every loaded module, incl. the current one). The
+        // current module wins when it declares the type; else the first
+        // declaring module in build order.
         if let Some(modules) = self
             .tysys
             .trait_env
@@ -311,8 +310,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             }
         }
 
-        // Newtype declarations (fallback, no current-module preference — matches
-        // the previous loaded-modules scan order).
+        // Newtype declarations (fallback; no current-module preference).
         if let Some(modules) = self.tysys.trait_env.newtype_decl_modules.get(struct_name)
             && let Some(first) = modules.first()
         {
@@ -1195,9 +1193,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         trait_names: &[String],
         method_name: &str,
     ) -> Option<Vec<ast::GenericParam>> {
-        // `trait_decl_headers` already covers every loaded module (including
-        // the current one), so a single pass over the digested headers
-        // replaces the previous loaded-modules + current-module scans.
+        // `trait_decl_headers` covers every loaded module (incl. the current
+        // one), so one pass suffices.
         for header in self.tysys.trait_env.trait_decl_headers.values() {
             if trait_names.iter().any(|n| n == &header.name) {
                 for trait_method in &header.methods {
@@ -1254,9 +1251,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         struct_module_source: Option<&ModuleSource>,
         method_name: &str,
     ) -> Option<Vec<ast::GenericParam>> {
-        // Impl-method passes read the digested impl headers (which cover every
-        // loaded module including the current one, so the prior separate
-        // current-module scans are redundant). Inherent impls are tried first
+        // Impl-method passes read the digested headers (which cover every loaded
+        // module, incl. the current one). Inherent impls first
         // (include_trait = false), preferring the receiver's home module.
         if let Some(module_source) = struct_module_source
             && let Some(names) = self.search_impl_headers_method_tps(
@@ -2741,8 +2737,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let callee_module = &callee.module;
         let func_name = callee.name.as_str();
         let fn_type_params = &self.tysys.trait_env.function_type_params;
-        // Entry-point callees are looked up in the current module's functions
-        // first (preserving the previous current-module scan).
+        // Entry-point callees are looked up in the current module's functions first.
         if callee_module.is_entry_point()
             && let Some(tps) =
                 fn_type_params.get(&(self.current_module_source.clone(), func_name.to_string()))

--- a/wado-compiler/src/elaborator/method_lookup.rs
+++ b/wado-compiler/src/elaborator/method_lookup.rs
@@ -1225,28 +1225,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         trait_names: &[String],
         method_name: &str,
     ) -> Option<Vec<ast::GenericParam>> {
-        for module in self.loaded_modules.values() {
-            for item in &module.items {
-                if let Item::Trait(trait_decl) = item
-                    && trait_names.iter().any(|n| n == &trait_decl.name)
-                {
-                    for trait_method in &trait_decl.methods {
-                        if trait_method.name == method_name
-                            && let Some(params) = Self::non_effect_type_params(trait_method)
-                        {
-                            return Some(params);
-                        }
-                    }
-                }
-            }
-        }
-        for item in self.current_module_items {
-            if let Item::Trait(trait_decl) = item
-                && trait_names.iter().any(|n| n == &trait_decl.name)
-            {
-                for trait_method in &trait_decl.methods {
+        // `trait_decl_headers` already covers every loaded module (including
+        // the current one), so a single pass over the digested headers
+        // replaces the previous loaded-modules + current-module scans.
+        for header in self.tysys.trait_env.trait_decl_headers.values() {
+            if trait_names.iter().any(|n| n == &header.name) {
+                for trait_method in &header.methods {
                     if trait_method.name == method_name
-                        && let Some(params) = Self::non_effect_type_params(trait_method)
+                        && let Some(params) = Self::non_effect_generic_params(&trait_method.type_params)
                     {
                         return Some(params);
                     }
@@ -1260,8 +1246,17 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// order), or `None` when there are none. Shared by the method
     /// type-parameter lookups used by `infer_method_type_args`.
     fn non_effect_type_params(method: &ast::Function) -> Option<Vec<ast::GenericParam>> {
-        let params: Vec<ast::GenericParam> = method
-            .type_params
+        Self::non_effect_generic_params(&method.type_params)
+    }
+
+    /// The non-effect subset of a type-parameter list (cloned, in declaration
+    /// order), or `None` when empty. Operates on the bare parameter slice so
+    /// digested headers ([`super::trait_env::ImplMethodHeader`]) can reuse it
+    /// without the method AST.
+    fn non_effect_generic_params(
+        type_params: &[ast::GenericParam],
+    ) -> Option<Vec<ast::GenericParam>> {
+        let params: Vec<ast::GenericParam> = type_params
             .iter()
             .filter(|p| !p.is_effect)
             .cloned()

--- a/wado-compiler/src/elaborator/method_lookup.rs
+++ b/wado-compiler/src/elaborator/method_lookup.rs
@@ -1242,13 +1242,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         None
     }
 
-    /// The method's non-effect type parameters (cloned, in declaration
-    /// order), or `None` when there are none. Shared by the method
-    /// type-parameter lookups used by `infer_method_type_args`.
-    fn non_effect_type_params(method: &ast::Function) -> Option<Vec<ast::GenericParam>> {
-        Self::non_effect_generic_params(&method.type_params)
-    }
-
     /// The non-effect subset of a type-parameter list (cloned, in declaration
     /// order), or `None` when empty. Operates on the bare parameter slice so
     /// digested headers ([`super::trait_env::ImplMethodHeader`]) can reuse it
@@ -1290,65 +1283,29 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         struct_module_source: Option<&ModuleSource>,
         method_name: &str,
     ) -> Option<Vec<ast::GenericParam>> {
-        let extract_names = Self::non_effect_type_params;
-
-        let impl_matches_struct = |impl_block: &ast::ImplBlock, include_trait: bool| -> bool {
-            if !include_trait && impl_block.trait_type.is_some() {
-                return false;
-            }
-            let impl_type_name = self.get_type_name(&impl_block.ty);
-            let impl_base_name = impl_type_name.split('<').next().unwrap_or(&impl_type_name);
-            impl_type_name == struct_name || impl_base_name == struct_name
-        };
-
-        let search_items =
-            |items: &[Item], include_trait: bool| -> Option<Vec<ast::GenericParam>> {
-                for item in items {
-                    if let Item::Impl(impl_block) = item
-                        && impl_matches_struct(impl_block, include_trait)
-                    {
-                        for method in &impl_block.methods {
-                            if method.name == method_name
-                                && let Some(names) = extract_names(method)
-                            {
-                                return Some(names);
-                            }
-                        }
-                    }
-                }
-                None
-            };
-
+        // Impl-method passes read the digested impl headers (which cover every
+        // loaded module including the current one, so the prior separate
+        // current-module scans are redundant). Inherent impls are tried first
+        // (include_trait = false), preferring the receiver's home module.
         if let Some(module_source) = struct_module_source
-            && let Some(module) = self.loaded_modules.get(module_source)
-            && let Some(names) = search_items(&module.items, false)
+            && let Some(names) =
+                self.search_impl_headers_method_tps(struct_name, method_name, false, Some(module_source))
+        {
+            return Some(names);
+        }
+        if let Some(names) = self.search_impl_headers_method_tps(struct_name, method_name, false, None)
         {
             return Some(names);
         }
 
-        for module in self.loaded_modules.values() {
-            if let Some(names) = search_items(&module.items, false) {
-                return Some(names);
-            }
-        }
-
-        if let Some(names) = search_items(self.current_module_items, false) {
-            return Some(names);
-        }
-
-        // Fallback: trait default methods. These have no enclosing impl, so
-        // their "impl type params" are empty.
-        for module in self.loaded_modules.values() {
-            for item in &module.items {
-                if let Item::Trait(trait_decl) = item {
-                    for default_method in &trait_decl.methods {
-                        if default_method.name == method_name
-                            && default_method.body.is_some()
-                            && let Some(names) = extract_names(default_method)
-                        {
-                            return Some(names);
-                        }
-                    }
+        // Fallback: trait default methods (those with a body).
+        for header in self.tysys.trait_env.trait_decl_headers.values() {
+            for m in &header.methods {
+                if m.name == method_name
+                    && m.has_body
+                    && let Some(names) = Self::non_effect_generic_params(&m.type_params)
+                {
+                    return Some(names);
                 }
             }
         }
@@ -1358,38 +1315,64 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // (e.g. `fn put<T: Display>(&mut self, v: &T)`), which the inference
         // solver needs to materialise.
         if let Some(module_source) = struct_module_source
-            && let Some(module) = self.loaded_modules.get(module_source)
-            && let Some(names) = search_items(&module.items, true)
+            && let Some(names) =
+                self.search_impl_headers_method_tps(struct_name, method_name, true, Some(module_source))
+        {
+            return Some(names);
+        }
+        if let Some(names) = self.search_impl_headers_method_tps(struct_name, method_name, true, None)
         {
             return Some(names);
         }
 
-        for module in self.loaded_modules.values() {
-            if let Some(names) = search_items(&module.items, true) {
-                return Some(names);
-            }
-        }
-
-        if let Some(names) = search_items(self.current_module_items, true) {
-            return Some(names);
-        }
-
-        // Fallback: trait method declarations without default body. These can
-        // be called through a trait impl that reuses the declared type params.
-        for module in self.loaded_modules.values() {
-            for item in &module.items {
-                if let Item::Trait(trait_decl) = item {
-                    for trait_method in &trait_decl.methods {
-                        if trait_method.name == method_name
-                            && let Some(names) = extract_names(trait_method)
-                        {
-                            return Some(names);
-                        }
-                    }
+        // Fallback: trait method declarations (any body). These can be called
+        // through a trait impl that reuses the declared type params.
+        for header in self.tysys.trait_env.trait_decl_headers.values() {
+            for m in &header.methods {
+                if m.name == method_name
+                    && let Some(names) = Self::non_effect_generic_params(&m.type_params)
+                {
+                    return Some(names);
                 }
             }
         }
 
+        None
+    }
+
+    /// Scan the digested impl headers for a method named `method_name` on
+    /// `struct_name` (by exact name or generic base name) and return its
+    /// non-effect type parameters. `include_trait` controls whether trait
+    /// impls participate (inherent-only when false); `only_module` restricts
+    /// the scan to a single module's impls when set.
+    fn search_impl_headers_method_tps(
+        &self,
+        struct_name: &str,
+        method_name: &str,
+        include_trait: bool,
+        only_module: Option<&ModuleSource>,
+    ) -> Option<Vec<ast::GenericParam>> {
+        for (key, header) in &self.tysys.trait_env.impl_headers {
+            if let Some(m) = only_module
+                && &key.0 != m
+            {
+                continue;
+            }
+            if !include_trait && header.trait_name.is_some() {
+                continue;
+            }
+            let impl_type_name = self.get_type_name(&header.ty);
+            let impl_base_name = impl_type_name.split('<').next().unwrap_or(&impl_type_name);
+            if impl_type_name == struct_name || impl_base_name == struct_name {
+                for method in &header.methods {
+                    if method.name == method_name
+                        && let Some(names) = Self::non_effect_generic_params(&method.type_params)
+                    {
+                        return Some(names);
+                    }
+                }
+            }
+        }
         None
     }
 

--- a/wado-compiler/src/elaborator/method_lookup.rs
+++ b/wado-compiler/src/elaborator/method_lookup.rs
@@ -554,19 +554,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 // (the impl may live in a different module than the receiver
                 // type's declaration), and it reveals which declaration the
                 // impl's bare target name refers to.
-                let (target_imports, target_originals) = self
-                    .loaded_modules
-                    .get(impl_module)
-                    .map(|m| {
-                        Self::build_imported_type_sources(
-                            &mut self.interner.borrow_mut(),
-                            m,
-                            impl_module,
-                            Some(&self.entry_module_source),
-                            &self.invocations,
-                        )
-                    })
-                    .unwrap_or_default();
+                let (target_imports, target_originals) =
+                    self.tysys.trait_env.import_scope(impl_module);
                 // Identity guard: the impl's target type must be the receiver's
                 // own declaration. An impl in the receiver's home module
                 // declares it; otherwise the impl must import that same
@@ -1734,19 +1723,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 };
                 if !skip_filter {
                     let impl_module = impl_ref.0.clone();
-                    let (imports, originals) = self
-                        .loaded_modules
-                        .get(&impl_module)
-                        .map(|m| {
-                            Self::build_imported_type_sources(
-                                &mut self.interner.borrow_mut(),
-                                m,
-                                &impl_module,
-                                Some(&self.entry_module_source),
-                                &self.invocations,
-                            )
-                        })
-                        .unwrap_or_default();
+                    let (imports, originals) = self.tysys.trait_env.import_scope(&impl_module);
                     let impl_recv_id =
                         self.with_module_perspective(impl_module, imports, originals, |s| {
                             s.resolve_type(&impl_ty_clone)

--- a/wado-compiler/src/elaborator/method_lookup.rs
+++ b/wado-compiler/src/elaborator/method_lookup.rs
@@ -608,7 +608,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     &impl_block.type_params,
                     receiver_type_args.as_deref(),
                     impl_module,
-                ) && self.check_impl_block_bounds(impl_block, receiver_type_args.as_deref()))
+                ) && self.check_impl_block_bounds(&impl_block.type_params, &impl_block.ty, receiver_type_args.as_deref()))
                 {
                     continue;
                 }
@@ -798,7 +798,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         receiver_type_args.as_deref(),
                         search_module_source,
                     )
-                    && self.check_impl_block_bounds(impl_block, receiver_type_args.as_deref())
+                    && self.check_impl_block_bounds(&impl_block.type_params, &impl_block.ty, receiver_type_args.as_deref())
                 {
                     for method in &impl_block.methods {
                         if method.name == method_name {

--- a/wado-compiler/src/elaborator/method_lookup.rs
+++ b/wado-compiler/src/elaborator/method_lookup.rs
@@ -310,7 +310,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             }
         }
 
-        // Newtype declarations (fallback; no current-module preference).
         if let Some(modules) = self.tysys.trait_env.newtype_decl_modules.get(struct_name)
             && let Some(first) = modules.first()
         {
@@ -2744,7 +2743,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         {
             return tps.clone();
         }
-        // Then the callee's own module.
         if let Some(tps) = fn_type_params.get(&(callee_module.clone(), func_name.to_string())) {
             return tps.clone();
         }

--- a/wado-compiler/src/elaborator/method_lookup.rs
+++ b/wado-compiler/src/elaborator/method_lookup.rs
@@ -13,6 +13,7 @@ use crate::token::Span;
 
 use super::Elaborator;
 use super::infer::InferCtx;
+use super::tysys::TypeSystem;
 use super::types::{
     ArithmeticTraitInfo, FunctionContext, IndexAssignTraitInfo, IndexMutTraitInfo, IndexTraitInfo,
     IndexValueTraitInfo, KeyValueLiteralTraitInfo, MethodInfo, SequenceLiteralTraitInfo, TypeError,
@@ -2545,16 +2546,15 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 None => continue,
             };
             let declared_type_params = self.build_declared_type_params(impl_block);
-            let type_param_mapping = Self::build_type_param_mapping(
+            let type_param_mapping = TypeSystem::build_type_param_mapping(
                 &impl_block.ty,
                 &concrete_type_args,
                 &declared_type_params,
             );
-            if !Self::verify_impl_type_compatibility(
+            if !self.tysys.verify_impl_type_compatibility(
                 &impl_block.ty,
                 &concrete_type_args,
                 &declared_type_params,
-                &self.tysys.type_table,
             ) {
                 continue;
             }
@@ -2807,7 +2807,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // keeps Self substitution on a single mechanism shared with
             // `find_trait_method_for_type`.
             let impl_block = self.get_impl_block(impl_ref);
-            let type_param_mapping = Self::build_type_param_mapping(
+            let type_param_mapping = TypeSystem::build_type_param_mapping(
                 &impl_block.ty,
                 &concrete_type_args,
                 &IndexSet::default(),
@@ -3035,7 +3035,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             let declared_type_params = self.build_declared_type_params(impl_block);
 
             let impl_block = self.get_impl_block(impl_ref);
-            let type_param_mapping = Self::build_type_param_mapping(
+            let type_param_mapping = TypeSystem::build_type_param_mapping(
                 &impl_block.ty,
                 &concrete_type_args,
                 &declared_type_params,
@@ -3064,11 +3064,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
             // Verify non-type-parameter positions match the concrete type args
             let impl_block = self.get_impl_block(impl_ref);
-            if !Self::verify_impl_type_compatibility(
+            if !self.tysys.verify_impl_type_compatibility(
                 &impl_block.ty,
                 &concrete_type_args,
                 &declared_type_params,
-                &self.tysys.type_table,
             ) {
                 continue;
             }
@@ -3238,17 +3237,16 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             };
 
             let declared_type_params = self.build_declared_type_params(impl_block);
-            let type_param_mapping = Self::build_type_param_mapping(
+            let type_param_mapping = TypeSystem::build_type_param_mapping(
                 &impl_block.ty,
                 &concrete_type_args,
                 &declared_type_params,
             );
 
-            if !Self::verify_impl_type_compatibility(
+            if !self.tysys.verify_impl_type_compatibility(
                 &impl_block.ty,
                 &concrete_type_args,
                 &declared_type_params,
-                &self.tysys.type_table,
             ) {
                 continue;
             }

--- a/wado-compiler/src/elaborator/method_lookup.rs
+++ b/wado-compiler/src/elaborator/method_lookup.rs
@@ -1616,28 +1616,31 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Blanket impl fallback: check `impl<T: Bound> Trait for T` where the receiver
         // type satisfies the bound.  e.g., `impl<I: Iterator> IntoIterator for I` matches
         // any concrete type that implements Iterator.
-        for (module_src, item_idx) in &self.tysys.trait_env.blanket_impl_index {
-            let module = &self.loaded_modules[module_src];
-            if let Item::Impl(impl_block) = &module.items[*item_idx]
-                && impl_block.trait_type.is_some()
-            {
-                // Find the type param that is the impl target
-                let impl_type_name = Self::get_type_name_static(&impl_block.ty);
-                let matching_param = impl_block
-                    .type_params
-                    .iter()
-                    .find(|tp| tp.name == impl_type_name);
-                if let Some(param) = matching_param {
-                    // Check if the receiver type satisfies ALL trait bounds
-                    let bounds_satisfied = param.bounds.iter().all(|bound| {
-                        let bound_trait_name = &bound.name;
-                        names_to_check
-                            .iter()
-                            .any(|name| self.find_trait_impl_for_type(name, bound_trait_name))
-                    });
-                    if bounds_satisfied {
-                        impl_refs.push(ImplBlockRef(module_src.clone(), *item_idx));
-                    }
+        let blanket_entries = self.tysys.trait_env.blanket_impl_index.clone();
+        for entry in &blanket_entries {
+            let Some(header) = self.tysys.trait_env.impl_headers.get(entry) else {
+                continue;
+            };
+            if header.trait_name.is_none() {
+                continue;
+            }
+            // Find the type param that is the impl target
+            let impl_type_name = Self::get_type_name_static(&header.ty);
+            let matching_param = header
+                .type_params
+                .iter()
+                .find(|tp| tp.name == impl_type_name)
+                .cloned();
+            if let Some(param) = matching_param {
+                // Check if the receiver type satisfies ALL trait bounds
+                let bounds_satisfied = param.bounds.iter().all(|bound| {
+                    let bound_trait_name = &bound.name;
+                    names_to_check
+                        .iter()
+                        .any(|name| self.find_trait_impl_for_type(name, bound_trait_name))
+                });
+                if bounds_satisfied {
+                    impl_refs.push(ImplBlockRef(entry.0.clone(), entry.1));
                 }
             }
         }

--- a/wado-compiler/src/elaborator/method_lookup.rs
+++ b/wado-compiler/src/elaborator/method_lookup.rs
@@ -281,49 +281,22 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             return ModuleSource::primitive();
         }
 
-        // Check current module
-        for item in self.current_module_items {
-            match item {
-                Item::Struct(s) if s.name == struct_name => {
-                    return self.current_module_source.clone();
-                }
-                Item::Resource(r) if r.name == struct_name => {
-                    return self.current_module_source.clone();
-                }
-                Item::Variant(v) if v.name == struct_name => {
-                    return self.current_module_source.clone();
-                }
-                Item::Enum(e) if e.name == struct_name => {
-                    return self.current_module_source.clone();
-                }
-                Item::BuiltinTypeDecl(d) if d.name == struct_name => {
-                    return self.current_module_source.clone();
-                }
-                _ => {}
+        // Struct / resource / variant / enum / builtin declarations, read from
+        // the digested index (covers every loaded module including the current
+        // one). The current module wins when it declares the type, matching the
+        // previous current-module-first scan; otherwise the first declaring
+        // module in build order is returned.
+        if let Some(modules) = self
+            .tysys
+            .trait_env
+            .struct_like_decl_modules
+            .get(struct_name)
+        {
+            if modules.contains(&self.current_module_source) {
+                return self.current_module_source.clone();
             }
-        }
-
-        // Check loaded modules
-        for (module_source, module) in self.loaded_modules {
-            for item in &module.items {
-                match item {
-                    Item::Struct(s) if s.name == struct_name => {
-                        return module_source.clone();
-                    }
-                    Item::Resource(r) if r.name == struct_name => {
-                        return module_source.clone();
-                    }
-                    Item::Variant(v) if v.name == struct_name => {
-                        return module_source.clone();
-                    }
-                    Item::Enum(e) if e.name == struct_name => {
-                        return module_source.clone();
-                    }
-                    Item::BuiltinTypeDecl(d) if d.name == struct_name => {
-                        return module_source.clone();
-                    }
-                    _ => {}
-                }
+            if let Some(first) = modules.first() {
+                return first.clone();
             }
         }
 
@@ -339,15 +312,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             }
         }
 
-        // Check loaded modules for newtype definitions
-        for (module_source, module) in self.loaded_modules {
-            for item in &module.items {
-                if let Item::Newtype(alias) = item
-                    && alias.name == struct_name
-                {
-                    return module_source.clone();
-                }
-            }
+        // Newtype declarations (fallback, no current-module preference — matches
+        // the previous loaded-modules scan order).
+        if let Some(modules) = self.tysys.trait_env.newtype_decl_modules.get(struct_name)
+            && let Some(first) = modules.first()
+        {
+            return first.clone();
         }
 
         // Aliased imports (`use { Counter as CounterA }`) aren't declared
@@ -2750,28 +2720,19 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     ) -> Vec<ast::GenericParam> {
         let callee_module = &callee.module;
         let func_name = callee.name.as_str();
-        // Try local functions
-        if callee_module.is_entry_point() {
-            for item in self.current_module_items {
-                if let ast::Item::Function(func) = item
-                    && func.name == func_name
-                {
-                    return func.type_params.clone();
-                }
-            }
+        let fn_type_params = &self.tysys.trait_env.function_type_params;
+        // Entry-point callees are looked up in the current module's functions
+        // first (preserving the previous current-module scan).
+        if callee_module.is_entry_point()
+            && let Some(tps) =
+                fn_type_params.get(&(self.current_module_source.clone(), func_name.to_string()))
+        {
+            return tps.clone();
         }
-
-        // Try loaded modules
-        if let Some(module) = self.loaded_modules.get(callee_module) {
-            for item in &module.items {
-                if let ast::Item::Function(func) = item
-                    && func.name == func_name
-                {
-                    return func.type_params.clone();
-                }
-            }
+        // Then the callee's own module.
+        if let Some(tps) = fn_type_params.get(&(callee_module.clone(), func_name.to_string())) {
+            return tps.clone();
         }
-
         Vec::new()
     }
 

--- a/wado-compiler/src/elaborator/module.rs
+++ b/wado-compiler/src/elaborator/module.rs
@@ -181,7 +181,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     let type_param_type_ids: Vec<TypeId> = variant_decl
                         .type_params
                         .iter()
-                        .filter_map(|p| scope.annotate_ctx.trait_ctx.type_params.get(&p.name).map(|&(_, id)| id))
+                        .filter_map(|p| {
+                            scope
+                                .annotate_ctx
+                                .trait_ctx
+                                .type_params
+                                .get(&p.name)
+                                .map(|&(_, id)| id)
+                        })
                         .collect();
 
                     // Collect type parameters
@@ -399,16 +406,19 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 .make_type_param(param.name.clone(), actual_idx)
                         };
                         scope
-                            .annotate_ctx.trait_ctx
+                            .annotate_ctx
+                            .trait_ctx
                             .type_params
                             .insert(param.name.clone(), (actual_idx, type_id));
                         scope
-                            .annotate_ctx.trait_ctx
+                            .annotate_ctx
+                            .trait_ctx
                             .type_param_decls
                             .insert(param.name.clone(), param.id);
                         if !param.bounds.is_empty() {
                             scope
-                                .annotate_ctx.trait_ctx
+                                .annotate_ctx
+                                .trait_ctx
                                 .type_param_bounds
                                 .insert(param.name.clone(), param.bounds.clone());
                         }
@@ -441,7 +451,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                         .borrow_mut()
                                         .make_type_param(name.clone(), index);
                                     scope
-                                        .annotate_ctx.trait_ctx
+                                        .annotate_ctx
+                                        .trait_ctx
                                         .type_params
                                         .insert(name.clone(), (index, type_id));
                                 }
@@ -454,7 +465,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         for binding in &impl_block.associated_types {
                             let type_id = scope.resolve_type(&binding.ty);
                             scope
-                                .annotate_ctx.trait_ctx
+                                .annotate_ctx
+                                .trait_ctx
                                 .assoc_type_bindings
                                 .insert(binding.name.clone(), type_id);
                         }
@@ -510,16 +522,19 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 .borrow_mut()
                                 .make_type_param(param.name.clone(), idx);
                             scope
-                                .annotate_ctx.trait_ctx
+                                .annotate_ctx
+                                .trait_ctx
                                 .type_params
                                 .insert(param.name.clone(), (idx, type_id));
                             scope
-                                .annotate_ctx.trait_ctx
+                                .annotate_ctx
+                                .trait_ctx
                                 .type_param_decls
                                 .insert(param.name.clone(), param.id);
                             if !param.bounds.is_empty() {
                                 scope
-                                    .annotate_ctx.trait_ctx
+                                    .annotate_ctx
+                                    .trait_ctx
                                     .type_param_bounds
                                     .insert(param.name.clone(), param.bounds.clone());
                             }
@@ -535,7 +550,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         // Remove method-level type params from scope
                         for name in &method_type_param_names {
                             scope.annotate_ctx.trait_ctx.type_params.shift_remove(name);
-                            scope.annotate_ctx.trait_ctx.type_param_bounds.shift_remove(name);
+                            scope
+                                .annotate_ctx
+                                .trait_ctx
+                                .type_param_bounds
+                                .shift_remove(name);
                         }
 
                         let mangled_name = MethodName::format_local(

--- a/wado-compiler/src/elaborator/module.rs
+++ b/wado-compiler/src/elaborator/module.rs
@@ -86,8 +86,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     // visible — only `type_params` and `type_param_bounds` are
                     // replaced, matching the original `mem::take` semantics.
                     let mut scope = self.enter_inherited_type_param_scope();
-                    scope.trait_ctx.type_params.clear();
-                    scope.trait_ctx.type_param_bounds.clear();
+                    scope.annotate_ctx.trait_ctx.type_params.clear();
+                    scope.annotate_ctx.trait_ctx.type_param_bounds.clear();
                     scope.register_generic_params(&struct_decl.type_params, 0);
 
                     let mut fields = Vec::new();
@@ -174,14 +174,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     // Set up type parameters in scope for resolving field types.
                     // Use an inherited scope so caller-provided context stays
                     // visible — only `type_params` is replaced, matching the
-                    // original `mem::take(&mut self.trait_ctx.type_params)`.
+                    // original `mem::take(&mut self.annotate_ctx.trait_ctx.type_params)`.
                     let mut scope = self.enter_inherited_type_param_scope();
-                    scope.trait_ctx.type_params.clear();
+                    scope.annotate_ctx.trait_ctx.type_params.clear();
                     scope.register_generic_params(&variant_decl.type_params, 0);
                     let type_param_type_ids: Vec<TypeId> = variant_decl
                         .type_params
                         .iter()
-                        .filter_map(|p| scope.trait_ctx.type_params.get(&p.name).map(|&(_, id)| id))
+                        .filter_map(|p| scope.annotate_ctx.trait_ctx.type_params.get(&p.name).map(|&(_, id)| id))
                         .collect();
 
                     // Collect type parameters
@@ -350,8 +350,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     // only `type_params` and `type_param_bounds` are replaced
                     // (matching the original `mem::take` semantics).
                     let mut scope = self.enter_inherited_type_param_scope();
-                    scope.trait_ctx.type_params.clear();
-                    scope.trait_ctx.type_param_bounds.clear();
+                    scope.annotate_ctx.trait_ctx.type_params.clear();
+                    scope.annotate_ctx.trait_ctx.type_param_bounds.clear();
                     scope.register_generic_params(&func.type_params, 0);
                     let return_type = func
                         .return_type
@@ -371,9 +371,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     // `assoc_type_bindings` are replaced (matching the
                     // original `mem::take` semantics for those fields).
                     let mut scope = self.enter_inherited_type_param_scope();
-                    scope.trait_ctx.type_params.clear();
-                    scope.trait_ctx.type_param_bounds.clear();
-                    scope.trait_ctx.assoc_type_bindings.clear();
+                    scope.annotate_ctx.trait_ctx.type_params.clear();
+                    scope.annotate_ctx.trait_ctx.type_param_bounds.clear();
+                    scope.annotate_ctx.trait_ctx.assoc_type_bindings.clear();
 
                     // First, collect explicit type params from impl<T>, skipping concrete types
                     // (e.g., `impl<i32, T> IndexValue<i32> for Triple<T>` — skip "i32").
@@ -399,16 +399,16 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 .make_type_param(param.name.clone(), actual_idx)
                         };
                         scope
-                            .trait_ctx
+                            .annotate_ctx.trait_ctx
                             .type_params
                             .insert(param.name.clone(), (actual_idx, type_id));
                         scope
-                            .trait_ctx
+                            .annotate_ctx.trait_ctx
                             .type_param_decls
                             .insert(param.name.clone(), param.id);
                         if !param.bounds.is_empty() {
                             scope
-                                .trait_ctx
+                                .annotate_ctx.trait_ctx
                                 .type_param_bounds
                                 .insert(param.name.clone(), param.bounds.clone());
                         }
@@ -429,7 +429,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         for (i, arg) in generic.args.iter().enumerate() {
                             if let ast::Type::Named(named) = arg {
                                 let name = &named.name;
-                                if !scope.trait_ctx.type_params.contains_key(name)
+                                if !scope.annotate_ctx.trait_ctx.type_params.contains_key(name)
                                     && !scope
                                         .tysys
                                         .is_known_type_name_in(&scope.current_module_source, name)
@@ -441,7 +441,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                         .borrow_mut()
                                         .make_type_param(name.clone(), index);
                                     scope
-                                        .trait_ctx
+                                        .annotate_ctx.trait_ctx
                                         .type_params
                                         .insert(name.clone(), (index, type_id));
                                 }
@@ -454,7 +454,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         for binding in &impl_block.associated_types {
                             let type_id = scope.resolve_type(&binding.ty);
                             scope
-                                .trait_ctx
+                                .annotate_ctx.trait_ctx
                                 .assoc_type_bindings
                                 .insert(binding.name.clone(), type_id);
                         }
@@ -501,7 +501,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         // Set up method-level type parameters so that `V::Output`-style
                         // associated type projections can be resolved in the return type.
                         let mut method_type_param_names: Vec<String> = Vec::new();
-                        let offset = scope.trait_ctx.type_params.len();
+                        let offset = scope.annotate_ctx.trait_ctx.type_params.len();
                         for (i, param) in method.type_params.iter().enumerate() {
                             let idx = (offset + i) as u32;
                             let type_id = scope
@@ -510,16 +510,16 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 .borrow_mut()
                                 .make_type_param(param.name.clone(), idx);
                             scope
-                                .trait_ctx
+                                .annotate_ctx.trait_ctx
                                 .type_params
                                 .insert(param.name.clone(), (idx, type_id));
                             scope
-                                .trait_ctx
+                                .annotate_ctx.trait_ctx
                                 .type_param_decls
                                 .insert(param.name.clone(), param.id);
                             if !param.bounds.is_empty() {
                                 scope
-                                    .trait_ctx
+                                    .annotate_ctx.trait_ctx
                                     .type_param_bounds
                                     .insert(param.name.clone(), param.bounds.clone());
                             }
@@ -534,8 +534,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
                         // Remove method-level type params from scope
                         for name in &method_type_param_names {
-                            scope.trait_ctx.type_params.shift_remove(name);
-                            scope.trait_ctx.type_param_bounds.shift_remove(name);
+                            scope.annotate_ctx.trait_ctx.type_params.shift_remove(name);
+                            scope.annotate_ctx.trait_ctx.type_param_bounds.shift_remove(name);
                         }
 
                         let mangled_name = MethodName::format_local(

--- a/wado-compiler/src/elaborator/operators.rs
+++ b/wado-compiler/src/elaborator/operators.rs
@@ -399,7 +399,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 _ => None,
             };
             if let Some(name) = type_param_name
-                && let Some(bounds) = self.annotate_ctx.trait_ctx.type_param_bounds.get(&name).cloned()
+                && let Some(bounds) = self
+                    .annotate_ctx
+                    .trait_ctx
+                    .type_param_bounds
+                    .get(&name)
+                    .cloned()
             {
                 let bound_names: Vec<String> = bounds.iter().map(|b| b.name.clone()).collect();
                 if matches!(op, BinaryOp::Eq | BinaryOp::NotEq)
@@ -544,7 +549,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
             // TypeParam with trait bounds: resolve arithmetic operators via trait bound methods
             if let ResolvedType::TypeParam { name, .. } = &left_type
-                && let Some(bounds) = self.annotate_ctx.trait_ctx.type_param_bounds.get(name).cloned()
+                && let Some(bounds) = self
+                    .annotate_ctx
+                    .trait_ctx
+                    .type_param_bounds
+                    .get(name)
+                    .cloned()
             {
                 let operand_type_id = left.type_id;
                 let bound_names: Vec<String> = bounds.iter().map(|b| b.name.clone()).collect();

--- a/wado-compiler/src/elaborator/operators.rs
+++ b/wado-compiler/src/elaborator/operators.rs
@@ -287,7 +287,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     match tt.get(ultimate) {
                         ResolvedType::Struct { .. } | ResolvedType::GenericInstance { .. } => {
                             drop(tt);
-                            self.struct_name_for_type(*base_type)
+                            self.tysys.struct_name_for_type(*base_type)
                         }
                         _ => None,
                     }
@@ -511,7 +511,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
                 // For newtypes, resolve base type for trait impl fallback
                 let (lookup_name, lookup_type_id) =
-                    self.newtype_base_lookup(&struct_name, left.type_id);
+                    self.tysys.newtype_base_lookup(&struct_name, left.type_id);
 
                 // Find the arithmetic trait implementation
                 let (trait_info_opt, impl_name) = self
@@ -607,7 +607,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
                 // For newtypes, resolve base type for trait impl fallback
                 let (lookup_name, lookup_type_id) =
-                    self.newtype_base_lookup(&struct_name, left.type_id);
+                    self.tysys.newtype_base_lookup(&struct_name, left.type_id);
 
                 // Find the shift trait implementation
                 let (trait_info_opt, impl_name) = self
@@ -927,7 +927,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             };
             if let Some(struct_name) = struct_name {
                 let (lookup_name, lookup_type_id) =
-                    self.newtype_base_lookup(&struct_name, expr_type);
+                    self.tysys.newtype_base_lookup(&struct_name, expr_type);
                 let resolved = self
                     .resolve_trait_method_for_op(
                         &struct_name,
@@ -1141,7 +1141,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
                 // For newtypes, resolve the base type name for trait impl lookup
                 let (lookup_name, lookup_type_id) =
-                    self.newtype_base_lookup(&struct_name, base_type_id);
+                    self.tysys.newtype_base_lookup(&struct_name, base_type_id);
 
                 if !struct_name.is_empty() {
                     let index_type = self.resolve_expr(&index_expr.index, ctx, None);

--- a/wado-compiler/src/elaborator/operators.rs
+++ b/wado-compiler/src/elaborator/operators.rs
@@ -399,7 +399,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 _ => None,
             };
             if let Some(name) = type_param_name
-                && let Some(bounds) = self.trait_ctx.type_param_bounds.get(&name).cloned()
+                && let Some(bounds) = self.annotate_ctx.trait_ctx.type_param_bounds.get(&name).cloned()
             {
                 let bound_names: Vec<String> = bounds.iter().map(|b| b.name.clone()).collect();
                 if matches!(op, BinaryOp::Eq | BinaryOp::NotEq)
@@ -544,7 +544,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
             // TypeParam with trait bounds: resolve arithmetic operators via trait bound methods
             if let ResolvedType::TypeParam { name, .. } = &left_type
-                && let Some(bounds) = self.trait_ctx.type_param_bounds.get(name).cloned()
+                && let Some(bounds) = self.annotate_ctx.trait_ctx.type_param_bounds.get(name).cloned()
             {
                 let operand_type_id = left.type_id;
                 let bound_names: Vec<String> = bounds.iter().map(|b| b.name.clone()).collect();

--- a/wado-compiler/src/elaborator/orchestration.rs
+++ b/wado-compiler/src/elaborator/orchestration.rs
@@ -1362,8 +1362,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                 current_module_items: &[], // Set in Elaborator::resolve_module
                 current_effect_params: IndexSet::default(),
                 current_effect_param_decls: IndexMap::default(),
-                trait_ctx: super::trait_env::TraitContext::default(),
-                trait_check_stack: RefCell::new(Vec::new()),
+                annotate_ctx: super::trait_env::AnnotateCtx::default(),
                 default_scope_module: None,
                 invocations: Rc::clone(&state.invocations),
                 interner: Rc::clone(&state.interner),

--- a/wado-compiler/src/elaborator/orchestration.rs
+++ b/wado-compiler/src/elaborator/orchestration.rs
@@ -34,7 +34,6 @@ use crate::compiler_host::CompilerHost;
 use crate::component_model::CmInterfaceRegistry;
 use crate::logger::{Bail, Logger};
 use crate::module_source::{ModuleSource, ModuleSourceInterner};
-use crate::name::{self as name};
 use crate::symbol::SymbolTable;
 use crate::tir::{ResolvedType, TirModule, TypeId, TypeTable};
 use crate::world_registry::WorldRegistry;
@@ -798,7 +797,13 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         // Also runs orphan rule checking; violations are emitted as errors.
         let (trait_env, orphan_violations) = {
             let _span = logger.span("elaborate/trait_env");
-            super::trait_env::TraitEnv::build(modules, symbols)
+            super::trait_env::TraitEnv::build(
+                modules,
+                symbols,
+                &mut interner.borrow_mut(),
+                Some(entry_module_source),
+                &invocations,
+            )
         };
         for violation in orphan_violations {
             let _ = logger.error(violation);
@@ -1579,34 +1584,13 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         entry_module: Option<&ModuleSource>,
         invocations: &crate::kiln::InvocationIndex,
     ) -> (IndexMap<String, ModuleSource>, IndexMap<String, String>) {
-        let mut sources = IndexMap::default();
-        let mut original_names = IndexMap::default();
-        for item in &module.items {
-            if let Item::Use(use_decl) = item {
-                let source = name::resolve_import_with_invocations(
-                    interner,
-                    from_module,
-                    &use_decl.source,
-                    entry_module,
-                    invocations,
-                );
-                for use_item in &use_decl.items {
-                    match use_item {
-                        ast::UseItem::Simple { name, alias, .. } => {
-                            let local_name = alias.as_ref().unwrap_or(name);
-                            sources.insert(local_name.clone(), source.clone());
-                            if alias.is_some() {
-                                original_names.insert(local_name.clone(), name.clone());
-                            }
-                        }
-                        ast::UseItem::InterfaceFunctions { .. }
-                        | ast::UseItem::Wildcard
-                        | ast::UseItem::Namespace { .. } => {}
-                    }
-                }
-            }
-        }
-        (sources, original_names)
+        super::trait_env::module_import_scope(
+            interner,
+            module,
+            from_module,
+            entry_module,
+            invocations,
+        )
     }
 
     /// Resolve an optional AST return type using the source module's type context.

--- a/wado-compiler/src/elaborator/stmt.rs
+++ b/wado-compiler/src/elaborator/stmt.rs
@@ -1849,12 +1849,17 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             {
                 inner_type_id = t;
             }
-            let implements_into_iter = self.type_implements_trait(&self.annotate_ctx, iterable_type_id, "IntoIterator")
-                || self.type_implements_trait(&self.annotate_ctx, inner_type_id, "IntoIterator")
-                || matches!(
-                    self.tysys.type_table.borrow().get(iterable_type_id),
-                    ResolvedType::Unknown | ResolvedType::TypeParam { .. }
-                );
+            let implements_into_iter =
+                self.type_implements_trait(&self.annotate_ctx, iterable_type_id, "IntoIterator")
+                    || self.type_implements_trait(
+                        &self.annotate_ctx,
+                        inner_type_id,
+                        "IntoIterator",
+                    )
+                    || matches!(
+                        self.tysys.type_table.borrow().get(iterable_type_id),
+                        ResolvedType::Unknown | ResolvedType::TypeParam { .. }
+                    );
             if !implements_into_iter {
                 let type_name = self.tysys.type_table.borrow().type_name(iterable_type_id);
                 let _ = self.logger.error(TypeError::MissingTraitImpl {

--- a/wado-compiler/src/elaborator/stmt.rs
+++ b/wado-compiler/src/elaborator/stmt.rs
@@ -1849,8 +1849,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             {
                 inner_type_id = t;
             }
-            let implements_into_iter = self.type_implements_trait(iterable_type_id, "IntoIterator")
-                || self.type_implements_trait(inner_type_id, "IntoIterator")
+            let implements_into_iter = self.type_implements_trait(&self.annotate_ctx, iterable_type_id, "IntoIterator")
+                || self.type_implements_trait(&self.annotate_ctx, inner_type_id, "IntoIterator")
                 || matches!(
                     self.tysys.type_table.borrow().get(iterable_type_id),
                     ResolvedType::Unknown | ResolvedType::TypeParam { .. }
@@ -2214,7 +2214,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Iterator-trait conformance check, mirroring the pre-refactor
         // surface error.
-        if !self.type_implements_trait(iter_type, "Iterator")
+        if !self.type_implements_trait(&self.annotate_ctx, iter_type, "Iterator")
             && !matches!(
                 self.tysys.type_table.borrow().get(iter_type),
                 ResolvedType::Unknown | ResolvedType::TypeParam { .. }

--- a/wado-compiler/src/elaborator/trait_env.rs
+++ b/wado-compiler/src/elaborator/trait_env.rs
@@ -218,6 +218,19 @@ pub struct TraitEnv {
     /// method signatures without re-fetching the trait AST. See
     /// [`TraitDeclHeader`].
     pub(super) trait_decl_headers: IndexMap<(ModuleSource, usize), TraitDeclHeader>,
+    /// Free-function type parameters keyed by `(declaring module, function
+    /// name)`. Lets `lookup_function_type_params` read a callee's type params
+    /// without scanning the module AST.
+    pub(super) function_type_params: IndexMap<(ModuleSource, String), Vec<ast::GenericParam>>,
+    /// Type name → modules declaring a struct / resource / variant / enum /
+    /// builtin type of that name, in build order. Powers
+    /// `find_struct_module_source` without an AST scan. Newtypes are tracked
+    /// separately in [`Self::newtype_decl_modules`] because the query consults
+    /// them only as a later fallback.
+    pub(super) struct_like_decl_modules: IndexMap<String, Vec<ModuleSource>>,
+    /// Type name → modules declaring a `newtype` of that name, in build order.
+    /// The fallback half of `find_struct_module_source`'s module lookup.
+    pub(super) newtype_decl_modules: IndexMap<String, Vec<ModuleSource>>,
     /// `trait_name` → modules that host a blanket impl of that trait
     /// (`impl<T: Bound> Trait for T`). Used by the monomorphizer to find
     /// the home module of a generic dispatch when the receiver type
@@ -348,6 +361,10 @@ impl TraitEnv {
         let mut impl_headers: IndexMap<(ModuleSource, usize), ImplHeader> = IndexMap::default();
         let mut trait_decl_headers: IndexMap<(ModuleSource, usize), TraitDeclHeader> =
             IndexMap::default();
+        let mut function_type_params: IndexMap<(ModuleSource, String), Vec<ast::GenericParam>> =
+            IndexMap::default();
+        let mut struct_like_decl_modules: IndexMap<String, Vec<ModuleSource>> = IndexMap::default();
+        let mut newtype_decl_modules: IndexMap<String, Vec<ModuleSource>> = IndexMap::default();
         let mut blanket_trait_impl_modules: IndexMap<String, Vec<ModuleSource>> =
             IndexMap::default();
         let mut trait_impl_modules: TraitImplModuleIndex = IndexMap::default();
@@ -500,6 +517,43 @@ impl TraitEnv {
         // every PascalCase reference to its declaring module.
         for (module_source, module) in modules {
             for (item_idx, item) in module.items.iter().enumerate() {
+                // Digest the per-item facts that `lookup_function_type_params`
+                // and `find_struct_module_source` read, so neither needs to
+                // re-scan `loaded_modules`. (Non-impl items fall through to the
+                // `Item::Impl` guard below and `continue`.)
+                match item {
+                    Item::Function(f) => {
+                        function_type_params.insert(
+                            (module_source.clone(), f.name.clone()),
+                            f.type_params.clone(),
+                        );
+                    }
+                    Item::Struct(s) => struct_like_decl_modules
+                        .entry(s.name.clone())
+                        .or_default()
+                        .push(module_source.clone()),
+                    Item::Resource(r) => struct_like_decl_modules
+                        .entry(r.name.clone())
+                        .or_default()
+                        .push(module_source.clone()),
+                    Item::Variant(v) => struct_like_decl_modules
+                        .entry(v.name.clone())
+                        .or_default()
+                        .push(module_source.clone()),
+                    Item::Enum(e) => struct_like_decl_modules
+                        .entry(e.name.clone())
+                        .or_default()
+                        .push(module_source.clone()),
+                    Item::BuiltinTypeDecl(d) => struct_like_decl_modules
+                        .entry(d.name.clone())
+                        .or_default()
+                        .push(module_source.clone()),
+                    Item::Newtype(n) => newtype_decl_modules
+                        .entry(n.name.clone())
+                        .or_default()
+                        .push(module_source.clone()),
+                    _ => {}
+                }
                 if let Item::Trait(trait_decl) = item {
                     trait_decl_headers.insert(
                         (module_source.clone(), item_idx),
@@ -645,6 +699,9 @@ impl TraitEnv {
                 blanket_impl_index,
                 impl_headers,
                 trait_decl_headers,
+                function_type_params,
+                struct_like_decl_modules,
+                newtype_decl_modules,
                 blanket_trait_impl_modules,
                 static_method_index,
                 resource_static_method_index,

--- a/wado-compiler/src/elaborator/trait_env.rs
+++ b/wado-compiler/src/elaborator/trait_env.rs
@@ -95,6 +95,10 @@ pub(super) struct ImplHeader {
 pub(super) struct ImplMethodHeader {
     pub(super) name: String,
     pub(super) type_params: Vec<ast::GenericParam>,
+    /// Whether the method has a body. Always true for impl methods; for trait
+    /// declarations it distinguishes default methods from bare signatures,
+    /// which method-lookup's fallback ordering depends on.
+    pub(super) has_body: bool,
 }
 
 /// Digested header of a `trait` declaration: its name plus per-method
@@ -507,6 +511,7 @@ impl TraitEnv {
                                 .map(|m| ImplMethodHeader {
                                     name: m.name.clone(),
                                     type_params: m.type_params.clone(),
+                                    has_body: m.body.is_some(),
                                 })
                                 .collect(),
                         },
@@ -532,6 +537,7 @@ impl TraitEnv {
                             .map(|m| ImplMethodHeader {
                                 name: m.name.clone(),
                                 type_params: m.type_params.clone(),
+                                has_body: m.body.is_some(),
                             })
                             .collect(),
                         associated_types: impl_block.associated_types.clone(),

--- a/wado-compiler/src/elaborator/trait_env.rs
+++ b/wado-compiler/src/elaborator/trait_env.rs
@@ -10,8 +10,58 @@ use std::sync::Arc;
 use crate::ast::{self, Item, Module, Type};
 use crate::compiler_host::CompilerHost;
 use crate::hashmap::{IndexMap, IndexSet};
-use crate::module_source::ModuleSource;
+use crate::kiln::InvocationIndex;
+use crate::module_source::{ModuleSource, ModuleSourceInterner};
+use crate::name;
 use crate::tir::{TypeId, TypeTable};
+
+/// A module's import scope: `(imported_type_sources, import_original_names)`.
+/// The first maps each in-scope bare type name to its declaring module; the
+/// second maps an aliased local name back to its original declaration name.
+pub(super) type ModuleImportScope = (IndexMap<String, ModuleSource>, IndexMap<String, String>);
+
+/// Compute a module's import scope from its `use` declarations. Pure over
+/// `(module, from_module, entry_module, invocations)` plus the (idempotent,
+/// loader-warmed) interner; safe to memoize per module. This is the body
+/// behind `Elaborator::build_imported_type_sources`, lifted to a free
+/// function so [`TraitEnv::build`] can pre-compute the per-module scopes
+/// without an `Elaborator`/host in hand.
+pub(super) fn module_import_scope(
+    interner: &mut ModuleSourceInterner,
+    module: &Module,
+    from_module: &ModuleSource,
+    entry_module: Option<&ModuleSource>,
+    invocations: &InvocationIndex,
+) -> ModuleImportScope {
+    let mut sources = IndexMap::default();
+    let mut original_names = IndexMap::default();
+    for item in &module.items {
+        if let Item::Use(use_decl) = item {
+            let source = name::resolve_import_with_invocations(
+                interner,
+                from_module,
+                &use_decl.source,
+                entry_module,
+                invocations,
+            );
+            for use_item in &use_decl.items {
+                match use_item {
+                    ast::UseItem::Simple { name, alias, .. } => {
+                        let local_name = alias.as_ref().unwrap_or(name);
+                        sources.insert(local_name.clone(), source.clone());
+                        if alias.is_some() {
+                            original_names.insert(local_name.clone(), name.clone());
+                        }
+                    }
+                    ast::UseItem::InterfaceFunctions { .. }
+                    | ast::UseItem::Wildcard
+                    | ast::UseItem::Namespace { .. } => {}
+                }
+            }
+        }
+    }
+    (sources, original_names)
+}
 
 use super::Elaborator;
 use super::types::TypeError;
@@ -233,6 +283,12 @@ pub struct TraitEnv {
     /// Type name → modules declaring a `newtype` of that name, in build order.
     /// The fallback half of `find_struct_module_source`'s module lookup.
     pub(super) newtype_decl_modules: IndexMap<String, Vec<ModuleSource>>,
+    /// Per-module import scope (`use`-derived `imported_type_sources` /
+    /// `import_original_names`), pre-computed once. Dispatch-core queries that
+    /// resolve type names in a foreign impl/callee signature read this instead
+    /// of rebuilding it from the module AST in `loaded_modules`. See
+    /// [`module_import_scope`].
+    pub(super) module_import_scopes: IndexMap<ModuleSource, ModuleImportScope>,
     /// `trait_name` → modules that host a blanket impl of that trait
     /// (`impl<T: Bound> Trait for T`). Used by the monomorphizer to find
     /// the home module of a generic dispatch when the receiver type
@@ -353,7 +409,20 @@ impl TraitEnv {
     pub(super) fn build(
         modules: &IndexMap<ModuleSource, Module>,
         symbols: &SymbolTable,
+        interner: &mut ModuleSourceInterner,
+        entry_module: Option<&ModuleSource>,
+        invocations: &InvocationIndex,
     ) -> (Arc<Self>, Vec<TypeError>) {
+        // Pre-compute every module's `use`-derived import scope so dispatch
+        // queries read it instead of rebuilding from the module AST.
+        let mut module_import_scopes: IndexMap<ModuleSource, ModuleImportScope> =
+            IndexMap::default();
+        for (module_source, module) in modules {
+            module_import_scopes.insert(
+                module_source.clone(),
+                module_import_scope(interner, module, module_source, entry_module, invocations),
+            );
+        }
         let mut impl_index: TraitImplIndex = IndexMap::default();
         let mut inherent_impl_index: TraitImplIndex = IndexMap::default();
         let mut decl_index: TraitDeclIndex = IndexMap::default();
@@ -705,6 +774,7 @@ impl TraitEnv {
                 function_type_params,
                 struct_like_decl_modules,
                 newtype_decl_modules,
+                module_import_scopes,
                 blanket_trait_impl_modules,
                 static_method_index,
                 resource_static_method_index,
@@ -729,6 +799,14 @@ impl TraitEnv {
     /// `find_trait_impl_for_type_with_args` iterates [`TraitImplIndex`] and
     /// checks each candidate impl individually instead of collapsing on the
     /// `(name, trait)` key.
+    /// The pre-computed import scope for `module`, cloned for callers that
+    /// install it via `with_module_perspective` (which takes the maps by
+    /// value). Returns empty maps for a module with no recorded scope,
+    /// matching the previous `…unwrap_or_default()` behaviour.
+    pub(super) fn import_scope(&self, module: &ModuleSource) -> ModuleImportScope {
+        self.module_import_scopes.get(module).cloned().unwrap_or_default()
+    }
+
     pub(crate) fn impl_module_for(
         &self,
         type_name: &str,

--- a/wado-compiler/src/elaborator/trait_env.rs
+++ b/wado-compiler/src/elaborator/trait_env.rs
@@ -4,6 +4,7 @@
 //! It provides O(1) lookup of trait implementations by type name and trait name,
 //! replacing linear scans across all modules.
 
+use std::cell::RefCell;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
@@ -1186,6 +1187,21 @@ pub(super) struct TraitContext {
     pub(super) self_type: Option<TypeId>,
 }
 
+/// Per-function annotate-time scope: the trait-resolution context
+/// ([`TraitContext`]) plus the `type_implements_trait` recursion guard.
+/// Bundled so the two pieces of per-call state live and move as a unit; a
+/// later step threads `&AnnotateCtx` explicitly into the resolution queries
+/// (WEP 2026-05-26, the trait_ctx scoping work) so they can leave the
+/// `Elaborator` God Object. Neither piece may move onto the shared
+/// `TypeSystem`: `trait_ctx` is per-function and `trait_check_stack` is a
+/// per-call frame stack (empty at quiescence) whose sharing would leak
+/// frames across module walks.
+#[derive(Default)]
+pub(super) struct AnnotateCtx {
+    pub(super) trait_ctx: TraitContext,
+    pub(super) trait_check_stack: RefCell<Vec<(TypeId, String)>>,
+}
+
 /// RAII guard that restores `Elaborator::trait_ctx` to its saved value on drop.
 ///
 /// Implements `Deref<Target = Elaborator>` so it can be used as a transparent
@@ -1196,7 +1212,7 @@ pub(super) struct TraitContext {
 /// It preserves the current `trait_ctx` so the child scope can register new
 /// entries on top of the parent's. Callers that want a clean slate for a
 /// specific field (matching the legacy `mem::take` pattern) should clear that
-/// field on `scope.trait_ctx` after entering.
+/// field on `scope.annotate_ctx.trait_ctx` after entering.
 pub(super) struct TypeParamScope<'r, 'a, H: CompilerHost> {
     elaborator: &'r mut Elaborator<'a, H>,
     saved: TraitContext,
@@ -1226,7 +1242,7 @@ impl<H: CompilerHost> TypeParamScope<'_, '_, H> {
 
 impl<H: CompilerHost> Drop for TypeParamScope<'_, '_, H> {
     fn drop(&mut self) {
-        self.elaborator.trait_ctx = std::mem::take(&mut self.saved);
+        self.elaborator.annotate_ctx.trait_ctx = std::mem::take(&mut self.saved);
     }
 }
 
@@ -1237,12 +1253,12 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
     /// original context is restored when the returned guard is dropped.
     ///
     /// Callers that want a clean slate (matching the legacy
-    /// `mem::take(&mut self.trait_ctx.type_params)` pattern) should clear the
-    /// specific fields they want to reset on `scope.trait_ctx` after entering
+    /// `mem::take(&mut self.annotate_ctx.trait_ctx.type_params)` pattern) should clear the
+    /// specific fields they want to reset on `scope.annotate_ctx.trait_ctx` after entering
     /// the scope — only the fields they touch need to be cleared, all others
     /// are inherited from the parent scope.
     pub(super) fn enter_inherited_type_param_scope(&mut self) -> TypeParamScope<'_, 'a, H> {
-        let saved = self.trait_ctx.clone();
+        let saved = self.annotate_ctx.trait_ctx.clone();
         TypeParamScope {
             elaborator: self,
             saved,
@@ -1299,10 +1315,10 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                     true,
                 )
             };
-            self.trait_ctx
+            self.annotate_ctx.trait_ctx
                 .type_params
                 .insert(tp.name.clone(), (idx, type_id));
-            self.trait_ctx
+            self.annotate_ctx.trait_ctx
                 .type_param_decls
                 .insert(tp.name.clone(), tp.id);
             // Filter out `fn`/`fn mut` bounds before recording (they're already
@@ -1315,7 +1331,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                 .cloned()
                 .collect();
             if !real_bounds.is_empty() {
-                self.trait_ctx
+                self.annotate_ctx.trait_ctx
                     .type_param_bounds
                     .insert(tp.name.clone(), real_bounds);
             }
@@ -1351,19 +1367,19 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             .filter(|p| !p.is_effect)
             .enumerate()
         {
-            if self.trait_ctx.type_params.contains_key(&tp.name) {
+            if self.annotate_ctx.trait_ctx.type_params.contains_key(&tp.name) {
                 continue;
             }
             let Some(arg_ast) = trait_args.get(i) else {
                 continue;
             };
             let resolved_arg = self.resolve_type(arg_ast);
-            let idx = self.trait_ctx.type_params.len() as u32;
-            self.trait_ctx
+            let idx = self.annotate_ctx.trait_ctx.type_params.len() as u32;
+            self.annotate_ctx.trait_ctx
                 .type_params
                 .insert(tp.name.clone(), (idx, resolved_arg));
             if !tp.bounds.is_empty() {
-                self.trait_ctx
+                self.annotate_ctx.trait_ctx
                     .type_param_bounds
                     .entry(tp.name.clone())
                     .or_default()

--- a/wado-compiler/src/elaborator/trait_env.rs
+++ b/wado-compiler/src/elaborator/trait_env.rs
@@ -115,11 +115,9 @@ pub(crate) type DeclKey = (ModuleSource, String);
 pub(super) type TraitImplIndex = IndexMap<String, Vec<(ModuleSource, usize)>>;
 
 /// Digested header of an `impl` block, pre-extracted at [`TraitEnv::build`]
-/// time so trait and method queries can read the trait name, target type,
+/// time so trait/method queries read its trait name, target type, methods,
 /// and type parameters without re-fetching the impl block from
-/// `loaded_modules`. This is the data-modelling half of the WEP 2026-05-26
-/// goal of keeping resolution queries off the raw AST: every index entry's
-/// `(ModuleSource, item_idx)` has a matching header in
+/// `loaded_modules`. Keyed by `(ModuleSource, item_idx)` in
 /// [`TraitEnv::impl_headers`].
 #[derive(Clone, Debug)]
 pub(super) struct ImplHeader {
@@ -1188,13 +1186,10 @@ pub(super) struct TraitContext {
 }
 
 /// Per-function annotate-time scope: the trait-resolution context
-/// ([`TraitContext`]) plus the `type_implements_trait` recursion guard.
-/// Bundled so the two pieces of per-call state live and move as a unit; a
-/// later step threads `&AnnotateCtx` explicitly into the resolution queries
-/// (WEP 2026-05-26, the trait_ctx scoping work) so they can leave the
-/// `Elaborator` God Object. Neither piece may move onto the shared
-/// `TypeSystem`: `trait_ctx` is per-function and `trait_check_stack` is a
-/// per-call frame stack (empty at quiescence) whose sharing would leak
+/// ([`TraitContext`]) plus the `type_implements_trait` recursion guard,
+/// bundled so they move as one unit (queries take `&AnnotateCtx`). Neither
+/// may move onto the shared `TypeSystem`: `trait_ctx` is per-function and
+/// `trait_check_stack` is a per-call frame stack whose sharing would leak
 /// frames across module walks.
 #[derive(Default)]
 pub(super) struct AnnotateCtx {

--- a/wado-compiler/src/elaborator/trait_env.rs
+++ b/wado-compiler/src/elaborator/trait_env.rs
@@ -652,10 +652,7 @@ impl TraitEnv {
                 impl_headers.insert(
                     (module_source.clone(), item_idx),
                     ImplHeader {
-                        trait_name: impl_block
-                            .trait_type
-                            .as_ref()
-                            .map(get_type_name_static),
+                        trait_name: impl_block.trait_type.as_ref().map(get_type_name_static),
                         ty: impl_block.ty.clone(),
                         type_params: impl_block.type_params.clone(),
                         methods: impl_block
@@ -805,7 +802,10 @@ impl TraitEnv {
     /// value). Returns empty maps for a module with no recorded scope,
     /// matching the previous `…unwrap_or_default()` behaviour.
     pub(super) fn import_scope(&self, module: &ModuleSource) -> ModuleImportScope {
-        self.module_import_scopes.get(module).cloned().unwrap_or_default()
+        self.module_import_scopes
+            .get(module)
+            .cloned()
+            .unwrap_or_default()
     }
 
     pub(crate) fn impl_module_for(
@@ -1315,10 +1315,12 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                     true,
                 )
             };
-            self.annotate_ctx.trait_ctx
+            self.annotate_ctx
+                .trait_ctx
                 .type_params
                 .insert(tp.name.clone(), (idx, type_id));
-            self.annotate_ctx.trait_ctx
+            self.annotate_ctx
+                .trait_ctx
                 .type_param_decls
                 .insert(tp.name.clone(), tp.id);
             // Filter out `fn`/`fn mut` bounds before recording (they're already
@@ -1331,7 +1333,8 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                 .cloned()
                 .collect();
             if !real_bounds.is_empty() {
-                self.annotate_ctx.trait_ctx
+                self.annotate_ctx
+                    .trait_ctx
                     .type_param_bounds
                     .insert(tp.name.clone(), real_bounds);
             }
@@ -1367,7 +1370,12 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             .filter(|p| !p.is_effect)
             .enumerate()
         {
-            if self.annotate_ctx.trait_ctx.type_params.contains_key(&tp.name) {
+            if self
+                .annotate_ctx
+                .trait_ctx
+                .type_params
+                .contains_key(&tp.name)
+            {
                 continue;
             }
             let Some(arg_ast) = trait_args.get(i) else {
@@ -1375,11 +1383,13 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             };
             let resolved_arg = self.resolve_type(arg_ast);
             let idx = self.annotate_ctx.trait_ctx.type_params.len() as u32;
-            self.annotate_ctx.trait_ctx
+            self.annotate_ctx
+                .trait_ctx
                 .type_params
                 .insert(tp.name.clone(), (idx, resolved_arg));
             if !tp.bounds.is_empty() {
-                self.annotate_ctx.trait_ctx
+                self.annotate_ctx
+                    .trait_ctx
                     .type_param_bounds
                     .entry(tp.name.clone())
                     .or_default()

--- a/wado-compiler/src/elaborator/trait_env.rs
+++ b/wado-compiler/src/elaborator/trait_env.rs
@@ -79,6 +79,19 @@ pub(super) struct ImplHeader {
     pub(super) ty: Type,
     /// The impl block's type parameters.
     pub(super) type_params: Vec<ast::GenericParam>,
+    /// Digested signatures of the block's methods, in source order. Carries
+    /// only what method-lookup queries read off the AST today; extended as
+    /// further consumers move onto the digest.
+    pub(super) methods: Vec<ImplMethodHeader>,
+}
+
+/// Digested signature of a single method inside an [`ImplHeader`]. Holds the
+/// name and type parameters method-lookup queries need without the method
+/// body; grows field-by-field as consumers migrate off the impl-block AST.
+#[derive(Clone, Debug)]
+pub(super) struct ImplMethodHeader {
+    pub(super) name: String,
+    pub(super) type_params: Vec<ast::GenericParam>,
 }
 
 /// Pre-built index: `(declaring module, trait name)` → (`ModuleSource`, item index)
@@ -475,6 +488,14 @@ impl TraitEnv {
                             .map(get_type_name_static),
                         ty: impl_block.ty.clone(),
                         type_params: impl_block.type_params.clone(),
+                        methods: impl_block
+                            .methods
+                            .iter()
+                            .map(|m| ImplMethodHeader {
+                                name: m.name.clone(),
+                                type_params: m.type_params.clone(),
+                            })
+                            .collect(),
                     },
                 );
                 if let Some(trait_type) = &impl_block.trait_type {

--- a/wado-compiler/src/elaborator/trait_env.rs
+++ b/wado-compiler/src/elaborator/trait_env.rs
@@ -109,6 +109,8 @@ pub(super) struct ImplMethodHeader {
 #[derive(Clone, Debug)]
 pub(super) struct TraitDeclHeader {
     pub(super) name: String,
+    /// The trait's own type parameters (e.g. `<T, U>` in `trait Foo<T, U>`).
+    pub(super) type_params: Vec<ast::GenericParam>,
     pub(super) methods: Vec<ImplMethodHeader>,
 }
 
@@ -559,6 +561,7 @@ impl TraitEnv {
                         (module_source.clone(), item_idx),
                         TraitDeclHeader {
                             name: trait_decl.name.clone(),
+                            type_params: trait_decl.type_params.clone(),
                             methods: trait_decl
                                 .methods
                                 .iter()

--- a/wado-compiler/src/elaborator/trait_env.rs
+++ b/wado-compiler/src/elaborator/trait_env.rs
@@ -63,6 +63,24 @@ pub(crate) type DeclKey = (ModuleSource, String);
 /// without ambiguity.
 pub(super) type TraitImplIndex = IndexMap<String, Vec<(ModuleSource, usize)>>;
 
+/// Digested header of an `impl` block, pre-extracted at [`TraitEnv::build`]
+/// time so trait and method queries can read the trait name, target type,
+/// and type parameters without re-fetching the impl block from
+/// `loaded_modules`. This is the data-modelling half of the WEP 2026-05-26
+/// goal of keeping resolution queries off the raw AST: every index entry's
+/// `(ModuleSource, item_idx)` has a matching header in
+/// [`TraitEnv::impl_headers`].
+#[derive(Clone, Debug)]
+pub(super) struct ImplHeader {
+    /// Trait name for `impl Trait for Type` blocks (via `get_type_name_static`
+    /// on the trait reference); `None` for inherent `impl Type { … }` blocks.
+    pub(super) trait_name: Option<String>,
+    /// The impl target type (`impl_block.ty`).
+    pub(super) ty: Type,
+    /// The impl block's type parameters.
+    pub(super) type_params: Vec<ast::GenericParam>,
+}
+
 /// Pre-built index: `(declaring module, trait name)` → (`ModuleSource`, item index)
 /// for trait declarations.
 pub(super) type TraitDeclIndex = IndexMap<DeclKey, (ModuleSource, usize)>;
@@ -160,6 +178,10 @@ pub struct TraitEnv {
     pub(super) resource_decl_index: ResourceDeclIndex,
     /// Blanket impls (`impl<T: Bound> Trait for T`), checked as fallback.
     pub(super) blanket_impl_index: BlanketTraitImplIndex,
+    /// Digested headers for every indexed impl block, keyed by
+    /// `(ModuleSource, item_idx)`. Trait/method queries read this instead of
+    /// re-fetching the impl block AST from `loaded_modules`. See [`ImplHeader`].
+    pub(super) impl_headers: IndexMap<(ModuleSource, usize), ImplHeader>,
     /// `trait_name` → modules that host a blanket impl of that trait
     /// (`impl<T: Bound> Trait for T`). Used by the monomorphizer to find
     /// the home module of a generic dispatch when the receiver type
@@ -287,6 +309,7 @@ impl TraitEnv {
         let mut effect_decl_index: EffectDeclIndex = IndexMap::default();
         let mut resource_decl_index: ResourceDeclIndex = IndexMap::default();
         let mut blanket_impl_index: BlanketTraitImplIndex = Vec::new();
+        let mut impl_headers: IndexMap<(ModuleSource, usize), ImplHeader> = IndexMap::default();
         let mut blanket_trait_impl_modules: IndexMap<String, Vec<ModuleSource>> =
             IndexMap::default();
         let mut trait_impl_modules: TraitImplModuleIndex = IndexMap::default();
@@ -443,6 +466,17 @@ impl TraitEnv {
                     continue;
                 };
                 let type_name = get_type_name_static(&impl_block.ty);
+                impl_headers.insert(
+                    (module_source.clone(), item_idx),
+                    ImplHeader {
+                        trait_name: impl_block
+                            .trait_type
+                            .as_ref()
+                            .map(get_type_name_static),
+                        ty: impl_block.ty.clone(),
+                        type_params: impl_block.type_params.clone(),
+                    },
+                );
                 if let Some(trait_type) = &impl_block.trait_type {
                     let trait_name = get_type_name_static(trait_type);
                     let is_blanket = impl_block
@@ -543,6 +577,7 @@ impl TraitEnv {
                 effect_decl_index,
                 resource_decl_index,
                 blanket_impl_index,
+                impl_headers,
                 blanket_trait_impl_modules,
                 static_method_index,
                 resource_static_method_index,

--- a/wado-compiler/src/elaborator/trait_env.rs
+++ b/wado-compiler/src/elaborator/trait_env.rs
@@ -83,6 +83,9 @@ pub(super) struct ImplHeader {
     /// only what method-lookup queries read off the AST today; extended as
     /// further consumers move onto the digest.
     pub(super) methods: Vec<ImplMethodHeader>,
+    /// The block's `type X = …;` associated-type bindings, cloned so
+    /// associated-type resolution reads them without the impl-block AST.
+    pub(super) associated_types: Vec<ast::AssociatedTypeBinding>,
 }
 
 /// Digested signature of a single method inside an [`ImplHeader`]. Holds the
@@ -496,6 +499,7 @@ impl TraitEnv {
                                 type_params: m.type_params.clone(),
                             })
                             .collect(),
+                        associated_types: impl_block.associated_types.clone(),
                     },
                 );
                 if let Some(trait_type) = &impl_block.trait_type {

--- a/wado-compiler/src/elaborator/trait_env.rs
+++ b/wado-compiler/src/elaborator/trait_env.rs
@@ -97,6 +97,17 @@ pub(super) struct ImplMethodHeader {
     pub(super) type_params: Vec<ast::GenericParam>,
 }
 
+/// Digested header of a `trait` declaration: its name plus per-method
+/// signatures method-lookup queries read off the AST. Built in
+/// [`TraitEnv::build`] and keyed by `(ModuleSource, item_idx)` in
+/// [`TraitEnv::trait_decl_headers`]. Reuses [`ImplMethodHeader`] for the
+/// per-method digest (name + type parameters).
+#[derive(Clone, Debug)]
+pub(super) struct TraitDeclHeader {
+    pub(super) name: String,
+    pub(super) methods: Vec<ImplMethodHeader>,
+}
+
 /// Pre-built index: `(declaring module, trait name)` → (`ModuleSource`, item index)
 /// for trait declarations.
 pub(super) type TraitDeclIndex = IndexMap<DeclKey, (ModuleSource, usize)>;
@@ -198,6 +209,11 @@ pub struct TraitEnv {
     /// `(ModuleSource, item_idx)`. Trait/method queries read this instead of
     /// re-fetching the impl block AST from `loaded_modules`. See [`ImplHeader`].
     pub(super) impl_headers: IndexMap<(ModuleSource, usize), ImplHeader>,
+    /// Digested headers for every `trait` declaration, keyed by
+    /// `(ModuleSource, item_idx)`. Lets method-lookup queries read trait
+    /// method signatures without re-fetching the trait AST. See
+    /// [`TraitDeclHeader`].
+    pub(super) trait_decl_headers: IndexMap<(ModuleSource, usize), TraitDeclHeader>,
     /// `trait_name` → modules that host a blanket impl of that trait
     /// (`impl<T: Bound> Trait for T`). Used by the monomorphizer to find
     /// the home module of a generic dispatch when the receiver type
@@ -326,6 +342,8 @@ impl TraitEnv {
         let mut resource_decl_index: ResourceDeclIndex = IndexMap::default();
         let mut blanket_impl_index: BlanketTraitImplIndex = Vec::new();
         let mut impl_headers: IndexMap<(ModuleSource, usize), ImplHeader> = IndexMap::default();
+        let mut trait_decl_headers: IndexMap<(ModuleSource, usize), TraitDeclHeader> =
+            IndexMap::default();
         let mut blanket_trait_impl_modules: IndexMap<String, Vec<ModuleSource>> =
             IndexMap::default();
         let mut trait_impl_modules: TraitImplModuleIndex = IndexMap::default();
@@ -478,6 +496,23 @@ impl TraitEnv {
         // every PascalCase reference to its declaring module.
         for (module_source, module) in modules {
             for (item_idx, item) in module.items.iter().enumerate() {
+                if let Item::Trait(trait_decl) = item {
+                    trait_decl_headers.insert(
+                        (module_source.clone(), item_idx),
+                        TraitDeclHeader {
+                            name: trait_decl.name.clone(),
+                            methods: trait_decl
+                                .methods
+                                .iter()
+                                .map(|m| ImplMethodHeader {
+                                    name: m.name.clone(),
+                                    type_params: m.type_params.clone(),
+                                })
+                                .collect(),
+                        },
+                    );
+                    continue;
+                }
                 let Item::Impl(impl_block) = item else {
                     continue;
                 };
@@ -603,6 +638,7 @@ impl TraitEnv {
                 resource_decl_index,
                 blanket_impl_index,
                 impl_headers,
+                trait_decl_headers,
                 blanket_trait_impl_modules,
                 static_method_index,
                 resource_static_method_index,

--- a/wado-compiler/src/elaborator/trait_query.rs
+++ b/wado-compiler/src/elaborator/trait_query.rs
@@ -12,6 +12,7 @@ use crate::token::Span;
 
 use super::Elaborator;
 use super::callee::CalleeRef;
+use super::tysys::TypeSystem;
 use super::types::{MethodInfo, ResolvedTraitMethod, TraitMethodMatch, TypeError};
 
 /// Free-function form of [`Elaborator::canonical_decl_key`], callable from
@@ -108,6 +109,115 @@ pub(crate) fn find_trait_decl_methods_with_module_with(
         }
     }
     None
+}
+
+impl TypeSystem {
+    /// Build the mapping from an impl block's declared type-parameter names to
+    /// the concrete type arguments at a use site, by position. Pure over the
+    /// AST impl type and the concrete arg list — needs no type table.
+    pub(crate) fn build_type_param_mapping(
+        impl_ty: &Type,
+        concrete_type_args: &[TypeId],
+        declared_type_params: &IndexSet<String>,
+    ) -> IndexMap<String, TypeId> {
+        let mut mapping = IndexMap::default();
+
+        // Extract type parameter names from impl_ty, tracking positions
+        // Position tracking is needed to map type params to the correct concrete arg
+        if let Type::Generic(g) = impl_ty {
+            for (concrete_idx, arg) in g.args.iter().enumerate() {
+                if let Type::Named(n) = arg {
+                    let is_type_param = if declared_type_params.is_empty() {
+                        true // legacy: treat all Named as type params
+                    } else {
+                        declared_type_params.contains(&n.name)
+                    };
+                    if is_type_param && let Some(&type_id) = concrete_type_args.get(concrete_idx) {
+                        mapping.insert(n.name.clone(), type_id);
+                    }
+                }
+            }
+        }
+
+        mapping
+    }
+
+    /// Check that concrete type args at non-type-parameter positions match the impl type.
+    /// e.g., `impl KeyValueLiteral for TreeMap<String, V>` with `TreeMap<i32, String>` should fail
+    /// because position 0 expects String but got i32.
+    pub(crate) fn verify_impl_type_compatibility(
+        &self,
+        impl_ty: &Type,
+        concrete_type_args: &[TypeId],
+        declared_type_params: &IndexSet<String>,
+    ) -> bool {
+        if declared_type_params.is_empty() {
+            return true; // No filtering available, assume compatible
+        }
+        let Type::Generic(g) = impl_ty else {
+            return true;
+        };
+        let tt = self.type_table.borrow();
+        for (i, arg) in g.args.iter().enumerate() {
+            let Some(&concrete_id) = concrete_type_args.get(i) else {
+                continue;
+            };
+            if !Self::impl_type_matches_concrete(arg, concrete_id, declared_type_params, &tt) {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Recursively check whether an impl type argument matches a concrete type ID.
+    /// - `Type::Named` that is a declared type param → always matches (free type param)
+    /// - `Type::Named` not in type params → concrete name must equal `type_table.type_name()`
+    /// - `Type::Generic` → concrete must be a `GenericInstance` with same outer name; inner args checked recursively
+    /// - Other types → not validated (return true)
+    pub(crate) fn impl_type_matches_concrete(
+        impl_ty: &Type,
+        concrete_id: TypeId,
+        declared_type_params: &IndexSet<String>,
+        type_table: &TypeTable,
+    ) -> bool {
+        match impl_ty {
+            Type::Named(n) => {
+                if declared_type_params.contains(&n.name) {
+                    true // free type param — matches anything
+                } else {
+                    type_table.type_name(concrete_id) == n.name
+                }
+            }
+            Type::Generic(g) => {
+                let resolved = type_table.get(concrete_id).clone();
+                match resolved {
+                    ResolvedType::GenericInstance {
+                        name, type_args, ..
+                    } => {
+                        if name != g.name {
+                            return false;
+                        }
+                        for (i, inner) in g.args.iter().enumerate() {
+                            let Some(&inner_id) = type_args.get(i) else {
+                                return false;
+                            };
+                            if !Self::impl_type_matches_concrete(
+                                inner,
+                                inner_id,
+                                declared_type_params,
+                                type_table,
+                            ) {
+                                return false;
+                            }
+                        }
+                        true
+                    }
+                    _ => false,
+                }
+            }
+            _ => true,
+        }
+    }
 }
 
 impl<H: CompilerHost> Elaborator<'_, H> {
@@ -1201,110 +1311,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// treated as type parameters. This prevents concrete types (e.g., `String` in
     /// `impl Trait for Map<String, V>`) from being incorrectly mapped.
     /// When empty, all `Named` types are assumed to be type parameters (legacy behavior).
-    pub(super) fn build_type_param_mapping(
-        impl_ty: &Type,
-        concrete_type_args: &[TypeId],
-        declared_type_params: &IndexSet<String>,
-    ) -> IndexMap<String, TypeId> {
-        let mut mapping = IndexMap::default();
-
-        // Extract type parameter names from impl_ty, tracking positions
-        // Position tracking is needed to map type params to the correct concrete arg
-        if let Type::Generic(g) = impl_ty {
-            for (concrete_idx, arg) in g.args.iter().enumerate() {
-                if let Type::Named(n) = arg {
-                    let is_type_param = if declared_type_params.is_empty() {
-                        true // legacy: treat all Named as type params
-                    } else {
-                        declared_type_params.contains(&n.name)
-                    };
-                    if is_type_param && let Some(&type_id) = concrete_type_args.get(concrete_idx) {
-                        mapping.insert(n.name.clone(), type_id);
-                    }
-                }
-            }
-        }
-
-        mapping
-    }
-
-    /// Check that concrete type args at non-type-parameter positions match the impl type.
-    /// e.g., `impl KeyValueLiteral for TreeMap<String, V>` with `TreeMap<i32, String>` should fail
-    /// because position 0 expects String but got i32.
-    pub(super) fn verify_impl_type_compatibility(
-        impl_ty: &Type,
-        concrete_type_args: &[TypeId],
-        declared_type_params: &IndexSet<String>,
-        type_table: &std::cell::RefCell<TypeTable>,
-    ) -> bool {
-        if declared_type_params.is_empty() {
-            return true; // No filtering available, assume compatible
-        }
-        let Type::Generic(g) = impl_ty else {
-            return true;
-        };
-        let tt = type_table.borrow();
-        for (i, arg) in g.args.iter().enumerate() {
-            let Some(&concrete_id) = concrete_type_args.get(i) else {
-                continue;
-            };
-            if !Self::impl_type_matches_concrete(arg, concrete_id, declared_type_params, &tt) {
-                return false;
-            }
-        }
-        true
-    }
-
-    /// Recursively check whether an impl type argument matches a concrete type ID.
-    /// - `Type::Named` that is a declared type param → always matches (free type param)
-    /// - `Type::Named` not in type params → concrete name must equal `type_table.type_name()`
-    /// - `Type::Generic` → concrete must be a `GenericInstance` with same outer name; inner args checked recursively
-    /// - Other types → not validated (return true)
-    pub(super) fn impl_type_matches_concrete(
-        impl_ty: &Type,
-        concrete_id: TypeId,
-        declared_type_params: &IndexSet<String>,
-        type_table: &TypeTable,
-    ) -> bool {
-        match impl_ty {
-            Type::Named(n) => {
-                if declared_type_params.contains(&n.name) {
-                    true // free type param — matches anything
-                } else {
-                    type_table.type_name(concrete_id) == n.name
-                }
-            }
-            Type::Generic(g) => {
-                let resolved = type_table.get(concrete_id).clone();
-                match resolved {
-                    ResolvedType::GenericInstance {
-                        name, type_args, ..
-                    } => {
-                        if name != g.name {
-                            return false;
-                        }
-                        for (i, inner) in g.args.iter().enumerate() {
-                            let Some(&inner_id) = type_args.get(i) else {
-                                return false;
-                            };
-                            if !Self::impl_type_matches_concrete(
-                                inner,
-                                inner_id,
-                                declared_type_params,
-                                type_table,
-                            ) {
-                                return false;
-                            }
-                        }
-                        true
-                    }
-                    _ => false,
-                }
-            }
-            _ => true,
-        }
-    }
-
     /// Single entry point for resolving a trait method that a binary operator
     /// dispatches to (Eq / Ord / Add / Sub / Mul / Div / Rem / `BitAnd` / `BitOr` /
     /// `BitXor` / Shl / Shr). Produces a fully-populated

--- a/wado-compiler/src/elaborator/trait_query.rs
+++ b/wado-compiler/src/elaborator/trait_query.rs
@@ -651,9 +651,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         trait_name: &str,
         type_args: Option<&[TypeId]>,
     ) -> bool {
-        // Use pre-built index for O(1) lookup by type name; read each impl's
-        // digested header (trait name, target type, type params) rather than
-        // re-fetching the impl block from `loaded_modules`.
+        // O(1) lookup by type name; read each impl's digested header rather than
+        // the impl block AST.
         let trait_env = self.tysys.trait_env.clone();
         if let Some(entries) = trait_env.impl_index.get(type_name) {
             for entry in entries {

--- a/wado-compiler/src/elaborator/trait_query.rs
+++ b/wado-compiler/src/elaborator/trait_query.rs
@@ -12,6 +12,7 @@ use crate::token::Span;
 
 use super::Elaborator;
 use super::callee::CalleeRef;
+use super::trait_env::AnnotateCtx;
 use super::tysys::TypeSystem;
 use super::types::{MethodInfo, ResolvedTraitMethod, TraitMethodMatch, TypeError};
 
@@ -273,7 +274,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     }
 
     /// Check if a type implements a specific trait (for trait bound checking)
-    pub(super) fn type_implements_trait(&self, type_id: TypeId, trait_name: &str) -> bool {
+    pub(super) fn type_implements_trait(
+        &self,
+        ctx: &AnnotateCtx,
+        type_id: TypeId,
+        trait_name: &str,
+    ) -> bool {
         let resolved = self.tysys.type_table.borrow().get(type_id).clone();
 
         // Recursion guard: if we're already checking this (type, trait) pair,
@@ -283,18 +289,18 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // If any non-recursive field fails the trait check, it will be caught on that path.
         {
             let key = (type_id, trait_name.to_string());
-            let stack = self.annotate_ctx.trait_check_stack.borrow();
+            let stack = ctx.trait_check_stack.borrow();
             if stack.contains(&key) {
                 return true;
             }
         }
-        self.annotate_ctx.trait_check_stack
+        ctx.trait_check_stack
             .borrow_mut()
             .push((type_id, trait_name.to_string()));
 
-        let result = self.type_implements_trait_inner(&resolved, trait_name);
+        let result = self.type_implements_trait_inner(ctx, &resolved, trait_name);
 
-        self.annotate_ctx.trait_check_stack.borrow_mut().pop();
+        ctx.trait_check_stack.borrow_mut().pop();
 
         result
     }
@@ -390,7 +396,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Report the first member that breaks the trait, then recurse to
         // explain that member in turn.
         for (label, member_tid) in members {
-            if !self.type_implements_trait(member_tid, trait_name) {
+            if !self.type_implements_trait(&self.annotate_ctx, member_tid, trait_name) {
                 let owner = self.tysys.type_id_to_string(type_id);
                 let member_ty = self.tysys.type_id_to_string(member_tid);
                 chain.push(format!(
@@ -402,12 +408,17 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
     }
 
-    fn type_implements_trait_inner(&self, resolved: &ResolvedType, trait_name: &str) -> bool {
+    fn type_implements_trait_inner(
+        &self,
+        ctx: &AnnotateCtx,
+        resolved: &ResolvedType,
+        trait_name: &str,
+    ) -> bool {
         // Type parameters satisfy bounds declared on them (e.g., T: Describable
         // means T implements Describable within the scope of that declaration)
         if let ResolvedType::TypeParam { name, .. } | ResolvedType::TypePack { name, .. } = resolved
         {
-            if let Some(bounds) = self.annotate_ctx.trait_ctx.type_param_bounds.get(name) {
+            if let Some(bounds) = ctx.trait_ctx.type_param_bounds.get(name) {
                 return bounds.iter().any(|b| b.name == trait_name);
             }
             return false;
@@ -458,7 +469,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             && let Some(info) = self.lookup_variant_case(name)
         {
             let all_impl = info.cases.iter().all(|c| {
-                c.payload == TypeTable::UNIT || self.type_implements_trait(c.payload, trait_name)
+                c.payload == TypeTable::UNIT || self.type_implements_trait(ctx, c.payload, trait_name)
             });
             if all_impl {
                 return true;
@@ -473,7 +484,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             let field_types: Vec<TypeId> = info.fields.iter().map(|(_, tid, _)| *tid).collect();
             let all_impl = field_types
                 .iter()
-                .all(|tid| self.type_implements_trait(*tid, trait_name));
+                .all(|tid| self.type_implements_trait(ctx, *tid, trait_name));
             if all_impl {
                 return true;
             }
@@ -507,7 +518,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 .collect();
             let all_impl = info.fields.iter().all(|(_, field_tid, _)| {
                 let concrete_tid = param_map.get(field_tid).copied().unwrap_or(*field_tid);
-                self.type_implements_trait(concrete_tid, trait_name)
+                self.type_implements_trait(ctx, concrete_tid, trait_name)
             });
             if all_impl {
                 return true;
@@ -533,7 +544,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     return true;
                 }
                 let concrete_tid = param_map.get(&c.payload).copied().unwrap_or(c.payload);
-                self.type_implements_trait(concrete_tid, trait_name)
+                self.type_implements_trait(ctx, concrete_tid, trait_name)
             });
             if all_impl {
                 return true;
@@ -561,7 +572,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     let elems = type_args.clone();
                     return elems
                         .iter()
-                        .all(|e| self.type_implements_trait(*e, trait_name));
+                        .all(|e| self.type_implements_trait(ctx, *e, trait_name));
                 }
                 (
                     name.clone(),
@@ -582,7 +593,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 if self.find_trait_impl_for_type_with_args("&", trait_name, Some(&[inner_id])) {
                     return true;
                 }
-                return self.type_implements_trait(inner_id, trait_name);
+                return self.type_implements_trait(ctx, inner_id, trait_name);
             }
             ResolvedType::MutRef(inner) => {
                 // Mutable references always implement Eq via ref.eq (identity comparison)
@@ -593,7 +604,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 if self.find_trait_impl_for_type_with_args("&mut", trait_name, Some(&[inner_id])) {
                     return true;
                 }
-                return self.type_implements_trait(inner_id, trait_name);
+                return self.type_implements_trait(ctx, inner_id, trait_name);
             }
             ResolvedType::AssocTypeProjection { bounds, .. } => {
                 // An associated type projection T::Assoc implements a trait if
@@ -610,7 +621,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 }
                 // Fall back to base type's trait implementation
                 let base_id = *base_type;
-                return self.type_implements_trait(base_id, trait_name);
+                return self.type_implements_trait(ctx, base_id, trait_name);
             }
             ResolvedType::Flags { name, .. } => {
                 // Check for a direct impl on the flags type first (e.g., impl Serialize for Perms)
@@ -618,7 +629,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     return true;
                 }
                 // Fall back to u32's trait implementation
-                return self.type_implements_trait(TypeTable::U32, trait_name);
+                return self.type_implements_trait(ctx, TypeTable::U32, trait_name);
             }
             _ => return false,
         };
@@ -1025,7 +1036,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         continue;
                     }
                     for bound in bounds {
-                        if !self.type_implements_trait(type_arg, bound) {
+                        if !self.type_implements_trait(&self.annotate_ctx, type_arg, bound) {
                             return false;
                         }
                     }
@@ -1042,7 +1053,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 )
             {
                 for bound in bounds {
-                    if !self.type_implements_trait(type_arg, bound) {
+                    if !self.type_implements_trait(&self.annotate_ctx, type_arg, bound) {
                         return false;
                     }
                 }
@@ -1073,7 +1084,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     if bound.fn_signature.is_some() {
                         continue;
                     }
-                    if self.type_implements_trait(type_arg, &bound.name) {
+                    if self.type_implements_trait(&self.annotate_ctx, type_arg, &bound.name) {
                         // Register associated type resolutions so the monomorphizer can
                         // substitute e.g. I::Iter → ListIter<u8> when I = List<u8>.
                         self.register_assoc_types_for_concrete_type_and_trait(
@@ -1253,7 +1264,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         let bounds_ok = blanket_param
                             .bounds
                             .iter()
-                            .all(|bound| self.type_implements_trait(concrete_type_id, &bound.name));
+                            .all(|bound| self.type_implements_trait(&self.annotate_ctx, concrete_type_id, &bound.name));
                         if bounds_ok {
                             result.push(BlanketImplInfo {
                                 blanket_param_name: blanket_param.name.clone(),
@@ -1367,7 +1378,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             };
             let param_types = info.rhs_type.map(|t| vec![t]).unwrap_or_default();
             (info.trait_name, info.self_kind, param_types, return_type)
-        } else if (is_eq || is_ord) && self.type_implements_trait(lookup_type_id, trait_name) {
+        } else if (is_eq || is_ord) && self.type_implements_trait(&self.annotate_ctx, lookup_type_id, trait_name) {
             let ref_self_ty = self
                 .tysys
                 .type_table
@@ -1461,7 +1472,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         if !self.tysys.auto_derive_eligible_kind(base_type_id) {
             return None;
         }
-        if !self.type_implements_trait(base_type_id, &trait_name) {
+        if !self.type_implements_trait(&self.annotate_ctx, base_type_id, &trait_name) {
             return None;
         }
         let ref_self_ty = self

--- a/wado-compiler/src/elaborator/trait_query.rs
+++ b/wado-compiler/src/elaborator/trait_query.rs
@@ -1140,18 +1140,18 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             impl_ty_param_names: Vec<String>,
             assoc_types: Vec<ast::AssociatedTypeBinding>,
         }
+        let trait_env = self.tysys.trait_env.clone();
         let impl_infos: Vec<ImplInfo> = {
             let mut result = vec![];
-            if let Some(entries) = self.tysys.trait_env.impl_index.get(&type_name) {
-                let entries = entries.clone();
-                for (module_src, item_idx) in entries {
-                    let module = &self.loaded_modules[&module_src];
-                    if let Item::Impl(impl_block) = &module.items[item_idx]
-                        && let Some(trait_type) = &impl_block.trait_type
-                        && self.get_type_name(trait_type) == trait_name
-                        && !impl_block.associated_types.is_empty()
+            if let Some(entries) = trait_env.impl_index.get(&type_name) {
+                for entry in entries {
+                    let Some(header) = trait_env.impl_headers.get(entry) else {
+                        continue;
+                    };
+                    if header.trait_name.as_deref() == Some(trait_name)
+                        && !header.associated_types.is_empty()
                     {
-                        let impl_ty_param_names: Vec<String> = match &impl_block.ty {
+                        let impl_ty_param_names: Vec<String> = match &header.ty {
                             ast::Type::Generic(g) => g
                                 .args
                                 .iter()
@@ -1166,9 +1166,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             _ => vec![],
                         };
                         result.push(ImplInfo {
-                            type_params: impl_block.type_params.clone(),
+                            type_params: header.type_params.clone(),
                             impl_ty_param_names,
-                            assoc_types: impl_block.associated_types.clone(),
+                            assoc_types: header.associated_types.clone(),
                         });
                     }
                 }
@@ -1236,15 +1236,15 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
         let blanket_infos: Vec<BlanketImplInfo> = {
             let mut result = vec![];
-            for (module_src, item_idx) in &self.tysys.trait_env.blanket_impl_index {
-                let module = &self.loaded_modules[module_src];
-                if let Item::Impl(impl_block) = &module.items[*item_idx]
-                    && let Some(trait_type) = &impl_block.trait_type
-                    && self.get_type_name(trait_type) == trait_name
-                    && !impl_block.associated_types.is_empty()
+            for entry in &trait_env.blanket_impl_index {
+                let Some(header) = trait_env.impl_headers.get(entry) else {
+                    continue;
+                };
+                if header.trait_name.as_deref() == Some(trait_name)
+                    && !header.associated_types.is_empty()
                 {
-                    let impl_type_name = Self::get_type_name_static(&impl_block.ty);
-                    if let Some(blanket_param) = impl_block
+                    let impl_type_name = Self::get_type_name_static(&header.ty);
+                    if let Some(blanket_param) = header
                         .type_params
                         .iter()
                         .find(|tp| tp.name == impl_type_name && !tp.bounds.is_empty())
@@ -1258,7 +1258,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             result.push(BlanketImplInfo {
                                 blanket_param_name: blanket_param.name.clone(),
                                 blanket_param_bounds: blanket_param.bounds.clone(),
-                                assoc_types: impl_block.associated_types.clone(),
+                                assoc_types: header.associated_types.clone(),
                             });
                         }
                     }

--- a/wado-compiler/src/elaborator/trait_query.rs
+++ b/wado-compiler/src/elaborator/trait_query.rs
@@ -256,17 +256,17 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // `canonical_decl_key` is local-first (issue #1298), so the type-param
         // list and the default-method bodies resolve to the same trait.
         let canonical_key = self.canonical_decl_key(trait_name);
-        if let Some((module_src, item_idx)) = self.tysys.trait_env.decl_index.get(&canonical_key) {
-            let module = &self.loaded_modules[module_src];
-            if let Item::Trait(trait_decl) = &module.items[*item_idx] {
-                return Some(trait_decl.type_params.clone());
-            }
+        if let Some(loc) = self.tysys.trait_env.decl_index.get(&canonical_key)
+            && let Some(header) = self.tysys.trait_env.trait_decl_headers.get(loc)
+        {
+            return Some(header.type_params.clone());
         }
-        for item in self.current_module_items {
-            if let Item::Trait(trait_decl) = item
-                && trait_decl.name == trait_name
-            {
-                return Some(trait_decl.type_params.clone());
+        // Fallback: a trait declared in the current module whose canonical key
+        // missed the decl index. (`trait_decl_headers` covers every loaded
+        // module, so the current module is included.)
+        for (key, header) in &self.tysys.trait_env.trait_decl_headers {
+            if key.0 == self.current_module_source && header.name == trait_name {
+                return Some(header.type_params.clone());
             }
         }
         None

--- a/wado-compiler/src/elaborator/trait_query.rs
+++ b/wado-compiler/src/elaborator/trait_query.rs
@@ -283,18 +283,18 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // If any non-recursive field fails the trait check, it will be caught on that path.
         {
             let key = (type_id, trait_name.to_string());
-            let stack = self.trait_check_stack.borrow();
+            let stack = self.annotate_ctx.trait_check_stack.borrow();
             if stack.contains(&key) {
                 return true;
             }
         }
-        self.trait_check_stack
+        self.annotate_ctx.trait_check_stack
             .borrow_mut()
             .push((type_id, trait_name.to_string()));
 
         let result = self.type_implements_trait_inner(&resolved, trait_name);
 
-        self.trait_check_stack.borrow_mut().pop();
+        self.annotate_ctx.trait_check_stack.borrow_mut().pop();
 
         result
     }
@@ -407,7 +407,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // means T implements Describable within the scope of that declaration)
         if let ResolvedType::TypeParam { name, .. } | ResolvedType::TypePack { name, .. } = resolved
         {
-            if let Some(bounds) = self.trait_ctx.type_param_bounds.get(name) {
+            if let Some(bounds) = self.annotate_ctx.trait_ctx.type_param_bounds.get(name) {
                 return bounds.iter().any(|b| b.name == trait_name);
             }
             return false;
@@ -737,7 +737,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     // Self::ns.name → type_param_name::ns.name
                     // Look in current_type_param_bounds[type_param_name] for direct binding
                     if let Some(param_bounds) = self
-                        .trait_ctx
+                        .annotate_ctx.trait_ctx
                         .type_param_bounds
                         .get(type_param_name)
                         .cloned()
@@ -822,8 +822,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 // Save the entire trait context; we'll modify self_type, assoc_type_bindings,
                 // type_params, and type_param_bounds during this resolution scope.
                 let mut scope = self.enter_inherited_type_param_scope();
-                scope.trait_ctx.self_type = Some(self_type_id);
-                scope.trait_ctx.assoc_type_bindings.clear();
+                scope.annotate_ctx.trait_ctx.self_type = Some(self_type_id);
+                scope.annotate_ctx.trait_ctx.assoc_type_bindings.clear();
 
                 // Set up associated type bindings as projections so that
                 // Self::AssocType resolves to AssocTypeProjection(self_type_id, "AssocType").
@@ -879,7 +879,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             )
                     });
                     scope
-                        .trait_ctx
+                        .annotate_ctx.trait_ctx
                         .assoc_type_bindings
                         .insert(assoc_decl.name.clone(), projection);
                 }
@@ -898,12 +898,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         .borrow_mut()
                         .make_type_param(param.name.clone(), index as u32);
                     scope
-                        .trait_ctx
+                        .annotate_ctx.trait_ctx
                         .type_params
                         .insert(param.name.clone(), (index as u32, type_id));
                     if !param.bounds.is_empty() {
                         scope
-                            .trait_ctx
+                            .annotate_ctx.trait_ctx
                             .type_param_bounds
                             .insert(param.name.clone(), param.bounds.clone());
                     }
@@ -1186,7 +1186,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             for (i, tp_name) in info.impl_ty_param_names.iter().enumerate() {
                 if let Some(&concrete_arg) = concrete_type_args.get(i) {
                     scope
-                        .trait_ctx
+                        .annotate_ctx.trait_ctx
                         .type_params
                         .insert(tp_name.clone(), (i as u32, concrete_arg));
                 }
@@ -1195,7 +1195,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             for param in &info.type_params {
                 if !param.bounds.is_empty() {
                     scope
-                        .trait_ctx
+                        .annotate_ctx.trait_ctx
                         .type_param_bounds
                         .entry(param.name.clone())
                         .or_default()
@@ -1274,11 +1274,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // For `impl<I: Iterator> IntoIterator for I` with StrUtf8ByteIter:
             // → set current_type_params["I"] = (0, StrUtf8ByteIter_typeid)
             scope
-                .trait_ctx
+                .annotate_ctx.trait_ctx
                 .type_params
                 .insert(info.blanket_param_name.clone(), (0, concrete_type_id));
             scope
-                .trait_ctx
+                .annotate_ctx.trait_ctx
                 .type_param_bounds
                 .insert(info.blanket_param_name.clone(), info.blanket_param_bounds);
 

--- a/wado-compiler/src/elaborator/trait_query.rs
+++ b/wado-compiler/src/elaborator/trait_query.rs
@@ -13,8 +13,8 @@ use crate::token::Span;
 use super::Elaborator;
 use super::callee::CalleeRef;
 use super::trait_env::AnnotateCtx;
-use super::tysys::TypeSystem;
 use super::types::{MethodInfo, ResolvedTraitMethod, TraitMethodMatch, TypeError};
+use super::tysys::TypeSystem;
 
 /// Free-function form of [`Elaborator::canonical_decl_key`], callable from
 /// any module that has the inputs in hand. Reify uses this for trait
@@ -469,7 +469,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             && let Some(info) = self.lookup_variant_case(name)
         {
             let all_impl = info.cases.iter().all(|c| {
-                c.payload == TypeTable::UNIT || self.type_implements_trait(ctx, c.payload, trait_name)
+                c.payload == TypeTable::UNIT
+                    || self.type_implements_trait(ctx, c.payload, trait_name)
             });
             if all_impl {
                 return true;
@@ -748,7 +749,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     // Self::ns.name → type_param_name::ns.name
                     // Look in current_type_param_bounds[type_param_name] for direct binding
                     if let Some(param_bounds) = self
-                        .annotate_ctx.trait_ctx
+                        .annotate_ctx
+                        .trait_ctx
                         .type_param_bounds
                         .get(type_param_name)
                         .cloned()
@@ -890,7 +892,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             )
                     });
                     scope
-                        .annotate_ctx.trait_ctx
+                        .annotate_ctx
+                        .trait_ctx
                         .assoc_type_bindings
                         .insert(assoc_decl.name.clone(), projection);
                 }
@@ -909,12 +912,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         .borrow_mut()
                         .make_type_param(param.name.clone(), index as u32);
                     scope
-                        .annotate_ctx.trait_ctx
+                        .annotate_ctx
+                        .trait_ctx
                         .type_params
                         .insert(param.name.clone(), (index as u32, type_id));
                     if !param.bounds.is_empty() {
                         scope
-                            .annotate_ctx.trait_ctx
+                            .annotate_ctx
+                            .trait_ctx
                             .type_param_bounds
                             .insert(param.name.clone(), param.bounds.clone());
                     }
@@ -1197,7 +1202,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             for (i, tp_name) in info.impl_ty_param_names.iter().enumerate() {
                 if let Some(&concrete_arg) = concrete_type_args.get(i) {
                     scope
-                        .annotate_ctx.trait_ctx
+                        .annotate_ctx
+                        .trait_ctx
                         .type_params
                         .insert(tp_name.clone(), (i as u32, concrete_arg));
                 }
@@ -1206,7 +1212,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             for param in &info.type_params {
                 if !param.bounds.is_empty() {
                     scope
-                        .annotate_ctx.trait_ctx
+                        .annotate_ctx
+                        .trait_ctx
                         .type_param_bounds
                         .entry(param.name.clone())
                         .or_default()
@@ -1261,10 +1268,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         .find(|tp| tp.name == impl_type_name && !tp.bounds.is_empty())
                     {
                         // Check if the concrete type satisfies the blanket param's bounds
-                        let bounds_ok = blanket_param
-                            .bounds
-                            .iter()
-                            .all(|bound| self.type_implements_trait(&self.annotate_ctx, concrete_type_id, &bound.name));
+                        let bounds_ok = blanket_param.bounds.iter().all(|bound| {
+                            self.type_implements_trait(
+                                &self.annotate_ctx,
+                                concrete_type_id,
+                                &bound.name,
+                            )
+                        });
                         if bounds_ok {
                             result.push(BlanketImplInfo {
                                 blanket_param_name: blanket_param.name.clone(),
@@ -1285,11 +1295,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // For `impl<I: Iterator> IntoIterator for I` with StrUtf8ByteIter:
             // → set current_type_params["I"] = (0, StrUtf8ByteIter_typeid)
             scope
-                .annotate_ctx.trait_ctx
+                .annotate_ctx
+                .trait_ctx
                 .type_params
                 .insert(info.blanket_param_name.clone(), (0, concrete_type_id));
             scope
-                .annotate_ctx.trait_ctx
+                .annotate_ctx
+                .trait_ctx
                 .type_param_bounds
                 .insert(info.blanket_param_name.clone(), info.blanket_param_bounds);
 
@@ -1378,7 +1390,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             };
             let param_types = info.rhs_type.map(|t| vec![t]).unwrap_or_default();
             (info.trait_name, info.self_kind, param_types, return_type)
-        } else if (is_eq || is_ord) && self.type_implements_trait(&self.annotate_ctx, lookup_type_id, trait_name) {
+        } else if (is_eq || is_ord)
+            && self.type_implements_trait(&self.annotate_ctx, lookup_type_id, trait_name)
+        {
             let ref_self_ty = self
                 .tysys
                 .type_table
@@ -1513,5 +1527,4 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             is_blanket_ref_impl: false,
         })
     }
-
 }

--- a/wado-compiler/src/elaborator/trait_query.rs
+++ b/wado-compiler/src/elaborator/trait_query.rs
@@ -651,8 +651,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         trait_name: &str,
         type_args: Option<&[TypeId]>,
     ) -> bool {
-        // O(1) lookup by type name; read each impl's digested header rather than
-        // the impl block AST.
         let trait_env = self.tysys.trait_env.clone();
         if let Some(entries) = trait_env.impl_index.get(type_name) {
             for entry in entries {

--- a/wado-compiler/src/elaborator/trait_query.rs
+++ b/wado-compiler/src/elaborator/trait_query.rs
@@ -648,7 +648,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 {
                     let impl_trait_name = self.get_type_name(trait_type);
                     if impl_trait_name == trait_name
-                        && self.inherent_impl_type_args_match(
+                        && self.tysys.inherent_impl_type_args_match(
                             &impl_block.ty,
                             &impl_block.type_params,
                             type_args,

--- a/wado-compiler/src/elaborator/trait_query.rs
+++ b/wado-compiler/src/elaborator/trait_query.rs
@@ -639,25 +639,29 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         trait_name: &str,
         type_args: Option<&[TypeId]>,
     ) -> bool {
-        // Use pre-built index for O(1) lookup by type name.
-        if let Some(entries) = self.tysys.trait_env.impl_index.get(type_name) {
-            for (module_src, item_idx) in entries {
-                let module = &self.loaded_modules[module_src];
-                if let Item::Impl(impl_block) = &module.items[*item_idx]
-                    && let Some(trait_type) = &impl_block.trait_type
+        // Use pre-built index for O(1) lookup by type name; read each impl's
+        // digested header (trait name, target type, type params) rather than
+        // re-fetching the impl block from `loaded_modules`.
+        let trait_env = self.tysys.trait_env.clone();
+        if let Some(entries) = trait_env.impl_index.get(type_name) {
+            for entry in entries {
+                let (module_src, _) = entry;
+                let Some(header) = trait_env.impl_headers.get(entry) else {
+                    continue;
+                };
+                let Some(impl_trait_name) = &header.trait_name else {
+                    continue;
+                };
+                if impl_trait_name == trait_name
+                    && self.tysys.inherent_impl_type_args_match(
+                        &header.ty,
+                        &header.type_params,
+                        type_args,
+                        module_src,
+                    )
+                    && self.check_impl_block_bounds(&header.type_params, &header.ty, type_args)
                 {
-                    let impl_trait_name = self.get_type_name(trait_type);
-                    if impl_trait_name == trait_name
-                        && self.tysys.inherent_impl_type_args_match(
-                            &impl_block.ty,
-                            &impl_block.type_params,
-                            type_args,
-                            module_src,
-                        )
-                        && self.check_impl_block_bounds(impl_block, type_args)
-                    {
-                        return true;
-                    }
+                    return true;
                 }
             }
         }
@@ -668,26 +672,26 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Blanket impl fallback: check `impl<T: Bound> Trait for T` where the
         // concrete type satisfies the bound.
-        for (module_src, item_idx) in &self.tysys.trait_env.blanket_impl_index {
-            let module = &self.loaded_modules[module_src];
-            if let Item::Impl(impl_block) = &module.items[*item_idx]
-                && let Some(trait_type) = &impl_block.trait_type
-            {
-                let impl_trait_name = self.get_type_name(trait_type);
-                if impl_trait_name == trait_name {
-                    let impl_type_name = Self::get_type_name_static(&impl_block.ty);
-                    let matching_param = impl_block
-                        .type_params
+        for entry in &trait_env.blanket_impl_index {
+            let Some(header) = trait_env.impl_headers.get(entry) else {
+                continue;
+            };
+            let Some(impl_trait_name) = &header.trait_name else {
+                continue;
+            };
+            if impl_trait_name == trait_name {
+                let impl_type_name = Self::get_type_name_static(&header.ty);
+                let matching_param = header
+                    .type_params
+                    .iter()
+                    .find(|tp| tp.name == impl_type_name);
+                if let Some(param) = matching_param {
+                    let bounds_satisfied = param
+                        .bounds
                         .iter()
-                        .find(|tp| tp.name == impl_type_name);
-                    if let Some(param) = matching_param {
-                        let bounds_satisfied = param
-                            .bounds
-                            .iter()
-                            .all(|bound| self.find_trait_impl_for_type(type_name, &bound.name));
-                        if bounds_satisfied {
-                            return true;
-                        }
+                        .all(|bound| self.find_trait_impl_for_type(type_name, &bound.name));
+                    if bounds_satisfied {
+                        return true;
                     }
                 }
             }
@@ -967,11 +971,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// For `impl<T: Ord> List<T>`, checks that the concrete type substituted for T implements Ord.
     pub(super) fn check_impl_block_bounds(
         &self,
-        impl_block: &ast::ImplBlock,
+        type_params: &[ast::GenericParam],
+        impl_ty: &ast::Type,
         type_args: Option<&[TypeId]>,
     ) -> bool {
         // No type params with bounds → always OK
-        if impl_block.type_params.iter().all(|p| p.bounds.is_empty()) {
+        if type_params.iter().all(|p| p.bounds.is_empty()) {
             return true;
         }
 
@@ -981,8 +986,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         };
 
         // Build name → bounds map from impl block type params (trait names only)
-        let bounds_map: IndexMap<&str, Vec<String>> = impl_block
-            .type_params
+        let bounds_map: IndexMap<&str, Vec<String>> = type_params
             .iter()
             .filter(|p| !p.bounds.is_empty())
             .map(|p| {
@@ -995,7 +999,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Match type params to receiver type args via generic type arg positions
         let inner_type_name: Option<&str> =
-            if let ast::Type::Reference(boxed) | ast::Type::MutReference(boxed) = &impl_block.ty {
+            if let ast::Type::Reference(boxed) | ast::Type::MutReference(boxed) = impl_ty {
                 if let ast::Type::Named(inner) = boxed.as_ref() {
                     Some(&inner.name)
                 } else {
@@ -1005,7 +1009,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 None
             };
 
-        if let ast::Type::Generic(generic) = &impl_block.ty {
+        if let ast::Type::Generic(generic) = impl_ty {
             for (i, arg) in generic.args.iter().enumerate() {
                 if let ast::Type::Named(named) = arg
                     && let Some(bounds) = bounds_map.get(named.name.as_str())

--- a/wado-compiler/src/elaborator/trait_query.rs
+++ b/wado-compiler/src/elaborator/trait_query.rs
@@ -391,8 +391,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // explain that member in turn.
         for (label, member_tid) in members {
             if !self.type_implements_trait(member_tid, trait_name) {
-                let owner = self.type_id_to_string(type_id);
-                let member_ty = self.type_id_to_string(member_tid);
+                let owner = self.tysys.type_id_to_string(type_id);
+                let member_ty = self.tysys.type_id_to_string(member_tid);
                 chain.push(format!(
                     "`{owner}` does not implement `{trait_name}` because {label} of type `{member_ty}` does not implement `{trait_name}`"
                 ));
@@ -1077,7 +1077,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             &bound.name.clone(),
                         );
                     } else {
-                        let type_name = self.type_id_to_string(type_arg);
+                        let type_name = self.tysys.type_id_to_string(type_arg);
                         let reason = self.trait_unimpl_reason_chain(type_arg, &bound.name);
                         let _ = self.logger.error(TypeError::TraitBoundNotSatisfied {
                             type_name,
@@ -1453,8 +1453,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             "cmp" => ord_name,
             _ => return None,
         };
-        let base_type_id = self.get_base_type(receiver_type_id);
-        if !self.auto_derive_eligible_kind(base_type_id) {
+        let base_type_id = self.tysys.get_base_type(receiver_type_id);
+        if !self.tysys.auto_derive_eligible_kind(base_type_id) {
             return None;
         }
         if !self.type_implements_trait(base_type_id, &trait_name) {
@@ -1499,18 +1499,4 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         })
     }
 
-    /// Whether the given type is a kind for which `synthesis::traits` emits
-    /// auto-derived `Eq` / `Ord` method bodies: named structs, variants, and
-    /// enums (including generic instances thereof). Primitives and reference
-    /// types are excluded because their equality lowers to Wasm instructions
-    /// rather than a callable method.
-    fn auto_derive_eligible_kind(&self, type_id: TypeId) -> bool {
-        matches!(
-            self.tysys.type_table.borrow().get(type_id),
-            ResolvedType::Struct { .. }
-                | ResolvedType::Variant { .. }
-                | ResolvedType::Enum { .. }
-                | ResolvedType::GenericInstance { .. }
-        )
-    }
 }

--- a/wado-compiler/src/elaborator/type_resolution.rs
+++ b/wado-compiler/src/elaborator/type_resolution.rs
@@ -102,7 +102,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             Type::NamespacedGeneric(namespaced) => self.resolve_namespaced_generic_type(namespaced),
             Type::TypePackSpread(name, span) => {
                 // Look up the type pack parameter
-                if let Some((index, _type_id)) = self.trait_ctx.type_params.get(name) {
+                if let Some((index, _type_id)) = self.annotate_ctx.trait_ctx.type_params.get(name) {
                     self.tysys
                         .type_table
                         .borrow_mut()
@@ -129,7 +129,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Handle Self::AssociatedType
         if namespaced.namespace.as_str() == "Self" {
             // Look up the associated type binding
-            if let Some(&type_id) = self.trait_ctx.assoc_type_bindings.get(&namespaced.name) {
+            if let Some(&type_id) = self.annotate_ctx.trait_ctx.assoc_type_bindings.get(&namespaced.name) {
                 return type_id;
             }
             // If not found, it's an unknown associated type
@@ -141,7 +141,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
 
         // Handle T::AssociatedType where T is a type parameter in scope
-        if let Some(&(_, param_type_id)) = self.trait_ctx.type_params.get(&namespaced.namespace) {
+        if let Some(&(_, param_type_id)) = self.annotate_ctx.trait_ctx.type_params.get(&namespaced.namespace) {
             // If the param is bound to a concrete type (not a TypeParam), look up the assoc
             // type from the TypeTable directly. This handles cases like blanket impl resolution
             // where we temporarily bind e.g. I = StrUtf8ByteIter (concrete struct), and
@@ -236,7 +236,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     pub(super) fn resolve_named_type(&mut self, name: &str, _span: Span) -> TypeId {
         // Handle `Self` type reference in impl blocks
         if name == "Self" {
-            if let Some(self_type) = self.trait_ctx.self_type {
+            if let Some(self_type) = self.annotate_ctx.trait_ctx.self_type {
                 return self_type;
             }
             // Self used outside of impl block - return Unknown
@@ -244,7 +244,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
 
         // First check if it's a type parameter in scope
-        if let Some(&(_, type_id)) = self.trait_ctx.type_params.get(name) {
+        if let Some(&(_, type_id)) = self.annotate_ctx.trait_ctx.type_params.get(name) {
             return type_id;
         }
 
@@ -510,7 +510,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         param_name: &str,
         assoc_name: &str,
     ) -> Option<TypeId> {
-        let bounds = self.trait_ctx.type_param_bounds.get(param_name)?.clone();
+        let bounds = self.annotate_ctx.trait_ctx.type_param_bounds.get(param_name)?.clone();
         for bound in &bounds {
             for assoc in &bound.assoc_types {
                 if assoc.name == assoc_name {

--- a/wado-compiler/src/elaborator/type_resolution.rs
+++ b/wado-compiler/src/elaborator/type_resolution.rs
@@ -401,7 +401,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         for (i, (param_name, bounds)) in info.type_param_bounds.iter().enumerate() {
                             if let Some(&type_arg) = type_args.get(i) {
                                 for bound in bounds {
-                                    if !self.type_implements_trait(type_arg, bound) {
+                                    if !self.type_implements_trait(&self.annotate_ctx, type_arg, bound) {
                                         // Get the type name for the error message
                                         let type_name = self.tysys.type_id_to_string(type_arg);
                                         let reason =

--- a/wado-compiler/src/elaborator/type_resolution.rs
+++ b/wado-compiler/src/elaborator/type_resolution.rs
@@ -403,7 +403,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 for bound in bounds {
                                     if !self.type_implements_trait(type_arg, bound) {
                                         // Get the type name for the error message
-                                        let type_name = self.type_id_to_string(type_arg);
+                                        let type_name = self.tysys.type_id_to_string(type_arg);
                                         let reason =
                                             self.trait_unimpl_reason_chain(type_arg, bound);
                                         let _ =
@@ -450,7 +450,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         args.iter().map(|t| self.resolve_type(t)).collect();
                     let arg_names: Vec<String> = resolved_args
                         .iter()
-                        .map(|&tid| self.type_id_to_string(tid))
+                        .map(|&tid| self.tysys.type_id_to_string(tid))
                         .collect();
                     let display_name = format!("{}<{}>", name, arg_names.join(", "));
                     self.tysys.type_table.borrow_mut().make_newtype(

--- a/wado-compiler/src/elaborator/type_resolution.rs
+++ b/wado-compiler/src/elaborator/type_resolution.rs
@@ -129,7 +129,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Handle Self::AssociatedType
         if namespaced.namespace.as_str() == "Self" {
             // Look up the associated type binding
-            if let Some(&type_id) = self.annotate_ctx.trait_ctx.assoc_type_bindings.get(&namespaced.name) {
+            if let Some(&type_id) = self
+                .annotate_ctx
+                .trait_ctx
+                .assoc_type_bindings
+                .get(&namespaced.name)
+            {
                 return type_id;
             }
             // If not found, it's an unknown associated type
@@ -141,7 +146,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
 
         // Handle T::AssociatedType where T is a type parameter in scope
-        if let Some(&(_, param_type_id)) = self.annotate_ctx.trait_ctx.type_params.get(&namespaced.namespace) {
+        if let Some(&(_, param_type_id)) = self
+            .annotate_ctx
+            .trait_ctx
+            .type_params
+            .get(&namespaced.namespace)
+        {
             // If the param is bound to a concrete type (not a TypeParam), look up the assoc
             // type from the TypeTable directly. This handles cases like blanket impl resolution
             // where we temporarily bind e.g. I = StrUtf8ByteIter (concrete struct), and
@@ -401,7 +411,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         for (i, (param_name, bounds)) in info.type_param_bounds.iter().enumerate() {
                             if let Some(&type_arg) = type_args.get(i) {
                                 for bound in bounds {
-                                    if !self.type_implements_trait(&self.annotate_ctx, type_arg, bound) {
+                                    if !self.type_implements_trait(
+                                        &self.annotate_ctx,
+                                        type_arg,
+                                        bound,
+                                    ) {
                                         // Get the type name for the error message
                                         let type_name = self.tysys.type_id_to_string(type_arg);
                                         let reason =
@@ -510,7 +524,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         param_name: &str,
         assoc_name: &str,
     ) -> Option<TypeId> {
-        let bounds = self.annotate_ctx.trait_ctx.type_param_bounds.get(param_name)?.clone();
+        let bounds = self
+            .annotate_ctx
+            .trait_ctx
+            .type_param_bounds
+            .get(param_name)?
+            .clone();
         for bound in &bounds {
             for assoc in &bound.assoc_types {
                 if assoc.name == assoc_name {

--- a/wado-compiler/src/elaborator/tysys.rs
+++ b/wado-compiler/src/elaborator/tysys.rs
@@ -56,13 +56,13 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
 
-use crate::ast::{BinaryOp, Expr, Literal, UnaryOp};
+use crate::ast::{BinaryOp, Expr, ImplBlock, Literal, Type, UnaryOp};
 use crate::builtin_registry::BuiltinRegistry;
 use crate::compiler_item::CompilerItem;
 use crate::component_model::CmInterfaceRegistry;
 use crate::hashmap::{IndexMap, IndexSet};
 use crate::module_source::ModuleSource;
-use crate::tir::{TypeId, TypeTable};
+use crate::tir::{ResolvedType, TypeId, TypeTable};
 
 use super::trait_env::TraitEnv;
 use super::types::{
@@ -258,6 +258,216 @@ impl TypeSystem {
             )),
             // Logical `&&` / `||` short-circuit on `bool`; no trait dispatch.
             BinaryOp::And | BinaryOp::Or => None,
+        }
+    }
+}
+
+/// Pure type-shape helpers — queries answerable from the type table alone
+/// (peeling references, extracting a declared type's name, newtype-base
+/// resolution, type stringification). Relocated off `impl Elaborator` as
+/// part of the WEP 2026-05-26 God-Object decomposition (Stage A): they
+/// touch only `self.type_table`, so they belong on the type system, and
+/// both the body walk and reify reach them through `self.tysys`.
+impl TypeSystem {
+    /// Build declared type params for an impl block, filtering out known type names.
+    pub(crate) fn build_declared_type_params(&self, impl_block: &ImplBlock) -> IndexSet<String> {
+        let mut declared: IndexSet<String> = impl_block
+            .type_params
+            .iter()
+            .map(|p| p.name.clone())
+            .filter(|name| !self.is_known_type_name(name))
+            .collect();
+        if let Type::Generic(g) = &impl_block.ty {
+            for arg in &g.args {
+                if let Type::Named(n) = arg
+                    && !self.is_known_type_name(&n.name)
+                {
+                    declared.insert(n.name.clone());
+                }
+            }
+        }
+        declared
+    }
+
+    /// Get the struct name from a type ID, if it's a struct, generic instance, newtype, or flags.
+    pub(crate) fn struct_name_for_type(&self, type_id: TypeId) -> Option<String> {
+        match self.type_table.borrow().get(type_id) {
+            ResolvedType::Struct { name, .. }
+            | ResolvedType::GenericInstance { name, .. }
+            | ResolvedType::Newtype { name, .. }
+            | ResolvedType::Flags { name, .. } => Some(name.clone()),
+            _ => None,
+        }
+    }
+
+    /// For newtypes, get the base type name and ID for trait impl lookup fallback.
+    /// Returns (`base_name`, `base_type_id`) if the type is a newtype; otherwise returns the same name/id.
+    pub(crate) fn newtype_base_lookup(&self, name: &str, type_id: TypeId) -> (String, TypeId) {
+        let tt = self.type_table.borrow();
+        if let Some(base_id) = tt.get_newtype_base(type_id) {
+            drop(tt);
+            if let Some(base_name) = self.struct_name_for_type(base_id) {
+                return (base_name, base_id);
+            }
+        }
+        (name.to_string(), type_id)
+    }
+
+    /// Peel a chain of trailing newtypes / generic instances down to the
+    /// ultimate base struct (or builtin) name that owns its methods.
+    pub(crate) fn get_ultimate_base_struct_name(&self, type_id: TypeId) -> String {
+        let mut current = type_id;
+        loop {
+            match self.type_table.borrow().get(current).clone() {
+                ResolvedType::Struct { name, .. } => return name,
+                ResolvedType::GenericInstance { name, .. } => return name,
+                ResolvedType::Newtype { base_type, .. } => current = base_type,
+                ResolvedType::Flags { .. } => return "u32".to_string(),
+                // The raw GC array's base method-owner name is "Array"
+                // (its type args are carried separately), not the full
+                // `type_name` spelling `Array<T>`.
+                ResolvedType::BuiltinArray(_) => return TypeTable::ARRAY_TYPE_NAME.to_string(),
+                _ => return self.type_table.borrow().type_name(current),
+            }
+        }
+    }
+
+    /// Peel reference / mutable-reference wrappers to reach the underlying type.
+    pub(crate) fn get_base_type(&self, type_id: TypeId) -> TypeId {
+        let mut current = type_id;
+        loop {
+            match self.type_table.borrow().get(current).clone() {
+                ResolvedType::Ref(inner) | ResolvedType::MutRef(inner) => {
+                    current = inner;
+                }
+                _ => return current,
+            }
+        }
+    }
+
+    /// Whether `type_id` is a kind that participates in `Eq`/`Ord` auto-derive.
+    pub(crate) fn auto_derive_eligible_kind(&self, type_id: TypeId) -> bool {
+        matches!(
+            self.type_table.borrow().get(type_id),
+            ResolvedType::Struct { .. }
+                | ResolvedType::Variant { .. }
+                | ResolvedType::Enum { .. }
+                | ResolvedType::GenericInstance { .. }
+        )
+    }
+
+    /// Substitute every occurrence of `base_type` with `newtype` inside
+    /// `type_id`, recursing through references and generic-instance args.
+    /// Returns the original id unchanged when no occurrence is found.
+    pub(crate) fn substitute_newtype_in_type(
+        &self,
+        type_id: TypeId,
+        base_type: TypeId,
+        newtype: TypeId,
+    ) -> TypeId {
+        let ty = self.type_table.borrow().get(type_id).clone();
+        match ty {
+            // Direct match: base type -> newtype
+            _ if type_id == base_type => newtype,
+
+            // Reference: substitute the inner type
+            ResolvedType::Ref(inner) => {
+                let new_inner = self.substitute_newtype_in_type(inner, base_type, newtype);
+                if new_inner == inner {
+                    type_id
+                } else {
+                    self.type_table
+                        .borrow_mut()
+                        .intern(ResolvedType::Ref(new_inner))
+                }
+            }
+            ResolvedType::MutRef(inner) => {
+                let new_inner = self.substitute_newtype_in_type(inner, base_type, newtype);
+                if new_inner == inner {
+                    type_id
+                } else {
+                    self.type_table
+                        .borrow_mut()
+                        .intern(ResolvedType::MutRef(new_inner))
+                }
+            }
+
+            // Generic instance (e.g., Option<T>, List<T>): substitute in type args
+            ResolvedType::GenericInstance {
+                name,
+                module_source,
+                type_args,
+            } => {
+                let new_args: Vec<TypeId> = type_args
+                    .iter()
+                    .map(|&arg| self.substitute_newtype_in_type(arg, base_type, newtype))
+                    .collect();
+                if new_args == type_args {
+                    type_id
+                } else {
+                    self.type_table.borrow_mut().intern(ResolvedType::GenericInstance {
+                        name,
+                        module_source,
+                        type_args: new_args,
+                    })
+                }
+            }
+
+            // Other types: no substitution
+            _ => type_id,
+        }
+    }
+
+    /// Render a type as a user-facing Wado type string (used in diagnostics
+    /// and synthesized names). Recurses through references, generic args,
+    /// tuples, and function types.
+    pub(crate) fn type_id_to_string(&self, type_id: TypeId) -> String {
+        let resolved = self.type_table.borrow().get(type_id).clone();
+        match resolved {
+            ResolvedType::Primitive(prim) => format!("{prim:?}").to_lowercase(),
+            ResolvedType::Struct { name, .. } => name,
+            ResolvedType::GenericInstance {
+                name,
+                module_source,
+                type_args,
+            } => {
+                if TypeTable::is_tuple_type(&name, &module_source) {
+                    let parts: Vec<String> = type_args
+                        .iter()
+                        .map(|&t| self.type_id_to_string(t))
+                        .collect();
+                    format!("[{}]", parts.join(", "))
+                } else if type_args.is_empty() {
+                    name
+                } else {
+                    let args: Vec<String> = type_args
+                        .iter()
+                        .map(|&t| self.type_id_to_string(t))
+                        .collect();
+                    format!("{}<{}>", name, args.join(", "))
+                }
+            }
+            ResolvedType::BuiltinArray(elem) => {
+                format!("Array<{}>", self.type_id_to_string(elem))
+            }
+            ResolvedType::Ref(inner) => format!("&{}", self.type_id_to_string(inner)),
+            ResolvedType::MutRef(inner) => format!("&mut {}", self.type_id_to_string(inner)),
+            ResolvedType::Function {
+                params,
+                return_type,
+                ..
+            } => {
+                let param_strs: Vec<String> =
+                    params.iter().map(|&t| self.type_id_to_string(t)).collect();
+                let ret_str = self.type_id_to_string(return_type);
+                format!("fn({}) -> {}", param_strs.join(", "), ret_str)
+            }
+            ResolvedType::TypeParam { name, .. } => name,
+            ResolvedType::Unit => "()".to_string(),
+            ResolvedType::Never => "!".to_string(),
+            ResolvedType::Unknown => "<unknown>".to_string(),
+            ResolvedType::Error => "<error>".to_string(),
+            _ => format!("{resolved:?}"),
         }
     }
 }

--- a/wado-compiler/src/elaborator/tysys.rs
+++ b/wado-compiler/src/elaborator/tysys.rs
@@ -406,11 +406,13 @@ impl TypeSystem {
                 if new_args == type_args {
                     type_id
                 } else {
-                    self.type_table.borrow_mut().intern(ResolvedType::GenericInstance {
-                        name,
-                        module_source,
-                        type_args: new_args,
-                    })
+                    self.type_table
+                        .borrow_mut()
+                        .intern(ResolvedType::GenericInstance {
+                            name,
+                            module_source,
+                            type_args: new_args,
+                        })
                 }
             }
 

--- a/wado-compiler/src/elaborator/tysys.rs
+++ b/wado-compiler/src/elaborator/tysys.rs
@@ -263,12 +263,10 @@ impl TypeSystem {
     }
 }
 
-/// Pure type-shape helpers — queries answerable from the type table alone
-/// (peeling references, extracting a declared type's name, newtype-base
-/// resolution, type stringification). Relocated off `impl Elaborator` as
-/// part of the WEP 2026-05-26 God-Object decomposition (Stage A): they
-/// touch only `self.type_table`, so they belong on the type system, and
-/// both the body walk and reify reach them through `self.tysys`.
+/// Pure type-shape helpers answerable from the type table alone (peel
+/// references, extract a declared type's name, newtype-base resolution, type
+/// stringification). They touch only `self.type_table`; the body walk and
+/// reify both reach them through `self.tysys`.
 impl TypeSystem {
     /// Build declared type params for an impl block, filtering out known type names.
     pub(crate) fn build_declared_type_params(&self, impl_block: &ImplBlock) -> IndexSet<String> {

--- a/wado-compiler/src/elaborator/tysys.rs
+++ b/wado-compiler/src/elaborator/tysys.rs
@@ -74,7 +74,8 @@ use super::types::{
 /// `annotate_modules` time.
 ///
 /// See the module-level documentation for the membership rule and the
-/// migration plan around the deferred `Elaborator` caches.
+/// rationale for the `Elaborator` caches that were removed rather than
+/// migrated here.
 #[derive(Clone)]
 pub(crate) struct TypeSystem {
     /// Shared type arena. Anonymous structs synthesised from struct


### PR DESCRIPTION
## Summary

Phase 2 of the `wep-2026-05-26` elaborator re-architecture: continue dismantling the `Elaborator` God Object by moving **operations** off it (Phase 1 had moved the data into `TypeSystem` / `ModuleSemantics` / `reify`). The goal is to let the trait/method-resolution queries become `impl TypeSystem` operations that take only type IDs, names, pre-digested decl facts, and an explicit per-function scope — instead of reading the borrowed `loaded_modules` AST map and the `Elaborator`-owned `trait_ctx`.

Behaviour-preserving throughout; the E2E suite (2934 tests) is green at every commit.

## What changed

- **Pure type-system ops → `impl TypeSystem`.** Operations answerable from the type table alone (impl-type matching, the type-shape helpers `struct_name_for_type` / `get_base_type` / `newtype_base_lookup` / `substitute_newtype_in_type` / `type_id_to_string` / …, inherent-impl arg matching) moved off `impl Elaborator`. They read `self.type_table` directly; both the body walk and reify reach them via `self.tysys`.

- **`TraitEnv` build-time decl digests (read facts, not ASTs).** `TraitEnv::build` now pre-computes, keyed by `(ModuleSource, item_idx)` or by type/fn name: `ImplHeader` (trait name / target type / type params / method signatures / associated types), `TraitDeclHeader`, `function_type_params`, `struct_like_decl_modules` + `newtype_decl_modules`, and `module_import_scopes` (the per-module `use`-derived import scope). Resolution queries — `find_trait_impl_for_type_with_args`, `register_assoc_types_for_concrete_type_and_trait`, `find_method_type_param(s)_*`, `find_struct_module_source`, `lookup_function_type_params`, `find_trait_decl_type_params`, `collect_trait_impl_refs(_multi)`, `lookup_static_method_type_params`, the blanket-impl loops, and the dispatch-core import-context sites — now read these digests instead of scanning `loaded_modules`.

- **`AnnotateCtx` per-function scope.** `trait_ctx` and the `type_implements_trait` recursion guard (`trait_check_stack`) are bundled into a single `Elaborator.annotate_ctx`, and `type_implements_trait` / `type_implements_trait_inner` now take an explicit `ctx: &AnnotateCtx` — the first step toward threading the scope through the resolution subgraph so those queries can leave the God Object.

- **Docs.** `wep-2026-05-26` refreshed: completed Phase 1 compressed to concise done-summaries, a new Phase 2 section records what landed and stages the remaining work (Track B Stages C–E and the dispatch-core method-signature digest) as a pick-up-ready checklist.

## Net effect

`Elaborator` `self.loaded_modules` use is down substantially (the remaining sites are the dispatch core — `lookup_method_info_uncached` / `call` / `method_call` — which need a method-signature digest plus the scope threading, both staged in the WEP — and `reify`, whose use is legitimate). The pre-digest infrastructure and `AnnotateCtx` are in place for the next phase.

https://claude.ai/code/session_01BknF85Pgf1yrWdqX4zyuPK

---
_Generated by [Claude Code](https://claude.ai/code/session_01BknF85Pgf1yrWdqX4zyuPK)_