### PR TITLE
chore(claude): SKILL-driven PR-conventions hook; deny AskUserQuestion

### DIFF
--- a/.claude/hooks/pr-conventions.sh
+++ b/.claude/hooks/pr-conventions.sh
@@ -1,45 +1,52 @@
 #!/usr/bin/env bash
 # PreToolUse hook for the `mcp__github__create_pull_request` tool.
 #
-# Enforces the repo's PR conventions (see .claude/skills/pull-request) at the
-# deterministic point a PR is created, independent of whether the model invoked
-# the pull-request skill:
-#   - Title MUST follow Conventional Commits.
-#   - Description conventions are surfaced (outcome of origin/main...HEAD; no
-#     trial-and-error history; no test section).
+# Enforces the repo's PR conventions at the deterministic point a PR is created,
+# independent of whether the model invoked the pull-request skill. The
+# conventions themselves are read from the pull-request skill so this hook never
+# drifts from the documented source of truth:
+#   - Title MUST follow Conventional Commits (the allowed types are derived from
+#     the skill's title list).
+#   - The skill body is surfaced as the description reminder.
 #
 # An invalid title is denied with the conventions; a valid title is allowed and
-# the description conventions are injected as a reminder.
+# the conventions are injected as a reminder. If the skill file is missing the
+# hook fails open (allows) rather than blocking all PR creation.
 
 set -euo pipefail
 
 input=$(cat)
 title=$(printf '%s' "$input" | jq -r '.tool_input.title // ""')
 
-# Conventional Commits: type(scope)?!?: subject
-cc_regex='^(feat|fix|docs|perf|refactor|chore)(\([^)]+\))?!?: .+'
+script_dir=$(cd "$(dirname "$0")" && pwd)
+skill="$script_dir/../skills/pull-request/SKILL.md"
 
-conventions='PR conventions (.claude/skills/pull-request):
-- Title: Conventional Commits — feat|fix|docs|perf|refactor|chore, optional (scope), optional ! for a breaking change. e.g. "feat(optimizer): add pass", "refactor!: drop X".
-- Description: the outcome of the whole branch (git diff origin/main...HEAD, three dots). No trial-and-error history — the commits carry that. No test section — CI runs the suite.'
+allow() {
+    # $1: additionalContext (may be empty)
+    jq -nc --arg ctx "$1" \
+        '{hookSpecificOutput: ({hookEventName: "PreToolUse"} + (if $ctx == "" then {} else {additionalContext: $ctx} end))}'
+    exit 0
+}
+
+# Fail open if the source of truth is unavailable.
+[[ -f "$skill" ]] || allow ""
+
+# Conventions surfaced to the model = the skill body (frontmatter stripped).
+conventions=$(awk '/^---$/{c++; next} c>=2' "$skill")
+
+# Allowed Conventional Commits types, derived from the skill's title list
+# (e.g. "- \`feat\`: ..." / "- \`feat!\`: ..." -> feat).
+types=$(sed -nE 's/^- `([a-z]+)!?`.*/\1/p' "$skill" | sort -u | paste -sd'|' -)
+[[ -n "$types" ]] || allow "$conventions"
+
+cc_regex="^(${types})(\([^)]+\))?!?: .+"
 
 if [[ "$title" =~ $cc_regex ]]; then
-    jq -nc --arg ctx "$conventions" '{
-      hookSpecificOutput: {
-        hookEventName: "PreToolUse",
-        additionalContext: $ctx
-      }
-    }'
-    exit 0
+    allow "$conventions"
 fi
 
 reason="PR title is not Conventional Commits: \"$title\".
 
 $conventions"
-jq -nc --arg r "$reason" '{
-  hookSpecificOutput: {
-    hookEventName: "PreToolUse",
-    permissionDecision: "deny",
-    permissionDecisionReason: $r
-  }
-}'
+jq -nc --arg r "$reason" \
+    '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $r}}'

--- a/.claude/hooks/pr-conventions.sh
+++ b/.claude/hooks/pr-conventions.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# PreToolUse hook for the `mcp__github__create_pull_request` tool.
+#
+# Enforces the repo's PR conventions (see .claude/skills/pull-request) at the
+# deterministic point a PR is created, independent of whether the model invoked
+# the pull-request skill:
+#   - Title MUST follow Conventional Commits.
+#   - Description conventions are surfaced (outcome of origin/main...HEAD; no
+#     trial-and-error history; no test section).
+#
+# An invalid title is denied with the conventions; a valid title is allowed and
+# the description conventions are injected as a reminder.
+
+set -euo pipefail
+
+input=$(cat)
+title=$(printf '%s' "$input" | jq -r '.tool_input.title // ""')
+
+# Conventional Commits: type(scope)?!?: subject
+cc_regex='^(feat|fix|docs|perf|refactor|chore)(\([^)]+\))?!?: .+'
+
+conventions='PR conventions (.claude/skills/pull-request):
+- Title: Conventional Commits — feat|fix|docs|perf|refactor|chore, optional (scope), optional ! for a breaking change. e.g. "feat(optimizer): add pass", "refactor!: drop X".
+- Description: the outcome of the whole branch (git diff origin/main...HEAD, three dots). No trial-and-error history — the commits carry that. No test section — CI runs the suite.'
+
+if [[ "$title" =~ $cc_regex ]]; then
+    jq -nc --arg ctx "$conventions" '{
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        additionalContext: $ctx
+      }
+    }'
+    exit 0
+fi
+
+reason="PR title is not Conventional Commits: \"$title\".
+
+$conventions"
+jq -nc --arg r "$reason" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny",
+    permissionDecisionReason: $r
+  }
+}'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,6 +22,15 @@
             "command": "./.claude/hooks/bash-pipefail.sh"
           }
         ]
+      },
+      {
+        "matcher": "mcp__github__create_pull_request",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./.claude/hooks/pr-conventions.sh"
+          }
+        ]
       }
     ]
   }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,9 @@
   "enabledPlugins": {
     "rust-analyzer-lsp@claude-plugins-official": true
   },
+  "permissions": {
+    "deny": ["AskUserQuestion"]
+  },
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## Summary

Two `.claude/` harness-config changes:

### PR-conventions PreToolUse hook

`.claude/hooks/pr-conventions.sh` runs on `mcp__github__create_pull_request` and applies the repo's pull-request conventions deterministically, so they hold even if the model forgets to invoke the `pull-request` skill:

- Validates the PR title against Conventional Commits — a non-conforming title is **denied** with the conventions.
- Surfaces the description conventions as a reminder on a valid title.

The conventions are **read from `.claude/skills/pull-request/SKILL.md`** (allowed commit types derived from its title list, body surfaced verbatim), so the hook never drifts from the documented source of truth. It resolves the skill path relative to the script (cwd-independent) and fails open if the skill is missing, so it never blocks PR creation outright.

Registered alongside the existing Bash `PreToolUse` and `SessionStart` hooks (both preserved).

### Deny the `AskUserQuestion` tool

`permissions.deny: ["AskUserQuestion"]` — the multiple-choice question UI is hard to read; the assistant now makes a decision and proceeds in prose instead of prompting.

## Rationale

Skill invocation is model-driven (probabilistic); a hook and a permission rule are harness-driven (deterministic). This closes the gap where a PR could be opened without the conventions, and reading the conventions from the skill keeps a single source of truth.

https://claude.ai/code/session_01VDPyqie7ni8Ttx3pZgyaAm