### PR TITLE
feat(deps): bare-name dependency resolution and Kiln build-dependency generators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3029,6 +3029,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "wado-compiler",
+ "wado-manifest",
 ]
 
 [[package]]

--- a/benchmark/sqlite_parse/sqlite_parse.wado
+++ b/benchmark/sqlite_parse/sqlite_parse.wado
@@ -9,7 +9,7 @@ use { Benchmark } from "core:benchmark";
 use sqlite from "../../package-gale/tests/grammars/SQLite.g4"
     with {
         generator: {
-            module: "../../package-gale/src/generator.wado",
+            module: "gale",
             options: { highlight: false },
         },
     };

--- a/benchmark/syntax_highlight/syntax_highlight.wado
+++ b/benchmark/syntax_highlight/syntax_highlight.wado
@@ -10,7 +10,7 @@ use { Benchmark } from "core:benchmark";
 use sqlite from "../../package-gale/tests/grammars/SQLite.g4"
     with {
         generator: {
-            module: "../../package-gale/src/generator.wado",
+            module: "gale",
             options: { highlight: true },
         },
     };

--- a/docs/wep-2026-02-14-package-manifest.md
+++ b/docs/wep-2026-02-14-package-manifest.md
@@ -23,8 +23,10 @@ The project manifest is `wado.toml`, placed at the project root.
 namespace = "myorg"
 name = "my-app"
 version = "0.1.0"
-command = "src/main.wado"
 lib = "src/lib.wado"
+
+[world]
+"wasi:cli/command" = "src/main.wado"
 
 [registries]
 default = "https://wa.dev"
@@ -45,9 +47,7 @@ bench = { git = "https://gitlab.com/user/bench.git", ref = "main" }
 | `namespace` | `string` | No       | Organization or user namespace (e.g., `"myorg"`) |
 | `name`      | `string` | Yes      | Package name (e.g., `"my-app"`)                  |
 | `version`   | `string` | Yes      | Semver version (e.g., `"0.1.0"`)                 |
-| `command`   | `string` | No       | Entry point for `wasi:cli/command` world         |
-| `service`   | `string` | No       | Entry point for `wasi:http/service` world        |
-| `lib`       | `string` | No       | Library interface file                           |
+| `lib`       | `string` | No       | Entry module of the package's library world      |
 
 `namespace` and `name` together form the registry identity (`namespace:name`, e.g., `myorg:my-app`). Without `namespace`, the package cannot be published to a registry — this is the natural state for closed-source applications and internal tools.
 
@@ -57,38 +57,38 @@ Both `namespace` and `name` must match `[a-zA-Z0-9_-]+` (minimum 1 character, ma
 
 Dependency keys in `[dependencies]` follow the same rules. This ensures they are valid TOML bare keys and unambiguous in import paths.
 
-At least one of `command`, `service`, or `lib` should be specified. A package can have multiple entry points (e.g., both `command` and `lib`).
+A package must declare at least one world: a `[world]` entry, `[package].lib`, or both.
 
 ### Entry Points and Worlds
 
-Each entry point field corresponds to a hosted world or a library world:
+A package targets one or more Component Model worlds. Hosted worlds are declared in the `[world]` table, keyed by the fully-qualified world name; the library world is declared by `[package].lib`.
 
-| Field     | Category      | WASI World          | CLI Command  | Required Export                           |
-| --------- | ------------- | ------------------- | ------------ | ----------------------------------------- |
-| `command` | hosted world  | `wasi:cli/command`  | `wado run`   | `export fn run()`                         |
-| `service` | hosted world  | `wasi:http/service` | `wado serve` | `export fn handle(request: Request) -> …` |
-| `lib`     | library world | (none — interface)  | (none)       | `export` items become the public API      |
+| Declaration                     | World                 | Driver       | Required export                           |
+| ------------------------------- | --------------------- | ------------ | ----------------------------------------- |
+| `[world]."wasi:cli/command"`    | `wasi:cli/command`    | `wado run`   | `export fn run()`                         |
+| `[world]."wasi:http/service"`   | `wasi:http/service`   | `wado serve` | `export fn handle(request: Request) -> …` |
+| `[world]."core:kiln/generator"` | `core:kiln/generator` | Kiln         | `export fn generate(...)`                 |
+| `[package].lib`                 | the library world     | (none)       | `export` items become the public API      |
+
+The library world's name is the package name. It is the contract other packages compose against, but it is not observable in a wado-to-wado source dependency: the CM boundary is skipped and the dependency's modules compile into the consumer's component (see "Wado-to-Wado Optimization"). The world materializes only when the package is built as a standalone `.wasm` component.
 
 ```toml
-# CLI tool with library
+# CLI tool with a library world
 [package]
 name = "markdown"
-command = "src/cli.wado"
 lib = "src/lib.wado"
+
+[world]
+"wasi:cli/command" = "src/cli.wado"
 
 # HTTP service only
 [package]
 name = "my-api"
-service = "src/server.wado"
 
-# Development tool with CLI + Web UI
-[package]
-name = "devtool"
-command = "src/cli.wado"
-service = "src/dashboard.wado"
-lib = "src/lib.wado"
+[world]
+"wasi:http/service" = "src/server.wado"
 
-# Library only
+# Library only (world name = "json")
 [package]
 name = "json"
 lib = "src/lib.wado"
@@ -121,6 +121,8 @@ use { parse } from "markdown";        // OK: exported from lib
 ```
 
 When published as a `.wasm` component (e.g., to wa.dev), only `export` items appear in the component's interface.
+
+Crossing the package boundary requires `export`: a consumer may import only the `export` items of a dependency's `lib`, never its `pub` or private items. This is a settled rule; enforcing it for wado-to-wado source dependencies (rejecting `use` of a non-`export` item) is not yet implemented.
 
 ### Wado-to-Wado Optimization
 
@@ -234,6 +236,8 @@ use { helper } from "./utils.wado";         // relative → local file
 use { Router } from "router";              // bare → wado.toml dependency
 ```
 
+A bare name binds to the dependency's library world — its `[package].lib` entry module — and resolves the imported symbols against that module's `export` items. Only the consuming project resolves its own `[dependencies]`: a bare import from within a dependency module does not bind to the consumer's dependencies.
+
 Dependency keys must not contain `:` (TOML bare keys naturally enforce this). This makes scheme-based and bare name resolution structurally unambiguous.
 
 `core` and `wasi` are **not reserved**. `"core:cli"` (with `:`) resolves via scheme; `"core"` (bare) resolves via `wado.toml`. These are different resolution paths.
@@ -247,8 +251,11 @@ pub enum ModuleSource {
     Local { path: String },
     Remote { url: String },
     EntryPoint { filename: Option<String> },
-    // New:
-    Dependency { id: String },  // resolved package id (e.g., "registry+https://wa.dev/docs:regex@0.1.2")
+    // A dependency's library-world module. Identified by its resolved entry
+    // module so that two aliases for the same package unify: the resolved
+    // path for a path dependency; the resolved package id for a
+    // registry/git dependency.
+    Dependency { path: String },
 }
 ```
 
@@ -404,7 +411,7 @@ id = "git+https://gitlab.com/user/bench.git/bench-tool"
 version = "0.1.0"
 resolved-ref = "def5678901234567890abcdef12345678abc1234d"
 dev = true
-command = "src/main.wado"
+world = { "wasi:cli/command" = "src/main.wado" }
 deps = []
 
 [[package]]
@@ -461,12 +468,11 @@ Each `[[package]]` entry is uniquely identified by `(id, version)`. The `id` fie
 | `resolved-ref` | git only      | Exact commit SHA (40 hex chars)                                                                  |
 | `integrity`    | registry only | Content hash with algorithm prefix (see below)                                                   |
 | `dev`          | dev-deps only | `true` for dev-only packages (excluded from production)                                          |
-| `command`      | optional      | Entry point for `wasi:cli/command` (from dependency's `wado.toml`)                               |
-| `service`      | optional      | Entry point for `wasi:http/service` (from dependency's `wado.toml`)                              |
-| `lib`          | optional      | Library entry point (from dependency's `wado.toml`)                                              |
+| `world`        | optional      | CM world FQ name → entry path, mirroring the dependency's `[world]` table (inline table)         |
+| `lib`          | optional      | Library-world entry module (from the dependency's `[package].lib`)                               |
 | `deps`         | all           | List of `id@version` strings referencing other entries                                           |
 
-Entry point fields (`command`, `service`, `lib`) are copied from the dependency's `wado.toml` at resolution time. This makes the lock file self-sufficient — the `CompilerHost` can resolve all imports and locate all source files using only the root `wado.toml` and `wado.lock`.
+The `world` table and `lib` are copied from the dependency's `wado.toml` at resolution time. This makes the lock file self-sufficient — the `CompilerHost` can resolve all imports and locate all source files using only the root `wado.toml` and `wado.lock`.
 
 `path` dependencies are not locked (always resolved fresh).
 
@@ -565,7 +571,9 @@ lib = "src/lib.wado"
 [package]
 name = "my-tool"
 version = "0.1.0"
-command = "src/main.wado"
+
+[world]
+"wasi:cli/command" = "src/main.wado"
 
 [dependencies]
 core = { path = "../core" }
@@ -670,7 +678,7 @@ This enables seamless local development while ensuring published packages are se
 - Lock file with `integrity` ensures reproducible and tamper-evident builds for registry deps
 - Auto re-resolve keeps lock file fresh; `--locked` ensures CI reproducibility
 - Compiler remains agnostic to dependency resolution — `CompilerHost` handles all mapping
-- Entry point fields (`command`, `service`, `lib`) map directly to WASI worlds and CLI commands
+- The `[world]` table and `[package].lib` map directly to CM worlds; `wado run` / `wado serve` select a hosted world by its FQ name
 - `export` as CM boundary gives clear, consistent public API semantics across all consumption modes
 - Wado-to-Wado optimization eliminates CM overhead for same-language dependencies without changing semantics
 - `namespace` absence naturally indicates non-publishable packages — no extra `publish = false` flag needed
@@ -694,7 +702,7 @@ This enables seamless local development while ensuring published packages are se
 - **Bare name resolution**: requires `wado.toml` lookup at compile time, adding a project-discovery step. The compiler itself is not affected — only `CompilerHost` implementations need to handle this.
 - **Self-sufficient lock file**: duplicates entry points and dependency edges from each package's `wado.toml`. This makes the lock file larger and introduces a potential staleness risk (if a dependency's `wado.toml` changes entry points without version bump). The trade-off is worth it — builds skip all transitive manifest I/O, and staleness is caught by `wado update` or integrity mismatch.
 - **Archive-level integrity** (not source-level): simpler and unambiguous, but means the hash depends on the registry's archive format. If a registry changes its packaging format, hashes change even if sources are identical.
-- **`command` over `bin`/`cli`**: `command` matches the WASI world name (`wasi:cli/command`) directly, making the mapping explicit. `bin` (Cargo's term) describes artifact format, which is less meaningful in the Wasm world. `cli` describes the interface but doesn't match the world name.
+- **`[world]` table keyed by FQ world name**: hosted worlds are declared by their Component Model world name (`"wasi:cli/command"`) rather than a short alias (`command`/`bin`/`cli`). The key is the world the entry conforms to, so new worlds need no new manifest field and the mapping to the CM world is explicit. The library world is the one exception — it has no externally-fixed FQ name, so it is named after the package and declared by `[package].lib`.
 - **`[package]` over `[project]`**: `[package]` aligns with CM's "package" concept (`package ns:name@version` in WIT). The file itself represents the project; `[package]` describes the distributable unit within it. `[workspace]` > `[package]` hierarchy is natural, whereas `[workspace]` > `[project]` would be confusing.
 - **`path` + `registry` dual source**: adds complexity to the dependency spec but eliminates the "path deps can't be published" problem. The alternative (Cargo's separate `[patch]` section) is more complex and harder to maintain.
 

--- a/wado-cli/src/check.rs
+++ b/wado-cli/src/check.rs
@@ -113,9 +113,15 @@ pub async fn run(opts: CheckOptions) -> Result<(), CliExit> {
         .parent()
         .map(std::path::Path::to_path_buf)
         .unwrap_or_default();
-    let host = FilesystemCompilerHost::with_log_level(base_path, opts.log_level);
-
     let manifest_pair = crate::compile::load_nearest_manifest(path);
+    let dep_index = manifest_pair
+        .as_ref()
+        .map(|(manifest, root)| wado_lsp::host::dependency_index_from(manifest, root, &base_path));
+    let mut host = FilesystemCompilerHost::with_log_level(base_path, opts.log_level);
+    if let Some(index) = dep_index {
+        host = host.with_dependency_index(index);
+    }
+
     let manifest_root = manifest_pair
         .as_ref()
         .map(|(_, root)| root.clone())
@@ -124,7 +130,7 @@ pub async fn run(opts: CheckOptions) -> Result<(), CliExit> {
                 .map(std::path::Path::to_path_buf)
                 .unwrap_or_else(|| std::path::PathBuf::from("."))
         });
-    let inline = crate::compile::collect_inline_invocations_for_entry(path, &manifest_root);
+    let mut inline = crate::compile::collect_inline_invocations_for_entry(path, &manifest_root);
 
     let outcome = if inline.is_empty() {
         CheckOutcome::default()
@@ -132,6 +138,7 @@ pub async fn run(opts: CheckOptions) -> Result<(), CliExit> {
         let manifest = manifest_pair
             .map(|(m, _)| m)
             .unwrap_or_else(crate::compile::empty_manifest);
+        crate::compile::rewrite_build_dep_modules(&mut inline, &manifest, &manifest_root);
         let provider = CliGeneratorProvider::new(manifest_root.clone());
         crate::kiln_driver::check_pipeline(&manifest, &manifest_root, &host, &provider, inline)
             .await

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -356,16 +356,16 @@ pub async fn try_compile(
         host = host.with_dependency_index(index);
     }
 
-    let pipeline_outcome = match maybe_run_pipeline(path, &host, flags.no_cache, manifest_pair).await
-    {
-        Ok(outcome) => outcome,
-        Err(e) => {
-            eprintln!("{e}");
-            return Err(wado_compiler::CompileFailure {
-                is_todo_module: false,
-            });
-        }
-    };
+    let pipeline_outcome =
+        match maybe_run_pipeline(path, &host, flags.no_cache, manifest_pair).await {
+            Ok(outcome) => outcome,
+            Err(e) => {
+                eprintln!("{e}");
+                return Err(wado_compiler::CompileFailure {
+                    is_todo_module: false,
+                });
+            }
+        };
 
     let options = wado_compiler::CompilerOptions {
         opt_level: to_compiler_opt_level(flags.opt_level),

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -419,7 +419,9 @@ async fn maybe_run_pipeline(
     if inline.is_empty() {
         return Ok(PipelineOutcome::default());
     }
-    let provider = CliGeneratorProvider::new(manifest_root.clone()).with_no_cache(no_cache);
+    let provider = CliGeneratorProvider::new(manifest_root.clone())
+        .with_no_cache(no_cache)
+        .with_build_dependencies(build_dependency_paths(&manifest));
     crate::kiln_driver::run_pipeline(&manifest, &manifest_root, host, &provider, inline, no_cache)
         .await
 }
@@ -503,6 +505,21 @@ fn normalized_components(p: &Path) -> Vec<String> {
         }
     }
     out
+}
+
+/// `[build-dependencies]` name → package path (relative to the manifest
+/// root) for every path build-dependency. Consumed by the Kiln provider to
+/// resolve `module: "<name>"` generator references. Registry/git build-deps
+/// are skipped (unsupported for now).
+fn build_dependency_paths(manifest: &wado_manifest::Manifest) -> HashMap<String, String> {
+    manifest
+        .build_dependencies
+        .iter()
+        .filter_map(|(name, dep)| match &dep.source {
+            DependencySource::Path { path, .. } => Some((name.clone(), path.clone())),
+            _ => None,
+        })
+        .collect()
 }
 
 /// Empty in-memory `wado.toml` manifest used as a fallback when the

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -1,6 +1,9 @@
+use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::fs;
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
+
+use wado_manifest::DependencySource;
 
 use lexopt::Arg::Value;
 use lexopt::Parser;
@@ -364,6 +367,7 @@ pub async fn try_compile(
         log_level: Some(flags.log_level),
         allocator: flags.allocator.clone(),
         invocations: pipeline_outcome.invocations,
+        dependencies: build_dependency_index(path),
         test_name_filters: flags.test_name_filters.clone(),
         codegen_flags: flags.codegen_flags.clone(),
         ..Default::default()
@@ -418,6 +422,87 @@ async fn maybe_run_pipeline(
     let provider = CliGeneratorProvider::new(manifest_root.clone()).with_no_cache(no_cache);
     crate::kiln_driver::run_pipeline(&manifest, &manifest_root, host, &provider, inline, no_cache)
         .await
+}
+
+/// Build the bare-name → entry-path dependency index from the nearest
+/// manifest's `[dependencies]`. Each dependency's entry module (its
+/// `[package].lib`, or the file itself for a single-`.wado` path dependency)
+/// is recorded relative to `entry_file`'s directory — the compiler host's
+/// base path — so `use { … } from "<name>"` resolves to it.
+///
+/// Only `path` dependencies are supported for now; registry/git resolution
+/// is a later step.
+fn build_dependency_index(entry_file: &Path) -> HashMap<String, String> {
+    let mut index = HashMap::new();
+    let Some((manifest, root)) = load_nearest_manifest(entry_file) else {
+        return index;
+    };
+    let base_abs = absolutize(entry_file.parent().unwrap_or_else(|| Path::new(".")));
+    for (name, dep) in &manifest.dependencies {
+        let DependencySource::Path { path, .. } = &dep.source else {
+            continue;
+        };
+        let Some(entry) = dependency_entry_path(&root.join(path)) else {
+            continue;
+        };
+        index.insert(name.clone(), relative_path(&base_abs, &absolutize(&entry)));
+    }
+    index
+}
+
+/// The entry module file of a path dependency: the file itself when the path
+/// points at a `.wado` file, otherwise the directory's `[package].lib`.
+fn dependency_entry_path(dep_path: &Path) -> Option<PathBuf> {
+    if dep_path.extension().is_some_and(|e| e == "wado") {
+        return Some(dep_path.to_path_buf());
+    }
+    let text = fs::read_to_string(dep_path.join("wado.toml")).ok()?;
+    let manifest: wado_manifest::Manifest = text.parse().ok()?;
+    Some(dep_path.join(manifest.package?.lib?))
+}
+
+fn absolutize(p: &Path) -> PathBuf {
+    if p.is_absolute() {
+        p.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map(|cwd| cwd.join(p))
+            .unwrap_or_else(|_| p.to_path_buf())
+    }
+}
+
+/// Lexical relative path from directory `from_dir` to file `to_file`. Both
+/// must be absolute; symlinks are not resolved.
+fn relative_path(from_dir: &Path, to_file: &Path) -> String {
+    let from = normalized_components(from_dir);
+    let to = normalized_components(to_file);
+    let common = from.iter().zip(&to).take_while(|(a, b)| a == b).count();
+    let mut parts: Vec<String> = vec!["..".to_string(); from.len() - common];
+    parts.extend(to[common..].iter().cloned());
+    if parts.is_empty() {
+        ".".to_string()
+    } else {
+        parts.join("/")
+    }
+}
+
+fn normalized_components(p: &Path) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for comp in p.components() {
+        match comp {
+            Component::CurDir | Component::Prefix(_) => {}
+            Component::RootDir => out.push(String::new()),
+            Component::ParentDir => {
+                if matches!(out.last().map(String::as_str), None | Some("..")) {
+                    out.push("..".to_string());
+                } else {
+                    out.pop();
+                }
+            }
+            Component::Normal(s) => out.push(s.to_string_lossy().into_owned()),
+        }
+    }
+    out
 }
 
 /// Empty in-memory `wado.toml` manifest used as a fallback when the

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::fs;
 use std::path::Path;
@@ -346,9 +345,19 @@ pub async fn try_compile(
         .parent()
         .map(std::path::Path::to_path_buf)
         .unwrap_or_default();
-    let host = FilesystemCompilerHost::with_log_level(base_path, flags.log_level);
+    // Load the nearest manifest once: it seeds both the host's `[dependencies]`
+    // index and the Kiln pipeline's `[build-dependencies]` resolution.
+    let manifest_pair = load_nearest_manifest(path);
+    let dep_index = manifest_pair
+        .as_ref()
+        .map(|(manifest, root)| wado_lsp::host::dependency_index_from(manifest, root, &base_path));
+    let mut host = FilesystemCompilerHost::with_log_level(base_path, flags.log_level);
+    if let Some(index) = dep_index {
+        host = host.with_dependency_index(index);
+    }
 
-    let pipeline_outcome = match maybe_run_pipeline(path, &host, flags.no_cache).await {
+    let pipeline_outcome = match maybe_run_pipeline(path, &host, flags.no_cache, manifest_pair).await
+    {
         Ok(outcome) => outcome,
         Err(e) => {
             eprintln!("{e}");
@@ -397,9 +406,8 @@ async fn maybe_run_pipeline(
     entry_file: &Path,
     host: &FilesystemCompilerHost,
     no_cache: bool,
+    manifest_pair: Option<(wado_manifest::Manifest, std::path::PathBuf)>,
 ) -> Result<PipelineOutcome, PipelineError> {
-    let manifest_pair = load_nearest_manifest(entry_file);
-
     let manifest_root_for_inline = manifest_pair.as_ref().map(|(_, root)| root.clone());
     let probe_manifest_root = manifest_root_for_inline.clone().unwrap_or_else(|| {
         entry_file
@@ -418,26 +426,56 @@ async fn maybe_run_pipeline(
     if inline.is_empty() {
         return Ok(PipelineOutcome::default());
     }
-    let provider = CliGeneratorProvider::new(manifest_root.clone())
-        .with_no_cache(no_cache)
-        .with_build_dependencies(build_dependency_paths(&manifest));
+    let mut inline = inline;
+    rewrite_build_dep_modules(&mut inline, &manifest, &manifest_root);
+    let provider = CliGeneratorProvider::new(manifest_root.clone()).with_no_cache(no_cache);
     crate::kiln_driver::run_pipeline(&manifest, &manifest_root, host, &provider, inline, no_cache)
         .await
 }
 
-/// `[build-dependencies]` name → package path (relative to the manifest
-/// root) for every path build-dependency. Consumed by the Kiln provider to
-/// resolve `module: "<name>"` generator references. Registry/git build-deps
-/// are skipped (unsupported for now).
-fn build_dependency_paths(manifest: &wado_manifest::Manifest) -> HashMap<String, String> {
-    manifest
-        .build_dependencies
-        .iter()
-        .filter_map(|(name, dep)| match &dep.source {
-            DependencySource::Path { path, .. } => Some((name.clone(), path.clone())),
-            _ => None,
-        })
-        .collect()
+/// Rewrite each inline invocation whose `module` is a bare
+/// `[build-dependencies]` name (`module: "gale"`) into a concrete
+/// `LocalPath` pointing at the dependency package's
+/// `[world]."core:kiln/generator"` entry. This resolves build-dep
+/// generators once, off the already-loaded manifest, so the rest of the
+/// pipeline (cache key, generator identity, provider) sees a path-addressed
+/// module. Unresolvable names are left as `BuildDep` for the provider to
+/// report.
+pub(crate) fn rewrite_build_dep_modules(
+    inline: &mut [wado_compiler::kiln::Invocation],
+    manifest: &wado_manifest::Manifest,
+    manifest_root: &Path,
+) {
+    use wado_compiler::kiln::GeneratorModule;
+    for inv in inline.iter_mut() {
+        let GeneratorModule::BuildDep(name) = &inv.module else {
+            continue;
+        };
+        if let Some(local) = build_dep_generator_local_path(name, manifest, manifest_root) {
+            inv.module = GeneratorModule::LocalPath(local);
+        }
+    }
+}
+
+/// The generator entry of a path `[build-dependencies]` package, as a
+/// manifest-root-relative [`InvocationPath`]: `<dep-path>/<generator world
+/// entry>`. `None` when the dependency is absent, not a path dep, or declares
+/// no `core:kiln/generator` world.
+fn build_dep_generator_local_path(
+    name: &str,
+    manifest: &wado_manifest::Manifest,
+    manifest_root: &Path,
+) -> Option<wado_compiler::kiln::InvocationPath> {
+    let dep = manifest.build_dependencies.get(name)?;
+    let DependencySource::Path { path, .. } = &dep.source else {
+        return None;
+    };
+    let dep_manifest_text = fs::read_to_string(manifest_root.join(path).join("wado.toml")).ok()?;
+    let dep_manifest: wado_manifest::Manifest = dep_manifest_text.parse().ok()?;
+    let entry = dep_manifest.world_entry("core:kiln/generator")?;
+    Some(wado_compiler::kiln::InvocationPath::normalize(&format!(
+        "{path}/{entry}"
+    )))
 }
 
 /// Empty in-memory `wado.toml` manifest used as a fallback when the

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::fs;
-use std::path::{Component, Path, PathBuf};
+use std::path::Path;
 
 use wado_manifest::DependencySource;
 
@@ -367,7 +367,6 @@ pub async fn try_compile(
         log_level: Some(flags.log_level),
         allocator: flags.allocator.clone(),
         invocations: pipeline_outcome.invocations,
-        dependencies: build_dependency_index(path),
         test_name_filters: flags.test_name_filters.clone(),
         codegen_flags: flags.codegen_flags.clone(),
         ..Default::default()
@@ -424,87 +423,6 @@ async fn maybe_run_pipeline(
         .with_build_dependencies(build_dependency_paths(&manifest));
     crate::kiln_driver::run_pipeline(&manifest, &manifest_root, host, &provider, inline, no_cache)
         .await
-}
-
-/// Build the bare-name → entry-path dependency index from the nearest
-/// manifest's `[dependencies]`. Each dependency's entry module (its
-/// `[package].lib`, or the file itself for a single-`.wado` path dependency)
-/// is recorded relative to `entry_file`'s directory — the compiler host's
-/// base path — so `use { … } from "<name>"` resolves to it.
-///
-/// Only `path` dependencies are supported for now; registry/git resolution
-/// is a later step.
-fn build_dependency_index(entry_file: &Path) -> HashMap<String, String> {
-    let mut index = HashMap::new();
-    let Some((manifest, root)) = load_nearest_manifest(entry_file) else {
-        return index;
-    };
-    let base_abs = absolutize(entry_file.parent().unwrap_or_else(|| Path::new(".")));
-    for (name, dep) in &manifest.dependencies {
-        let DependencySource::Path { path, .. } = &dep.source else {
-            continue;
-        };
-        let Some(entry) = dependency_entry_path(&root.join(path)) else {
-            continue;
-        };
-        index.insert(name.clone(), relative_path(&base_abs, &absolutize(&entry)));
-    }
-    index
-}
-
-/// The entry module file of a path dependency: the file itself when the path
-/// points at a `.wado` file, otherwise the directory's `[package].lib`.
-fn dependency_entry_path(dep_path: &Path) -> Option<PathBuf> {
-    if dep_path.extension().is_some_and(|e| e == "wado") {
-        return Some(dep_path.to_path_buf());
-    }
-    let text = fs::read_to_string(dep_path.join("wado.toml")).ok()?;
-    let manifest: wado_manifest::Manifest = text.parse().ok()?;
-    Some(dep_path.join(manifest.package?.lib?))
-}
-
-fn absolutize(p: &Path) -> PathBuf {
-    if p.is_absolute() {
-        p.to_path_buf()
-    } else {
-        std::env::current_dir()
-            .map(|cwd| cwd.join(p))
-            .unwrap_or_else(|_| p.to_path_buf())
-    }
-}
-
-/// Lexical relative path from directory `from_dir` to file `to_file`. Both
-/// must be absolute; symlinks are not resolved.
-fn relative_path(from_dir: &Path, to_file: &Path) -> String {
-    let from = normalized_components(from_dir);
-    let to = normalized_components(to_file);
-    let common = from.iter().zip(&to).take_while(|(a, b)| a == b).count();
-    let mut parts: Vec<String> = vec!["..".to_string(); from.len() - common];
-    parts.extend(to[common..].iter().cloned());
-    if parts.is_empty() {
-        ".".to_string()
-    } else {
-        parts.join("/")
-    }
-}
-
-fn normalized_components(p: &Path) -> Vec<String> {
-    let mut out: Vec<String> = Vec::new();
-    for comp in p.components() {
-        match comp {
-            Component::CurDir | Component::Prefix(_) => {}
-            Component::RootDir => out.push(String::new()),
-            Component::ParentDir => {
-                if matches!(out.last().map(String::as_str), None | Some("..")) {
-                    out.push("..".to_string());
-                } else {
-                    out.pop();
-                }
-            }
-            Component::Normal(s) => out.push(s.to_string_lossy().into_owned()),
-        }
-    }
-    out
 }
 
 /// `[build-dependencies]` name → package path (relative to the manifest

--- a/wado-cli/src/compiler_host.rs
+++ b/wado-cli/src/compiler_host.rs
@@ -185,6 +185,10 @@ impl CompilerHost for FilesystemCompilerHost {
         self.inner.collect_diagnostic(diagnostic);
     }
 
+    fn dependency_index(&self) -> std::collections::HashMap<String, String> {
+        self.inner.dependency_index()
+    }
+
     async fn run_generator(
         &self,
         component_wasm: &[u8],

--- a/wado-cli/src/compiler_host.rs
+++ b/wado-cli/src/compiler_host.rs
@@ -31,6 +31,10 @@ pub struct FilesystemCompilerHost {
     /// Cache misses on `kiln_components`. Tests assert against this
     /// rather than wall-clock timing.
     kiln_component_compile_count: AtomicUsize,
+    /// Precomputed `[dependencies]` index. When set, `dependency_index`
+    /// returns it instead of having the inner host re-read the manifest —
+    /// the caller already parsed it for the Kiln pipeline.
+    dep_index: Option<std::collections::HashMap<String, String>>,
 }
 
 impl FilesystemCompilerHost {
@@ -44,6 +48,7 @@ impl FilesystemCompilerHost {
             kiln_engine: OnceLock::new(),
             kiln_components: Mutex::new(Vec::new()),
             kiln_component_compile_count: AtomicUsize::new(0),
+            dep_index: None,
         }
     }
 
@@ -57,6 +62,7 @@ impl FilesystemCompilerHost {
             kiln_engine: OnceLock::new(),
             kiln_components: Mutex::new(Vec::new()),
             kiln_component_compile_count: AtomicUsize::new(0),
+            dep_index: None,
         }
     }
 
@@ -70,7 +76,19 @@ impl FilesystemCompilerHost {
             kiln_engine: OnceLock::new(),
             kiln_components: Mutex::new(Vec::new()),
             kiln_component_compile_count: AtomicUsize::new(0),
+            dep_index: None,
         }
+    }
+
+    /// Supply a precomputed `[dependencies]` index so the inner host does not
+    /// re-read the manifest the caller already parsed for the Kiln pipeline.
+    #[must_use]
+    pub fn with_dependency_index(
+        mut self,
+        index: std::collections::HashMap<String, String>,
+    ) -> Self {
+        self.dep_index = Some(index);
+        self
     }
 
     #[must_use]
@@ -186,7 +204,10 @@ impl CompilerHost for FilesystemCompilerHost {
     }
 
     fn dependency_index(&self) -> std::collections::HashMap<String, String> {
-        self.inner.dependency_index()
+        match &self.dep_index {
+            Some(index) => index.clone(),
+            None => self.inner.dependency_index(),
+        }
     }
 
     async fn run_generator(

--- a/wado-cli/src/compiler_host.rs
+++ b/wado-cli/src/compiler_host.rs
@@ -34,7 +34,7 @@ pub struct FilesystemCompilerHost {
     /// Precomputed `[dependencies]` index. When set, `dependency_index`
     /// returns it instead of having the inner host re-read the manifest —
     /// the caller already parsed it for the Kiln pipeline.
-    dep_index: Option<std::collections::HashMap<String, String>>,
+    dep_index: Option<wado_compiler::DependencyIndex>,
 }
 
 impl FilesystemCompilerHost {
@@ -83,10 +83,7 @@ impl FilesystemCompilerHost {
     /// Supply a precomputed `[dependencies]` index so the inner host does not
     /// re-read the manifest the caller already parsed for the Kiln pipeline.
     #[must_use]
-    pub fn with_dependency_index(
-        mut self,
-        index: std::collections::HashMap<String, String>,
-    ) -> Self {
+    pub fn with_dependency_index(mut self, index: wado_compiler::DependencyIndex) -> Self {
         self.dep_index = Some(index);
         self
     }
@@ -203,7 +200,7 @@ impl CompilerHost for FilesystemCompilerHost {
         self.inner.collect_diagnostic(diagnostic);
     }
 
-    fn dependency_index(&self) -> std::collections::HashMap<String, String> {
+    fn dependency_index(&self) -> wado_compiler::DependencyIndex {
         match &self.dep_index {
             Some(index) => index.clone(),
             None => self.inner.dependency_index(),

--- a/wado-cli/src/kiln_provider.rs
+++ b/wado-cli/src/kiln_provider.rs
@@ -54,9 +54,6 @@ pub struct CliGeneratorProvider {
     /// When true, skip reads from the on-disk generator cache. Writes
     /// still happen so the next non-bypass run sees a warm tree.
     no_cache: bool,
-    /// `[build-dependencies]` name → package path, relative to the manifest
-    /// root. Used to resolve `module: "<name>"` generator references.
-    build_dependencies: std::collections::HashMap<String, String>,
 }
 
 impl CliGeneratorProvider {
@@ -66,22 +63,12 @@ impl CliGeneratorProvider {
             manifest_root,
             compile_count: Arc::new(AtomicUsize::new(0)),
             no_cache: false,
-            build_dependencies: std::collections::HashMap::new(),
         }
     }
 
     #[must_use]
     pub fn with_no_cache(mut self, no_cache: bool) -> Self {
         self.no_cache = no_cache;
-        self
-    }
-
-    #[must_use]
-    pub fn with_build_dependencies(
-        mut self,
-        build_dependencies: std::collections::HashMap<String, String>,
-    ) -> Self {
-        self.build_dependencies = build_dependencies;
         self
     }
 
@@ -587,40 +574,6 @@ impl CliGeneratorProvider {
         })
     }
 
-    /// Resolve a `[build-dependencies]` name to its generator entry: the
-    /// dependency package's `core:kiln/generator` world entry, as a
-    /// manifest-root-relative path.
-    fn build_dep_generator_path(&self, name: &str) -> Result<InvocationPath, ProviderError> {
-        let dep_path = self.build_dependencies.get(name).ok_or_else(|| {
-            ProviderError::Internal {
-                message: format!(
-                    "kiln: generator module `{name}` is not declared in [build-dependencies]"
-                ),
-            }
-        })?;
-        let dep_manifest_path = self.resolve_path(dep_path).join("wado.toml");
-        let text = std::fs::read_to_string(&dep_manifest_path).map_err(|e| {
-            ProviderError::Internal {
-                message: format!(
-                    "kiln: build-dependency `{name}`: cannot read `{}`: {e}",
-                    dep_manifest_path.display()
-                ),
-            }
-        })?;
-        let manifest: wado_manifest::Manifest =
-            text.parse().map_err(|e| ProviderError::Internal {
-                message: format!("kiln: build-dependency `{name}`: invalid wado.toml: {e}"),
-            })?;
-        let entry = manifest
-            .world_entry("core:kiln/generator")
-            .ok_or_else(|| ProviderError::Internal {
-                message: format!(
-                    "kiln: build-dependency `{name}` does not declare a \
-                     [world].\"core:kiln/generator\" entry"
-                ),
-            })?;
-        Ok(InvocationPath::normalize(&format!("{dep_path}/{entry}")))
-    }
 }
 
 impl GeneratorProvider for CliGeneratorProvider {
@@ -634,10 +587,17 @@ impl GeneratorProvider for CliGeneratorProvider {
                 ),
             }),
             GeneratorModule::LocalPath(path) => self.resolve_local(path).await,
-            GeneratorModule::BuildDep(name) => {
-                let path = self.build_dep_generator_path(name)?;
-                self.resolve_local(&path).await
-            }
+            // `BuildDep` is rewritten to `LocalPath` by the CLI before the
+            // pipeline runs (see `compile::rewrite_build_dep_modules`); an
+            // unresolved one means the `[build-dependencies]` entry was
+            // missing or declared no `core:kiln/generator` world.
+            GeneratorModule::BuildDep(name) => Err(ProviderError::Internal {
+                message: format!(
+                    "kiln: generator module `{name}` could not be resolved against \
+                     [build-dependencies]: no such path dependency, or it declares no \
+                     [world].\"core:kiln/generator\" entry"
+                ),
+            }),
         }
     }
 }

--- a/wado-cli/src/kiln_provider.rs
+++ b/wado-cli/src/kiln_provider.rs
@@ -2,11 +2,12 @@
 //!
 //! Resolves a [`GeneratorModule`] into a [`ResolvedGenerator`] (wasm
 //! bytes + options descriptor + source-closure hash) for the Kiln
-//! driver. v1 supports [`GeneratorModule::LocalPath`] (`module = { path
-//! = "..." }`) resolution. Spec-form generators (`module =
-//! "ns:name@ver"`) surface [`ProviderError::Unsupported`] with a clear
-//! message, matching WEP open-q #4 — registry/git module sources are
-//! deferred to a follow-up.
+//! driver. Supports [`GeneratorModule::LocalPath`] (`module:
+//! "./generator.wado"`) and [`GeneratorModule::BuildDep`] (`module:
+//! "gale"`, resolved against `[build-dependencies]` to the package's
+//! `core:kiln/generator` world entry). Spec-form generators (`module =
+//! "ns:name@ver"`) surface [`ProviderError::Unsupported`] — registry/git
+//! module sources are deferred to a follow-up.
 //!
 //! For `LocalPath`, `resolve` reads the generator source, consults the
 //! on-disk cache at `build/kiln/{generators,metadata}/<stable-id>.*`
@@ -28,7 +29,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use wado_compiler::kiln::{GeneratorModule, OptionsDescriptor};
+use wado_compiler::kiln::{GeneratorModule, InvocationPath, OptionsDescriptor};
 use wado_compiler::lexer::lex;
 use wado_compiler::token::canonical_token_bytes;
 use wado_compiler::{CompilerHost, CompilerOptions, Diagnostic, LogLevel};
@@ -53,6 +54,9 @@ pub struct CliGeneratorProvider {
     /// When true, skip reads from the on-disk generator cache. Writes
     /// still happen so the next non-bypass run sees a warm tree.
     no_cache: bool,
+    /// `[build-dependencies]` name → package path, relative to the manifest
+    /// root. Used to resolve `module: "<name>"` generator references.
+    build_dependencies: std::collections::HashMap<String, String>,
 }
 
 impl CliGeneratorProvider {
@@ -62,12 +66,22 @@ impl CliGeneratorProvider {
             manifest_root,
             compile_count: Arc::new(AtomicUsize::new(0)),
             no_cache: false,
+            build_dependencies: std::collections::HashMap::new(),
         }
     }
 
     #[must_use]
     pub fn with_no_cache(mut self, no_cache: bool) -> Self {
         self.no_cache = no_cache;
+        self
+    }
+
+    #[must_use]
+    pub fn with_build_dependencies(
+        mut self,
+        build_dependencies: std::collections::HashMap<String, String>,
+    ) -> Self {
+        self.build_dependencies = build_dependencies;
         self
     }
 
@@ -549,6 +563,66 @@ fn hex32(bytes: &[u8; 32]) -> String {
     out
 }
 
+impl CliGeneratorProvider {
+    /// Compile (or read from cache) a generator at a manifest-root-relative
+    /// path. Shared by `LocalPath` and `BuildDep` resolution.
+    async fn resolve_local(
+        &self,
+        path: &InvocationPath,
+    ) -> Result<ResolvedGenerator, ProviderError> {
+        let (abs, _source, source_str, stable_id) = self.read_local_source(path)?;
+        let base = abs.parent().map(Path::to_path_buf).unwrap_or_default();
+        if !self.no_cache
+            && let Some(resolved) = self.try_read_cache(&stable_id, &base)
+        {
+            return Ok(resolved);
+        }
+        let artifacts = self
+            .compile_local(path.as_str().to_string(), abs, source_str, stable_id)
+            .await?;
+        Ok(ResolvedGenerator {
+            wasm: artifacts.wasm,
+            descriptor: artifacts.descriptor,
+            source_hash: artifacts.source_hash,
+        })
+    }
+
+    /// Resolve a `[build-dependencies]` name to its generator entry: the
+    /// dependency package's `core:kiln/generator` world entry, as a
+    /// manifest-root-relative path.
+    fn build_dep_generator_path(&self, name: &str) -> Result<InvocationPath, ProviderError> {
+        let dep_path = self.build_dependencies.get(name).ok_or_else(|| {
+            ProviderError::Internal {
+                message: format!(
+                    "kiln: generator module `{name}` is not declared in [build-dependencies]"
+                ),
+            }
+        })?;
+        let dep_manifest_path = self.resolve_path(dep_path).join("wado.toml");
+        let text = std::fs::read_to_string(&dep_manifest_path).map_err(|e| {
+            ProviderError::Internal {
+                message: format!(
+                    "kiln: build-dependency `{name}`: cannot read `{}`: {e}",
+                    dep_manifest_path.display()
+                ),
+            }
+        })?;
+        let manifest: wado_manifest::Manifest =
+            text.parse().map_err(|e| ProviderError::Internal {
+                message: format!("kiln: build-dependency `{name}`: invalid wado.toml: {e}"),
+            })?;
+        let entry = manifest
+            .world_entry("core:kiln/generator")
+            .ok_or_else(|| ProviderError::Internal {
+                message: format!(
+                    "kiln: build-dependency `{name}` does not declare a \
+                     [world].\"core:kiln/generator\" entry"
+                ),
+            })?;
+        Ok(InvocationPath::normalize(&format!("{dep_path}/{entry}")))
+    }
+}
+
 impl GeneratorProvider for CliGeneratorProvider {
     async fn resolve(&self, module: &GeneratorModule) -> Result<ResolvedGenerator, ProviderError> {
         match module {
@@ -559,22 +633,10 @@ impl GeneratorProvider for CliGeneratorProvider {
                      Use `module = {{ path = \"...\" }}` to point at a local generator package."
                 ),
             }),
-            GeneratorModule::LocalPath(path) => {
-                let (abs, _source, source_str, stable_id) = self.read_local_source(path)?;
-                let base = abs.parent().map(Path::to_path_buf).unwrap_or_default();
-                if !self.no_cache
-                    && let Some(resolved) = self.try_read_cache(&stable_id, &base)
-                {
-                    return Ok(resolved);
-                }
-                let artifacts = self
-                    .compile_local(path.as_str().to_string(), abs, source_str, stable_id)
-                    .await?;
-                Ok(ResolvedGenerator {
-                    wasm: artifacts.wasm,
-                    descriptor: artifacts.descriptor,
-                    source_hash: artifacts.source_hash,
-                })
+            GeneratorModule::LocalPath(path) => self.resolve_local(path).await,
+            GeneratorModule::BuildDep(name) => {
+                let path = self.build_dep_generator_path(name)?;
+                self.resolve_local(&path).await
             }
         }
     }

--- a/wado-cli/src/kiln_provider.rs
+++ b/wado-cli/src/kiln_provider.rs
@@ -573,7 +573,6 @@ impl CliGeneratorProvider {
             source_hash: artifacts.source_hash,
         })
     }
-
 }
 
 impl GeneratorProvider for CliGeneratorProvider {

--- a/wado-cli/tests/dependency_resolution.rs
+++ b/wado-cli/tests/dependency_resolution.rs
@@ -1,0 +1,84 @@
+//! End-to-end tests for `[dependencies]` resolution via bare-name `use`.
+//!
+//! Per WEP 2026-02-14 §"Module Resolution with Dependencies", a bare name
+//! (no `:`, no `./`/`../`, no `http(s)://`) in a `use ... from "<name>"`
+//! clause resolves against the `[dependencies]` table in `wado.toml`. The
+//! dependency's entry is its `[package].lib` module; only `export` items are
+//! visible to the consumer. For wado-to-wado source dependencies the CM world
+//! is not observable — the consumer just imports the exported functions.
+//!
+//! This is a black-box test driving the real `wado` binary against a
+//! self-contained two-package layout under a tempdir, which is the only place
+//! that exercises the full vertical slice: manifest parse → CompilerHost
+//! dependency mapping → loader `resolve_import` → compile/run.
+
+use predicates::prelude::*;
+use std::fs;
+
+mod common;
+use common::wado_in;
+
+/// Lay out an `app` package that depends, via a relative `path` dependency,
+/// on a sibling `greet` library package, and import `greet`'s exported
+/// `hello` by its bare dependency name.
+#[test]
+fn path_dependency_resolves_via_bare_name_use() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+
+    // Library package: entry is `[package].lib`; `export fn` is its API.
+    let greet = root.join("greet");
+    fs::create_dir_all(greet.join("src")).unwrap();
+    fs::write(
+        greet.join("wado.toml"),
+        r#"[package]
+name = "greet"
+version = "0.1.0"
+lib = "src/lib.wado"
+"#,
+    )
+    .unwrap();
+    fs::write(
+        greet.join("src/lib.wado"),
+        r#"export fn hello() -> String {
+    return "hello from greet";
+}
+"#,
+    )
+    .unwrap();
+
+    // Application package: depends on `greet` by path, imports it by name.
+    let app = root.join("app");
+    fs::create_dir_all(app.join("src")).unwrap();
+    fs::write(
+        app.join("wado.toml"),
+        r#"[package]
+name = "app"
+version = "0.1.0"
+
+[world]
+"wasi:cli/command" = "src/main.wado"
+
+[dependencies]
+greet = { path = "../greet" }
+"#,
+    )
+    .unwrap();
+    fs::write(
+        app.join("src/main.wado"),
+        r#"use { println, Stdout } from "core:cli";
+use { hello } from "greet";
+
+export fn run() with Stdout {
+    println(hello());
+}
+"#,
+    )
+    .unwrap();
+
+    wado_in(&app)
+        .args(["run", "src/main.wado"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("hello from greet"));
+}

--- a/wado-cli/tests/dependency_resolution.rs
+++ b/wado-cli/tests/dependency_resolution.rs
@@ -222,3 +222,70 @@ export fn run() {
                 .or(predicate::str::contains("declares no")),
         ));
 }
+
+/// Two separate consumer projects may use the SAME dependency alias
+/// (`greet`) for DIFFERENT packages. The dependency index is built per
+/// project (per compile, on a fresh interner), so each resolves to its own
+/// package with no cross-contamination.
+#[test]
+fn same_alias_different_package_resolves_per_project() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+
+    for (pkg, msg) in [("greet_a", "from A"), ("greet_b", "from B")] {
+        let dir = root.join(pkg);
+        fs::create_dir_all(dir.join("src")).unwrap();
+        fs::write(
+            dir.join("wado.toml"),
+            format!("[package]\nname = \"{pkg}\"\nversion = \"0.1.0\"\nlib = \"src/lib.wado\"\n"),
+        )
+        .unwrap();
+        fs::write(
+            dir.join("src/lib.wado"),
+            format!("export fn greeting() -> String {{ return \"{msg}\"; }}\n"),
+        )
+        .unwrap();
+    }
+
+    // Both apps alias the dependency as `greet`, pointing at different packages.
+    for (app, dep, expected) in [
+        ("app_a", "greet_a", "from A"),
+        ("app_b", "greet_b", "from B"),
+    ] {
+        let dir = root.join(app);
+        fs::create_dir_all(dir.join("src")).unwrap();
+        fs::write(
+            dir.join("wado.toml"),
+            format!(
+                r#"[package]
+name = "{app}"
+version = "0.1.0"
+
+[world]
+"wasi:cli/command" = "src/main.wado"
+
+[dependencies]
+greet = {{ path = "../{dep}" }}
+"#
+            ),
+        )
+        .unwrap();
+        fs::write(
+            dir.join("src/main.wado"),
+            r#"use { println, Stdout } from "core:cli";
+use { greeting } from "greet";
+
+export fn run() with Stdout {
+    println(greeting());
+}
+"#,
+        )
+        .unwrap();
+
+        wado_in(&dir)
+            .args(["run", "src/main.wado"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(expected));
+    }
+}

--- a/wado-cli/tests/dependency_resolution.rs
+++ b/wado-cli/tests/dependency_resolution.rs
@@ -9,7 +9,7 @@
 //!
 //! This is a black-box test driving the real `wado` binary against a
 //! self-contained two-package layout under a tempdir, which is the only place
-//! that exercises the full vertical slice: manifest parse → CompilerHost
+//! that exercises the full vertical slice: manifest parse → `CompilerHost`
 //! dependency mapping → loader `resolve_import` → compile/run.
 
 use predicates::prelude::*;
@@ -218,8 +218,7 @@ export fn run() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("greet").and(
-            predicate::str::contains("[package].lib")
-                .or(predicate::str::contains("declares no")),
+            predicate::str::contains("[package].lib").or(predicate::str::contains("declares no")),
         ));
 }
 

--- a/wado-cli/tests/dependency_resolution.rs
+++ b/wado-cli/tests/dependency_resolution.rs
@@ -289,3 +289,75 @@ export fn run() with Stdout {
             .stdout(predicate::str::contains(expected));
     }
 }
+
+/// Two different aliases pointing at the SAME package resolve to one module
+/// identity, so a type defined in that package unifies across both import
+/// paths (no duplicate compilation / mismatched types).
+#[test]
+fn two_aliases_for_one_package_share_type_identity() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+
+    let shared = root.join("shared");
+    fs::create_dir_all(shared.join("src")).unwrap();
+    fs::write(
+        shared.join("wado.toml"),
+        "[package]\nname = \"shared\"\nversion = \"0.1.0\"\nlib = \"src/lib.wado\"\n",
+    )
+    .unwrap();
+    fs::write(
+        shared.join("src/lib.wado"),
+        r#"pub struct Point {
+    pub x: i32,
+}
+
+export fn origin() -> Point {
+    return Point { x: 42 };
+}
+
+export fn get_x(p: Point) -> i32 {
+    return p.x;
+}
+"#,
+    )
+    .unwrap();
+
+    let app = root.join("app");
+    fs::create_dir_all(app.join("src")).unwrap();
+    fs::write(
+        app.join("wado.toml"),
+        r#"[package]
+name = "app"
+version = "0.1.0"
+
+[world]
+"wasi:cli/command" = "src/main.wado"
+
+[dependencies]
+a = { path = "../shared" }
+b = { path = "../shared" }
+"#,
+    )
+    .unwrap();
+    // `origin` comes via alias `a`, `get_x` via alias `b`; the `Point` value
+    // flows from one to the other and must be the same type.
+    fs::write(
+        app.join("src/main.wado"),
+        r#"use { println, Stdout } from "core:cli";
+use { origin } from "a";
+use { get_x } from "b";
+
+export fn run() with Stdout {
+    let p = origin();
+    println(`{get_x(p)}`);
+}
+"#,
+    )
+    .unwrap();
+
+    wado_in(&app)
+        .args(["run", "src/main.wado"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("42"));
+}

--- a/wado-cli/tests/dependency_resolution.rs
+++ b/wado-cli/tests/dependency_resolution.rs
@@ -82,3 +82,75 @@ export fn run() with Stdout {
         .success()
         .stdout(predicate::str::contains("hello from greet"));
 }
+
+/// The dependency's own modules resolve relative imports inside the
+/// dependency package: `greet`'s lib `use`s a sibling helper.
+#[test]
+fn dependency_internal_relative_import_resolves() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+
+    let greet = root.join("greet");
+    fs::create_dir_all(greet.join("src")).unwrap();
+    fs::write(
+        greet.join("wado.toml"),
+        r#"[package]
+name = "greet"
+version = "0.1.0"
+lib = "src/lib.wado"
+"#,
+    )
+    .unwrap();
+    fs::write(
+        greet.join("src/lib.wado"),
+        r#"use { subject } from "./helper.wado";
+
+export fn hello() -> String {
+    return `hello {subject()}`;
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        greet.join("src/helper.wado"),
+        r#"pub fn subject() -> String {
+    return "world";
+}
+"#,
+    )
+    .unwrap();
+
+    let app = root.join("app");
+    fs::create_dir_all(app.join("src")).unwrap();
+    fs::write(
+        app.join("wado.toml"),
+        r#"[package]
+name = "app"
+version = "0.1.0"
+
+[world]
+"wasi:cli/command" = "src/main.wado"
+
+[dependencies]
+greet = { path = "../greet" }
+"#,
+    )
+    .unwrap();
+    fs::write(
+        app.join("src/main.wado"),
+        r#"use { println, Stdout } from "core:cli";
+use { hello } from "greet";
+
+export fn run() with Stdout {
+    println(hello());
+}
+"#,
+    )
+    .unwrap();
+
+    wado_in(&app)
+        .args(["run", "src/main.wado"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("hello world"));
+}

--- a/wado-cli/tests/dependency_resolution.rs
+++ b/wado-cli/tests/dependency_resolution.rs
@@ -81,6 +81,13 @@ export fn run() with Stdout {
         .assert()
         .success()
         .stdout(predicate::str::contains("hello from greet"));
+
+    // `wado check` must resolve bare-name dependencies too (same host-provided
+    // dependency index as compile/run), not just `wado run`.
+    wado_in(&app)
+        .args(["check", "src/main.wado"])
+        .assert()
+        .success();
 }
 
 /// The dependency's own modules resolve relative imports inside the

--- a/wado-cli/tests/dependency_resolution.rs
+++ b/wado-cli/tests/dependency_resolution.rs
@@ -161,3 +161,64 @@ export fn run() with Stdout {
         .success()
         .stdout(predicate::str::contains("hello world"));
 }
+
+/// A declared path dependency whose package has no `[package].lib` is
+/// reported precisely (not as a generic "invalid module path").
+#[test]
+fn dependency_without_lib_reports_precise_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+
+    // greet declares a package but no `lib` entry.
+    let greet = root.join("greet");
+    fs::create_dir_all(greet.join("src")).unwrap();
+    fs::write(
+        greet.join("wado.toml"),
+        r#"[package]
+name = "greet"
+version = "0.1.0"
+"#,
+    )
+    .unwrap();
+    fs::write(
+        greet.join("src/lib.wado"),
+        "export fn hello() -> String { return \"hi\"; }\n",
+    )
+    .unwrap();
+
+    let app = root.join("app");
+    fs::create_dir_all(app.join("src")).unwrap();
+    fs::write(
+        app.join("wado.toml"),
+        r#"[package]
+name = "app"
+version = "0.1.0"
+
+[world]
+"wasi:cli/command" = "src/main.wado"
+
+[dependencies]
+greet = { path = "../greet" }
+"#,
+    )
+    .unwrap();
+    fs::write(
+        app.join("src/main.wado"),
+        r#"use { hello } from "greet";
+
+export fn run() {
+    let _ = hello();
+}
+"#,
+    )
+    .unwrap();
+
+    wado_in(&app)
+        .args(["compile", "-o", "out.wasm", "src/main.wado"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("greet").and(
+            predicate::str::contains("[package].lib")
+                .or(predicate::str::contains("declares no")),
+        ));
+}

--- a/wado-cli/tests/kiln_build_dep.rs
+++ b/wado-cli/tests/kiln_build_dep.rs
@@ -92,4 +92,10 @@ export fn run() with Stdout {
         .assert()
         .success()
         .stdout(predicate::str::contains("hi from generator"));
+
+    // `wado check` resolves the build-dependency generator too.
+    wado_in(&app)
+        .args(["check", "src/main.wado"])
+        .assert()
+        .success();
 }

--- a/wado-cli/tests/kiln_build_dep.rs
+++ b/wado-cli/tests/kiln_build_dep.rs
@@ -1,0 +1,95 @@
+//! End-to-end test: a Kiln generator referenced by its `[build-dependencies]`
+//! name (`module: "gen"`) instead of a relative path.
+//!
+//! The bare name resolves against `[build-dependencies]`; the provider reads
+//! the dependency package's `[world]."core:kiln/generator"` entry, compiles
+//! it, runs it, and the generated module is imported by the consumer.
+
+use predicates::prelude::*;
+use std::fs;
+
+mod common;
+use common::wado_in;
+
+#[test]
+fn generator_resolved_by_build_dependency_name() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+
+    // Generator package: declares the `core:kiln/generator` world entry.
+    let gen_pkg = root.join("gen");
+    fs::create_dir_all(gen_pkg.join("src")).unwrap();
+    fs::write(
+        gen_pkg.join("wado.toml"),
+        r#"[package]
+name = "gen"
+version = "0.1.0"
+
+[world]
+"core:kiln/generator" = "src/generator.wado"
+"#,
+    )
+    .unwrap();
+    fs::write(
+        gen_pkg.join("src/generator.wado"),
+        r#"use { RawRequest, Response, OutputFile, Error } from "core:kiln";
+
+pub struct Options {
+    pub verbose: bool,
+}
+
+export fn generate(raw: RawRequest) -> Result<Response, Error> {
+    let _ = raw;
+    return Result::Ok(Response {
+        files: [OutputFile {
+            path: "greeting.wado",
+            content: "pub fn greeting() -> String { return \"hi from generator\"; }",
+            is_entry: true,
+        }],
+    });
+}
+"#,
+    )
+    .unwrap();
+
+    // Consumer: references the generator by its build-dependency name.
+    let app = root.join("app");
+    fs::create_dir_all(app.join("src")).unwrap();
+    fs::write(
+        app.join("wado.toml"),
+        r#"[package]
+name = "app"
+version = "0.1.0"
+
+[world]
+"wasi:cli/command" = "src/main.wado"
+
+[build-dependencies]
+gen = { path = "../gen" }
+"#,
+    )
+    .unwrap();
+    fs::write(app.join("src/schema.idl"), "anything\n").unwrap();
+    fs::write(
+        app.join("src/main.wado"),
+        r#"use { println, Stdout } from "core:cli";
+use { greeting } from "./schema.idl" with {
+    generator: {
+        module: "gen",
+        options: { verbose: false },
+    },
+};
+
+export fn run() with Stdout {
+    println(greeting());
+}
+"#,
+    )
+    .unwrap();
+
+    wado_in(&app)
+        .args(["run", "src/main.wado"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("hi from generator"));
+}

--- a/wado-compiler/src/compiler_host.rs
+++ b/wado-compiler/src/compiler_host.rs
@@ -395,6 +395,15 @@ pub trait CompilerHost: Send + Sync {
     ) -> impl Future<Output = Result<GeneratorResponse, GeneratorRunnerError>> + Send {
         async move { Err(GeneratorRunnerError::Unsupported) }
     }
+
+    /// Bare dependency name → entry-module path (the dependency's
+    /// `[package].lib`), relative to the host's base. Resolves
+    /// `use { … } from "<name>"` against `[dependencies]`. Consulted once
+    /// when the module loader is created; empty by default (single-file and
+    /// in-memory hosts have no manifest).
+    fn dependency_index(&self) -> std::collections::HashMap<String, String> {
+        std::collections::HashMap::new()
+    }
 }
 
 /// Request handed to a Kiln generator by the compiler.

--- a/wado-compiler/src/compiler_host.rs
+++ b/wado-compiler/src/compiler_host.rs
@@ -396,14 +396,24 @@ pub trait CompilerHost: Send + Sync {
         async move { Err(GeneratorRunnerError::Unsupported) }
     }
 
-    /// Bare dependency name → entry-module path (the dependency's
-    /// `[package].lib`), relative to the host's base. Resolves
-    /// `use { … } from "<name>"` against `[dependencies]`. Consulted once
-    /// when the module loader is created; empty by default (single-file and
-    /// in-memory hosts have no manifest).
-    fn dependency_index(&self) -> std::collections::HashMap<String, String> {
-        std::collections::HashMap::new()
+    /// Resolve `[dependencies]` for bare-name `use { … } from "<name>"`.
+    /// Consulted once when the module loader is created; empty by default
+    /// (single-file and in-memory hosts have no manifest).
+    fn dependency_index(&self) -> DependencyIndex {
+        DependencyIndex::default()
     }
+}
+
+/// The project's `[dependencies]`, resolved for bare-name imports.
+#[derive(Debug, Clone, Default)]
+pub struct DependencyIndex {
+    /// name → entry-module path (the dependency's `[package].lib`), relative
+    /// to the host base.
+    pub resolved: std::collections::HashMap<String, String>,
+    /// name → human-readable reason a *declared* dependency could not be
+    /// resolved (e.g. its package declares no `[package].lib`). Surfaced at
+    /// the `use` site instead of a generic "invalid module path".
+    pub unresolved: std::collections::HashMap<String, String>,
 }
 
 /// Request handed to a Kiln generator by the compiler.

--- a/wado-compiler/src/elaborator/liveness.rs
+++ b/wado-compiler/src/elaborator/liveness.rs
@@ -322,6 +322,7 @@ pub(crate) fn is_user_authored(source: &ModuleSource) -> bool {
     match source {
         ModuleSource::EntryPoint { .. }
         | ModuleSource::Remote { .. }
+        | ModuleSource::Dependency { .. }
         | ModuleSource::Redirected { .. } => true,
         ModuleSource::Local { path } => {
             let path = path.as_str();

--- a/wado-compiler/src/elaborator/trait_env.rs
+++ b/wado-compiler/src/elaborator/trait_env.rs
@@ -949,6 +949,7 @@ pub(super) fn is_user_local(ms: &ModuleSource) -> bool {
     matches!(
         ms,
         ModuleSource::Local { .. }
+            | ModuleSource::Dependency { .. }
             | ModuleSource::EntryPoint { .. }
             | ModuleSource::Redirected { .. }
     )

--- a/wado-compiler/src/kiln/cache.rs
+++ b/wado-compiler/src/kiln/cache.rs
@@ -303,6 +303,7 @@ pub fn generator_identity(module: &GeneratorModule) -> String {
     match module {
         GeneratorModule::Spec(s) => s.clone(),
         GeneratorModule::LocalPath(p) => format!("local:{}", p.as_str()),
+        GeneratorModule::BuildDep(s) => format!("builddep:{s}"),
     }
 }
 

--- a/wado-compiler/src/kiln/import_check.rs
+++ b/wado-compiler/src/kiln/import_check.rs
@@ -319,6 +319,7 @@ fn should_check(source: &ModuleSource) -> bool {
     match source {
         ModuleSource::EntryPoint { .. }
         | ModuleSource::Local { .. }
+        | ModuleSource::Dependency { .. }
         | ModuleSource::Remote { .. }
         | ModuleSource::Redirected { .. } => true,
         ModuleSource::Core { .. } | ModuleSource::Wasi { .. } | ModuleSource::Wasm { .. } => false,

--- a/wado-compiler/src/kiln/inline.rs
+++ b/wado-compiler/src/kiln/inline.rs
@@ -371,12 +371,22 @@ fn lower_module_specifier(
     {
         return Some(GeneratorModule::Spec(spec.to_string()));
     }
+    // Bare `[build-dependencies]` key (`module: "gale"`). Resolved by the
+    // host against the manifest's build-dependency graph.
+    if !spec.is_empty()
+        && spec
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        return Some(GeneratorModule::BuildDep(spec.to_string()));
+    }
     errors.push(Diagnostic {
         severity: Severity::Error,
         code: Code::GeneratorOptionsInvalid,
         message: format!(
-            "kiln: `generator.module` must be a relative path (\"./generator.wado\") \
-             or a namespaced spec (\"ns:name@ver\"), got `{spec}`"
+            "kiln: `generator.module` must be a relative path (\"./generator.wado\"), \
+             a `[build-dependencies]` name (\"gale\"), or a namespaced spec \
+             (\"ns:name@ver\"), got `{spec}`"
         ),
         span: Some(span_of(module_path, use_decl)),
     });
@@ -445,6 +455,7 @@ fn module_key(module: &GeneratorModule) -> String {
     match module {
         GeneratorModule::Spec(s) => format!("spec:{s}"),
         GeneratorModule::LocalPath(p) => format!("path:{}", p.as_str()),
+        GeneratorModule::BuildDep(s) => format!("builddep:{s}"),
     }
 }
 

--- a/wado-compiler/src/kiln/invocation.rs
+++ b/wado-compiler/src/kiln/invocation.rs
@@ -74,6 +74,9 @@ pub enum GeneratorModule {
     Spec(String),
     /// Resolved local path, already joined against the consuming file's directory.
     LocalPath(InvocationPath),
+    /// A bare `[build-dependencies]` key (`module: "gale"`). Resolved by the
+    /// host to the dependency package's `core:kiln/generator` world entry.
+    BuildDep(String),
 }
 
 /// Compiler-internal canonical form of a Kiln generator invocation.

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -199,6 +199,10 @@ pub struct CompilerOptions {
     /// that have run the Kiln pipeline (wado-cli, wado-lsp) populate this;
     /// everyone else leaves it empty.
     pub invocations: kiln::InvocationIndex,
+    /// Bare dependency name → entry-module path (the dependency's
+    /// `[package].lib`), relative to the entry directory. Populated by the
+    /// CLI from `[dependencies]`; empty for single-file compilation.
+    pub dependencies: std::collections::HashMap<String, String>,
     /// `--test-name` substring filters for the test world. When non-empty,
     /// only `test "name"` blocks whose name contains one of these strings are
     /// exported; the rest become dead code and are removed by early DCE, so
@@ -227,6 +231,7 @@ impl Default for CompilerOptions {
             log_level: None,
             allocator: None,
             invocations: kiln::InvocationIndex::default(),
+            dependencies: std::collections::HashMap::new(),
             test_name_filters: Vec::new(),
             codegen_flags: Vec::new(),
             unused_diagnostics: true,
@@ -356,7 +361,8 @@ pub async fn compile_with_options<H: CompilerHost>(
     // the entry AST for tooling that takes it by value.
     let load_result = {
         let module_loader = loader::ModuleLoader::new(host, log_level)
-            .with_invocations(options.invocations.clone());
+            .with_invocations(options.invocations.clone())
+            .with_dependencies(options.dependencies.clone());
         module_loader
             .load_all(source, filename.as_deref())
             .await

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -64,10 +64,9 @@ pub use bind::{BindError, Binder};
 pub use codegen_flags::CodegenFlags;
 pub use compiler_host::{
     Code, CompilerHost, DependencyIndex, Diagnostic, DiagnosticSpan, GeneratorDiagnostic,
-    GeneratorDiagnosticLevel,
-    GeneratorError, GeneratorInputFile, GeneratorOutputFile, GeneratorReadRecord, GeneratorRequest,
-    GeneratorResponse, GeneratorRunnerError, GeneratorSourceSpan, KILN_GENERATOR_WIT, LogLevel,
-    Severity, SourceError,
+    GeneratorDiagnosticLevel, GeneratorError, GeneratorInputFile, GeneratorOutputFile,
+    GeneratorReadRecord, GeneratorRequest, GeneratorResponse, GeneratorRunnerError,
+    GeneratorSourceSpan, KILN_GENERATOR_WIT, LogLevel, Severity, SourceError,
 };
 pub use logger::{Bail, Logger};
 pub use remarks::{Remark, collect_value_copy_remarks};

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -199,10 +199,6 @@ pub struct CompilerOptions {
     /// that have run the Kiln pipeline (wado-cli, wado-lsp) populate this;
     /// everyone else leaves it empty.
     pub invocations: kiln::InvocationIndex,
-    /// Bare dependency name → entry-module path (the dependency's
-    /// `[package].lib`), relative to the entry directory. Populated by the
-    /// CLI from `[dependencies]`; empty for single-file compilation.
-    pub dependencies: std::collections::HashMap<String, String>,
     /// `--test-name` substring filters for the test world. When non-empty,
     /// only `test "name"` blocks whose name contains one of these strings are
     /// exported; the rest become dead code and are removed by early DCE, so
@@ -231,7 +227,6 @@ impl Default for CompilerOptions {
             log_level: None,
             allocator: None,
             invocations: kiln::InvocationIndex::default(),
-            dependencies: std::collections::HashMap::new(),
             test_name_filters: Vec::new(),
             codegen_flags: Vec::new(),
             unused_diagnostics: true,
@@ -361,8 +356,7 @@ pub async fn compile_with_options<H: CompilerHost>(
     // the entry AST for tooling that takes it by value.
     let load_result = {
         let module_loader = loader::ModuleLoader::new(host, log_level)
-            .with_invocations(options.invocations.clone())
-            .with_dependencies(options.dependencies.clone());
+            .with_invocations(options.invocations.clone());
         module_loader
             .load_all(source, filename.as_deref())
             .await

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -63,7 +63,8 @@ pub use ast::{AstId, AstNodeKind, AstPtr};
 pub use bind::{BindError, Binder};
 pub use codegen_flags::CodegenFlags;
 pub use compiler_host::{
-    Code, CompilerHost, Diagnostic, DiagnosticSpan, GeneratorDiagnostic, GeneratorDiagnosticLevel,
+    Code, CompilerHost, DependencyIndex, Diagnostic, DiagnosticSpan, GeneratorDiagnostic,
+    GeneratorDiagnosticLevel,
     GeneratorError, GeneratorInputFile, GeneratorOutputFile, GeneratorReadRecord, GeneratorRequest,
     GeneratorResponse, GeneratorRunnerError, GeneratorSourceSpan, KILN_GENERATOR_WIT, LogLevel,
     Severity, SourceError,

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -1409,9 +1409,7 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         // base-path joining or relative-path normalization happens.
         if !self.invocations.is_empty() {
             let decl_file = match from_module_source {
-                ModuleSource::Local { path } | ModuleSource::Dependency { path } => {
-                    path.as_str()
-                }
+                ModuleSource::Local { path } | ModuleSource::Dependency { path } => path.as_str(),
                 ModuleSource::EntryPoint { filename } => filename.as_str(),
                 ModuleSource::Redirected { uri } => uri.as_str(),
                 _ => "",

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -53,6 +53,10 @@ pub enum LoadError {
     UnknownNamespace { namespace: String },
     /// Invalid module path format (e.g., "foo.wado" without "./" prefix)
     InvalidModulePath { path: String },
+    /// A bare name matched a declared `[dependencies]` entry, but the
+    /// dependency could not be resolved to an entry module (e.g. its package
+    /// declares no `[package].lib`). `reason` explains why.
+    DependencyUnresolved { name: String, reason: String },
     /// Wasm-asset import (`with { type: "wat"|"wasm" }`) failed validation.
     WasmImport {
         module_source: ModuleSource,
@@ -130,6 +134,9 @@ impl std::fmt::Display for LoadError {
                     f,
                     "invalid module path '{path}'; use './' for local modules or 'namespace:' for library modules"
                 )
+            }
+            LoadError::DependencyUnresolved { name, reason } => {
+                write!(f, "cannot resolve dependency '{name}': {reason}")
             }
             LoadError::WasmImport {
                 module_source,
@@ -1465,10 +1472,18 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         // Bare dependency name: resolve against `[dependencies]`. Only the
         // consuming project resolves its own deps; a bare import from within
         // a dependency must not bind to the consumer's deps.
-        if !matches!(from_module_source, ModuleSource::Dependency { .. })
-            && let Some(dep) = self.interner.resolve_dependency(import_source)
-        {
-            return Ok(dep);
+        if !matches!(from_module_source, ModuleSource::Dependency { .. }) {
+            if let Some(dep) = self.interner.resolve_dependency(import_source) {
+                return Ok(dep);
+            }
+            // Declared but unresolvable (e.g. missing `[package].lib`): report
+            // why, instead of a generic "invalid module path".
+            if let Some(reason) = self.interner.unresolved_dependency(import_source) {
+                return Err(LoadError::DependencyUnresolved {
+                    name: import_source.to_string(),
+                    reason: reason.to_string(),
+                });
+            }
         }
 
         // Check for unknown namespace pattern (xxx:yyy)

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -387,7 +387,9 @@ pub fn resolve_wasm_asset_path(
             "wasi:{}",
             join_namespace_relative_path(interface, import_source)
         )),
-        ModuleSource::Local { path } => Ok(resolve_module_path(path, import_source)),
+        ModuleSource::Local { path } | ModuleSource::Dependency { path, .. } => {
+            Ok(resolve_module_path(path, import_source))
+        }
         ModuleSource::Remote { url } => Ok(resolve_module_path(url, import_source)),
         ModuleSource::EntryPoint { .. } => Ok(normalize_module_path(import_source)),
         ModuleSource::Redirected { uri } => Ok(resolve_module_path(uri, import_source)),
@@ -1455,13 +1457,20 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
                 let resolved = resolve_module_path(from_url, import_source);
                 return Ok(self.interner.remote(&resolved));
             }
+            // Relative import from within a dependency module stays inside
+            // that dependency package.
+            if let ModuleSource::Dependency { package, path } = from_module_source {
+                let resolved = resolve_module_path(path, import_source);
+                let package = package.to_string();
+                return Ok(self.interner.dependency(&package, &resolved));
+            }
             // Entry point or stdlib: treat as relative to project root
             let canonical = normalize_module_path(import_source);
             return Ok(self.interner.local(&canonical));
         }
 
         // Bare dependency name: resolve against `[dependencies]`.
-        if let Some(dep) = self.interner.dependency(import_source) {
+        if let Some(dep) = self.interner.resolve_dependency(import_source) {
             return Ok(dep);
         }
 
@@ -1493,7 +1502,7 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         _from_module_source: &ModuleSource,
     ) -> Result<String, LoadError> {
         match module_source {
-            ModuleSource::Local { path } => {
+            ModuleSource::Local { path } | ModuleSource::Dependency { path, .. } => {
                 let bytes = self.host.load_source(path).await.map_err(LoadError::from)?;
                 String::from_utf8(bytes).map_err(|_| LoadError::IoError {
                     path: path.to_string(),

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -394,7 +394,7 @@ pub fn resolve_wasm_asset_path(
             "wasi:{}",
             join_namespace_relative_path(interface, import_source)
         )),
-        ModuleSource::Local { path } | ModuleSource::Dependency { path, .. } => {
+        ModuleSource::Local { path } | ModuleSource::Dependency { path } => {
             Ok(resolve_module_path(path, import_source))
         }
         ModuleSource::Remote { url } => Ok(resolve_module_path(url, import_source)),
@@ -1376,7 +1376,7 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
     ) {
         use crate::compiler_host::{Code, Diagnostic, DiagnosticSpan, Severity};
         let file = match from_module_source {
-            ModuleSource::Local { path } | ModuleSource::Dependency { path, .. } => path.to_string(),
+            ModuleSource::Local { path } | ModuleSource::Dependency { path } => path.to_string(),
             ModuleSource::EntryPoint { filename } => filename.to_string(),
             ModuleSource::Redirected { uri } => uri.to_string(),
             _ => String::new(),
@@ -1409,7 +1409,7 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         // base-path joining or relative-path normalization happens.
         if !self.invocations.is_empty() {
             let decl_file = match from_module_source {
-                ModuleSource::Local { path } | ModuleSource::Dependency { path, .. } => {
+                ModuleSource::Local { path } | ModuleSource::Dependency { path } => {
                     path.as_str()
                 }
                 ModuleSource::EntryPoint { filename } => filename.as_str(),
@@ -1459,10 +1459,9 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
             }
             // Relative import from within a dependency module stays inside
             // that dependency package.
-            if let ModuleSource::Dependency { package, path } = from_module_source {
+            if let ModuleSource::Dependency { path } = from_module_source {
                 let resolved = resolve_module_path(path, import_source);
-                let package = package.to_string();
-                return Ok(self.interner.dependency(&package, &resolved));
+                return Ok(self.interner.dependency(&resolved));
             }
             // Entry point or stdlib: treat as relative to project root
             let canonical = normalize_module_path(import_source);
@@ -1514,7 +1513,7 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         _from_module_source: &ModuleSource,
     ) -> Result<String, LoadError> {
         match module_source {
-            ModuleSource::Local { path } | ModuleSource::Dependency { path, .. } => {
+            ModuleSource::Local { path } | ModuleSource::Dependency { path } => {
                 let bytes = self.host.load_source(path).await.map_err(LoadError::from)?;
                 String::from_utf8(bytes).map_err(|_| LoadError::IoError {
                     path: path.to_string(),

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -985,6 +985,17 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         self
     }
 
+    /// Seed `[dependencies]` resolution: bare-name → entry-module path. Must
+    /// be called before [`Self::load_all`].
+    #[must_use]
+    pub fn with_dependencies(
+        mut self,
+        dependencies: std::collections::HashMap<String, String>,
+    ) -> Self {
+        self.interner.set_dependencies(dependencies);
+        self
+    }
+
     /// Load all modules starting from the entry source
     ///
     /// This loads the entry module and all its transitive dependencies.
@@ -1447,6 +1458,11 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
             // Entry point or stdlib: treat as relative to project root
             let canonical = normalize_module_path(import_source);
             return Ok(self.interner.local(&canonical));
+        }
+
+        // Bare dependency name: resolve against `[dependencies]`.
+        if let Some(dep) = self.interner.dependency(import_source) {
+            return Ok(dep);
         }
 
         // Check for unknown namespace pattern (xxx:yyy)

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -954,11 +954,13 @@ pub struct ModuleLoader<'a, H: CompilerHost> {
 impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
     /// Create a new module loader with the given host and log level
     pub fn new(host: &'a H, log_level: LogLevel) -> Self {
+        let mut interner = ModuleSourceInterner::new();
+        interner.set_dependencies(host.dependency_index());
         Self {
             host,
             log_level,
             logger: Logger::new(host, log_level),
-            interner: ModuleSourceInterner::new(),
+            interner,
             loaded: IndexMap::default(),
             loading: IndexSet::default(),
             implicit_modules: IndexSet::default(),
@@ -984,17 +986,6 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
     #[must_use]
     pub fn with_invocations(mut self, invocations: crate::kiln::InvocationIndex) -> Self {
         self.invocations = invocations;
-        self
-    }
-
-    /// Seed `[dependencies]` resolution: bare-name → entry-module path. Must
-    /// be called before [`Self::load_all`].
-    #[must_use]
-    pub fn with_dependencies(
-        mut self,
-        dependencies: std::collections::HashMap<String, String>,
-    ) -> Self {
-        self.interner.set_dependencies(dependencies);
         self
     }
 

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -1378,7 +1378,7 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
     ) {
         use crate::compiler_host::{Code, Diagnostic, DiagnosticSpan, Severity};
         let file = match from_module_source {
-            ModuleSource::Local { path } => path.to_string(),
+            ModuleSource::Local { path } | ModuleSource::Dependency { path, .. } => path.to_string(),
             ModuleSource::EntryPoint { filename } => filename.to_string(),
             ModuleSource::Redirected { uri } => uri.to_string(),
             _ => String::new(),
@@ -1411,7 +1411,9 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         // base-path joining or relative-path normalization happens.
         if !self.invocations.is_empty() {
             let decl_file = match from_module_source {
-                ModuleSource::Local { path } => path.as_str(),
+                ModuleSource::Local { path } | ModuleSource::Dependency { path, .. } => {
+                    path.as_str()
+                }
                 ModuleSource::EntryPoint { filename } => filename.as_str(),
                 ModuleSource::Redirected { uri } => uri.as_str(),
                 _ => "",
@@ -1469,8 +1471,12 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
             return Ok(self.interner.local(&canonical));
         }
 
-        // Bare dependency name: resolve against `[dependencies]`.
-        if let Some(dep) = self.interner.resolve_dependency(import_source) {
+        // Bare dependency name: resolve against `[dependencies]`. Only the
+        // consuming project resolves its own deps; a bare import from within
+        // a dependency must not bind to the consumer's deps.
+        if !matches!(from_module_source, ModuleSource::Dependency { .. })
+            && let Some(dep) = self.interner.resolve_dependency(import_source)
+        {
             return Ok(dep);
         }
 

--- a/wado-compiler/src/module_source.rs
+++ b/wado-compiler/src/module_source.rs
@@ -165,9 +165,8 @@ impl ModuleSourceInterner {
         self.dependencies = dependencies;
     }
 
-    pub fn dependency(&mut self, package: &str, path: &str) -> ModuleSource {
+    pub fn dependency(&mut self, path: &str) -> ModuleSource {
         ModuleSource::Dependency {
-            package: self.intern(package),
             path: self.intern(path),
         }
     }
@@ -176,7 +175,7 @@ impl ModuleSourceInterner {
     /// declared in `[dependencies]` and successfully resolved.
     pub fn resolve_dependency(&mut self, name: &str) -> Option<ModuleSource> {
         let path = self.dependencies.resolved.get(name)?.clone();
-        Some(self.dependency(name, &path))
+        Some(self.dependency(&path))
     }
 
     /// The reason a *declared* dependency could not be resolved, if any.
@@ -234,9 +233,7 @@ impl ModuleSourceInterner {
             [first] if first.starts_with("./") || first.starts_with("../") => self.local(first),
             [first, rest @ ..] if first == "core" => self.core(&rest.join("/")),
             [first, rest @ ..] if first == "wasi" => self.wasi(&rest.join("/")),
-            [first, package, rest @ ..] if first == "dep" => {
-                self.dependency(package, &rest.join("/"))
-            }
+            [first, rest @ ..] if first == "dep" => self.dependency(&rest.join("/")),
             segments => self.local(&segments.join("/")),
         }
     }
@@ -321,16 +318,17 @@ pub enum ModuleSource {
     /// A module belonging to a dependency package, resolved from a bare-name
     /// `use { … } from "<dep>"` clause against `[dependencies]`.
     ///
-    /// `package` is the dependency's identity (the `[dependencies]` key for
-    /// path deps; a resolved package id once registry/git land). It keeps
-    /// type identity from crossing the package boundary even when two
-    /// packages have a file at the same `path`. `path` is the module file,
-    /// loaded by the host exactly like [`ModuleSource::Local`] — wado-to-wado
+    /// Identity is the resolved entry-module `path` — within a compilation
+    /// the same resolved path is the same file, hence the same package, so
+    /// two `[dependencies]` aliases that point at the same package unify.
+    /// The variant is distinct from [`ModuleSource::Local`] to carry the
+    /// package boundary (only `export` items are visible across it) and to
+    /// keep dependency modules from resolving the consumer's `[dependencies]`.
+    /// `path` is loaded by the host exactly like `Local` — wado-to-wado
     /// source dependencies compile into the same component (the CM boundary
     /// is skipped), so dependency modules are ordinary Wado source once
     /// loaded.
     Dependency {
-        package: InternedStr,
         path: InternedStr,
     },
     /// Remote module loaded via HTTP/HTTPS
@@ -387,16 +385,7 @@ impl PartialEq for ModuleSource {
             (Self::Core { name: a }, Self::Core { name: b }) => a == b,
             (Self::Wasi { interface: a }, Self::Wasi { interface: b }) => a == b,
             (Self::Local { path: a }, Self::Local { path: b }) => a == b,
-            (
-                Self::Dependency {
-                    package: pa,
-                    path: a,
-                },
-                Self::Dependency {
-                    package: pb,
-                    path: b,
-                },
-            ) => pa == pb && a == b,
+            (Self::Dependency { path: a }, Self::Dependency { path: b }) => a == b,
             (Self::Remote { url: a }, Self::Remote { url: b }) => a == b,
             (Self::Redirected { uri: a }, Self::Redirected { uri: b }) => a == b,
             (
@@ -426,10 +415,7 @@ impl std::hash::Hash for ModuleSource {
             Self::Core { name } => name.hash(state),
             Self::Wasi { interface } => interface.hash(state),
             Self::Local { path } => path.hash(state),
-            Self::Dependency { package, path } => {
-                package.hash(state);
-                path.hash(state);
-            }
+            Self::Dependency { path } => path.hash(state),
             Self::Remote { url } => url.hash(state),
             Self::Redirected { uri } => uri.hash(state),
             Self::Wasm { path, kind } => {
@@ -530,9 +516,7 @@ impl ModuleSource {
             Self::Core { name } => vec!["core".to_string(), name.to_string()],
             Self::Wasi { interface } => vec!["wasi".to_string(), interface.to_string()],
             Self::Local { path } => vec![path.to_string()],
-            Self::Dependency { package, path } => {
-                vec!["dep".to_string(), package.to_string(), path.to_string()]
-            }
+            Self::Dependency { path } => vec!["dep".to_string(), path.to_string()],
             Self::Remote { url } => vec![url.to_string()],
             Self::EntryPoint { filename } => vec![filename.to_string()],
             Self::Redirected { uri } => vec![uri.to_string()],
@@ -686,7 +670,7 @@ impl fmt::Display for ModuleSource {
             Self::Core { name } => write!(f, "core:{name}"),
             Self::Wasi { interface } => write!(f, "wasi:{interface}"),
             Self::Local { path } => write!(f, "{path}"),
-            Self::Dependency { package, path } => write!(f, "dep:{package}:{path}"),
+            Self::Dependency { path } => write!(f, "dep:{path}"),
             Self::Remote { url } => write!(f, "{url}"),
             Self::EntryPoint { filename } => {
                 write!(f, "{filename}")
@@ -702,18 +686,20 @@ mod tests {
     use super::*;
 
     #[test]
-    fn dependency_identity_includes_package() {
+    fn dependency_identity_is_the_resolved_path() {
         let mut interner = ModuleSourceInterner::new();
-        let a = interner.dependency("greet", "../greet/src/lib.wado");
-        let b = interner.dependency("greet", "../greet/src/lib.wado");
-        let other_pkg = interner.dependency("other", "../greet/src/lib.wado");
+        let a = interner.dependency("../greet/src/lib.wado");
+        let b = interner.dependency("../greet/src/lib.wado");
+        let other = interner.dependency("../other/src/lib.wado");
+        // Same resolved path = same package, regardless of the alias used to
+        // reach it, so two aliases for one package unify.
         assert_eq!(a, b);
-        assert_ne!(a, other_pkg);
-        // Distinct from a Local at the same path: identity must not cross the
-        // package boundary.
+        assert_ne!(a, other);
+        // Still distinct from a `Local` at the same path: the variant carries
+        // the package boundary.
         let local = interner.local("../greet/src/lib.wado");
         assert_ne!(a, local);
-        assert_eq!(a.qualify_name("hello"), "dep:greet:../greet/src/lib.wado//hello");
+        assert_eq!(a.qualify_name("hello"), "dep:../greet/src/lib.wado//hello");
     }
 
     #[test]
@@ -729,7 +715,7 @@ mod tests {
         interner.set_dependencies(index);
         assert_eq!(
             interner.resolve_dependency("greet"),
-            Some(interner.dependency("greet", "../greet/src/lib.wado"))
+            Some(interner.dependency("../greet/src/lib.wado"))
         );
         assert_eq!(interner.resolve_dependency("missing"), None);
         // Declared-but-unresolved entries surface their reason instead.

--- a/wado-compiler/src/module_source.rs
+++ b/wado-compiler/src/module_source.rs
@@ -229,6 +229,9 @@ impl ModuleSourceInterner {
             [first] if first.starts_with("./") || first.starts_with("../") => self.local(first),
             [first, rest @ ..] if first == "core" => self.core(&rest.join("/")),
             [first, rest @ ..] if first == "wasi" => self.wasi(&rest.join("/")),
+            [first, package, rest @ ..] if first == "dep" => {
+                self.dependency(package, &rest.join("/"))
+            }
             segments => self.local(&segments.join("/")),
         }
     }
@@ -522,7 +525,9 @@ impl ModuleSource {
             Self::Core { name } => vec!["core".to_string(), name.to_string()],
             Self::Wasi { interface } => vec!["wasi".to_string(), interface.to_string()],
             Self::Local { path } => vec![path.to_string()],
-            Self::Dependency { package, path } => vec![package.to_string(), path.to_string()],
+            Self::Dependency { package, path } => {
+                vec!["dep".to_string(), package.to_string(), path.to_string()]
+            }
             Self::Remote { url } => vec![url.to_string()],
             Self::EntryPoint { filename } => vec![filename.to_string()],
             Self::Redirected { uri } => vec![uri.to_string()],

--- a/wado-compiler/src/module_source.rs
+++ b/wado-compiler/src/module_source.rs
@@ -147,22 +147,21 @@ static STDLIB_NAME_ARCS: LazyLock<Vec<Arc<str>>> = LazyLock::new(|| {
 #[derive(Debug)]
 pub struct ModuleSourceInterner {
     strings: StringInterner,
-    /// Bare dependency name → entry module path, relative to the consuming
-    /// project's entry directory. Populated from `[dependencies]` so that a
-    /// `use { … } from "<name>"` clause resolves to the dependency's
-    /// `[package].lib`. Empty for single-file compilation.
-    dependencies: std::collections::HashMap<String, String>,
+    /// Resolved `[dependencies]`, consulted for bare-name `use` clauses, plus
+    /// declared-but-unresolved entries (with reasons) for precise errors.
+    /// Empty for single-file compilation.
+    dependencies: crate::compiler_host::DependencyIndex,
 }
 
 impl ModuleSourceInterner {
     pub fn new() -> Self {
         Self {
             strings: StringInterner::with_well_known_arcs(well_known_arcs()),
-            dependencies: std::collections::HashMap::new(),
+            dependencies: crate::compiler_host::DependencyIndex::default(),
         }
     }
 
-    pub fn set_dependencies(&mut self, dependencies: std::collections::HashMap<String, String>) {
+    pub fn set_dependencies(&mut self, dependencies: crate::compiler_host::DependencyIndex) {
         self.dependencies = dependencies;
     }
 
@@ -174,10 +173,16 @@ impl ModuleSourceInterner {
     }
 
     /// Resolve a bare dependency name to its entry module `ModuleSource`, if
-    /// declared in `[dependencies]`.
+    /// declared in `[dependencies]` and successfully resolved.
     pub fn resolve_dependency(&mut self, name: &str) -> Option<ModuleSource> {
-        let path = self.dependencies.get(name)?.clone();
+        let path = self.dependencies.resolved.get(name)?.clone();
         Some(self.dependency(name, &path))
+    }
+
+    /// The reason a *declared* dependency could not be resolved, if any.
+    #[must_use]
+    pub fn unresolved_dependency(&self, name: &str) -> Option<&str> {
+        self.dependencies.unresolved.get(name).map(String::as_str)
     }
 
     pub fn intern(&mut self, s: &str) -> InternedStr {
@@ -714,16 +719,25 @@ mod tests {
     #[test]
     fn resolve_dependency_uses_registered_path() {
         let mut interner = ModuleSourceInterner::new();
-        interner.set_dependencies(
-            [("greet".to_string(), "../greet/src/lib.wado".to_string())]
-                .into_iter()
-                .collect(),
-        );
+        let mut index = crate::compiler_host::DependencyIndex::default();
+        index
+            .resolved
+            .insert("greet".to_string(), "../greet/src/lib.wado".to_string());
+        index
+            .unresolved
+            .insert("broken".to_string(), "declares no [package].lib".to_string());
+        interner.set_dependencies(index);
         assert_eq!(
             interner.resolve_dependency("greet"),
             Some(interner.dependency("greet", "../greet/src/lib.wado"))
         );
         assert_eq!(interner.resolve_dependency("missing"), None);
+        // Declared-but-unresolved entries surface their reason instead.
+        assert_eq!(interner.resolve_dependency("broken"), None);
+        assert_eq!(
+            interner.unresolved_dependency("broken"),
+            Some("declares no [package].lib")
+        );
     }
 
     #[test]

--- a/wado-compiler/src/module_source.rs
+++ b/wado-compiler/src/module_source.rs
@@ -328,9 +328,7 @@ pub enum ModuleSource {
     /// source dependencies compile into the same component (the CM boundary
     /// is skipped), so dependency modules are ordinary Wado source once
     /// loaded.
-    Dependency {
-        path: InternedStr,
-    },
+    Dependency { path: InternedStr },
     /// Remote module loaded via HTTP/HTTPS
     Remote {
         /// Full URL (e.g., "<https://example.com/lib.wado>")
@@ -709,9 +707,10 @@ mod tests {
         index
             .resolved
             .insert("greet".to_string(), "../greet/src/lib.wado".to_string());
-        index
-            .unresolved
-            .insert("broken".to_string(), "declares no [package].lib".to_string());
+        index.unresolved.insert(
+            "broken".to_string(),
+            "declares no [package].lib".to_string(),
+        );
         interner.set_dependencies(index);
         assert_eq!(
             interner.resolve_dependency("greet"),

--- a/wado-compiler/src/module_source.rs
+++ b/wado-compiler/src/module_source.rs
@@ -166,11 +166,18 @@ impl ModuleSourceInterner {
         self.dependencies = dependencies;
     }
 
+    pub fn dependency(&mut self, package: &str, path: &str) -> ModuleSource {
+        ModuleSource::Dependency {
+            package: self.intern(package),
+            path: self.intern(path),
+        }
+    }
+
     /// Resolve a bare dependency name to its entry module `ModuleSource`, if
     /// declared in `[dependencies]`.
-    pub fn dependency(&mut self, name: &str) -> Option<ModuleSource> {
+    pub fn resolve_dependency(&mut self, name: &str) -> Option<ModuleSource> {
         let path = self.dependencies.get(name)?.clone();
-        Some(self.local(&path))
+        Some(self.dependency(name, &path))
     }
 
     pub fn intern(&mut self, s: &str) -> InternedStr {
@@ -303,6 +310,21 @@ pub enum ModuleSource {
         /// Relative path (e.g., "./geometry.wado", "./utils/helper.wado")
         path: InternedStr,
     },
+    /// A module belonging to a dependency package, resolved from a bare-name
+    /// `use { … } from "<dep>"` clause against `[dependencies]`.
+    ///
+    /// `package` is the dependency's identity (the `[dependencies]` key for
+    /// path deps; a resolved package id once registry/git land). It keeps
+    /// type identity from crossing the package boundary even when two
+    /// packages have a file at the same `path`. `path` is the module file,
+    /// loaded by the host exactly like [`ModuleSource::Local`] — wado-to-wado
+    /// source dependencies compile into the same component (the CM boundary
+    /// is skipped), so dependency modules are ordinary Wado source once
+    /// loaded.
+    Dependency {
+        package: InternedStr,
+        path: InternedStr,
+    },
     /// Remote module loaded via HTTP/HTTPS
     Remote {
         /// Full URL (e.g., "<https://example.com/lib.wado>")
@@ -357,6 +379,16 @@ impl PartialEq for ModuleSource {
             (Self::Core { name: a }, Self::Core { name: b }) => a == b,
             (Self::Wasi { interface: a }, Self::Wasi { interface: b }) => a == b,
             (Self::Local { path: a }, Self::Local { path: b }) => a == b,
+            (
+                Self::Dependency {
+                    package: pa,
+                    path: a,
+                },
+                Self::Dependency {
+                    package: pb,
+                    path: b,
+                },
+            ) => pa == pb && a == b,
             (Self::Remote { url: a }, Self::Remote { url: b }) => a == b,
             (Self::Redirected { uri: a }, Self::Redirected { uri: b }) => a == b,
             (
@@ -386,6 +418,10 @@ impl std::hash::Hash for ModuleSource {
             Self::Core { name } => name.hash(state),
             Self::Wasi { interface } => interface.hash(state),
             Self::Local { path } => path.hash(state),
+            Self::Dependency { package, path } => {
+                package.hash(state);
+                path.hash(state);
+            }
             Self::Remote { url } => url.hash(state),
             Self::Redirected { uri } => uri.hash(state),
             Self::Wasm { path, kind } => {
@@ -486,6 +522,7 @@ impl ModuleSource {
             Self::Core { name } => vec!["core".to_string(), name.to_string()],
             Self::Wasi { interface } => vec!["wasi".to_string(), interface.to_string()],
             Self::Local { path } => vec![path.to_string()],
+            Self::Dependency { package, path } => vec![package.to_string(), path.to_string()],
             Self::Remote { url } => vec![url.to_string()],
             Self::EntryPoint { filename } => vec![filename.to_string()],
             Self::Redirected { uri } => vec![uri.to_string()],
@@ -639,6 +676,7 @@ impl fmt::Display for ModuleSource {
             Self::Core { name } => write!(f, "core:{name}"),
             Self::Wasi { interface } => write!(f, "wasi:{interface}"),
             Self::Local { path } => write!(f, "{path}"),
+            Self::Dependency { package, path } => write!(f, "dep:{package}:{path}"),
             Self::Remote { url } => write!(f, "{url}"),
             Self::EntryPoint { filename } => {
                 write!(f, "{filename}")
@@ -652,6 +690,36 @@ impl fmt::Display for ModuleSource {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn dependency_identity_includes_package() {
+        let mut interner = ModuleSourceInterner::new();
+        let a = interner.dependency("greet", "../greet/src/lib.wado");
+        let b = interner.dependency("greet", "../greet/src/lib.wado");
+        let other_pkg = interner.dependency("other", "../greet/src/lib.wado");
+        assert_eq!(a, b);
+        assert_ne!(a, other_pkg);
+        // Distinct from a Local at the same path: identity must not cross the
+        // package boundary.
+        let local = interner.local("../greet/src/lib.wado");
+        assert_ne!(a, local);
+        assert_eq!(a.qualify_name("hello"), "dep:greet:../greet/src/lib.wado//hello");
+    }
+
+    #[test]
+    fn resolve_dependency_uses_registered_path() {
+        let mut interner = ModuleSourceInterner::new();
+        interner.set_dependencies(
+            [("greet".to_string(), "../greet/src/lib.wado".to_string())]
+                .into_iter()
+                .collect(),
+        );
+        assert_eq!(
+            interner.resolve_dependency("greet"),
+            Some(interner.dependency("greet", "../greet/src/lib.wado"))
+        );
+        assert_eq!(interner.resolve_dependency("missing"), None);
+    }
 
     #[test]
     fn test_module_source_from_path_core() {

--- a/wado-compiler/src/module_source.rs
+++ b/wado-compiler/src/module_source.rs
@@ -147,13 +147,30 @@ static STDLIB_NAME_ARCS: LazyLock<Vec<Arc<str>>> = LazyLock::new(|| {
 #[derive(Debug)]
 pub struct ModuleSourceInterner {
     strings: StringInterner,
+    /// Bare dependency name → entry module path, relative to the consuming
+    /// project's entry directory. Populated from `[dependencies]` so that a
+    /// `use { … } from "<name>"` clause resolves to the dependency's
+    /// `[package].lib`. Empty for single-file compilation.
+    dependencies: std::collections::HashMap<String, String>,
 }
 
 impl ModuleSourceInterner {
     pub fn new() -> Self {
         Self {
             strings: StringInterner::with_well_known_arcs(well_known_arcs()),
+            dependencies: std::collections::HashMap::new(),
         }
+    }
+
+    pub fn set_dependencies(&mut self, dependencies: std::collections::HashMap<String, String>) {
+        self.dependencies = dependencies;
+    }
+
+    /// Resolve a bare dependency name to its entry module `ModuleSource`, if
+    /// declared in `[dependencies]`.
+    pub fn dependency(&mut self, name: &str) -> Option<ModuleSource> {
+        let path = self.dependencies.get(name)?.clone();
+        Some(self.local(&path))
     }
 
     pub fn intern(&mut self, s: &str) -> InternedStr {

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -180,6 +180,9 @@ impl fmt::Display for FreeFunctionName {
             ModuleSource::Core { name: module } => write!(f, "core/{}/{}", module, self.name),
             ModuleSource::Wasi { interface } => write!(f, "wasi/{}/{}", interface, self.name),
             ModuleSource::Local { path } => write!(f, "{}/{}", path, self.name),
+            ModuleSource::Dependency { package, path } => {
+                write!(f, "{}/{}/{}", package, path, self.name)
+            }
             ModuleSource::Remote { url } => write!(f, "{}/{}", url, self.name),
             ModuleSource::Redirected { uri } => write!(f, "{}/{}", uri, self.name),
             ModuleSource::Wasm { path, .. } => write!(f, "{}/{}", path, self.name),
@@ -899,11 +902,21 @@ pub fn resolve_import_with_entry(
         return interner.remote(import_source);
     }
 
+    // Relative import from within a dependency module stays inside that
+    // dependency package (same `package`, resolved file path).
+    if let ModuleSource::Dependency { package, path } = from_module
+        && (import_source.starts_with("./") || import_source.starts_with("../"))
+    {
+        let resolved = resolve_module_path(path, import_source);
+        let package = package.to_string();
+        return interner.dependency(&package, &resolved);
+    }
+
     // Bare dependency name (`use { … } from "router"`): resolve against
     // `[dependencies]` before treating it as a relative sibling file.
     if !import_source.starts_with("./")
         && !import_source.starts_with("../")
-        && let Some(dep) = interner.dependency(import_source)
+        && let Some(dep) = interner.resolve_dependency(import_source)
     {
         return dep;
     }

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -180,8 +180,8 @@ impl fmt::Display for FreeFunctionName {
             ModuleSource::Core { name: module } => write!(f, "core/{}/{}", module, self.name),
             ModuleSource::Wasi { interface } => write!(f, "wasi/{}/{}", interface, self.name),
             ModuleSource::Local { path } => write!(f, "{}/{}", path, self.name),
-            ModuleSource::Dependency { package, path } => {
-                write!(f, "{}/{}/{}", package, path, self.name)
+            ModuleSource::Dependency { .. } => {
+                write!(f, "{}/{}", self.module_source.to_path_string(), self.name)
             }
             ModuleSource::Remote { url } => write!(f, "{}/{}", url, self.name),
             ModuleSource::Redirected { uri } => write!(f, "{}/{}", uri, self.name),
@@ -873,7 +873,7 @@ pub fn resolve_import_with_invocations(
 ) -> ModuleSource {
     if !invocations.is_empty() {
         let decl_file = match from_module {
-            ModuleSource::Local { path } => path.as_str(),
+            ModuleSource::Local { path } | ModuleSource::Dependency { path, .. } => path.as_str(),
             ModuleSource::EntryPoint { filename } => filename.as_str(),
             ModuleSource::Redirected { uri } => uri.as_str(),
             _ => "",
@@ -913,9 +913,12 @@ pub fn resolve_import_with_entry(
     }
 
     // Bare dependency name (`use { … } from "router"`): resolve against
-    // `[dependencies]` before treating it as a relative sibling file.
+    // `[dependencies]` before treating it as a relative sibling file. Only
+    // the consuming project resolves its own `[dependencies]`; a bare import
+    // from within a dependency must not bind to the consumer's deps.
     if !import_source.starts_with("./")
         && !import_source.starts_with("../")
+        && !matches!(from_module, ModuleSource::Dependency { .. })
         && let Some(dep) = interner.resolve_dependency(import_source)
     {
         return dep;
@@ -1252,6 +1255,27 @@ pub fn test_name_to_snake(name: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn bare_dep_resolves_only_for_consumer_not_inside_dependency() {
+        let mut interner = ModuleSourceInterner::new();
+        interner.set_dependencies(
+            [("logger".to_string(), "../logger/src/lib.wado".to_string())]
+                .into_iter()
+                .collect(),
+        );
+        let entry = interner.entry_point("main.wado");
+        // From the consuming project, a bare name binds to its dependency.
+        let from_entry = resolve_import_with_entry(&mut interner, &entry, "logger", None);
+        assert!(matches!(from_entry, ModuleSource::Dependency { .. }));
+        // From inside a dependency, the same bare name must NOT bind to the
+        // consumer's deps — it falls through to the local fallback.
+        let from_dep = interner.dependency("greet", "../greet/src/lib.wado");
+        let resolved = resolve_import_with_entry(&mut interner, &from_dep, "logger", None);
+        assert!(
+            !matches!(resolved, ModuleSource::Dependency { ref package, .. } if package == "logger")
+        );
+    }
 
     #[test]
     fn test_test_name_to_snake_is_ascii_only() {

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -899,6 +899,15 @@ pub fn resolve_import_with_entry(
         return interner.remote(import_source);
     }
 
+    // Bare dependency name (`use { … } from "router"`): resolve against
+    // `[dependencies]` before treating it as a relative sibling file.
+    if !import_source.starts_with("./")
+        && !import_source.starts_with("../")
+        && let Some(dep) = interner.dependency(import_source)
+    {
+        return dep;
+    }
+
     // Handle relative imports from local modules
     // For entry points, we don't resolve against the filename - just use the import directly
     if let ModuleSource::Local { path: from_path } = from_module

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -873,7 +873,7 @@ pub fn resolve_import_with_invocations(
 ) -> ModuleSource {
     if !invocations.is_empty() {
         let decl_file = match from_module {
-            ModuleSource::Local { path } | ModuleSource::Dependency { path, .. } => path.as_str(),
+            ModuleSource::Local { path } | ModuleSource::Dependency { path } => path.as_str(),
             ModuleSource::EntryPoint { filename } => filename.as_str(),
             ModuleSource::Redirected { uri } => uri.as_str(),
             _ => "",
@@ -903,13 +903,12 @@ pub fn resolve_import_with_entry(
     }
 
     // Relative import from within a dependency module stays inside that
-    // dependency package (same `package`, resolved file path).
-    if let ModuleSource::Dependency { package, path } = from_module
+    // dependency package (resolved against the importing dependency file).
+    if let ModuleSource::Dependency { path } = from_module
         && (import_source.starts_with("./") || import_source.starts_with("../"))
     {
         let resolved = resolve_module_path(path, import_source);
-        let package = package.to_string();
-        return interner.dependency(&package, &resolved);
+        return interner.dependency(&resolved);
     }
 
     // Bare dependency name (`use { … } from "router"`): resolve against
@@ -1270,11 +1269,10 @@ mod tests {
         assert!(matches!(from_entry, ModuleSource::Dependency { .. }));
         // From inside a dependency, the same bare name must NOT bind to the
         // consumer's deps — it falls through to the local fallback.
-        let from_dep = interner.dependency("greet", "../greet/src/lib.wado");
+        let from_dep = interner.dependency("../greet/src/lib.wado");
         let resolved = resolve_import_with_entry(&mut interner, &from_dep, "logger", None);
-        assert!(
-            !matches!(resolved, ModuleSource::Dependency { ref package, .. } if package == "logger")
-        );
+        let logger_dep = interner.dependency("../logger/src/lib.wado");
+        assert_ne!(resolved, logger_dep);
     }
 
     #[test]

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -1259,11 +1259,11 @@ mod tests {
     #[test]
     fn bare_dep_resolves_only_for_consumer_not_inside_dependency() {
         let mut interner = ModuleSourceInterner::new();
-        interner.set_dependencies(
-            [("logger".to_string(), "../logger/src/lib.wado".to_string())]
-                .into_iter()
-                .collect(),
-        );
+        let mut index = crate::compiler_host::DependencyIndex::default();
+        index
+            .resolved
+            .insert("logger".to_string(), "../logger/src/lib.wado".to_string());
+        interner.set_dependencies(index);
         let entry = interner.entry_point("main.wado");
         // From the consuming project, a bare name binds to its dependency.
         let from_entry = resolve_import_with_entry(&mut interner, &entry, "logger", None);

--- a/wado-lsp/Cargo.toml
+++ b/wado-lsp/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/bin/wado-lsp.rs"
 
 [dependencies]
 wado-compiler = { path = "../wado-compiler" }
+wado-manifest = { path = "../wado-manifest" }
 indexmap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/wado-lsp/src/host.rs
+++ b/wado-lsp/src/host.rs
@@ -5,11 +5,10 @@
 //! want to decorate output (timestamps, log-level filtering, stderr printing)
 //! wrap this host.
 
-use std::collections::HashMap;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Mutex;
 
-use wado_compiler::{CompilerHost, Diagnostic, Severity, SourceError};
+use wado_compiler::{CompilerHost, DependencyIndex, Diagnostic, Severity, SourceError};
 use wado_manifest::DependencySource;
 
 #[derive(Debug)]
@@ -66,9 +65,9 @@ impl CompilerHost for FilesystemCompilerHost {
         self.collect_diagnostic(diagnostic);
     }
 
-    fn dependency_index(&self) -> HashMap<String, String> {
+    fn dependency_index(&self) -> DependencyIndex {
         let Some((manifest, root)) = nearest_manifest(&self.base_path) else {
-            return HashMap::new();
+            return DependencyIndex::default();
         };
         dependency_index_from(&manifest, &root, &self.base_path)
     }
@@ -87,17 +86,23 @@ pub fn dependency_index_from(
     manifest: &wado_manifest::Manifest,
     manifest_dir: &Path,
     base: &Path,
-) -> HashMap<String, String> {
-    let mut index = HashMap::new();
+) -> DependencyIndex {
+    let mut index = DependencyIndex::default();
     let base_abs = absolutize(base);
     for (name, dep) in &manifest.dependencies {
         let DependencySource::Path { path, .. } = &dep.source else {
             continue;
         };
-        let Some(entry) = dependency_entry_path(&manifest_dir.join(path)) else {
-            continue;
-        };
-        index.insert(name.clone(), relative_path(&base_abs, &absolutize(&entry)));
+        match dependency_entry_path(&manifest_dir.join(path)) {
+            Ok(entry) => {
+                index
+                    .resolved
+                    .insert(name.clone(), relative_path(&base_abs, &absolutize(&entry)));
+            }
+            Err(reason) => {
+                index.unresolved.insert(name.clone(), reason);
+            }
+        }
     }
     index
 }
@@ -120,14 +125,23 @@ fn nearest_manifest(start: &Path) -> Option<(wado_manifest::Manifest, PathBuf)> 
 }
 
 /// The entry module file of a path dependency: the file itself when the path
-/// points at a `.wado` file, otherwise the directory's `[package].lib`.
-fn dependency_entry_path(dep_path: &Path) -> Option<PathBuf> {
+/// points at a `.wado` file, otherwise the directory's `[package].lib`. The
+/// `Err` describes why a declared dependency has no usable entry.
+fn dependency_entry_path(dep_path: &Path) -> Result<PathBuf, String> {
     if dep_path.extension().is_some_and(|e| e == "wado") {
-        return Some(dep_path.to_path_buf());
+        return Ok(dep_path.to_path_buf());
     }
-    let text = std::fs::read_to_string(dep_path.join("wado.toml")).ok()?;
-    let manifest: wado_manifest::Manifest = text.parse().ok()?;
-    Some(dep_path.join(manifest.package?.lib?))
+    let manifest_path = dep_path.join("wado.toml");
+    let text = std::fs::read_to_string(&manifest_path)
+        .map_err(|e| format!("cannot read {}: {e}", manifest_path.display()))?;
+    let manifest: wado_manifest::Manifest = text
+        .parse()
+        .map_err(|e| format!("invalid {}: {e}", manifest_path.display()))?;
+    let lib = manifest
+        .package
+        .and_then(|p| p.lib)
+        .ok_or_else(|| format!("{} declares no [package].lib entry", manifest_path.display()))?;
+    Ok(dep_path.join(lib))
 }
 
 fn absolutize(p: &Path) -> PathBuf {

--- a/wado-lsp/src/host.rs
+++ b/wado-lsp/src/host.rs
@@ -67,28 +67,34 @@ impl CompilerHost for FilesystemCompilerHost {
     }
 
     fn dependency_index(&self) -> HashMap<String, String> {
-        dependency_index(&self.base_path)
+        let Some((manifest, root)) = nearest_manifest(&self.base_path) else {
+            return HashMap::new();
+        };
+        dependency_index_from(&manifest, &root, &self.base_path)
     }
 }
 
-/// Build the bare-name → entry-path dependency index from the nearest
-/// `wado.toml`'s `[dependencies]`. Each path dependency's entry module (its
+/// Build the bare-name → entry-path dependency index from a manifest's
+/// `[dependencies]`. Each path dependency's entry module (its
 /// `[package].lib`, or the file itself for a single-`.wado` path dependency)
 /// is recorded relative to `base` — the same base `load_source` joins against
-/// — so `use { … } from "<name>"` resolves to it.
+/// — so `use { … } from "<name>"` resolves to it. `manifest_dir` is the
+/// directory containing the manifest (path deps resolve against it).
 ///
 /// Only `path` dependencies are supported for now; registry/git are skipped.
-fn dependency_index(base: &Path) -> HashMap<String, String> {
+#[must_use]
+pub fn dependency_index_from(
+    manifest: &wado_manifest::Manifest,
+    manifest_dir: &Path,
+    base: &Path,
+) -> HashMap<String, String> {
     let mut index = HashMap::new();
-    let Some((manifest, root)) = nearest_manifest(base) else {
-        return index;
-    };
     let base_abs = absolutize(base);
     for (name, dep) in &manifest.dependencies {
         let DependencySource::Path { path, .. } = &dep.source else {
             continue;
         };
-        let Some(entry) = dependency_entry_path(&root.join(path)) else {
+        let Some(entry) = dependency_entry_path(&manifest_dir.join(path)) else {
             continue;
         };
         index.insert(name.clone(), relative_path(&base_abs, &absolutize(&entry)));

--- a/wado-lsp/src/host.rs
+++ b/wado-lsp/src/host.rs
@@ -137,10 +137,12 @@ fn dependency_entry_path(dep_path: &Path) -> Result<PathBuf, String> {
     let manifest: wado_manifest::Manifest = text
         .parse()
         .map_err(|e| format!("invalid {}: {e}", manifest_path.display()))?;
-    let lib = manifest
-        .package
-        .and_then(|p| p.lib)
-        .ok_or_else(|| format!("{} declares no [package].lib entry", manifest_path.display()))?;
+    let lib = manifest.package.and_then(|p| p.lib).ok_or_else(|| {
+        format!(
+            "{} declares no [package].lib entry",
+            manifest_path.display()
+        )
+    })?;
     Ok(dep_path.join(lib))
 }
 

--- a/wado-lsp/src/host.rs
+++ b/wado-lsp/src/host.rs
@@ -5,10 +5,12 @@
 //! want to decorate output (timestamps, log-level filtering, stderr printing)
 //! wrap this host.
 
-use std::path::PathBuf;
+use std::collections::HashMap;
+use std::path::{Component, Path, PathBuf};
 use std::sync::Mutex;
 
 use wado_compiler::{CompilerHost, Diagnostic, Severity, SourceError};
+use wado_manifest::DependencySource;
 
 #[derive(Debug)]
 pub struct FilesystemCompilerHost {
@@ -63,4 +65,105 @@ impl CompilerHost for FilesystemCompilerHost {
     fn emit_diagnostic(&self, diagnostic: Diagnostic) {
         self.collect_diagnostic(diagnostic);
     }
+
+    fn dependency_index(&self) -> HashMap<String, String> {
+        dependency_index(&self.base_path)
+    }
+}
+
+/// Build the bare-name → entry-path dependency index from the nearest
+/// `wado.toml`'s `[dependencies]`. Each path dependency's entry module (its
+/// `[package].lib`, or the file itself for a single-`.wado` path dependency)
+/// is recorded relative to `base` — the same base `load_source` joins against
+/// — so `use { … } from "<name>"` resolves to it.
+///
+/// Only `path` dependencies are supported for now; registry/git are skipped.
+fn dependency_index(base: &Path) -> HashMap<String, String> {
+    let mut index = HashMap::new();
+    let Some((manifest, root)) = nearest_manifest(base) else {
+        return index;
+    };
+    let base_abs = absolutize(base);
+    for (name, dep) in &manifest.dependencies {
+        let DependencySource::Path { path, .. } = &dep.source else {
+            continue;
+        };
+        let Some(entry) = dependency_entry_path(&root.join(path)) else {
+            continue;
+        };
+        index.insert(name.clone(), relative_path(&base_abs, &absolutize(&entry)));
+    }
+    index
+}
+
+/// Walk up from `start` to find the nearest `wado.toml`, returning the parsed
+/// manifest and its directory.
+fn nearest_manifest(start: &Path) -> Option<(wado_manifest::Manifest, PathBuf)> {
+    let mut dir = absolutize(start);
+    loop {
+        let candidate = dir.join("wado.toml");
+        if candidate.is_file() {
+            let text = std::fs::read_to_string(&candidate).ok()?;
+            let manifest: wado_manifest::Manifest = text.parse().ok()?;
+            return Some((manifest, dir));
+        }
+        if !dir.pop() {
+            return None;
+        }
+    }
+}
+
+/// The entry module file of a path dependency: the file itself when the path
+/// points at a `.wado` file, otherwise the directory's `[package].lib`.
+fn dependency_entry_path(dep_path: &Path) -> Option<PathBuf> {
+    if dep_path.extension().is_some_and(|e| e == "wado") {
+        return Some(dep_path.to_path_buf());
+    }
+    let text = std::fs::read_to_string(dep_path.join("wado.toml")).ok()?;
+    let manifest: wado_manifest::Manifest = text.parse().ok()?;
+    Some(dep_path.join(manifest.package?.lib?))
+}
+
+fn absolutize(p: &Path) -> PathBuf {
+    if p.is_absolute() {
+        p.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map(|cwd| cwd.join(p))
+            .unwrap_or_else(|_| p.to_path_buf())
+    }
+}
+
+/// Lexical relative path from directory `from_dir` to file `to_file`. Both
+/// must be absolute; symlinks are not resolved.
+fn relative_path(from_dir: &Path, to_file: &Path) -> String {
+    let from = normalized_components(from_dir);
+    let to = normalized_components(to_file);
+    let common = from.iter().zip(&to).take_while(|(a, b)| a == b).count();
+    let mut parts: Vec<String> = vec!["..".to_string(); from.len() - common];
+    parts.extend(to[common..].iter().cloned());
+    if parts.is_empty() {
+        ".".to_string()
+    } else {
+        parts.join("/")
+    }
+}
+
+fn normalized_components(p: &Path) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for comp in p.components() {
+        match comp {
+            Component::CurDir | Component::Prefix(_) => {}
+            Component::RootDir => out.push(String::new()),
+            Component::ParentDir => {
+                if matches!(out.last().map(String::as_str), None | Some("..")) {
+                    out.push("..".to_string());
+                } else {
+                    out.pop();
+                }
+            }
+            Component::Normal(s) => out.push(s.to_string_lossy().into_owned()),
+        }
+    }
+    out
 }

--- a/wado-lsp/src/location.rs
+++ b/wado-lsp/src/location.rs
@@ -28,7 +28,9 @@ pub(crate) fn module_uri(
     }
     match module {
         ModuleSource::EntryPoint { filename } => Some(filename_to_uri(filename)),
-        ModuleSource::Local { path } => Some(resolve_local_uri(path, request_uri)),
+        ModuleSource::Local { path } | ModuleSource::Dependency { path, .. } => {
+            Some(resolve_local_uri(path, request_uri))
+        }
         ModuleSource::Core { name } => Some(format!("core:{name}")),
         ModuleSource::Wasi { interface } => Some(format!("wasi:{interface}")),
         ModuleSource::Remote { url } => Some(url.to_string()),

--- a/wado-lsp/src/location.rs
+++ b/wado-lsp/src/location.rs
@@ -28,7 +28,7 @@ pub(crate) fn module_uri(
     }
     match module {
         ModuleSource::EntryPoint { filename } => Some(filename_to_uri(filename)),
-        ModuleSource::Local { path } | ModuleSource::Dependency { path, .. } => {
+        ModuleSource::Local { path } | ModuleSource::Dependency { path } => {
             Some(resolve_local_uri(path, request_uri))
         }
         ModuleSource::Core { name } => Some(format!("core:{name}")),

--- a/wado-manifest/src/manifest.rs
+++ b/wado-manifest/src/manifest.rs
@@ -12,9 +12,9 @@ use crate::version::VersionSpecifier;
 pub struct Manifest {
     pub package: Option<Package>,
     /// The `[world]` table: CM world FQ name (e.g. `"wasi:cli/command"`,
-    /// `"core:kiln/generator"`) → entry-point path. Replaces the former
-    /// `[package].{command,service,generator}` fields; the world-less `lib`
-    /// entry is abolished.
+    /// `"core:kiln/generator"`) → entry-point path, one entry per hosted
+    /// world the package targets. The library world is declared separately by
+    /// `[package].lib` (its world name is the package name).
     pub world: IndexMap<String, String>,
     pub registries: IndexMap<String, String>,
     pub dependencies: IndexMap<String, Dependency>,

--- a/wado-manifest/src/manifest.rs
+++ b/wado-manifest/src/manifest.rs
@@ -73,6 +73,10 @@ pub struct Package {
     pub namespace: Option<String>,
     pub name: String,
     pub version: String,
+    /// Entry-point module exposed when the package is consumed as a
+    /// dependency (`use { … } from "<dep-name>"`). Only `export` items are
+    /// visible to consumers.
+    pub lib: Option<String>,
 }
 
 /// The `[workspace]` section of `wado.toml`.
@@ -244,6 +248,7 @@ struct RawPackage {
     namespace: Option<String>,
     name: Option<String>,
     version: Option<String>,
+    lib: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -317,6 +322,7 @@ fn convert_package(raw: RawPackage) -> Result<Package, ManifestError> {
         namespace: raw.namespace,
         name,
         version,
+        lib: raw.lib,
     })
 }
 

--- a/wado-manifest/tests/manifest.rs
+++ b/wado-manifest/tests/manifest.rs
@@ -1,6 +1,29 @@
 use wado_manifest::{DependencySource, GitPin, Manifest, ManifestError};
 
 #[test]
+fn package_lib_entry_parsed() {
+    let toml = r#"
+[package]
+name = "greet"
+version = "0.1.0"
+lib = "src/lib.wado"
+"#;
+    let m: Manifest = toml.parse().unwrap();
+    assert_eq!(m.package.unwrap().lib.as_deref(), Some("src/lib.wado"));
+}
+
+#[test]
+fn package_lib_absent_is_none() {
+    let toml = r#"
+[package]
+name = "app"
+version = "0.1.0"
+"#;
+    let m: Manifest = toml.parse().unwrap();
+    assert!(m.package.unwrap().lib.is_none());
+}
+
+#[test]
 fn full_manifest_from_wep() {
     let toml = r#"
 [package]


### PR DESCRIPTION
## Summary

Implements bare-name module resolution against `wado.toml` dependency
sections, for both ordinary `[dependencies]` and Kiln `[build-dependencies]`
generators — the missing foundation that makes `module: "gale"` (a
`[build-dependencies]` name) usable in place of a hand-spelled relative path.

Per WEP 2026-02-14 §"Module Resolution with Dependencies", a bare name
(`use { X } from "router"`) should resolve against `[dependencies]`. That rule,
and the supporting `ModuleSource::Dependency`, were specified but unimplemented;
the loader rejected bare names with `invalid module path`. The Kiln side
(`module: "gale"`) was likewise unsupported.

## What's in here

- **`[package].lib`** re-added to `wado-manifest` as the entry module a package
  exposes when consumed as a dependency.
- **`ModuleSource::Dependency`** — a first-class variant for dependency modules,
  identified by their resolved entry path, so two aliases for one package unify
  and identity never crosses the package boundary. Handled across every
  `ModuleSource` consumer (resolution, `get_source`, name mangling, trait-impl
  collection, effect checking, the Kiln redirect, LSP URIs).
- **Bare-name resolution** wired as a `CompilerHost::dependency_index()`
  capability, seeded once in the module loader — so `wado run`, `wado compile`,
  `wado check`, and the LSP all resolve `[dependencies]` from one place. A bare
  import from within a dependency does not bind to the consumer's deps.
- **Kiln `module: "gale"`** — `GeneratorModule::BuildDep` resolves against
  `[build-dependencies]` to the dependency package's `core:kiln/generator` world
  entry, resolved once in the CLI. The `syntax_highlight` / `sqlite_parse`
  benchmarks now reference the generator as `module: "gale"`.
- **Diagnostics** — a declared dependency that can't be resolved (e.g. missing
  `[package].lib`) reports why, instead of a generic `invalid module path`.

Scope: path dependencies only — registry/git resolution and the package-boundary
visibility model (`export`-only) remain follow-ups.

https://claude.ai/code/session_01XoDqEY15EG2JiaGdMwhuBb

---
_Generated by [Claude Code](https://claude.ai/code/session_01XoDqEY15EG2JiaGdMwhuBb)_