### PR TITLE
perf(optimize): interprocedural worklist (Stage 9) + per-function ValueGraph sharing

### DIFF
--- a/docs/wep-2026-06-05-worklist-rewrite-engine.md
+++ b/docs/wep-2026-06-05-worklist-rewrite-engine.md
@@ -321,6 +321,36 @@ is deferred".
 - Compile-time target: package-gale optimise phase ~1.5× faster than
   the current substrate-only baseline. Aspirational, not committed.
 
+### Measured: optimizer hot path (package-gale, dev build)
+
+A native sampling profile (`samply`) of `wado compile -O2` on package-gale
+is flat — no single function exceeds ~1.6% self-time — but the inclusive view
+is clear: `run_gated` (the gated intra passes) is ~48% of compile CPU, and
+inside it the dominant rebuildable cost is the per-function `ValueGraph` build
+(`builder::build` + `Engine::value` ~22%, plus flow joins `join_overlay` /
+`join_heap` / `flow_join` ~16%) and the alias-set computation (~14%) — all
+rebuilt from scratch per pass per function and discarded.
+
+Two findings shaped the next steps:
+
+- Sharing the per-function `ValueGraph` (+ alias sets) across `cse` /
+  `store_load_forward` / `condition_implication`, keyed by `FunctionGate`'s
+  revision, lands byte-output-identical and cuts the optimise phase ~7%
+  (`store_load_forward` 1.77s → 1.13s, `condition_implication` 1.65s → 1.24s).
+  `licm` seeds loop-entry params differently and has no within-iteration
+  sharing partner, so it stays uncached.
+- The `ValueGraph` build is **compute-bound, not allocation-bound**: pooling
+  the output maps (`value_of` / `pool` / `literal_source` / `loop_entry_values`)
+  across builds measured no improvement (`licm`, which always rebuilds,
+  unchanged). The cost is the walk + hash-cons + flow joins, not the map
+  allocation. Buffer pooling is a dead end here.
+
+So the remaining levers are (1) an incremental `ValueGraph` — re-walk only the
+mutated region of a changed function instead of rebuilding it whole (the cache
+only helps _unchanged_ functions), and (2) function-level parallelism (the
+per-function build / walk is independent). Both are prerequisites to the ~1.5×
+target; the full single-worklist promotion subsumes (1).
+
 ### Additional effect — if optional acceleration ever activates
 
 - Phase-ordering hazards dissolve: rules co-exist under saturation; the

--- a/docs/wep-2026-06-05-worklist-rewrite-engine.md
+++ b/docs/wep-2026-06-05-worklist-rewrite-engine.md
@@ -237,10 +237,14 @@ WIR output stays byte-identical.
       `mark_changed` re-runs affected callers when a callee shrinks, with
       `OptConfig::iterations` the quiescence bound. Terminal stages
       (`multi_value_return`, `field_scalarize`, `const_object_globalization`,
-      `dce`) stay explicit. Propagation stays both-direction: a directed
-      (callee-shrink → callers) narrowing would miss the edges `inline` adds to
-      the build-once call graph, and is net-neutral until the graph is kept
-      fresh.
+      `dce`) stay explicit. Propagation stays both-direction; it over-approximates
+      but measured byte-identical to a fresh-graph rebuild, so it costs no
+      optimization quality today. A directed (callee-shrink → callers) narrowing
+      is deferred: it drops the edges `inline` adds to the build-once call graph,
+      and a per-iteration rebuild does **not** recover them (the staleness is
+      intra-iteration — `inline` adds an edge and a callee changes within the
+      same round), so it would need immediate incremental edge maintenance —
+      fragile, for a net-neutral gain.
 
 ### Open
 

--- a/docs/wep-2026-06-05-worklist-rewrite-engine.md
+++ b/docs/wep-2026-06-05-worklist-rewrite-engine.md
@@ -232,20 +232,15 @@ WIR output stays byte-identical.
     construction — a mutation changes the operand's `ValueId`); `licm` hoists by
     pre-header `ValueId` stability.
 - [x] **Stage 9 — interprocedural worklist.** `inline` / `dae` / `drve` /
-      `sroa_param` / `value_copy_demote` pull their candidate set from the
-      per-function gate's dirty set (`FunctionGate::dirty_funcs`) instead of
-      scanning every function each round; `mark_changed` re-runs affected callers
-      when a callee shrinks, and the fixed-point loop terminates at quiescence
-      with `OptConfig::iterations` as the bound. Terminal stages
+      `sroa_param` / `value_copy_demote` pull their candidates from the gate's
+      dirty set (`FunctionGate::dirty_funcs`) instead of scanning every function;
+      `mark_changed` re-runs affected callers when a callee shrinks, with
+      `OptConfig::iterations` the quiescence bound. Terminal stages
       (`multi_value_return`, `field_scalarize`, `const_object_globalization`,
-      `dce`) stay explicit. Propagation stays at the conservative both-direction
-      form: the call graph is built once and not refreshed, so an `inline`-added
-      edge is invisible to a directed (callee-shrink → callers) narrowing, which
-      would silently drop the dependent rewrite. A directed rule is net-neutral
-      until the graph is kept fresh (per-iteration rebuild costs roughly what the
-      narrowing saves), so it waits on that — the remaining loop cost is the
-      per-function dataflow the standalone walkers still rebuild, which is the
-      Layer-2 ValueGraph's domain, not the worklist's.
+      `dce`) stay explicit. Propagation stays both-direction: a directed
+      (callee-shrink → callers) narrowing would miss the edges `inline` adds to
+      the build-once call graph, and is net-neutral until the graph is kept
+      fresh.
 
 ### Open
 

--- a/docs/wep-2026-06-05-worklist-rewrite-engine.md
+++ b/docs/wep-2026-06-05-worklist-rewrite-engine.md
@@ -13,11 +13,12 @@ Stage 3 – 6 rule migrations onto the ValueGraph — culminating in the
 retirement of niri's per-local `field_env` (the ValueGraph now owns all
 field reaching-def; one `int128_cast` reinterpret assert is a +36-byte
 code-size residual deferred to `mod_ref.rs`). The interprocedural worklist
-(Stage 9) is the remaining required-path item. Full Layer-2 promotion (Skel
-pure-`ExprKind` retirement and saturation-driven engine) stays in this
-WEP as the terminal ideal but is gated behind measurement — see "Why
-Layer 2 promotion is deferred" and the "Optional acceleration" entries
-in the migration plan.
+(Stage 9) has landed: the interprocedural passes now pull their candidate set
+from the gate's dirty set rather than scanning every function. The required
+path is complete. Full Layer-2 promotion (Skel pure-`ExprKind` retirement and
+saturation-driven engine) stays in this WEP as the terminal ideal but is gated
+behind measurement — see "Why Layer 2 promotion is deferred" and the "Optional
+acceleration" entries in the migration plan.
 
 ## Context
 
@@ -230,6 +231,21 @@ WIR output stays byte-identical.
   - `condition_implication` unified into one `GuardFact` (facts go stale by
     construction — a mutation changes the operand's `ValueId`); `licm` hoists by
     pre-header `ValueId` stability.
+- [x] **Stage 9 — interprocedural worklist.** `inline` / `dae` / `drve` /
+      `sroa_param` / `value_copy_demote` pull their candidate set from the
+      per-function gate's dirty set (`FunctionGate::dirty_funcs`) instead of
+      scanning every function each round; `mark_changed` re-runs affected callers
+      when a callee shrinks, and the fixed-point loop terminates at quiescence
+      with `OptConfig::iterations` as the bound. Terminal stages
+      (`multi_value_return`, `field_scalarize`, `const_object_globalization`,
+      `dce`) stay explicit. Propagation stays at the conservative both-direction
+      form: the call graph is built once and not refreshed, so an `inline`-added
+      edge is invisible to a directed (callee-shrink → callers) narrowing, which
+      would silently drop the dependent rewrite. A directed rule is net-neutral
+      until the graph is kept fresh (per-iteration rebuild costs roughly what the
+      narrowing saves), so it waits on that — the remaining loop cost is the
+      per-function dataflow the standalone walkers still rebuild, which is the
+      Layer-2 ValueGraph's domain, not the worklist's.
 
 ### Open
 
@@ -240,12 +256,6 @@ WIR output stays byte-identical.
 - [ ] **Stage 6 — induction-variable recognition** (`Opaque` tagged
       `{ base, step }`). Not needed yet — post-increment reads already appear
       as `Add(opaque_i, step)` — so it lands when a rule first wants it.
-- [ ] **Stage 9 — interprocedural worklist.** Move `inline` / `dae` / `drve` /
-      `sroa_param` / `value_copy_demote` onto a call-graph worklist that re-runs
-      affected callers when a callee shrinks; `OptConfig::iterations` becomes the
-      worklist convergence bound. Terminal stages (`multi_value_return`,
-      `field_scalarize`, `const_object_globalization`, `dce`) stay explicit. The
-      stub per-pass walkers are then deleted in bulk.
 
 ### Optional acceleration (measured-deferred)
 

--- a/wado-compiler/src/nir_engine.rs
+++ b/wado-compiler/src/nir_engine.rs
@@ -80,6 +80,21 @@ impl EngineBuffers {
     }
 }
 
+/// A parked engine analysis — the `ValueGraph` plus the alias-set inputs it was
+/// built from — that an unchanged function reuses across passes (see
+/// [`Engine::with_analysis`] / [`Engine::into_analysis`]). Owns its data (no
+/// body borrow), so it survives between the per-pass engine sessions. Only
+/// passes that configure the session identically may share one: same alias
+/// sets and the same (empty) `param_locals` seeding.
+pub struct CachedAnalysis {
+    value_graph: crate::nir_value_graph::builder::ValueGraphBuild,
+    aliased_locals: IndexSet<u32>,
+    untrackable_locals: IndexSet<u32>,
+    mut_escaped_locals: IndexSet<u32>,
+    body_address_taken: Option<IndexSet<u32>>,
+    param_locals: Vec<u32>,
+}
+
 /// An engine session over one function body: the arena plus the [`EngineBuffers`]
 /// scratch (parent map, use index, and worklist) the worklist discipline needs,
 /// and the function's `locals` list so rules can allocate fresh locals.
@@ -156,6 +171,60 @@ impl<'a> Engine<'a> {
         engine.build_uses();
         engine.seed_post_order();
         engine
+    }
+
+    /// Build a session over `body`, seeding it with a previously-parked
+    /// [`CachedAnalysis`] instead of recomputing the alias sets and the
+    /// `ValueGraph`. Sound only when `body` is unchanged since the analysis was
+    /// parked (the caller gates this on a body-version). The parent map and use
+    /// index are still rebuilt — they are cheap and the buffers are scratch.
+    pub fn with_analysis(
+        body: &'a mut Body,
+        buf: &'a mut EngineBuffers,
+        locals: &'a mut Vec<NirLocal>,
+        type_table: &'a crate::tir::TypeTable,
+        cached: CachedAnalysis,
+    ) -> Self {
+        buf.reset_for(body);
+        let mut engine = Self {
+            body,
+            buf,
+            locals,
+            value_graph: Some(cached.value_graph),
+            body_address_taken: cached.body_address_taken,
+            aliased_locals: cached.aliased_locals,
+            untrackable_locals: cached.untrackable_locals,
+            mut_escaped_locals: cached.mut_escaped_locals,
+            param_locals: cached.param_locals,
+            vg_type_table: Some(type_table),
+        };
+        engine.build_parents();
+        engine.build_uses();
+        engine.seed_post_order();
+        engine
+    }
+
+    /// Extract the session's `ValueGraph` + alias analysis for parking, or
+    /// `None` if an edit invalidated the value graph (then a reuse would be
+    /// stale, so the caller must not park it).
+    pub fn into_analysis(self) -> Option<CachedAnalysis> {
+        let Engine {
+            value_graph,
+            aliased_locals,
+            untrackable_locals,
+            mut_escaped_locals,
+            body_address_taken,
+            param_locals,
+            ..
+        } = self;
+        Some(CachedAnalysis {
+            value_graph: value_graph?,
+            aliased_locals,
+            untrackable_locals,
+            mut_escaped_locals,
+            body_address_taken,
+            param_locals,
+        })
     }
 
     /// Return the [`ValueId`] of `expr` if the per-function `ValueGraph`

--- a/wado-compiler/src/optimize/condition_implication.rs
+++ b/wado-compiler/src/optimize/condition_implication.rs
@@ -66,23 +66,22 @@ pub fn eliminate_implied_conditions(project: &mut NirPackage, gate: &mut Functio
             ..
         } = &mut *func;
         let body = body.as_mut().expect("checked above");
-        let mut engine = match cached {
-            Some(cached) => Engine::with_analysis(body, &mut buffers, locals, &type_table, cached),
-            None => {
-                let (aliased, untrackable, mut_escaped) = super::alias::builder_alias_sets(
-                    body,
-                    locals,
-                    address_taken_locals,
-                    stores_aliased_locals,
-                    &type_table,
-                    &first_param_types,
-                    &call_immutability,
-                );
-                let mut engine = Engine::new(body, &mut buffers, locals);
-                engine.set_alias_sets(aliased, untrackable, mut_escaped);
-                engine.set_value_graph_type_table(&type_table);
-                engine
-            }
+        let mut engine = if let Some(cached) = cached {
+            Engine::with_analysis(body, &mut buffers, locals, &type_table, cached)
+        } else {
+            let (aliased, untrackable, mut_escaped) = super::alias::builder_alias_sets(
+                body,
+                locals,
+                address_taken_locals,
+                stores_aliased_locals,
+                &type_table,
+                &first_param_types,
+                &call_immutability,
+            );
+            let mut engine = Engine::new(body, &mut buffers, locals);
+            engine.set_alias_sets(aliased, untrackable, mut_escaped);
+            engine.set_value_graph_type_table(&type_table);
+            engine
         };
         let changed = engine.run(&[&rule]);
         let parked = if changed {

--- a/wado-compiler/src/optimize/condition_implication.rs
+++ b/wado-compiler/src/optimize/condition_implication.rs
@@ -50,10 +50,10 @@ pub fn eliminate_implied_conditions(project: &mut NirPackage, gate: &mut Functio
     let call_immutability = super::alias::CallImmutability::new(project, &type_table);
     let len = project.functions.len();
     let mut buffers = EngineBuffers::default();
-    gate.run_gated(GatedPass::ConditionImplication, len, |fid| {
+    gate.run_gated_cached(GatedPass::ConditionImplication, len, |fid, cached| {
         let mut func = project.functions[fid.index()].borrow_mut();
         if func.body.is_none() {
-            return false;
+            return (false, None);
         }
         let rule = ConditionImplicationRule {
             applied: Cell::new(false),
@@ -66,19 +66,31 @@ pub fn eliminate_implied_conditions(project: &mut NirPackage, gate: &mut Functio
             ..
         } = &mut *func;
         let body = body.as_mut().expect("checked above");
-        let (aliased, untrackable, mut_escaped) = super::alias::builder_alias_sets(
-            body,
-            locals,
-            address_taken_locals,
-            stores_aliased_locals,
-            &type_table,
-            &first_param_types,
-            &call_immutability,
-        );
-        let mut engine = Engine::new(body, &mut buffers, locals);
-        engine.set_alias_sets(aliased, untrackable, mut_escaped);
-        engine.set_value_graph_type_table(&type_table);
-        engine.run(&[&rule])
+        let mut engine = match cached {
+            Some(cached) => Engine::with_analysis(body, &mut buffers, locals, &type_table, cached),
+            None => {
+                let (aliased, untrackable, mut_escaped) = super::alias::builder_alias_sets(
+                    body,
+                    locals,
+                    address_taken_locals,
+                    stores_aliased_locals,
+                    &type_table,
+                    &first_param_types,
+                    &call_immutability,
+                );
+                let mut engine = Engine::new(body, &mut buffers, locals);
+                engine.set_alias_sets(aliased, untrackable, mut_escaped);
+                engine.set_value_graph_type_table(&type_table);
+                engine
+            }
+        };
+        let changed = engine.run(&[&rule]);
+        let parked = if changed {
+            None
+        } else {
+            engine.into_analysis()
+        };
+        (changed, parked)
     })
 }
 

--- a/wado-compiler/src/optimize/cse.rs
+++ b/wado-compiler/src/optimize/cse.rs
@@ -50,10 +50,10 @@ pub fn eliminate_common_subexprs(project: &mut NirPackage, gate: &mut FunctionGa
     let call_immutability = super::alias::CallImmutability::new(project, &type_table);
     let len = project.functions.len();
     let mut buffers = EngineBuffers::default();
-    gate.run_gated(GatedPass::Cse, len, |fid| {
+    gate.run_gated_cached(GatedPass::Cse, len, |fid, cached| {
         let mut func = project.functions[fid.index()].borrow_mut();
         if func.body.is_none() {
-            return false;
+            return (false, None);
         }
         let rule = CseRule {
             applied: Cell::new(false),
@@ -66,19 +66,31 @@ pub fn eliminate_common_subexprs(project: &mut NirPackage, gate: &mut FunctionGa
             ..
         } = &mut *func;
         let body = body.as_mut().expect("checked above");
-        let (aliased, untrackable, mut_escaped) = super::alias::builder_alias_sets(
-            body,
-            locals,
-            address_taken_locals,
-            stores_aliased_locals,
-            &type_table,
-            &first_param_types,
-            &call_immutability,
-        );
-        let mut engine = Engine::new(body, &mut buffers, locals);
-        engine.set_alias_sets(aliased, untrackable, mut_escaped);
-        engine.set_value_graph_type_table(&type_table);
-        engine.run(&[&rule])
+        let mut engine = match cached {
+            Some(cached) => Engine::with_analysis(body, &mut buffers, locals, &type_table, cached),
+            None => {
+                let (aliased, untrackable, mut_escaped) = super::alias::builder_alias_sets(
+                    body,
+                    locals,
+                    address_taken_locals,
+                    stores_aliased_locals,
+                    &type_table,
+                    &first_param_types,
+                    &call_immutability,
+                );
+                let mut engine = Engine::new(body, &mut buffers, locals);
+                engine.set_alias_sets(aliased, untrackable, mut_escaped);
+                engine.set_value_graph_type_table(&type_table);
+                engine
+            }
+        };
+        let changed = engine.run(&[&rule]);
+        let parked = if changed {
+            None
+        } else {
+            engine.into_analysis()
+        };
+        (changed, parked)
     })
 }
 

--- a/wado-compiler/src/optimize/cse.rs
+++ b/wado-compiler/src/optimize/cse.rs
@@ -66,23 +66,22 @@ pub fn eliminate_common_subexprs(project: &mut NirPackage, gate: &mut FunctionGa
             ..
         } = &mut *func;
         let body = body.as_mut().expect("checked above");
-        let mut engine = match cached {
-            Some(cached) => Engine::with_analysis(body, &mut buffers, locals, &type_table, cached),
-            None => {
-                let (aliased, untrackable, mut_escaped) = super::alias::builder_alias_sets(
-                    body,
-                    locals,
-                    address_taken_locals,
-                    stores_aliased_locals,
-                    &type_table,
-                    &first_param_types,
-                    &call_immutability,
-                );
-                let mut engine = Engine::new(body, &mut buffers, locals);
-                engine.set_alias_sets(aliased, untrackable, mut_escaped);
-                engine.set_value_graph_type_table(&type_table);
-                engine
-            }
+        let mut engine = if let Some(cached) = cached {
+            Engine::with_analysis(body, &mut buffers, locals, &type_table, cached)
+        } else {
+            let (aliased, untrackable, mut_escaped) = super::alias::builder_alias_sets(
+                body,
+                locals,
+                address_taken_locals,
+                stores_aliased_locals,
+                &type_table,
+                &first_param_types,
+                &call_immutability,
+            );
+            let mut engine = Engine::new(body, &mut buffers, locals);
+            engine.set_alias_sets(aliased, untrackable, mut_escaped);
+            engine.set_value_graph_type_table(&type_table);
+            engine
         };
         let changed = engine.run(&[&rule]);
         let parked = if changed {

--- a/wado-compiler/src/optimize/dae.rs
+++ b/wado-compiler/src/optimize/dae.rs
@@ -68,8 +68,7 @@ pub fn eliminate_dead_arguments(project: &mut NirPackage, gate: &mut FunctionGat
     let pinned = collect_pinned(project);
     let closure_call_keys = collect_closure_call_keys(project);
 
-    // Phase 1: identify candidate (function, dead positions) pairs. Validation
-    // below still scans every body, so a dirty candidate sees all its call sites.
+    // Phase 1: identify candidate (function, dead positions) pairs.
     let mut candidates: IndexMap<FnKey, Vec<bool>> = IndexMap::default();
     for fid in gate.dirty_funcs(GatedPass::Dae, project.functions.len()) {
         let func = project.functions[fid.index()].borrow();

--- a/wado-compiler/src/optimize/dae.rs
+++ b/wado-compiler/src/optimize/dae.rs
@@ -60,7 +60,7 @@ use crate::nir_arena::{Body, ExprId, ExprKind, NodeRef, PatKind, StmtKind};
 use crate::nir_package::NirPackage;
 
 use super::arena_query;
-use super::gate::{FunctionGate, FunctionId};
+use super::gate::{FunctionGate, FunctionId, GatedPass};
 
 pub(super) type FnKey = (ModuleSource, String);
 
@@ -68,10 +68,11 @@ pub fn eliminate_dead_arguments(project: &mut NirPackage, gate: &mut FunctionGat
     let pinned = collect_pinned(project);
     let closure_call_keys = collect_closure_call_keys(project);
 
-    // Phase 1: identify candidate (function, dead positions) pairs.
+    // Phase 1: identify candidate (function, dead positions) pairs. Validation
+    // below still scans every body, so a dirty candidate sees all its call sites.
     let mut candidates: IndexMap<FnKey, Vec<bool>> = IndexMap::default();
-    for func_rc in &project.functions {
-        let func = func_rc.borrow();
+    for fid in gate.dirty_funcs(GatedPass::Dae, project.functions.len()) {
+        let func = project.functions[fid.index()].borrow();
         let key = (func.module_source.clone(), func.name.clone());
         let is_closure_dae_relaxed = closure_call_keys.contains(&key);
         if !is_eligible(&func, &pinned, is_closure_dae_relaxed) {

--- a/wado-compiler/src/optimize/drve.rs
+++ b/wado-compiler/src/optimize/drve.rs
@@ -41,7 +41,7 @@ use cranelift_entity::EntityRef;
 
 use super::arena_query;
 use super::dae;
-use super::gate::{FunctionGate, FunctionId};
+use super::gate::{FunctionGate, FunctionId, GatedPass};
 
 type FnKey = dae::FnKey;
 
@@ -50,8 +50,8 @@ pub fn eliminate_dead_return_values(project: &mut NirPackage, gate: &mut Functio
     let type_table = project.type_table.borrow();
 
     let mut candidates: IndexSet<FnKey> = IndexSet::default();
-    for func_rc in &project.functions {
-        let func = func_rc.borrow();
+    for fid in gate.dirty_funcs(GatedPass::Drve, project.functions.len()) {
+        let func = project.functions[fid.index()].borrow();
         if !is_eligible(&func, &pinned, &type_table) {
             continue;
         }

--- a/wado-compiler/src/optimize/gate.rs
+++ b/wado-compiler/src/optimize/gate.rs
@@ -47,6 +47,7 @@ use cranelift_entity::EntityRef;
 use crate::hashmap::IndexMap;
 use crate::module_source::ModuleSource;
 use crate::nir_arena::ExprKind;
+use crate::nir_engine::CachedAnalysis;
 use crate::nir_package::NirPackage;
 
 /// Stable identity of a function within one optimizer run: its index in
@@ -149,6 +150,16 @@ pub struct FunctionGate {
     revision: Vec<u64>,
     watermarks: [Vec<u64>; GatedPass::COUNT],
     graph: CallGraph,
+    /// Parked per-function engine analysis (`ValueGraph` + alias sets), tagged
+    /// with the `revision` it was built at. A pass reuses it when the function
+    /// is unchanged since the park (`revision` matches); `revision` bumps on the
+    /// function's own change *and* any neighbour change, which over-covers the
+    /// analysis's real dependency (body + callee immutability), so a reuse is
+    /// never stale. Shared only among the identically-configured value-graph
+    /// passes `cse` / `store_load_forward` / `condition_implication` (no
+    /// `param_locals` seeding); `licm` seeds loop-entry params differently and
+    /// has no within-iteration sharing partner, so it stays uncached.
+    vg_cache: Vec<Option<(u64, CachedAnalysis)>>,
 }
 
 impl FunctionGate {
@@ -161,6 +172,7 @@ impl FunctionGate {
             revision: vec![1; n],
             watermarks: std::array::from_fn(|_| vec![0; n]),
             graph: CallGraph::build(project),
+            vg_cache: (0..n).map(|_| None).collect(),
         }
     }
 
@@ -179,6 +191,9 @@ impl FunctionGate {
             }
             self.graph.callees.push(Vec::new());
             self.graph.callers.push(Vec::new());
+        }
+        while self.vg_cache.len() < len {
+            self.vg_cache.push(None);
         }
     }
 
@@ -249,6 +264,53 @@ impl FunctionGate {
         }
         any
     }
+
+    /// Like [`Self::run_gated`], for the value-graph passes that share the
+    /// [`vg_cache`](Self::vg_cache). For each dirty function it hands `f` the
+    /// parked analysis (if the function is unchanged since the park) and parks
+    /// the returned analysis back when `f` reports no change. A changed function
+    /// has its revision bumped, so its stale parked entry is never reused.
+    pub fn run_gated_cached(
+        &mut self,
+        pass: GatedPass,
+        len: usize,
+        mut f: impl FnMut(FunctionId, Option<CachedAnalysis>) -> (bool, Option<CachedAnalysis>),
+    ) -> bool {
+        let mut any = false;
+        for i in 0..len {
+            let fid = FunctionId::new(i);
+            if !self.needs(pass, fid) {
+                continue;
+            }
+            let cached = self.take_analysis(fid);
+            let (changed, analysis) = f(fid, cached);
+            self.seen(pass, fid);
+            if changed {
+                self.mark_changed(fid);
+                any = true;
+            } else if let Some(analysis) = analysis {
+                self.park_analysis(fid, analysis);
+            }
+        }
+        any
+    }
+
+    /// Take the parked analysis for `func` if it is still valid (parked at the
+    /// current revision). A stale entry is dropped.
+    fn take_analysis(&mut self, func: FunctionId) -> Option<CachedAnalysis> {
+        let i = func.index();
+        match self.vg_cache.get_mut(i)?.take() {
+            Some((rev, analysis)) if rev == self.revision[i] => Some(analysis),
+            _ => None,
+        }
+    }
+
+    /// Park `analysis` for `func`, tagged with its current revision.
+    fn park_analysis(&mut self, func: FunctionId, analysis: CachedAnalysis) {
+        self.ensure(func.index() + 1);
+        let i = func.index();
+        self.vg_cache[i] = Some((self.revision[i], analysis));
+    }
 }
 
 #[cfg(test)]
@@ -314,6 +376,7 @@ mod tests {
             revision: vec![1; n],
             watermarks: std::array::from_fn(|_| vec![0; n]),
             graph: CallGraph { callees, callers },
+            vg_cache: (0..n).map(|_| None).collect(),
         }
     }
 

--- a/wado-compiler/src/optimize/gate.rs
+++ b/wado-compiler/src/optimize/gate.rs
@@ -29,11 +29,11 @@
 //! call site appearing or vanishing changes a callee's dead-argument analysis).
 //!
 //! Every fixed-point loop pass is gate-aware, so every change is reported at
-//! function granularity. The intra-procedural passes skip functions unchanged
-//! since they last ran (via [`FunctionGate::run_gated`]); the interprocedural
-//! passes (`inline` / `dae` / `drve` / `sroa_param` / `value_copy_demote`) gate
-//! their candidate scan on the dirty set and report the functions they touched
-//! (via [`FunctionGate::mark_changed`]).
+//! function granularity: a per-function pass skips functions it has already
+//! processed at their current revision (via [`FunctionGate::run_gated`]); an
+//! interprocedural pass pulls its candidate worklist from the dirty set (via
+//! [`FunctionGate::dirty_funcs`]) and reports exactly the ones it touched (via
+//! [`FunctionGate::mark_changed`]).
 //!
 //! # Safety
 //!
@@ -57,13 +57,6 @@ cranelift_entity::entity_impl!(FunctionId, "func");
 
 /// The gated passes. Each owns a column of per-function watermarks. Add a
 /// variant when a pass becomes gate-aware; `COUNT` sizes the watermark table.
-///
-/// Interprocedural passes gate on the function their candidate scan reads —
-/// caller-driven `inline` on the caller it walks; callee-driven `dae` / `drve`
-/// / `sroa_param` on the candidate callee; `value_copy_demote` on the function
-/// it rewrites. Both-direction 1-hop propagation makes a clean function one
-/// whose body and every call-graph neighbour are unchanged, so skipping its
-/// scan reproduces the previous no-op verdict — byte-output-identical.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum GatedPass {
     Peephole,
@@ -202,10 +195,7 @@ impl FunctionGate {
         self.watermarks[pass as usize][func.index()] = self.revision[func.index()];
     }
 
-    /// The functions `pass` must (re)examine this round, each marked seen. The
-    /// interprocedural passes pull this as their candidate worklist; a function
-    /// a later apply re-dirties (via [`Self::mark_changed`]) reappears next
-    /// round.
+    /// The functions `pass` must (re)examine this round, each marked seen.
     pub fn dirty_funcs(&mut self, pass: GatedPass, len: usize) -> Vec<FunctionId> {
         (0..len)
             .map(FunctionId::new)
@@ -220,10 +210,7 @@ impl FunctionGate {
     }
 
     /// Record that `func`'s body changed: bump its revision and, conservatively,
-    /// its 1-hop call-graph neighbours (callers and callees). The graph is built
-    /// once and not refreshed, so this over-approximation also absorbs the edges
-    /// a call-restructuring pass (e.g. `inline` copying a callee body in) adds
-    /// after the build — narrowing it to directed edges would miss those.
+    /// its 1-hop call-graph neighbours (callers and callees).
     pub fn mark_changed(&mut self, func: FunctionId) {
         self.ensure(func.index() + 1);
         let i = func.index();

--- a/wado-compiler/src/optimize/gate.rs
+++ b/wado-compiler/src/optimize/gate.rs
@@ -29,10 +29,11 @@
 //! call site appearing or vanishing changes a callee's dead-argument analysis).
 //!
 //! Every fixed-point loop pass is gate-aware, so every change is reported at
-//! function granularity: a per-function pass skips functions it has already
-//! processed at their current revision (via [`FunctionGate::run_gated`]); an
-//! interprocedural pass scans all functions but reports exactly the ones it
-//! touched (via [`FunctionGate::mark_changed`]).
+//! function granularity. The intra-procedural passes skip functions unchanged
+//! since they last ran (via [`FunctionGate::run_gated`]); the interprocedural
+//! passes (`inline` / `dae` / `drve` / `sroa_param` / `value_copy_demote`) gate
+//! their candidate scan on the dirty set and report the functions they touched
+//! (via [`FunctionGate::mark_changed`]).
 //!
 //! # Safety
 //!
@@ -56,6 +57,13 @@ cranelift_entity::entity_impl!(FunctionId, "func");
 
 /// The gated passes. Each owns a column of per-function watermarks. Add a
 /// variant when a pass becomes gate-aware; `COUNT` sizes the watermark table.
+///
+/// Interprocedural passes gate on the function their candidate scan reads —
+/// caller-driven `inline` on the caller it walks; callee-driven `dae` / `drve`
+/// / `sroa_param` on the candidate callee; `value_copy_demote` on the function
+/// it rewrites. Both-direction 1-hop propagation makes a clean function one
+/// whose body and every call-graph neighbour are unchanged, so skipping its
+/// scan reproduces the previous no-op verdict — byte-output-identical.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum GatedPass {
     Peephole,
@@ -68,10 +76,15 @@ pub enum GatedPass {
     StoreLoadForward,
     TmplHoist,
     ContainerSroa,
+    Inline,
+    Dae,
+    Drve,
+    SroaParam,
+    ValueCopyDemote,
 }
 
 impl GatedPass {
-    const COUNT: usize = 10;
+    const COUNT: usize = 15;
 }
 
 /// Static call graph over [`FunctionId`]s, built once at loop start.
@@ -189,8 +202,28 @@ impl FunctionGate {
         self.watermarks[pass as usize][func.index()] = self.revision[func.index()];
     }
 
+    /// The functions `pass` must (re)examine this round, each marked seen. The
+    /// interprocedural passes pull this as their candidate worklist; a function
+    /// a later apply re-dirties (via [`Self::mark_changed`]) reappears next
+    /// round.
+    pub fn dirty_funcs(&mut self, pass: GatedPass, len: usize) -> Vec<FunctionId> {
+        (0..len)
+            .map(FunctionId::new)
+            .filter(|&fid| {
+                let dirty = self.needs(pass, fid);
+                if dirty {
+                    self.seen(pass, fid);
+                }
+                dirty
+            })
+            .collect()
+    }
+
     /// Record that `func`'s body changed: bump its revision and, conservatively,
-    /// its 1-hop call-graph neighbours (callers and callees).
+    /// its 1-hop call-graph neighbours (callers and callees). The graph is built
+    /// once and not refreshed, so this over-approximation also absorbs the edges
+    /// a call-restructuring pass (e.g. `inline` copying a callee body in) adds
+    /// after the build — narrowing it to directed edges would miss those.
     pub fn mark_changed(&mut self, func: FunctionId) {
         self.ensure(func.index() + 1);
         let i = func.index();
@@ -253,6 +286,11 @@ mod tests {
             GatedPass::StoreLoadForward,
             GatedPass::TmplHoist,
             GatedPass::ContainerSroa,
+            GatedPass::Inline,
+            GatedPass::Dae,
+            GatedPass::Drve,
+            GatedPass::SroaParam,
+            GatedPass::ValueCopyDemote,
         ];
         for p in all {
             match p {
@@ -265,7 +303,12 @@ mod tests {
                 | GatedPass::ConditionImplication
                 | GatedPass::StoreLoadForward
                 | GatedPass::TmplHoist
-                | GatedPass::ContainerSroa => {}
+                | GatedPass::ContainerSroa
+                | GatedPass::Inline
+                | GatedPass::Dae
+                | GatedPass::Drve
+                | GatedPass::SroaParam
+                | GatedPass::ValueCopyDemote => {}
             }
         }
         assert_eq!(all.len(), GatedPass::COUNT);

--- a/wado-compiler/src/optimize/inline.rs
+++ b/wado-compiler/src/optimize/inline.rs
@@ -20,7 +20,7 @@ use crate::tir::{ResolvedType, TypeId, TypeTable};
 use cranelift_entity::EntityRef;
 
 use super::arena_query;
-use super::gate::{FunctionGate, FunctionId};
+use super::gate::{FunctionGate, FunctionId, GatedPass};
 use crate::token::Span;
 
 // The inline threshold is based on expression count, which provides a more
@@ -660,8 +660,11 @@ pub fn inline_functions(
 
     let mut changed = false;
 
-    // Inline at call sites
-    for (caller_idx, func_rc) in project.functions.iter().enumerate() {
+    // Inline at call sites. The candidate set spans every eligible callee, so a
+    // dirty caller still inlines clean callees.
+    for fid in gate.dirty_funcs(GatedPass::Inline, project.functions.len()) {
+        let caller_idx = fid.index();
+        let func_rc = project.functions[caller_idx].clone();
         let mut func = func_rc.borrow_mut();
         let caller_module_source = func.module_source.clone();
         let func_name = func.name.clone();

--- a/wado-compiler/src/optimize/inline.rs
+++ b/wado-compiler/src/optimize/inline.rs
@@ -660,8 +660,7 @@ pub fn inline_functions(
 
     let mut changed = false;
 
-    // Inline at call sites. The candidate set spans every eligible callee, so a
-    // dirty caller still inlines clean callees.
+    // Inline at call sites.
     for fid in gate.dirty_funcs(GatedPass::Inline, project.functions.len()) {
         let caller_idx = fid.index();
         let func_rc = project.functions[caller_idx].clone();

--- a/wado-compiler/src/optimize/sroa_param.rs
+++ b/wado-compiler/src/optimize/sroa_param.rs
@@ -37,7 +37,7 @@ use crate::tir::{ResolvedType, TypeId, TypeTable};
 use cranelift_entity::EntityRef;
 
 use super::arena_query::place_root_local;
-use super::gate::{FunctionGate, FunctionId};
+use super::gate::{FunctionGate, FunctionId, GatedPass};
 
 type FnKey = (ModuleSource, String);
 
@@ -55,7 +55,7 @@ struct SroaInfo {
 }
 
 pub fn sroa_single_field_parameters(project: &mut NirPackage, gate: &mut FunctionGate) -> bool {
-    let candidates = collect_and_validate(project);
+    let candidates = collect_and_validate(project, gate);
     if candidates.is_empty() {
         return false;
     }
@@ -111,13 +111,18 @@ fn build_single_field_index(project: &NirPackage) -> SingleFieldIndex {
     out
 }
 
-fn collect_and_validate(project: &NirPackage) -> IndexMap<(FnKey, usize), SroaInfo> {
+fn collect_and_validate(
+    project: &NirPackage,
+    gate: &mut FunctionGate,
+) -> IndexMap<(FnKey, usize), SroaInfo> {
     let type_table = project.type_table.borrow();
     let single_field = build_single_field_index(project);
 
+    // Candidacy is callee-local: call sites are rewritten unconditionally in
+    // apply, never consulted here.
     let mut candidates: IndexMap<(FnKey, usize), SroaInfo> = IndexMap::default();
-    for func_rc in &project.functions {
-        let func = func_rc.borrow();
+    for fid in gate.dirty_funcs(GatedPass::SroaParam, project.functions.len()) {
+        let func = project.functions[fid.index()].borrow();
         if !is_eligible(&func) || func.body.is_none() {
             continue;
         }

--- a/wado-compiler/src/optimize/sroa_param.rs
+++ b/wado-compiler/src/optimize/sroa_param.rs
@@ -118,8 +118,6 @@ fn collect_and_validate(
     let type_table = project.type_table.borrow();
     let single_field = build_single_field_index(project);
 
-    // Candidacy is callee-local: call sites are rewritten unconditionally in
-    // apply, never consulted here.
     let mut candidates: IndexMap<(FnKey, usize), SroaInfo> = IndexMap::default();
     for fid in gate.dirty_funcs(GatedPass::SroaParam, project.functions.len()) {
         let func = project.functions[fid.index()].borrow();

--- a/wado-compiler/src/optimize/store_load_forward.rs
+++ b/wado-compiler/src/optimize/store_load_forward.rs
@@ -23,7 +23,7 @@ use std::cell::Cell;
 use crate::hashmap::IndexSet;
 use crate::nir::NirFunction;
 use crate::nir_arena::{BlockId, Body, ExprId, ExprKind, NodeRef};
-use crate::nir_engine::{Engine, EngineBuffers, Rule};
+use crate::nir_engine::{CachedAnalysis, Engine, EngineBuffers, Rule};
 use crate::nir_package::NirPackage;
 use crate::nir_value_graph::{ValueId, ValueKind};
 
@@ -37,7 +37,7 @@ pub fn forward_stores_to_loads(project: &mut NirPackage, gate: &mut FunctionGate
     let call_immutability = super::alias::CallImmutability::new(project, &type_table);
     let len = project.functions.len();
     let mut buffers = EngineBuffers::default();
-    gate.run_gated(GatedPass::StoreLoadForward, len, |fid| {
+    gate.run_gated_cached(GatedPass::StoreLoadForward, len, |fid, cached| {
         let mut func = project.functions[fid.index()].borrow_mut();
         forward_one(
             &mut func,
@@ -45,6 +45,7 @@ pub fn forward_stores_to_loads(project: &mut NirPackage, gate: &mut FunctionGate
             &first_param_types,
             &call_immutability,
             &mut buffers,
+            cached,
         )
     })
 }
@@ -68,7 +69,9 @@ pub fn forward_stores_to_loads_all(project: &mut NirPackage) -> bool {
             &first_param_types,
             &call_immutability,
             &mut buffers,
-        );
+            None,
+        )
+        .0;
     }
     changed
 }
@@ -84,9 +87,10 @@ fn forward_one(
     >,
     call_immutability: &super::alias::CallImmutability,
     buffers: &mut EngineBuffers,
-) -> bool {
+    cached: Option<CachedAnalysis>,
+) -> (bool, Option<CachedAnalysis>) {
     if func.body.is_none() {
-        return false;
+        return (false, None);
     }
     // `Local`-read forwarding excludes address-taken / `stores`-aliased
     // locals: the canonical sets plus the engine's body scan — the
@@ -102,24 +106,36 @@ fn forward_one(
         ..
     } = &mut *func;
     let body = body.as_mut().expect("checked above");
-    let (aliased, untrackable, mut_escaped) = super::alias::builder_alias_sets(
-        body,
-        locals,
-        address_taken_locals,
-        stores_aliased_locals,
-        type_table,
-        first_param_types,
-        call_immutability,
-    );
-    let mut engine = Engine::new(body, buffers, locals);
-    engine.set_alias_sets(aliased, untrackable, mut_escaped);
-    engine.set_value_graph_type_table(type_table);
+    let mut engine = match cached {
+        Some(cached) => Engine::with_analysis(body, buffers, locals, type_table, cached),
+        None => {
+            let (aliased, untrackable, mut_escaped) = super::alias::builder_alias_sets(
+                body,
+                locals,
+                address_taken_locals,
+                stores_aliased_locals,
+                type_table,
+                first_param_types,
+                call_immutability,
+            );
+            let mut engine = Engine::new(body, buffers, locals);
+            engine.set_alias_sets(aliased, untrackable, mut_escaped);
+            engine.set_value_graph_type_table(type_table);
+            engine
+        }
+    };
     unsafe_locals.extend(engine.body_address_taken().iter().copied());
     let rule = StoreLoadForwardRule {
         applied: Cell::new(false),
         unsafe_locals,
     };
-    engine.run(&[&rule])
+    let changed = engine.run(&[&rule]);
+    let parked = if changed {
+        None
+    } else {
+        engine.into_analysis()
+    };
+    (changed, parked)
 }
 
 /// Standalone-session rule whose single `apply_block` performs the whole-

--- a/wado-compiler/src/optimize/store_load_forward.rs
+++ b/wado-compiler/src/optimize/store_load_forward.rs
@@ -106,23 +106,22 @@ fn forward_one(
         ..
     } = &mut *func;
     let body = body.as_mut().expect("checked above");
-    let mut engine = match cached {
-        Some(cached) => Engine::with_analysis(body, buffers, locals, type_table, cached),
-        None => {
-            let (aliased, untrackable, mut_escaped) = super::alias::builder_alias_sets(
-                body,
-                locals,
-                address_taken_locals,
-                stores_aliased_locals,
-                type_table,
-                first_param_types,
-                call_immutability,
-            );
-            let mut engine = Engine::new(body, buffers, locals);
-            engine.set_alias_sets(aliased, untrackable, mut_escaped);
-            engine.set_value_graph_type_table(type_table);
-            engine
-        }
+    let mut engine = if let Some(cached) = cached {
+        Engine::with_analysis(body, buffers, locals, type_table, cached)
+    } else {
+        let (aliased, untrackable, mut_escaped) = super::alias::builder_alias_sets(
+            body,
+            locals,
+            address_taken_locals,
+            stores_aliased_locals,
+            type_table,
+            first_param_types,
+            call_immutability,
+        );
+        let mut engine = Engine::new(body, buffers, locals);
+        engine.set_alias_sets(aliased, untrackable, mut_escaped);
+        engine.set_value_graph_type_table(type_table);
+        engine
     };
     unsafe_locals.extend(engine.body_address_taken().iter().copied());
     let rule = StoreLoadForwardRule {

--- a/wado-compiler/src/optimize/value_copy_demote.rs
+++ b/wado-compiler/src/optimize/value_copy_demote.rs
@@ -42,7 +42,7 @@ use crate::nir_package::NirPackage;
 use crate::tir::{ResolvedType, TypeTable};
 
 use super::arena_query::{expr_mentions_local, is_local, strip_refs};
-use super::gate::{FunctionGate, FunctionId};
+use super::gate::{FunctionGate, FunctionId, GatedPass};
 use cranelift_entity::EntityRef;
 
 type FuncKey = (ModuleSource, String);
@@ -100,8 +100,9 @@ pub fn demote_value_copies(project: &mut NirPackage, gate: &mut FunctionGate) ->
     // being collaterally demoted.
     let mut site_elig: IndexMap<(usize, u32), bool> = IndexMap::default();
     let mut site_key: IndexMap<(usize, u32), FuncKey> = IndexMap::default();
-    for (fi, f) in project.functions.iter().enumerate() {
-        let f = f.borrow();
+    for fid in gate.dirty_funcs(GatedPass::ValueCopyDemote, project.functions.len()) {
+        let fi = fid.index();
+        let f = project.functions[fi].borrow();
         if f.value_copy_type().is_some() {
             continue;
         }


### PR DESCRIPTION
## Summary

Two byte-output-identical optimizer speedups, plus the profiling findings that
shaped them (recorded in the worklist-engine WEP).

### Stage 9 — interprocedural worklist
`inline` / `dae` / `drve` / `sroa_param` / `value_copy_demote` now pull their
candidate set from the per-function gate's dirty set (`FunctionGate::dirty_funcs`)
instead of scanning every function each round. `mark_changed` re-runs affected
callers when a callee shrinks; the fixed-point loop terminates at quiescence with
`OptConfig::iterations` as the bound. Terminal stages stay explicit. This
completes the required path of the worklist-engine WEP.

Directed-edge propagation (callee-shrink → callers only) was prototyped and
deferred: the call graph is built once and a per-iteration rebuild does **not**
make it lossless (the staleness is intra-iteration), so it would need fragile
immediate edge maintenance for a net-neutral gain. Propagation stays
both-direction. The finding is recorded in the WEP.

### Per-function ValueGraph sharing
A native profile pins ~48% of compile CPU to `run_gated`, dominated by the
per-function `ValueGraph` build (+ flow joins) and alias-set computation, all
rebuilt per pass per function. `cse` / `store_load_forward` /
`condition_implication` now share one parked `ValueGraph` (+ alias sets) keyed by
the function's gate revision — which bumps on the function's own change *and* any
call-graph neighbour change, over-covering the analysis's real dependency (body +
callee immutability), so a reuse is never stale.

The WEP also records the key negative result: the `ValueGraph` build is
**compute-bound, not allocation-bound** — pooling its output buffers measured no
improvement — so the remaining levers are an incremental `ValueGraph` and
function-level parallelism, not buffer pooling.

## Measured (package-gale `gale gen SQLite.g4`, dev build)
optimize phase ~13.5s → ~12.5s (~7%): `store_load_forward` 1.77s → 1.13s,
`condition_implication` 1.65s → 1.24s.

## Correctness
- 16 golden WIR dumps (gale, zlib, fts, cbor, json, mandelbrot, count_prime,
  sieve at -O2/-O3) byte-identical at every step.
- Full compiler test suite green (61 groups, 0 failures); gate unit tests green.

## Commits
- Stage 9 interprocedural worklist
- ValueGraph sharing cache
- WEP: directed-propagation + hot-path profiling findings

https://claude.ai/code/session_01H6VBguUxY59TZNGbTQAtEQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6VBguUxY59TZNGbTQAtEQ)_