### PR TITLE
docs: tighten comment and documentation guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,9 +42,10 @@ mise run report-wasm-size  # hello_world, pi_approx, zlib, and so on
 
 ## General Rules
 
-- Documentation and comments must be written in English.
+- Write all documentation and comments in English, and keep them concise — cut filler and low-information words.
+  - Comments: add one only when the intent can't be read from the code. Never use comments as section dividers or to restate what the code already says.
+  - Docs: lead with the information; drop throat-clearing, restating the obvious, and redundant phrasing.
 - Avoid ad-hoc workarounds. Write proper code based on a sound design.
-- Do not use comment sections to separate or organize code.
 - Perform red/green TDD.
 - A compiler bug is always P0 — no exceptions. Stop, write a minimal reproducible e2e fixture, and fix it before continuing if it blocks the current task.
 - A pre-existing issue — whether you find it or a reviewer points it out — must be fixed, with TDD when practical.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,6 +1,6 @@
-# Overview of Docs
+# docs
 
-This is the documentation directory of Wado.
+Wado documentation, including the WEP (Wado Evolution Proposals) archive.
 
 ## Rules for Markdown
 

--- a/wado-compiler/AGENTS.md
+++ b/wado-compiler/AGENTS.md
@@ -1,6 +1,6 @@
-# Overview
+# wado-compiler
 
-This is the wado-compiler crate.
+The Wado compiler crate: frontend, IR pipeline, optimizer, and codegen.
 
 ## Rules
 


### PR DESCRIPTION
## Summary

Tightens the documentation/comment guidance in the root `AGENTS.md` and brings the per-crate `AGENTS.md` files into line with it.

- Root `AGENTS.md`: consolidate the comment rules into one principle — write docs and comments in English and keep them concise (cut filler), with split guidance for comments (only when intent can't be read from code; never as section dividers or to restate code) and docs (lead with the information; drop throat-clearing, restating the obvious, redundant phrasing). The old standalone "Do not use comment sections..." rule is absorbed.
- `wado-compiler/AGENTS.md` and `docs/AGENTS.md`: replace the throat-clearing `# Overview` / "This is the X" openers with a crate-named heading plus a one-line substantive description, matching the other `AGENTS.md` files.

Audited all `AGENTS.md` files (excluding `vendor/`); the remaining four (`benchmark`, `wasm-size`, `wado-lsp`, `package-gale`) already follow the principle.

Note: `CLAUDE.md` is a symlink to `AGENTS.md`, so both names reflect these changes.

https://claude.ai/code/session_01T5mYpsz9Jem3A6vnFuv17T

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5mYpsz9Jem3A6vnFuv17T)_