### PR TITLE
feat(kiln): resolve a directory generator module to its package entry

### DIFF
--- a/example/Wado.g4
+++ b/example/Wado.g4
@@ -19,23 +19,30 @@ item
 
 itemKind
     : useDecl
-    | functionDecl
+    | implBlock
+    | testDecl
+    | 'export' 'async'? 'fn' funcSig
+    | 'pub'? pubItem
+    ;
+
+// Item kinds that take an optional `pub` (plus plain `fn`). The leading
+// `pub` is left-factored into `itemKind` so the dispatch is token-led.
+pubItem
+    : 'fn' funcSig
+    | globalDecl
+    | typeAliasDecl
     | structDecl
     | enumDecl
     | variantDecl
     | traitDecl
-    | implBlock
-    | globalDecl
-    | typeAliasDecl
-    | testDecl
     ;
 
 globalDecl
-    : 'pub'? 'global' IDENTIFIER ':' typeRef '=' expression ';'
+    : 'global' IDENTIFIER ':' typeRef '=' expression ';'
     ;
 
 typeAliasDecl
-    : 'pub'? 'type' IDENTIFIER genericParams? '=' typeRef ';'
+    : 'type' IDENTIFIER genericParams? '=' typeRef ';'
     ;
 
 // `test` is a contextual keyword; modeled as a literal here for simplicity.
@@ -56,8 +63,7 @@ attrArgs
     ;
 
 attrArg
-    : IDENTIFIER '=' literal
-    | IDENTIFIER
+    : IDENTIFIER ('=' literal)?
     | literal
     ;
 
@@ -79,8 +85,11 @@ importItem
     ;
 
 functionDecl
-    : ('pub' | 'export' 'async'?)? 'fn' IDENTIFIER genericParams? '(' paramList? ')'
-        returnType? withClause? (block | ';')
+    : ('pub' | 'export' 'async'?)? 'fn' funcSig
+    ;
+
+funcSig
+    : IDENTIFIER genericParams? '(' paramList? ')' returnType? withClause? (block | ';')
     ;
 
 paramList
@@ -110,7 +119,7 @@ withItem
     ;
 
 structDecl
-    : 'pub'? 'struct' IDENTIFIER genericParams? '{' fieldList? '}'
+    : 'struct' IDENTIFIER genericParams? '{' fieldList? '}'
     ;
 
 fieldList
@@ -122,7 +131,7 @@ fieldDecl
     ;
 
 enumDecl
-    : 'pub'? 'enum' IDENTIFIER '{' enumCaseList? '}'
+    : 'enum' IDENTIFIER '{' enumCaseList? '}'
     ;
 
 enumCaseList
@@ -130,7 +139,7 @@ enumCaseList
     ;
 
 variantDecl
-    : 'pub'? 'variant' IDENTIFIER genericParams? '{' variantCaseList? '}'
+    : 'variant' IDENTIFIER genericParams? '{' variantCaseList? '}'
     ;
 
 variantCaseList
@@ -142,7 +151,7 @@ variantCase
     ;
 
 traitDecl
-    : 'pub'? 'trait' IDENTIFIER genericParams? '{' traitMember* '}'
+    : 'trait' IDENTIFIER genericParams? '{' traitMember* '}'
     ;
 
 traitMember
@@ -156,9 +165,16 @@ implBlock
 
 implMember
     : 'type' IDENTIFIER '=' typeRef ';'
-    | 'pub'? 'const' IDENTIFIER ':' typeRef '=' expression ';'
-    | 'pub'? functionDecl
     | '..'
+    | 'export' 'async'? 'fn' funcSig
+    | 'pub'? implPubMember
+    ;
+
+// `const` / `fn` members share an optional `pub`, left-factored here so the
+// dispatch is token-led (`const` vs `fn`) instead of a tournament.
+implPubMember
+    : 'const' IDENTIFIER ':' typeRef '=' expression ';'
+    | 'fn' funcSig
     ;
 
 genericParams
@@ -320,9 +336,7 @@ postfix
 postfixOp
     : '(' argumentList? ')'
     | '::' typeArgs '(' argumentList? ')'
-    | '.' memberName ('::' typeArgs)? '(' argumentList? ')'
-    | '.' memberName
-    | '.' INTEGER
+    | '.' (memberName ('::' typeArgs)? ('(' argumentList? ')')? | INTEGER)
     | '[' expression ']'
     | 'matches' '{' pattern ('&&' expression)? '}'
     | '?'
@@ -376,7 +390,7 @@ mapEntry
 // keyword method name resolves there, e.g. `Instant::from(x)` — mirroring how
 // `.from` is already accepted after `.`.
 exprPath
-    : IDENTIFIER ('::' memberName | '::' typeArgs)*
+    : IDENTIFIER ('::' (typeArgs | memberName))*
     ;
 
 // Compile-time literals and macros: `#file`, `#include_str("...")`.
@@ -433,8 +447,7 @@ fieldInitList
     ;
 
 fieldInit
-    : IDENTIFIER ':' expression
-    | IDENTIFIER
+    : IDENTIFIER (':' expression)?
     | '..' expression
     ;
 
@@ -497,8 +510,7 @@ patternFieldList
     ;
 
 patternField
-    : IDENTIFIER ':' pattern
-    | IDENTIFIER
+    : IDENTIFIER (':' pattern)?
     ;
 
 literal

--- a/example/wado_syntax_highlight.wado
+++ b/example/wado_syntax_highlight.wado
@@ -9,7 +9,7 @@ use { Preopens, Descriptor, Filesize, PathFlags, OpenFlags, DescriptorFlags } fr
 use wado from "./Wado.g4"
     with {
         generator: {
-            module: "../package-gale/src/generator.wado",
+            module: "../package-gale",
             options: { highlight: true },
             output_dir: "build/wado-highlight",
         },

--- a/wado-cli/src/check.rs
+++ b/wado-cli/src/check.rs
@@ -139,6 +139,7 @@ pub async fn run(opts: CheckOptions) -> Result<(), CliExit> {
             .map(|(m, _)| m)
             .unwrap_or_else(crate::compile::empty_manifest);
         crate::compile::rewrite_build_dep_modules(&mut inline, &manifest, &manifest_root);
+        crate::compile::rewrite_local_dir_modules(&mut inline, &manifest_root);
         let provider = CliGeneratorProvider::new(manifest_root.clone());
         crate::kiln_driver::check_pipeline(&manifest, &manifest_root, &host, &provider, inline)
             .await

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -428,6 +428,7 @@ async fn maybe_run_pipeline(
     }
     let mut inline = inline;
     rewrite_build_dep_modules(&mut inline, &manifest, &manifest_root);
+    rewrite_local_dir_modules(&mut inline, &manifest_root);
     let provider = CliGeneratorProvider::new(manifest_root.clone()).with_no_cache(no_cache);
     crate::kiln_driver::run_pipeline(&manifest, &manifest_root, host, &provider, inline, no_cache)
         .await
@@ -457,6 +458,37 @@ pub(crate) fn rewrite_build_dep_modules(
     }
 }
 
+/// Rewrite each inline invocation whose `module` is a `LocalPath` pointing
+/// at a *directory* (a generator package) into a `LocalPath` pointing at
+/// that package's `[world]."core:kiln/generator"` entry file. This collapses
+/// `module: "../pkg"` onto the same path-addressed identity — and therefore
+/// the same cache key — as `module: "../pkg/src/generator.wado"` and the
+/// `[build-dependencies]` name form, all of which resolve to one entry file.
+/// Resolved off the filesystem before the pipeline runs, mirroring
+/// [`rewrite_build_dep_modules`]. A directory without a resolvable generator
+/// world entry is left untouched for the provider to report.
+pub(crate) fn rewrite_local_dir_modules(
+    inline: &mut [wado_compiler::kiln::Invocation],
+    manifest_root: &Path,
+) {
+    use wado_compiler::kiln::{GeneratorModule, InvocationPath};
+    for inv in inline.iter_mut() {
+        let GeneratorModule::LocalPath(path) = &inv.module else {
+            continue;
+        };
+        let abs = manifest_root.join(path.as_str());
+        if !abs.is_dir() {
+            continue;
+        }
+        if let Some(entry) = package_generator_entry(&abs) {
+            inv.module = GeneratorModule::LocalPath(InvocationPath::normalize(&format!(
+                "{}/{entry}",
+                path.as_str()
+            )));
+        }
+    }
+}
+
 /// The generator entry of a path `[build-dependencies]` package, as a
 /// manifest-root-relative [`InvocationPath`]: `<dep-path>/<generator world
 /// entry>`. `None` when the dependency is absent, not a path dep, or declares
@@ -470,12 +502,23 @@ fn build_dep_generator_local_path(
     let DependencySource::Path { path, .. } = &dep.source else {
         return None;
     };
-    let dep_manifest_text = fs::read_to_string(manifest_root.join(path).join("wado.toml")).ok()?;
-    let dep_manifest: wado_manifest::Manifest = dep_manifest_text.parse().ok()?;
-    let entry = dep_manifest.world_entry("core:kiln/generator")?;
+    let entry = package_generator_entry(&manifest_root.join(path))?;
     Some(wado_compiler::kiln::InvocationPath::normalize(&format!(
         "{path}/{entry}"
     )))
+}
+
+/// Resolve a generator *package directory* (absolute) to its
+/// `[world]."core:kiln/generator"` entry, as a path relative to that
+/// directory. `None` when the directory has no readable `wado.toml` or the
+/// manifest declares no such world entry. The single source of truth for
+/// mapping a package to its generator entry, shared by the
+/// `[build-dependencies]`-name and directory-`module:` resolution paths so
+/// both spellings land on the same entry file.
+fn package_generator_entry(pkg_dir: &Path) -> Option<String> {
+    let manifest_text = fs::read_to_string(pkg_dir.join("wado.toml")).ok()?;
+    let manifest: wado_manifest::Manifest = manifest_text.parse().ok()?;
+    Some(manifest.world_entry("core:kiln/generator")?.to_string())
 }
 
 /// Empty in-memory `wado.toml` manifest used as a fallback when the
@@ -599,4 +642,105 @@ pub async fn run(opts: CompileOptions) -> Result<(), CliExit> {
         .map_err(|e| CliExit::error(format!("writing output file: {e}")))?;
     eprintln!("Generated: {}", output_path.display());
     Ok(())
+}
+
+#[cfg(test)]
+mod kiln_dir_module_tests {
+    use super::*;
+    use wado_compiler::kiln::{DeclSite, GeneratorModule, Invocation, InvocationPath};
+
+    fn local_invocation(module_path: &str) -> Invocation {
+        Invocation {
+            decl_site: DeclSite {
+                module: "consumer.wado".to_string(),
+                synthetic_id: "kiln-test".to_string(),
+            },
+            module: GeneratorModule::LocalPath(InvocationPath::normalize(module_path)),
+            from: InvocationPath::normalize("./grammar.g4"),
+            inputs: Vec::new(),
+            output_dir: InvocationPath::normalize("build"),
+            options_canonical: Vec::new(),
+            raw_options: None,
+        }
+    }
+
+    fn write_pkg(root: &Path, name: &str, world_entry: Option<&str>) -> std::path::PathBuf {
+        let pkg = root.join(name);
+        std::fs::create_dir_all(pkg.join("src")).unwrap();
+        let mut manifest = format!("[package]\nname = \"{name}\"\nversion = \"0.1.0\"\n");
+        if let Some(entry) = world_entry {
+            manifest.push_str(&format!(
+                "\n[world]\n\"core:kiln/generator\" = \"{entry}\"\n"
+            ));
+        }
+        std::fs::write(pkg.join("wado.toml"), manifest).unwrap();
+        std::fs::write(pkg.join("src/generator.wado"), "// generator\n").unwrap();
+        pkg
+    }
+
+    fn unique_tmp(tag: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("wado-kiln-dir-{tag}-{}", std::process::id()))
+    }
+
+    #[test]
+    fn package_generator_entry_reads_world_entry() {
+        let root = unique_tmp("entry");
+        let _ = std::fs::remove_dir_all(&root);
+        let pkg = write_pkg(&root, "gen-pkg", Some("src/generator.wado"));
+        assert_eq!(
+            package_generator_entry(&pkg).as_deref(),
+            Some("src/generator.wado")
+        );
+        let plain = write_pkg(&root, "plain-pkg", None);
+        assert_eq!(package_generator_entry(&plain), None);
+        assert_eq!(package_generator_entry(&root.join("absent")), None);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn rewrite_local_dir_modules_resolves_directory_to_entry_file() {
+        let root = unique_tmp("rewrite");
+        let _ = std::fs::remove_dir_all(&root);
+        write_pkg(&root, "gen-pkg", Some("src/generator.wado"));
+
+        // A directory module is rewritten to its package generator entry,
+        // landing on the same path identity as a direct entry-file module.
+        let mut inline = vec![local_invocation("./gen-pkg")];
+        rewrite_local_dir_modules(&mut inline, &root);
+        match &inline[0].module {
+            GeneratorModule::LocalPath(p) => {
+                assert_eq!(p.as_str(), "gen-pkg/src/generator.wado")
+            }
+            other => panic!("expected LocalPath, got {other:?}"),
+        }
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn rewrite_local_dir_modules_leaves_files_and_unresolvable_dirs() {
+        let root = unique_tmp("leave");
+        let _ = std::fs::remove_dir_all(&root);
+        // A package directory without a generator world entry is left alone
+        // (the provider reports the misconfiguration).
+        write_pkg(&root, "plain-pkg", None);
+        // A plain `.wado` file module must never be touched.
+        std::fs::write(root.join("gen.wado"), "// gen\n").unwrap();
+
+        let mut inline = vec![
+            local_invocation("./plain-pkg"),
+            local_invocation("./gen.wado"),
+        ];
+        rewrite_local_dir_modules(&mut inline, &root);
+        match &inline[0].module {
+            GeneratorModule::LocalPath(p) => assert_eq!(p.as_str(), "plain-pkg"),
+            other => panic!("expected untouched LocalPath, got {other:?}"),
+        }
+        match &inline[1].module {
+            GeneratorModule::LocalPath(p) => assert_eq!(p.as_str(), "gen.wado"),
+            other => panic!("expected untouched LocalPath, got {other:?}"),
+        }
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
 }

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -709,7 +709,7 @@ mod kiln_dir_module_tests {
         rewrite_local_dir_modules(&mut inline, &root);
         match &inline[0].module {
             GeneratorModule::LocalPath(p) => {
-                assert_eq!(p.as_str(), "gen-pkg/src/generator.wado")
+                assert_eq!(p.as_str(), "gen-pkg/src/generator.wado");
             }
             other => panic!("expected LocalPath, got {other:?}"),
         }

--- a/wado-cli/src/kiln_provider.rs
+++ b/wado-cli/src/kiln_provider.rs
@@ -3,7 +3,9 @@
 //! Resolves a [`GeneratorModule`] into a [`ResolvedGenerator`] (wasm
 //! bytes + options descriptor + source-closure hash) for the Kiln
 //! driver. Supports [`GeneratorModule::LocalPath`] (`module:
-//! "./generator.wado"`) and [`GeneratorModule::BuildDep`] (`module:
+//! "./generator.wado"`, or a directory like `module: "../package-gale"`
+//! that resolves to the package's `[world]."core:kiln/generator"` entry)
+//! and [`GeneratorModule::BuildDep`] (`module:
 //! "gale"`, resolved against `[build-dependencies]` to the package's
 //! `core:kiln/generator` world entry). Spec-form generators (`module =
 //! "ns:name@ver"`) surface [`ProviderError::Unsupported`] — registry/git
@@ -135,8 +137,8 @@ impl CliGeneratorProvider {
         &self,
         path: &wado_compiler::kiln::InvocationPath,
     ) -> Result<(PathBuf, Vec<u8>, String, String), ProviderError> {
-        let abs = self.resolve_path(path.as_str());
-        if !abs.exists() {
+        let resolved = self.resolve_path(path.as_str());
+        if !resolved.exists() {
             return Err(ProviderError::Internal {
                 message: format!(
                     "kiln: generator path `{}` does not exist (relative to manifest root {})",
@@ -145,6 +147,16 @@ impl CliGeneratorProvider {
                 ),
             });
         }
+        // A directory `module:` points at a generator *package*: resolve its
+        // `[world]."core:kiln/generator"` entry from the package's `wado.toml`,
+        // mirroring how a bare `[build-dependencies]` name resolves. This lets
+        // `module: "../package-gale"` work the same as pointing `module`
+        // straight at `../package-gale/src/generator.wado`.
+        let abs = if resolved.is_dir() {
+            resolve_package_generator_entry(&resolved)?
+        } else {
+            resolved
+        };
         let source = std::fs::read(&abs).map_err(|e| ProviderError::Internal {
             message: format!(
                 "kiln: failed to read generator source at `{}`: {e}",
@@ -296,6 +308,34 @@ impl CliGeneratorProvider {
 
         Ok(artifacts)
     }
+}
+
+/// Resolve a directory `module:` path to the generator package's
+/// `[world]."core:kiln/generator"` entry file. `dir` must contain a
+/// `wado.toml` that declares such a world entry; the returned path is
+/// `dir.join(<entry>)`. This is the filesystem counterpart of
+/// [`crate::compile::rewrite_build_dep_modules`] for path-addressed
+/// (rather than `[build-dependencies]`-named) generator packages.
+fn resolve_package_generator_entry(dir: &Path) -> Result<PathBuf, ProviderError> {
+    let manifest_path = dir.join("wado.toml");
+    let text = std::fs::read_to_string(&manifest_path).map_err(|e| ProviderError::Internal {
+        message: format!(
+            "kiln: generator module `{}` is a directory but its `wado.toml` could not be read: {e}",
+            dir.display()
+        ),
+    })?;
+    let manifest: wado_manifest::Manifest = text.parse().map_err(|e| ProviderError::Internal {
+        message: format!("kiln: failed to parse `{}`: {e}", manifest_path.display()),
+    })?;
+    let entry = manifest
+        .world_entry("core:kiln/generator")
+        .ok_or_else(|| ProviderError::Internal {
+            message: format!(
+                "kiln: generator package `{}` declares no [world].\"core:kiln/generator\" entry",
+                dir.display()
+            ),
+        })?;
+    Ok(dir.join(entry))
 }
 
 /// Convert the absolute paths the recording host captured into project-
@@ -651,6 +691,91 @@ mod tests {
             }
             _ => panic!("expected Unsupported"),
         }
+    }
+
+    #[test]
+    fn directory_module_resolves_package_generator_entry() {
+        // `module: "../package-gale"` (a directory) must resolve to the
+        // package's `[world]."core:kiln/generator"` entry, exactly as if
+        // the author had pointed `module` at that entry file directly.
+        let tmp = std::env::temp_dir().join(format!(
+            "wado-kiln-provider-dir-module-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&tmp);
+        let pkg = tmp.join("gen-pkg");
+        std::fs::create_dir_all(pkg.join("src")).unwrap();
+        std::fs::write(
+            pkg.join("wado.toml"),
+            "[package]\nname = \"genpkg\"\nversion = \"0.1.0\"\n\n\
+             [world]\n\"core:kiln/generator\" = \"src/generator.wado\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            pkg.join("src/generator.wado"),
+            "\
+use { RawRequest, Response, Error, bind_request } from \"core:kiln\";\n\
+\n\
+pub struct Options {\n\
+    pub verbose: bool,\n\
+}\n\
+\n\
+export fn generate(raw: RawRequest) -> Result<Response, Error> {\n\
+    let req = match bind_request::<Options>(raw) {\n\
+        Ok(r) => r,\n\
+        Err(e) => return Result::Err(e),\n\
+    };\n\
+    let _ = req.options.verbose;\n\
+    return Result::Ok(Response { files: [] });\n\
+}\n",
+        )
+        .unwrap();
+
+        let provider = CliGeneratorProvider::new(tmp.clone());
+        let module = GeneratorModule::LocalPath(InvocationPath::normalize("./gen-pkg"));
+        let resolved = runtime()
+            .block_on(async { provider.resolve(&module).await })
+            .unwrap_or_else(|e| panic!("directory module resolve failed: {e:?}"));
+        assert!(resolved.wasm.starts_with(b"\0asm"), "wasm magic missing");
+        let descriptor = resolved
+            .descriptor
+            .as_ref()
+            .expect("Options struct present → descriptor must be Some");
+        assert_eq!(descriptor.fields[0].name, "verbose");
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn directory_module_without_generator_world_surfaces_internal() {
+        let tmp = std::env::temp_dir().join(format!(
+            "wado-kiln-provider-dir-noworld-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&tmp);
+        let pkg = tmp.join("plain-pkg");
+        std::fs::create_dir_all(&pkg).unwrap();
+        std::fs::write(
+            pkg.join("wado.toml"),
+            "[package]\nname = \"plain\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+
+        let provider = CliGeneratorProvider::new(tmp.clone());
+        let module = GeneratorModule::LocalPath(InvocationPath::normalize("./plain-pkg"));
+        let err = runtime()
+            .block_on(async { provider.resolve(&module).await })
+            .unwrap_err();
+        match err {
+            ProviderError::Internal { message } => {
+                assert!(
+                    message.contains("core:kiln/generator"),
+                    "unexpected message: {message}"
+                );
+            }
+            _ => panic!("expected Internal, got {err:?}"),
+        }
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     #[test]

--- a/wado-cli/src/kiln_provider.rs
+++ b/wado-cli/src/kiln_provider.rs
@@ -3,11 +3,14 @@
 //! Resolves a [`GeneratorModule`] into a [`ResolvedGenerator`] (wasm
 //! bytes + options descriptor + source-closure hash) for the Kiln
 //! driver. Supports [`GeneratorModule::LocalPath`] (`module:
-//! "./generator.wado"`, or a directory like `module: "../package-gale"`
-//! that resolves to the package's `[world]."core:kiln/generator"` entry)
-//! and [`GeneratorModule::BuildDep`] (`module:
+//! "./generator.wado"`) and [`GeneratorModule::BuildDep`] (`module:
 //! "gale"`, resolved against `[build-dependencies]` to the package's
-//! `core:kiln/generator` world entry). Spec-form generators (`module =
+//! `core:kiln/generator` world entry). A directory `module:` (e.g.
+//! `"../package-gale"`) is rewritten to its package's
+//! `[world]."core:kiln/generator"` entry by
+//! [`crate::compile::rewrite_local_dir_modules`] before resolution, so it
+//! reaches this provider as a plain `LocalPath` to the entry file.
+//! Spec-form generators (`module =
 //! "ns:name@ver"`) surface [`ProviderError::Unsupported`] — registry/git
 //! module sources are deferred to a follow-up.
 //!
@@ -137,8 +140,8 @@ impl CliGeneratorProvider {
         &self,
         path: &wado_compiler::kiln::InvocationPath,
     ) -> Result<(PathBuf, Vec<u8>, String, String), ProviderError> {
-        let resolved = self.resolve_path(path.as_str());
-        if !resolved.exists() {
+        let abs = self.resolve_path(path.as_str());
+        if !abs.exists() {
             return Err(ProviderError::Internal {
                 message: format!(
                     "kiln: generator path `{}` does not exist (relative to manifest root {})",
@@ -147,16 +150,21 @@ impl CliGeneratorProvider {
                 ),
             });
         }
-        // A directory `module:` points at a generator *package*: resolve its
-        // `[world]."core:kiln/generator"` entry from the package's `wado.toml`,
-        // mirroring how a bare `[build-dependencies]` name resolves. This lets
-        // `module: "../package-gale"` work the same as pointing `module`
-        // straight at `../package-gale/src/generator.wado`.
-        let abs = if resolved.is_dir() {
-            resolve_package_generator_entry(&resolved)?
-        } else {
-            resolved
-        };
+        // A directory module is resolved to its package's
+        // `[world]."core:kiln/generator"` entry up front by
+        // `compile::rewrite_local_dir_modules`, so a directory reaching the
+        // provider is a package that declared no such entry. Report that
+        // instead of letting `std::fs::read` surface a bare "Is a directory".
+        if abs.is_dir() {
+            return Err(ProviderError::Internal {
+                message: format!(
+                    "kiln: generator module `{}` is a directory but is not a generator package: \
+                     its `wado.toml` is missing or declares no [world].\"core:kiln/generator\" \
+                     entry. Point `module` at a generator package directory or a `.wado` file",
+                    path.as_str(),
+                ),
+            });
+        }
         let source = std::fs::read(&abs).map_err(|e| ProviderError::Internal {
             message: format!(
                 "kiln: failed to read generator source at `{}`: {e}",
@@ -308,34 +316,6 @@ impl CliGeneratorProvider {
 
         Ok(artifacts)
     }
-}
-
-/// Resolve a directory `module:` path to the generator package's
-/// `[world]."core:kiln/generator"` entry file. `dir` must contain a
-/// `wado.toml` that declares such a world entry; the returned path is
-/// `dir.join(<entry>)`. This is the filesystem counterpart of
-/// [`crate::compile::rewrite_build_dep_modules`] for path-addressed
-/// (rather than `[build-dependencies]`-named) generator packages.
-fn resolve_package_generator_entry(dir: &Path) -> Result<PathBuf, ProviderError> {
-    let manifest_path = dir.join("wado.toml");
-    let text = std::fs::read_to_string(&manifest_path).map_err(|e| ProviderError::Internal {
-        message: format!(
-            "kiln: generator module `{}` is a directory but its `wado.toml` could not be read: {e}",
-            dir.display()
-        ),
-    })?;
-    let manifest: wado_manifest::Manifest = text.parse().map_err(|e| ProviderError::Internal {
-        message: format!("kiln: failed to parse `{}`: {e}", manifest_path.display()),
-    })?;
-    let entry = manifest
-        .world_entry("core:kiln/generator")
-        .ok_or_else(|| ProviderError::Internal {
-            message: format!(
-                "kiln: generator package `{}` declares no [world].\"core:kiln/generator\" entry",
-                dir.display()
-            ),
-        })?;
-    Ok(dir.join(entry))
 }
 
 /// Convert the absolute paths the recording host captured into project-
@@ -694,62 +674,13 @@ mod tests {
     }
 
     #[test]
-    fn directory_module_resolves_package_generator_entry() {
-        // `module: "../package-gale"` (a directory) must resolve to the
-        // package's `[world]."core:kiln/generator"` entry, exactly as if
-        // the author had pointed `module` at that entry file directly.
+    fn directory_module_reaching_provider_surfaces_internal() {
+        // A directory is resolved to its package entry up front by
+        // `compile::rewrite_local_dir_modules`; one that still reaches the
+        // provider declared no `core:kiln/generator` entry, so the provider
+        // reports that instead of a bare "Is a directory" read error.
         let tmp = std::env::temp_dir().join(format!(
             "wado-kiln-provider-dir-module-{}",
-            std::process::id()
-        ));
-        let _ = std::fs::remove_dir_all(&tmp);
-        let pkg = tmp.join("gen-pkg");
-        std::fs::create_dir_all(pkg.join("src")).unwrap();
-        std::fs::write(
-            pkg.join("wado.toml"),
-            "[package]\nname = \"genpkg\"\nversion = \"0.1.0\"\n\n\
-             [world]\n\"core:kiln/generator\" = \"src/generator.wado\"\n",
-        )
-        .unwrap();
-        std::fs::write(
-            pkg.join("src/generator.wado"),
-            "\
-use { RawRequest, Response, Error, bind_request } from \"core:kiln\";\n\
-\n\
-pub struct Options {\n\
-    pub verbose: bool,\n\
-}\n\
-\n\
-export fn generate(raw: RawRequest) -> Result<Response, Error> {\n\
-    let req = match bind_request::<Options>(raw) {\n\
-        Ok(r) => r,\n\
-        Err(e) => return Result::Err(e),\n\
-    };\n\
-    let _ = req.options.verbose;\n\
-    return Result::Ok(Response { files: [] });\n\
-}\n",
-        )
-        .unwrap();
-
-        let provider = CliGeneratorProvider::new(tmp.clone());
-        let module = GeneratorModule::LocalPath(InvocationPath::normalize("./gen-pkg"));
-        let resolved = runtime()
-            .block_on(async { provider.resolve(&module).await })
-            .unwrap_or_else(|e| panic!("directory module resolve failed: {e:?}"));
-        assert!(resolved.wasm.starts_with(b"\0asm"), "wasm magic missing");
-        let descriptor = resolved
-            .descriptor
-            .as_ref()
-            .expect("Options struct present → descriptor must be Some");
-        assert_eq!(descriptor.fields[0].name, "verbose");
-
-        let _ = std::fs::remove_dir_all(&tmp);
-    }
-
-    #[test]
-    fn directory_module_without_generator_world_surfaces_internal() {
-        let tmp = std::env::temp_dir().join(format!(
-            "wado-kiln-provider-dir-noworld-{}",
             std::process::id()
         ));
         let _ = std::fs::remove_dir_all(&tmp);
@@ -769,7 +700,7 @@ export fn generate(raw: RawRequest) -> Result<Response, Error> {\n\
         match err {
             ProviderError::Internal { message } => {
                 assert!(
-                    message.contains("core:kiln/generator"),
+                    message.contains("is a directory") && message.contains("core:kiln/generator"),
                     "unexpected message: {message}"
                 );
             }


### PR DESCRIPTION
## Summary

A `use ... with { generator: { module } }` clause now accepts a generator **package directory**, not just a `.wado` file. Pointing `module` at a package (e.g. `module: "../package-gale"`) previously failed with `failed to read generator source ...: Is a directory`; it now resolves to the package's `[world]."core:kiln/generator"` entry, the same way a bare `[build-dependencies]` name does. `example/wado_syntax_highlight.wado` (the Gale-based highlighter example) uses the directory form.

Directory resolution happens **before** the Kiln pipeline runs, in `rewrite_local_dir_modules` — a sibling of the existing `rewrite_build_dep_modules`. The directory `module:` is rewritten to a `LocalPath` pointing at the package's entry file, so the directory / direct-file / `[build-dependencies]` spellings of one generator collapse onto a single path-addressed identity (and cache key) instead of three separate slots. The package-directory → generator-entry lookup is one shared helper, `package_generator_entry`, used by both the directory rewrite and `build_dep_generator_local_path`, so the two paths cannot drift. The provider no longer resolves directories; it only reports a clear error when a non-package directory reaches it.

## Also: left-factor `example/Wado.g4`

The example grammar is left-factored to remove 7 of Gale's 12 overlap-tournament advisories — the alternatives that could be made token-led by hoisting a shared prefix (`attrArg`, `fieldInit`, `patternField`, `exprPath`, `postfixOp`, and the `pub`-prefixed `itemKind` / `implMember`). These are equivalence-preserving rewrites. The remaining 5 advisories are genuine LL ambiguities (statement/expression overlap, struct-literal vs path on an identifier, type-vs-expr in `with` bindings, block-vs-map in `(block | expression)`) that Gale resolves soundly via its longest-match tournament and that cannot be removed without changing the accepted language.

https://claude.ai/code/session_01F5bz3SVyTR82YgZGogqqBw

---
_Generated by [Claude Code](https://claude.ai/code/session_01F5bz3SVyTR82YgZGogqqBw)_