### PR TITLE
feat(cli): default `wado test` to -O0

### DIFF
--- a/wado-cli/src/test.rs
+++ b/wado-cli/src/test.rs
@@ -350,7 +350,13 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<TestOptions, CliExit> {
     let mut test_name_filters: Vec<String> = Vec::new();
     let mut cli_excludes: Vec<String> = Vec::new();
     let mut jobs: Option<usize> = None;
-    let mut opt_level = OptLevel::default();
+    // `wado test` defaults to -O0, not the `wado compile` production O2. The
+    // NIR optimizer buys nothing for test correctness, and on large generated
+    // modules (e.g. package-gale fixtures) it dominates compile time —
+    // `store_load_forward` / `condition_implication` run superlinearly, e.g.
+    // ~96s at O2 vs ~5s at O0 for the generated css3 parser. Pass `-O2`
+    // explicitly to test optimized codegen.
+    let mut opt_level = OptLevel::O0;
     let mut log_level = args::DEFAULT_LOG_LEVEL;
     let mut inline_threshold: Option<usize> = None;
     let mut opt_iterations: Option<u32> = None;

--- a/wado-cli/src/test.rs
+++ b/wado-cli/src/test.rs
@@ -350,12 +350,6 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<TestOptions, CliExit> {
     let mut test_name_filters: Vec<String> = Vec::new();
     let mut cli_excludes: Vec<String> = Vec::new();
     let mut jobs: Option<usize> = None;
-    // `wado test` defaults to -O0, not the `wado compile` production O2. The
-    // NIR optimizer buys nothing for test correctness, and on large generated
-    // modules (e.g. package-gale fixtures) it dominates compile time —
-    // `store_load_forward` / `condition_implication` run superlinearly, e.g.
-    // ~96s at O2 vs ~5s at O0 for the generated css3 parser. Pass `-O2`
-    // explicitly to test optimized codegen.
     let mut opt_level = OptLevel::O0;
     let mut log_level = args::DEFAULT_LOG_LEVEL;
     let mut inline_threshold: Option<usize> = None;

--- a/wado-cli/tests/cli_parse.rs
+++ b/wado-cli/tests/cli_parse.rs
@@ -498,10 +498,6 @@ fn test_with_exclude_drops_matching_explicit_file() {
 
 #[test]
 fn test_defaults_to_o0() {
-    // `wado test` defaults to -O0: the heavy NIR optimizer (production
-    // default for `wado compile`) buys nothing for test correctness and
-    // dominates compile time on large generated modules (e.g. package-gale
-    // fixtures). Tests opt into a higher level explicitly when they need it.
     let parser = Parser::from_args(&["a.wado"]);
     let opts = wado_cli::test::parse_args(parser).unwrap();
     assert_eq!(opts.opt_level, OptLevel::O0);

--- a/wado-cli/tests/cli_parse.rs
+++ b/wado-cli/tests/cli_parse.rs
@@ -497,6 +497,24 @@ fn test_with_exclude_drops_matching_explicit_file() {
 }
 
 #[test]
+fn test_defaults_to_o0() {
+    // `wado test` defaults to -O0: the heavy NIR optimizer (production
+    // default for `wado compile`) buys nothing for test correctness and
+    // dominates compile time on large generated modules (e.g. package-gale
+    // fixtures). Tests opt into a higher level explicitly when they need it.
+    let parser = Parser::from_args(&["a.wado"]);
+    let opts = wado_cli::test::parse_args(parser).unwrap();
+    assert_eq!(opts.opt_level, OptLevel::O0);
+}
+
+#[test]
+fn test_opt_level_override() {
+    let parser = Parser::from_args(&["-O2", "a.wado"]);
+    let opts = wado_cli::test::parse_args(parser).unwrap();
+    assert_eq!(opts.opt_level, OptLevel::O2);
+}
+
+#[test]
 fn test_with_parallel() {
     let parser = Parser::from_args(&["-p", "4", "a.wado"]);
     let opts = wado_cli::test::parse_args(parser).unwrap();


### PR DESCRIPTION
## Problem

`wado test` inherited `wado compile`'s production `-O2` default, so every test
target ran through the full NIR optimizer. That optimization buys nothing for
test correctness and dominates compile time on large generated modules.

This is the root cause of the slow CI tidy step (`wado test --no-run
package-gale`, ~50min). Investigation showed:

- The Gale generator is **not** rebuilt per file — it is compiled once and
  cached in `build/kiln/generators/`; warm resolves are sub-second.
- The time sink is compiling the large generated parser fixtures at O2. The
  generated css3 parser (41k lines) takes **~96s at -O2 vs ~5s at -O0**, almost
  entirely in `nir/store_load_forward` (39s) and `nir/condition_implication`
  (23s).

## Change

Default `wado test` to `-O0` (`wado compile` stays at O2). Measured ~12x on a
10-fixture warm subset (99s → 8s); kiln artifacts are unaffected.

Jobs that need a specific optimization level already pass `-O` explicitly and
are unaffected:

- `test-gale-o1/o2/o3` → `wado test -O1/-O2/-O3 package-gale`

## Tests

- `test_defaults_to_o0` — default is O0 (red before the change).
- `test_opt_level_override` — `-O2` still overrides.

https://claude.ai/code/session_01BpXNqhYP6TWmWF42jYqQmA

---
_Generated by [Claude Code](https://claude.ai/code/session_01BpXNqhYP6TWmWF42jYqQmA)_