### PR TITLE
feat(cli): support --world on check, document the option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ The CLI is implemented in `wado-cli/` as a subcommand-style CLI. The sections be
 
 In the examples below, `wado` is shorthand for `cargo run --bin wado --`.
 
-A Wado program targets a Wasm _world_: the CLI command (`wasi:cli/command`, the default), the HTTP service (`wasi:http/service`, run via `wado serve`), or the test world (`wasi:test`, used by E2E tests). Several defaults — including the allocator — depend on the target world.
+A Wado program targets a Wasm _world_: the CLI command (`wasi:cli/command`, the default), the HTTP service (`wasi:http/service`, run via `wado serve`), or the synthetic test world (selected with `--world test`, used by E2E tests). Several defaults — including the allocator — depend on the target world.
 
 ### Compile Command
 
@@ -125,6 +125,15 @@ wado compile --no-validate --wat-to-stdout file.wado
 ```
 
 Optimization levels: `-O0` (none), `-O1` (development), `-O2` (production, default), `-O3` (aggressive), `-Os` (`-O2` + strip symbols).
+
+#### Target World
+
+`--world <name>` overrides the target world (default: `wasi:cli/command`). `--world test` selects the test world, exporting the entry module's `test` blocks and dropping everything else. `compile` and `check` accept it; `serve` and `test` pick their world automatically.
+
+```sh
+wado compile --world test file.wado  # compile against the test world
+wado check --world test file.wado    # type-check against the test world
+```
 
 #### Allocators
 

--- a/wado-cli/src/check.rs
+++ b/wado-cli/src/check.rs
@@ -24,18 +24,22 @@ pub struct CheckOptions {
     /// `false` (default) → Kiln warnings produce a non-zero exit. `true`
     /// → keep them as warnings (developer-friendly local triage).
     pub warn_only: bool,
+    /// Target world to check against (default: `wasi:cli/command`). `Some("test")`
+    /// type-checks the entry module as the synthetic test world.
+    pub target_world: Option<String>,
     pub log_level: LogLevel,
 }
 
 #[derive(Clone, Copy)]
 enum Opt {
     Warn,
+    World,
     LogLevel,
     Help,
 }
 
 impl Opt {
-    const ALL: &[Self] = &[Self::Warn, Self::LogLevel, Self::Help];
+    const ALL: &[Self] = &[Self::Warn, Self::World, Self::LogLevel, Self::Help];
 
     const fn spec(self) -> args::OptSpec {
         match self {
@@ -45,6 +49,7 @@ impl Opt {
                 value: None,
                 desc: "Keep Kiln warnings as warnings instead of promoting them to errors",
             },
+            Self::World => args::WORLD_SPEC,
             Self::LogLevel => args::LOG_LEVEL_SPEC,
             Self::Help => args::HELP_SPEC,
         }
@@ -82,11 +87,13 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<CheckOptions, CliExit> {
     let usage = format_usage();
     let mut input: Option<String> = None;
     let mut warn_only = false;
+    let mut target_world: Option<String> = None;
     let mut log_level = args::DEFAULT_LOG_LEVEL;
     while let Some(arg) = args::next_arg(&mut parser)? {
         if let Some(opt) = args::match_opt(&arg, Opt::ALL, |o| o.spec()) {
             match opt {
                 Opt::Warn => warn_only = true,
+                Opt::World => target_world = Some(args::require_string(&mut parser)?),
                 Opt::LogLevel => log_level = args::parse_log_level_arg(&mut parser)?,
                 Opt::Help => {
                     return Err(CliExit::help(usage));
@@ -103,6 +110,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<CheckOptions, CliExit> {
     Ok(CheckOptions {
         input,
         warn_only,
+        target_world,
         log_level,
     })
 }
@@ -157,6 +165,7 @@ pub async fn run(opts: CheckOptions) -> Result<(), CliExit> {
     })?;
     let compiler_options = wado_compiler::CompilerOptions {
         log_level: Some(opts.log_level),
+        target_world: opts.target_world.clone(),
         invocations: outcome.invocations.clone(),
         ..Default::default()
     };

--- a/wado-cli/tests/cli.rs
+++ b/wado-cli/tests/cli.rs
@@ -60,6 +60,67 @@ fn test_compile_wat_to_stdout() {
 }
 
 #[test]
+fn test_compile_world_test_exports_tests() {
+    // `--world test` targets the synthetic test world: the entry module's
+    // `test` blocks become component exports (kebab-cased, plus a
+    // `wado:test-names` custom section), and no `run` entry point is required.
+    wado()
+        .args([
+            "compile",
+            "--world",
+            "test",
+            "--wat-to-stdout",
+            "wado-compiler/tests/fixtures/test_decl.wado",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("test-0-simple"))
+        .stdout(predicate::str::contains("wado:test-names"));
+}
+
+#[test]
+fn test_compile_world_default_requires_run() {
+    // Without `--world test` the same file targets `wasi:cli/command`, which
+    // requires a `run` entry point the fixture does not define — proof the
+    // world selection actually changes compilation.
+    wado()
+        .args([
+            "compile",
+            "--wat-to-stdout",
+            "wado-compiler/tests/fixtures/test_decl.wado",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("run"));
+}
+
+#[test]
+fn test_check_world_test_accepts_test_only_module() {
+    // `wado check --world test` type-checks against the test world, so a
+    // module with only `test` blocks (no `run`) passes.
+    wado()
+        .args([
+            "check",
+            "--world",
+            "test",
+            "wado-compiler/tests/fixtures/test_decl.wado",
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_check_world_default_requires_run() {
+    // Without `--world test`, `wado check` targets `wasi:cli/command` and the
+    // missing `run` entry point makes the check fail.
+    wado()
+        .args(["check", "wado-compiler/tests/fixtures/test_decl.wado"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("run"));
+}
+
+#[test]
 fn test_run_hello() {
     wado()
         .args(["run", "example/hello.wado"])

--- a/wado-cli/tests/cli_parse.rs
+++ b/wado-cli/tests/cli_parse.rs
@@ -6,6 +6,7 @@
 use lexopt::Parser;
 
 use wado_cli::args::CliExit;
+use wado_cli::check;
 use wado_cli::compile::{self, OptLevel, OutputFormat};
 
 /// Assert that a `Result<T, CliExit>` is an error with exit code 1
@@ -118,6 +119,20 @@ fn compile_world() {
     let parser = Parser::from_args(&["--world", "test", "input.wado"]);
     let opts = compile::parse_args(parser).unwrap();
     assert_eq!(opts.target_world, Some("test".to_string()));
+}
+
+#[test]
+fn check_world() {
+    let parser = Parser::from_args(&["--world", "test", "input.wado"]);
+    let opts = check::parse_args(parser).unwrap();
+    assert_eq!(opts.target_world, Some("test".to_string()));
+}
+
+#[test]
+fn check_world_defaults_to_none() {
+    let parser = Parser::from_args(&["input.wado"]);
+    let opts = check::parse_args(parser).unwrap();
+    assert_eq!(opts.target_world, None);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`--world` was only wired into `wado compile`. This extends it to `wado check` and adds the missing documentation and tests.

- **`wado check --world <name>`**: forwards the target world to the compiler, so a test-only module (no `run`) can be type-checked against the synthetic test world. Previously `check` was hardwired to the default `wasi:cli/command`.
- **Docs**: `AGENTS.md` now documents the `--world` option in a `Target World` subsection, and the world overview is corrected — the test world is selected via `--world test`, not `wasi:test`.

## Tests

- Parse-level (`cli_parse.rs`): `check --world test` and its `None` default.
- E2E (`cli.rs`): `compile`/`check --world test` accept a test-only module (and `compile` emits test-world exports), while the default world fails for the missing `run` entry point — proof the world selection actually changes compilation.

All new tests pass (`cli`: 20, `cli_parse`: 93). `cargo fmt` and markdown formatting applied.

https://claude.ai/code/session_01PjnCGNKbNbgHezDNNfK8Qa

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjnCGNKbNbgHezDNNfK8Qa)_