### PR TITLE
perf(elaborator): index-driven method &amp; trait lookup

### DIFF
--- a/wado-compiler/src/elaborator/expr.rs
+++ b/wado-compiler/src/elaborator/expr.rs
@@ -1376,9 +1376,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
             // First, try Index trait (returns reference)
             // Try the direct name first, then fall back to base type name for newtypes
-            let index_trait_info = self
-                .find_index_trait_impl(&struct_name, base_type_id, index_type)
-                .or_else(|| self.find_index_trait_impl(&lookup_name, lookup_type_id, index_type));
+            let index_trait_info = self.index_lookup_or_newtype_base(
+                &struct_name,
+                base_type_id,
+                &lookup_name,
+                lookup_type_id,
+                |s, n, t| s.find_index_trait_impl(n, t, index_type),
+            );
             if let Some(trait_info) = index_trait_info {
                 // Generate: *expr.index(index_expr)
                 let mangled_method_name =
@@ -1423,11 +1427,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             }
 
             // Fallback: try IndexValue trait (returns value by copy)
-            let index_value_info = self
-                .find_index_value_trait_impl(&struct_name, base_type_id, index_type)
-                .or_else(|| {
-                    self.find_index_value_trait_impl(&lookup_name, lookup_type_id, index_type)
-                });
+            let index_value_info = self.index_lookup_or_newtype_base(
+                &struct_name,
+                base_type_id,
+                &lookup_name,
+                lookup_type_id,
+                |s, n, t| s.find_index_value_trait_impl(n, t, index_type),
+            );
             if let Some(trait_info) = index_value_info {
                 // Generate: expr.index_value(index_expr)
                 let mangled_method_name = MethodName::format_local(

--- a/wado-compiler/src/elaborator/method_call.rs
+++ b/wado-compiler/src/elaborator/method_call.rs
@@ -2399,11 +2399,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         None
     }
 
-    /// Impl blocks whose receiver base name is `struct_name`, from the
-    /// pre-built `all_impl_index`, ordered current-module-first to preserve the
-    /// former "current items, then loaded modules" scan precedence. Replaces an
-    /// O(all items in all modules) walk per call. `all_impl_index` is already
-    /// in global order, so partitioning by module needs no per-call sort.
+    /// Impl blocks on `struct_name`, current-module-first. `all_impl_index` is
+    /// already in global order, so the partition needs no per-call sort.
     fn impl_blocks_for_type<'b>(&'b self, struct_name: &str) -> Vec<&'b ast::ImplBlock> {
         let Some(keys) = self.tysys.trait_env.all_impl_index.get(struct_name) else {
             return Vec::new();

--- a/wado-compiler/src/elaborator/method_call.rs
+++ b/wado-compiler/src/elaborator/method_call.rs
@@ -2400,34 +2400,32 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     }
 
     /// Impl blocks whose receiver base name is `struct_name`, from the
-    /// pre-built inherent + trait impl indices, ordered current-module-first to
-    /// preserve the former "current items, then loaded modules" scan
-    /// precedence. Replaces an O(all items in all modules) walk per call.
+    /// pre-built `all_impl_index`, ordered current-module-first to preserve the
+    /// former "current items, then loaded modules" scan precedence. Replaces an
+    /// O(all items in all modules) walk per call. `all_impl_index` is already
+    /// in global order, so partitioning by module needs no per-call sort.
     fn impl_blocks_for_type<'b>(&'b self, struct_name: &str) -> Vec<&'b ast::ImplBlock> {
-        let env = &self.tysys.trait_env;
-        let mut keys: Vec<&(ModuleSource, usize)> = Vec::new();
-        if let Some(entries) = env.inherent_impl_index.get(struct_name) {
-            keys.extend(entries.iter());
+        let Some(keys) = self.tysys.trait_env.all_impl_index.get(struct_name) else {
+            return Vec::new();
+        };
+        let mut current: Vec<&ast::ImplBlock> = Vec::new();
+        let mut others: Vec<&ast::ImplBlock> = Vec::new();
+        for key in keys {
+            let Some(Item::Impl(impl_block)) = self
+                .loaded_modules
+                .get(&key.0)
+                .and_then(|m| m.items.get(key.1))
+            else {
+                continue;
+            };
+            if key.0 == self.current_module_source {
+                current.push(impl_block);
+            } else {
+                others.push(impl_block);
+            }
         }
-        if let Some(entries) = env.impl_index.get(struct_name) {
-            keys.extend(entries.iter());
-        }
-        keys.sort_by_key(|key| {
-            // false (current module) sorts before true; within each group keep
-            // the original global insertion order via the header index.
-            (
-                key.0 != self.current_module_source,
-                env.impl_headers.get_index_of(*key),
-            )
-        });
-        keys.into_iter()
-            .filter_map(
-                |key| match self.loaded_modules.get(&key.0)?.items.get(key.1) {
-                    Some(Item::Impl(impl_block)) => Some(impl_block),
-                    _ => None,
-                },
-            )
-            .collect()
+        current.extend(others);
+        current
     }
 
     /// Look up whether each non-self parameter of an instance method is `mut`.

--- a/wado-compiler/src/elaborator/method_call.rs
+++ b/wado-compiler/src/elaborator/method_call.rs
@@ -2399,37 +2399,50 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         None
     }
 
+    /// Impl blocks whose receiver base name is `struct_name`, from the
+    /// pre-built inherent + trait impl indices, ordered current-module-first to
+    /// preserve the former "current items, then loaded modules" scan
+    /// precedence. Replaces an O(all items in all modules) walk per call.
+    fn impl_blocks_for_type<'b>(&'b self, struct_name: &str) -> Vec<&'b ast::ImplBlock> {
+        let env = &self.tysys.trait_env;
+        let mut keys: Vec<&(ModuleSource, usize)> = Vec::new();
+        if let Some(entries) = env.inherent_impl_index.get(struct_name) {
+            keys.extend(entries.iter());
+        }
+        if let Some(entries) = env.impl_index.get(struct_name) {
+            keys.extend(entries.iter());
+        }
+        keys.sort_by_key(|key| {
+            // false (current module) sorts before true; within each group keep
+            // the original global insertion order via the header index.
+            (
+                key.0 != self.current_module_source,
+                env.impl_headers.get_index_of(*key),
+            )
+        });
+        keys.into_iter()
+            .filter_map(
+                |key| match self.loaded_modules.get(&key.0)?.items.get(key.1) {
+                    Some(Item::Impl(impl_block)) => Some(impl_block),
+                    _ => None,
+                },
+            )
+            .collect()
+    }
+
     /// Look up whether each non-self parameter of an instance method is `mut`.
     /// Returns empty vec (conservative) for unknown methods.
     fn lookup_method_param_is_mut(&self, struct_name: &str, method_name: &str) -> Vec<bool> {
-        let find_in_items = |items: &[Item]| -> Option<Vec<bool>> {
-            items.iter().find_map(|item| {
-                if let Item::Impl(impl_block) = item {
-                    let impl_struct_name = Self::get_type_name_static(&impl_block.ty);
-                    if impl_struct_name == struct_name {
-                        for method in &impl_block.methods {
-                            if method.name == method_name {
-                                let is_muts: Vec<bool> = method
-                                    .params
-                                    .iter()
-                                    .filter(|p| p.self_kind == ast::SelfKind::None)
-                                    .map(|p| p.is_mut)
-                                    .collect();
-                                return Some(is_muts);
-                            }
-                        }
-                    }
+        for impl_block in self.impl_blocks_for_type(struct_name) {
+            for method in &impl_block.methods {
+                if method.name == method_name {
+                    return method
+                        .params
+                        .iter()
+                        .filter(|p| p.self_kind == ast::SelfKind::None)
+                        .map(|p| p.is_mut)
+                        .collect();
                 }
-                None
-            })
-        };
-
-        if let Some(result) = find_in_items(self.current_module_items) {
-            return result;
-        }
-        for module in self.loaded_modules.values() {
-            if let Some(result) = find_in_items(&module.items) {
-                return result;
             }
         }
         Vec::new()
@@ -2442,32 +2455,15 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         struct_name: &str,
         method_name: &str,
     ) -> Vec<bool> {
-        let find_in_items = |items: &[Item]| -> Option<Vec<bool>> {
-            items.iter().find_map(|item| {
-                if let Item::Impl(impl_block) = item {
-                    let impl_struct_name = Self::get_type_name_static(&impl_block.ty);
-                    if impl_struct_name == struct_name {
-                        for method in &impl_block.methods {
-                            let has_self = method
-                                .params
-                                .iter()
-                                .any(|p| p.self_kind != ast::SelfKind::None);
-                            if method.name == method_name && !has_self {
-                                return Some(method.params.iter().map(|p| p.is_mut).collect());
-                            }
-                        }
-                    }
+        for impl_block in self.impl_blocks_for_type(struct_name) {
+            for method in &impl_block.methods {
+                let has_self = method
+                    .params
+                    .iter()
+                    .any(|p| p.self_kind != ast::SelfKind::None);
+                if method.name == method_name && !has_self {
+                    return method.params.iter().map(|p| p.is_mut).collect();
                 }
-                None
-            })
-        };
-
-        if let Some(result) = find_in_items(self.current_module_items) {
-            return result;
-        }
-        for module in self.loaded_modules.values() {
-            if let Some(result) = find_in_items(&module.items) {
-                return result;
             }
         }
         Vec::new()

--- a/wado-compiler/src/elaborator/method_lookup.rs
+++ b/wado-compiler/src/elaborator/method_lookup.rs
@@ -211,25 +211,17 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     }
 
     /// Shared scan-and-map prologue behind `find_indexing_trait_impl`,
-    /// `find_assoc_type_in_trait_impl`, and `find_arithmetic_trait_impl`.
-    ///
-    /// Walks the trait impls on `struct_name` whose trait name satisfies
-    /// `trait_matches`, builds each candidate's type-parameter mapping from
-    /// `concrete_type_args`, and returns the first non-`None` `project` result.
-    /// Each caller's per-candidate filtering, `Self` handling, and projection
-    /// stay inside `project` (returning `None` skips the candidate); the
-    /// prologue owns only the two mechanical axes the three copies drifted on:
+    /// `find_assoc_type_in_trait_impl`, and `find_arithmetic_trait_impl`: walk
+    /// the trait impls on `struct_name` whose name satisfies `trait_matches`,
+    /// build each candidate's type-parameter mapping from `concrete_type_args`,
+    /// and return the first non-`None` `project` (per-candidate filtering,
+    /// `Self` handling, and projection live in `project`; `None` skips it).
     ///
     /// - `trait_matches`: prefix (indexing / assoc) vs exact (arithmetic).
     /// - `use_declared_type_params`: when false, `build_type_param_mapping`
-    ///   treats every `Named` impl arg as a type parameter (the arithmetic
-    ///   path's legacy behavior); when true it consults the impl's declared
-    ///   params. The resolved declared set is handed to `project` so callers
-    ///   that also run `verify_impl_type_compatibility` reuse it.
-    ///
-    /// `collect_trait_impl_refs` already keys on `struct_name`, so the former
-    /// per-candidate `get_type_name(&impl.ty) == struct_name` re-check (always
-    /// true here) is dropped.
+    ///   treats every `Named` impl arg as a type parameter (arithmetic's legacy
+    ///   behavior); when true it consults the impl's declared params, which are
+    ///   also handed to `project`.
     fn probe_trait_impls<R>(
         &mut self,
         struct_name: &str,
@@ -1522,12 +1514,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         include_trait: bool,
         only_module: Option<&ModuleSource>,
     ) -> Option<Vec<ast::GenericParam>> {
-        // Candidate impl-header keys for this receiver type, in global build
-        // order, keyed by the bare receiver name `get_type_name_static` yields
-        // (the same name the former scan compared against). Iterating
-        // `all_impl_index` directly preserves the original order — and the
-        // original `!include_trait` `trait_name.is_some()` skip — with no merge
-        // or per-call sort.
+        // `all_impl_index` is already in global build order, so iterating it
+        // directly preserves the original order with no merge or per-call sort.
         let Some(candidates) = self.tysys.trait_env.all_impl_index.get(struct_name) else {
             return None;
         };
@@ -1732,8 +1720,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
     /// `struct_name` plus the base names of its newtype chain
     /// (`type Alias = Base` → `Base`, `Flags` → `u32`), so a trait impl on a
-    /// base type is reachable through the alias. Phase A of
-    /// [`Self::find_trait_method_for_type_inner`].
+    /// base type is reachable through the alias.
     fn newtype_chain_names(&self, struct_name: &str) -> Vec<String> {
         let mut names = vec![struct_name.to_string()];
         if let Some(newtype_id) = self.lookup_newtype(struct_name) {
@@ -1756,9 +1743,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         names
     }
 
-    /// Candidate trait impls for [`Self::find_trait_method_for_type_inner`]
-    /// (Phase A): every trait impl on one of `names_to_check`, plus blanket
-    /// impls (`impl<T: Bound> Trait for T`) whose bound the receiver satisfies.
+    /// Every trait impl on one of `names_to_check`, plus blanket impls
+    /// (`impl<T: Bound> Trait for T`) whose bound the receiver satisfies.
     fn trait_method_candidates(&mut self, names_to_check: &[String]) -> Vec<ImplBlockRef> {
         // Collect lightweight impl block references (avoiding deep clones).
         let mut impl_refs = self.collect_trait_impl_refs_multi(names_to_check);
@@ -1797,10 +1783,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         impl_refs
     }
 
-    /// Phase B of [`Self::find_trait_method_for_type_inner`]: decide whether
-    /// a candidate impl applies to the receiver. Returns the impl's receiver
-    /// name and whether it is a blanket type-param impl (both consumed by
-    /// Phase C), or `None` to skip the candidate.
+    /// Whether a candidate impl applies to the receiver. Returns its receiver
+    /// name and whether it is a blanket type-param impl, or `None` to skip.
     fn candidate_matches_receiver(
         &mut self,
         impl_ref: &ImplBlockRef,
@@ -1826,16 +1810,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         Some((impl_struct_name, is_blanket_type_param))
     }
 
-    /// For a reference-typed impl (`impl ... for &Container<T>` / `&mut …`),
-    /// whether its inner outer name matches the receiver's outer name.
-    ///
-    /// The name match in [`Self::candidate_matches_receiver`] only sees `"&"` /
-    /// `"&mut"` (`get_type_name` collapses every reference to that literal), so
-    /// without this inner-type check every ref impl would match any `&T`
-    /// receiver — e.g. `&TreeSet<String>` wrongly wiring to `impl<T>
-    /// IntoIterator for &List<T>` and ICEing in WIR validation. Blanket
-    /// `impl<T: Bound> Trait for &T` (inner is a bare type-param name) is exempt:
-    /// widely-applicable by design, soundness handled by the bound check.
+    /// For a reference-typed impl (`impl ... for &Container<T>`), whether its
+    /// inner outer name matches the receiver's. `candidate_matches_receiver`'s
+    /// name match only sees `"&"` / `"&mut"` (`get_type_name` collapses every
+    /// reference to that literal), so without this check every ref impl would
+    /// match any `&T` receiver. Blanket `impl<T: Bound> Trait for &T` (inner is
+    /// a bare type-param name) is exempt — soundness handled by the bound check.
     /// Returns `true` (keep) for any non-reference impl.
     fn ref_impl_targets_receiver(
         &self,
@@ -1875,10 +1855,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // The raw GC array's outer constructor is "Array", so a `&Array<T>`
             // ref impl (`impl Trait for &Array<T>`) matches a `&Array<_>` receiver.
             ResolvedType::BuiltinArray(_) => TypeTable::ARRAY_TYPE_NAME.to_string(),
-            // Receiver types with no nominal outer name (`TypeParam`, `Unknown`,
-            // `AssocTypeProjection`, …) are reachable here — e.g. `&T` for a
-            // generic `T`. The empty sentinel never equals the non-empty
-            // `impl_inner`, so the ref impl is conservatively not matched.
+            // Receivers with no nominal outer name (`TypeParam`, `Unknown`, …)
+            // reach here, e.g. `&T`. The empty sentinel never equals the
+            // non-empty `impl_inner`, so the ref impl is not matched.
             _ => String::new(),
         };
         impl_inner == receiver_outer
@@ -1907,22 +1886,16 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         })
     }
 
-    /// `TypeId`-equality disambiguation for concrete `impl Trait for <NamedType>`
-    /// impls. The bare-name check in [`Self::candidate_matches_receiver`] accepts
-    /// every such impl with a matching name, so two `impl Describe for Data`
-    /// blocks in different modules — each targeting its own `struct Data` — both
-    /// land here even though only one matches the receiver. Resolve the impl's
-    /// receiver type in the impl's own module context and compare `TypeId`s
-    /// (each module's `Data` interns distinctly), walking the receiver's newtype
-    /// chain so an impl on a base struct stays reachable through `type Alias = Base`.
-    ///
-    /// Widely-applicable receivers are exempt (return `true`): blanket impls
-    /// (type-param receivers), ref-shape impls (already filtered by the
-    /// inner-name check), and *parametric* generic impls (`impl<V> X for
-    /// Bag<V>`), which dispatch through the monomorphizer where the impl's `ty`
-    /// is `TypeParam`-bearing and cannot be compared to a concrete receiver. A
-    /// fully concrete generic impl (`impl X for List<u8>`) interns to a concrete
-    /// `TypeId` and IS checked, or it would also match a `List<i32>` receiver.
+    /// Whether a concrete `impl Trait for <NamedType>` actually targets the
+    /// receiver. The bare-name check in `candidate_matches_receiver` accepts
+    /// every same-named impl, so two `impl Describe for Data` in different
+    /// modules both reach here; resolve the impl's receiver in its own module
+    /// and compare `TypeId`s (each module's `Data` interns distinctly), walking
+    /// the receiver's newtype chain. Widely-applicable receivers — blanket,
+    /// ref-shape, and *parametric* generic impls (`impl<V> X for Bag<V>`) — are
+    /// exempt (`true`), since their `ty` is `TypeParam`-bearing; a fully
+    /// concrete generic impl (`impl X for List<u8>`) interns concretely and is
+    /// checked (else it would also match `List<i32>`).
     fn concrete_impl_matches_receiver(
         &mut self,
         impl_ref: &ImplBlockRef,
@@ -1972,11 +1945,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
     }
 
-    /// The body of [`Self::find_trait_method_for_type`] (the wrapper runs it
+    /// The body of [`Self::find_trait_method_for_type`]; the wrapper runs it
     /// with use→def reference recording suppressed, since foreign impl
-    /// signatures are walked here). Orchestrates candidate collection,
-    /// per-candidate receiver matching, projection, and final selection across
-    /// the dedicated helpers below.
+    /// signatures are walked here.
     fn find_trait_method_for_type_inner(
         &mut self,
         struct_name: &str,
@@ -1988,25 +1959,15 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         use super::types::TraitMethodMatch;
         let mut found_traits: Vec<TraitMethodMatch> = Vec::new();
 
-        // Struct name plus its newtype-chain base names, so an impl on a base
-        // type stays reachable through `type Alias = Base`.
         let names_to_check = self.newtype_chain_names(struct_name);
-
-        // Candidate trait impls for any of those names, plus blanket impls the
-        // receiver satisfies.
         let impl_refs = self.trait_method_candidates(&names_to_check);
 
-        // Now process the collected impl blocks with mutable access.
-        // Re-access impl block fields via index to avoid cloning.
         for impl_ref in &impl_refs {
-            // Filter by receiver match (Phase B); skip non-matching candidates.
             let Some((impl_struct_name, is_blanket_type_param)) =
                 self.candidate_matches_receiver(impl_ref, &names_to_check, receiver_type_id)
             else {
                 continue;
             };
-
-            // Project this candidate into 0+ trait-method matches (Phase C).
             found_traits.extend(self.collect_trait_method_matches_from_impl(
                 impl_ref,
                 impl_struct_name,
@@ -2033,11 +1994,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         None
     }
 
-    /// Project one candidate trait impl into 0+ [`TraitMethodMatch`]es
-    /// (Phase C of [`Self::find_trait_method_for_type_inner`]). Sets up the
-    /// impl's type-parameter / associated-type scope, then emits a match for the
-    /// impl's own method (if it defines `method_name`) or, failing that, for any
-    /// matching trait default method with a body.
+    /// Project one candidate trait impl into 0+ [`TraitMethodMatch`]es: set up
+    /// the impl's type-parameter / associated-type scope, then emit a match for
+    /// the impl's own `method_name`, or failing that for any matching trait
+    /// default method with a body.
     fn collect_trait_method_matches_from_impl(
         &mut self,
         impl_ref: &ImplBlockRef,
@@ -2503,11 +2463,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         found_traits
     }
 
-    /// Phase D of [`Self::find_trait_method_for_type_inner`]: choose the
-    /// winning match from the collected candidates. Prefers a trait impl in the
-    /// current module, deduplicates `(trait, module)` pairs, and returns the
-    /// first remaining (multiple survivors are ambiguous, resolved later by
-    /// explicit disambiguation syntax).
+    /// Choose the winning match: prefer a trait impl in the current module,
+    /// dedup `(trait, module)` pairs, return the first remaining (multiple
+    /// survivors are ambiguous, resolved later by explicit disambiguation).
     fn select_trait_match(
         &self,
         mut found_traits: Vec<super::types::TraitMethodMatch>,
@@ -2853,9 +2811,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         self.probe_trait_impls(
             struct_name,
             &concrete_type_args,
-            // Arithmetic's mapping treats every `Named` impl arg as a type
-            // parameter (empty declared set), unlike the indexing/assoc paths.
-            false,
+            false, // legacy mapping: every `Named` impl arg is a type param
             |found_trait_name| found_trait_name == trait_name,
             |s, impl_ref, mapping, _declared| {
                 // Check trait bounds on type parameters (e.g., impl<T: Eq> Eq for List<T>)

--- a/wado-compiler/src/elaborator/method_lookup.rs
+++ b/wado-compiler/src/elaborator/method_lookup.rs
@@ -1720,7 +1720,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // via an AstId collision in `bindings.references` (cf.
         // `lookup_method_info` which suppresses for the same reason).
         self.with_reference_recording_suppressed(|s| {
-            s.find_trait_method_for_type_uncached(
+            s.find_trait_method_for_type_unrecorded(
                 struct_name,
                 method_name,
                 struct_module,
@@ -1730,44 +1730,38 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         })
     }
 
-    fn find_trait_method_for_type_uncached(
-        &mut self,
-        struct_name: &str,
-        method_name: &str,
-        _struct_module: &ModuleSource,
-        receiver_type_args: Option<&[TypeId]>,
-        receiver_type_id: Option<TypeId>,
-    ) -> Option<super::types::TraitMethodMatch> {
-        use super::types::TraitMethodMatch;
-        let mut found_traits: Vec<TraitMethodMatch> = Vec::new();
-
-        // Build names_to_check first (struct name + newtype chain), then use the
-        // pre-built index to fetch only the matching impl blocks instead of scanning
-        // all items in all modules.
-        let names_to_check: Vec<String> = {
-            let mut names = vec![struct_name.to_string()];
-            if let Some(newtype_id) = self.lookup_newtype(struct_name) {
-                let mut current = newtype_id;
-                loop {
-                    match self.tysys.type_table.borrow().get(current).clone() {
-                        ResolvedType::Newtype { base_type, .. } => {
-                            let base_name = self.tysys.type_table.borrow().type_name(base_type);
-                            names.push(base_name);
-                            current = base_type;
-                        }
-                        ResolvedType::Flags { .. } => {
-                            names.push("u32".to_string());
-                            break;
-                        }
-                        _ => break,
+    /// `struct_name` plus the base names of its newtype chain
+    /// (`type Alias = Base` → `Base`, `Flags` → `u32`), so a trait impl on a
+    /// base type is reachable through the alias. Phase A of
+    /// [`Self::find_trait_method_for_type_unrecorded`].
+    fn newtype_chain_names(&self, struct_name: &str) -> Vec<String> {
+        let mut names = vec![struct_name.to_string()];
+        if let Some(newtype_id) = self.lookup_newtype(struct_name) {
+            let mut current = newtype_id;
+            loop {
+                match self.tysys.type_table.borrow().get(current).clone() {
+                    ResolvedType::Newtype { base_type, .. } => {
+                        let base_name = self.tysys.type_table.borrow().type_name(base_type);
+                        names.push(base_name);
+                        current = base_type;
                     }
+                    ResolvedType::Flags { .. } => {
+                        names.push("u32".to_string());
+                        break;
+                    }
+                    _ => break,
                 }
             }
-            names
-        };
+        }
+        names
+    }
 
+    /// Candidate trait impls for [`Self::find_trait_method_for_type_unrecorded`]
+    /// (Phase A): every trait impl on one of `names_to_check`, plus blanket
+    /// impls (`impl<T: Bound> Trait for T`) whose bound the receiver satisfies.
+    fn trait_method_candidates(&mut self, names_to_check: &[String]) -> Vec<ImplBlockRef> {
         // Collect lightweight impl block references (avoiding deep clones).
-        let mut impl_refs = self.collect_trait_impl_refs_multi(&names_to_check);
+        let mut impl_refs = self.collect_trait_impl_refs_multi(names_to_check);
 
         // Blanket impl fallback: check `impl<T: Bound> Trait for T` where the receiver
         // type satisfies the bound.  e.g., `impl<I: Iterator> IntoIterator for I` matches
@@ -1800,650 +1794,231 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 }
             }
         }
+        impl_refs
+    }
+
+    /// Phase B of [`Self::find_trait_method_for_type_unrecorded`]: decide whether
+    /// a candidate impl applies to the receiver. Returns the impl's receiver
+    /// name and whether it is a blanket type-param impl (both consumed by
+    /// Phase C), or `None` to skip the candidate.
+    fn candidate_matches_receiver(
+        &mut self,
+        impl_ref: &ImplBlockRef,
+        names_to_check: &[String],
+        receiver_type_id: Option<TypeId>,
+    ) -> Option<(String, bool)> {
+        let impl_block = self.get_impl_block(impl_ref);
+        let impl_struct_name = self.get_type_name(&impl_block.ty);
+        // Accept if the type matches by name, or if it's a blanket impl type parameter.
+        let is_blanket_type_param = matches!(&impl_block.ty, Type::Named(named) if !self.tysys.is_known_type_name(&named.name));
+        if !names_to_check.contains(&impl_struct_name) && !is_blanket_type_param {
+            return None;
+        }
+        if !self.ref_impl_targets_receiver(&impl_block.ty, &impl_struct_name, receiver_type_id) {
+            return None;
+        }
+        if !self.blanket_target_bounds_satisfied(impl_block, receiver_type_id) {
+            return None;
+        }
+        if !self.concrete_impl_matches_receiver(impl_ref, receiver_type_id) {
+            return None;
+        }
+        Some((impl_struct_name, is_blanket_type_param))
+    }
+
+    /// For a reference-typed impl (`impl ... for &Container<T>` / `&mut …`),
+    /// whether its inner outer name matches the receiver's outer name.
+    ///
+    /// The name match in [`Self::candidate_matches_receiver`] only sees `"&"` /
+    /// `"&mut"` (`get_type_name` collapses every reference to that literal), so
+    /// without this inner-type check every ref impl would match any `&T`
+    /// receiver — e.g. `&TreeSet<String>` wrongly wiring to `impl<T>
+    /// IntoIterator for &List<T>` and ICEing in WIR validation. Blanket
+    /// `impl<T: Bound> Trait for &T` (inner is a bare type-param name) is exempt:
+    /// widely-applicable by design, soundness handled by the bound check.
+    /// Returns `true` (keep) for any non-reference impl.
+    fn ref_impl_targets_receiver(
+        &self,
+        impl_ty: &Type,
+        impl_struct_name: &str,
+        receiver_type_id: Option<TypeId>,
+    ) -> bool {
+        if impl_struct_name != "&" && impl_struct_name != "&mut" {
+            return true;
+        }
+        let Some(rt) = receiver_type_id else {
+            return true;
+        };
+        let impl_inner_outer = match impl_ty {
+            Type::Reference(inner) | Type::MutReference(inner) => match inner.as_ref() {
+                Type::Generic(g) => Some(g.name.clone()),
+                Type::Named(named) if self.tysys.is_known_type_name(&named.name) => {
+                    Some(named.name.clone())
+                }
+                _ => None, // blanket `&T` form — handled by the bound check
+            },
+            _ => None,
+        };
+        let Some(impl_inner) = impl_inner_outer else {
+            return true;
+        };
+        let receiver_outer = match self.tysys.type_table.borrow().get(rt) {
+            ResolvedType::GenericInstance { name, .. }
+            | ResolvedType::Struct { name, .. }
+            | ResolvedType::Enum { name, .. }
+            | ResolvedType::Resource { name, .. }
+            | ResolvedType::GenericResource { name, .. }
+            | ResolvedType::Newtype { name, .. }
+            | ResolvedType::Flags { name, .. }
+            | ResolvedType::Variant { name, .. } => name.clone(),
+            ResolvedType::Primitive(p) => p.as_str().to_string(),
+            // The raw GC array's outer constructor is "Array", so a `&Array<T>`
+            // ref impl (`impl Trait for &Array<T>`) matches a `&Array<_>` receiver.
+            ResolvedType::BuiltinArray(_) => TypeTable::ARRAY_TYPE_NAME.to_string(),
+            // Receiver types with no nominal outer name (`TypeParam`, `Unknown`,
+            // `AssocTypeProjection`, …) are reachable here — e.g. `&T` for a
+            // generic `T`. The empty sentinel never equals the non-empty
+            // `impl_inner`, so the ref impl is conservatively not matched.
+            _ => String::new(),
+        };
+        impl_inner == receiver_outer
+    }
+
+    /// For a blanket impl (target type is one of its own type params with
+    /// bounds), whether the receiver satisfies those bounds. Prevents using e.g.
+    /// `impl<I: Iterator> IntoIterator for I` for a `TypeParam` `I` that is not
+    /// itself `Iterator`. Returns `true` (keep) for non-blanket impls.
+    fn blanket_target_bounds_satisfied(
+        &self,
+        impl_block: &ast::ImplBlock,
+        receiver_type_id: Option<TypeId>,
+    ) -> bool {
+        let impl_ty_name = Self::get_type_name_static(&impl_block.ty);
+        let Some(param) = impl_block
+            .type_params
+            .iter()
+            .find(|tp| tp.name == impl_ty_name && !tp.bounds.is_empty())
+        else {
+            return true;
+        };
+        param.bounds.iter().all(|bound| {
+            receiver_type_id
+                .is_some_and(|rt| self.type_implements_trait(&self.annotate_ctx, rt, &bound.name))
+        })
+    }
+
+    /// `TypeId`-equality disambiguation for concrete `impl Trait for <NamedType>`
+    /// impls. The bare-name check in [`Self::candidate_matches_receiver`] accepts
+    /// every such impl with a matching name, so two `impl Describe for Data`
+    /// blocks in different modules — each targeting its own `struct Data` — both
+    /// land here even though only one matches the receiver. Resolve the impl's
+    /// receiver type in the impl's own module context and compare `TypeId`s
+    /// (each module's `Data` interns distinctly), walking the receiver's newtype
+    /// chain so an impl on a base struct stays reachable through `type Alias = Base`.
+    ///
+    /// Widely-applicable receivers are exempt (return `true`): blanket impls
+    /// (type-param receivers), ref-shape impls (already filtered by the
+    /// inner-name check), and *parametric* generic impls (`impl<V> X for
+    /// Bag<V>`), which dispatch through the monomorphizer where the impl's `ty`
+    /// is `TypeParam`-bearing and cannot be compared to a concrete receiver. A
+    /// fully concrete generic impl (`impl X for List<u8>`) interns to a concrete
+    /// `TypeId` and IS checked, or it would also match a `List<i32>` receiver.
+    fn concrete_impl_matches_receiver(
+        &mut self,
+        impl_ref: &ImplBlockRef,
+        receiver_type_id: Option<TypeId>,
+    ) -> bool {
+        let Some(receiver) = receiver_type_id else {
+            return true;
+        };
+        let (skip_filter, impl_ty_clone) = {
+            let impl_block = self.get_impl_block(impl_ref);
+            let is_blanket_tp = matches!(
+                &impl_block.ty,
+                Type::Named(named) if !self.tysys.is_known_type_name(&named.name)
+            );
+            let generic_is_parametric = matches!(&impl_block.ty, Type::Generic(g)
+                if g.args.iter().any(|a| matches!(a,
+                    Type::Named(n)
+                        if !self.tysys.is_known_type_name(&n.name)
+                            || impl_block.type_params.iter().any(|p| p.name == n.name))));
+            let skip = !impl_block.type_params.is_empty()
+                || is_blanket_tp
+                || matches!(&impl_block.ty, Type::Reference(_) | Type::MutReference(_))
+                || generic_is_parametric;
+            (skip, impl_block.ty.clone())
+        };
+        if skip_filter {
+            return true;
+        }
+        let impl_module = impl_ref.0.clone();
+        let (imports, originals) = self.tysys.trait_env.import_scope(&impl_module);
+        let impl_recv_id = self.with_module_perspective(impl_module, imports, originals, |s| {
+            s.resolve_type(&impl_ty_clone)
+        });
+        let tt = self.tysys.type_table.borrow();
+        let target = tt.peel_refs(impl_recv_id);
+        let mut current = tt.peel_refs(receiver);
+        loop {
+            if current == target {
+                return true;
+            }
+            match tt.get(current) {
+                ResolvedType::Newtype { base_type, .. } => {
+                    current = tt.peel_refs(*base_type);
+                }
+                _ => return false,
+            }
+        }
+    }
+
+    /// The body of [`Self::find_trait_method_for_type`], run with use→def
+    /// reference recording suppressed (foreign impl signatures are walked
+    /// here; see the wrapper). Despite the former `_uncached` name there is no
+    /// cache — the pre-built impl indices are the shared memo. Orchestrates
+    /// candidate collection, per-candidate receiver matching, projection, and
+    /// final selection across the dedicated helpers below.
+    fn find_trait_method_for_type_unrecorded(
+        &mut self,
+        struct_name: &str,
+        method_name: &str,
+        _struct_module: &ModuleSource,
+        receiver_type_args: Option<&[TypeId]>,
+        receiver_type_id: Option<TypeId>,
+    ) -> Option<super::types::TraitMethodMatch> {
+        use super::types::TraitMethodMatch;
+        let mut found_traits: Vec<TraitMethodMatch> = Vec::new();
+
+        // Struct name plus its newtype-chain base names, so an impl on a base
+        // type stays reachable through `type Alias = Base`.
+        let names_to_check = self.newtype_chain_names(struct_name);
+
+        // Candidate trait impls for any of those names, plus blanket impls the
+        // receiver satisfies.
+        let impl_refs = self.trait_method_candidates(&names_to_check);
 
         // Now process the collected impl blocks with mutable access.
         // Re-access impl block fields via index to avoid cloning.
         for impl_ref in &impl_refs {
-            let impl_block = self.get_impl_block(impl_ref);
-            let impl_struct_name = self.get_type_name(&impl_block.ty);
-            // Accept if the type matches by name, or if it's a blanket impl type parameter.
-            let is_blanket_type_param = matches!(&impl_block.ty, Type::Named(named) if !self.tysys.is_known_type_name(&named.name));
-            if !names_to_check.contains(&impl_struct_name) && !is_blanket_type_param {
+            // Filter by receiver match (Phase B); skip non-matching candidates.
+            let Some((impl_struct_name, is_blanket_type_param)) =
+                self.candidate_matches_receiver(impl_ref, &names_to_check, receiver_type_id)
+            else {
                 continue;
-            }
-
-            // For reference-typed impls (`impl ... for &Container<T>` or
-            // `impl ... for &mut Container<T>`), the name match above only
-            // checks `"&"` / `"&mut"` because `get_type_name` collapses
-            // every reference to that literal — by design, since many
-            // elaborator paths use the literal as a key. Without an
-            // additional inner-type check, EVERY ref impl in scope would
-            // appear to match any `&T` receiver, and the elaborator would
-            // commit to whichever one happened to land first in
-            // `impl_refs`. That is exactly how `&TreeSet<String>` ended
-            // up wired to `impl<T> IntoIterator for &List<T>`, which
-            // then ICEd in WIR validation when `arr.repr` / `arr.used`
-            // accesses lowered against the receiver's actual layout.
-            //
-            // Verify the impl's inner outer name matches the receiver's
-            // outer name. Blanket `impl<T: Bound> Trait for &T` (where
-            // the inner is a bare `Type::Named` whose name is a type
-            // param, not a known concrete type) is exempt — those are
-            // intentionally widely-applicable and the bound check below
-            // handles their soundness.
-            if (impl_struct_name == "&" || impl_struct_name == "&mut")
-                && let Some(rt) = receiver_type_id
-            {
-                let impl_inner_outer = match &impl_block.ty {
-                    Type::Reference(inner) | Type::MutReference(inner) => match inner.as_ref() {
-                        Type::Generic(g) => Some(g.name.clone()),
-                        Type::Named(named) if self.tysys.is_known_type_name(&named.name) => {
-                            Some(named.name.clone())
-                        }
-                        _ => None, // blanket `&T` form — handled by the bound check
-                    },
-                    _ => None,
-                };
-                if let Some(impl_inner) = impl_inner_outer {
-                    let receiver_outer = match self.tysys.type_table.borrow().get(rt) {
-                        ResolvedType::GenericInstance { name, .. }
-                        | ResolvedType::Struct { name, .. }
-                        | ResolvedType::Enum { name, .. }
-                        | ResolvedType::Resource { name, .. }
-                        | ResolvedType::GenericResource { name, .. }
-                        | ResolvedType::Newtype { name, .. }
-                        | ResolvedType::Flags { name, .. }
-                        | ResolvedType::Variant { name, .. } => name.clone(),
-                        ResolvedType::Primitive(p) => p.as_str().to_string(),
-                        // The raw GC array's outer constructor is "Array", so a
-                        // `&Array<T>` ref impl (`impl Trait for &Array<T>`)
-                        // matches a `&Array<_>` receiver.
-                        ResolvedType::BuiltinArray(_) => TypeTable::ARRAY_TYPE_NAME.to_string(),
-                        _ => String::new(),
-                    };
-                    if impl_inner != receiver_outer {
-                        continue;
-                    }
-                }
-            }
-
-            // If this impl block is a blanket impl (its target type is one of its own type params
-            // with bounds), verify the receiver satisfies those bounds. This prevents incorrectly
-            // using e.g. `impl<I: Iterator> IntoIterator for I` for a TypeParam `I: IntoIterator`.
-            {
-                let impl_ty_name = Self::get_type_name_static(&impl_block.ty);
-                let blanket_param = impl_block
-                    .type_params
-                    .iter()
-                    .find(|tp| tp.name == impl_ty_name && !tp.bounds.is_empty());
-                if let Some(param) = blanket_param {
-                    let bounds_ok = param.bounds.iter().all(|bound| {
-                        receiver_type_id.is_some_and(|rt| {
-                            self.type_implements_trait(&self.annotate_ctx, rt, &bound.name)
-                        })
-                    });
-                    if !bounds_ok {
-                        continue;
-                    }
-                }
-            }
-
-            // TypeId-equality disambiguation for concrete `impl Trait for
-            // <NamedType>` impls. The bare-name check at the top of the
-            // loop accepts every such impl with a matching name, so two
-            // `impl Describe for Data` blocks in different modules — each
-            // targeting its own `struct Data` — both land here even
-            // though only one corresponds to the receiver's actual type.
-            //
-            // Resolve the impl's receiver type in the impl's own module
-            // context and compare against the receiver type id; the
-            // elaborator intern table guarantees each module's `Data`
-            // resolves to a distinct `TypeId`. Skip the filter for impls
-            // whose receiver is intentionally widely-applicable (blanket
-            // impls, generic impls, ref-shape impls) — those already have
-            // dedicated checks above.
-            if let Some(receiver) = receiver_type_id {
-                let (skip_filter, impl_ty_clone) = {
-                    let impl_block = self.get_impl_block(impl_ref);
-                    let is_blanket_tp = matches!(
-                        &impl_block.ty,
-                        Type::Named(named) if !self.tysys.is_known_type_name(&named.name)
-                    );
-                    // Skip the filter for impls whose receiver is
-                    // intentionally widely-applicable: blanket impls
-                    // (type-param receivers), ref-shape impls (already
-                    // filtered by the inner-name check above), and
-                    // *parametric* generic impls (`impl<V> X for Bag<V>`)
-                    // — those dispatch through the monomorphizer's
-                    // substitution path, where the impl's `ty` resolves
-                    // to a `TypeParam`-bearing form that can't be
-                    // compared directly against a concrete receiver's
-                    // `TypeId`.
-                    //
-                    // A generic impl whose arguments are all concrete
-                    // (`impl X for List<u8>`) resolves to a concrete
-                    // `TypeId`, so it must go through the equality check
-                    // below — otherwise `impl X for List<u8>` would also
-                    // match a `List<i32>` receiver.
-                    // Only a *parametric* generic impl is widely-applicable and
-                    // must skip the concrete `TypeId` equality check below; a
-                    // fully concrete generic impl (`impl X for List<u8>`)
-                    // resolves to a concrete `TypeId` and must be checked, or it
-                    // would match a `List<i32>` receiver too.
-                    let generic_is_parametric = matches!(&impl_block.ty, Type::Generic(g)
-                        if g.args.iter().any(|a| matches!(a,
-                            Type::Named(n)
-                                if !self.tysys.is_known_type_name(&n.name)
-                                    || impl_block.type_params.iter().any(|p| p.name == n.name))));
-                    let skip = !impl_block.type_params.is_empty()
-                        || is_blanket_tp
-                        || matches!(&impl_block.ty, Type::Reference(_) | Type::MutReference(_))
-                        || generic_is_parametric;
-                    (skip, impl_block.ty.clone())
-                };
-                if !skip_filter {
-                    let impl_module = impl_ref.0.clone();
-                    let (imports, originals) = self.tysys.trait_env.import_scope(&impl_module);
-                    let impl_recv_id =
-                        self.with_module_perspective(impl_module, imports, originals, |s| {
-                            s.resolve_type(&impl_ty_clone)
-                        });
-                    let tt = self.tysys.type_table.borrow();
-                    let target = tt.peel_refs(impl_recv_id);
-                    // Walk the receiver's newtype chain so an impl on a
-                    // base struct stays reachable through `type
-                    // Location = Point`: the receiver's `TypeId` for
-                    // `Location` differs from `Point`'s, but the impl
-                    // is supposed to inherit via the newtype.
-                    let mut current = tt.peel_refs(receiver);
-                    let mut matched = false;
-                    loop {
-                        if current == target {
-                            matched = true;
-                            break;
-                        }
-                        match tt.get(current) {
-                            ResolvedType::Newtype { base_type, .. } => {
-                                current = tt.peel_refs(*base_type);
-                            }
-                            _ => break,
-                        }
-                    }
-                    if !matched {
-                        continue;
-                    }
-                }
-            }
-
-            // Extract type param mappings from the impl block before mutating self.
-            let impl_block = self.get_impl_block(impl_ref);
-            // Track variadic type pack spreads: (pack_name, param_index)
-            let mut variadic_pack_entry: Option<(String, u32)> = None;
-            let type_param_entries: Vec<(String, u32)> =
-                if let Type::Generic(generic) = &impl_block.ty {
-                    generic
-                        .args
-                        .iter()
-                        .enumerate()
-                        .filter_map(|(i, arg)| {
-                            if let Type::Named(named) = arg {
-                                Some((named.name.clone(), i as u32))
-                            } else {
-                                None
-                            }
-                        })
-                        .collect()
-                } else if let Type::Reference(boxed) | Type::MutReference(boxed) = &impl_block.ty {
-                    if let Type::Named(inner) = boxed.as_ref() {
-                        // impl<T: Bound> Trait for &T / &mut T: T is at position 0
-                        vec![(inner.name.clone(), 0u32)]
-                    } else if let Type::Generic(generic) = boxed.as_ref() {
-                        // impl<T> Trait for &Container<T>: extract type params from generic args
-                        generic
-                            .args
-                            .iter()
-                            .enumerate()
-                            .filter_map(|(i, arg)| {
-                                if let Type::Named(named) = arg {
-                                    Some((named.name.clone(), i as u32))
-                                } else {
-                                    None
-                                }
-                            })
-                            .collect()
-                    } else {
-                        Vec::new()
-                    }
-                } else if let Type::Tuple(elems) = &impl_block.ty {
-                    // Handle variadic tuple impls: impl<..T> Trait for [..T]
-                    // TypePackSpread elements map the pack name to its index.
-                    let mut entries = Vec::new();
-                    for (i, elem) in elems.iter().enumerate() {
-                        match elem {
-                            Type::TypePackSpread(name, _) => {
-                                // Find the pack's index from the impl block's type_params
-                                let pack_idx = impl_block
-                                    .type_params
-                                    .iter()
-                                    .position(|tp| tp.name == *name)
-                                    .map(|p| p as u32)
-                                    .unwrap_or(i as u32);
-                                variadic_pack_entry = Some((name.clone(), pack_idx));
-                            }
-                            Type::Named(named) => {
-                                entries.push((named.name.clone(), i as u32));
-                            }
-                            _ => {}
-                        }
-                    }
-                    entries
-                } else {
-                    Vec::new()
-                };
-            // Extract blanket type param info
-            let blanket_name = if let Type::Named(named) = &impl_block.ty {
-                Some(named.name.clone())
-            } else {
-                None
-            };
-            // Extract associated type bindings (lightweight: just name+type, not methods)
-            let assoc_bindings: Vec<(String, ast::Type)> = impl_block
-                .associated_types
-                .iter()
-                .map(|b| (b.name.clone(), b.ty.clone()))
-                .collect();
-            let impl_module_source = self.impl_block_module_source(impl_ref);
-            // A concrete generic instantiation trait impl (`impl Tag for
-            // List<u8>`) yields a per-instantiation concrete method, called
-            // directly (no monomorphization), living in the impl's module.
-            let impl_is_concrete =
-                self.impl_is_concrete_instantiation(impl_block, &impl_module_source);
-
-            // Save trait context for this impl block scope. We use an inherited
-            // scope (saves the full ctx via clone) and then selectively clear
-            // just type_params and assoc_type_bindings — other parts (bounds,
-            // self_type, …) are kept from the parent for this lookup.
-            let mut scope = self.enter_inherited_type_param_scope();
-            scope.annotate_ctx.trait_ctx.type_params.clear();
-            scope.annotate_ctx.trait_ctx.assoc_type_bindings.clear();
-
-            // Set up type parameters for resolving generic associated types
-            if let Some(type_args) = receiver_type_args {
-                for (name, idx) in &type_param_entries {
-                    let i = *idx as usize;
-                    if i < type_args.len() {
-                        scope
-                            .annotate_ctx
-                            .trait_ctx
-                            .type_params
-                            .insert(name.clone(), (*idx, type_args[i]));
-                    }
-                }
-                // For variadic pack params (..T in impl<..T> Trait for [..T]),
-                // map the pack to a TypePack so that the method body can reference it.
-                if let Some((pack_name, pack_idx)) = &variadic_pack_entry {
-                    let pack_type = scope
-                        .tysys
-                        .type_table
-                        .borrow_mut()
-                        .make_tuple(type_args.to_vec());
-                    scope
-                        .annotate_ctx
-                        .trait_ctx
-                        .type_params
-                        .insert(pack_name.clone(), (*pack_idx, pack_type));
-                }
-            }
-
-            // For blanket impls where impl_ty is a free type parameter
-            if let Some(ref name) = blanket_name
-                && !scope.annotate_ctx.trait_ctx.type_params.contains_key(name)
-                && !scope.tysys.is_known_type_name(name)
-            {
-                if let Some(recv_id) = receiver_type_id {
-                    scope
-                        .annotate_ctx
-                        .trait_ctx
-                        .type_params
-                        .insert(name.clone(), (0, recv_id));
-                } else {
-                    let type_id = scope
-                        .tysys
-                        .type_table
-                        .borrow_mut()
-                        .make_type_param(name.clone(), 0);
-                    scope
-                        .annotate_ctx
-                        .trait_ctx
-                        .type_params
-                        .insert(name.clone(), (0, type_id));
-                }
-            }
-
-            // Set up associated type bindings for resolving Self::* types
-            for (name, ty) in &assoc_bindings {
-                let type_id = scope.resolve_type(ty);
-                scope
-                    .annotate_ctx
-                    .trait_ctx
-                    .assoc_type_bindings
-                    .insert(name.clone(), type_id);
-            }
-
-            let blanket_type_param = if is_blanket_type_param {
-                Some(impl_struct_name.clone())
-            } else {
-                None
             };
 
-            // Detect blanket ref impls: `impl<T: Bound> Trait for &T` where the inner type
-            // is a type parameter. These should NOT override base-type methods.
-            let is_blanket_ref_impl = {
-                let impl_block = scope.get_impl_block(impl_ref);
-                match &impl_block.ty {
-                    Type::Reference(inner) | Type::MutReference(inner) => {
-                        if let Type::Named(named) = inner.as_ref() {
-                            // Inner is a bare name — check if it's a type parameter
-                            impl_block
-                                .type_params
-                                .iter()
-                                .any(|tp| tp.name == named.name)
-                        } else {
-                            false
-                        }
-                    }
-                    _ => false,
-                }
-            };
-
-            // Extract method info from impl block before calling &mut self methods
-            let impl_block = scope.get_impl_block(impl_ref);
-            let method_data: Option<(
-                Option<ast::Type>,
-                ast::SelfKind,
-                Vec<ast::Param>,
-                Vec<ast::GenericParam>,
-            )> = impl_block
-                .methods
-                .iter()
-                .find(|m| m.name == method_name)
-                .map(|m| {
-                    (
-                        m.return_type.clone(),
-                        m.params
-                            .first()
-                            .map(|p| p.self_kind)
-                            .unwrap_or(ast::SelfKind::None),
-                        m.params.clone(),
-                        m.type_params.clone(),
-                    )
-                });
-            let trait_type_for_name = impl_block.trait_type.as_ref().unwrap().clone();
-
-            let mut method_found = false;
-            if let Some((return_type_ast, self_kind, params, method_type_params)) = method_data {
-                let trait_name = scope.get_type_name_full(&trait_type_for_name);
-
-                // Set up method-level type params (e.g., V in deserialize_any<V: Visitor>)
-                let impl_offset = scope.annotate_ctx.trait_ctx.type_params.len() as u32;
-                for (i, type_param) in method_type_params.iter().enumerate() {
-                    let index = impl_offset + i as u32;
-                    let type_param_id =
-                        scope
-                            .tysys
-                            .type_table
-                            .borrow_mut()
-                            .intern(ResolvedType::TypeParam {
-                                name: type_param.name.clone(),
-                                index,
-                            });
-                    scope
-                        .annotate_ctx
-                        .trait_ctx
-                        .type_params
-                        .insert(type_param.name.clone(), (index, type_param_id));
-                    if !type_param.bounds.is_empty() {
-                        scope
-                            .annotate_ctx
-                            .trait_ctx
-                            .type_param_bounds
-                            .insert(type_param.name.clone(), type_param.bounds.clone());
-                    }
-                }
-
-                // Make `Self` in the method signature resolve to the concrete
-                // receiver type (e.g. `&Self` → `&Result<String, i32>` when
-                // calling through `impl<T: Eq, E: Eq> Eq for Result<T, E>`).
-                // Without this, `resolve_type("Self")` falls through to
-                // UNKNOWN and the caller's argument typecheck silently
-                // accepts anything, surfacing as an ICE at codegen.
-                let old_self_type = scope.annotate_ctx.trait_ctx.self_type;
-                if let Some(recv_id) = receiver_type_id {
-                    scope.annotate_ctx.trait_ctx.self_type = Some(recv_id);
-                }
-
-                let return_type = return_type_ast
-                    .as_ref()
-                    .map(|t| scope.resolve_type(t))
-                    .unwrap_or(TypeTable::UNIT);
-
-                // Extract param_types while method-level type params are still
-                // in scope — otherwise `&T` in a parameter would not resolve to
-                // the proper `TypeParam` id that inference expects.
-                let param_types = scope.extract_param_types(&params);
-
-                scope.annotate_ctx.trait_ctx.self_type = old_self_type;
-
-                // Remove method-level type params from scope
-                for type_param in &method_type_params {
-                    scope
-                        .annotate_ctx
-                        .trait_ctx
-                        .type_params
-                        .shift_remove(&type_param.name);
-                    scope
-                        .annotate_ctx
-                        .trait_ctx
-                        .type_param_bounds
-                        .shift_remove(&type_param.name);
-                }
-                let param_is_mut: Vec<bool> = params
-                    .iter()
-                    .filter(|p| p.name != "self")
-                    .map(|p| p.is_mut)
-                    .collect();
-                let param_names: Vec<String> = params
-                    .iter()
-                    .filter(|p| p.name != "self")
-                    .map(|p| p.name.clone())
-                    .collect();
-                // Parameter defaults live on the trait declaration only (WEP
-                // 2026-04-11). Pull them from the trait's method, keyed by
-                // parameter name, instead of the impl's re-specified params.
-                let trait_name_base = scope.get_type_name(&trait_type_for_name);
-                let param_defaults: Vec<Option<ast::Expr>> = {
-                    let trait_method_params: Option<Vec<ast::Param>> = scope
-                        .find_trait_decl_methods(&trait_name_base)
-                        .and_then(|methods| {
-                            methods
-                                .into_iter()
-                                .find(|m| m.name == method_name)
-                                .map(|m| m.params)
-                        });
-                    param_names
-                        .iter()
-                        .map(|name| {
-                            trait_method_params.as_ref().and_then(|tp| {
-                                tp.iter()
-                                    .find(|p| &p.name == name)
-                                    .and_then(|p| p.default.clone())
-                            })
-                        })
-                        .collect()
-                };
-                found_traits.push(TraitMethodMatch {
-                    trait_name,
-                    method_info: MethodInfo {
-                        return_type,
-                        self_kind,
-                        param_types,
-                        param_is_mut,
-                        inherited_from_base: None,
-                        cm_name: None,
-                        is_ref_impl: false,
-                        method_type_param_ids: vec![],
-                        impl_module: Some(impl_module_source.clone()),
-                        from_concrete_impl: impl_is_concrete,
-                        param_defaults,
-                        param_names,
-                    },
-                    impl_module_source: impl_module_source.clone(),
-                    blanket_type_param: blanket_type_param.clone(),
-                    impl_struct_name: impl_struct_name.clone(),
-                    is_blanket_ref_impl,
-                });
-                method_found = true;
-            }
-
-            // If the method wasn't found in the impl block, check the trait
-            // declaration for a default method with that name
-            if !method_found {
-                let trait_name_base = scope.get_type_name(&trait_type_for_name);
-                let trait_name_str = scope.get_type_name_full(&trait_type_for_name);
-                if let Some(trait_methods) = scope.find_trait_decl_methods(&trait_name_base) {
-                    for default_method in &trait_methods {
-                        if default_method.name == method_name && default_method.body.is_some() {
-                            // Set up Self type so that `Self` in the default method's
-                            // return type resolves to the concrete receiver type
-                            let old_self_type = scope.annotate_ctx.trait_ctx.self_type;
-                            if let Some(recv_id) = receiver_type_id {
-                                scope.annotate_ctx.trait_ctx.self_type = Some(recv_id);
-                            }
-
-                            // Bind the trait's own type parameters to the impl's
-                            // concrete trait args so that a default method's
-                            // return/param types written in terms of the trait's
-                            // `T` resolve to the concrete type at the call site
-                            // (e.g., `Maker<i32>::make_with_default` returns i32,
-                            // not the unresolved T).
-                            scope.bind_trait_type_params_from_impl(&trait_type_for_name);
-
-                            // Set up method-level type params (e.g., U in map<U>)
-                            let impl_offset = scope.annotate_ctx.trait_ctx.type_params.len() as u32;
-                            for (i, type_param) in default_method.type_params.iter().enumerate() {
-                                let index = impl_offset + i as u32;
-                                let type_param_id = scope.tysys.type_table.borrow_mut().intern(
-                                    ResolvedType::TypeParam {
-                                        name: type_param.name.clone(),
-                                        index,
-                                    },
-                                );
-                                scope
-                                    .annotate_ctx
-                                    .trait_ctx
-                                    .type_params
-                                    .insert(type_param.name.clone(), (index, type_param_id));
-                                if !type_param.bounds.is_empty() {
-                                    scope
-                                        .annotate_ctx
-                                        .trait_ctx
-                                        .type_param_bounds
-                                        .insert(type_param.name.clone(), type_param.bounds.clone());
-                                }
-                            }
-
-                            let return_type = default_method
-                                .return_type
-                                .as_ref()
-                                .map(|t| scope.resolve_type(t))
-                                .unwrap_or(TypeTable::UNIT);
-                            let self_kind = default_method
-                                .params
-                                .first()
-                                .map(|p| p.self_kind)
-                                .unwrap_or(ast::SelfKind::None);
-                            let param_types = scope.extract_param_types(&default_method.params);
-                            let param_is_mut: Vec<bool> = default_method
-                                .params
-                                .iter()
-                                .filter(|p| p.name != "self")
-                                .map(|p| p.is_mut)
-                                .collect();
-                            let param_defaults: Vec<Option<ast::Expr>> = default_method
-                                .params
-                                .iter()
-                                .filter(|p| p.name != "self")
-                                .map(|p| p.default.clone())
-                                .collect();
-                            let param_names: Vec<String> = default_method
-                                .params
-                                .iter()
-                                .filter(|p| p.name != "self")
-                                .map(|p| p.name.clone())
-                                .collect();
-
-                            // Remove method-level type params from scope
-                            for type_param in &default_method.type_params {
-                                scope
-                                    .annotate_ctx
-                                    .trait_ctx
-                                    .type_params
-                                    .shift_remove(&type_param.name);
-                                scope
-                                    .annotate_ctx
-                                    .trait_ctx
-                                    .type_param_bounds
-                                    .shift_remove(&type_param.name);
-                            }
-                            scope.annotate_ctx.trait_ctx.self_type = old_self_type;
-
-                            found_traits.push(TraitMethodMatch {
-                                trait_name: trait_name_str.clone(),
-                                method_info: MethodInfo {
-                                    return_type,
-                                    self_kind,
-                                    param_types,
-                                    param_is_mut,
-                                    inherited_from_base: None,
-                                    cm_name: None,
-                                    is_ref_impl: false,
-                                    method_type_param_ids: vec![],
-                                    impl_module: Some(impl_module_source.clone()),
-                                    from_concrete_impl: impl_is_concrete,
-                                    param_defaults,
-                                    param_names,
-                                },
-                                impl_module_source: impl_module_source.clone(),
-                                blanket_type_param: blanket_type_param.clone(),
-                                impl_struct_name: impl_struct_name.clone(),
-                                is_blanket_ref_impl,
-                            });
-                        }
-                    }
-                }
-            }
-
-            // Trait context is auto-restored on drop(scope).
-            drop(scope);
+            // Project this candidate into 0+ trait-method matches (Phase C).
+            found_traits.extend(self.collect_trait_method_matches_from_impl(
+                impl_ref,
+                impl_struct_name,
+                is_blanket_type_param,
+                method_name,
+                receiver_type_args,
+                receiver_type_id,
+            ));
         }
 
-        // Prefer trait from the current module over cross-module traits.
-        // Sort BEFORE dedup_by, since dedup_by only removes adjacent duplicates.
-        let current_module = &self.current_module_source;
-        found_traits.sort_by(|a, b| {
-            let a_local = &a.impl_module_source == current_module;
-            let b_local = &b.impl_module_source == current_module;
-            b_local.cmp(&a_local)
-        });
-
-        // Remove duplicates (same trait from same module)
-        found_traits.dedup_by(|a, b| {
-            a.trait_name == b.trait_name && a.impl_module_source == b.impl_module_source
-        });
-
-        // Return the first one found (if there are multiple, it would be ambiguous,
-        // but we'll handle that later with explicit disambiguation syntax)
-        if let Some(m) = found_traits.into_iter().next() {
+        if let Some(m) = self.select_trait_match(found_traits) {
             return Some(m);
         }
 
@@ -2457,6 +2032,498 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             return self.try_auto_derived_method_match(struct_name, method_name, recv_id);
         }
         None
+    }
+
+    /// Project one candidate trait impl into 0+ [`TraitMethodMatch`]es
+    /// (Phase C of [`Self::find_trait_method_for_type_unrecorded`]). Sets up the
+    /// impl's type-parameter / associated-type scope, then emits a match for the
+    /// impl's own method (if it defines `method_name`) or, failing that, for any
+    /// matching trait default method with a body.
+    fn collect_trait_method_matches_from_impl(
+        &mut self,
+        impl_ref: &ImplBlockRef,
+        impl_struct_name: String,
+        is_blanket_type_param: bool,
+        method_name: &str,
+        receiver_type_args: Option<&[TypeId]>,
+        receiver_type_id: Option<TypeId>,
+    ) -> Vec<super::types::TraitMethodMatch> {
+        use super::types::TraitMethodMatch;
+        let mut found_traits: Vec<TraitMethodMatch> = Vec::new();
+
+        // Extract type param mappings from the impl block before mutating self.
+        let impl_block = self.get_impl_block(impl_ref);
+        // Track variadic type pack spreads: (pack_name, param_index)
+        let mut variadic_pack_entry: Option<(String, u32)> = None;
+        let type_param_entries: Vec<(String, u32)> = if let Type::Generic(generic) = &impl_block.ty
+        {
+            generic
+                .args
+                .iter()
+                .enumerate()
+                .filter_map(|(i, arg)| {
+                    if let Type::Named(named) = arg {
+                        Some((named.name.clone(), i as u32))
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        } else if let Type::Reference(boxed) | Type::MutReference(boxed) = &impl_block.ty {
+            if let Type::Named(inner) = boxed.as_ref() {
+                // impl<T: Bound> Trait for &T / &mut T: T is at position 0
+                vec![(inner.name.clone(), 0u32)]
+            } else if let Type::Generic(generic) = boxed.as_ref() {
+                // impl<T> Trait for &Container<T>: extract type params from generic args
+                generic
+                    .args
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(i, arg)| {
+                        if let Type::Named(named) = arg {
+                            Some((named.name.clone(), i as u32))
+                        } else {
+                            None
+                        }
+                    })
+                    .collect()
+            } else {
+                Vec::new()
+            }
+        } else if let Type::Tuple(elems) = &impl_block.ty {
+            // Handle variadic tuple impls: impl<..T> Trait for [..T]
+            // TypePackSpread elements map the pack name to its index.
+            let mut entries = Vec::new();
+            for (i, elem) in elems.iter().enumerate() {
+                match elem {
+                    Type::TypePackSpread(name, _) => {
+                        // Find the pack's index from the impl block's type_params
+                        let pack_idx = impl_block
+                            .type_params
+                            .iter()
+                            .position(|tp| tp.name == *name)
+                            .map(|p| p as u32)
+                            .unwrap_or(i as u32);
+                        variadic_pack_entry = Some((name.clone(), pack_idx));
+                    }
+                    Type::Named(named) => {
+                        entries.push((named.name.clone(), i as u32));
+                    }
+                    _ => {}
+                }
+            }
+            entries
+        } else {
+            Vec::new()
+        };
+        // Extract blanket type param info
+        let blanket_name = if let Type::Named(named) = &impl_block.ty {
+            Some(named.name.clone())
+        } else {
+            None
+        };
+        // Extract associated type bindings (lightweight: just name+type, not methods)
+        let assoc_bindings: Vec<(String, ast::Type)> = impl_block
+            .associated_types
+            .iter()
+            .map(|b| (b.name.clone(), b.ty.clone()))
+            .collect();
+        let impl_module_source = self.impl_block_module_source(impl_ref);
+        // A concrete generic instantiation trait impl (`impl Tag for
+        // List<u8>`) yields a per-instantiation concrete method, called
+        // directly (no monomorphization), living in the impl's module.
+        let impl_is_concrete = self.impl_is_concrete_instantiation(impl_block, &impl_module_source);
+
+        // Save trait context for this impl block scope. We use an inherited
+        // scope (saves the full ctx via clone) and then selectively clear
+        // just type_params and assoc_type_bindings — other parts (bounds,
+        // self_type, …) are kept from the parent for this lookup.
+        let mut scope = self.enter_inherited_type_param_scope();
+        scope.annotate_ctx.trait_ctx.type_params.clear();
+        scope.annotate_ctx.trait_ctx.assoc_type_bindings.clear();
+
+        // Set up type parameters for resolving generic associated types
+        if let Some(type_args) = receiver_type_args {
+            for (name, idx) in &type_param_entries {
+                let i = *idx as usize;
+                if i < type_args.len() {
+                    scope
+                        .annotate_ctx
+                        .trait_ctx
+                        .type_params
+                        .insert(name.clone(), (*idx, type_args[i]));
+                }
+            }
+            // For variadic pack params (..T in impl<..T> Trait for [..T]),
+            // map the pack to a TypePack so that the method body can reference it.
+            if let Some((pack_name, pack_idx)) = &variadic_pack_entry {
+                let pack_type = scope
+                    .tysys
+                    .type_table
+                    .borrow_mut()
+                    .make_tuple(type_args.to_vec());
+                scope
+                    .annotate_ctx
+                    .trait_ctx
+                    .type_params
+                    .insert(pack_name.clone(), (*pack_idx, pack_type));
+            }
+        }
+
+        // For blanket impls where impl_ty is a free type parameter
+        if let Some(ref name) = blanket_name
+            && !scope.annotate_ctx.trait_ctx.type_params.contains_key(name)
+            && !scope.tysys.is_known_type_name(name)
+        {
+            if let Some(recv_id) = receiver_type_id {
+                scope
+                    .annotate_ctx
+                    .trait_ctx
+                    .type_params
+                    .insert(name.clone(), (0, recv_id));
+            } else {
+                let type_id = scope
+                    .tysys
+                    .type_table
+                    .borrow_mut()
+                    .make_type_param(name.clone(), 0);
+                scope
+                    .annotate_ctx
+                    .trait_ctx
+                    .type_params
+                    .insert(name.clone(), (0, type_id));
+            }
+        }
+
+        // Set up associated type bindings for resolving Self::* types
+        for (name, ty) in &assoc_bindings {
+            let type_id = scope.resolve_type(ty);
+            scope
+                .annotate_ctx
+                .trait_ctx
+                .assoc_type_bindings
+                .insert(name.clone(), type_id);
+        }
+
+        let blanket_type_param = if is_blanket_type_param {
+            Some(impl_struct_name.clone())
+        } else {
+            None
+        };
+
+        // Detect blanket ref impls: `impl<T: Bound> Trait for &T` where the inner type
+        // is a type parameter. These should NOT override base-type methods.
+        let is_blanket_ref_impl = {
+            let impl_block = scope.get_impl_block(impl_ref);
+            match &impl_block.ty {
+                Type::Reference(inner) | Type::MutReference(inner) => {
+                    if let Type::Named(named) = inner.as_ref() {
+                        // Inner is a bare name — check if it's a type parameter
+                        impl_block
+                            .type_params
+                            .iter()
+                            .any(|tp| tp.name == named.name)
+                    } else {
+                        false
+                    }
+                }
+                _ => false,
+            }
+        };
+
+        // Extract method info from impl block before calling &mut self methods
+        let impl_block = scope.get_impl_block(impl_ref);
+        let method_data: Option<(
+            Option<ast::Type>,
+            ast::SelfKind,
+            Vec<ast::Param>,
+            Vec<ast::GenericParam>,
+        )> = impl_block
+            .methods
+            .iter()
+            .find(|m| m.name == method_name)
+            .map(|m| {
+                (
+                    m.return_type.clone(),
+                    m.params
+                        .first()
+                        .map(|p| p.self_kind)
+                        .unwrap_or(ast::SelfKind::None),
+                    m.params.clone(),
+                    m.type_params.clone(),
+                )
+            });
+        let trait_type_for_name = impl_block.trait_type.as_ref().unwrap().clone();
+
+        let mut method_found = false;
+        if let Some((return_type_ast, self_kind, params, method_type_params)) = method_data {
+            let trait_name = scope.get_type_name_full(&trait_type_for_name);
+
+            // Set up method-level type params (e.g., V in deserialize_any<V: Visitor>)
+            let impl_offset = scope.annotate_ctx.trait_ctx.type_params.len() as u32;
+            for (i, type_param) in method_type_params.iter().enumerate() {
+                let index = impl_offset + i as u32;
+                let type_param_id =
+                    scope
+                        .tysys
+                        .type_table
+                        .borrow_mut()
+                        .intern(ResolvedType::TypeParam {
+                            name: type_param.name.clone(),
+                            index,
+                        });
+                scope
+                    .annotate_ctx
+                    .trait_ctx
+                    .type_params
+                    .insert(type_param.name.clone(), (index, type_param_id));
+                if !type_param.bounds.is_empty() {
+                    scope
+                        .annotate_ctx
+                        .trait_ctx
+                        .type_param_bounds
+                        .insert(type_param.name.clone(), type_param.bounds.clone());
+                }
+            }
+
+            // Make `Self` in the method signature resolve to the concrete
+            // receiver type (e.g. `&Self` → `&Result<String, i32>` when
+            // calling through `impl<T: Eq, E: Eq> Eq for Result<T, E>`).
+            // Without this, `resolve_type("Self")` falls through to
+            // UNKNOWN and the caller's argument typecheck silently
+            // accepts anything, surfacing as an ICE at codegen.
+            let old_self_type = scope.annotate_ctx.trait_ctx.self_type;
+            if let Some(recv_id) = receiver_type_id {
+                scope.annotate_ctx.trait_ctx.self_type = Some(recv_id);
+            }
+
+            let return_type = return_type_ast
+                .as_ref()
+                .map(|t| scope.resolve_type(t))
+                .unwrap_or(TypeTable::UNIT);
+
+            // Extract param_types while method-level type params are still
+            // in scope — otherwise `&T` in a parameter would not resolve to
+            // the proper `TypeParam` id that inference expects.
+            let param_types = scope.extract_param_types(&params);
+
+            scope.annotate_ctx.trait_ctx.self_type = old_self_type;
+
+            // Remove method-level type params from scope
+            for type_param in &method_type_params {
+                scope
+                    .annotate_ctx
+                    .trait_ctx
+                    .type_params
+                    .shift_remove(&type_param.name);
+                scope
+                    .annotate_ctx
+                    .trait_ctx
+                    .type_param_bounds
+                    .shift_remove(&type_param.name);
+            }
+            let param_is_mut: Vec<bool> = params
+                .iter()
+                .filter(|p| p.name != "self")
+                .map(|p| p.is_mut)
+                .collect();
+            let param_names: Vec<String> = params
+                .iter()
+                .filter(|p| p.name != "self")
+                .map(|p| p.name.clone())
+                .collect();
+            // Parameter defaults live on the trait declaration only (WEP
+            // 2026-04-11). Pull them from the trait's method, keyed by
+            // parameter name, instead of the impl's re-specified params.
+            let trait_name_base = scope.get_type_name(&trait_type_for_name);
+            let param_defaults: Vec<Option<ast::Expr>> = {
+                let trait_method_params: Option<Vec<ast::Param>> = scope
+                    .find_trait_decl_methods(&trait_name_base)
+                    .and_then(|methods| {
+                        methods
+                            .into_iter()
+                            .find(|m| m.name == method_name)
+                            .map(|m| m.params)
+                    });
+                param_names
+                    .iter()
+                    .map(|name| {
+                        trait_method_params.as_ref().and_then(|tp| {
+                            tp.iter()
+                                .find(|p| &p.name == name)
+                                .and_then(|p| p.default.clone())
+                        })
+                    })
+                    .collect()
+            };
+            found_traits.push(TraitMethodMatch {
+                trait_name,
+                method_info: MethodInfo {
+                    return_type,
+                    self_kind,
+                    param_types,
+                    param_is_mut,
+                    inherited_from_base: None,
+                    cm_name: None,
+                    is_ref_impl: false,
+                    method_type_param_ids: vec![],
+                    impl_module: Some(impl_module_source.clone()),
+                    from_concrete_impl: impl_is_concrete,
+                    param_defaults,
+                    param_names,
+                },
+                impl_module_source: impl_module_source.clone(),
+                blanket_type_param: blanket_type_param.clone(),
+                impl_struct_name: impl_struct_name.clone(),
+                is_blanket_ref_impl,
+            });
+            method_found = true;
+        }
+
+        // If the method wasn't found in the impl block, check the trait
+        // declaration for a default method with that name
+        if !method_found {
+            let trait_name_base = scope.get_type_name(&trait_type_for_name);
+            let trait_name_str = scope.get_type_name_full(&trait_type_for_name);
+            if let Some(trait_methods) = scope.find_trait_decl_methods(&trait_name_base) {
+                for default_method in &trait_methods {
+                    if default_method.name == method_name && default_method.body.is_some() {
+                        // Set up Self type so that `Self` in the default method's
+                        // return type resolves to the concrete receiver type
+                        let old_self_type = scope.annotate_ctx.trait_ctx.self_type;
+                        if let Some(recv_id) = receiver_type_id {
+                            scope.annotate_ctx.trait_ctx.self_type = Some(recv_id);
+                        }
+
+                        // Bind the trait's own type parameters to the impl's
+                        // concrete trait args so that a default method's
+                        // return/param types written in terms of the trait's
+                        // `T` resolve to the concrete type at the call site
+                        // (e.g., `Maker<i32>::make_with_default` returns i32,
+                        // not the unresolved T).
+                        scope.bind_trait_type_params_from_impl(&trait_type_for_name);
+
+                        // Set up method-level type params (e.g., U in map<U>)
+                        let impl_offset = scope.annotate_ctx.trait_ctx.type_params.len() as u32;
+                        for (i, type_param) in default_method.type_params.iter().enumerate() {
+                            let index = impl_offset + i as u32;
+                            let type_param_id = scope.tysys.type_table.borrow_mut().intern(
+                                ResolvedType::TypeParam {
+                                    name: type_param.name.clone(),
+                                    index,
+                                },
+                            );
+                            scope
+                                .annotate_ctx
+                                .trait_ctx
+                                .type_params
+                                .insert(type_param.name.clone(), (index, type_param_id));
+                            if !type_param.bounds.is_empty() {
+                                scope
+                                    .annotate_ctx
+                                    .trait_ctx
+                                    .type_param_bounds
+                                    .insert(type_param.name.clone(), type_param.bounds.clone());
+                            }
+                        }
+
+                        let return_type = default_method
+                            .return_type
+                            .as_ref()
+                            .map(|t| scope.resolve_type(t))
+                            .unwrap_or(TypeTable::UNIT);
+                        let self_kind = default_method
+                            .params
+                            .first()
+                            .map(|p| p.self_kind)
+                            .unwrap_or(ast::SelfKind::None);
+                        let param_types = scope.extract_param_types(&default_method.params);
+                        let param_is_mut: Vec<bool> = default_method
+                            .params
+                            .iter()
+                            .filter(|p| p.name != "self")
+                            .map(|p| p.is_mut)
+                            .collect();
+                        let param_defaults: Vec<Option<ast::Expr>> = default_method
+                            .params
+                            .iter()
+                            .filter(|p| p.name != "self")
+                            .map(|p| p.default.clone())
+                            .collect();
+                        let param_names: Vec<String> = default_method
+                            .params
+                            .iter()
+                            .filter(|p| p.name != "self")
+                            .map(|p| p.name.clone())
+                            .collect();
+
+                        // Remove method-level type params from scope
+                        for type_param in &default_method.type_params {
+                            scope
+                                .annotate_ctx
+                                .trait_ctx
+                                .type_params
+                                .shift_remove(&type_param.name);
+                            scope
+                                .annotate_ctx
+                                .trait_ctx
+                                .type_param_bounds
+                                .shift_remove(&type_param.name);
+                        }
+                        scope.annotate_ctx.trait_ctx.self_type = old_self_type;
+
+                        found_traits.push(TraitMethodMatch {
+                            trait_name: trait_name_str.clone(),
+                            method_info: MethodInfo {
+                                return_type,
+                                self_kind,
+                                param_types,
+                                param_is_mut,
+                                inherited_from_base: None,
+                                cm_name: None,
+                                is_ref_impl: false,
+                                method_type_param_ids: vec![],
+                                impl_module: Some(impl_module_source.clone()),
+                                from_concrete_impl: impl_is_concrete,
+                                param_defaults,
+                                param_names,
+                            },
+                            impl_module_source: impl_module_source.clone(),
+                            blanket_type_param: blanket_type_param.clone(),
+                            impl_struct_name: impl_struct_name.clone(),
+                            is_blanket_ref_impl,
+                        });
+                    }
+                }
+            }
+        }
+
+        // Trait context is auto-restored on drop(scope).
+        drop(scope);
+
+        found_traits
+    }
+
+    /// Phase D of [`Self::find_trait_method_for_type_unrecorded`]: choose the
+    /// winning match from the collected candidates. Prefers a trait impl in the
+    /// current module, deduplicates `(trait, module)` pairs, and returns the
+    /// first remaining (multiple survivors are ambiguous, resolved later by
+    /// explicit disambiguation syntax).
+    fn select_trait_match(
+        &self,
+        mut found_traits: Vec<super::types::TraitMethodMatch>,
+    ) -> Option<super::types::TraitMethodMatch> {
+        // Sort BEFORE dedup_by, since dedup_by only removes adjacent duplicates.
+        let current_module = &self.current_module_source;
+        found_traits.sort_by(|a, b| {
+            let a_local = &a.impl_module_source == current_module;
+            let b_local = &b.impl_module_source == current_module;
+            b_local.cmp(&a_local)
+        });
+        found_traits.dedup_by(|a, b| {
+            a.trait_name == b.trait_name && a.impl_module_source == b.impl_module_source
+        });
+        found_traits.into_iter().next()
     }
 
     /// Run an indexing-trait lookup on `(struct_name, base_type_id)`, falling

--- a/wado-compiler/src/elaborator/method_lookup.rs
+++ b/wado-compiler/src/elaborator/method_lookup.rs
@@ -592,13 +592,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // permits it), so search every module that hosts an
             // `impl <struct_name>` — disambiguated by type identity below so
             // a same-named type declared in a different module is not matched.
-            let entries: Vec<(ModuleSource, usize)> = self
-                .tysys
-                .trait_env
-                .inherent_impl_index
-                .get(&struct_name)
-                .cloned()
-                .unwrap_or_default();
+            let entries: Vec<(ModuleSource, usize)> =
+                self.tysys.trait_env.inherent_impl_keys(&struct_name);
             for (impl_module, item_idx) in &entries {
                 let Item::Impl(impl_block) = &self.loaded_modules[impl_module].items[*item_idx]
                 else {
@@ -810,13 +805,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         if struct_module_source.is_none() {
             // No specific module: fetch every inherent impl registered for
             // this type name across all loaded modules from the index.
-            let entries: Vec<(ModuleSource, usize)> = self
-                .tysys
-                .trait_env
-                .inherent_impl_index
-                .get(&struct_name)
-                .cloned()
-                .unwrap_or_default();
+            let entries: Vec<(ModuleSource, usize)> =
+                self.tysys.trait_env.inherent_impl_keys(&struct_name);
             for (search_module_source, item_idx) in &entries {
                 let Item::Impl(impl_block) =
                     &self.loaded_modules[search_module_source].items[*item_idx]
@@ -1532,23 +1522,15 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         include_trait: bool,
         only_module: Option<&ModuleSource>,
     ) -> Option<Vec<ast::GenericParam>> {
-        // Candidate impl-header keys for this receiver type from the pre-built
-        // indices, both keyed by the bare receiver name `get_type_name_static`
-        // yields — the same name the former scan compared against. Inherent and
-        // trait impls live in disjoint indices, so selecting by `include_trait`
-        // reproduces the old `trait_name.is_some()` skip without touching every
-        // impl in the program.
-        let mut candidates: Vec<&(ModuleSource, usize)> = Vec::new();
-        if let Some(entries) = self.tysys.trait_env.inherent_impl_index.get(struct_name) {
-            candidates.extend(entries.iter());
-        }
-        if include_trait && let Some(entries) = self.tysys.trait_env.impl_index.get(struct_name) {
-            candidates.extend(entries.iter());
-        }
-        // Restore the original global insertion order so a tie between two
-        // impls defining the same method keeps the previous winner.
-        candidates.sort_by_key(|key| self.tysys.trait_env.impl_headers.get_index_of(*key));
-
+        // Candidate impl-header keys for this receiver type, in global build
+        // order, keyed by the bare receiver name `get_type_name_static` yields
+        // (the same name the former scan compared against). Iterating
+        // `all_impl_index` directly preserves the original order — and the
+        // original `!include_trait` `trait_name.is_some()` skip — with no merge
+        // or per-call sort.
+        let Some(candidates) = self.tysys.trait_env.all_impl_index.get(struct_name) else {
+            return None;
+        };
         for key in candidates {
             if let Some(m) = only_module
                 && &key.0 != m
@@ -1558,6 +1540,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             let Some(header) = self.tysys.trait_env.impl_headers.get(key) else {
                 continue;
             };
+            if !include_trait && header.trait_name.is_some() {
+                continue;
+            }
             for method in &header.methods {
                 if method.name == method_name
                     && let Some(names) = Self::non_effect_generic_params(&method.type_params)

--- a/wado-compiler/src/elaborator/method_lookup.rs
+++ b/wado-compiler/src/elaborator/method_lookup.rs
@@ -210,6 +210,60 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         refs
     }
 
+    /// Shared scan-and-map prologue behind `find_indexing_trait_impl`,
+    /// `find_assoc_type_in_trait_impl`, and `find_arithmetic_trait_impl`.
+    ///
+    /// Walks the trait impls on `struct_name` whose trait name satisfies
+    /// `trait_matches`, builds each candidate's type-parameter mapping from
+    /// `concrete_type_args`, and returns the first non-`None` `project` result.
+    /// Each caller's per-candidate filtering, `Self` handling, and projection
+    /// stay inside `project` (returning `None` skips the candidate); the
+    /// prologue owns only the two mechanical axes the three copies drifted on:
+    ///
+    /// - `trait_matches`: prefix (indexing / assoc) vs exact (arithmetic).
+    /// - `use_declared_type_params`: when false, `build_type_param_mapping`
+    ///   treats every `Named` impl arg as a type parameter (the arithmetic
+    ///   path's legacy behavior); when true it consults the impl's declared
+    ///   params. The resolved declared set is handed to `project` so callers
+    ///   that also run `verify_impl_type_compatibility` reuse it.
+    ///
+    /// `collect_trait_impl_refs` already keys on `struct_name`, so the former
+    /// per-candidate `get_type_name(&impl.ty) == struct_name` re-check (always
+    /// true here) is dropped.
+    fn probe_trait_impls<R>(
+        &mut self,
+        struct_name: &str,
+        concrete_type_args: &[TypeId],
+        use_declared_type_params: bool,
+        trait_matches: impl Fn(&str) -> bool,
+        mut project: impl FnMut(
+            &mut Self,
+            &ImplBlockRef,
+            &IndexMap<String, TypeId>,
+            &IndexSet<String>,
+        ) -> Option<R>,
+    ) -> Option<R> {
+        let impl_refs = self.collect_trait_impl_refs(struct_name);
+        for impl_ref in &impl_refs {
+            let impl_block = self.get_impl_block(impl_ref);
+            let trait_name = self.get_type_name(impl_block.trait_type.as_ref().unwrap());
+            if !trait_matches(&trait_name) {
+                continue;
+            }
+            let declared = if use_declared_type_params {
+                self.tysys.build_declared_type_params(impl_block)
+            } else {
+                IndexSet::default()
+            };
+            let mapping =
+                TypeSystem::build_type_param_mapping(&impl_block.ty, concrete_type_args, &declared);
+            if let Some(result) = project(self, impl_ref, &mapping, &declared) {
+                return Some(result);
+            }
+        }
+        None
+    }
+
     /// Find the rhs parameter type for an operator trait on a struct type.
     /// Used to determine what type a literal rhs should be coerced to.
     pub(super) fn find_operator_rhs_type(
@@ -2420,6 +2474,28 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         None
     }
 
+    /// Run an indexing-trait lookup on `(struct_name, base_type_id)`, falling
+    /// back to the receiver's newtype base `(lookup_name, lookup_type_id)` only
+    /// when it actually differs. For a non-newtype receiver the base equals the
+    /// primary, so the former `lookup(primary).or_else(|| lookup(base))` re-ran
+    /// the identical scan on every `a[i]`; this skips that redundant call.
+    pub(super) fn index_lookup_or_newtype_base<T>(
+        &mut self,
+        struct_name: &str,
+        base_type_id: TypeId,
+        lookup_name: &str,
+        lookup_type_id: TypeId,
+        mut lookup: impl FnMut(&mut Self, &str, TypeId) -> Option<T>,
+    ) -> Option<T> {
+        if let Some(found) = lookup(self, struct_name, base_type_id) {
+            return Some(found);
+        }
+        if lookup_name != struct_name || lookup_type_id != base_type_id {
+            return lookup(self, lookup_name, lookup_type_id);
+        }
+        None
+    }
+
     /// Find Index trait implementation for a type
     pub(super) fn find_index_trait_impl(
         &mut self,
@@ -2523,40 +2599,30 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 Vec::new()
             };
 
-        let impl_refs = self.collect_trait_impl_refs(struct_name);
-
-        for impl_ref in &impl_refs {
-            let impl_block = self.get_impl_block(impl_ref);
-            let trait_type = impl_block.trait_type.as_ref().unwrap();
-            let trait_name = self.get_type_name(trait_type);
-            if !trait_name.starts_with(trait_base_name) {
-                continue;
-            }
-            let impl_block = self.get_impl_block(impl_ref);
-            let binding_ty = match impl_block
-                .associated_types
-                .iter()
-                .find(|b| b.name == assoc_name)
-            {
-                Some(b) => b.ty.clone(),
-                None => continue,
-            };
-            let declared_type_params = self.tysys.build_declared_type_params(impl_block);
-            let type_param_mapping = TypeSystem::build_type_param_mapping(
-                &impl_block.ty,
-                &concrete_type_args,
-                &declared_type_params,
-            );
-            if !self.tysys.verify_impl_type_compatibility(
-                &impl_block.ty,
-                &concrete_type_args,
-                &declared_type_params,
-            ) {
-                continue;
-            }
-            return Some(self.resolve_type_with_param_mapping(&binding_ty, &type_param_mapping));
-        }
-        None
+        self.probe_trait_impls(
+            struct_name,
+            &concrete_type_args,
+            true,
+            |trait_name| trait_name.starts_with(trait_base_name),
+            |s, impl_ref, mapping, declared| {
+                let impl_block = s.get_impl_block(impl_ref);
+                let binding_ty = impl_block
+                    .associated_types
+                    .iter()
+                    .find(|b| b.name == assoc_name)?
+                    .ty
+                    .clone();
+                let impl_block = s.get_impl_block(impl_ref);
+                if !s.tysys.verify_impl_type_compatibility(
+                    &impl_block.ty,
+                    &concrete_type_args,
+                    declared,
+                ) {
+                    return None;
+                }
+                Some(s.resolve_type_with_param_mapping(&binding_ty, mapping))
+            },
+        )
     }
 
     /// Find `SequenceLiteralBuilder` trait implementation for a type.
@@ -2733,142 +2799,115 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 Vec::new()
             };
 
-        let impl_refs = self.collect_trait_impl_refs(struct_name);
+        self.probe_trait_impls(
+            struct_name,
+            &concrete_type_args,
+            // Arithmetic's mapping treats every `Named` impl arg as a type
+            // parameter (empty declared set), unlike the indexing/assoc paths.
+            false,
+            |found_trait_name| found_trait_name == trait_name,
+            |s, impl_ref, mapping, _declared| {
+                // Check trait bounds on type parameters (e.g., impl<T: Eq> Eq for List<T>)
+                let impl_block = s.get_impl_block(impl_ref);
+                if !impl_block.type_params.iter().all(|p| p.bounds.is_empty())
+                    && !concrete_type_args.is_empty()
+                {
+                    let bounds_map: IndexMap<&str, Vec<String>> = impl_block
+                        .type_params
+                        .iter()
+                        .filter(|p| !p.bounds.is_empty())
+                        .map(|p| {
+                            (
+                                p.name.as_str(),
+                                p.bounds.iter().map(|b| b.name.clone()).collect(),
+                            )
+                        })
+                        .collect();
 
-        for impl_ref in &impl_refs {
-            let impl_block = self.get_impl_block(impl_ref);
-            let impl_struct_name = self.get_type_name(&impl_block.ty);
-            if impl_struct_name != struct_name {
-                continue;
-            }
-
-            // Check if this is the target trait
-            let impl_block = self.get_impl_block(impl_ref);
-            let found_trait_name = self.get_type_name(impl_block.trait_type.as_ref().unwrap());
-            if found_trait_name != trait_name {
-                continue;
-            }
-
-            // Check trait bounds on type parameters (e.g., impl<T: Eq> Eq for List<T>)
-            let impl_block = self.get_impl_block(impl_ref);
-            if !impl_block.type_params.iter().all(|p| p.bounds.is_empty())
-                && !concrete_type_args.is_empty()
-            {
-                let bounds_map: IndexMap<&str, Vec<String>> = impl_block
-                    .type_params
-                    .iter()
-                    .filter(|p| !p.bounds.is_empty())
-                    .map(|p| {
-                        (
-                            p.name.as_str(),
-                            p.bounds.iter().map(|b| b.name.clone()).collect(),
-                        )
-                    })
-                    .collect();
-
-                let mut bounds_satisfied = true;
-                if let ast::Type::Generic(generic) = &impl_block.ty {
-                    for (i, arg) in generic.args.iter().enumerate() {
-                        if let ast::Type::Named(named) = arg
-                            && let Some(bounds) = bounds_map.get(named.name.as_str())
-                            && let Some(&type_arg) = concrete_type_args.get(i)
-                        {
-                            if matches!(
-                                self.tysys.type_table.borrow().get(type_arg),
-                                ResolvedType::TypeParam { .. }
-                            ) {
-                                continue;
-                            }
-                            for bound in bounds {
-                                if !self.type_implements_trait(&self.annotate_ctx, type_arg, bound)
-                                {
-                                    bounds_satisfied = false;
-                                    break;
+                    let mut bounds_satisfied = true;
+                    if let ast::Type::Generic(generic) = &impl_block.ty {
+                        for (i, arg) in generic.args.iter().enumerate() {
+                            if let ast::Type::Named(named) = arg
+                                && let Some(bounds) = bounds_map.get(named.name.as_str())
+                                && let Some(&type_arg) = concrete_type_args.get(i)
+                            {
+                                if matches!(
+                                    s.tysys.type_table.borrow().get(type_arg),
+                                    ResolvedType::TypeParam { .. }
+                                ) {
+                                    continue;
+                                }
+                                for bound in bounds {
+                                    if !s.type_implements_trait(&s.annotate_ctx, type_arg, bound) {
+                                        bounds_satisfied = false;
+                                        break;
+                                    }
                                 }
                             }
-                        }
-                        if !bounds_satisfied {
-                            break;
+                            if !bounds_satisfied {
+                                break;
+                            }
                         }
                     }
+                    if !bounds_satisfied {
+                        return None;
+                    }
                 }
-                if !bounds_satisfied {
-                    continue;
+
+                // Gather everything we need from the impl block up front, then
+                // drop the borrow on `self` before touching `trait_ctx.self_type`
+                // (which requires a mutable borrow). `Self` is NOT inserted into
+                // `mapping` — it is substituted through `trait_ctx.self_type`
+                // (set just below) via the `resolve_type_with_param_mapping`
+                // fallback, shared with `find_trait_method_for_type`.
+                let impl_block = s.get_impl_block(impl_ref);
+                let method = impl_block.methods.iter().find(|m| m.name == method_name)?;
+                let assoc_types: Vec<(String, ast::Type)> = impl_block
+                    .associated_types
+                    .iter()
+                    .map(|a| (a.name.clone(), a.ty.clone()))
+                    .collect();
+                let self_kind = method
+                    .params
+                    .first()
+                    .map(|p| p.self_kind)
+                    .unwrap_or(ast::SelfKind::None);
+                let rhs_param_ty = method
+                    .params
+                    .iter()
+                    .find(|p| p.self_kind == ast::SelfKind::None)
+                    .map(|p| p.ty.clone());
+
+                let saved_self_type = s.annotate_ctx.trait_ctx.self_type;
+                s.annotate_ctx.trait_ctx.self_type = Some(base_type_id);
+
+                // Process associated types (e.g., `type Output = Self`)
+                let mut assoc_type_map: IndexMap<String, TypeId> = IndexMap::default();
+                for (name, ty) in &assoc_types {
+                    let resolved_type = s.resolve_type_with_param_mapping(ty, mapping);
+                    assoc_type_map.insert(name.clone(), resolved_type);
                 }
-            }
 
-            // Build type parameter mapping from impl_ty to concrete types.
-            // `Self` is NOT inserted into this mapping — it is substituted
-            // through `trait_ctx.self_type` (set just below) via the
-            // fallback path in `resolve_type_with_param_mapping`.  This
-            // keeps Self substitution on a single mechanism shared with
-            // `find_trait_method_for_type`.
-            let impl_block = self.get_impl_block(impl_ref);
-            let type_param_mapping = TypeSystem::build_type_param_mapping(
-                &impl_block.ty,
-                &concrete_type_args,
-                &IndexSet::default(),
-            );
+                let output_type = assoc_type_map
+                    .get("Output")
+                    .copied()
+                    .unwrap_or(base_type_id);
 
-            // Gather everything we need from the impl block up front, then
-            // drop the borrow on `self` before touching `trait_ctx.self_type`
-            // (which requires a mutable borrow).
-            let impl_block = self.get_impl_block(impl_ref);
-            let Some(method) = impl_block.methods.iter().find(|m| m.name == method_name) else {
-                continue;
-            };
-            let assoc_types: Vec<(String, ast::Type)> = impl_block
-                .associated_types
-                .iter()
-                .map(|a| (a.name.clone(), a.ty.clone()))
-                .collect();
-            let self_kind = method
-                .params
-                .first()
-                .map(|p| p.self_kind)
-                .unwrap_or(ast::SelfKind::None);
-            let rhs_param_ty = method
-                .params
-                .iter()
-                .find(|p| p.self_kind == ast::SelfKind::None)
-                .map(|p| p.ty.clone());
+                // Resolve the rhs parameter type (first non-self parameter)
+                let rhs_type = rhs_param_ty
+                    .as_ref()
+                    .map(|ty| s.resolve_type_with_param_mapping(ty, mapping));
 
-            // Bind `Self` for the duration of signature resolution. The
-            // single-source-of-truth for `Self` substitution is
-            // `trait_ctx.self_type` (consulted by both `resolve_type` and
-            // the `resolve_type_with_param_mapping` fallback above).
-            let saved_self_type = self.annotate_ctx.trait_ctx.self_type;
-            self.annotate_ctx.trait_ctx.self_type = Some(base_type_id);
+                s.annotate_ctx.trait_ctx.self_type = saved_self_type;
 
-            // Process associated types (e.g., `type Output = Self`)
-            let mut assoc_type_map: IndexMap<String, TypeId> = IndexMap::default();
-            for (name, ty) in &assoc_types {
-                let resolved_type = self.resolve_type_with_param_mapping(ty, &type_param_mapping);
-                assoc_type_map.insert(name.clone(), resolved_type);
-            }
-
-            // Get the output type from associated types
-            let output_type = assoc_type_map
-                .get("Output")
-                .copied()
-                .unwrap_or(base_type_id);
-
-            // Resolve the rhs parameter type (first non-self parameter)
-            let rhs_type = rhs_param_ty
-                .as_ref()
-                .map(|ty| self.resolve_type_with_param_mapping(ty, &type_param_mapping));
-
-            self.annotate_ctx.trait_ctx.self_type = saved_self_type;
-
-            return Some(ArithmeticTraitInfo {
-                output_type,
-                self_kind,
-                trait_name: trait_name.to_string(),
-                rhs_type,
-            });
-        }
-
-        None
+                Some(ArithmeticTraitInfo {
+                    output_type,
+                    self_kind,
+                    trait_name: trait_name.to_string(),
+                    rhs_type,
+                })
+            },
+        )
     }
 
     /// Look up the type parameters of a static method from its impl header.
@@ -2933,67 +2972,46 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 _ => Vec::new(),
             };
 
-        let impl_refs = self.collect_trait_impl_refs(struct_name);
-
-        for impl_ref in &impl_refs {
-            let impl_block = self.get_impl_block(impl_ref);
-            let impl_struct_name = self.get_type_name(&impl_block.ty);
-            if impl_struct_name != struct_name {
-                continue;
-            }
-
-            // Check if this is the target trait (Index or IndexAssign)
-            let impl_block = self.get_impl_block(impl_ref);
-            let trait_base = self.get_type_name(impl_block.trait_type.as_ref().unwrap());
-            if !trait_base.starts_with(trait_base_name) {
-                continue;
-            }
-            let trait_name = self.get_type_name_full(impl_block.trait_type.as_ref().unwrap());
-
-            let impl_block = self.get_impl_block(impl_ref);
-            let declared_type_params = self.tysys.build_declared_type_params(impl_block);
-
-            let impl_block = self.get_impl_block(impl_ref);
-            let type_param_mapping = TypeSystem::build_type_param_mapping(
-                &impl_block.ty,
-                &concrete_type_args,
-                &declared_type_params,
-            );
-
-            // If an expected index type is provided, check the trait's type argument matches.
-            // e.g., for `impl IndexValue<RangeExclusive<i32>> for List<T>`, the trait type arg
-            // is `RangeExclusive<i32>` which must match the actual index expression type.
-            if let Some(expected_idx_type) = expected_index_type {
-                let impl_block = self.get_impl_block(impl_ref);
-                let trait_index_arg = impl_block.trait_type.as_ref().and_then(|t| {
-                    if let ast::Type::Generic(g) = t {
-                        g.args.first().cloned()
-                    } else {
-                        None
-                    }
-                });
-                if let Some(ref arg) = trait_index_arg {
-                    let resolved_trait_idx =
-                        self.resolve_type_with_param_mapping(arg, &type_param_mapping);
-                    if resolved_trait_idx != expected_idx_type {
-                        continue;
+        self.probe_trait_impls(
+            struct_name,
+            &concrete_type_args,
+            true,
+            |trait_base| trait_base.starts_with(trait_base_name),
+            |s, impl_ref, mapping, declared| {
+                // If an expected index type is provided, check the trait's type
+                // argument matches. e.g. for `impl IndexValue<RangeExclusive<i32>>
+                // for List<T>` the trait type arg `RangeExclusive<i32>` must match
+                // the actual index expression type.
+                if let Some(expected_idx_type) = expected_index_type {
+                    let impl_block = s.get_impl_block(impl_ref);
+                    let trait_index_arg = impl_block.trait_type.as_ref().and_then(|t| {
+                        if let ast::Type::Generic(g) = t {
+                            g.args.first().cloned()
+                        } else {
+                            None
+                        }
+                    });
+                    if let Some(ref arg) = trait_index_arg {
+                        let resolved_trait_idx = s.resolve_type_with_param_mapping(arg, mapping);
+                        if resolved_trait_idx != expected_idx_type {
+                            return None;
+                        }
                     }
                 }
-            }
 
-            // Verify non-type-parameter positions match the concrete type args
-            let impl_block = self.get_impl_block(impl_ref);
-            if !self.tysys.verify_impl_type_compatibility(
-                &impl_block.ty,
-                &concrete_type_args,
-                &declared_type_params,
-            ) {
-                continue;
-            }
+                // Verify non-type-parameter positions match the concrete type args
+                let impl_block = s.get_impl_block(impl_ref);
+                if !s.tysys.verify_impl_type_compatibility(
+                    &impl_block.ty,
+                    &concrete_type_args,
+                    declared,
+                ) {
+                    return None;
+                }
 
-            // Find the method
-            let impl_block = self.get_impl_block(impl_ref);
-            if let Some(method) = impl_block.methods.iter().find(|m| m.name == method_name) {
+                // Find the method
+                let impl_block = s.get_impl_block(impl_ref);
+                let method = impl_block.methods.iter().find(|m| m.name == method_name)?;
                 let self_kind = method
                     .params
                     .first()
@@ -3005,13 +3023,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     .iter()
                     .map(|b| (b.name.clone(), b.ty.clone()))
                     .collect();
-                let impl_source = self.impl_block_module_source(impl_ref);
+                let trait_name = s.get_type_name_full(impl_block.trait_type.as_ref().unwrap());
+                let impl_source = s.impl_block_module_source(impl_ref);
 
                 // Set up associated type bindings (auto-restored on scope drop)
-                let mut scope = self.enter_inherited_type_param_scope();
+                let mut scope = s.enter_inherited_type_param_scope();
                 scope.annotate_ctx.trait_ctx.assoc_type_bindings.clear();
                 for (name, ty) in &assoc_bindings {
-                    let type_id = scope.resolve_type_with_param_mapping(ty, &type_param_mapping);
+                    let type_id = scope.resolve_type_with_param_mapping(ty, mapping);
                     scope
                         .annotate_ctx
                         .trait_ctx
@@ -3030,11 +3049,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
                 drop(scope);
 
-                return Some((assoc_type, self_kind, trait_name, impl_source));
-            }
-        }
-
-        None
+                Some((assoc_type, self_kind, trait_name, impl_source))
+            },
+        )
     }
 
     /// Resolve a type, substituting type parameters using the provided mapping.

--- a/wado-compiler/src/elaborator/method_lookup.rs
+++ b/wado-compiler/src/elaborator/method_lookup.rs
@@ -212,21 +212,16 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
     /// Shared scan-and-map prologue behind `find_indexing_trait_impl`,
     /// `find_assoc_type_in_trait_impl`, and `find_arithmetic_trait_impl`: walk
-    /// the trait impls on `struct_name` whose name satisfies `trait_matches`,
-    /// build each candidate's type-parameter mapping from `concrete_type_args`,
-    /// and return the first non-`None` `project` (per-candidate filtering,
-    /// `Self` handling, and projection live in `project`; `None` skips it).
-    ///
-    /// - `trait_matches`: prefix (indexing / assoc) vs exact (arithmetic).
-    /// - `use_declared_type_params`: when false, `build_type_param_mapping`
-    ///   treats every `Named` impl arg as a type parameter (arithmetic's legacy
-    ///   behavior); when true it consults the impl's declared params, which are
-    ///   also handed to `project`.
+    /// the trait impls on `struct_name` whose name satisfies `trait_matches`
+    /// (prefix for indexing / assoc, exact for arithmetic), build each
+    /// candidate's type-parameter mapping from `concrete_type_args`, and return
+    /// the first non-`None` `project`. Per-candidate filtering, `Self` handling,
+    /// and projection live in `project` (which also receives the impl's declared
+    /// type params); returning `None` skips the candidate.
     fn probe_trait_impls<R>(
         &mut self,
         struct_name: &str,
         concrete_type_args: &[TypeId],
-        use_declared_type_params: bool,
         trait_matches: impl Fn(&str) -> bool,
         mut project: impl FnMut(
             &mut Self,
@@ -242,11 +237,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             if !trait_matches(&trait_name) {
                 continue;
             }
-            let declared = if use_declared_type_params {
-                self.tysys.build_declared_type_params(impl_block)
-            } else {
-                IndexSet::default()
-            };
+            let declared = self.tysys.build_declared_type_params(impl_block);
             let mapping =
                 TypeSystem::build_type_param_mapping(&impl_block.ty, concrete_type_args, &declared);
             if let Some(result) = project(self, impl_ref, &mapping, &declared) {
@@ -2611,7 +2602,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         self.probe_trait_impls(
             struct_name,
             &concrete_type_args,
-            true,
             |trait_name| trait_name.starts_with(trait_base_name),
             |s, impl_ref, mapping, declared| {
                 let impl_block = s.get_impl_block(impl_ref);
@@ -2811,7 +2801,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         self.probe_trait_impls(
             struct_name,
             &concrete_type_args,
-            false, // legacy mapping: every `Named` impl arg is a type param
             |found_trait_name| found_trait_name == trait_name,
             |s, impl_ref, mapping, _declared| {
                 // Check trait bounds on type parameters (e.g., impl<T: Eq> Eq for List<T>)
@@ -2982,7 +2971,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         self.probe_trait_impls(
             struct_name,
             &concrete_type_args,
-            true,
             |trait_base| trait_base.starts_with(trait_base_name),
             |s, impl_ref, mapping, declared| {
                 // If an expected index type is provided, check the trait's type

--- a/wado-compiler/src/elaborator/method_lookup.rs
+++ b/wado-compiler/src/elaborator/method_lookup.rs
@@ -1720,7 +1720,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // via an AstId collision in `bindings.references` (cf.
         // `lookup_method_info` which suppresses for the same reason).
         self.with_reference_recording_suppressed(|s| {
-            s.find_trait_method_for_type_unrecorded(
+            s.find_trait_method_for_type_inner(
                 struct_name,
                 method_name,
                 struct_module,
@@ -1733,7 +1733,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// `struct_name` plus the base names of its newtype chain
     /// (`type Alias = Base` → `Base`, `Flags` → `u32`), so a trait impl on a
     /// base type is reachable through the alias. Phase A of
-    /// [`Self::find_trait_method_for_type_unrecorded`].
+    /// [`Self::find_trait_method_for_type_inner`].
     fn newtype_chain_names(&self, struct_name: &str) -> Vec<String> {
         let mut names = vec![struct_name.to_string()];
         if let Some(newtype_id) = self.lookup_newtype(struct_name) {
@@ -1756,7 +1756,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         names
     }
 
-    /// Candidate trait impls for [`Self::find_trait_method_for_type_unrecorded`]
+    /// Candidate trait impls for [`Self::find_trait_method_for_type_inner`]
     /// (Phase A): every trait impl on one of `names_to_check`, plus blanket
     /// impls (`impl<T: Bound> Trait for T`) whose bound the receiver satisfies.
     fn trait_method_candidates(&mut self, names_to_check: &[String]) -> Vec<ImplBlockRef> {
@@ -1797,7 +1797,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         impl_refs
     }
 
-    /// Phase B of [`Self::find_trait_method_for_type_unrecorded`]: decide whether
+    /// Phase B of [`Self::find_trait_method_for_type_inner`]: decide whether
     /// a candidate impl applies to the receiver. Returns the impl's receiver
     /// name and whether it is a blanket type-param impl (both consumed by
     /// Phase C), or `None` to skip the candidate.
@@ -1972,13 +1972,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
     }
 
-    /// The body of [`Self::find_trait_method_for_type`], run with use→def
-    /// reference recording suppressed (foreign impl signatures are walked
-    /// here; see the wrapper). Despite the former `_uncached` name there is no
-    /// cache — the pre-built impl indices are the shared memo. Orchestrates
-    /// candidate collection, per-candidate receiver matching, projection, and
-    /// final selection across the dedicated helpers below.
-    fn find_trait_method_for_type_unrecorded(
+    /// The body of [`Self::find_trait_method_for_type`] (the wrapper runs it
+    /// with use→def reference recording suppressed, since foreign impl
+    /// signatures are walked here). Orchestrates candidate collection,
+    /// per-candidate receiver matching, projection, and final selection across
+    /// the dedicated helpers below.
+    fn find_trait_method_for_type_inner(
         &mut self,
         struct_name: &str,
         method_name: &str,
@@ -2035,7 +2034,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     }
 
     /// Project one candidate trait impl into 0+ [`TraitMethodMatch`]es
-    /// (Phase C of [`Self::find_trait_method_for_type_unrecorded`]). Sets up the
+    /// (Phase C of [`Self::find_trait_method_for_type_inner`]). Sets up the
     /// impl's type-parameter / associated-type scope, then emits a match for the
     /// impl's own method (if it defines `method_name`) or, failing that, for any
     /// matching trait default method with a body.
@@ -2504,7 +2503,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         found_traits
     }
 
-    /// Phase D of [`Self::find_trait_method_for_type_unrecorded`]: choose the
+    /// Phase D of [`Self::find_trait_method_for_type_inner`]: choose the
     /// winning match from the collected candidates. Prefers a trait impl in the
     /// current module, deduplicates `(trait, module)` pairs, and returns the
     /// first remaining (multiple survivors are ambiguous, resolved later by

--- a/wado-compiler/src/elaborator/method_lookup.rs
+++ b/wado-compiler/src/elaborator/method_lookup.rs
@@ -1478,24 +1478,37 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         include_trait: bool,
         only_module: Option<&ModuleSource>,
     ) -> Option<Vec<ast::GenericParam>> {
-        for (key, header) in &self.tysys.trait_env.impl_headers {
+        // Candidate impl-header keys for this receiver type from the pre-built
+        // indices, both keyed by the bare receiver name `get_type_name_static`
+        // yields — the same name the former scan compared against. Inherent and
+        // trait impls live in disjoint indices, so selecting by `include_trait`
+        // reproduces the old `trait_name.is_some()` skip without touching every
+        // impl in the program.
+        let mut candidates: Vec<&(ModuleSource, usize)> = Vec::new();
+        if let Some(entries) = self.tysys.trait_env.inherent_impl_index.get(struct_name) {
+            candidates.extend(entries.iter());
+        }
+        if include_trait && let Some(entries) = self.tysys.trait_env.impl_index.get(struct_name) {
+            candidates.extend(entries.iter());
+        }
+        // Restore the original global insertion order so a tie between two
+        // impls defining the same method keeps the previous winner.
+        candidates.sort_by_key(|key| self.tysys.trait_env.impl_headers.get_index_of(*key));
+
+        for key in candidates {
             if let Some(m) = only_module
                 && &key.0 != m
             {
                 continue;
             }
-            if !include_trait && header.trait_name.is_some() {
+            let Some(header) = self.tysys.trait_env.impl_headers.get(key) else {
                 continue;
-            }
-            let impl_type_name = self.get_type_name(&header.ty);
-            let impl_base_name = impl_type_name.split('<').next().unwrap_or(&impl_type_name);
-            if impl_type_name == struct_name || impl_base_name == struct_name {
-                for method in &header.methods {
-                    if method.name == method_name
-                        && let Some(names) = Self::non_effect_generic_params(&method.type_params)
-                    {
-                        return Some(names);
-                    }
+            };
+            for method in &header.methods {
+                if method.name == method_name
+                    && let Some(names) = Self::non_effect_generic_params(&method.type_params)
+                {
+                    return Some(names);
                 }
             }
         }

--- a/wado-compiler/src/elaborator/operators.rs
+++ b/wado-compiler/src/elaborator/operators.rs
@@ -1186,15 +1186,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         self.typecheck(index_type, expected, index_expr.index.span());
                     }
 
-                    let assign_info = self
-                        .find_index_assign_trait_impl(&struct_name, base_type_id, index_type)
-                        .or_else(|| {
-                            self.find_index_assign_trait_impl(
-                                &lookup_name,
-                                lookup_type_id,
-                                index_type,
-                            )
-                        });
+                    let assign_info = self.index_lookup_or_newtype_base(
+                        &struct_name,
+                        base_type_id,
+                        &lookup_name,
+                        lookup_type_id,
+                        |s, n, t| s.find_index_assign_trait_impl(n, t, index_type),
+                    );
                     if let Some(trait_info) = assign_info {
                         // Generate: expr.index_assign(index, value)
                         let value_span = value.span();

--- a/wado-compiler/src/elaborator/trait_env.rs
+++ b/wado-compiler/src/elaborator/trait_env.rs
@@ -240,19 +240,12 @@ pub struct TraitEnv {
     /// Type name → impl blocks that implement traits for that type.
     pub(super) impl_index: TraitImplIndex,
     /// Type name → **every** impl block (inherent and trait) on that type, in
-    /// global build order (module-then-item, matching `impl_headers`'s
-    /// insertion order). Lets instance-method lookup fetch only the candidate
-    /// impls for a receiver type instead of scanning every item in every
-    /// loaded module — the dominant cost for module-less receivers
-    /// (primitives, `Array<T>`, `unit`) whose inherent methods previously
-    /// triggered a full `O(modules × items)` sweep. Keyed by the same bare
-    /// type name as `impl_index` (via `get_type_name_static`), so two
-    /// same-named types in different modules share a bucket and are
-    /// disambiguated by the per-entry `ModuleSource` at the call site.
-    ///
-    /// Because entries are already globally ordered, candidate scans iterate
-    /// directly — no per-call sort to reconstruct order — and the inherent
-    /// subset is the `trait_name.is_none()` filter ([`Self::inherent_impl_keys`]).
+    /// global build order (matching `impl_headers`'s insertion order), so
+    /// candidate scans iterate directly with no per-call sort. Keyed like
+    /// `impl_index` (bare name via `get_type_name_static`); same-named types in
+    /// different modules share a bucket, disambiguated by the per-entry
+    /// `ModuleSource`. The inherent subset is the `trait_name.is_none()` filter
+    /// ([`Self::inherent_impl_keys`]).
     pub(super) all_impl_index: TraitImplIndex,
     /// Trait name → trait declaration location.
     pub(super) decl_index: TraitDeclIndex,
@@ -669,9 +662,8 @@ impl TraitEnv {
                         associated_types: impl_block.associated_types.clone(),
                     },
                 );
-                // Every impl (inherent or trait) joins `all_impl_index` here,
-                // before the trait/inherent split below, so its order matches
-                // `impl_headers`'s global insertion order.
+                // Joins `all_impl_index` before the trait/inherent split, so its
+                // order matches `impl_headers`'s global insertion order.
                 all_impl_index
                     .entry(type_name.clone())
                     .or_default()
@@ -736,9 +728,8 @@ impl TraitEnv {
                         }
                     }
                 } else {
-                    // Non-trait (inherent) impl block: already recorded in
-                    // `all_impl_index` above; here only its static methods need
-                    // the dedicated index.
+                    // Inherent impl: already in `all_impl_index`; here only its
+                    // static methods need the dedicated index.
                     let recv_key = canonical_key(module_source, &type_name);
                     for (method_idx, method) in impl_block.methods.iter().enumerate() {
                         let has_self = method

--- a/wado-compiler/src/elaborator/trait_env.rs
+++ b/wado-compiler/src/elaborator/trait_env.rs
@@ -239,17 +239,21 @@ pub(crate) type TraitImplModuleIndex = IndexMap<(String, String), Vec<ModuleSour
 pub struct TraitEnv {
     /// Type name → impl blocks that implement traits for that type.
     pub(super) impl_index: TraitImplIndex,
-    /// Type name → **inherent** impl blocks (`impl Type { … }`, no trait) for
-    /// that type. The inherent counterpart of [`Self::impl_index`]. Lets
-    /// instance-method lookup fetch only the candidate impls for a receiver
-    /// type instead of scanning every item in every loaded module — the
-    /// dominant cost for module-less receivers (primitives, `Array<T>`,
-    /// `unit`) whose inherent methods previously triggered a full
-    /// `O(modules × items)` sweep. Keyed by the same bare type name as
-    /// `impl_index` (via `get_type_name_static`), so two same-named types in
-    /// different modules share a bucket and are disambiguated by the
-    /// per-entry `ModuleSource` at the call site.
-    pub(super) inherent_impl_index: TraitImplIndex,
+    /// Type name → **every** impl block (inherent and trait) on that type, in
+    /// global build order (module-then-item, matching `impl_headers`'s
+    /// insertion order). Lets instance-method lookup fetch only the candidate
+    /// impls for a receiver type instead of scanning every item in every
+    /// loaded module — the dominant cost for module-less receivers
+    /// (primitives, `Array<T>`, `unit`) whose inherent methods previously
+    /// triggered a full `O(modules × items)` sweep. Keyed by the same bare
+    /// type name as `impl_index` (via `get_type_name_static`), so two
+    /// same-named types in different modules share a bucket and are
+    /// disambiguated by the per-entry `ModuleSource` at the call site.
+    ///
+    /// Because entries are already globally ordered, candidate scans iterate
+    /// directly — no per-call sort to reconstruct order — and the inherent
+    /// subset is the `trait_name.is_none()` filter ([`Self::inherent_impl_keys`]).
+    pub(super) all_impl_index: TraitImplIndex,
     /// Trait name → trait declaration location.
     pub(super) decl_index: TraitDeclIndex,
     /// Effect name → effect declaration location.
@@ -423,7 +427,7 @@ impl TraitEnv {
             );
         }
         let mut impl_index: TraitImplIndex = IndexMap::default();
-        let mut inherent_impl_index: TraitImplIndex = IndexMap::default();
+        let mut all_impl_index: TraitImplIndex = IndexMap::default();
         let mut decl_index: TraitDeclIndex = IndexMap::default();
         let mut effect_decl_index: EffectDeclIndex = IndexMap::default();
         let mut resource_decl_index: ResourceDeclIndex = IndexMap::default();
@@ -665,6 +669,13 @@ impl TraitEnv {
                         associated_types: impl_block.associated_types.clone(),
                     },
                 );
+                // Every impl (inherent or trait) joins `all_impl_index` here,
+                // before the trait/inherent split below, so its order matches
+                // `impl_headers`'s global insertion order.
+                all_impl_index
+                    .entry(type_name.clone())
+                    .or_default()
+                    .push((module_source.clone(), item_idx));
                 if let Some(trait_type) = &impl_block.trait_type {
                     let trait_name = get_type_name_static(trait_type);
                     let is_blanket = impl_block
@@ -725,14 +736,9 @@ impl TraitEnv {
                         }
                     }
                 } else {
-                    // Non-trait (inherent) impl block: index the block by its
-                    // receiver type name so instance-method lookup can fetch
-                    // just these candidates instead of scanning all modules.
-                    inherent_impl_index
-                        .entry(type_name.clone())
-                        .or_default()
-                        .push((module_source.clone(), item_idx));
-                    // Also index static methods.
+                    // Non-trait (inherent) impl block: already recorded in
+                    // `all_impl_index` above; here only its static methods need
+                    // the dedicated index.
                     let recv_key = canonical_key(module_source, &type_name);
                     for (method_idx, method) in impl_block.methods.iter().enumerate() {
                         let has_self = method
@@ -760,7 +766,7 @@ impl TraitEnv {
         (
             Arc::new(Self {
                 impl_index,
-                inherent_impl_index,
+                all_impl_index,
                 decl_index,
                 effect_decl_index,
                 resource_decl_index,
@@ -803,6 +809,25 @@ impl TraitEnv {
         self.module_import_scopes
             .get(module)
             .cloned()
+            .unwrap_or_default()
+    }
+
+    /// Keys of the **inherent** impls on `type_name`, in global build order —
+    /// the `trait_name.is_none()` subset of [`Self::all_impl_index`]. Used by
+    /// instance-method lookup, which must not treat trait impls as inherent.
+    pub(super) fn inherent_impl_keys(&self, type_name: &str) -> Vec<(ModuleSource, usize)> {
+        self.all_impl_index
+            .get(type_name)
+            .map(|keys| {
+                keys.iter()
+                    .filter(|key| {
+                        self.impl_headers
+                            .get(*key)
+                            .is_some_and(|h| h.trait_name.is_none())
+                    })
+                    .cloned()
+                    .collect()
+            })
             .unwrap_or_default()
     }
 

--- a/wado-compiler/src/elaborator/tysys.rs
+++ b/wado-compiler/src/elaborator/tysys.rs
@@ -29,7 +29,7 @@
 //! every loaded module for inherent impls (`O(modules × items)`), and
 //! `find_indexing_trait_impl` re-derived its answer from the same impl
 //! scan. Once both lookups became index-driven — inherent impls via
-//! [`super::trait_env::TraitEnv::inherent_impl_index`], trait impls via
+//! [`super::trait_env::TraitEnv::all_impl_index`], trait impls via
 //! the existing `impl_index` — the caches were pure overhead. Each also
 //! carried a latent staleness hazard: `method_info_cache` keyed on
 //! `(TypeId, name)` with no module-visibility component, and


### PR DESCRIPTION
## Motivation

On large generated files (package-gale's `css3.wado`, a 41k-line generated parser), `wado compile -O0` was dominated by `elaborate/resolve_funcs` — ~56% of the run. Profiling pinned the cost on method-call / trait resolution doing **per-call-site linear scans over every impl block in every loaded module** (an O(call_sites × impls) blowup).

## What changed

- **Index-driven lookups.** The hot method/trait lookups now fetch only the candidate impls for the receiver type from the pre-built impl indices, instead of scanning all impls. Covers instance-method param-mutability lookup, trait-method-type-param search, and the trait-method resolver.

- **Unified scan skeleton.** `find_indexing_trait_impl`, `find_assoc_type_in_trait_impl`, and `find_arithmetic_trait_impl` carried three drifted copies of the same "scan candidate impls → build type-param mapping → project" prologue. They now share one `probe_trait_impls` core (trait predicate parameterized; per-candidate filtering / `Self` handling / projection in a closure). The redundant newtype-base fallback that re-ran an identical scan on every `a[i]` is centralized in `index_lookup_or_newtype_base` and only runs when the base actually differs.

- **One globally-ordered impl index.** Instance-method lookup kept two parallel per-type indices (`impl_index` for trait, `inherent_impl_index` for inherent) and reconstructed their combined global order with a per-call `sort_by_key`. `inherent_impl_index` is replaced by a single `all_impl_index` (every impl on a type, in global build order); the inherent subset is the `trait_name.is_none()` filter behind `inherent_impl_keys`. Callers iterate the already-ordered list directly — no per-call sort.

- **Decomposed trait-method resolver.** The ~280-line `find_trait_method_for_type_uncached` (no cache despite the name) is renamed `find_trait_method_for_type_inner` and split into single-responsibility helpers: `newtype_chain_names`, `trait_method_candidates`, `candidate_matches_receiver` (itself three named receiver-match guards), `collect_trait_method_matches_from_impl`, and `select_trait_match`.

- **Fix: arithmetic trait lookup type-param mapping.** `find_arithmetic_trait_impl` was the lone caller forcing an empty declared-type-param set, triggering `build_type_param_mapping`'s "legacy" fallback that treats every `Named` impl arg as a type parameter. For a mixed `impl<T> Add for Pair<T, i32>`, that maps the concrete `i32` as a substitutable parameter. It now uses `build_declared_type_params` like every other path (which filters out known type names), and `probe_trait_impls`'s now-always-true flag is removed.

## Result

`resolve_funcs` on `css3.wado`: ~2.24s → ~1.25s; total `-O0` compile ~4.2s → ~3.1s. Behavior is preserved (the arithmetic change only drops bogus concrete-name mappings, never a real type-param mapping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCfbtjUNdFv1Gu2WosPpK2

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCfbtjUNdFv1Gu2WosPpK2)_