### PR TITLE
docs: redesign module specifier syntax (lib: scheme + CM coordinates)

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -128,3 +128,4 @@ It may include TODOs on WIP.
 - [Library-Defined Derivation: `Reflect` Extensions and the `#[validate]` Attribute](./wep-2026-06-13-reflect-derivation.md)
 - [Compile-Time Data Providers (bundled ICU)](./wep-2026-06-13-compile-time-data-providers.md)
 - [Symbol Notation](./wep-2026-06-14-symbol-notation.md)
+- [Package and Module Specifier Syntax](./wep-2026-06-17-package-module-syntax.md)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3247,42 +3247,48 @@ All entity definitions can have `pub` visibility, including struct fields.
 | Source Type   | Syntax                        | Example                              |
 | ------------- | ----------------------------- | ------------------------------------ |
 | WASI standard | `"wasi:<package>"`            | `"wasi:cli"`, `"wasi:filesystem"`    |
-| Core library  | `"core:<module>"`             | `"core:cli"`, `"core:fmt"`           |
+| Core library  | `"core:<module>"`             | `"core:cli"`, `"core:json"`          |
+| CM coordinate | `"<ns>:<pkg>[@<ver>]"`        | `"docs:regex"`, `"docs:regex@1.0.0"` |
+| Library alias | `"lib:<nick>"`                | `"lib:router"`, `"lib:shared"`       |
 | Remote (HTTP) | `"https://..."`               | `"https://example.com/lib.wado"`     |
 | Local file    | `"./<path>"` or `"../<path>"` | `"./utils.wado"`, `"../config.wado"` |
-| Package       | `"<package-name>"`            | `"parser-lib"`, `"json-utils"`       |
+
+A specifier names a package only — no interface segment; interfaces and members are selected in the `use { ... }` list. `wasi:`/`core:` are bundled coordinates, not a separate scheme. See [WEP: Package and Module Specifier Syntax](./wep-2026-06-17-package-module-syntax.md).
 
 ### Module Path Validation
 
 Module paths are validated before loading to provide clear error messages:
 
-**Namespace Resolution:**
+**Namespace Resolution** (a namespace is reserved iff the compiler bundles it):
 
-1. **Reserved namespaces** (`identifier:`): Paths matching `xxx:` pattern are namespace paths
-   - `core:` - Wado standard library
-   - `wasi:` - WASI interface modules
-   - Unknown namespaces result in compile error: `unknown module namespace 'xxx'; expected 'core' or 'wasi'`
+1. **Bundled namespaces** `core:` / `wasi:` — resolved from embedded stdlib.
 
-2. **Remote modules** (`http://` or `https://`): Delegated to CompilerHost
+2. **Open coordinates** `<ns>:<pkg>` (any other namespace) — resolved from the default registry, or a `with`/manifest source override.
 
-3. **Local modules** (`./` or `../`): Resolved relative to importing module
+3. **Library aliases** `lib:<nick>` — indirection (rename, short name, multiple majors, or a dependency with no public coordinate), resolved via `wado.toml` or an inline `with`.
 
-4. **Invalid paths**: Paths not matching any pattern are rejected
-   - Error: `invalid module path 'xxx'; use './' for local modules or 'namespace:' for library modules`
+4. **Remote modules** (`http://` or `https://`): Delegated to CompilerHost.
+
+5. **Local modules** (`./` or `../`): Resolved relative to importing module.
+
+6. **Invalid paths**: Paths not matching any pattern are rejected.
+   - Error: `invalid module path 'xxx'; use './' for local modules or a 'namespace:package' coordinate`
+
+Bare names (`"router"`) are rejected. See [WEP: Package and Module Specifier Syntax](./wep-2026-06-17-package-module-syntax.md) for resolution and version rules.
 
 ### Import Syntax
 
 ```wado
 // ============================================
 // WIT Package = Wado Module
-// WIT Interface = Wado Effect
+// WIT Interface = Wado interface
 // ============================================
 
 // 1. WASI standard modules (wasi:*)
 use {Stdout, Stderr} from "wasi:cli";
 use {Stdout::{write_via_stream}} from "wasi:cli";
 
-// Effect and its functions together
+// Interface and its members together
 use {Stdout, Stdout::{write_via_stream}} from "wasi:cli";
 
 // 2. Core library (core:*)
@@ -3297,8 +3303,11 @@ use config from "https://example.com/data.json" with { type: "json" };
 use {Helper} from "./utils.wado";
 use {Config} from "../config.wado";
 
-// 5. Package dependencies (name only)
-use {Parser} from "parser-lib";
+// 5. CM coordinate (resolved via wado.toml or default registry)
+use {Regexp} from "docs:regex";
+
+// 6. Library alias (rename / private / coordinate-less dependency)
+use {Router} from "lib:router";
 ```
 
 ### Import Attributes (`with`)
@@ -3306,8 +3315,11 @@ use {Parser} from "parser-lib";
 Use `with { ... }` to specify import metadata:
 
 ```wado
-// Version specification (optional for standard namespaces)
-use {Stdout} from "wasi:cli" with { version: "0.3.0" };
+// Inline dependency source (single-file scripts; no wado.toml needed).
+// Same vocabulary as a [dependencies] value, with an exact version.
+use {Regexp} from "docs:regex@1.0.0";  // exact pin via the specifier
+use {Router} from "lib:router" with { git = "https://github.com/user/router.git", ref = "v1.0" };
+use {Parse}  from "lib:rx"     with { registry = "https://wa.dev", package = "docs:regex", version = "1.0.0" };
 
 // Type attribute (REQUIRED for non-.wado imports)
 use config from "./config.json" with { type: "json" };
@@ -3320,16 +3332,18 @@ use {foo} from "./external.wasm" with {
 };
 ```
 
+An inline `with` source and a `wado.toml` entry for the same specifier are mutually exclusive. Version ranges (`^`/`~`/`=`) are allowed only in `wado.toml`, where a lock file resolves them; the specifier `@ver` and a single-file `with` take an **exact** version — a range there is an error.
+
 **Type Attribute Requirement**:
 
-| Import Source        | `type` Attribute | Notes                          |
-| -------------------- | ---------------- | ------------------------------ |
-| `.wado` files        | Optional         | Type inferred from Wado source |
-| `.wasm` files        | **Required**     | `type: "wasm"`                 |
-| `.json` files        | **Required**     | `type: "json"`                 |
-| `core:*`, `wasi:*`   | Not applicable   | Special namespace handling     |
-| `https:` URLs        | **Required**     | Must specify content type      |
-| Package dependencies | Optional         | Type inferred from package     |
+| Import Source      | `type` Attribute | Notes                          |
+| ------------------ | ---------------- | ------------------------------ |
+| `.wado` files      | Optional         | Type inferred from Wado source |
+| `.wasm` files      | **Required**     | `type: "wasm"`                 |
+| `.json` files      | **Required**     | `type: "json"`                 |
+| `core:*`, `wasi:*` | Not applicable   | Bundled namespace handling     |
+| `https:` URLs      | **Required**     | Must specify content type      |
+| CM / `lib:` deps   | Optional         | Type inferred from package     |
 
 **Rationale**: Explicit type annotations prevent ambiguity and make dependencies clear, aligning with Wado's design philosophy of explicit imports.
 
@@ -3470,8 +3484,8 @@ Notation distinction:
 ### Renaming Imports
 
 ```wado
-use {write_via_stream as stdout_write} from "wasi:cli/Stdout";
-use {write_via_stream as stderr_write} from "wasi:cli/Stderr";
+use {Stdout::{write_via_stream as stdout_write}} from "wasi:cli";
+use {Stderr::{write_via_stream as stderr_write}} from "wasi:cli";
 
 fn log() with Stdout, Stderr {
     stdout_write(out_stream);
@@ -3492,8 +3506,8 @@ pub fn cos(x: f64) -> f64 { ... }
 pub use {sin, cos} from "./internal/trig.wado";
 pub use {sin as sine} from "./internal/trig.wado";  // with rename
 
-// user code - import from the facade
-use {sin, cos, sine} from "math";
+// user code - import from the facade (a "math" dependency declared in wado.toml)
+use {sin, cos, sine} from "lib:math";
 ```
 
 Re-export rules:

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1703,9 +1703,9 @@ This design aligns with TypeScript (primary target audience) and enables intuiti
 ```
 
 ```wado
-use config from "./config.json" with { type: "json" };
-// config::point is [i32, i32]
-// config::mixed is [i32, String, bool]
+// A JSON array maps naturally to a tuple (JSON file import is provided by Kiln):
+let point: [i32, i32] = [10, 20];
+let mixed: [i32, String, bool] = [1, "hello", true];
 ```
 
 See `docs/wep-2026-01-15-tuple-and-array-literals.md` for detailed rationale.
@@ -3297,7 +3297,6 @@ use {format} from "core:fmt";
 
 // 3. Remote modules (https:)
 use {ApiClient} from "https://example.com/api.wado";
-use config from "https://example.com/data.json" with { type: "json" };
 
 // 4. Local files (relative path, extension required)
 use {Helper} from "./utils.wado";
@@ -3322,7 +3321,6 @@ use {Router} from "lib:router" with { git = "https://github.com/user/router.git"
 use {Parse}  from "lib:rx"     with { registry = "https://wa.dev", package = "docs:regex", version = "1.0.0" };
 
 // Type attribute (REQUIRED for non-.wado imports)
-use config from "./config.json" with { type: "json" };
 use {sin, cos} from "./libm.wasm" with { type: "wasm" };
 
 // WIT specification for Wasm imports (optional)
@@ -3336,22 +3334,23 @@ An inline `with` source and a `wado.toml` entry for the same specifier are mutua
 
 **Type Attribute Requirement**:
 
-| Import Source      | `type` Attribute | Notes                          |
-| ------------------ | ---------------- | ------------------------------ |
-| `.wado` files      | Optional         | Type inferred from Wado source |
-| `.wasm` files      | **Required**     | `type: "wasm"`                 |
-| `.json` files      | **Required**     | `type: "json"`                 |
-| `core:*`, `wasi:*` | Not applicable   | Bundled namespace handling     |
-| `https:` URLs      | **Required**     | Must specify content type      |
-| CM / `lib:` deps   | Optional         | Type inferred from package     |
+| Import Source      | `type` Attribute         | Notes                          |
+| ------------------ | ------------------------ | ------------------------------ |
+| `.wado` files      | Optional                 | Type inferred from Wado source |
+| `.wasm` files      | **Required**             | `type: "wasm"`                 |
+| `core:*`, `wasi:*` | Not applicable           | Bundled namespace handling     |
+| `https:` URLs      | Required for non-`.wado` | Must specify content type      |
+| CM / `lib:` deps   | Optional                 | Type inferred from package     |
 
 **Rationale**: Explicit type annotations prevent ambiguity and make dependencies clear, aligning with Wado's design philosophy of explicit imports.
+
+JSON and other schema files (`.json`, `.g4`, `.proto`, …) are not core import types — they are lowered by Kiln generators (below).
 
 ### Schema Imports (Kiln)
 
 See [WEP: Kiln](./wep-2026-04-12-kiln.md) and [WEP: Gale](./wep-2026-03-02-gale.md).
 
-A `use` clause whose source is a non-`.wado`, non-`.wasm`, non-`.json` schema file (e.g. `.g4`, `.proto`, `.graphql`, `.wit`) is processed by **Kiln** — a schema-driven code-generation pipeline that lowers the schema to ordinary Wado source which the compiler then handles like any user-authored module. The `with { generator: { ... } }` clause specifies which generator to invoke:
+A `use` clause whose source is a non-`.wado`, non-`.wasm` schema file (e.g. `.json`, `.g4`, `.proto`, `.graphql`, `.wit`) is processed by **Kiln** — a schema-driven code-generation pipeline that lowers the schema to ordinary Wado source which the compiler then handles like any user-authored module. (`.json` file import is provided this way, not as a core import type.) The `with { generator: { ... } }` clause specifies which generator to invoke:
 
 ```wado
 // Gale generates a parser from an ANTLR4 grammar
@@ -3416,13 +3415,9 @@ In hosts that cannot execute generators (today's wasm32-bundled LSP / browser pl
 Use `use name from "..."` (without curly braces) to import an entire module as a namespace:
 
 ```wado
-// Import JSON file as a namespace
-use config from "./config.json" with { type: "json" };
-let value = config::key; // not config["key"], as it's analyzed at compile time
-
 // Import a module as a namespace
 use utils from "./utils.wado";
-utils::helper_function();
+utils::helper_function();      // not utils["helper_function"], as it's analyzed at compile time
 ```
 
 A namespace import makes all pub symbols from the source module available. At the source level, symbols are accessed with the `ns::` prefix. Internally, the compiler desugars the prefix away during the desugar phase and registers all pub symbols from the source module as named imports:

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3344,13 +3344,11 @@ An inline `with` source and a `wado.toml` entry for the same specifier are mutua
 
 **Rationale**: Explicit type annotations prevent ambiguity and make dependencies clear, aligning with Wado's design philosophy of explicit imports.
 
-JSON and other schema files (`.json`, `.g4`, `.proto`, …) are not core import types — they are lowered by Kiln generators (below).
-
 ### Schema Imports (Kiln)
 
 See [WEP: Kiln](./wep-2026-04-12-kiln.md) and [WEP: Gale](./wep-2026-03-02-gale.md).
 
-A `use` clause whose source is a non-`.wado`, non-`.wasm` schema file (e.g. `.json`, `.g4`, `.proto`, `.graphql`, `.wit`) is processed by **Kiln** — a schema-driven code-generation pipeline that lowers the schema to ordinary Wado source which the compiler then handles like any user-authored module. (`.json` file import is provided this way, not as a core import type.) The `with { generator: { ... } }` clause specifies which generator to invoke:
+A `use` clause whose source is a non-`.wado`, non-`.wasm` schema file (e.g. `.g4`, `.proto`, `.graphql`, `.wit`) is processed by **Kiln** — a schema-driven code-generation pipeline that lowers the schema to ordinary Wado source which the compiler then handles like any user-authored module. The `with { generator: { ... } }` clause specifies which generator to invoke:
 
 ```wado
 // Gale generates a parser from an ANTLR4 grammar

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1703,7 +1703,7 @@ This design aligns with TypeScript (primary target audience) and enables intuiti
 ```
 
 ```wado
-// A JSON array maps naturally to a tuple (JSON file import is provided by Kiln):
+// A JSON array maps naturally to a tuple:
 let point: [i32, i32] = [10, 20];
 let mixed: [i32, String, bool] = [1, "hello", true];
 ```

--- a/docs/wep-2026-01-15-tuple-and-array-literals.md
+++ b/docs/wep-2026-01-15-tuple-and-array-literals.md
@@ -23,12 +23,6 @@ TypeScript developers expect `[...]` syntax for tuples.
 
 ### JSON Interoperability
 
-Wado supports importing JSON files (provided by a Kiln generator, not a core import type):
-
-```wado
-use config from "./config.json";
-```
-
 JSON arrays use `[...]` syntax and are inherently heterogeneous:
 
 ```json

--- a/docs/wep-2026-01-15-tuple-and-array-literals.md
+++ b/docs/wep-2026-01-15-tuple-and-array-literals.md
@@ -23,10 +23,10 @@ TypeScript developers expect `[...]` syntax for tuples.
 
 ### JSON Interoperability
 
-Wado supports importing JSON modules:
+Wado supports importing JSON files (provided by a Kiln generator, not a core import type):
 
 ```wado
-use config from "./config.json" with { type: "json" };
+use config from "./config.json";
 ```
 
 JSON arrays use `[...]` syntax and are inherently heterogeneous:

--- a/docs/wep-2026-01-24-module-loader.md
+++ b/docs/wep-2026-01-24-module-loader.md
@@ -26,9 +26,9 @@ Module paths in `use` declarations follow this grammar:
 ```
 ModulePath := CoordinatePath | LibAlias | LocalPath | RemotePath
 
-CoordinatePath := Namespace (":" Namespace)* ":" Package ("/" Interface)? ("@" Version)?
+CoordinatePath := Namespace (":" Namespace)* ":" Package ("@" Version)?
 LibAlias := "lib:" Identifier
-Namespace, Package, Interface := Identifier
+Namespace, Package := Identifier
 
 LocalPath := ("." | "..") "/" RelativePath
 RelativePath := PathSegment ("/" PathSegment)*

--- a/docs/wep-2026-01-24-module-loader.md
+++ b/docs/wep-2026-01-24-module-loader.md
@@ -186,7 +186,7 @@ For non-Wado file imports:
 use helper from "./helper.wasm" with { type: "wasm" };
 ```
 
-See WEP-2026-01-10-wasm-import for details. JSON file import is no longer a core import type — it is lowered by a Kiln generator (WEP: Kiln).
+See WEP-2026-01-10-wasm-import for details. JSON file import is not a core import type.
 
 ## Implementation Status
 

--- a/docs/wep-2026-01-24-module-loader.md
+++ b/docs/wep-2026-01-24-module-loader.md
@@ -183,11 +183,10 @@ Future versions may add:
 For non-Wado file imports:
 
 ```wado
-use config from "./config.json" with { type: "json" };
 use helper from "./helper.wasm" with { type: "wasm" };
 ```
 
-See WEP-2026-01-18-json-module-import and WEP-2026-01-10-wasm-import for details.
+See WEP-2026-01-10-wasm-import for details. JSON file import is no longer a core import type — it is lowered by a Kiln generator (WEP: Kiln).
 
 ## Implementation Status
 

--- a/docs/wep-2026-01-24-module-loader.md
+++ b/docs/wep-2026-01-24-module-loader.md
@@ -13,16 +13,22 @@ Currently, unknown namespaces (e.g., `unknown:foo`) are silently treated as loca
 
 ## Decision
 
+> The namespace grammar and the "unknown namespace = error" rule below are
+> superseded by [Package and Module Specifier Syntax](./wep-2026-06-17-package-module-syntax.md):
+> a namespace is reserved iff the compiler bundles it (`wasi`, `core`), every
+> other coordinate namespace is open, and `lib:` is the single indirection
+> namespace. The local / remote / I/O-delegation rules below still hold.
+
 ### Module Path Syntax
 
 Module paths in `use` declarations follow this grammar:
 
 ```
-ModulePath := NamespacePath | LocalPath | RemotePath
+ModulePath := CoordinatePath | LibAlias | LocalPath | RemotePath
 
-NamespacePath := Namespace ":" Name
-Namespace := "core" | "wasi"
-Name := Identifier ("/" Identifier)*
+CoordinatePath := Namespace (":" Namespace)* ":" Package ("/" Interface)? ("@" Version)?
+LibAlias := "lib:" Identifier
+Namespace, Package, Interface := Identifier
 
 LocalPath := ("." | "..") "/" RelativePath
 RelativePath := PathSegment ("/" PathSegment)*
@@ -33,13 +39,14 @@ RemotePath := ("http://" | "https://") Url
 
 ### Namespace Resolution Rules
 
-1. **Reserved Namespaces (`xxx:`)**
-   - All paths matching `identifier:` pattern are reserved namespace paths
-   - Currently defined namespaces:
-     - `core:` - Wado standard library (`core:prelude`, `core:cli`, etc.)
-     - `wasi:` - WASI interface modules (`wasi:cli`, `wasi:filesystem`, etc.)
-   - **Unknown namespaces result in immediate compile error**
-   - Error message: `unknown module namespace 'xxx'; expected 'core' or 'wasi'`
+1. **Reserved namespace ⇔ bundled namespace**
+   - `core:` — Wado standard library (`core:prelude`, `core:cli`, etc.)
+   - `wasi:` — WASI interface modules (`wasi:cli`, `wasi:filesystem`, etc.)
+   - Every other coordinate namespace is **open** and resolves from outside
+     (default registry, or `with`/manifest source override).
+   - `lib:` is the single indirection namespace (alias / rename / private dep).
+   - See [Package and Module Specifier Syntax](./wep-2026-06-17-package-module-syntax.md)
+     for resolution and version rules.
 
 2. **Remote Modules (`http://` or `https://`)**
    - URLs starting with `http://` or `https://` are remote modules

--- a/docs/wep-2026-02-14-package-manifest.md
+++ b/docs/wep-2026-02-14-package-manifest.md
@@ -32,13 +32,18 @@ lib = "src/lib.wado"
 default = "https://wa.dev"
 
 [dependencies]
-router = { git = "https://github.com/user/router.git", version = "^1.0.0" }
-regex = { package = "docs:regex", version = "^0.1.0" }
-shared = { path = "../shared" }
+"docs:regex" = { version = "^0.1.0" }                                            # direct coordinate
+"user:router" = { git = "https://github.com/user/router.git", version = "^1.0.0" }  # coordinate, git source
+"lib:shared" = { path = "../shared" }                                            # nickname (no public coordinate)
 
 [dev-dependencies]
-bench = { git = "https://gitlab.com/user/bench.git", ref = "main" }
+"lib:bench" = { git = "https://gitlab.com/user/bench.git", ref = "main" }
 ```
+
+Each key is byte-identical to the `from "..."` specifier it backs (see
+[Package and Module Specifier Syntax](./wep-2026-06-17-package-module-syntax.md)):
+an open coordinate `ns:pkg`, or a `lib:` nickname for indirection. Bare keys
+(`router`) are rejected.
 
 ### `[package]`
 
@@ -55,7 +60,7 @@ bench = { git = "https://gitlab.com/user/bench.git", ref = "main" }
 
 Both `namespace` and `name` must match `[a-zA-Z0-9_-]+` (minimum 1 character, maximum 64 characters).
 
-Dependency keys in `[dependencies]` follow the same rules. This ensures they are valid TOML bare keys and unambiguous in import paths.
+Dependency keys in `[dependencies]` are quoted specifiers — an open coordinate `"ns:pkg"` or a `"lib:nick"` nickname — each segment matching the same `[a-zA-Z0-9_-]+` rule. The `lib:`-or-coordinate form makes a real registry identity and a local indirection distinguishable on sight.
 
 A package must declare at least one world: a `[world]` entry, `[package].lib`, or both.
 
@@ -111,13 +116,13 @@ pub fn build_ast(tokens: List<Token>) -> Document { ... } // project-internal
 export fn parse(input: String) -> Document { ... }         // public API
 ```
 
-When another project depends on `"markdown"`, only `export` items from the `lib` entry point are visible:
+When another project depends on the `markdown` package (declared `"lib:markdown" = { ... }`, since it has no public namespace), only `export` items from the `lib` entry point are visible:
 
 ```wado
 // In a consuming project
-use { parse } from "markdown";        // OK: exported from lib
-// use { build_ast } from "markdown";  // ERROR: pub but not exported
-// use { tokenize } from "markdown";   // ERROR: private
+use { parse } from "lib:markdown";        // OK: exported from lib
+// use { build_ast } from "lib:markdown";  // ERROR: pub but not exported
+// use { tokenize } from "lib:markdown";   // ERROR: private
 ```
 
 When published as a `.wasm` component (e.g., to wa.dev), only `export` items appear in the component's interface.
@@ -139,7 +144,7 @@ This optimization is transparent to the developer. The visible API is always det
 
 ### `[registries]`
 
-Named registry aliases. Keys are short names; values are registry URLs. The special key `default` sets the default registry — dependencies with `package` but no `registry` use it automatically.
+Named registry aliases. Keys are short names; values are registry URLs. The special key `default` sets the default registry — a registry dependency with no `registry` field uses it automatically.
 
 ```toml
 [registries]
@@ -149,15 +154,15 @@ custom = "https://registry.example.com"
 
 ```toml
 [dependencies]
-regex = { package = "docs:regex", version = "^0.1.0" }              # uses default registry
-special = { registry = "custom", package = "ns:lib", version = "^1.0.0" }  # uses named registry
+"docs:regex" = { version = "^0.1.0" }                                       # uses default registry
+"lib:special" = { registry = "custom", package = "ns:lib", version = "^1.0.0" }  # uses named registry
 ```
 
-A dependency with `package` and `version` but no `registry` requires `default` to be set. If `default` is not defined and `registry` is omitted, it is an error.
+A registry dependency with no `registry` field requires `default` to be set. If `default` is not defined and `registry` is omitted, it is an error.
 
 ### `[dependencies]` and `[dev-dependencies]`
 
-Each key is the **import name** used in Wado source code. Values are inline tables specifying the dependency source.
+Each key is the **specifier** used in Wado source code, byte-for-byte (`"docs:regex"`, `"lib:shared"`). Values are inline tables specifying the dependency source. See [Package and Module Specifier Syntax](./wep-2026-06-17-package-module-syntax.md) for the key forms and resolution rules.
 
 `[dev-dependencies]` are only available during `wado test` and are excluded from production builds.
 
@@ -168,12 +173,12 @@ Each dependency must have exactly one primary source type (`git`, `registry`, or
 #### Git
 
 ```toml
-# Semver on git tags
-router = { git = "https://github.com/user/router.git", version = "^1.0.0" }
+# Semver on git tags (identity = the coordinate key, source = git)
+"user:router" = { git = "https://github.com/user/router.git", version = "^1.0.0" }
 
 # Exact git ref (tag, branch, or SHA)
-router = { git = "https://github.com/user/router.git", ref = "v1.0.0" }
-router = { git = "https://github.com/user/router.git", ref = "main" }
+"user:router" = { git = "https://github.com/user/router.git", ref = "v1.0.0" }
+"user:router" = { git = "https://github.com/user/router.git", ref = "main" }
 ```
 
 | Field     | Required | Description                                   |
@@ -187,20 +192,25 @@ Exactly one of `version` or `ref` must be specified. `version` resolves against 
 #### Registry
 
 ```toml
-regex = { package = "docs:regex", version = "^0.1.0" }                      # uses default registry
-special = { registry = "custom", package = "ns:lib", version = "^1.0.0" }   # uses named registry
+"docs:regex" = { version = "^0.1.0" }                                       # direct coordinate, default registry
+"lib:rx" = { package = "docs:regex", version = "^0.1.0" }                   # nickname → coordinate
+"lib:special" = { registry = "custom", package = "ns:lib", version = "^1.0.0" }  # named registry
 ```
 
-| Field      | Required | Description                                                        |
-| ---------- | -------- | ------------------------------------------------------------------ |
-| `registry` | No       | Registry alias (defined in `[registries]`). Defaults to `default`. |
-| `package`  | Yes      | Package identity in `namespace:name` format                        |
-| `version`  | Yes      | Semver version range (e.g., `"^0.1.0"`)                            |
+| Field      | Required            | Description                                                                                |
+| ---------- | ------------------- | ------------------------------------------------------------------------------------------ |
+| `registry` | No                  | Registry alias (defined in `[registries]`). Defaults to `default`.                         |
+| `package`  | `lib:` aliases only | Real coordinate in `namespace:name` format. Omitted when the key is itself the coordinate. |
+| `version`  | Yes                 | Semver version range (e.g., `"^0.1.0"`)                                                    |
+
+When the key is an open coordinate (`"docs:regex"`), it _is_ the package
+identity and `package` is omitted. `package` appears only on a `lib:` nickname
+that aliases a registry coordinate.
 
 #### Local Path
 
 ```toml
-shared = { path = "../shared" }
+"lib:shared" = { path = "../shared" }
 ```
 
 | Field  | Required | Description                                  |
@@ -212,35 +222,36 @@ Local path dependencies are resolved relative to the `wado.toml` location. They 
 For publishing, `path` can be combined with a registry or git source. When publishing (`wado publish`), the `path` is stripped and the accompanying source is used in the published package manifest:
 
 ```toml
-shared = { path = "../shared", package = "myorg:shared", version = "^0.1.0" }
-shared = { path = "../shared", git = "https://github.com/org/shared.git", version = "^0.1.0" }
+"lib:shared" = { path = "../shared", package = "myorg:shared", version = "^0.1.0" }
+"lib:shared" = { path = "../shared", git = "https://github.com/org/shared.git", version = "^0.1.0" }
 ```
 
 ### Module Resolution with Dependencies
 
-The existing module resolution (WEP-2026-01-24) is extended with one new rule: **bare name** resolution.
+The specifier grammar and the reserved = bundled rule are defined in
+[Package and Module Specifier Syntax](./wep-2026-06-17-package-module-syntax.md).
+A dependency-backed specifier is one of:
 
-A bare name is an import path that does not contain `:` and does not start with `./`, `../`, or `http(s)://`.
+- an **open coordinate** `ns:pkg` (`ns` ∉ {`wasi`, `core`}), or
+- a **`lib:` nickname**.
 
-Resolution order:
-
-1. `"scheme:path"` (contains `:`) — scheme-based (`core:`, `wasi:`, etc.)
-2. `"./path"` or `"../path"` — relative file
-3. `"https://url"` — remote URL (source-level feature, not a `wado.toml` dependency)
-4. **bare name** — look up key in `[dependencies]` (or `[dev-dependencies]` during test)
+Both resolve by looking up the byte-identical key in `[dependencies]` (or
+`[dev-dependencies]` during test). `wasi:`/`core:` resolve to bundled sources,
+`./`/`../` to local files, `http(s)://` to a remote URL.
 
 ```wado
-use { println } from "core:cli";           // scheme → built-in
-use { Request } from "wasi:http";           // scheme → built-in
-use { helper } from "./utils.wado";         // relative → local file
-use { Router } from "router";              // bare → wado.toml dependency
+use { println } from "core:cli";        // bundled
+use { Request } from "wasi:http";        // bundled
+use { helper }  from "./utils.wado";     // local file
+use { Regexp }  from "docs:regex";       // open coordinate → wado.toml → registry
+use { Router }  from "lib:router";       // nickname → wado.toml
 ```
 
-A bare name binds to the dependency's library world — its `[package].lib` entry module — and resolves the imported symbols against that module's `export` items. Only the consuming project resolves its own `[dependencies]`: a bare import from within a dependency module does not bind to the consumer's dependencies.
-
-Dependency keys must not contain `:` (TOML bare keys naturally enforce this). This makes scheme-based and bare name resolution structurally unambiguous.
-
-`core` and `wasi` are **not reserved**. `"core:cli"` (with `:`) resolves via scheme; `"core"` (bare) resolves via `wado.toml`. These are different resolution paths.
+A dependency specifier binds to the dependency's library world — its
+`[package].lib` entry module — and resolves the imported symbols against that
+module's `export` items. Only the consuming project resolves its own
+`[dependencies]`: a dependency specifier from within a dependency module does
+not bind to the consumer's dependencies.
 
 #### `ModuleSource` Extension
 
@@ -252,7 +263,7 @@ pub enum ModuleSource {
     Remote { url: String },
     EntryPoint { filename: Option<String> },
     // A dependency's library-world module. Identified by its resolved entry
-    // module so that two aliases for the same package unify: the resolved
+    // module so that two specifiers for the same package unify: the resolved
     // path for a path dependency; the resolved package id for a
     // registry/git dependency.
     Dependency { path: String },
@@ -340,12 +351,12 @@ my-app
 Resolved: http 1.x AND http 2.x (two separate instances)
 ```
 
-Within a single `wado.toml`, a user can also explicitly depend on multiple major versions by using different import names:
+Within a single `wado.toml`, a user can also explicitly depend on multiple major versions through `lib:` nicknames, each pinning a different range of the same coordinate:
 
 ```toml
 [dependencies]
-http-v1 = { package = "std:http", version = "^1.0.0" }
-http-v2 = { package = "std:http", version = "^2.0.0" }
+"lib:http1" = { package = "std:http", version = "^1.0.0" }
+"lib:http2" = { package = "std:http", version = "^2.0.0" }
 ```
 
 #### Transitive Version Isolation
@@ -362,14 +373,14 @@ resolution key   = (package identity, major version)
 
 When two transitive dependencies require semver-incompatible versions of the same package, they each get their own resolved instance. The compiler does not need to know about this — it simply receives module sources from `CompilerHost`. The resolver (in the CLI) handles mapping.
 
-The existing `resolve_import(from_module_source, import_source)` signature already provides the necessary context. The `from_module_source` tells the `CompilerHost` _which package is doing the importing_, so the same bare name `"foo"` resolves to different packages depending on the caller:
+The existing `resolve_import(from_module_source, import_source)` signature already provides the necessary context. The `from_module_source` tells the `CompilerHost` _which package is doing the importing_, so the same specifier `"myns:foo"` resolves to different packages depending on the caller:
 
 ```
-resolve_import(from=EntryPoint, "foo")
+resolve_import(from=EntryPoint, "myns:foo")
   → CompilerHost looks up my-app's wado.toml → "myns:foo" version 2.0.0
   → returns ModuleSource::Dependency { id: "registry+https://wa.dev/myns:foo@2.0.0" }
 
-resolve_import(from=Dependency{id="registry+https://wa.dev/user:router@1.0.0"}, "foo")
+resolve_import(from=Dependency{id="registry+https://wa.dev/user:router@1.0.0"}, "myns:foo")
   → CompilerHost looks up router's wado.toml → "myns:foo" version 1.0.0
   → returns ModuleSource::Dependency { id: "registry+https://wa.dev/myns:foo@1.0.0" }
 ```
@@ -551,10 +562,10 @@ A workspace groups multiple packages for co-development. The workspace root has 
 members = ["packages/*"]
 
 [workspace.dependencies]
-json = { package = "std:json", version = "^1.0.0" }
+"std:json" = { version = "^1.0.0" }
 
 [workspace.dev-dependencies]
-bench = { git = "https://gitlab.com/user/bench.git", version = "^0.1.0" }
+"lib:bench" = { git = "https://gitlab.com/user/bench.git", version = "^0.1.0" }
 ```
 
 ```toml
@@ -576,7 +587,7 @@ version = "0.1.0"
 "wasi:cli/command" = "src/main.wado"
 
 [dependencies]
-core = { path = "../core" }
+"myorg:core" = { path = "../core" }
 ```
 
 | Field     | Type       | Required | Description                                  |
@@ -588,10 +599,10 @@ core = { path = "../core" }
 ```toml
 # In a workspace member's wado.toml
 [dependencies]
-json = { workspace = true }  # inherits from [workspace.dependencies]
+"std:json" = { workspace = true }   # inherits from [workspace.dependencies]
 
 [dev-dependencies]
-bench = { workspace = true }  # inherits from [workspace.dev-dependencies]
+"lib:bench" = { workspace = true }  # inherits from [workspace.dev-dependencies]
 ```
 
 A workspace root `wado.toml` can have both `[workspace]` and `[package]` — the root itself is both a workspace and a package (like Cargo).
@@ -607,17 +618,28 @@ Properties:
 
 When no `wado.toml` exists, the compiler operates in single-file mode:
 
-- Only `core:*`, `wasi:*`, `./`, `../`, and `https://` imports are available
-- Bare name imports produce a clear error: `unknown module "foo" (no wado.toml found)`
-- No behavioral change from current behavior
+- `core:*`, `wasi:*`, `./`, `../`, and `https://` imports work as always.
+- A dependency specifier (`ns:pkg` or `lib:nick`) must carry an inline
+  `with { ... }` supplying its source — the same vocabulary as a
+  `[dependencies]` value, with an **exact** `version` (no lock to resolve a
+  range). See [Package and Module Specifier Syntax](./wep-2026-06-17-package-module-syntax.md).
+- A dependency specifier without `with` produces a clear error:
+  `dependency "lib:foo" needs a source (add a with-clause or a wado.toml)`.
+- Inline `with` and a `[dependencies]` entry for the same specifier are mutually
+  exclusive (single-file uses `with`; a manifest project uses the table).
+
+```wado
+use { Regexp } from "docs:regex@1.0.0";   // exact pin, default registry
+use { Router } from "lib:router" with { git = "https://github.com/user/router.git", ref = "v1.0" };
+```
 
 ### Path Dependencies to Single Files
 
 `path` dependencies can point to a single `.wado` file (not just directories). The referenced file is implicitly treated as `lib = <that file>` — only `export` items are visible at the CM boundary:
 
 ```toml
-shared = { path = "../shared.wado" }    # treated as lib = "shared.wado"
-utils  = { path = "../utils" }          # reads ../utils/wado.toml for entry points
+"lib:shared" = { path = "../shared.wado" }    # treated as lib = "shared.wado"
+"lib:utils"  = { path = "../utils" }          # reads ../utils/wado.toml for entry points
 ```
 
 | Dependency type                      | Boundary    | Visible items                        |
@@ -646,15 +668,15 @@ When publishing a package to a registry (`wado publish`), the following validati
 [dependencies]
 # During development: resolved via path (fast, local edits)
 # When published: resolved via registry (self-contained)
-shared = { path = "../shared", package = "myorg:shared", version = "^0.1.0" }
+"lib:shared" = { path = "../shared", package = "myorg:shared", version = "^0.1.0" }
 ```
 
 Path dependencies without a registry or git fallback are errors:
 
 ```
 error: cannot publish with path-only dependency
-  → utils = { path = "../utils" }
-  help: add registry or git source: utils = { path = "../utils", package = "myorg:utils", version = "^0.1.0" }
+  → "lib:utils" = { path = "../utils" }
+  help: add registry or git source: "lib:utils" = { path = "../utils", package = "myorg:utils", version = "^0.1.0" }
 ```
 
 This enables seamless local development while ensuring published packages are self-contained.
@@ -668,8 +690,8 @@ This enables seamless local development while ensuring published packages are se
 - Git deps support both semver (`version`) and exact pinning (`ref`) — XOR ensures clarity
 - `dev-dependencies` keep test-only code out of production builds, tracked in lock file with `dev = true`
 - Registry aliases avoid URL repetition and enable easy migration
-- Bare name imports are short and ergonomic (`"router"` not `"dep:router"`)
-- No reserved namespaces — `core:` and `wasi:` are resolved by scheme syntax, not by name reservation
+- A dependency key is byte-identical to its `from "..."` specifier — no key-level indirection between manifest and source
+- Reserved namespace ⇔ bundled namespace (`wasi`, `core`); every other coordinate namespace is open, with `lib:` as the single home for indirection (see [Package and Module Specifier Syntax](./wep-2026-06-17-package-module-syntax.md))
 - PubGrub provides best-in-class error messages for resolution failures
 - Cyclic dependencies are detected early with clear error messages
 - Multiple semver-incompatible versions coexist naturally, matching Wasm Component Model's type isolation
@@ -684,7 +706,7 @@ This enables seamless local development while ensuring published packages are se
 - `namespace` absence naturally indicates non-publishable packages — no extra `publish = false` flag needed
 - Path deps with dual source (`path` + `registry`) enable seamless dev-to-publish workflow
 - Workspace support enables multi-package development with shared lock files and dependency declarations
-- Name/namespace validation (`[a-zA-Z0-9_-]+`) ensures valid TOML bare keys and unambiguous import paths
+- Name/namespace validation (`[a-zA-Z0-9_-]+` per segment) keeps dependency keys (`"ns:pkg"`, `"lib:nick"`) unambiguous as specifiers
 
 ### Negative
 
@@ -699,7 +721,7 @@ This enables seamless local development while ensuring published packages are se
 - **`version` XOR `ref` for git**: `version` enables semver resolution on tags (like Go/Swift PM), `ref` pins to an exact ref. XOR ensures the intent is always unambiguous — no implicit defaults.
 - **Bare version = error**: more verbose than Cargo's implicit caret, but eliminates a source of confusion ("does `1.0.0` mean exact or `^1.0.0`?"). Every `version` field is self-documenting.
 - **Registry names per-project**: avoids global configuration but requires repetition across projects. The `default` registry mitigates this for the common case. A future `~/.wado/config.toml` could provide user-level defaults.
-- **Bare name resolution**: requires `wado.toml` lookup at compile time, adding a project-discovery step. The compiler itself is not affected — only `CompilerHost` implementations need to handle this.
+- **Dependency specifier resolution**: an open coordinate or `lib:` nickname requires a `wado.toml` lookup at compile time, adding a project-discovery step. The compiler itself is not affected — only `CompilerHost` implementations need to handle this.
 - **Self-sufficient lock file**: duplicates entry points and dependency edges from each package's `wado.toml`. This makes the lock file larger and introduces a potential staleness risk (if a dependency's `wado.toml` changes entry points without version bump). The trade-off is worth it — builds skip all transitive manifest I/O, and staleness is caught by `wado update` or integrity mismatch.
 - **Archive-level integrity** (not source-level): simpler and unambiguous, but means the hash depends on the registry's archive format. If a registry changes its packaging format, hashes change even if sources are identical.
 - **`[world]` table keyed by FQ world name**: hosted worlds are declared by their Component Model world name (`"wasi:cli/command"`) rather than a short alias (`command`/`bin`/`cli`). The key is the world the entry conforms to, so new worlds need no new manifest field and the mapping to the CM world is explicit. The library world is the one exception — it has no externally-fixed FQ name, so it is named after the package and declared by `[package].lib`.

--- a/docs/wep-2026-06-17-package-module-syntax.md
+++ b/docs/wep-2026-06-17-package-module-syntax.md
@@ -1,0 +1,114 @@
+# WEP: Package and Module Specifier Syntax
+
+## Context
+
+The module specifier (`from "..."`) carried two unreconciled designs:
+
+- [Module Loader](./wep-2026-01-24-module-loader.md) fixed the namespace set to
+  `core` and `wasi` and rejected any other `ns:` as an unknown namespace.
+- [Package Manifest](./wep-2026-02-14-package-manifest.md) added bare-name
+  dependency aliases (`use { R } from "router"`) resolved through `wado.toml`.
+
+Neither lets a specifier name a Component Model package by its real registry
+coordinate (`ns:pkg@ver`), so the WIT identity a Wado package already has does
+not show through in source — counter to "Wasm in plain sight". Bare names are
+also ambiguous on sight (`"router"` reads like a mistyped path), and a
+single-file script has no way to declare an external dependency at all.
+
+This WEP settles the specifier grammar and the resolution rules behind it. It
+supersedes the namespace grammar of Module Loader and the bare-name resolution
+of Package Manifest; the latter is updated in place as a living spec.
+
+## Decision
+
+A specifier is a CM package coordinate, a `lib:` alias, a local path, or a
+remote URL. Two principles anchor the rest:
+
+- **Reserved namespace ⇔ bundled namespace.** A namespace is reserved iff the
+  compiler ships its bytes — today `wasi` and `core`. Every other namespace is
+  open and resolves from outside. `lib` is the one extra reserved namespace, and
+  carries a single responsibility (below).
+- **Manifest key ≡ specifier string.** A `[dependencies]` key is byte-identical
+  to the `from "..."` string it backs. There is no key-level indirection.
+
+### Specifier forms
+
+| Form                             | Resolver                                      |
+| -------------------------------- | --------------------------------------------- |
+| `wasi:…` / `core:…`              | Reserved → compiler-bundled                   |
+| `ns:pkg[/iface][@ver]` (open ns) | Default registry, or `with`/manifest override |
+| `lib:nick`                       | Indirection: alias / rename / private dep     |
+| `./` `../`                       | Local file                                    |
+| `http(s)://`                     | Remote                                        |
+
+`wasi:`/`core:` are not a separate scheme — they are coordinates whose
+namespace happens to be bundled. Nested namespaces (`a:b:pkg`) and `/iface`
+follow WIT.
+
+### `lib:` is the sole home for indirection
+
+Renames, short names, multiple coexisting majors, and dependencies that have no
+public coordinate (closed-source git/path, the natural state of an
+unpublishable package) all use `lib:nick`. Aliases are forbidden under any open
+`ns:`: that keeps a real coordinate (`from "foo:regexp"`, transparent) visually
+distinct from a local indirection (`from "lib:rx"`, "see the manifest").
+
+The `package` field bridges a `lib:` alias to its real coordinate:
+
+| Key (≡ specifier) | `package` | Source                                    |
+| ----------------- | --------- | ----------------------------------------- |
+| `"foo:regexp"`    | omitted   | key is the coordinate                     |
+| `"lib:rx"`        | required  | registry alias → `package = "foo:regexp"` |
+| `"lib:shared"`    | optional  | git/path; resolved package self-declares  |
+
+Multiple majors fall out of this without special keys:
+
+```toml
+"lib:http1" = { package = "std:http", version = "^1.0" }
+"lib:http2" = { package = "std:http", version = "^2.0" }
+```
+
+### Version: a range only where a lock backs it
+
+| Position                             | Form                                       |
+| ------------------------------------ | ------------------------------------------ |
+| Manifest `version`                   | range required (`^`/`~`/`=`); bare = error |
+| Specifier `@ver`, single-file `with` | exact only; a range here is an error       |
+
+A range is meaningful only when a `wado.lock` resolves it. Lock-less positions
+take an exact pin; a range there is reported with a clear message (use an exact
+version, or declare the dependency in `wado.toml`).
+
+### Single-file parity
+
+With no `wado.toml`, an inline `with { ... }` carries the same source vocabulary
+as a `[dependencies]` value (`git`/`ref`/`registry`/`package`/`path`/exact
+`version`). Inline `with` and a manifest entry for the same specifier are
+mutually exclusive. Single-file scripts have no lock file — reproducibility
+comes from the exact pins in `with`.
+
+Bare names (`from "router"`) are rejected everywhere.
+
+## Consequences
+
+### Positive
+
+- A specifier self-describes: a coordinate is a transparent CM identity; `lib:`
+  is the visible mark of indirection. Nothing is silently rewritten.
+- The Module Loader / Package Manifest contradiction is gone: reserved = bundled
+  is a single, non-arbitrary rule.
+- Single-file scripts gain the manifest's full expressive power inline.
+- Coverage is complete with one indirection point: public-transparent (direct
+  coordinate), rename/short/multi-major/coordinate-less (`lib:`), bundled
+  (`wasi:`/`core:`), local (`./`), remote (`http(s)://`).
+
+### Trade-offs
+
+- `lib` is reserved without being bundled — the one exception to reserved =
+  bundled, justified by its single responsibility (all indirection lives there).
+- A git-hosted package with a coordinate can be reached two ways (direct
+  coordinate + `with { git }`, or `lib:nick` + `package` + `git`). Accepted; it
+  mirrors Cargo's rename-vs-direct duality.
+- Requiring a namespace on every external coordinate is more typing than a bare
+  name, but it is the transparent, unambiguous form and follows from the
+  bare-name ban.

--- a/docs/wep-2026-06-17-package-module-syntax.md
+++ b/docs/wep-2026-06-17-package-module-syntax.md
@@ -58,6 +58,11 @@ unpublishable package) all use `lib:nick`. Aliases are forbidden under any open
 `ns:`: that keeps a real coordinate (`from "foo:regexp"`, transparent) visually
 distinct from a local indirection (`from "lib:rx"`, "see the manifest").
 
+Bundling is a default, not a lock-in: because `lib:` resolution is pure
+indirection, a registry-hosted alternative to a bundled namespace (a forked or
+newer `wasi:`/`core:` package) is reachable by aliasing it under `lib:` —
+slightly ugly, but possible. Easy things stay easy; hard things stay possible.
+
 The `package` field bridges a `lib:` alias to its real coordinate:
 
 | Key (≡ specifier) | `package` | Source                                    |

--- a/docs/wep-2026-06-17-package-module-syntax.md
+++ b/docs/wep-2026-06-17-package-module-syntax.md
@@ -33,17 +33,22 @@ remote URL. Two principles anchor the rest:
 
 ### Specifier forms
 
-| Form                             | Resolver                                      |
-| -------------------------------- | --------------------------------------------- |
-| `wasi:…` / `core:…`              | Reserved → compiler-bundled                   |
-| `ns:pkg[/iface][@ver]` (open ns) | Default registry, or `with`/manifest override |
-| `lib:nick`                       | Indirection: alias / rename / private dep     |
-| `./` `../`                       | Local file                                    |
-| `http(s)://`                     | Remote                                        |
+| Form                     | Resolver                                      |
+| ------------------------ | --------------------------------------------- |
+| `wasi:…` / `core:…`      | Reserved → compiler-bundled                   |
+| `ns:pkg[@ver]` (open ns) | Default registry, or `with`/manifest override |
+| `lib:nick`               | Indirection: alias / rename / private dep     |
+| `./` `../`               | Local file                                    |
+| `http(s)://`             | Remote                                        |
 
 `wasi:`/`core:` are not a separate scheme — they are coordinates whose
-namespace happens to be bundled. Nested namespaces (`a:b:pkg`) and `/iface`
-follow WIT.
+namespace happens to be bundled. Nested namespaces (`a:b:pkg`) follow WIT.
+
+A specifier names a **package only**; it carries no interface segment.
+Interfaces and their members are selected in the `use { ... }` list (`Iface`,
+`Iface::{op}`), as Wado already does. A package's internal file layout (the
+bundled stdlib's `core:prelude/array.wado`-style splits) is a loader detail,
+never a user-facing specifier.
 
 ### `lib:` is the sole home for indirection
 


### PR DESCRIPTION
Redesigns the module specifier (`use ... from "..."`) so a specifier names a package's real identity or its location, and reconciles the docs that previously disagreed about it (Module Loader fixed the namespace set to `core`/`wasi`; Package Manifest added bare-name aliases). Docs only.

## Specifier model

A specifier is one of:

- `ns:pkg[@ver]` — a Component Model package coordinate (nested namespaces ok). `wasi:`/`core:` are bundled coordinates, not a special scheme.
- `lib:nick` — an alias; the sole home for indirection.
- `./` `../` — local file.
- `http(s)://` — remote.

It names a package only — no interface segment; interfaces and members are selected in the `use { Iface, Iface::{op} }` list.

Anchoring rules:

- **Reserved namespace ⇔ bundled namespace** (`wasi`, `core`). Every other coordinate namespace is open and resolves from the default registry or a `with`/manifest source override. `lib` is the one extra reserved namespace.
- **Manifest key ≡ specifier string**: `[dependencies]` keys are byte-identical to the `from "..."` string (`"docs:regex"`, `"lib:shared"`). Bare names are rejected.
- **`lib:` carries all indirection** — rename, short name, multiple coexisting majors, and coordinate-less private deps; the `package` field bridges a `lib:` alias to its real coordinate.
- **Version ranges only where a lock backs them**: `wado.toml` `version` takes `^`/`~`/`=`; the specifier `@ver` and a single-file `with` take an exact pin.
- **Single-file parity**: an inline `with { ... }` declares a dependency source (same vocabulary as a `[dependencies]` value) without a `wado.toml`; mutually exclusive with a manifest entry.
- Bundling is a default, not a lock-in — a registry-hosted alternative to `wasi:`/`core:` is reachable by aliasing it under `lib:`.

JSON file import is no longer a core import type (`type: "json"` removed); `core:json`, the serde library, is unchanged.

## Documentation outcome

- Adds `docs/wep-2026-06-17-package-module-syntax.md` capturing the decision and rationale.
- `docs/wep-2026-02-14-package-manifest.md` (living spec): dependency keys are quoted specifiers, `package`-field semantics, multi-major via `lib:`, inline `with`, and every example/consequence reconciled with the model above.
- `docs/wep-2026-01-24-module-loader.md`: grammar and namespace rules updated to reserved=bundled + open coordinates + `lib:`, with a supersession note.
- `docs/spec.md`: Module System section synced; `/iface` segment and `type: "json"` core import removed.
- `docs/wep-2026-01-15-tuple-and-array-literals.md`: stale JSON-import example dropped.
- WEP index updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ukbfxr5qMbkTaeTHHx8wb